### PR TITLE
Swap GdsApi rummager references for search

### DIFF
--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,11 +1,11 @@
-require 'gds_api/rummager'
+require 'gds_api/search'
 
-Whitehall.government_search_client = GdsApi::Rummager.new(
+Whitehall.government_search_client = GdsApi::Search.new(
   Plek.find('search') + Whitehall::SearchIndex.government_search_index_path,
   bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
 )
 
-Whitehall.search_client = GdsApi::Rummager.new(
+Whitehall.search_client = GdsApi::Search.new(
   Plek.find('search'),
   bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
 )
@@ -14,7 +14,7 @@ def statistics_announcement_search_client
   if Rails.env.test?
     DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncements
   else
-    GdsApi::Rummager.new(
+    GdsApi::Search.new(
       Plek.find('search') + Whitehall::SearchIndex.government_search_index_path,
       bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
     )

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -71,7 +71,7 @@ Then(/^I should see both the news articles for the Deputy Prime Minister role$/)
 end
 
 Given(/^"([^"]*)" has news associated with her$/) do |arg1|
-  stub_any_rummager_search.to_return(
+  stub_any_search.to_return(
     body: {
       results: [
         { link: "/foo", title: "First article" },

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -79,7 +79,7 @@ end
 
 Then(/^I should see (#{THE_DOCUMENT}) in the (announcements|publications|consultations) section of the topical event "([^"]*)"$/) do |edition, section, topical_event_name|
   topical_event = TopicalEvent.find_by!(name: topical_event_name)
-  stub_any_rummager_search.to_return(body: rummager_response_of_single_edition(edition))
+  stub_any_search.to_return(body: rummager_response_of_single_edition(edition))
   visit topical_event_path(topical_event)
   within "##{section}.document-block" do
     assert page.has_css?("##{section}_#{edition.content_id}")
@@ -161,7 +161,7 @@ Given(/^a topical event with published documents$/) do
   @topical_event = create(:topical_event, name: name)
   stub_topical_event_in_content_store(name)
   create_recently_published_documents_for_topical_event(@topical_event)
-  stub_any_rummager_search.to_return(body: rummager_response)
+  stub_any_search.to_return(body: rummager_response)
 end
 
 When(/^I view that topical event page$/) do

--- a/features/support/rummager.rb
+++ b/features/support/rummager.rb
@@ -1,4 +1,4 @@
 Before do
   # Default stubbing for rummager requests for related policies
-  rummager_has_no_policies_for_any_type
+  stub_search_has_no_policies_for_any_type
 end

--- a/test/functional/latest_controller_test.rb
+++ b/test/functional/latest_controller_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require_relative "../support/search_rummager_helper"
 
 class LatestControllerTest < ActionController::TestCase
@@ -41,7 +41,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should expose rummager documents for the subject' do
     topical_event = create(:topical_event)
 
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
 
     get :index, params: { topical_events: [topical_event] }
 
@@ -52,7 +52,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should accept pagination parameters with rummager documents' do
     world_location = create(:world_location)
 
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
 
     get :index, params: { world_locations: [world_location], page: 2 }
 
@@ -62,7 +62,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should expose documents for the subject' do
     organisation = create(:organisation)
 
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
 
     get :index, params: { departments: [organisation] }
 
@@ -73,7 +73,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should accept pagination parameters' do
     organisation = create(:organisation)
 
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
 
     get :index, params: { departments: [organisation], page: 2 }
 

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -1,14 +1,14 @@
 require "test_helper"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 
 class MinisterialRolesControllerTest < ActionController::TestCase
   include FeedHelper
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
 
   should_be_a_public_facing_controller
 
   setup do
-    rummager_has_no_policies_for_any_type
+    stub_search_has_no_policies_for_any_type
   end
 
   test "shows cabinet roles in correct order" do

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -1,19 +1,19 @@
 require "test_helper"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 
 class OrganisationsControllerTest < ActionController::TestCase
   include ApplicationHelper
   include FeedHelper
   include FilterRoutesHelper
   include OrganisationControllerTestHelpers
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
 
   should_be_a_public_facing_controller
   should_display_organisation_page_elements_for(:organisation)
   should_display_organisation_page_elements_for(:executive_office)
 
   setup do
-    rummager_has_no_policies_for_any_type
+    stub_search_has_no_policies_for_any_type
 
     content_store_has_item(
       "/government/organisations",

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 
 class PeopleControllerTest < ActionController::TestCase
   include FeedHelper
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
 
   should_be_a_public_facing_controller
 
@@ -20,7 +20,7 @@ class PeopleControllerTest < ActionController::TestCase
 
   setup do
     @person = create(:person)
-    rummager_has_no_policies_for_any_type
+    stub_search_has_no_policies_for_any_type
   end
 
   view_test "#show displays the details of the person and their roles" do
@@ -70,7 +70,7 @@ class PeopleControllerTest < ActionController::TestCase
 
   view_test "should display the person's policies with content" do
     create(:ministerial_role_appointment, person: @person)
-    rummager_has_policies_for_every_type
+    stub_search_has_policies_for_every_type
 
     get :show, params: { id: @person }
 

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -110,7 +110,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
 
   def create_topical_event_and_stub_in_content_store(*args)
     topical_event = create(:topical_event, *args)
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
 
     payload = {
       format: "topical_event",

--- a/test/support/policy_tagging_helpers.rb
+++ b/test/support/policy_tagging_helpers.rb
@@ -1,12 +1,12 @@
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/publishing_api_v2"
 
 module PolicyTaggingHelpers
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
   include GdsApi::TestHelpers::PublishingApiV2
 
   def assert_published_policies_returns_all_tagged_policies(object)
-    rummager_has_policies_for_every_type
+    stub_search_has_policies_for_every_type
 
     all_policy_titles = [
       "Welfare reform",

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/search'
 
 class PersonSlugChangerTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
 
   setup do
     stub_any_publishing_api_call

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require_relative "../../support/search_rummager_helper"
 
 class LatestDocumentsFilterTest < ActiveSupport::TestCase
@@ -28,7 +28,7 @@ class LatestDocumentsFilterTest < ActiveSupport::TestCase
 
   test '#documents should return paginated results' do
     topical_event = create(:topical_event)
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
     filter = LatestDocumentsFilter::TopicalEventFilter.new(
       topical_event, page: 2, per_page: 2
     )
@@ -51,7 +51,7 @@ class LatestDocumentsFilterTest < ActiveSupport::TestCase
       }
     end
 
-    stub_any_rummager_search.to_return(body: results.to_json)
+    stub_any_search.to_return(body: results.to_json)
 
     filter = LatestDocumentsFilter::TopicalEventFilter.new(topical_event)
 

--- a/test/unit/services/search_rummager_service_test.rb
+++ b/test/unit/services/search_rummager_service_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require_relative "../../support/search_rummager_helper"
 
 class SearchRummagerServiceTest < ActiveSupport::TestCase
@@ -11,12 +11,12 @@ class SearchRummagerServiceTest < ActiveSupport::TestCase
   end
 
   test 'returns empty results array if topical event has no documents' do
-    stub_any_rummager_search_to_return_no_results
+    stub_any_search_to_return_no_results
     assert_equal [], SearchRummagerService.new.fetch_related_documents(topical_params)['results']
   end
 
   test 'fetches documents related to a topical event' do
-    stub_any_rummager_search.to_return(body: rummager_response)
+    stub_any_search.to_return(body: rummager_response)
     results = SearchRummagerService.new.fetch_related_documents(topical_params)['results']
 
     assert_instance_of RummagerDocumentPresenter, results.first


### PR DESCRIPTION
Resolves messages in logs like:

> GdsApi::Rummager is deprecated.  Use GdsApi::Search instead.

We'll be deleting a fair bit of Whitehall search code soonish so aren't intending to rename every reference to rummager now.