### PR TITLE
Reslug preventing-sexual-violence-initiative

### DIFF
--- a/db/data_migration/20190710170722_reslug_preventing_sexual_violence_initiative.rb
+++ b/db/data_migration/20190710170722_reslug_preventing_sexual_violence_initiative.rb
@@ -1,0 +1,5 @@
+require 'data_hygiene/organisation_reslugger'
+
+organisation = Organisation.find_by(slug: "preventing-sexual-violence-initiative")
+
+DataHygiene::OrganisationReslugger.new(organisation, "preventing-sexual-violence-in-conflict-initiative").run!


### PR DESCRIPTION
to reflect the name change to Preventing Sexual Violence in Conflict Initiative

see Zendesk: https://govuk.zendesk.com/agent/tickets/3740145