### PR TITLE
Link to content metrics

### DIFF
--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -1,5 +1,16 @@
 module Admin::ContentDataRoutesHelper
+  def content_data_home_url
+    @content_data_home_url ||= "#{content_data_base_url}/content"
+  end
+
+  def content_data_page_data_url(edition)
+    path = public_document_path(edition)
+    "#{content_data_base_url}/metrics#{path}"
+  end
+
+private
+
   def content_data_base_url
-    @content_data_base_url ||= "#{Plek.current.external_url_for('content-data')}/content"
+    Plek.current.external_url_for('content-data')
   end
 end

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -14,7 +14,8 @@ module Admin::EditionActionsHelper
       data: {
         track_category: 'external-link-clicked',
         track_action: url,
-        track_label:  'View data about page'
+        track_label:  'View data about page',
+        track_dimension_1: url
       }
   end
 

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -8,8 +8,14 @@ module Admin::EditionActionsHelper
   end
 
   def content_data_button(edition)
-    link_to 'View data about page', content_data_page_data_url(edition),
-     class: 'btn btn-default btn-lg pull-right'
+    url = content_data_page_data_url(edition)
+    link_to 'View data about page', url,
+      class: 'btn btn-default btn-lg pull-right',
+      data: {
+        track_category: 'external-link-clicked',
+        track_action: url,
+        track_label:  'View data about page'
+      }
   end
 
   def approve_retrospectively_edition_button(edition)

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -15,7 +15,8 @@ module Admin::EditionActionsHelper
         track_category: 'external-link-clicked',
         track_action: url,
         track_label:  'View data about page',
-        track_dimension_1: url
+        track_dimension_1: url,
+        track_dimension_2: edition.type.underscore
       }
   end
 

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -7,6 +7,11 @@ module Admin::EditionActionsHelper
     button_to 'Create new edition to edit', revise_admin_edition_path(edition), title: "Create new edition to edit", class: "btn btn-default btn-lg"
   end
 
+  def content_data_button(edition)
+    link_to 'View data about page', content_data_page_data_url(edition),
+     class: 'btn btn-default btn-lg pull-right'
+  end
+
   def approve_retrospectively_edition_button(edition)
     confirmation_prompt = "Are you sure you want to retrospectively approve this document?"
     content_tag(:div, class: "approve_retrospectively_button") do

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -16,7 +16,8 @@ module Admin::EditionActionsHelper
         track_action: url,
         track_label:  'View data about page',
         track_dimension_1: url,
-        track_dimension_2: edition.type.underscore
+        track_dimension_2: edition.type.underscore,
+        track_dimension_4: edition.document.content_id
       }
   end
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -8,10 +8,10 @@
     <h3>Writing and publishing</h3>
     <ul>
     <li><%= link_to('Content Data',
-                    content_data_base_url,
+                    content_data_home_url,
                     data: {
                         track_category: 'external-link-clicked',
-                        track_action: content_data_base_url,
+                        track_action: content_data_home_url,
                         track_label: 'Content Data'
                     })%>
     </li>

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -14,4 +14,7 @@
   <% elsif @edition.is_latest_edition? and @edition.published? %>
     <%= redraft_edition_button(@edition) %>
   <% end %>
+  <% if @edition.publicly_visible? %>
+      <%= content_data_button(@edition) %>
+  <% end %>
 </section>

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -19,7 +19,8 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
       'href' => url,
       'data-track-category' => 'external-link-clicked',
       'data-track-action' => url,
-      'data-track-label' => 'View data about page'
+      'data-track-label' => 'View data about page',
+      'data-track-dimension-1' => url
     }
 
     attributes = el.attributes.transform_values(&:value).slice(*expected_attributes.keys)

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -21,7 +21,8 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
       'data-track-action' => url,
       'data-track-label' => 'View data about page',
       'data-track-dimension-1' => url,
-      'data-track-dimension-2' => 'generic_edition'
+      'data-track-dimension-2' => 'generic_edition',
+      'data-track-dimension-4' => published_edition.document.content_id
     }
 
     attributes = el.attributes.transform_values(&:value).slice(*expected_attributes.keys)

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -14,10 +14,15 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
 
     get :show, params: { id: published_edition }
     el = css_select("a[text()='View data about page']").first
+    url = "https://content-data.test.gov.uk/metrics/government/generic-editions/#{published_edition.slug}"
     expected_attributes = {
-      'href' => "https://content-data.test.gov.uk/metrics/government/generic-editions/#{published_edition.slug}"
+      'href' => url,
+      'data-track-category' => 'external-link-clicked',
+      'data-track-action' => url,
+      'data-track-label' => 'View data about page'
     }
-    attributes = el.attributes.transform_values(&:value).slice('href', 'title')
+
+    attributes = el.attributes.transform_values(&:value).slice(*expected_attributes.keys)
 
     assert_equal expected_attributes, attributes
   end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Admin::GenericEditionsController::LinkingToContentDataTest < ActionController::TestCase
+  include TaxonomyHelper
+  tests Admin::GenericEditionsController
+
+  setup do
+    login_as :writer
+  end
+
+  view_test "should link to content-data when published" do
+    published_edition = create(:published_edition)
+    stub_publishing_api_expanded_links_with_taxons(published_edition.content_id, [])
+
+    get :show, params: { id: published_edition }
+    el = css_select("a[text()='View data about page']").first
+    expected_attributes = {
+      'href' => "https://content-data.test.gov.uk/metrics/government/generic-editions/#{published_edition.slug}"
+    }
+    attributes = el.attributes.transform_values(&:value).slice('href', 'title')
+
+    assert_equal expected_attributes, attributes
+  end
+
+  view_test "should not link to content-data when unpublished" do
+    draft_edition = create(:draft_edition)
+    stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
+
+    get :show, params: { id: draft_edition }
+    refute_select("a[text()='View data about page']")
+  end
+end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -20,7 +20,8 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
       'data-track-category' => 'external-link-clicked',
       'data-track-action' => url,
       'data-track-label' => 'View data about page',
-      'data-track-dimension-1' => url
+      'data-track-dimension-1' => url,
+      'data-track-dimension-2' => 'generic_edition'
     }
 
     attributes = el.attributes.transform_values(&:value).slice(*expected_attributes.keys)


### PR DESCRIPTION
# What

Add a link to `content-data` `/metrics` endpoint 
from the edition admin `show` page when the edition has been published.

Also adds tracking to the link.

There may be another PR to add taxonomy level 1 to the tracking dimensions.

# Why

We want to get more people to use `content-data`

Trello: https://trello.com/c/NagoCEK0/1439-3-add-button-to-content-data-from-whitehall