### PR TITLE
Add validation on length of unique reference

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -28,6 +28,7 @@ class Attachment < ApplicationRecord
   validates :price, numericality: {
     allow_blank: true, greater_than: 0
   }
+  validates :unique_reference, length: { maximum: 255 }, allow_blank: true
 
   scope :with_filename, ->(basename) {
     joins(:attachment_data).where('attachment_data.carrierwave_file = ?', basename)

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -167,6 +167,16 @@ class AttachmentTest < ActiveSupport::TestCase
     assert_nil attachment.price
   end
 
+  test 'should be valid without a unique_reference' do
+    attachment = build(:file_attachment, unique_reference: nil)
+    assert attachment.valid?
+  end
+
+  test 'should be invalid with a long unique_reference' do
+    attachment = build(:file_attachment, unique_reference: SecureRandom.hex(300))
+    refute attachment.valid?
+  end
+
   test 'should generate list of parliamentary sessions' do
     earliest_session = '1951-52'
     now = Time.zone.now


### PR DESCRIPTION
Since this is a MySQL string field, the database limits it to a length of 255. However, if a user enters a string longer than 255, we don't validate it and try and save it into the database anyway, leading to an unfriendly 500 error instead of a useful validation error.

[Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/3661890) · [Sentry Error](https://sentry.io/organizations/govuk/issues/906958908/?project=202259&query=is%3Aunresolved&statsPeriod=14d)