### PR TITLE
Add `Switch app` link to admin pages

### DIFF
--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -95,4 +95,8 @@ module Admin::UrlHelper
   def active_link_class(path_matcher)
     request.path.match?(path_matcher) ? 'active' : ''
   end
+
+  def signon_link
+    link_to 'Switch app', Plek.new.external_url_for('signon')
+  end
 end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -46,6 +46,9 @@
         </ul>
         <div class="navbar-text pull-right remove-bottom-margin">
           <ul class="list-inline">
+              <li>
+                  <%= signon_link %>
+              </li>
             <% if user_signed_in? %>
               <li>
                 <%= link_to current_user.name, admin_user_path(current_user), id: "#user_settings" %>


### PR DESCRIPTION
Adds a link to signon to the admin header.

# Before

<img width="532" alt="Screenshot 2019-06-06 at 17 15 31" src="https://user-images.githubusercontent.com/511319/59048924-ca221980-887e-11e9-8897-4ed670eb626f.png">
# After

<img width="505" alt="Screenshot 2019-06-06 at 17 15 41" src="https://user-images.githubusercontent.com/511319/59048944-d5754500-887e-11e9-85a2-d705af55caff.png">

Trello: https://trello.com/c/KJlQrRWB/1445-1-add-switch-app-to-whitehall

