### PR TITLE
Set lang attribute correctly on people page headings

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,7 +1,7 @@
 <% page_title @person.name %>
-<% page_class "people-show biographical-page" %>
+<% page_class 'people-show biographical-page' %>
 
-<%= content_tag_for :div, @person, class: "two-column-page" do %>
+<%= content_tag_for :div, @person, class: 'two-column-page' do %>
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
@@ -26,8 +26,8 @@
             </figure>
           </div>
         <% end %>
-        <h1 <%= t_lang('document.contents') %>><%= t('document.contents') %></h1>
-        <nav role="navigation">
+        <nav role="navigation" aria-labelledby="document-contents-heading">
+          <h2 id="document-contents-heading" <%= t_lang('document.contents') %>><%= t('document.contents') %></h2>
           <ul>
             <li <%= t_lang('people.biography') %> >
               <%= link_to t('people.biography'), '#biography' %>
@@ -61,14 +61,14 @@
   <div class="block-3">
     <div class="inner-block">
       <section class="biography" id="biography">
-        <h1 class="label"><%= t('people.biography') %></h1>
+        <h2 class="label gem-c-heading" <%= t_lang('people.biography') %>><%= t('people.biography') %></h2>
         <%= @person.biography %>
       </section>
 
       <div class="current-roles" id="current-roles">
         <% @person.current_role_appointments.each do |appointment| %>
           <%= content_tag_for :section, appointment, class: "role" do %>
-            <h1 id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h1>
+            <h2 id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h2>
             <%= appointment.role.responsibilities %>
             <div class="read-more">
               <% if appointment.role.ministerial? %>
@@ -88,8 +88,9 @@
 
       <% if @person.previous_role_appointments.any? %>
         <section class="previous-roles" id="previous-roles">
-          <h1><%= t('people.previous_roles_in_government') %></h1>
-
+          <h2 class="gem-c-heading" <%= t_lang('people.previous_roles_in_government') %>>
+            <%= t('people.previous_roles_in_government') %>
+          </h2>
           <ol class="document-list">
             <% @person.previous_role_appointments.each do |appointment| %>
               <%= content_tag_for :li, appointment, class: "document-row" do %>
@@ -105,8 +106,9 @@
 
       <% if @person.has_policy_responsibilities? %>
         <section id="policy">
-          <h1><%= t('policies.heading') %></h1>
-
+          <h2 class="gem-c-heading" <%= t_lang('policies.heading') %>>
+            <%= t('policies.heading') %>
+          </h2>
           <%= render 'policies/document_list', policies: @person.published_policies %>
         </section>
       <% end %>
@@ -114,10 +116,9 @@
       <% atom_discovery_link_tag atom_feed_url_for(@person), t('announcements.heading') %>
 
       <% if @person.announcements.any? %>
-        <section class="announcements" id="announcements">
-          <h2><%=  %></h2>
-          <%= render "govuk_publishing_components/components/heading", {
-            text: t("announcements.heading")
+        <section class="announcements" id="announcements" <%= t_lang('announcements.heading') %>>
+          <%= render 'govuk_publishing_components/components/heading', {
+            text: t('announcements.heading')
           } %>
 
           <%= render "govuk_publishing_components/components/subscription-links", {
@@ -127,7 +128,7 @@
 
           <%= render "govuk_publishing_components/components/document_list", items: @person.announcements %>
 
-          <div class="read-more">
+          <div class="read-more" <%= t_lang('announcements.view_all') %>>
             <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]) %>
           </div>
         </section>


### PR DESCRIPTION
When translated, the roles, policy, and announcements on a person page can have a mix of two different languages. 

This patch sets the headings to have the appropriate `lang` attribute depending on what language is being used. This is limited to content that comes from the internationalisation files because the language can be detected.

Other content doesn't seem to be have information about which language the content is written in so the `lang` attribute can't be set correctly. An example of this is the previous role - the string 'British High Commissioner to Singapore' hasn't been translated so defaults back to English.

These examples are from [Scott Wightman's page](https://www.gov.uk/government/people/scott-wightman.ko).

## Previous roles before
<img width="672" alt="Screen Shot 2019-07-29 at 16 35 38" src="https://user-images.githubusercontent.com/1732331/62061376-f45cdb80-b21e-11e9-9ed0-2c54c10418cf.png">
<img width="590" alt="Screen Shot 2019-07-29 at 16 36 31" src="https://user-images.githubusercontent.com/1732331/62061428-10607d00-b21f-11e9-9d91-b3f06aa4f10b.png">

## Previous roles after
![Screen Shot 2019-08-02 at 12 32 43](https://user-images.githubusercontent.com/1732331/62367508-cb3f9200-b521-11e9-9766-8380344d12b3.png)
![Screen Shot 2019-08-02 at 12 34 27](https://user-images.githubusercontent.com/1732331/62367549-eca07e00-b521-11e9-8326-14fe8af7be30.png)

## Biography heading before
![Screen Shot 2019-08-02 at 12 41 10](https://user-images.githubusercontent.com/1732331/62367896-d34c0180-b522-11e9-8412-86c6989849bf.png)

![Screen Shot 2019-08-02 at 12 36 05](https://user-images.githubusercontent.com/1732331/62367629-24a7c100-b522-11e9-9499-14db7aa7db79.png)


## Biography heading after
![Screen Shot 2019-08-02 at 12 40 49](https://user-images.githubusercontent.com/1732331/62367888-caf3c680-b522-11e9-9271-333553bac781.png)

![Screen Shot 2019-08-02 at 12 35 37](https://user-images.githubusercontent.com/1732331/62367609-148fe180-b522-11e9-8653-358d40bf30f3.png)

## Page navigation before
![Screen Shot 2019-08-02 at 12 38 38](https://user-images.githubusercontent.com/1732331/62367812-9253ed00-b522-11e9-87c9-5e960d677b02.png)

![Screen Shot 2019-08-02 at 12 36 58](https://user-images.githubusercontent.com/1732331/62367679-43a65300-b522-11e9-8abd-7ea4bcbd7ea2.png)

## Page navigation after
![Screen Shot 2019-08-02 at 12 39 37](https://user-images.githubusercontent.com/1732331/62367824-9bdd5500-b522-11e9-854e-846806e0aa73.png)

![Screen Shot 2019-08-02 at 12 38 00](https://user-images.githubusercontent.com/1732331/62367760-67699900-b522-11e9-9d0c-a6e945417677.png)


