### PR TITLE
Add API endpoint to export JSON representation of a document

### DIFF
--- a/app/controllers/admin/export/base_controller.rb
+++ b/app/controllers/admin/export/base_controller.rb
@@ -1,0 +1,14 @@
+class Admin::Export::BaseController < Admin::BaseController
+  before_action :require_export_data_permission!
+  respond_to :json
+
+private
+
+  def require_export_data_permission!
+    forbidden! unless current_user.can_export_data?
+  end
+
+  def forbidden!
+    respond_with Hash.new, status: :forbidden
+  end
+end

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -1,0 +1,31 @@
+class Admin::Export::DocumentController < Admin::BaseController
+  respond_to :json
+
+  self.responder = Api::Responder
+
+  def show
+    @document = Document.find(params[:id])
+    output = {
+               "document": @document,
+               "editions": []
+             }
+    @document.editions.each do |edition|
+      output[:editions].push(edition_associations(edition))
+    end
+    respond_with output
+  end
+
+private
+
+  def edition_associations(edition)
+    output = {
+               "edition": edition
+             }
+    output[:associations] = {}
+    associations = edition.class.reflect_on_all_associations.map(&:name)
+    associations.each do |association|
+      output[:associations][association] = edition.public_send(association)
+    end
+    output
+  end
+end

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -1,6 +1,4 @@
-class Admin::Export::DocumentController < Admin::BaseController
-  respond_to :json
-
+class Admin::Export::DocumentController < Admin::Export::BaseController
   self.responder = Api::Responder
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
     WORLD_EDITOR = 'World Editor'.freeze
     FORCE_PUBLISH_ANYTHING = 'Force publish anything'.freeze
     GDS_ADMIN = 'GDS Admin'.freeze
+    EXPORT_DATA = 'Export data'.freeze
   end
 
   def role
@@ -60,6 +61,10 @@ class User < ApplicationRecord
 
   def gds_admin?
     has_permission?(Permissions::GDS_ADMIN)
+  end
+
+  def can_export_data?
+    has_permission?(Permissions::EXPORT_DATA)
   end
 
   def scheduled_publishing_robot?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,10 @@ Whitehall::Application.routes.draw do
       namespace :admin do
         root to: 'dashboard#index', via: :get
 
+        namespace 'export' do
+          resources :document, only: [:show], defaults: { format: :json }
+        end
+
         get 'find-in-admin-bookmarklet' => 'find_in_admin_bookmarklet#index', as: :find_in_admin_bookmarklet_instructions_index
         get 'find-in-admin-bookmarklet/:browser' => 'find_in_admin_bookmarklet#show', as: :find_in_admin_bookmarklet_instructions
         get 'by-content-id/:content_id' => 'documents#by_content_id'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ else
   gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   User.create!(
     name: "Test user",
-    permissions: ["signin", "GDS Admin", "GDS Editor", "Managing Editor"],
+    permissions: ["signin", "GDS Admin", "GDS Editor", "Managing Editor", "Export data"],
     organisation_content_id: gds_organisation_id,
     organisation_slug: "test-organisation"
   )

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -62,6 +62,10 @@ FactoryBot.define do
     permissions { [User::Permissions::SIGNIN, User::Permissions::WORLD_WRITER] }
   end
 
+  factory :export_data_user, parent: :user do
+    permissions { [User::Permissions::SIGNIN, User::Permissions::EXPORT_DATA] }
+  end
+
   factory :gds_team_user, parent: :user do
     name { "GDS Inside Government Team" }
     email { 'govuk-whitehall@digital.cabinet-office.gov.uk' }

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Admin::Export::DocumentControllerTest < ActionController::TestCase
+  test "show responds with JSON representation of a document" do
+    document = stub_record(:document, id: 1, slug: 'some-document')
+    Document.stubs(:find).with(document.id.to_s).returns(document)
+
+    get :show, params: { id: document.id }, format: 'json'
+    assert_equal 'some-document', json_response['document']['slug']
+  end
+end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -5,7 +5,14 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     document = stub_record(:document, id: 1, slug: 'some-document')
     Document.stubs(:find).with(document.id.to_s).returns(document)
 
+    login_as :export_data_user
     get :show, params: { id: document.id }, format: 'json'
     assert_equal 'some-document', json_response['document']['slug']
+  end
+
+  test "shows forbidden if user does not have export data permission" do
+    login_as :world_editor
+    get :show, params: { id: '1' }, format: 'json'
+    assert_response :forbidden
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -80,6 +80,16 @@ class UserTest < ActiveSupport::TestCase
     refute user.world_writer?
   end
 
+  test 'should be be able to export data if has whitehall Export data role' do
+    user = build(:user, permissions: [User::Permissions::EXPORT_DATA])
+    assert user.can_export_data?
+  end
+
+  test 'should not be able to export data if does not have whitehall Export data role' do
+    user = build(:user, permissions: [])
+    refute user.can_export_data?
+  end
+
   test 'returns enabled users' do
     create(:disabled_user)
     user = create(:user)


### PR DESCRIPTION
Creates a new API endpoint (`/government/admin/export/document/:id`) which permits all data about a document to be     exported from Whitehall and will be used during the migration to Content Publisher.

We grab all associations for each edition of the document and get all fields for each of these, resulting in a JSON blob giving the entire history of a document and all it's associated data.

Additionally, this endpoint is access protected through the `Export data` permission in Signon.  Any controllers for further endpoints which require the same access restriction can inherit from `Admin::Export::BaseController`.

An example of the output (with editor personal information redacted) is attached to the Trello card.  This example comes from the Whitehall news article which has received the most edits.

Trello card: https://trello.com/c/gtyLTQ8P/985-work-out-how-to-get-data-out-of-whitehall