### PR TITLE
Configure GDS::SSO with caching for bearer token requests

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -3,4 +3,5 @@ GDS::SSO.config do |config|
   config.oauth_id     = ENV['OAUTH_ID'] || "abcdefghjasndjkasndwhitehall"
   config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.new.external_url_for("signon")
+  config.cache = Rails.cache
 end


### PR DESCRIPTION
This'll reduce the number of requests that Whitehall makes to Signon
for API user information. I think this is particularly relevant when
Search API makes requests to Whitehall.