### PR TITLE
Tags social media links as written in english

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -10,7 +10,7 @@
       <li><a href="/news-and-communications">News and communications</a></li>
     </ul>
   </nav>
-  <main id="content" role="main" class="whitehall-content"<%= " lang=#{locale.to_s}" unless locale == :en %>>
+  <main id="content" role="main" class="whitehall-content"<%= " lang=#{I18n.locale.to_s}" unless I18n.locale == :en %>>
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>
       <%= render_mustache_templates if Rails.env.development? %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -10,7 +10,7 @@
       <li><a href="/news-and-communications">News and communications</a></li>
     </ul>
   </nav>
-  <main id="content" role="main" class="whitehall-content">
+  <main id="content" role="main" class="whitehall-content"<%= " lang=#{locale.to_s}" unless locale == :en %>>
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>
       <%= render_mustache_templates if Rails.env.development? %>

--- a/app/views/shared/_social_media_accounts.html.erb
+++ b/app/views/shared/_social_media_accounts.html.erb
@@ -1,14 +1,14 @@
 <% followus ||= false %>
 <% if socialable.social_media_accounts.any? %>
-  <section>
+  <section lang="en">
     <% unless followus %>
-      <h2 class="label"><%= t('social_media.follow_us') %></h2>
+      <h2 class="label">Follow on social media</h2>
     <% end %>
     <ul class="social-media-accounts js-hide-extra-social-media">
       <% socialable.social_media_accounts.each do |account| %>
         <%= content_tag_for(:li, account) do %>
           <%= link_to account.url,
-                      class: "social-media-link #{account.service_name.parameterize}", lang: 'en' do %>
+                      class: "social-media-link #{account.service_name.parameterize}" do %>
             <span class="connect"></span><%= account.display_name %>
           <% end %>
         <% end %>

--- a/app/views/shared/_social_media_accounts.html.erb
+++ b/app/views/shared/_social_media_accounts.html.erb
@@ -8,8 +8,8 @@
       <% socialable.social_media_accounts.each do |account| %>
         <%= content_tag_for(:li, account) do %>
           <%= link_to account.url,
-                      class: "social-media-link #{account.service_name.parameterize}" do %>
-            <span class="connect">Connect with <%= account.socialable.display_name %> on</span> <%= account.display_name %>
+                      class: "social-media-link #{account.service_name.parameterize}", lang: 'en' do %>
+            <span class="connect"></span><%= account.display_name %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Why?
Pages that have been translated appear to be both in the translated language _and_ in english. This causes issues with screenreaders as they try and read one language with the 'voice' of another language. This should help fix that by making sure that social media links, such as the ones on the page for the [British Embassy in Seoul](https://www.gov.uk/world/organisations/british-embassy-seoul.ko), are marked as being written in english.

## What
 - Social media links were not being translated into languages other than English, despite being on a translated page. This change tags the links as being written in English.
 - Whitehall will now tag the `main` element with the locale language, unless the language is English which is already set on the `html` element.
