### PR TITLE
Remove translated withdrawal notice rake task

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -33,14 +33,3 @@ namespace :data_hygiene do
     end
   end
 end
-
-namespace :data_hygiene do
-  desc "Add the withdrawal note to all translations of withdrawn editions."
-  task add_translation_withdrawal_notices: :environment do
-    Edition.where(state: 'withdrawn').find_each do |edition|
-      if edition.translations.count > 1
-        ServiceListeners::PublishingApiPusher.new(edition).push(event: "withdraw")
-      end
-    end
-  end
-end


### PR DESCRIPTION
This was a one-off task that has now been run.