### PR TITLE
Add locked attribute to Document

### DIFF
--- a/db/migrate/20190711112443_add_locked_flag_to_document.rb
+++ b/db/migrate/20190711112443_add_locked_flag_to_document.rb
@@ -1,0 +1,5 @@
+class AddLockedFlagToDocument < ActiveRecord::Migration[5.1]
+  def change
+    add_column :documents, :locked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190426132424) do
+ActiveRecord::Schema.define(version: 20190711112443) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 20190426132424) do
     t.string "slug"
     t.string "document_type"
     t.string "content_id", null: false
+    t.boolean "locked", default: false, null: false
     t.index ["document_type"], name: "index_documents_on_document_type"
     t.index ["slug", "document_type"], name: "index_documents_on_slug_and_document_type", unique: true
   end


### PR DESCRIPTION
For https://trello.com/c/FAiIY6Eu/1016-add-flag-to-indicate-a-document-is-going-to-be-migrated-from-whitehall

This is in preparation for locking a document for editing before importing it
into Content Publisher.