### PR TITLE
Fix saving of HTML attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -45,7 +45,7 @@ module PublishingApi
       {
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
         organisations: parent.organisations.pluck(:content_id).uniq,
-        primary_publishing_organisation: [parent.lead_organisations.first.content_id]
+        primary_publishing_organisation: primary_publishing_organisation
       }
     end
 
@@ -77,6 +77,18 @@ module PublishingApi
 
     def public_timestamp
       parent.public_timestamp || parent.updated_at
+    end
+
+    def primary_publishing_organisation
+      [lead_org_id || first_org_id].compact
+    end
+
+    def lead_org_id
+      parent.try(:lead_organisations).try(:first).try(:content_id)
+    end
+
+    def first_org_id
+      parent.try(:organisations).try(:first).try(:content_id)
     end
 
     def parent

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -98,10 +98,19 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     create(:publication, :with_html_attachment, :published)
 
     html_attachment = HtmlAttachment.last
+
+    assert_equal [html_attachment.attachable.lead_organisations.first.content_id],
+      present(html_attachment).links[:primary_publishing_organisation]
+  end
+
+  test "HtmlAttachment presents primary_publishing_organisation from 1st org when lead_organisations is not implemented" do
+    create(:consultation_outcome, :with_html_attachment)
+
+    html_attachment = HtmlAttachment.last
     # if an organisation has multiple translations, pluck returns
     # duplicate content_ids because it constructs a left outer join
 
-    assert_equal [html_attachment.attachable.lead_organisations.first.content_id],
+    assert_equal [html_attachment.attachable.organisations.first.content_id],
       present(html_attachment).links[:primary_publishing_organisation]
   end
 end


### PR DESCRIPTION
Previously we were attempting to get the primary organisation
from the first of the parent's `lead_organisations`

The broke saving of attachments on some document types that
don't implement `lead_organisations`.

This commit makes the code more defensive, getting the primary
org from `organisations` if `lead_organisations` is not implemented.