### PR TITLE
Permit malformed array params when redirecting

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -51,16 +51,17 @@ private
   end
 
   def news_and_communications_query_string
+    allowed_params = cleaned_document_filter_params
     {
-      keywords: params['keywords'],
-      level_one_taxon: params['taxons'].try(:first),
-      level_two_taxon: params['subtaxons'].try(:first),
-      people: params['people'],
-      organisations: params['departments'],
-      world_locations: params['world_locations'],
+      keywords: allowed_params['keywords'],
+      level_one_taxon: allowed_params['taxons'].try(:first),
+      level_two_taxon: allowed_params['subtaxons'].try(:first),
+      people: allowed_params['people'],
+      organisations: allowed_params['departments'],
+      world_locations: allowed_params['world_locations'],
       public_timestamp: {
-        from: params['from_date'],
-        to: params['to_date']
+        from: allowed_params['from_date'],
+        to: allowed_params['to_date']
       }.compact.presence,
     }.compact.to_query
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -57,18 +57,19 @@ private
   end
 
   def publications_query_string
-    level_one_taxon = params['taxons'].try(:first) || params['topics'].try(:first)
-    level_two_taxon = params['subtaxons'].try(:first)
+    allowed_params = cleaned_document_filter_params
+    level_one_taxon = allowed_params['taxons'].try(:first) || allowed_params['topics'].try(:first)
+    level_two_taxon = allowed_params['subtaxons'].try(:first)
     level_one_taxon = nil if level_one_taxon == 'all'
     level_two_taxon = nil if level_two_taxon == 'all'
     {
       keywords: params['keywords'],
       level_one_taxon: level_one_taxon,
       level_two_taxon: level_two_taxon,
-      organisations: filter_query_array(params['departments'] || params['organisations']),
-      people: filter_query_array(params['people']),
-      world_locations: filter_query_array(params['world_locations']),
-      public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence
+      organisations: filter_query_array(allowed_params['departments'] || allowed_params['organisations']),
+      people: filter_query_array(allowed_params['people']),
+      world_locations: filter_query_array(allowed_params['world_locations']),
+      public_timestamp: { from: allowed_params['from_date'], to: allowed_params['to_date'] }.compact.presence
     }.compact.merge(special_params).to_query
   end
 

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -68,7 +68,10 @@ class AnnouncementsControllerTest < ActionController::TestCase
         taxons: %w[one],
         subtaxons: %w[two],
         people: %w[one two],
-        departments: %w[one two],
+        departments: {
+          '0' => 'one',
+          '1' => 'two',
+        },
         world_locations: %w[one two],
         from_date: '01/01/2014',
         to_date: '01/01/2014'

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -25,7 +25,10 @@ class PublicationsControllerTest < ActionController::TestCase
       keywords: "one two",
       taxons: %w[one],
       subtaxons: %w[two],
-      departments: %w[one two],
+      departments: {
+        '0': 'one',
+        '1': 'two',
+      },
       world_locations: %w[one two],
       from_date: '01/01/2014',
       to_date: '01/01/2014'


### PR DESCRIPTION
When redirecting old finders publications/announcements
to the new finders served by finder-frontend, we don't
support malformed arrays in the query string. This fixes
that by fixing the malformed arrays before we redirect.

Example

?departments%5B0%5D=department-for-education
is parsed by rails as
{departments=>{0=>department-for-education}}
but really it should be
{departments=>[department-for-education]}

This uses the existing Whitehall::DocumentFilter::CleanedParams
class (which contains the method clean_malformed_array_params)
to fix this in a consistent manner.

Trello: https://trello.com/c/eTCe4Vun/825.