### PR TITLE
Cache searches for page content

### DIFF
--- a/app/services/search_rummager_service.rb
+++ b/app/services/search_rummager_service.rb
@@ -1,9 +1,12 @@
 class SearchRummagerService
   def fetch_related_documents(filter_params = {})
     options = default_search_options.merge(filter_params)
-    search_response = Whitehall.search_client.search(options)
-    search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
-    search_response
+
+    Rails.cache.fetch(options, expires_in: 5.minutes) do
+      search_response = Whitehall.search_client.search(options)
+      search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
+      search_response
+    end
   end
 
   private


### PR DESCRIPTION
Pages such as topical event pages (eg https://www.gov.uk/government/topical-events/autumn-budget-2017) include content provided from search.

We've been experiencing some intermittent errors with some of these pages, and caching the searches for a short period of time should flatten out some of the bumps.  

This helps in particular, because some of these pages perform multiple searches to render a single page, so having some cached results close at hand means that we're more likely to get all the way through the rendering process successfully.

We've taken this approach for org pages (and others) in collections and
this caused the error rate to drop immediately.