### PR TITLE
Add migration to redirect atom feed

### DIFF
--- a/db/data_migration/20190709094308_redirect_department_health_atom.rb
+++ b/db/data_migration/20190709094308_redirect_department_health_atom.rb
@@ -1,0 +1,15 @@
+base_path = "/government/organisations/department-of-health"
+destination = "/government/organisations/department-of-health-and-social-care"
+redirects = [
+    { path: "#{base_path}.atom", type: "exact", destination: "#{destination}.atom" },
+    { path: base_path, type: "exact", destination: destination }
+]
+redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects)
+content_id = "b721cee0-b24c-42c0-a8c4-fa215af727eb"
+
+puts "Redirecting: #{base_path} to #{destination} with content_id: #{content_id}"
+
+Services.publishing_api.put_content(content_id, redirect.as_json)
+
+puts "Publishing content_id: #{content_id} with redirect #{redirect.as_json}"
+Services.publishing_api.publish(content_id, nil, locale: "en")


### PR DESCRIPTION
**What**
Redirect /government/organisations/department-of-health.atom 
to /government/organisations/department-of-health-and-social-care.atom

**Why**
Where Depts change their name (and are reslugged) their atom feeds give 404 errors. 

In the last 6 months, 84% of these 404s are for Department of Health. We should redirect that one to solve the biggest problem for users 

[trello](https://trello.com/c/47XrS1mp/1102-redirect-dept-of-health-update-feed)