### PR TITLE
Fix contact update not republishing org

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -16,6 +16,7 @@ class Contact < ApplicationRecord
 
   after_update :republish_dependent_editions
 
+  after_update :republish_organisation_to_publishing_api
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -125,6 +125,13 @@ class ContactTest < ActiveSupport::TestCase
     end
   end
 
+  test "updating a contact republishes the organisation" do
+    test_object = create(:organisation)
+    contact = create(:contact, contactable: test_object)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    contact.update!(title: "new title")
+  end
+
   test "creating a new contact republishes the organisation" do
     test_object = create(:organisation)
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3749668

Previously the organisation content item would not update if the data
for one of its contacts changed. This ensures any update to a contact
behaves similarly to their creation and destruction by republishing the
organisation content.