### PR TITLE
Publish role appointment start and end dates

### DIFF
--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -16,7 +16,7 @@ module PublishingApi
       {
         title: title,
         locale: locale,
-        details: {},
+        details: details,
         publishing_app: "whitehall",
         update_type: update_type,
         document_type: item.class.name.underscore,
@@ -40,6 +40,13 @@ module PublishingApi
 
     def title
       "#{item.person.name} - #{item.role.name}"
+    end
+
+    def details
+      {}.tap { |details|
+        details[:started_on] = item.started_at.rfc3339 if item.started_at.present?
+        details[:ended_on] = item.ended_at.rfc3339 if item.ended_at.present?
+      }
     end
 
     def locale

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -29,7 +29,9 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
       publishing_app: 'whitehall',
       public_updated_at: role.updated_at,
       update_type: 'major',
-      details: {}
+      details: {
+        started_on: '2011-11-10T11:11:11+00:00'
+      }
     }
     expected_links = {
       person: [person.content_id],


### PR DESCRIPTION
The data is already defined in the role_appointment schema but it's not published.