### PR TITLE
Remove deprecated "not" tags

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,8 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'

--- a/features/support/rummageable_and_document_filter.rb
+++ b/features/support/rummageable_and_document_filter.rb
@@ -18,7 +18,7 @@ After do
 end
 
 # For everything we don't explicitly want a "real" search for, use FakeSearch
-Before("~@not-quite-as-fake-search") do
+Before("not @not-quite-as-fake-search") do
   Whitehall.search_backend = Whitehall::DocumentFilter::FakeSearch
 end
 


### PR DESCRIPTION
Resolves the following issue:

> Deprecated: Found tags option '`~@wip`'. Support for '`~@tag`' will be removed from the next release of Cucumber. Please use '`not @tag`' instead.