### PR TITLE
Update language names

### DIFF
--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -328,7 +328,7 @@ da:
   i18n:
     direction: ltr
   language_names:
-    da:
+    da: Dansk
   latest_feed:
     no_updates:
     title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
     ms: Malay
     ps: Pashto
     si: Sinhala
-    sk: Slovakian
+    sk: Slovak
     so: Somali
     sw: Swahili
     ta: Tamil

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -328,7 +328,7 @@ fi:
   i18n:
     direction: ltr
   language_names:
-    fi:
+    fi: Suomi
   latest_feed:
     no_updates:
     title:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -430,7 +430,7 @@ gd:
   i18n:
     direction: ltr
   language_names:
-    gd:
+    gd: Gaeilge
   latest_feed:
     no_updates:
     title:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -430,7 +430,7 @@ hr:
   i18n:
     direction: ltr
   language_names:
-    hr:
+    hr: Hrvatski
   latest_feed:
     no_updates:
     title:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -328,7 +328,7 @@ is:
   i18n:
     direction: ltr
   language_names:
-    is:
+    is: Íslensk
   latest_feed:
     no_updates:
     title:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -430,7 +430,7 @@ mt:
   i18n:
     direction: ltr
   language_names:
-    mt:
+    mt: Malti
   latest_feed:
     no_updates:
     title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -328,7 +328,7 @@ nl:
   i18n:
     direction: ltr
   language_names:
-    nl:
+    nl: Nederlandse
   latest_feed:
     no_updates:
     title:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -328,7 +328,7 @@
   i18n:
     direction: ltr
   language_names:
-    'no':
+    'no': Norsk
   latest_feed:
     no_updates:
     title:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -430,7 +430,7 @@ sl:
   i18n:
     direction: ltr
   language_names:
-    sl:
+    sl: Slovenščina
   latest_feed:
     no_updates:
     title:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -328,7 +328,7 @@ sv:
   i18n:
     direction: ltr
   language_names:
-    sv:
+    sv: Svensk
   latest_feed:
     no_updates:
     title:


### PR DESCRIPTION
Home Office have suggested that Slovakian should actually be Slovak.
Also add in missing `language_names` to bring Whitehall in line with Government Frontend.