### PR TITLE
Fix topical events "see all" URLs

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -56,9 +56,10 @@ private
       keywords: allowed_params['keywords'],
       level_one_taxon: allowed_params['taxons'].try(:first),
       level_two_taxon: allowed_params['subtaxons'].try(:first),
-      people: allowed_params['people'],
-      organisations: allowed_params['departments'],
-      world_locations: allowed_params['world_locations'],
+      people: filter_query_array(allowed_params['people']),
+      organisations: filter_query_array(allowed_params['departments']),
+      topical_events: filter_query_array(allowed_params['topical_events']),
+      world_locations: filter_query_array(allowed_params['world_locations']),
       public_timestamp: {
         from: allowed_params['from_date'],
         to: allowed_params['to_date']

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -105,4 +105,10 @@ private
 
     set_slimmer_world_locations_header(@document.world_locations) if @document.can_be_associated_with_world_locations?
   end
+
+  def filter_query_array(arr)
+    if arr.respond_to? 'reject'
+      arr.reject { |v| v == 'all' }.compact.presence
+    end
+  end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -71,14 +71,9 @@ private
       organisations: filter_query_array(allowed_params['departments'] || allowed_params['organisations']),
       people: filter_query_array(allowed_params['people']),
       world_locations: filter_query_array(allowed_params['world_locations']),
+      topical_events: filter_query_array(allowed_params['topical_events']),
       public_timestamp: { from: allowed_params['from_date'], to: allowed_params['to_date'] }.compact.presence
     }.compact.merge(special_params).to_query
-  end
-
-  def filter_query_array(arr)
-    if arr.respond_to? 'reject'
-      arr.reject { |v| v == 'all' }.compact.presence
-    end
   end
 
   def publication_finder_type

--- a/app/helpers/filter_routes_helper.rb
+++ b/app/helpers/filter_routes_helper.rb
@@ -32,7 +32,7 @@ protected
       elsif obj.is_a? Topic
         out[:topics] = [obj.slug]
       elsif obj.is_a? TopicalEvent
-        out[:topics] = [obj.slug]
+        out[:topical_events] = [obj.slug]
       elsif obj.is_a? WorldLocation
         out[:world_locations] = [obj.slug]
       else

--- a/lib/whitehall/document_filter/cleaned_params.rb
+++ b/lib/whitehall/document_filter/cleaned_params.rb
@@ -1,7 +1,7 @@
 module Whitehall::DocumentFilter
   class CleanedParams < ActiveSupport::HashWithIndifferentAccess
     # These filter parameters are expected to be an array of values
-    PERMITTED_ARRAY_PARAMETER_KEYS  = %w(taxons subtaxons topics departments people world_locations).freeze
+    PERMITTED_ARRAY_PARAMETER_KEYS  = %w(taxons subtaxons topical_events topics departments people world_locations).freeze
     # These filter params are expected to be scalar values, as defined by the strong_parameters code
     PERMITTED_SCALAR_PARAMETER_KEYS = %w(page
                                          per_page

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -42,7 +42,8 @@ class AnnouncementsControllerTest < ActionController::TestCase
         departments: %w[one two],
         world_locations: %w[one two],
         from_date: '01/01/2014',
-        to_date: '01/01/2014'
+        to_date: '01/01/2014',
+        topical_events: %w[one two]
       }
 
       redirect_params_query = {
@@ -52,7 +53,8 @@ class AnnouncementsControllerTest < ActionController::TestCase
         people: %w[one two],
         organisations: %w[one two],
         world_locations: %w[one two],
-        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+        public_timestamp: { from: '01/01/2014', to: '01/01/2014' },
+        topical_events: %w[one two]
       }.to_query
 
       assert_redirected_to "#{Plek.new.website_root}/search/news-and-communications?#{redirect_params_query}"

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -31,7 +31,8 @@ class PublicationsControllerTest < ActionController::TestCase
       },
       world_locations: %w[one two],
       from_date: '01/01/2014',
-      to_date: '01/01/2014'
+      to_date: '01/01/2014',
+      topical_events: %w[one two]
     }
     @default_converted_params = {
       keywords: "one two",
@@ -39,7 +40,8 @@ class PublicationsControllerTest < ActionController::TestCase
       level_two_taxon: 'two',
       organisations: %w[one two],
       world_locations: %w[one two],
-      public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+      public_timestamp: { from: '01/01/2014', to: '01/01/2014' },
+      topical_events: %w[one two],
     }
   end
 


### PR DESCRIPTION
Affects pages like: https://www.gov.uk/government/topical-events/safeguarding-summit-2018

Partly answers https://govuk.zendesk.com/agent/tickets/3732860

At present this is redirected to new finders (e.g. /search/all), but with a "topic" URL that new search doesn't understand.  I'll need to dig into the Topic functionality separately.

We need to add topical events to the list of things that the whitehall search redirects will handle.

We'll address this more fully with planned work (by adding a facet etc.), but this resolves the broken link issue for now.