### PR TITLE
Include public URL of embedded Whitehall admin links in document export API

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -1,4 +1,7 @@
 class Admin::Export::DocumentController < Admin::Export::BaseController
+  include GovspeakHelper
+  include PublicDocumentRoutesHelper
+
   self.responder = Api::Responder
 
   def show
@@ -17,13 +20,31 @@ private
 
   def edition_associations(edition)
     output = {
-               "edition": edition
+               "edition": edition,
+               "associations": {},
+               "whitehall_admin_links": []
              }
-    output[:associations] = {}
     associations = edition.class.reflect_on_all_associations.map(&:name)
     associations.each do |association|
       output[:associations][association] = edition.public_send(association)
     end
+    output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.body))
+    if edition.withdrawn?
+      output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
+    end
     output
+  end
+
+  def resolve_whitehall_admin_links(body)
+    whitehall_admin_links(body).map { |link|
+      { "whitehall_admin_url": link, "public_url": public_url_for_admin_link(link) }
+    }
+  end
+
+  def public_url_for_admin_link(url)
+    edition = Whitehall::AdminLinkLookup.find_edition(url)
+    if edition.present?
+      public_document_url(edition)
+    end
   end
 end

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -1,50 +1,8 @@
 class Admin::Export::DocumentController < Admin::Export::BaseController
-  include GovspeakHelper
-  include PublicDocumentRoutesHelper
-
   self.responder = Api::Responder
 
   def show
     @document = Document.find(params[:id])
-    output = {
-               "document": @document,
-               "editions": []
-             }
-    @document.editions.each do |edition|
-      output[:editions].push(edition_associations(edition))
-    end
-    respond_with output
-  end
-
-private
-
-  def edition_associations(edition)
-    output = {
-               "edition": edition,
-               "associations": {},
-               "whitehall_admin_links": []
-             }
-    associations = edition.class.reflect_on_all_associations.map(&:name)
-    associations.each do |association|
-      output[:associations][association] = edition.public_send(association)
-    end
-    output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.body))
-    if edition.withdrawn?
-      output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
-    end
-    output
-  end
-
-  def resolve_whitehall_admin_links(body)
-    whitehall_admin_links(body).map { |link|
-      { "whitehall_admin_url": link, "public_url": public_url_for_admin_link(link) }
-    }
-  end
-
-  def public_url_for_admin_link(url)
-    edition = Whitehall::AdminLinkLookup.find_edition(url)
-    if edition.present?
-      public_document_url(edition)
-    end
+    respond_with DocumentExportPresenter.new(@document)
   end
 end

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -103,6 +103,12 @@ module GovspeakHelper
     { heading_numbering: numbering_method, contact_heading_tag: 'h4' }
   end
 
+  def whitehall_admin_links(body)
+    govspeak = build_govspeak_document(body)
+    links = Govspeak::LinkExtractor.new(govspeak).call
+    links.select { |link| DataHygiene::GovspeakLinkValidator::is_internal_admin_link?(link) }
+  end
+
 private
 
   def remove_extra_quotes_from_blockquotes(govspeak)

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -1,0 +1,46 @@
+class DocumentExportPresenter < Whitehall::Decorators::Decorator
+  include GovspeakHelper
+
+  def as_json
+    {
+      document: model,
+      editions: editions
+    }
+  end
+
+  private
+
+  def editions
+    model.editions.map do |edition|
+      edition_associations(edition)
+    end
+  end
+
+  def edition_associations(edition)
+    output = {
+               "edition": edition,
+               "associations": {},
+               "whitehall_admin_links": []
+             }
+    associations = edition.class.reflect_on_all_associations.map(&:name)
+    associations.each do |association|
+      output[:associations][association] = edition.public_send(association)
+    end
+    output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.body))
+    if edition.withdrawn?
+      output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
+    end
+    output
+  end
+
+  def resolve_whitehall_admin_links(body)
+    whitehall_admin_links(body).map do |link|
+      { "whitehall_admin_url": link, "public_url": public_url_for_admin_link(link) }
+    end
+  end
+
+  def public_url_for_admin_link(url)
+    edition = Whitehall::AdminLinkLookup.find_edition(url)
+    Whitehall.url_maker.public_document_url(edition) if edition.present?
+  end
+end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -15,4 +15,44 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     get :show, params: { id: '1' }, format: 'json'
     assert_response :forbidden
   end
+
+  test "resolves internal Whitehall URLs in edition body with a public URL" do
+    body = "Some text which contains an [internal link](/government/admin/news/2) to a public document"
+    document = create(:document)
+    create(:edition, document: document, body: body)
+
+    linked_document = create(:document, slug: 'some-article')
+    linked_edition = create(:published_edition, document: linked_document, state: 'published')
+
+    Whitehall::AdminLinkLookup.stubs(:find_edition).with('/government/admin/news/2').returns(linked_edition)
+
+    expected_whitehall_admin_links = [{
+      "whitehall_admin_url" => "/government/admin/news/2",
+      "public_url" => "www.test.gov.uk/government/generic-editions/some-article"
+    }]
+
+    login_as :export_data_user
+    get :show, params: { id: document.id }, format: 'json'
+    assert_equal expected_whitehall_admin_links, json_response['editions'][0]['whitehall_admin_links']
+  end
+
+  test "resolves internal Whitehall URLs in withdrawal explanation with a public URL" do
+    body = "Some text which contains an [internal link](/government/admin/news/2) to a public document"
+    edition = create(:withdrawn_edition)
+    edition.unpublishing.update_attribute(:explanation, body)
+
+    linked_document = create(:document, slug: 'some-article')
+    linked_edition = create(:published_edition, document: linked_document, state: 'published')
+
+    Whitehall::AdminLinkLookup.stubs(:find_edition).with('/government/admin/news/2').returns(linked_edition)
+
+    expected_whitehall_admin_links = [{
+      "whitehall_admin_url" => "/government/admin/news/2",
+      "public_url" => "www.test.gov.uk/government/generic-editions/some-article"
+    }]
+
+    login_as :export_data_user
+    get :show, params: { id: edition.document.id }, format: 'json'
+    assert_equal expected_whitehall_admin_links, json_response['editions'][-1]['whitehall_admin_links']
+  end
 end


### PR DESCRIPTION
Some publishers use Whitehall's admin URLs in their content, instead of public URLs.  Whitehall replaces these with public URLs when the document is published.

Since Content Publisher has no knowledge of the Whitehall document structure, these URLs need to be resolved during the export of content from Whitehall.

The resolved links are added to each edition, e.g.:
```
"whitehall_admin_links": [
  {
    "whitehall_admin_url": "/government/admin/publications/973699",
    "public_url": "http://www.dev.gov.uk/government/publications/pacer-competition-application-form-and-guidelines"
  },
  {
    "whitehall_admin_url": "/government/admin/news/958818",
    "public_url": "http://www.dev.gov.uk/government/news/new-trains-to-be-rolled-out-across-the-country-alongside-48-billion-investment-to-upgrade-tracks"
  },
  {
    "whitehall_admin_url": "/government/admin/news/815912",
    "public_url": "http://www.dev.gov.uk/government/news/grayling-progress-on-transpennine-route-upgrade-and-crossrail-2-to-advance-in-lockstep"
  }
]
```

Trello card: https://trello.com/c/Azgd0U80