### PR TITLE
Bundle video player in application javascript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 //= require jquery_ujs
 //= require jquery.ui.all
 //= require vendor/jquery/magna-charta.min
+//= require vendor/jquery/jquery.player.min.js
 //= require vendor/sorttable
 //= require vendor/object-create-polyfill
 //


### PR DESCRIPTION
Trello: https://trello.com/c/oiHODNuR/758-fix-embedding-videos-in-whitehall-rendered-content

This file was previously included by static however this was removed in
favour of govuk_publishing_components providing the functionality [1].

I had hoped to resolve the problem in this application by switching to
using govuk_publishing_components to wrap all frontend instances of
govspeak so that they could be initialised by
govuk_publishing_components. However this proved to be rather blocked by
govuk_publishing_components being significantly out of date for
Whitehall [2] and updating this being a non-trivial problem to fix.

This fix restores the video functionality across Whitehall frontend,
however this is achieved using the legacy approach to embedding videos
and barcharts in govspeak so may hit problems if/when Whitehall frontend
embraced the govspeak component.

[1]: https://github.com/alphagov/govuk_publishing_components/pull/751
[2]: https://github.com/alphagov/whitehall/pull/4720