### PR TITLE
Exclude locked documents from featuring

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -318,7 +318,8 @@ private
       merge(
         include_unpublishing: true,
         include_link_check_reports: true,
-        include_last_author: true
+        include_last_author: true,
+        include_locked_documents: true,
       )
   end
 

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -6,6 +6,10 @@ class Admin::FeaturesController < Admin::BaseController
   def new; end
 
   def create
+    if @feature.document.present?
+      raise "Cannot feature a locked document" if @feature.document.locked?
+    end
+
     if @feature.save
       PublishingApiDocumentRepublishingWorker.perform_async(@feature.document_id) if @feature.document_id.present?
       redirect_to admin_feature_list_path(@feature_list), notice: "The document has been saved"

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -117,7 +117,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_broken_links if only_broken_links
-      editions = editions.without_locked_documents
+      editions = editions.without_locked_documents unless include_locked_documents?
 
       editions = editions.includes(:unpublishing) if include_unpublishing?
       editions = editions.includes(:link_check_reports) if include_link_check_reports?
@@ -236,6 +236,10 @@ module Admin
 
     def only_broken_links
       options[:only_broken_links].present?
+    end
+
+    def include_locked_documents?
+      options[:include_locked_documents]
     end
 
     def include_unpublishing?

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -117,6 +117,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_broken_links if only_broken_links
+      editions = editions.without_locked_documents
 
       editions = editions.includes(:unpublishing) if include_unpublishing?
       editions = editions.includes(:link_check_reports) if include_link_check_reports?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -206,6 +206,12 @@ class Edition < ApplicationRecord
     .distinct
   end
 
+  # used by Admin::EditionFilter
+  def self.without_locked_documents
+    joins(:document)
+    .where.not('documents.locked = true')
+  end
+
   def self.latest_edition
     where("NOT EXISTS (
       SELECT 1

--- a/features/admin-locked-documents.feature
+++ b/features/admin-locked-documents.feature
@@ -1,0 +1,7 @@
+Feature: Viewing locked documents
+  Background:
+    Given a locked document titled "A document that will be migrated"
+
+  Scenario: Locked document appears on index page
+    When I visit the list of published documents
+    Then I should see the document "A document that will be migrated" in the list of published documents

--- a/features/featuring-locked-documents.feature
+++ b/features/featuring-locked-documents.feature
@@ -1,0 +1,25 @@
+Feature: Featuring locked documents
+
+Background:
+  Given a locked document titled "Quidditch World Cups comes to Hogsmeade"
+
+Scenario: Featuring a locked document on an organisation page
+  Given the organisation "Department of Magical Games and Sports" exists
+  And the locked document is tagged to organisation "Department of Magical Games and Sports"
+  When I visit the organisation admin page for "Department of Magical Games and Sports"
+  And I search for a document titled "Quidditch World Cups comes to Hogsmeade" in the list of featurable documents
+  Then I cannot see the document in the list of featurable documents
+
+Scenario: Featuring a locked document on a world location page
+  Given a world location "Hogsmeade" exists
+  And the locked document is tagged to the world location "Hogsmeade"
+  When I visit the world location admin page for "Hogsmeade"
+  And I search for a document titled "Quidditch World Cups comes to Hogsmeade" in the list of featurable documents
+  Then I cannot see the document in the list of featurable documents
+
+Scenario: Featuring a locked document on a topical event page
+  Given a topical event called "Quidditch World Cup" with description "Sporting event"
+  And the locked document is tagged to the topical event "Quidditch World Cup"
+  And I visit the topical event admin page for "Quidditch World Cup"
+  And I search for a document titled "Locked document" in the list of featurable documents
+  Then I cannot see the document in the list of featurable documents

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -108,6 +108,10 @@ When(/^I visit the list of documents awaiting review$/) do
   visit admin_editions_path(state: :submitted)
 end
 
+When(/^I visit the list of published documents$/) do
+  visit admin_editions_path(state: :published)
+end
+
 When(/^I select the "([^"]*)" edition filter$/) do |edition_type|
   filter_editions_by :type, edition_type
 end

--- a/features/step_definitions/featuring_locked_documents_steps.rb
+++ b/features/step_definitions/featuring_locked_documents_steps.rb
@@ -1,0 +1,44 @@
+Given(/^a locked document titled "([^"]*)"$/) do |title|
+  document = create(:document, locked: true)
+  @edition = create(:published_news_article, title: title, document: document)
+end
+
+And(/^the locked document is tagged to organisation "([^"]*)"$/) do |organisation_name|
+  organisation = Organisation.find_by(name: organisation_name)
+  @edition.organisations = [organisation]
+  @edition.save
+end
+
+And(/^I search for a document titled "([^"]*)" in the list of featurable documents$/) do |title|
+  click_on "Features"
+  fill_in "title", with: title
+  click_on "enter"
+end
+
+Then(/^I cannot see the document in the list of featurable documents$/) do
+  within "#search_results" do
+    assert page.has_no_css?(record_css_selector(@edition))
+  end
+end
+
+And(/^the locked document is tagged to the world location "([^"]*)"$/) do |world_location_name|
+  world_location = WorldLocation.find_by!(name: world_location_name)
+  @edition.world_locations = [world_location]
+  @edition.save
+end
+
+And(/^I visit the world location admin page for "([^"]*)"$/) do |world_location_name|
+  world_location = WorldLocation.find_by!(name: world_location_name)
+  visit admin_world_location_path(world_location)
+end
+
+And(/^the locked document is tagged to the topical event "([^"]*)"$/) do |topical_event_name|
+  topical_event = TopicalEvent.find_by(name: topical_event_name)
+  @edition.topical_events = [topical_event]
+  @edition.save
+end
+
+And(/^I visit the topical event admin page for "([^"]*)"$/) do |topical_event_name|
+  topical_event = TopicalEvent.find_by!(name: topical_event_name)
+  visit admin_topical_event_classification_featurings_path(topical_event)
+end

--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -45,4 +45,20 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
     assert_equal edition.document_id, Feature.last.document_id
   end
+
+  test "post :feature raises an error if the document is locked" do
+    organisation = create(:organisation)
+    document = create(:document, locked: true)
+    feature_list = create(:feature_list, featurable: organisation, locale: :en)
+
+    params = {
+      document_id: document.id,
+      image: fixture_file_upload("images/960x640_gif.gif"),
+      alt_text: "some text",
+    }
+
+    assert_raises "Cannot feature a locked document" do
+      post :create, params: { feature_list_id: feature_list.id, feature: params }
+    end
+  end
 end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -340,4 +340,11 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
     refute_includes filter.editions, edition
   end
+
+  test "should include locked document if 'include_locked_documents' flag is set" do
+    document = create(:document, locked: true)
+    edition = create(:edition, :published, document: document)
+    filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2, include_locked_documents: true)
+    assert_includes filter.editions, edition
+  end
 end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -333,4 +333,11 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     filter.stubs(:unpaginated_editions).returns(stub(count: 8001))
     refute filter.exportable?
   end
+
+  test "should exclude locked documents" do
+    document = create(:document, locked: true)
+    edition = create(:edition, :published, document: document)
+    filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
+    refute_includes filter.editions, edition
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/XeW2zCKr/1017-migrated-documents-appear-and-dont-appear-in-the-right-places-in-whitehall

This ensures that locked documents cannot be featured on organisation, world location and topical event pages, avoiding broken links to content that will eventually be managed in Content Publisher.