### PR TITLE
Add missing GOVUK_WEBSITE_ROOT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ADD . $APP_HOME
 
 RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
   GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=www.gov.uk \
   GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
   RAILS_ENV=production \
   bundle exec rake shared_mustache:compile assets:precompile


### PR DESCRIPTION
The Docker build as part of the Jenkins job requires vertain env vars
to run. This fixes a broken build.