### PR TITLE
Add deprecation message to government/statistics

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -10,6 +10,10 @@
   </div>
 </header>
 
+<%= render "govuk_publishing_components/components/notice", {
+    title: 'This page is being replaced by <a href="/search/research-and-statistics">Research and statistics search</a>'.html_safe
+} %>
+
 <%= render 'impartiality' %>
 
 <%= render 'statistics_announcements/upcoming_calendar_tabs' if params[:publication_filter_option] == "statistics"  %>


### PR DESCRIPTION
We are moving government/statistics to search/statistics. This is a message letting people who
reach this page through bookmarks etc know
 that the page is going away and shows a link
with the replacement

Trello: https://trello.com/c/Ac83bP1d/721-add-a-standard-banner-to-government-statistics-warning-users-its-going-away-soon-s

![image](https://user-images.githubusercontent.com/6050162/58551996-3e1e4b00-8209-11e9-8904-ab7688c7ba50.png)

