### PR TITLE
Send unpublishing ID along with html attachments worker

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -54,7 +54,9 @@ module ServiceListeners
     end
 
     def handle_html_attachments(event)
-      PublishingApiHtmlAttachmentsWorker.perform_async(edition.id, event)
+      PublishingApiHtmlAttachmentsWorker.perform_async(
+        edition.id, event, edition.unpublishing.try(:id)
+      )
     end
 
     def handle_publications(event)

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -9,11 +9,11 @@ module ServiceListeners
         .with(edition.id, event)
     end
 
-    def stub_html_attachment_pusher(edition, event)
+    def stub_html_attachment_pusher(edition, event, unpublishing = nil)
       PublishingApiHtmlAttachmentsWorker
         .any_instance
         .expects(:perform)
-        .with(edition.id, event)
+        .with(edition.id, event, unpublishing.try(:id))
     end
 
     def stub_publications_pusher(edition, event)
@@ -103,7 +103,7 @@ module ServiceListeners
     test "unpublish publishes the unpublishing" do
       edition = create(:unpublished_publication)
       Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
-      stub_html_attachment_pusher(edition, "unpublish")
+      stub_html_attachment_pusher(edition, "unpublish", edition.unpublishing)
       stub_publications_pusher(edition, "unpublish")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "unpublish")


### PR DESCRIPTION
There seems to be a race condition where the worker will run before the unpublishing has been attached to an edition, but after the unpublishing itself exists. That means that it wouldn't unpublish the attachments because `edition.unpublishing` was `nil`.

I've tested this solution multiple times in integration and it's worked every time. I'm not sure how best to test this case because I haven't worked out yet what's causing it.

An alternative solution that I found also worked:

```ruby
PublishingApiHtmlAttachmentsWorker.perform_in(1.second, edition.id, event)
```

However, this felt more brittle than explicitly passing the unpublishing to the worker.

[Trello Card](https://trello.com/c/MGVJuycb/1012-allow-html-attachments-to-be-removed-redirected-when-a-piece-of-content-is-unpublished)