### PR TITLE
Add welsh translation for "accessible documents policy"

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -496,7 +496,7 @@ cy:
         about: Amdanom ni
         about_our_services: Gwybodaeth am ein gwasanaethau
         access_and_opening: Mynediad i'n swyddfeydd ac amseroedd agor
-        accessible_documents_policy:
+        accessible_documents_policy: Polisi Dogfennau Hygyrch
         complaints_procedure: Trefn gwyno
         equality_and_diversity: Cydraddoldeb ac amrywiaeth
         media_enquiries: Ymholiadau'r cyfryngau


### PR DESCRIPTION
**What**
Add Welsh translation of ""Accessible documents policy" title to Whitehall and Gov-Frontend

It is "Polisi Dogfennau Hygyrch"

**Why**
We recently added a new type of corporate information page to Whitehall called "Accessible documents policy".

This needs translating into Welsh in the locale yml file in Whitehall so that it shows up properly translated when viewed. It may also need adding in government front end

[trello](https://trello.com/c/OMaEDsdv/639-add-welsh-translation-for-accessible-documents-policy)