### PR TITLE
Add primary publishing organisation to organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -50,6 +50,7 @@ module PublishingApi
         ordered_successor_organisations: successor_organisation_links,
         ordered_high_profile_groups: high_profile_groups_links,
         ordered_roles: roles_links,
+        primary_publishing_organisation: [content_id]
       }
     end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -75,6 +75,22 @@ namespace :publishing_api do
     puts "Finished queuing items for Publishing API"
   end
 
+  desc "Send links for all organisations to Publishing API."
+  task patch_organisation_links: :environment do
+    count = Organisation.count
+    puts "# Sending links for #{count} organisations to Publishing API"
+
+    Organisation.pluck(:id).each_with_index do |item_id, i|
+      item = Organisation.find(item_id)
+
+      Whitehall::PublishingApi.patch_links(item, bulk_publishing: true)
+
+      puts "Processing #{i}-#{i + 99} of #{count} items" if (i % 100).zero?
+    end
+
+    puts "Finished sending links for all organisations to Publishing API"
+  end
+
   desc "Send withdrawn item links to Publishing API."
   task patch_withdrawn_item_links: :environment do
     editions = Edition.withdrawn

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -61,7 +61,7 @@ module Whitehall
       end
     end
 
-    def self.patch_links(model_instance)
+    def self.patch_links(model_instance, bulk_publishing: false)
       presenter = PublishingApiPresenters.presenter_for(model_instance)
 
       links = presenter.links
@@ -69,7 +69,8 @@ module Whitehall
 
       Services.publishing_api.patch_links(
         presenter.content_id,
-        links: links
+        links: links,
+        bulk_publishing: bulk_publishing
       )
     end
 

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -102,6 +102,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       ordered_successor_organisations: [],
       ordered_high_profile_groups: [],
       ordered_roles: [role.content_id],
+      primary_publishing_organisation: [organisation.content_id]
     }
 
     presented_item = present(organisation)


### PR DESCRIPTION
Currently Organisations don't have primary publishing organisation set. This PR changes Whitehall to set a primary publishing organisation. It also adds a rake task to update links for all organisations.