### PR TITLE
Link to content data from admin dashboard

### DIFF
--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -1,0 +1,5 @@
+module Admin::ContentDataRoutesHelper
+  def content_data_base_url
+    @content_data_base_url ||= "#{Plek.find('content-data')}/content"
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,6 +7,14 @@
   <div class="col-md-4">
     <h3>Writing and publishing</h3>
     <ul>
+    <li><%= link_to('Content Data',
+                    content_data_base_url,
+                    data: {
+                        track_category: 'external-link-clicked',
+                        track_action: content_data_base_url,
+                        track_label: 'Content Data'
+                    })%>
+    </li>
       <li><a href="https://www.gov.uk/guidance/style-guide">GOV.UK style guide</a></li>
       <li><a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk">How to publish content on GOV.UK</a></li>
       <li><a href="https://www.gov.uk/guidance/content-design">Planning, writing and managing content</a></li>

--- a/features/admin-dashboard.feature
+++ b/features/admin-dashboard.feature
@@ -15,3 +15,4 @@ Feature: Admin Dashboard
     And I visit the admin dashboard
     Then I should see the draft document "draft document"
     And I should see the force published document "forced document"
+    And I should see a link to the content data app

--- a/features/step_definitions/admin_dashboard_steps.rb
+++ b/features/step_definitions/admin_dashboard_steps.rb
@@ -11,3 +11,10 @@ Then(/^I should see the force published document "([^"]*)"$/) do |title|
   edition = Edition.find_by!(title: title).latest_edition
   assert has_css?(".force-published-documents #{record_css_selector(edition)}")
 end
+
+Then(/^I should see a link to the content data app$/) do
+  link = find_link('Content Data', href: 'https://content-data.test.gov.uk/content')
+  assert_equal 'external-link-clicked', link['data-track-category']
+  assert_equal 'https://content-data.test.gov.uk/content', link['data-track-action']
+  assert_equal 'Content Data', link['data-track-label']
+end


### PR DESCRIPTION
Adds a link to the `content-data` app in each environment.

Includes basic tracking.

Possibly there will be further PRs to improve the tracking.

# Before 
<img width="631" alt="Screenshot 2019-05-22 at 15 54 34" src="https://user-images.githubusercontent.com/511319/58185046-2fd0ac00-7caa-11e9-9541-32985cfd4eec.png">

# After
<img width="600" alt="Screenshot 2019-05-22 at 15 53 56" src="https://user-images.githubusercontent.com/511319/58185070-39f2aa80-7caa-11e9-96aa-abc74dc5a5c7.png">

Trello: https://trello.com/c/QQzBWx3s/1442-2-add-main-link-to-content-data-from-whitehall
