### PR TITLE
Add lang attribute to contents list

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -29,6 +29,25 @@ module TranslationHelper
     I18n.t("document.speech.#{speech_type.published_externally_key}")
   end
 
+  def t_lang(key, options = {})
+    fallback = t_fallback(key, options)
+    if fallback && fallback != I18n.locale
+      "lang=#{fallback}"
+    end
+  end
+
+  def t_fallback(key, options = {})
+    translation = I18n.t(key, options, locale: I18n.locale, fallback: false, default: "fallback")
+
+    if !translation || translation.eql?("fallback")
+      I18n.default_locale
+    elsif translation.is_a? Hash
+      translation.values.all?(&:nil?) ? I18n.default_locale : false
+    else
+      false
+    end
+  end
+
   def t_corporate_information_page_type_link_text(page)
     if I18n.exists?("corporate_information_page.type.link_text.#{page.display_type_key}")
       t("corporate_information_page.type.link_text.#{page.display_type_key}")

--- a/app/views/corporate_information_pages/show.html.erb
+++ b/app/views/corporate_information_pages/show.html.erb
@@ -10,7 +10,7 @@
         <% headers = govspeak_headers(@corporate_information_page.body) %>
         <% if headers.any? %>
           <nav>
-            <h1><%= t 'document.contents' %></h1>
+            <h1 <%= t_lang('document.contents') %> ><%= t 'document.contents' %></h1>
             <ol class="dash-list">
               <% headers.each do |header| %>
                 <li><%= link_to header.text, "##{header.id}" %></li>

--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -36,21 +36,33 @@
   <div class="block-2 ">
     <div class="inner-block">
       <section class="contextual-info in-page-navigation ">
-        <h1><%= t('document.contents') %></h1>
+        <h1 <%= t_lang('document.contents') %> >
+          <%= t('document.contents') %>
+        </h1>
         <nav role="navigation">
           <ul>
-            <li><%= link_to t('roles.headings.responsibilities'), '#responsibilities' %></li>
+            <li <%= t_lang('roles.headings.responsibilities') %> >
+              <%= link_to t('roles.headings.responsibilities'), '#responsibilities' %>
+            </li>
             <% if @ministerial_role.occupied? %>
-              <li><%= link_to t('roles.headings.current_holder'), "#current-role-holder" %></li>
+              <li <%= t_lang('roles.headings.current_holder') %> >
+                <%= link_to t('roles.headings.current_holder'), "#current-role-holder" %>
+              </li>
             <% end %>
             <% if @ministerial_role.published_policies.any? %>
-              <li><%= link_to t('policies.heading'), "#policies" %></li>
+              <li <%= t_lang('policies.heading') %> >
+                <%= link_to t('policies.heading'), "#policies" %>
+              </li>
             <% end %>
             <% if @ministerial_role.previous_appointments.any? %>
-              <li><%= link_to t('roles.headings.previous_holders'), "#previous-holders-of-this-role" %></li>
+              <li <%= t_lang('roles.headings.previous_holders') %> >
+                <%= link_to t('roles.headings.previous_holders'), "#previous-holders-of-this-role" %>
+              </li>
             <% end %>
             <% if @ministerial_role.announcements.any? %>
-              <li><%= link_to t('announcements.heading'), "#announcements" %></li>
+              <li <%= t_lang('announcements.heading') %> >
+                <%= link_to t('announcements.heading'), "#announcements" %>
+              </li>
             <% end %>
           </ul>
         </nav>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -26,21 +26,31 @@
             </figure>
           </div>
         <% end %>
-        <h1><%= t('document.contents') %></h1>
+        <h1 <%= t_lang('document.contents') %>><%= t('document.contents') %></h1>
         <nav role="navigation">
           <ul>
-            <li><%= link_to t('people.biography'), '#biography' %></li>
+            <li <%= t_lang('people.biography') %> >
+              <%= link_to t('people.biography'), '#biography' %>
+            </li>
             <% if @person.currently_in_a_role? %>
-              <li><%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %></li>
+              <li <%= t_lang('roles.heading', count: @person.current_role_appointments.count) %> >
+                <%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %>
+              </li>
             <% end %>
             <% if @person.previous_role_appointments.any? %>
-              <li><%= link_to t('people.previous_roles'), "#previous-roles" %></li>
+              <li <%= t_lang('people.previous_roles') %>>
+                <%= link_to t('people.previous_roles'), "#previous-roles" %>
+              </li>
             <% end %>
             <% if @person.has_policy_responsibilities? %>
