### PR TITLE
Present primary pub org for html attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -45,6 +45,7 @@ module PublishingApi
       {
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
         organisations: parent.organisations.pluck(:content_id).uniq,
+        primary_publishing_organisation: [parent.lead_organisations.first.content_id]
       }
     end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -139,6 +139,24 @@ namespace :publishing_api do
     end
   end
 
+  desc "Patch links for html publications to include primary_publishing_organisation"
+  task patch_html_publication_links: :environment do
+    scope = Publicationesque.published
+    count = scope.count
+    attachment_count = 0
+    puts "# Sending HTML attachments for #{count} publications to Publishing API"
+    scope.each_with_index do |pub, i|
+      pub.html_attachments.each do |attachment|
+        Whitehall::PublishingApi.patch_links(attachment, bulk_publishing: true)
+        attachment_count += 1
+      rescue StandardError => e
+        puts e.inspect
+      end
+      puts "Processing #{i}-#{i + 99} of #{count} publications - #{attachment_count} attachments updated" if (i % 100).zero?
+    end
+    puts 'Finished sending HTML Attachments to publishing API'
+  end
+
   desc "Discard all draft about pages that have the same base_path as their WorldwideOrganisation"
   task discard_draft_worldwide_organisation_about_pages: :environment do
     about_pages = YAML.load_file(File.join(Rails.root, 'lib', 'tasks', 'about_pages.yml'))

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -51,7 +51,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     expected_content = expected_hash.merge(links: presented_item.links)
     assert_equal expected_content, presented_content
 
-    %i(organisations parent).each { |k| assert_includes(expected_content[:links].keys, k) }
+    %i(organisations parent primary_publishing_organisation).each { |k| assert_includes(expected_content[:links].keys, k) }
   end
 
   test "HtmlAttachment presentation includes the correct locale" do
@@ -92,5 +92,16 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     html_attachment.attachable.organisations.expects(:pluck).with(:content_id).returns(%w(abcdef abcdef))
 
     assert_equal %w[abcdef], present(html_attachment).links[:organisations]
+  end
+
+  test "HtmlAttachment presents primary_publishing_organisation" do
+    create(:publication, :with_html_attachment, :published)
+
+    html_attachment = HtmlAttachment.last
+    # if an organisation has multiple translations, pluck returns
+    # duplicate content_ids because it constructs a left outer join
+
+    assert_equal [html_attachment.attachable.lead_organisations.first.content_id],
+      present(html_attachment).links[:primary_publishing_organisation]
   end
 end


### PR DESCRIPTION
# What

This commit sends primary_publishing_organisation to the publishing API.

The value is the first of the lead_organisations (the same logic other document types use).

# Why

html_attachment only sends `organisations` to the publishing API. We need `primary_publishing_organisation` to be available in the `content-data-api`