### PR TITLE
Fix missing @unpublishing variable

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -99,6 +99,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
     if @service_object.perform!
       redirect_to admin_edition_path(@edition), notice: unpublish_success_notice
     else
+      @unpublishing = @edition.unpublishing
       flash.now[:alert] = @service_object.failure_reason
       render :confirm_unpublish
     end

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -257,7 +257,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'No longer government publication', published_edition.reload.unpublishing.explanation
   end
 
-  test '#unpublish when there are validation errors re-renders the unpublish form' do
+  view_test '#unpublish when there are validation errors re-renders the unpublish form' do
     login_as create(:managing_editor)
     unpublish_params = {
         unpublishing_reason_id: UnpublishingReason::Consolidated.id,


### PR DESCRIPTION
This partly reverts commit 3a81b62371199676f5ec181595e9b0b12ff161ab.

There's [a problem where `@unpublishing` isn't set when calling `render :confirm_unpublish`](https://sentry.io/organizations/govuk/issues/1024026412/).

I'm not quite sure why [this test](https://github.com/alphagov/whitehall/blob/f098ffc2a8d8c965db9371a83d0c24b3262d33a0/test/functional/admin/edition_workflow_controller_test.rb#L260-L271) didn't catch the problem.

[Trello Card](https://trello.com/c/MGVJuycb/1012-allow-html-attachments-to-be-removed-redirected-when-a-piece-of-content-is-unpublished)