### PR TITLE
Use organisation_logo for WorldwideOrganisation

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
@@ -13,10 +13,11 @@
         float: right;
       }
     }
-    h1 {
+    .gem-c-organisation-logo {
       margin: 0 $gutter-half;
     }
   }
+
   .headings-block {
     float: left;
     width: $one-third;

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -6,17 +6,19 @@
 <header class="block worldwide-organisation-header">
   <div class="inner-block floated-children">
     <div class="logo">
-      <h1>
-        <% if link_to_organisation %>
-          <%= link_to content_tag(:span, organisation_logo_name(organisation)), organisation, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
-        <% else %>
-          <%= content_tag :span, content_tag(:span, organisation_logo_name(organisation)), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
-        <% end %>
-      </h1>
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: {
+          name: organisation_logo_name(organisation),
+          url: link_to_organisation ? worldwide_organisation_path(organisation) : nil,
+          crest: "single-identity",
+        }
+      } %>
     </div>
+
     <div class="headings-block">
-      <%= render partial: 'shared/available_languages', locals: {object: object_for_translation } %>
+      <%= render partial: 'shared/available_languages', locals: { object: object_for_translation } %>
     </div>
+
     <div class="metadata">
       <dl>
         <% if world_locations.any? %>


### PR DESCRIPTION
This comes from govuk_publishing_components so it will look consistent with the rest of the site. I've had to slightly modify the CSS for it to appear correctly on the page.

Using this component does reduce the text size of the component, but I think it's better to follow the design guide and stick with the size specified by this component since it matches [organisation pages](https://www.gov.uk/government/organisations/department-for-international-trade).

This will also make it easier to change the crest in the future.

### Before
<img width="1026" alt="Screen Shot 2019-06-28 at 10 36 29" src="https://user-images.githubusercontent.com/510498/60333347-a8edae00-9990-11e9-8074-d5bfad3108fa.png">

### After
<img width="1017" alt="Screen Shot 2019-06-28 at 10 36 24" src="https://user-images.githubusercontent.com/510498/60333346-a8edae00-9990-11e9-83e5-8a2dfa89a8dd.png">

[Trello Card](https://trello.com/c/Gg8p7dGs/1090-update-the-logo-on-dits-worldwide-org-pages)