### PR TITLE
Add task to update in search editions published in a given range

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -82,8 +82,10 @@ namespace :rummager do
 
     desc "indexes all documents which were last updated in the given date range, the time defaults to midnight if only a date is given"
     task :published_between, %i(start_date end_date) => :environment do |_t, args|
-      eds = Document.joins(:published_edition).where(editions: { updated_at: args[:start_date]..args[:end_date] }).map(&:published_edition)
-      eds.each(&:update_in_search_index)
+      Document
+        .joins(:published_edition)
+        .where(editions: { updated_at: args[:start_date]..args[:end_date] })
+        .find_each { |doc| doc.published_edition&.update_in_search_index }
     end
   end
 

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -79,6 +79,15 @@ namespace :rummager do
       end
       puts "Complete."
     end
+
+    desc "indexes all documents which were last updated in the given
+    date range.  The time defaults to midnight if only a date is
+    given, so date ranges include the start date but exclude the end
+    date."
+    task :published_between, %i(start_date end_date) => :environment do |_t, args|
+      eds = Document.joins(:published_edition).where(editions: { updated_at: args[:start_date]..args[:end_date] }).map(&:published_edition)
+      eds.each(&:update_in_search_index)
+    end
   end
 
   desc "removes and re-indexes all searchable whitehall content"

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -80,10 +80,7 @@ namespace :rummager do
       puts "Complete."
     end
 
-    desc "indexes all documents which were last updated in the given
-    date range.  The time defaults to midnight if only a date is
-    given, so date ranges include the start date but exclude the end
-    date."
+    desc "indexes all documents which were last updated in the given date range, the time defaults to midnight if only a date is given"
     task :published_between, %i(start_date end_date) => :environment do |_t, args|
       eds = Document.joins(:published_edition).where(editions: { updated_at: args[:start_date]..args[:end_date] }).map(&:published_edition)
       eds.each(&:update_in_search_index)


### PR DESCRIPTION
The traffic replay from rummager to search-api doesn't seem to be 100%
reliable.  Over the weekend it looks like 7 documents didn't make it
across (a miss rate of about 5%), and resending them individually to
search fixed them.

Hopefully talking to search-api directly will be more reliable than
the traffic replay but, in any case, it looks like 2ndline will
occasionally need to update documents in search at least in the
immediate future.  So let's make it easier.

This is also a far easier alternative to reindexing Whitehall content
than doing the traffic replay.