### PR TITLE
Rename Burma to Myanmar

### DIFF
--- a/db/data_migration/20190612144109_rename_burma_to_myanmar.rb
+++ b/db/data_migration/20190612144109_rename_burma_to_myanmar.rb
@@ -1,0 +1,5 @@
+burma = WorldLocation.find_by(slug: "burma")
+if burma
+  burma.update!(slug: "myanmar")
+  burma.translation.update!(name: "Myanmar")
+end

--- a/db/data_migration/20190613132701_world_wide_organisation_slug_change_from_burma_to_myanmar.rb
+++ b/db/data_migration/20190613132701_world_wide_organisation_slug_change_from_burma_to_myanmar.rb
@@ -1,0 +1,7 @@
+require 'data_hygiene/organisation_reslugger'
+
+ dfid = WorldwideOrganisation.find_by(slug: "dfid-burma")
+ dit = WorldwideOrganisation.find_by(slug: "department-for-international-trade-burma")
+
+ DataHygiene::OrganisationReslugger.new(dfid, "dfid-myanmar").run!
+ DataHygiene::OrganisationReslugger.new(dit, "department-for-international-trade-myanmar").run!


### PR DESCRIPTION
[Burma is now going to be referred to officially as Myanmar.](https://trello.com/c/8Y2fbezn/1066-country-name-change-burma-myanmar)