### PR TITLE
Add deprecation banner for upcoming stats

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -11,7 +11,7 @@
 </header>
 
 <%= render "govuk_publishing_components/components/notice", {
-    title: 'This page is being replaced by <a href="/search/research-and-statistics">Research and statistics search</a>'.html_safe
+    title: 'This page is being replaced by <a href="/search/research-and-statistics">research and statistics search</a>'.html_safe
 } %>
 
 <%= render 'impartiality' %>

--- a/app/views/statistics_announcements/index.html.erb
+++ b/app/views/statistics_announcements/index.html.erb
@@ -14,6 +14,10 @@
   </div>
 </header>
 
+<%= render "govuk_publishing_components/components/notice", {
+    title: 'This page is being replaced by <a href="/search/research-and-statistics?content_store_document_type=upcoming_statistics">research and statistics search</a>'.html_safe
+} %>
+
 <%= render 'statistics/impartiality' %>
 <%= render 'upcoming_calendar_tabs' %>
 


### PR DESCRIPTION
This navigates directly to the upcoming statistics view of the new finder.

The default sort on the new finder is "Release date (latest)" do we don't need to include that in the URL.

It's for the same purpose as https://github.com/alphagov/whitehall/pull/4808

![www-origin integration publishing service gov uk_government_statistics_announcements(16x9)](https://user-images.githubusercontent.com/773037/58872476-01949880-86bc-11e9-9fd6-2b2560bbb47a.png)

https://trello.com/c/Ac83bP1d/721-add-a-standard-banner-to-government-statistics-warning-users-its-going-away-soon-s