-              <li><%= link_to t('policies.heading'), "#policy" %></li>
+              <li <%= t_lang('policies.heading') %>>
+                <%= link_to t('policies.heading'), "#policy" %>
+              </li>
             <% end %>
             <% if @person.announcements.any? %>
-              <li><%= link_to t('announcements.heading'), "#announcements" %></li>
+              <li <%= t_lang('announcements.heading') %>>
+                <%= link_to t('announcements.heading'), "#announcements" %>
+              </li>
             <% end %>
           </ul>
         </nav>

--- a/test/unit/helpers/translation_helper_test.rb
+++ b/test/unit/helpers/translation_helper_test.rb
@@ -77,4 +77,51 @@ class TranslationHelperTest < ActionView::TestCase
       assert_match %r[Ecrit le], t_delivered_on(stub('speech_type', published_externally_key: 'written_on'))
     end
   end
+
+  test "t_fallback returns false if string is translated successfully" do
+    I18n.backend.store_translations :en, document: { one: "string" }
+    I18n.with_locale(:en) do
+      assert_equal false, t_fallback("document.one", {})
+    end
+  end
+
+  test "t_fallback returns default locale if translated string is nil" do
+    I18n.with_locale(:de) do
+      assert_equal :en, t_fallback("testing.nil", {})
+    end
+  end
+
+  test "t_fallback returns default locale if translated string uses fallback" do
+    I18n.default_locale = :en
+    I18n.backend.store_translations :en, document: { one: "string" }
+
+    I18n.with_locale(:de) do
+      assert_equal :en, t_fallback("document.one", {})
+    end
+  end
+
+  test "t_fallback returns default locale if translated string hash is all nil" do
+    I18n.default_locale = :en
+
+
+    I18n.with_locale(:de) do
+      I18n.backend.store_translations :de, testing: { test: { one: nil, others: nil } }
+      assert_equal :en, t_fallback("testing.test", count: 2)
+    end
+  end
+
+  test "t_lang returns nil if the translated string matches the current locale" do
+    I18n.backend.store_translations :en, document: { one: "string" }
+    I18n.with_locale(:en) do
+      assert_nil t_lang("document.one")
+    end
+  end
+
+  test "t_lang returns lang attribute if translated string does not match current locale" do
+    I18n.backend.store_translations :en, document: { one: "string" }
+
+    I18n.with_locale(:de) do
+      assert_equal "lang=en", t_lang("document.one")
+    end
+  end
 end


### PR DESCRIPTION
## What
Add a function to Whitehall `TranslationHelper` which detects whether a translation is using the current locale or falling back to the default locale. Use this method to add the `lang` attribute to contents list items when appropriate.

## Why
We have some cases where a translated page contains links that are still in English, because we do not have the translations for that particular langauge ([example here](https://www.gov.uk/government/people/scott-wightman.ko)). These currently don't have the `lang` attribute, meaning a screenreader thinks the text is in the same language as the page. This PR adds`lang="en" when the text is falling back to English.

## Before (no lang present)
<img width="145" alt="Screen Shot 2019-07-24 at 13 21 19" src="https://user-images.githubusercontent.com/29889908/61792991-f20d1280-ae15-11e9-83cc-d51df4d31d99.png">
<img width="164" alt="Screen Shot 2019-07-24 at 13 26 35" src="https://user-images.githubusercontent.com/29889908/61793282-b0309c00-ae16-11e9-8a83-a160a1f2d76e.png">

## After
<img width="145" alt="Screen Shot 2019-07-24 at 13 21 19" src="https://user-images.githubusercontent.com/29889908/61793005-f9342080-ae15-11e9-8950-9ec2aea726e6.png">
<img width="190" alt="Screen Shot 2019-07-24 at 13 26 21" src="https://user-images.githubusercontent.com/29889908/61793287-b45cb980-ae16-11e9-881e-b6f2c9b1a5f7.png">

## Notes
There doesn't seem to be a built-in I18n method for detecting which locale is serving the translation. The closest they have is the `I18n.exists?` method. This doesn't work for our use case as it takes fallbacks into account, so it will return true for `I18n.exists?(:de, "people.biography")` even if that translation doesn't exist, as long as an English translation exists.

Other approaches considered:

- Removing the ability to translate these strings and always marking the section as english. This means we wouldn't have mixed languages on the page, but ideally we want to make the most of the translations we have, especially if we may add more in the future.

Trello: https://trello.com/c/Uq7gAzCu/13-3-mark-language-as-english-on-subscription-links