### PR TITLE
Remove "all" from search parameters sent to finder-frontend

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -61,11 +61,17 @@ private
       keywords: params['keywords'],
       level_one_taxon: params['taxons'].try(:first) || params['topics'].try(:first),
       level_two_taxon: params['subtaxons'].try(:first),
-      organisations: params['departments'] || params['organisations'],
-      people: params['people'],
-      world_locations: params['world_locations'],
+      organisations: filter_query_array(params['departments'] || params['organisations']),
+      people: filter_query_array(params['people']),
+      world_locations: filter_query_array(params['world_locations']),
       public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence
     }.compact.merge(special_params).to_query
+  end
+
+  def filter_query_array(arr)
+    if arr.respond_to? 'reject'
+      arr.reject { |v| v == 'all' }.compact.presence
+    end
   end
 
   def publication_finder_type

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -50,6 +50,21 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.to_query}"
   end
 
+  test "strips out 'all' departments from query string in redirect" do
+    get :index, params: @default_params.merge(departments: %w[all])
+    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(organisations: nil).compact.to_query}"
+  end
+
+  test "strips out 'all' people from query string in redirect" do
+    get :index, params: @default_params.merge(people: %w[all])
+    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.to_query}"
+  end
+
+  test "strips out 'all' world locations from query string in redirect" do
+    get :index, params: @default_params.merge(world_locations: %w[all])
+    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(world_locations: nil).compact.to_query}"
+  end
+
   view_test "#index only displays *published* publications" do
     Sidekiq::Testing.inline! do
       superseded_publication = create(:superseded_publication, translated_into: :fr)


### PR DESCRIPTION
finder-frontend doesn't support "all", so make sure it's not present.

~This PR doesn't fix all of the examples in [Fix issue with param `=all` in finder redirects](https://trello.com/c/M1yHmq8q/713-fix-issue-with-param-all-in-finder-redirects) because there's also a problem with the `level_one_taxon` parameter.~ We've decided that the `level_one_taxon` thing isn't an issue because it's only a problem for links to Whitehall finders which pre-date replacing policy areas with taxons.