### PR TITLE
Add a footer to emails sent from integration or staging

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -88,6 +88,8 @@ class Notifications < ActionMailer::Base
       subject: "Consultation deadline breached"
   end
 
+  helper_method :production?
+
   def production?
     GovukAdminTemplate.environment_style == "production"
   end

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -88,15 +88,24 @@ class Notifications < ActionMailer::Base
       subject: "Consultation deadline breached"
   end
 
+  def production?
+    GovukAdminTemplate.environment_style == "production"
+  end
+
 private
 
   def no_reply_email_address
     name = "GOV.UK publishing"
-    if !/production/i.match?(GovukAdminTemplate.environment_label)
+    unless production?
       name.prepend("[GOV.UK #{GovukAdminTemplate.environment_label}] ")
     end
 
-    address = Mail::Address.new("inside-government@digital.cabinet-office.gov.uk")
+    email_address = "inside-government@digital.cabinet-office.gov.uk"
+    unless production?
+      email_address = "inside-government+#{GovukAdminTemplate.environment_style}@digital.cabinet-office.gov.uk"
+    end
+
+    address = Mail::Address.new(email_address)
     address.display_name = name
     address.format
   end

--- a/app/views/layouts/notifications.text.erb
+++ b/app/views/layouts/notifications.text.erb
@@ -1,0 +1,5 @@
+<%= yield %>
+
+<% unless production? -%>
+Note: this email has been sent from a GOV.UK testing environment (<%= GovukAdminTemplate.environment_label %>). Depending on the contents of the email, this likely means it's safe to ignore any calls to action. Due to the way that we sync content to our testing environments, you may sometimes receive emails about content being published in those environments.
+<%- end %>

--- a/test/unit/services/service_listeners/author_notifier_test.rb
+++ b/test/unit/services/service_listeners/author_notifier_test.rb
@@ -35,18 +35,18 @@ class ServiceListeners::AuthorNotifierTest < ActiveSupport::TestCase
     assert_match(/\'#{edition.title}\' has been published/, first_notification.subject)
   end
 
+  def notify(environment: nil)
+    GovukAdminTemplate.environment_style = environment
+    GovukAdminTemplate.environment_label = environment.try(:titleize)
+
+    edition = create(:edition)
+    ServiceListeners::AuthorNotifier.new(edition).notify!
+
+    GovukAdminTemplate.environment_style = nil
+    GovukAdminTemplate.environment_label = nil
+  end
+
   test 'sets a suitable "from" including a quoted display name' do
-    def notify(environment: nil)
-      GovukAdminTemplate.environment_style = environment
-      GovukAdminTemplate.environment_label = environment.try(:titleize)
-
-      edition = create(:edition)
-      ServiceListeners::AuthorNotifier.new(edition).notify!
-
-      GovukAdminTemplate.environment_style = nil
-      GovukAdminTemplate.environment_label = nil
-    end
-
     notify
     notify(environment: "integration")
     notify(environment: "production")
@@ -62,5 +62,24 @@ class ServiceListeners::AuthorNotifierTest < ActiveSupport::TestCase
 
     production_notification = ActionMailer::Base.deliveries.third
     assert_equal '"GOV.UK publishing" <inside-government@digital.cabinet-office.gov.uk>', production_notification[:from].to_s
+  end
+
+  test 'sets a suitable footer' do
+    notify
+    notify(environment: "integration")
+    notify(environment: "production")
+
+    assert_equal 3, ActionMailer::Base.deliveries.size
+
+    pattern = /this email has been sent from a GOV\.UK testing environment/
+
+    first_notification = ActionMailer::Base.deliveries.first
+    assert_match pattern, first_notification.to_s
+
+    integration_notification = ActionMailer::Base.deliveries.second
+    assert_match pattern, integration_notification.to_s
+
+    production_notification = ActionMailer::Base.deliveries.third
+    refute_match pattern, production_notification.to_s
   end
 end

--- a/test/unit/services/service_listeners/author_notifier_test.rb
+++ b/test/unit/services/service_listeners/author_notifier_test.rb
@@ -36,14 +36,31 @@ class ServiceListeners::AuthorNotifierTest < ActiveSupport::TestCase
   end
 
   test 'sets a suitable "from" including a quoted display name' do
-    edition = create(:edition)
+    def notify(environment: nil)
+      GovukAdminTemplate.environment_style = environment
+      GovukAdminTemplate.environment_label = environment.try(:titleize)
 
-    ServiceListeners::AuthorNotifier.new(edition).notify!
+      edition = create(:edition)
+      ServiceListeners::AuthorNotifier.new(edition).notify!
 
-    assert_equal 1, ActionMailer::Base.deliveries.size
+      GovukAdminTemplate.environment_style = nil
+      GovukAdminTemplate.environment_label = nil
+    end
+
+    notify
+    notify(environment: "integration")
+    notify(environment: "production")
+
+    assert_equal 3, ActionMailer::Base.deliveries.size
 
     first_notification = ActionMailer::Base.deliveries.first
     # GovukAdminTemplate.environment_label isn't set in tests, hence the space inside the brackets
-    assert_equal '"[GOV.UK ] GOV.UK publishing" <inside-government@digital.cabinet-office.gov.uk>', first_notification[:from].to_s
+    assert_equal '"[GOV.UK ] GOV.UK publishing" <inside-government+@digital.cabinet-office.gov.uk>', first_notification[:from].to_s
+
+    integration_notification = ActionMailer::Base.deliveries.second
+    assert_equal '"[GOV.UK Integration] GOV.UK publishing" <inside-government+integration@digital.cabinet-office.gov.uk>', integration_notification[:from].to_s
+
+    production_notification = ActionMailer::Base.deliveries.third
+    assert_equal '"GOV.UK publishing" <inside-government@digital.cabinet-office.gov.uk>', production_notification[:from].to_s
   end
 end


### PR DESCRIPTION
This adds a clear note to emails stating if they have come from integration or staging, which should avoid anyone getting confused if they receive these emails.

From the card:

> We can't really disable emails from integration because there are many legitimate uses of integration - including content designers testing scheduled publications.

> We could stop the data sync from creating the jobs which schedule content but then 2nd line would see an alert about missing jobs, likely manually create them, and we'd have the same problem.

[Trello Card](https://trello.com/c/M9H2hnHe/1040-whitehall-sending-integration-emails-to-publishers-when-scheduling-publishing)