### PR TITLE
Update change note for international driving permits page

### DIFF
--- a/db/data_migration/20190402145311_fix_driving_license_change_note.rb
+++ b/db/data_migration/20190402145311_fix_driving_license_change_note.rb
@@ -1,0 +1,10 @@
+original_change_note = "UK driving licence holders now need a 1969 IDP to drive in Albania, Armenia, Azerbaijan, Bahamas, Bahrain, Belarus, Bosnia and Herzegovina, Brazil, Cape Verde, Central African Republic, Cote d’Ivoire, Cuba, Democratic Republic of Congo, Eswatini, French Polynesia, Georgia, Guyana, Iran, Iraq, Israel, Kazakhstan, Kenya, Kuwait, Kyrgyzstan, Liberia, Moldova, Monaco, Mongolia, Montenegro, Morocco, Niger, North Macedonia, Pakistan, Peru, Philippines, Qatar, Russian Federation, San Marino, Saudi Arabia, Senegal, Serbia, Seychelles, South Africa, Tajikistan, Tunisia, Turkey, Turkmenistan, Ukraine, United Arab Emirates, Uruguay, Uzbekistan, Vietnam, Zimbabwe."
+new_change_note = "UK driving licence holders now need a 1968 IDP to drive in Albania, Armenia, Azerbaijan, Bahamas, Bahrain, Belarus, Bosnia and Herzegovina, Brazil, Central African Republic, Cote d’Ivoire, Cuba, Democratic Republic of Congo, Eswatini, French Polynesia, Georgia, Guyana, Iran, Iraq, Israel, Kazakhstan, Kenya, Kuwait, Kyrgyzstan, Liberia, Moldova, Monaco, Mongolia, Montenegro, Morocco, Niger, North Macedonia, Pakistan, Peru, Philippines, Qatar, Russian Federation, San Marino, Saudi Arabia, Senegal, Serbia, Seychelles, South Africa, Tajikistan, Tunisia, Turkey, Turkmenistan, Ukraine, United Arab Emirates, Uruguay, Uzbekistan, Vietnam, Zimbabwe."
+
+document = Document.find_by(slug: "international-driving-permits-for-uk-drivers-from-28-march-2019")
+
+edition = document.editions.find_by(change_note: original_change_note)
+
+edition.update_attributes(change_note: new_change_note)
+
+PublishingApiDocumentRepublishingWorker.perform_async(document.id)


### PR DESCRIPTION
See zendesk ticket: https://govuk.zendesk.com/agent/tickets/3642152

- change 1969 to 1968 in the 28 March 2019 change note 
- remove Cape Verde from the change note