### PR TITLE
Redirect statistics announcement with internal path

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -250,6 +250,24 @@ private
   end
 
   def publish_redirect_to_redirect_url
-    Whitehall::PublishingApi.publish_redirect_async(content_id, redirect_url)
+    Whitehall::PublishingApi.publish_redirect_async(content_id, redirect_path)
+  end
+
+  def redirect_uri
+    @redirect_uri ||= begin
+                        return if redirect_url.nil?
+
+                        Addressable::URI.parse(redirect_url)
+                      rescue URI::InvalidURIError
+                        nil
+                      end
+  end
+
+  def redirect_path
+    return if redirect_uri.nil?
+
+    path = redirect_uri.path
+    path << "##{redirect_uri.fragment}" if redirect_uri.fragment.present?
+    path
   end
 end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -192,7 +192,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     statistics_announcement = create(:statistics_announcement)
 
     Whitehall::PublishingApi.expects(:publish_redirect_async)
-      .with(statistics_announcement.content_id, "https://www.test.gov.uk/government/something-else")
+      .with(statistics_announcement.content_id, "/government/something-else")
 
     statistics_announcement.update_attributes!(
       publishing_state: "unpublished",


### PR DESCRIPTION
The publishing-api [expects redirects to another page on gov.uk to not include the gov.uk host and instead just be a path](https://github.com/alphagov/publishing-api/blob/29e84d61e323ab1020813ae5e3c797e0c781a4d0/app/validators/routes_and_redirects_validator.rb#L190-L191).

We know that this path is guaranteed to be a gov.uk path because we have a validation on the full `redirect_url` to check that `gov_uk_url: true`.

This [copies similar code we already have in the `Unpublishing` model which does the same thing](https://github.com/alphagov/whitehall/blob/76dbcfddb06ebc17c1316a2bb581c2460d16165c/app/models/unpublishing.rb#L63-L69).

[Trello Card](https://trello.com/c/dx1p5UHp/1049-statistics-announcements-not-being-redirected)