### PR TITLE
Fix overflow of text in navigation links

### DIFF
--- a/app/assets/stylesheets/frontend/views/_corporate-information-pages-worldwide-organisation.scss
+++ b/app/assets/stylesheets/frontend/views/_corporate-information-pages-worldwide-organisation.scss
@@ -10,6 +10,7 @@
     li {
       list-style: none;
       margin-left: 1.2em;
+      word-wrap: break-word;
 
       &:before {
         content: "-";


### PR DESCRIPTION
This PR fixes an issue found on this page: https://www.gov.uk/world/organisations/british-embassy-lisbon/about/about.pt

It adds the CSS `word-wrap: break-word;` property to the left hand navigation links, which lets the browser wrap a long word part way through it.

BEFORE:

![Screen Shot 2019-04-18 at 11 44 34](https://user-images.githubusercontent.com/861310/56355980-8fc9c380-61cf-11e9-9000-fb1a9c6fa535.png)

AFTER:

![Screen Shot 2019-04-18 at 11 44 24](https://user-images.githubusercontent.com/861310/56355987-95bfa480-61cf-11e9-8b1e-f552aaa8f536.png)
