### PR TITLE
Add endpoint to export documents information

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -5,4 +5,38 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     @document = Document.find(params[:id])
     respond_with DocumentExportPresenter.new(@document)
   end
+
+  def index
+    result_set = Whitehall::Exporters::DocumentsInfoExporter.new(paginated_document_ids).call
+
+    respond_with(
+      documents: result_set,
+      page_number: page_number,
+      page_count: result_set.count
+    )
+  end
+
+  private
+
+  def paginated_document_ids
+    Edition
+      .joins("INNER JOIN edition_organisations eo ON eo.edition_id = editions.id")
+      .joins("INNER JOIN organisations o ON o.id = eo.organisation_id")
+      .where(o: { content_id: params.require(:lead_organisation) })
+      .where(eo: { lead: true })
+      .where(type: params.require(:type))
+      .latest_edition
+      .order(:document_id)
+      .page(page_number)
+      .per(items_per_page)
+      .pluck(:document_id)
+  end
+
+  def page_number
+    params.fetch(:page_number, 1)
+  end
+
+  def items_per_page
+    params.fetch(:page_count, 100)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,7 +184,7 @@ Whitehall::Application.routes.draw do
         root to: 'dashboard#index', via: :get
 
         namespace 'export' do
-          resources :document, only: [:show], defaults: { format: :json }
+          resources :document, only: %i[show index], defaults: { format: :json }
         end
 
         get 'find-in-admin-bookmarklet' => 'find_in_admin_bookmarklet#index', as: :find_in_admin_bookmarklet_instructions_index

--- a/lib/whitehall/exporters/documents_info_exporter.rb
+++ b/lib/whitehall/exporters/documents_info_exporter.rb
@@ -1,0 +1,64 @@
+class Whitehall::Exporters::DocumentsInfoExporter
+  attr_reader :document_ids
+
+  def initialize(document_ids)
+    @document_ids = document_ids
+  end
+
+  def call
+    document_ids.map do |doc_id|
+      {
+        document_id: doc_id,
+        document_information: {
+          locales: locales_hash[doc_id],
+          subtypes: subtypes_hash[doc_id],
+          lead_organisations: lead_orgs_for_latest_edition_hash[doc_id]
+        }
+      }
+    end
+  end
+
+  private
+
+  def locales_hash
+    @locales_hash ||= Edition
+      .joins(:translations)
+      .where(document_id: document_ids)
+      .group(:document_id)
+      .pluck(:document_id, "GROUP_CONCAT(DISTINCT(edition_translations.locale))")
+      .each_with_object({}) { |(k, v), memo| memo[k] = v.split(",") }
+  end
+
+  def subtypes_hash
+    @subtypes_hash ||= subtypes_query.each_with_object({}) do |(document_id, news, speeches, publications, corporate), memo|
+      news_article_types = news.to_s.split(",").map { |id| NewsArticleType.find_by_id(id.to_i)&.key }
+      speech_types = speeches.to_s.split(",").map { |id| SpeechType.find_by_id(id.to_i)&.key }
+      publications_types = publications.to_s.split(",").map { |id| PublicationType.find_by_id(id.to_i)&.key }
+      corporate_types = corporate.to_s.split(",").map { |id| CorporateInformationPageType.find_by_id(id.to_i)&.key }
+      memo[document_id] = [news_article_types, speech_types, publications_types, corporate_types].flatten
+    end
+  end
+
+  def lead_orgs_for_latest_edition_hash
+    @lead_orgs_for_latest_edition_hash ||= Edition
+      .joins("INNER JOIN edition_organisations eo ON eo.edition_id = editions.id")
+      .joins("INNER JOIN organisations o ON o.id = eo.organisation_id")
+      .latest_edition
+      .where(document_id: document_ids)
+      .where(eo: { lead: true })
+      .group(:document_id)
+      .pluck(:document_id, "GROUP_CONCAT(DISTINCT(o.content_id))")
+      .each_with_object({}) { |(k, v), memo| memo[k] = v.split(",") }
+  end
+
+  def subtypes_query
+    Edition
+      .where(document_id: document_ids)
+      .group(:document_id)
+      .pluck(:document_id,
+             "GROUP_CONCAT(DISTINCT(editions.news_article_type_id))",
+             "GROUP_CONCAT(DISTINCT(editions.speech_type_id))",
+             "GROUP_CONCAT(DISTINCT(editions.publication_type_id))",
+             "GROUP_CONCAT(DISTINCT(editions.corporate_information_page_type_id))")
+  end
+end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -15,4 +15,72 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     get :show, params: { id: '1' }, format: 'json'
     assert_response :forbidden
   end
