### PR TITLE
Revert "Remove deprecated "not" tags"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,6 @@ group :test_coverage do
 end
 
 group :cucumber, :test do
-  gem 'bourne'
   gem 'cucumber', '~> 2.4.0'
   gem 'cucumber-rails', require: false
   gem 'govuk_test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,6 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    bourne (1.6.0)
-      mocha (~> 1.1)
     builder (3.2.3)
     byebug (11.0.0)
     capybara (2.18.0)
@@ -571,7 +569,6 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap-kaminari-views (= 0.0.5)
-  bourne
   carrierwave (~> 1.3.1)
   carrierwave-i18n
   chronic

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,8 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip

--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -4,7 +4,7 @@ Given(/^a document that has gone through many changes$/) do
   assert page.has_content?('An frequently changed publication')
   @the_publication = Publication.find_by(title: 'An frequently changed publication')
   # fake it
-  states = %w[draft submitted published superseded]
+  states = %w[draft submitted published]
   50.times do |i|
     Timecop.travel i.hours.from_now do
       @the_publication.versions.create event: 'update', whodunnit: @user, state: states.sample

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -6,7 +6,14 @@ end
 
 Given(/^a published news article "([^"]*)" associated with "([^"]*)"$/) do |title, appointee|
   appointment = find_person(appointee).current_role_appointments.last
-  create(:published_news_article, title: title, role_appointments: [appointment])
+  news_article = create(:published_news_article, title: title, role_appointments: [appointment])
+
+  stub_any_search.to_return(
+    body: {
+      results: [
+        { link: document_path(news_article), title: news_article.title },
+      ]
+    }.to_json)
 end
 
 Given(/^a published news article "([^"]*)" which isn't explicitly associated with "([^"]*)"$/) do |title, _thing|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -31,7 +31,7 @@ end
 
 Then(/^the "([^"]*)" logo should show correctly with the HMG crest$/) do |name|
   worldwide_organisation = WorldwideOrganisation.find_by(name: name)
-  assert page.has_css?(".organisation-logo-stacked-single-identity", text: worldwide_organisation.logo_formatted_name)
+  assert page.has_css?(".gem-c-organisation-logo", text: worldwide_organisation.logo_formatted_name)
 end
 
 Then(/^I should see that it is part of the "([^"]*)"$/) do |sponsoring_organisation|

--- a/features/support/admin_taxonomy_helper.rb
+++ b/features/support/admin_taxonomy_helper.rb
@@ -19,11 +19,8 @@ module AdminTaxonomyHelper
     Services.publishing_api.stubs(patch_links: { status: 200 })
   end
 
-
   def check_links_patched_in_publishing_api
-    assert_received(Services.publishing_api, :patch_links) do |expect|
-      expect.with(Publication.last.content_id, { links: { taxons: ['grandparent'] }, previous_version: "0" })
-    end
+    assert_respond_to(Services.publishing_api, :patch_links)
   end
 end
 World(AdminTaxonomyHelper)

--- a/features/support/rummageable_and_document_filter.rb
+++ b/features/support/rummageable_and_document_filter.rb
@@ -18,7 +18,7 @@ After do
 end
 
 # For everything we don't explicitly want a "real" search for, use FakeSearch
-Before("not @not-quite-as-fake-search") do
+Before("~@not-quite-as-fake-search") do
   Whitehall.search_backend = Whitehall::DocumentFilter::FakeSearch
 end
 


### PR DESCRIPTION
Reverts alphagov/whitehall#4815

This change has had the unfortunate side effect of stopping Cucumber tests from running, so we should revert it until a solution is found.