### PR TITLE
Use Plek.current.external_url_for to get content-data

### DIFF
--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -1,5 +1,5 @@
 module Admin::ContentDataRoutesHelper
   def content_data_base_url
-    @content_data_base_url ||= "#{Plek.find('content-data')}/content"
+    @content_data_base_url ||= "#{Plek.current.external_url_for('content-data')}/content"
   end
 end


### PR DESCRIPTION
Previously I was using the wrong Plek call to get the URL
for content-data, in [this PR](https://github.com/alphagov/whitehall/pull/4800)

This commit corrects that.