### PR TITLE
Add a timeout on calculating the number of pages

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -1,4 +1,5 @@
 require 'pdf-reader'
+require 'timeout'
 
 class AttachmentData < ApplicationRecord
   mount_uploader :file, AttachmentUploader, mount_on: :carrierwave_file
@@ -186,8 +187,10 @@ private
   end
 
   def calculate_number_of_pages
-    PDF::Reader.new(path).page_count
-  rescue PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError, OpenSSL::Cipher::CipherError
+    Timeout::timeout(10) do
+      PDF::Reader.new(path).page_count
+    end
+  rescue Timeout::Error, PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError, OpenSSL::Cipher::CipherError
     nil
   end
 


### PR DESCRIPTION
Sometimes a malformed PDF will cause calculating the number of pages to take a significant amount of time (we have one specific example that takes over 2 minutes). This causes the user to see a timeout error when uploading the PDF.

By adding a timeout, we can avoid the bad user experience of seeing a timeout error, for the alternative of not having a number of pages set for that attachment.

Ideally, we would restructure the way this code works to perform the number of pages calculation in a background worker, however this would require significant refactoring on how attachments work and this is a pragmatic solution.

[Trello Card](https://trello.com/c/DCZQ4AWu/1076-timeout-error-uploading-hs2-pdf-in-whitehall)