### PR TITLE
Add root taxons to tracking on the link to content data

### DIFF
--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -4,8 +4,7 @@ module Admin::ContentDataRoutesHelper
   end
 
   def content_data_page_data_url(edition)
-    path = public_document_path(edition)
-    "#{content_data_base_url}/metrics#{path}"
+    "#{content_data_base_url}/metrics#{public_document_path(edition)}"
   end
 
 private

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -17,6 +17,7 @@ module Admin::EditionActionsHelper
         track_label:  'View data about page',
         track_dimension_1: url,
         track_dimension_2: edition.type.underscore,
+        track_dimension_3: root_taxon_paths,
         track_dimension_4: edition.document.content_id
       }
   end
@@ -151,5 +152,15 @@ private
       'Speech sub-types' => SpeechType.all.map { |sub_type| [sub_type.plural_name, "speech_#{sub_type.id}"] }
     }
     grouped_options_for_select(subtype_options_hash, selected)
+  end
+
+  def root_taxon_paths
+    @edition_taxons.map(&method(:get_root)).map(&:base_path).uniq.sort.join(',')
+  end
+
+  def get_root(taxon)
+    return taxon if taxon.parent_node.nil?
+
+    get_root(taxon.parent_node)
   end
 end

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -9,17 +9,23 @@ module Admin::EditionActionsHelper
 
   def content_data_button(edition)
     url = content_data_page_data_url(edition)
+
     link_to 'View data about page', url,
       class: 'btn btn-default btn-lg pull-right',
       data: {
         track_category: 'external-link-clicked',
         track_action: url,
-        track_label:  'View data about page',
-        track_dimension_1: url,
-        track_dimension_2: edition.type.underscore,
-        track_dimension_3: root_taxon_paths,
-        track_dimension_4: edition.document.content_id
+        track_label:  'View data about page'
       }
+  end
+
+  def custom_track_dimensions(edition)
+    {
+      1 => public_document_path(edition),
+      2 => edition.type.underscore,
+      3 => root_taxon_paths,
+      4 => edition.document.content_id
+    }
   end
 
   def approve_retrospectively_edition_button(edition)
@@ -155,7 +161,16 @@ private
   end
 
   def root_taxon_paths
-    @edition_taxons.map(&method(:get_root)).map(&:base_path).uniq.sort.join(',')
+    @edition_taxons
+      .map(&method(:get_root))
+      .map(&:base_path)
+      .uniq
+      .map(&method(:delete_leading_slash))
+      .sort.join(', ')
+  end
+
+  def delete_leading_slash(str)
+    str.delete_prefix('/')
   end
 
   def get_root(taxon)

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -18,3 +18,8 @@
       <%= content_data_button(@edition) %>
   <% end %>
 </section>
+<% content_for :before_pageview_js do %>
+ <% custom_track_dimensions(@edition).each do |k,v| %>
+ GOVUKAdmin.setDimension(<%= k %>, '<%= v %>');
+ <% end %>
+<% end %>

--- a/test/factories/taxon_hash.rb
+++ b/test/factories/taxon_hash.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       is_level_one_taxon { true }
       children { [] }
+      parents { [] }
       visibility { true }
     end
     sequence("title") { |i| "Taxon Name #{i}" }
@@ -11,7 +12,8 @@ FactoryBot.define do
     phase { 'live' }
     after :build do |hash, evaluator|
       hash["links"] = {
-        "child_taxons" => evaluator.children
+        "child_taxons" => evaluator.children,
+        "parent_taxons" => evaluator.parents
       }
       hash["details"] = {
         "visible_to_departmental_editors" => evaluator.visibility

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -22,10 +22,6 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
       'data-track-category' => 'external-link-clicked',
       'data-track-action' => url,
       'data-track-label' => 'View data about page',
-      'data-track-dimension-1' => url,
-      'data-track-dimension-2' => 'generic_edition',
-      'data-track-dimension-3' => '/education,/money',
-      'data-track-dimension-4' => published_edition.document.content_id
     }
 
     attributes = el.attributes.transform_values(&:value).slice(*expected_attributes.keys)

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_content_data_test.rb
@@ -10,8 +10,10 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
 
   view_test "should link to content-data when published" do
     published_edition = create(:published_edition)
-    stub_publishing_api_expanded_links_with_taxons(published_edition.content_id, [])
+    stub_publishing_api_expanded_links_with_taxons(published_edition.content_id,
+      [taxon_with_parents, taxon_with_different_root, taxon_with_same_root])
 
+    redis_cache_has_world_taxons([world_taxon])
     get :show, params: { id: published_edition }
     el = css_select("a[text()='View data about page']").first
     url = "https://content-data.test.gov.uk/metrics/government/generic-editions/#{published_edition.slug}"
@@ -22,6 +24,7 @@ class Admin::GenericEditionsController::LinkingToContentDataTest < ActionControl
       'data-track-label' => 'View data about page',
       'data-track-dimension-1' => url,
       'data-track-dimension-2' => 'generic_edition',
+      'data-track-dimension-3' => '/education,/money',
       'data-track-dimension-4' => published_edition.document.content_id
     }
 

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -13,6 +13,10 @@ module TaxonomyHelper
     "root"
   end
 
+  def different_root_taxon_content_id
+    'money'
+  end
+
   def parent_taxon_content_id
     "parent"
   end
@@ -134,6 +138,46 @@ private
                      base_path: "/education",
                      content_id: root_taxon_content_id,
                      children: [grandparent_taxon])
+  end
+
+  def different_root_taxon
+    FactoryBot.build(:taxon_hash,
+                     title: "Money",
+                     base_path: "/money",
+                     content_id: different_root_taxon_content_id,
+                     children: [])
+  end
+
+  def taxon_with_parents
+    FactoryBot.build(:taxon_hash,
+                     title: 'Student finance',
+                     base_path: '/education/funding/student-finance',
+                     content_id: 'grandchild-with-parent',
+                     parents: [parent_with_root_parent])
+  end
+
+  def taxon_with_same_root
+    FactoryBot.build(:taxon_hash,
+                     title: 'Another thing',
+                     base_path: '/education/another-thing',
+                     content_id: 'another-thing',
+                     parents: [root_taxon])
+  end
+
+  def taxon_with_different_root
+    FactoryBot.build(:taxon_hash,
+                     title: 'Personal tax',
+                     base_path: '/money/personal-tax',
+                     content_id: 'personal-tax-1',
+                     parents: [different_root_taxon])
+  end
+
+  def parent_with_root_parent
+    FactoryBot.build(:taxon_hash,
+                     title: 'Finance',
+                     base_path: '/education/funding/',
+                     content_id: 'parent-with-root',
+                     parents: [root_taxon])
   end
 
   def draft_taxon_1


### PR DESCRIPTION
Adds 'data-track-dimension-3' to the link attributes for
the link to content-data metrics page.

It contains a comma separated list of base paths for each root taxon
linked to the content item.