### PR TITLE
Add length validation for featured_link url

### DIFF
--- a/app/models/featured_link.rb
+++ b/app/models/featured_link.rb
@@ -9,6 +9,7 @@ class FeaturedLink < ApplicationRecord
 
   validates :url, :title, presence: true
   validates :url, uri: true
+  validates_length_of :url, maximum: 255, message: "The URL can have maximum of 255 characters"
 
   def republish_organisation_to_publishing_api
     if linkable_type == "Organisation" && linkable.persisted?

--- a/app/views/admin/shared/_featured_link_fields.html.erb
+++ b/app/views/admin/shared/_featured_link_fields.html.erb
@@ -16,7 +16,7 @@
   <%= form.fields_for(:featured_links, featured_links) do |featured_links_form| %>
     <div class="js-duplicate-fields-set well">
       <%= featured_links_form.text_field :title, class: 'input-md-4' %>
-      <%= featured_links_form.text_field :url, label_text: 'URL' %>
+      <%= featured_links_form.text_field :url, label_text: 'URL', maxlength: 255 %>
       <%= featured_links_form.hidden_field :_destroy, class: 'js-hidden-destroy' %>
     </div>
   <% end %>


### PR DESCRIPTION
The URL can have maximum of 255 characters as this is the default length of a
string in an ActiveRecord model. Users were getting a general “We're sorry, but
something went wrong” message when the URL they entered was too long.  This sets
the `maxlength` attribute on the edit form field and adds validation as well as
an error message in the model.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3643823