### PR TITLE
Remove the 20190219130915_redirect_macedonia_news data migration

### DIFF
--- a/db/data_migration/20190219130915_redirect_macedonia_news.rb
+++ b/db/data_migration/20190219130915_redirect_macedonia_news.rb
@@ -1,6 +1,0 @@
-puts "Unpublishing /world/macedonia/news and redirecting to /world/north-macedonia/news"
-Services.publishing_api.unpublish(
-  "52434a45-7d30-4e4e-8190-c8d963901bef",
-  type: "redirect",
-  alternative_path: "/world/north-macedonia/news",
-)


### PR DESCRIPTION
It doesn't work, and has never worked, because it's not necessary. The
Publishing API has handled this when the base_path of the page
changed.