### PR TITLE
Send attachments for editions with `withdrawn` state

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -141,7 +141,7 @@ namespace :publishing_api do
 
   desc "Patch links for html publications to include primary_publishing_organisation"
   task patch_html_publication_links: :environment do
-    scope = Publicationesque.published
+    scope = Publicationesque.publicly_visible
     count = scope.count
     attachment_count = 0
     puts "# Sending HTML attachments for #{count} publications to Publishing API"


### PR DESCRIPTION
Previously the rake task `publishing_api:patch_html_publication_links`
only updated the `primary_publishing_organisation` for
published editions.

This has resulted in a large number of `withdrawn` editions
in `content-data-api` which have no primary organisation.

This commit uses the `publicly_visible` scope instead of the `published`
scope to send more attachments.