### PR TITLE
Republish political content with less urgency

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -23,7 +23,8 @@ namespace :election do
       print "."
       PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
         "bulk_republishing",
-        document_id
+        document_id,
+        bulk_publishing: true
       )
     end
   end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -37,16 +37,17 @@ module Whitehall
       end
     end
 
-    def self.save_draft(model_instance, update_type_override = nil)
+    def self.save_draft(model_instance, update_type_override = nil, bulk_publishing = false)
       locales_for(model_instance).each do |locale|
-        save_draft_translation(model_instance, locale, update_type_override)
+        save_draft_translation(model_instance, locale, update_type_override, bulk_publishing)
       end
     end
 
     def self.save_draft_translation(
       model_instance,
       locale,
-      update_type_override = nil
+      update_type_override = nil,
+      bulk_publishing = false
     )
       presenter = PublishingApiPresenters.presenter_for(
         model_instance,
@@ -54,10 +55,11 @@ module Whitehall
       )
 
       I18n.with_locale(locale) do
-        Services.publishing_api.put_content(
-          presenter.content_id,
-          presenter.content
-        )
+        content = presenter.content
+
+        content.merge!(bulk_publishing: true) if bulk_publishing
+
+        Services.publishing_api.put_content(presenter.content_id, content)
       end
     end
 

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -201,7 +201,7 @@ module ServiceListeners
 
       Whitehall::PublishingApi
         .expects(:save_draft_translation)
-        .with(edition, :en, nil)
+        .with(edition, :en, nil, false)
 
       PublishingApiPusher.new(edition).push(event: 'update_draft')
     end
@@ -211,7 +211,7 @@ module ServiceListeners
 
       Whitehall::PublishingApi
         .expects(:save_draft_translation)
-        .with(edition, :en, nil)
+        .with(edition, :en, nil, false)
 
       PublishingApiPusher.new(edition).push(event: 'update_draft')
     end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -14,7 +14,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     Document.stubs(:find).returns(document)
 
     PublishingApiWorker.expects(:new).returns(api_worker = mock)
-    api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en")
+    api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en", false)
 
     Whitehall::PublishingApi
       .expects(:save_draft)
@@ -100,7 +100,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
     Document.stubs(:find).returns(document)
     PublishingApiWorker.expects(:new).returns(api_worker = mock)
-    api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en")
+    api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en", false)
 
     PublishingApiUnpublishingWorker.expects(:new).returns(unpublishing_worker = mock)
     unpublishing_worker.expects(:perform).with(published_edition.unpublishing.id, false)

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -18,7 +18,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
     Whitehall::PublishingApi
       .expects(:save_draft)
-      .with(draft_edition, "republish")
+      .with(draft_edition, "republish", false)
 
     invocation_order = sequence('invocation_order')
     PublishingApiHtmlAttachmentsWorker


### PR DESCRIPTION
This means it'll be processed through the low priority Publishing API
queue, and won't block higher priority publishing.