### PR TITLE
Delegate consultation response images to the consultation

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -48,7 +48,7 @@ class Response < ApplicationRecord
     true
   end
 
-  delegate :public_timestamp, :first_published_version?, :slug, :document, to: :consultation
+  delegate :public_timestamp, :first_published_version?, :slug, :document, :images, to: :consultation
 
 private
 

--- a/test/unit/govspeak_content_test.rb
+++ b/test/unit/govspeak_content_test.rb
@@ -105,6 +105,18 @@ class GovspeakContentTest < ActiveSupport::TestCase
     assert_equivalent_html expected_body_html, govspeak_content.computed_body_html
   end
 
+  test "#render_govspeak adds images from consultations to HTML attachments on the consultation's responses" do
+    consultation = FactoryBot.create(:consultation_with_outcome, images: [FactoryBot.create(:image)])
+    consultation_outcome = consultation.outcome
+
+    html_attachment = FactoryBot.create(:html_attachment, body: "!!1", attachable: consultation_outcome)
+
+    govspeak_content = html_attachment.govspeak_content
+    govspeak_content.render_govspeak!
+
+    assert_includes govspeak_content.computed_body_html, "image"
+  end
+
 private
 
   def compute_govspeak(govspeak_content)


### PR DESCRIPTION
This allows people to add an image to the consultation and then use it in the consultation response.

I tried to restructure these long lines so they were more readable but rubocop was having none of it.

https://govuk.zendesk.com/agent/tickets/3636856
https://trello.com/c/mrTq1ZyH/1004-image-uploads-might-be-broken-for-all-html-attachments-in-consultation-publications