### PR TITLE
Adds a redirect for announcements atom feed

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -26,6 +26,8 @@ class AnnouncementsController < DocumentsController
         )
       end
       format.atom do
+        return redirect_to_news_and_communications(".atom") if is_english_locale?
+
         @announcements = @filter.documents
       end
     end
@@ -43,8 +45,8 @@ private
     params[:locale].nil?
   end
 
-  def redirect_to_news_and_communications
-    base_path = "#{Plek.new.website_root}/search/news-and-communications"
+  def redirect_to_news_and_communications(format = "")
+    base_path = "#{Plek.new.website_root}/search/news-and-communications#{format}"
     redirect_to("#{base_path}?#{news_and_communications_query_string}")
   end
 


### PR DESCRIPTION
This change introduces a redirect in the announcements finder
controller. When going to an announcements finder atom feed,
this checks to see if the locale selected is English, and if so it will
redirect to the news and comms finder atom feed instead.

Tests have also been removed/added to account for this, but there might be some missing feature tests that should be included. 

This is part of [this card](https://trello.com/c/E5QJ99L5/805-redirect-english-announcements-atom-feeds), and thanks to @koetsier for helping! 