### PR TITLE
Sort world locations API using same method as UI

### DIFF
--- a/app/controllers/api/world_locations_controller.rb
+++ b/app/controllers/api/world_locations_controller.rb
@@ -1,4 +1,6 @@
 class Api::WorldLocationsController < PublicFacingController
+  include WorldLocationHelper
+
   skip_before_action :set_cache_control_headers
   skip_before_action :restrict_request_formats
   before_action :set_api_cache_control_headers
@@ -18,7 +20,7 @@ class Api::WorldLocationsController < PublicFacingController
 
   def index
     respond_with Api::WorldLocationPresenter.paginate(
-      WorldLocation.ordered_by_name,
+      Kaminari.paginate_array(sorted_world_locations),
       view_context
     )
   end
@@ -27,5 +29,10 @@ private
 
   def respond_with_not_found
     respond_with Hash.new, status: :not_found
+  end
+
+  def sorted_world_locations
+    group_and_sort(WorldLocation.ordered_by_name)
+      .flat_map { |_, locations| locations }
   end
 end

--- a/test/functional/api/world_locations_controller_test.rb
+++ b/test/functional/api/world_locations_controller_test.rb
@@ -5,9 +5,7 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
   test "sets cache expiry to 30 minutes" do
-    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
-    presenter.stubs(:as_json).returns(paged: :representation)
-    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+    Api::WorldLocationsController.any_instance.stubs(:sorted_world_locations).returns([])
 
     get :index, format: 'json'
 
@@ -15,9 +13,7 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "sets Access-Control-Allow-Origin to *" do
-    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
-    presenter.stubs(:as_json).returns(paged: :representation)
-    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+    Api::WorldLocationsController.any_instance.stubs(:sorted_world_locations).returns([])
 
     get :index, format: 'json'
 
@@ -56,9 +52,8 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
   end
 
   view_test "index paginates world locations" do
-    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
-    presenter.stubs(:as_json).returns(paged: :representation)
-    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+    Api::WorldLocationsController.any_instance.stubs(:sorted_world_locations).returns([])
+    Api::PagePresenter.any_instance.stubs(:as_json).returns(paged: :representation)
 
     get :index, format: 'json'
 
@@ -66,9 +61,7 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
   end
 
   view_test "index includes _response_info in response" do
-    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
-    presenter.stubs(:as_json).returns(paged: :representation)
-    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+    Api::WorldLocationsController.any_instance.stubs(:sorted_world_locations).returns([])
 
     get :index, format: 'json'
 


### PR DESCRIPTION
This means that countries such as 'The Gambia' will appear nearer the top of the alphabet, under 'G'.

https://www-origin.integration.publishing.service.gov.uk/api/world-locations?page=4:

```
{
    "id": "https://www-origin.integration.publishing.service.gov.uk/api/world-locations/gabon",
    "title": "Gabon",
    ...
},
{
    "id": "https://www-origin.integration.publishing.service.gov.uk/api/world-locations/the-gambia",
    "title": "The Gambia",
    ...
},
{
    "id": "https://www-origin.integration.publishing.service.gov.uk/api/world-locations/georgia",
    "title": "Georgia",
    ...
```

[Trello Card](https://trello.com/c/X2u3t3br/1011-check-if-you-need-a-uk-visa-update-the-gambia-in-dropdown)