### PR TITLE
Add finder redirect for official document status

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -79,7 +79,7 @@ private
   end
 
   def publication_finder_type
-    params[:publication_filter_option] || params[:publication_type]
+    params[:official_document_status] || params[:publication_filter_option] || params[:publication_type]
   end
 
   def expire_cache_when_next_publication_published

--- a/lib/publications_routes.rb
+++ b/lib/publications_routes.rb
@@ -1,6 +1,21 @@
 module PublicationsRoutes
   DEFAULT_PUBLICATIONS_PATH = 'search/all'.freeze
   PUBLICATIONS_ROUTES = {
+    'command_and_act_papers' => {
+      base_path: 'official-documents',
+    },
+    'command_papers' => {
+      base_path: 'official-documents',
+      special_params: {
+        content_store_document_type: 'command_papers',
+      }
+    },
+    'act_papers' => {
+      base_path: 'official-documents',
+      special_params: {
+        content_store_document_type: 'act_papers',
+      }
+    },
     'consultations' => {
       base_path: 'search/policy-papers-and-consultations',
       special_params: {

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -50,6 +50,11 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.to_query}"
   end
 
+  test "when official_document_status is specified redirects with params for official-documents finder" do
+    get :index, params: @default_params.merge(official_document_status: "command_and_act_papers")
+    assert_redirected_to "#{Plek.new.website_root}/official-documents?#{@default_converted_params.to_query}"
+  end
+
   test "strips out 'all' taxons from query string in redirect" do
     get :index, params: @default_params.merge(taxons: %w[all])
     assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(level_one_taxon: nil).compact.to_query}"


### PR DESCRIPTION
Adds in an additional check to see if an `official_document_status` has been selected - if it has, the redirect will go to the /official-documents finder, taking priority over any other facets

Thanks to @barrucadu for helping with this!

Tied to [this card](https://trello.com/c/BrVseRTp/739-add-finder-redirect-for-official-document-status-content-m)