### PR TITLE
Update org page public timestamp automatically

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -31,7 +31,6 @@ module PublishingApi
         description: text_summary,
         details: details,
         document_type: item.class.name.underscore,
-        public_updated_at: item.updated_at,
         rendering_app: rendering_app,
         schema_name: schema_name,
       )

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -46,7 +46,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       locale: 'en',
       publishing_app: 'whitehall',
       rendering_app: 'collections',
-      public_updated_at: organisation.updated_at,
       routes: [
         { path: public_path, type: "exact" },
         { path: public_atom_path, type: "exact" }


### PR DESCRIPTION
If we omit the public timestamp from the payload, then publishing-api will generate one for us.  If we include it in the payload, then it should be more accurate than this.  For example, the timestamp on https://www.gov.uk/government/organisations/ministry-of-defence is `2018-01-09T10:07:59.000+00:00` which is just plain wrong (and at least one ministerial change ago).

At present lots of things can change on an org page before the public timestamp changes.  Before this change we were only updating the public timestamp if a property of the organisation model had been updated.

Organisation pages include ministers, featured content, featured links, other important members (such as high ranking civil servants or military staff).  We really want the page to update when these things change, particularly because it prompts external search engines to crawl them again.  (Bing still seems to think that Gavin Williamson is Secretary of State for Defence)

Organisation pages always do `major` updates on save, so it seems sensible to update the public timestamp at the same time, whatever is edited.