### PR TITLE
Rake task to republish an organisation

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -91,6 +91,12 @@ namespace :publishing_api do
     puts "Finished sending links for all organisations to Publishing API"
   end
 
+  desc "Republish an organisation to the Publishing API"
+  task :republish_organisation, [:slug] => :environment do |_, args|
+    organisation = Organisation.find_by!(slug: args[:slug])
+    organisation.publish_to_publishing_api
+  end
+
   desc "Send withdrawn item links to Publishing API."
   task patch_withdrawn_item_links: :environment do
     editions = Edition.withdrawn


### PR DESCRIPTION
Zendesk ticket 3719552 had an issue with an organisations ordering of contacts, this rake task
solves publishing issues for organisations.