### PR TITLE
Add a World Location to database seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,3 +59,12 @@ else
     description: "Test Policy Area Description"
   )
 end
+
+if WorldLocation.where(name: "Test World Location").present?
+  puts "Skipping because Test World Location already exists"
+else
+  WorldLocation.create(
+    name: "Test World Location",
+    world_location_type_id: 1
+  )
+end


### PR DESCRIPTION
This commit adds a new test World Location to the database seeds, which is used by the publishing end-to-end tests.