### PR TITLE
Route courts and tribunals pages to collections

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -31,7 +31,7 @@ module PublishingApi
         description: text_summary,
         details: details,
         document_type: item.class.name.underscore,
-        rendering_app: rendering_app,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: schema_name,
       )
       content.merge!(
@@ -57,14 +57,6 @@ module PublishingApi
 
     def schema_name
       "organisation"
-    end
-
-    def rendering_app
-      if court_or_tribunal?
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
-      else
-        Whitehall::RenderingApp::COLLECTIONS_FRONTEND
-      end
     end
 
     def additional_routes

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -239,14 +239,14 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal("<div class=\"govspeak\"><p>Habeus loudius noisus</p>\n</div>", presented_item.content[:details][:body])
   end
 
-  test 'renders courts and tribunals using Whitehall' do
+  test 'renders courts and tribunals using Collections' do
     organisation = create(
       :court,
       name: 'Court at mid-wicket'
     )
     presented_item = present(organisation)
 
-    assert_equal("whitehall-frontend", presented_item.content[:rendering_app])
+    assert_equal("collections", presented_item.content[:rendering_app])
     assert_equal([{ path: "/courts-tribunals/court-at-mid-wicket", type: "exact" }], presented_item.content[:routes])
   end
 


### PR DESCRIPTION
Those pages are ready and waiting for traffic in the collections app as can be seen in http://govuk-collections.herokuapp.com/courts-tribunals/employment-tribunal (for example)

(Old version is at https://www.gov.uk/courts-tribunals/employment-tribunal and is rendered by whitehall-frontend)

https://trello.com/c/QefFo34M/108-courts-and-tribunals-still-being-rendered-by-whitehall