### PR TITLE
Exclude locked documents from document collection search

### DIFF
--- a/app/controllers/admin/document_searches_controller.rb
+++ b/app/controllers/admin/document_searches_controller.rb
@@ -19,6 +19,7 @@ class Admin::DocumentSearchesController < Admin::BaseController
     def edition_scope
       Edition
         .with_translations(I18n.locale)
+        .without_locked_documents
         .limit(10)
     end
 

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -26,6 +26,13 @@ Feature: Grouping documents into a collection
     Then I should be redirected to the "Rail statistics" document collection
 
   @javascript
+  Scenario:
+    Given a locked document titled "Wimbledon wombats and where to find them"
+    When I draft a new document collection called "Wildlife of Wimbledon Common"
+    And I search for "Wimbledon wombats and where to find them" to add it to the document collection
+    Then the document does not appear in the search results
+
+  @javascript
   Scenario: Reordering documents in a document collection
     Given a published document "Wombats of Wimbledon" exists
     And a published document "Feeding Wombats" exists

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -134,3 +134,16 @@ And(/^I tag that document collection to the policy "(.*?)"$/) do |policy|
   select policy, from: "Policies"
   click_button "Save"
 end
+
+And(/^I search for "(.*?)" to add it to the document collection$/) do |document_title|
+  visit admin_document_collection_path(@document_collection)
+  click_on "Edit draft"
+  click_on "Collection documents"
+  fill_in "title", with: document_title
+  click_on "Find"
+end
+
+Then(/^the document does not appear in the search results$/) do
+  result = find('li.ui-menu-item')
+  assert_equal result.text, "No results matching search criteria"
+end


### PR DESCRIPTION
For https://trello.com/c/XeW2zCKr/1017-migrated-documents-appear-and-dont-appear-in-the-right-places-in-whitehall

We want to prevent locked documents from appearing in document collection
search so that they aren't accidentally added to a collection, resulting in a
broken link.