### PR TITLE
Add content_id to world locations API

### DIFF
--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -14,7 +14,8 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),
         web_url: Whitehall.url_maker.world_location_url(model, anchor: 'organisations'),
-      }
+      },
+      content_id: model.content_id
     }
   end
 

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -62,6 +62,11 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
     assert_equal 'location-display-type', @presenter.as_json[:format]
   end
 
+  test "json includes content_id" do
+    @location.stubs(:content_id).returns('world-location-content-id')
+    assert_equal 'world-location-content-id', @presenter.as_json[:content_id]
+  end
+
   test "json includes public location url as web_url" do
     assert_equal Whitehall.url_maker.world_location_url(@location), @presenter.as_json[:web_url]
   end


### PR DESCRIPTION
Finder Frontend needs to be use content_ids of world locations
to set up an email alert.

This commit adds the content-id to the hash returned from the
world locations API

See also: https://trello.com/c/JinK1IxW/868-fix-email-bug-in-new-finders