### PR TITLE
Present org alternative format contact email

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -76,6 +76,7 @@ module PublishingApi
     def details
       details = {
         acronym: acronym,
+        alternative_format_contact_email: alternative_format_contact_email,
         body: html_summary,
         brand: brand,
         logo: {
@@ -107,6 +108,10 @@ module PublishingApi
 
     def acronym
       item.acronym
+    end
+
+    def alternative_format_contact_email
+      item.alternative_format_contact_email
     end
 
     def govspeak_summary

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -55,6 +55,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       update_type: "major",
       details: {
         acronym: nil,
+        alternative_format_contact_email: nil,
         body: govspeak_to_html("This org is a thing!\n\nOrganisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>."),
         brand: nil,
         logo: {
@@ -273,5 +274,16 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     document_type = presented_item.content.dig(:details, :ordered_featured_documents, 0, :document_type)
 
     assert_equal document_type, offsite_link.display_type
+  end
+
+  test 'presents the alternative format contact email' do
+    organisation = create(
+      :organisation,
+      alternative_format_contact_email: "foo@bar.com"
+    )
+    presented_item = present(organisation)
+    email = presented_item.content.dig(:details, :alternative_format_contact_email)
+
+    assert_equal email, "foo@bar.com"
   end
 end


### PR DESCRIPTION
https://trello.com/c/OcuVomSb/820-determine-the-alternative-format-email-address-for-an-attachment

This extends the Publishing API presenter for organisations to
include the alternative format contact email for the org.