### PR TITLE
Make Rails initialiser idempotent

### DIFF
--- a/config/initializers/bulk_upload_zip_file.rb
+++ b/config/initializers/bulk_upload_zip_file.rb
@@ -4,4 +4,8 @@ BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY = if Rails.env.test?
                                                Rails.root.join('bulk-upload-zip-file-tmp')
                                              end
 
-FileUtils.mkdir_p(BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY)
+begin
+  FileUtils.mkdir_p(BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY)
+rescue Errno::EEXIST
+  puts "#{BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY} exists"
+end


### PR DESCRIPTION
`mkdir_p` will crash if the directory already exists, which happens in Docker. This adds a check first.

https://trello.com/c/jRbKkgHd