### PR TITLE
Add a Rake task to redirect HTML attachments

### DIFF
--- a/lib/data_hygiene/edition_not_unpublished.rb
+++ b/lib/data_hygiene/edition_not_unpublished.rb
@@ -1,0 +1,3 @@
+module DataHygiene
+  class EditionNotUnpublished < StandardError; end
+end

--- a/lib/data_hygiene/html_attachments_not_found.rb
+++ b/lib/data_hygiene/html_attachments_not_found.rb
@@ -1,0 +1,3 @@
+module DataHygiene
+  class HTMLAttachmentsNotFound < StandardError; end
+end

--- a/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
+++ b/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
@@ -1,0 +1,58 @@
+module DataHygiene
+  class PublishingApiHtmlAttachmentRedirector
+    def initialize(content_id, destination, dry_run:)
+      @content_id = content_id
+      @destination = destination
+      @dry_run = dry_run
+    end
+
+    def call
+      raise DataHygiene::EditionNotUnpublished.new unless unpublished_or_withdrawn
+      raise DataHygiene::HTMLAttachmentsNotFound.new unless html_attachments.any?
+      return dry_run_results if dry_run
+
+      send_redirects_to_publishing_api
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :content_id, :destination, :dry_run
+
+    def document
+      @document ||= Document.find_by(content_id: content_id)
+    end
+
+    def last_edition
+      @last_edition ||= document.editions.last
+    end
+
+    def unpublished_or_withdrawn
+      last_edition.unpublished? || last_edition.withdrawn?
+    end
+
+    def html_attachments
+      @html_attachments ||= last_edition.html_attachments
+    end
+
+    def dry_run_results
+      puts "Would have redirected: #{html_attachments.map(&:slug).to_s}\n to #{destination}"
+    end
+
+    def send_redirects_to_publishing_api
+      html_attachments.each do |attachment|
+        PublishingApiRedirectWorker.new.perform(
+          attachment.content_id,
+          destination,
+          attachment.locale || I18n.default_locale.to_s,
+        )
+      end
+      "Redirected #{html_attachments.count} HTML attachments to #{destination}"
+    end
+  end
+end

--- a/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
+++ b/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
@@ -41,7 +41,7 @@ module DataHygiene
     end
 
     def dry_run_results
-      puts "Would have redirected: #{html_attachments.map(&:slug).to_s}\n to #{destination}"
+      puts "Would have redirected: #{html_attachments.map(&:slug)}\nto #{destination}"
     end
 
     def send_redirects_to_publishing_api
@@ -52,7 +52,7 @@ module DataHygiene
           attachment.locale || I18n.default_locale.to_s,
         )
       end
-      "Redirected #{html_attachments.count} HTML attachments to #{destination}"
+      puts "Redirected: #{html_attachments.map(&:slug)}\nto #{destination}"
     end
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -111,4 +111,15 @@ namespace :publishing_api do
     document = Document.find_by!(slug: args[:slug])
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
+
+  desc "Redirect HTML Attachments to a given URL"
+  namespace :redirect_html_attachments do
+    task :dry, %i[content_id destination] => :environment do |_, args|
+      DataHygiene::PublishingApiHtmlAttachmentRedirector.call(args[:content_id], args[:destination], dry_run: true)
+    end
+
+    task :real, %i[content_id destination] => :environment do |_, args|
+      DataHygiene::PublishingApiHtmlAttachmentRedirector.call(args[:content_id], args[:destination], dry_run: false)
+    end
+  end
 end

--- a/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
+++ b/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let!(:document)               { create(:document) }
+  let!(:attachment)             { create(:html_attachment, locale: 'en') }
+  let!(:superseded_edition)     { create(:superseded_edition) }
+  let!(:edition)                {
+    create(
+      :unpublished_edition,
+                                  state: "withdrawn",
+                                  document: document,
+                                  attachments: [attachment]
+)
+  }
+  let!(:redirection)            { "www.example.com/attachment_path" }
+  let(:queried_document_id)     {}
+
+  def call_html_attachment_redirector
+    DataHygiene::PublishingApiHtmlAttachmentRedirector.call(
+      queried_document_id,
+      redirection,
+      dry_run: dry_run
+    )
+  end
+
+  context "during a dry run" do
+    let(:dry_run) { true }
+    let(:queried_document_id) { document.content_id }
+
+    it "does not send the redirection to the Publishing API" do
+      PublishingApiRedirectWorker.any_instance.expects(:perform).never
+      call_html_attachment_redirector
+    end
+
+    it "reports the html attachment that would have changed" do
+      output = "Would have redirected: #{[attachment.slug]}\nto #{redirection}\n"
+      assert_output(output) { call_html_attachment_redirector }
+    end
+  end
+
+  context "during a real run" do
+    let(:dry_run) { false }
+
+    context "the last edition has not been unpublished" do
+      let!(:published_document)   { create(:document) }
+      let!(:published_edition)    { create(:edition, document: published_document, attachments: []) }
+      let(:queried_document_id)   { published_document.content_id }
+
+      it "raises an exception" do
+        assert_raises DataHygiene::EditionNotUnpublished do
+          call_html_attachment_redirector
+        end
+      end
+    end
+
+    context "the last edition has no HTML attachments" do
+      let!(:unattached_document)   { create(:document) }
+      let!(:unattached_edition)    { create(:unpublished_edition, document: unattached_document, attachments: []) }
+      let(:queried_document_id)    { unattached_document.content_id }
+
+      it "raises an exception" do
+        assert_raises DataHygiene::HTMLAttachmentsNotFound do
+          call_html_attachment_redirector
+        end
+      end
+    end
+
+    context "the edition has been unpublished" do
+      let(:queried_document_id)   { document.content_id }
+
+      it "calls the redirect worker with the HTML attachments to redirect" do
+        PublishingApiRedirectWorker
+          .any_instance
+          .expects(:perform)
+          .with(attachment.content_id, redirection, attachment.locale)
+
+        call_html_attachment_redirector
+      end
+
+      it "reports the redirections sent to the Publishing API" do
+        output = "Redirected: #{[attachment.slug]}\nto #{redirection}\n"
+        assert_output(output) { call_html_attachment_redirector }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some unpublished and redirected editions have html attachments that have not been redirected.

This task will allow developers to manually send redirection URLS to the Publishing API for a given
document's HTML attachments. If the latests edition of a document has been unpublished or withdrawn, the HTML attachments will be redirected to the chosen URL.

Republishing the edition causes the redirects to be removed.

[trello](https://trello.com/c/vdhnOI7A/883-script-for-redirecting-html-attachments-after-unpublishing)

Tested in integration, with an unpublished edition:

```'publishing_api:redirect_html_attachments:dry[3dec281e-4f69-4dc9-beb5-1b368d3fcd20, https://www.integration.publishing.service.gov.uk/browse/disabilities/carers]'```
```
11:01:24 Would have redirected: ["eds-test-attachment", "attachment-2"]
11:01:24 to https://www.integration.publishing.service.gov.uk/browse/disabilities/carers
11:01:24 Finished: SUCCESS
```

```'publishing_api:redirect_html_attachments:real[3dec281e-4f69-4dc9-beb5-1b368d3fcd20, https://www.integration.publishing.service.gov.uk/browse/disabilities/carers]'```
```
11:03:01 Redirected: ["eds-test-attachment", "attachment-2"]
11:03:01 to https://www.integration.publishing.service.gov.uk/browse/disabilities/carers
11:03:02 Finished: SUCCESS
```