### PR TITLE
Publish default withdrawal notice for all translations of withdrawn edition

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -24,11 +24,13 @@ module ServiceListeners
       when "unpublish"
         api.unpublish_async(edition.unpublishing)
       when "withdraw"
-        api.publish_withdrawal_async(
-          edition.content_id,
-          edition.unpublishing.explanation,
-          edition.primary_locale
-        )
+        edition.translations.each do |translation|
+          api.publish_withdrawal_async(
+            edition.content_id,
+            edition.unpublishing.explanation,
+            translation.locale.to_s
+          )
+        end
       when "force_schedule", "schedule"
         api.schedule_async(edition)
       when "unschedule"

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -33,3 +33,14 @@ namespace :data_hygiene do
     end
   end
 end
+
+namespace :data_hygiene do
+  desc "Add the withdrawal note to all translations of withdrawn editions."
+  task add_translation_withdrawal_notices: :environment do
+    Edition.where(state: 'withdrawn').find_each do |edition|
+      if edition.translations.count > 1
+        ServiceListeners::PublishingApiPusher.new(edition).push(event: "withdraw")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently only the default locale of a withdrawn edition displays a withdrawal notice. This can be confusing for translations, which have no indication that an edition is no longer valid.

This PR will allows all translations to display the given (untranslated) withdrawal notice to offer the user some indication that it is not valid.

### Published
<img width="800" alt="Screen Shot 2019-04-16 at 16 29 26" src="https://user-images.githubusercontent.com/13475227/56224448-91787780-6067-11e9-9b68-49a4cfcdcd4a.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 29 36" src="https://user-images.githubusercontent.com/13475227/56224449-91787780-6067-11e9-9746-9b5f796a95ae.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 29 48" src="https://user-images.githubusercontent.com/13475227/56224450-91787780-6067-11e9-81b0-c08109f9af8a.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 29 57" src="https://user-images.githubusercontent.com/13475227/56224452-91787780-6067-11e9-935e-4b3434c15bab.png">

### Withdrawn
<img width="800" alt="Screen Shot 2019-04-16 at 16 43 45" src="https://user-images.githubusercontent.com/13475227/56224852-3b580400-6068-11e9-90d5-2f0bc85f788d.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 43 54" src="https://user-images.githubusercontent.com/13475227/56224853-3b580400-6068-11e9-9fc8-9e3361fd3e78.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 44 05" src="https://user-images.githubusercontent.com/13475227/56224927-4f036a80-6068-11e9-8e79-5d6153093dad.png">
----
<img width="800" alt="Screen Shot 2019-04-16 at 16 44 12" src="https://user-images.githubusercontent.com/13475227/56224856-3b580400-6068-11e9-8498-c0a8011f1be6.png">