+
+  test "index responds with document information for a lead org and type" do
+    org = create(:organisation)
+    news_story = create(
+      :news_article,
+      organisations: [org],
+      news_article_type: NewsArticleType::NewsStory,
+    )
+
+    login_as :export_data_user
+
+    get :index, params: { lead_organisation: org.content_id,
+                          type: 'NewsArticle' }, format: 'json'
+
+    expected_response =
+      {
+        "documents" => [{
+          "document_id" => news_story.document_id,
+          "document_information" => {
+            "locales" => %w[en],
+            "subtypes" => %w[news_story],
+            "lead_organisations" => [org.content_id]
+          }
+        }],
+        "page_number" => 1,
+        "page_count" => 1,
+        "_response_info" => { "status" => "ok" }
+    }
+
+    assert_equal expected_response, json_response
+  end
+
+
+  test "doesnt return the document where the latest edition is not associated with lead org" do
+    published_edition_org = create(:organisation)
+    draft_edition_org = create(:organisation)
+    document = create(:document)
+    create(
+      :news_article,
+      :published,
+      document: document,
+      organisations: [published_edition_org],
+      news_article_type: NewsArticleType::NewsStory,
+    )
+
+    create(
+      :news_article,
+      :draft,
+      document: document,
+      organisations: [draft_edition_org],
+      news_article_type: NewsArticleType::NewsStory,
+    )
+
+    login_as :export_data_user
+
+    get :index, params: { lead_organisation: published_edition_org.content_id,
+                          type: 'NewsArticle' }, format: 'json'
+
+    expected_response =
+      {
+        "documents" => [],
+        "page_number" => 1,
+        "page_count" => 0,
+        "_response_info" => { "status" => "ok" }
+    }
+
+    assert_equal expected_response, json_response
+  end
 end

--- a/test/unit/whitehall/exporters/documents_info_exporter_test.rb
+++ b/test/unit/whitehall/exporters/documents_info_exporter_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+module Whitehall::Exporters
+  class DocumentsInfoExporterTest < ActiveSupport::TestCase
+    test 'returns all subtype information of a document' do
+      org = create(:organisation)
+      document = create(:document)
+      create(
+        :news_article,
+        :superseded,
+        organisations: [org],
+        document: document,
+        news_article_type: NewsArticleType::NewsStory,
+      )
+      create(
+        :news_article,
+        :published,
+        organisations: [org],
+        document: document,
+        news_article_type: NewsArticleType::PressRelease,
+      )
+
+      documents_info_exporter = DocumentsInfoExporter.new(
+        [document.id]
+      )
+
+      assert_equal(
+        %w[news_story press_release],
+        documents_info_exporter.call.first[:document_information][:subtypes]
+      )
+    end
+
+
+    test 'returns all the locales of a document' do
+      org = create(:organisation)
+      news_story = create(
+        :news_article,
+        :published,
+        :translated, primary_locale: 'en', translated_into: %w(ms ar cy),
+        organisations: [org],
+        news_article_type: NewsArticleType::NewsStory,
+      )
+
+      documents_info_exporter = DocumentsInfoExporter.new(
+        [news_story.document_id]
+      )
+
+      assert_same_elements(
+        %w[ar cy en ms],
+        documents_info_exporter.call.first[:document_information][:locales]
+      )
+    end
+
+    test 'returns the lead organisations of the latest edition of a document' do
+      published_edition_org = create(:organisation)
+      published_edition_org_2 = create(:organisation)
+      superseded_edition_org = create(:organisation)
+      document = create(:document)
+      create(
+        :news_article,
+        :superseded,
+        document: document,
+        organisations: [superseded_edition_org],
+        news_article_type: NewsArticleType::NewsStory,
+      )
+
+      create(
+        :news_article,
+        :published,
+        document: document,
+        organisations: [published_edition_org, published_edition_org_2],
+        news_article_type: NewsArticleType::NewsStory,
+      )
+
+      documents_info_exporter = DocumentsInfoExporter.new(
+        [document.id]
+      )
+
+      assert_same_elements(
+        [published_edition_org.content_id, published_edition_org_2.content_id],
+        documents_info_exporter.call.first[:document_information][:lead_organisations]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This endpoint takes two arguments, `lead_organisation` and
`type` as well as pagination options like `items_per_page` and `page_number`.

`lead_organisation` is needed to find all the documents where
the `lead_organisation` is present on the latest edition of each
document. `type` is used to specify the whitehall edition type of the documents
you want returning, e.g NewsArticle or Publication.

The endpoint returns the following information for every document:
  - the document_id
  - all the locales the document has had
  - all the subtypes the document has had (news_article_type, speech_type, publication_type, corporate_information_page_type)
  - all the lead_organisations of the most recent edition

Trello:
https://trello.com/c/Tmq0PbYg/1037-create-an-endpoint-for-getting-a-list-of-documents-from-a-publisher