### PR TITLE
Redirect by publication_type if publication_filter_option is missing

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -48,12 +48,12 @@ private
   end
 
   def publications_base_path
-    base_path = PUBLICATIONS_ROUTES.dig(params[:publication_filter_option], :base_path)
+    base_path = PUBLICATIONS_ROUTES.dig(publication_finder_type, :base_path)
     base_path || DEFAULT_PUBLICATIONS_PATH
   end
 
   def special_params
-    PUBLICATIONS_ROUTES.dig(params[:publication_filter_option], :special_params) || {}
+    PUBLICATIONS_ROUTES.dig(publication_finder_type, :special_params) || {}
   end
 
   def publications_query_string
@@ -66,6 +66,10 @@ private
       world_locations: params['world_locations'],
       public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence
     }.compact.merge(special_params).to_query
+  end
+
+  def publication_finder_type
+    params[:publication_filter_option] || params[:publication_type]
   end
 
   def expire_cache_when_next_publication_published

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -40,7 +40,11 @@ private
 
   def redirect_to_finder_frontend_finder
     base_path = "#{Plek.new.website_root}/#{publications_base_path}"
-    redirect_to("#{base_path}?#{publications_query_string}")
+    if publications_query_string == ''
+      redirect_to(base_path)
+    else
+      redirect_to("#{base_path}?#{publications_query_string}")
+    end
   end
 
   def publications_base_path


### PR DESCRIPTION
Also remove an unnecessary `?` when the query string is empty.

[Trello card](https://trello.com/c/9slzg0DH/712-change-finder-redirect-for-foi-releases-m)