### PR TITLE
Amends rake task to index statistics announcements

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -107,7 +107,7 @@ namespace :search do
   desc "indexes statistics announcements"
   task statistics_announcements: :environment do
     index = Whitehall::SearchIndex.for(:government)
-    index.add_batch(StatisticsAnnouncement.all.map(&:search_index))
+    index.add_batch(StatisticsAnnouncement.without_published_publication.map(&:search_index))
     index.commit
   end
 end


### PR DESCRIPTION
The rake task added in #4757 reindexes all statistics announcements.
But once a statistic has been released, its announcement is no longer presented by the finder. This task now reindexes only the stats announcements which have an unpublished publication.

