### PR TITLE
Fixes the paginator for empty collections

### DIFF
--- a/app/presenters/api/page_presenter.rb
+++ b/app/presenters/api/page_presenter.rb
@@ -27,7 +27,7 @@ Api::PagePresenter = Struct.new(:page, :context) do
   end
 
   def next_page_url
-    unless page.last_page?
+    if !page.last_page? && !page.out_of_range?
       url(page: page.current_page + 1)
     end
   end

--- a/test/functional/api/world_locations_controller_test.rb
+++ b/test/functional/api/world_locations_controller_test.rb
@@ -74,4 +74,10 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
 
     assert_equal 'ok', json_response['_response_info']['status']
   end
+
+  view_test "no world locations" do
+    ActiveRecord::Base.connection.unstub(:select)
+    get :index, format: 'json'
+    assert_equal nil, json_response['next_page_url']
+  end
 end

--- a/test/unit/presenters/api/page_presenter_test.rb
+++ b/test/unit/presenters/api/page_presenter_test.rb
@@ -23,6 +23,7 @@ class Api::PagePresenterTest < PresenterTestCase
 
   test "json includes next page url if next page available" do
     @page.stubs(:last_page?).returns(false)
+    @page.stubs(:out_of_range?).returns(false)
     assert_equal api_organisations_url(page: 3), @presenter.as_json[:next_page_url]
   end
 
@@ -72,6 +73,7 @@ class Api::PagePresenterTest < PresenterTestCase
 
   test 'links include a rel=next url pointing to the next page if it has a next page' do
     @page.stubs(:last_page?).returns false
+    @page.stubs(:out_of_range?).returns(false)
     next_link = @presenter.links.detect { |(_url, attrs)| attrs['rel'] == 'next' }
     assert next_link
     next_url, = *next_link
@@ -80,6 +82,13 @@ class Api::PagePresenterTest < PresenterTestCase
 
   test 'links do not include a rel=next url if it is the last page' do
     @page.stubs(:last_page?).returns true
+    next_link = @presenter.links.detect { |(_url, attrs)| attrs['rel'] == 'next' }
+    refute next_link
+  end
+
+  test 'links do not include a rel=next url if it is the page is out of range' do
+    @page.stubs(:last_page?).returns false
+    @page.stubs(:out_of_range?).returns true
     next_link = @presenter.links.detect { |(_url, attrs)| attrs['rel'] == 'next' }
     refute next_link
   end


### PR DESCRIPTION
For empty collections, used for instance in end-to-end testing
the paginator breaks.

This fix addresses this.