### PR TITLE
Change data type of featured_link url to text

### DIFF
--- a/db/migrate/20190426132424_change_featured_link_url_type_to_text.rb
+++ b/db/migrate/20190426132424_change_featured_link_url_type_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeFeaturedLinkUrlTypeToText < ActiveRecord::Migration[5.1]
+  def change
+    change_column :featured_links, :url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181023071345) do
+ActiveRecord::Schema.define(version: 20190426132424) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -467,7 +467,7 @@ ActiveRecord::Schema.define(version: 20181023071345) do
   end
 
   create_table "featured_links", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "url"
+    t.text "url"
     t.string "title"
     t.integer "linkable_id"
     t.string "linkable_type"


### PR DESCRIPTION
Since the default length of a string is 255 characters, users were getting 
“We're sorry, but something went wrong” message when the URL they
entered was too long.  This migration will allow users to enter long URLs
without causing an error.

Tested on integration. 
It requires running `db:migrate` rake task once deployed.