### PR TITLE
[DO NOT MERGE] Use the internal name for taxons

### DIFF
--- a/lib/taxonomy/taxon.rb
+++ b/lib/taxonomy/taxon.rb
@@ -19,7 +19,7 @@ module Taxonomy
 
     def self.from_taxon_hash(taxon_hash)
       taxon = Taxon.new(
-        title: taxon_hash['title'],
+        title: taxon_hash.dig('details', 'internal_name') || taxon_hash['title'],
         base_path: taxon_hash['base_path'],
         content_id: taxon_hash['content_id'],
         phase: taxon_hash['phase'],


### PR DESCRIPTION
We want to use the internal name for taxons in the tagging interface, rather than the public name, because some taxons have an internal name which conveys more guidance than the public name (for example, saying that a taxon is for GDS use only).

---

[Trello card](https://trello.com/c/8PrfgmAS/582-make-whitehall-tagging-interface-look-at-internal-taxon-name)