### PR TITLE
Index public_timestamp for statistics announcements

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -79,6 +79,7 @@ class StatisticsAnnouncement < ApplicationRecord
               slug: :slug,
               organisations: :organisations_slugs,
               policy_areas: :topic_slugs,
+              public_timestamp: :updated_at,
               release_timestamp: :release_date,
               statistics_announcement_state: :state,
               metadata: :search_metadata,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -103,4 +103,11 @@ namespace :rummager do
       Rake::Task["rummager:index:detailed"].invoke
     end
   end
+
+  desc "indexes statistics announcements"
+  task statistics_announcements: :environment do
+    index = Whitehall::SearchIndex.for(:government)
+    index.add_batch(StatisticsAnnouncement.all.map(&:search_index))
+    index.commit
+  end
 end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -59,6 +59,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       'description' => announcement.summary,
       'organisations' => announcement.organisations.map(&:slug),
       'policy_areas' => announcement.topics.map(&:slug),
+      'public_timestamp' => announcement.updated_at,
       'display_type' => announcement.display_type,
       'slug' => announcement.slug,
       'release_timestamp' => announcement.release_date,


### PR DESCRIPTION
This is useful because it will let us sort on public_timestamp when looking at statistics and their corresponding announcements.

We are going to run rake rummager:index:goverment on all environments.

https://trello.com/c/TV5xhCBX/649-give-stats-announcement-doc-types-publictimestamp-so-date-sort-works-in-faceted-search