### PR TITLE
Change link to Open Document Format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -454,7 +454,7 @@ en:
         version of this document in a more accessible format, please email %{email}.
         Please tell us what format you need. It will help us if you say what assistive technology you use.
     opendocument:
-      help_html: This file is in an <a href="https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software">OpenDocument</a> format
+      help_html: This file is in an <a href="https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation">OpenDocument</a> format
     see_more: See more information about this %{document_type}
   see_all:
     announcement: See all our announcements


### PR DESCRIPTION
This was requested in ticket no. 3676676.

The current link goes to a redirect content item. I've replaced that link with the one it currently redirects to.

Old (redirect): https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software
New (what is currently redirected to): https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation