### PR TITLE
Use the published corporate information page in links

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -265,7 +265,7 @@ module PublishingApi
     end
 
     def t_corporate_information_page_link(organisation, slug)
-      page = organisation.corporate_information_pages.for_slug(slug)
+      page = organisation.corporate_information_pages.published.for_slug(slug)
       page.extend(UseSlugAsParam)
       link_to(
         t_corporate_information_page_type_link_text(page),


### PR DESCRIPTION
The most recent corporate information page is guaranteed to have the latest translations and therefore the links will correctly be generated in the current locale.

Take this example for the animal and plant health agency:

```
irb(main):027:0> I18n.locale = :cy

irb(main):028:0> page = organisation.corporate_information_pages.published.for_slug('welsh-language-scheme')
irb(main):029:0> Whitehall.url_maker.public_document_path(page)
=> "/government/organisations/animal-and-plant-health-agency/about/welsh-language-scheme.cy"

irb(main):030:0> page = organisation.corporate_information_pages.for_slug('welsh-language-scheme')
irb(main):031:0> Whitehall.url_maker.public_document_path(page)
=> "/government/organisations/animal-and-plant-health-agency/about/welsh-language-scheme"
```

In this example we were getting an old superseeded version of the corporate information page that didn't include the appropriate welsh translation.

[Trello Card](https://trello.com/c/ZA1Z6AQZ/989-welsh-corporate-information-pages-not-linking-to-welsh-versions)