### PR TITLE
Fix data migration.

### DIFF
--- a/db/data_migration/20190402145311_fix_driving_license_change_note.rb
+++ b/db/data_migration/20190402145311_fix_driving_license_change_note.rb
@@ -5,6 +5,6 @@ document = Document.find_by(slug: "international-driving-permits-for-uk-drivers-
 
 edition = document.editions.find_by(change_note: original_change_note)
 
-edition.update_attributes(change_note: new_change_note)
+edition.update_column(:change_note, new_change_note)
 
 PublishingApiDocumentRepublishingWorker.perform_async(document.id)


### PR DESCRIPTION
The relevant edition is already published so has to skip validations.

see also:https://github.com/alphagov/whitehall/pull/4717