### PR TITLE
Audit trail tidy up

### DIFF
--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -3,6 +3,6 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
 
   def index
     @edition = Edition.find(params[:id])
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail.reverse).page(params[:page]).per(30)
+    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
   end
 end

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -30,7 +30,7 @@ private
 
   def load_translated_models
     @edition_remarks = @edition.document_remarks_trail.reverse
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail.reverse).page(params[:page]).per(30)
+    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
     @translated_edition = LocalisedModel.new(@edition, translation_locale.code)
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -164,7 +164,7 @@ private
 
   def fetch_version_and_remark_trails
     @edition_remarks = @edition.document_remarks_trail.reverse
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail.reverse).page(params[:page]).per(30)
+    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
   end
 
   def edition_class


### PR DESCRIPTION
Don't show supersede actions in document version trails.  These are in the wrong place in the list and are in any case a side effect of the publish action, so we're removing them from the user view.

https://trello.com/c/Wn4KFEbZ/1095-history-within-whitehall-is-out-of-order