### PR TITLE
Prevent external API calls for locked documents

### DIFF
--- a/app/concerns/locked_document_concern.rb
+++ b/app/concerns/locked_document_concern.rb
@@ -3,11 +3,12 @@ module LockedDocumentConcern
 
   class LockedDocumentError < RuntimeError; end
 
-  def check_if_locked_document(content_id: nil, document: nil)
+  def check_if_locked_document(content_id: nil, document: nil, edition: nil)
     content_id_locked = content_id && Document.exists?(locked: true, content_id: content_id)
     document_locked = document && document.locked?
+    edition_locked = edition && edition.locked?
 
-    if content_id_locked || document_locked
+    if content_id_locked || document_locked || edition_locked
       raise LockedDocumentError, "Cannot perform this operation on a locked document"
     end
   end

--- a/app/concerns/locked_document_concern.rb
+++ b/app/concerns/locked_document_concern.rb
@@ -1,0 +1,13 @@
+module LockedDocumentConcern
+  extend ActiveSupport::Concern
+
+  class LockedDocumentError < RuntimeError; end
+
+  def check_if_locked_document(content_id: nil)
+    content_id_locked = content_id && Document.exists?(locked: true, content_id: content_id)
+
+    if content_id_locked
+      raise LockedDocumentError, "Cannot perform this operation on a locked document"
+    end
+  end
+end

--- a/app/concerns/locked_document_concern.rb
+++ b/app/concerns/locked_document_concern.rb
@@ -3,10 +3,11 @@ module LockedDocumentConcern
 
   class LockedDocumentError < RuntimeError; end
 
-  def check_if_locked_document(content_id: nil)
+  def check_if_locked_document(content_id: nil, document: nil)
     content_id_locked = content_id && Document.exists?(locked: true, content_id: content_id)
+    document_locked = document && document.locked?
 
-    if content_id_locked
+    if content_id_locked || document_locked
       raise LockedDocumentError, "Cannot perform this operation on a locked document"
     end
   end

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -1,4 +1,6 @@
 class Admin::FeaturesController < Admin::BaseController
+  include LockedDocumentConcern
+
   before_action :find_feature_list
   before_action :build_feature
   before_action :find_edition, :find_topical_event, :find_offsite_link, only: [:new]
@@ -7,7 +9,7 @@ class Admin::FeaturesController < Admin::BaseController
 
   def create
     if @feature.document.present?
-      raise "Cannot feature a locked document" if @feature.document.locked?
+      check_if_locked_document(document: @feature.document)
     end
 
     if @feature.save

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -680,6 +680,10 @@ class Edition < ApplicationRecord
     false
   end
 
+  def locked?
+    document.locked?
+  end
+
 private
 
   def date_for_government

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -1,6 +1,12 @@
 module ServiceListeners
   class AttachmentUpdater
+    extend LockedDocumentConcern
+
     def self.call(attachable: nil, attachment_data: nil)
+      if attachable.is_a?(Edition)
+        check_if_locked_document(edition: attachable)
+      end
+
       update_attachable! attachable if attachable
       update_attachment_data! attachment_data if attachment_data
     end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -7,6 +7,10 @@ module ServiceListeners
     end
 
     def push(event:, options: {})
+      if edition.locked?
+        raise RuntimeError, "Cannot send a locked document to the Publishing API"
+      end
+
       # This is done synchronously before the rest of the publishing.
       # Currently (02/11/2016) publishing-api links
       # are not recalculated on parent documents when their translations are unpublished.

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -1,5 +1,7 @@
 module ServiceListeners
   class PublishingApiPusher
+    include LockedDocumentConcern
+
     attr_reader :edition
 
     def initialize(edition)
@@ -7,9 +9,7 @@ module ServiceListeners
     end
 
     def push(event:, options: {})
-      if edition.locked?
-        raise RuntimeError, "Cannot send a locked document to the Publishing API"
-      end
+      check_if_locked_document(edition: edition)
 
       # This is done synchronously before the rest of the publishing.
       # Currently (02/11/2016) publishing-api links

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,5 +1,7 @@
 class PublishingApiDiscardDraftWorker < PublishingApiWorker
   def perform(content_id, locale)
+    check_if_locked_document(content_id)
+
     Services.publishing_api.discard_draft(content_id, locale: locale)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as the draft has already been deleted

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiDiscardDraftWorker < PublishingApiWorker
   def perform(content_id, locale)
-    check_if_locked_document(content_id)
+    check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.discard_draft(content_id, locale: locale)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -12,6 +12,8 @@
 # and sending it again after republishing. This also changes the version
 # numbering and would probably appear in the version history.
 class PublishingApiDocumentRepublishingWorker < WorkerBase
+  include LockedDocumentConcern
+
   attr_reader :published_edition, :pre_publication_edition
 
   sidekiq_options queue: 'publishing_api'
@@ -19,9 +21,7 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
   def perform(document_id, bulk_publishing = false)
     @bulk_publishing = bulk_publishing
     document = Document.find(document_id)
-    if document.locked?
-      raise RuntimeError, "Cannot send a locked document to the Publishing API"
-    end
+    check_if_locked_document(document: document)
 
     #this the latest edition in a visible state ie: withdrawn, published
     @published_edition = document.published_edition

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -19,6 +19,10 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
   def perform(document_id, bulk_publishing = false)
     @bulk_publishing = bulk_publishing
     document = Document.find(document_id)
+    if document.locked?
+      raise RuntimeError, "Cannot send a locked document to the Publishing API"
+    end
+
     #this the latest edition in a visible state ie: withdrawn, published
     @published_edition = document.published_edition
     #this is the latest edition in a non visible state - draft, scheduled

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,7 @@
 class PublishingApiGoneWorker < PublishingApiWorker
   def perform(content_id, alternative_path, explanation, locale, allow_draft = false)
+    check_if_locked_document(content_id)
+
     if explanation.present?
       rendered_explanation = Whitehall::GovspeakRenderer
         .new.govspeak_to_html(explanation)

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiGoneWorker < PublishingApiWorker
   def perform(content_id, alternative_path, explanation, locale, allow_draft = false)
-    check_if_locked_document(content_id)
+    check_if_locked_document(content_id: content_id)
 
     if explanation.present?
       rendered_explanation = Whitehall::GovspeakRenderer

--- a/app/workers/publishing_api_links_worker.rb
+++ b/app/workers/publishing_api_links_worker.rb
@@ -1,12 +1,12 @@
 # Worker for batch sending of links to the publishing api
 class PublishingApiLinksWorker < WorkerBase
+  include LockedDocumentConcern
+
   sidekiq_options queue: "bulk_republishing"
 
   def perform(edition_id)
     item = Edition.find(edition_id)
-    if item.locked?
-      raise RuntimeError, "Cannot send a locked document to the Publishing API"
-    end
+    check_if_locked_document(edition: item)
 
     content_id = item.content_id
     links = PublishingApiPresenters.presenter_for(item).links

--- a/app/workers/publishing_api_links_worker.rb
+++ b/app/workers/publishing_api_links_worker.rb
@@ -4,8 +4,13 @@ class PublishingApiLinksWorker < WorkerBase
 
   def perform(edition_id)
     item = Edition.find(edition_id)
+    if item.locked?
+      raise RuntimeError, "Cannot send a locked document to the Publishing API"
+    end
+
     content_id = item.content_id
     links = PublishingApiPresenters.presenter_for(item).links
+
     if links && !links.empty?
       Services.publishing_api.patch_links(
         content_id,

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
   def perform(content_id, destination, locale, allow_draft = false)
-    check_if_locked_document(content_id)
+    check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.unpublish(
       content_id,

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,5 +1,7 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
   def perform(content_id, destination, locale, allow_draft = false)
+    check_if_locked_document(content_id)
+
     Services.publishing_api.unpublish(
       content_id,
       type: "redirect",

--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -1,14 +1,13 @@
 class PublishingApiUnpublishingWorker
   include Sidekiq::Worker
+  include LockedDocumentConcern
 
   sidekiq_options queue: 'publishing_api'
 
   def perform(unpublishing_id, allow_draft = false)
     unpublishing = Unpublishing.includes(:edition).find(unpublishing_id)
     edition = unpublishing.edition
-    if edition.locked?
-      raise RuntimeError, "Cannot send a locked document to the Publishing API"
-    end
+    check_if_locked_document(edition: edition)
 
     content_id = Document.where(id: edition.document_id).pluck(:content_id).first
 

--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -6,6 +6,10 @@ class PublishingApiUnpublishingWorker
   def perform(unpublishing_id, allow_draft = false)
     unpublishing = Unpublishing.includes(:edition).find(unpublishing_id)
     edition = unpublishing.edition
+    if edition.locked?
+      raise RuntimeError, "Cannot send a locked document to the Publishing API"
+    end
+
     content_id = Document.where(id: edition.document_id).pluck(:content_id).first
 
     edition.available_locales.each do |locale|

--- a/app/workers/publishing_api_vanish_worker.rb
+++ b/app/workers/publishing_api_vanish_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiVanishWorker < PublishingApiWorker
   def perform(content_id, locale)
-    check_if_locked_document(content_id)
+    check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.unpublish(
       content_id,

--- a/app/workers/publishing_api_vanish_worker.rb
+++ b/app/workers/publishing_api_vanish_worker.rb
@@ -1,5 +1,7 @@
 class PublishingApiVanishWorker < PublishingApiWorker
   def perform(content_id, locale)
+    check_if_locked_document(content_id)
+
     Services.publishing_api.unpublish(
       content_id,
       type: "vanish",

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -1,5 +1,7 @@
 class PublishingApiWithdrawalWorker < PublishingApiWorker
   def perform(content_id, explanation, locale, allow_draft = false)
+    check_if_locked_document(content_id)
+
     unpublished_at = Edition
       .joins(:document)
       .where(documents: { content_id: content_id })

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiWithdrawalWorker < PublishingApiWorker
   def perform(content_id, explanation, locale, allow_draft = false)
-    check_if_locked_document(content_id)
+    check_if_locked_document(content_id: content_id)
 
     unpublished_at = Edition
       .joins(:document)

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -12,7 +12,7 @@ class PublishingApiWorker < WorkerBase
     return if model.nil?
 
     if model.is_a?(Edition)
-      check_if_locked_document(content_id: model.content_id)
+      check_if_locked_document(edition: model)
     end
 
     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)

--- a/features/step_definitions/featuring_locked_documents_steps.rb
+++ b/features/step_definitions/featuring_locked_documents_steps.rb
@@ -1,6 +1,7 @@
 Given(/^a locked document titled "([^"]*)"$/) do |title|
-  document = create(:document, locked: true)
-  @edition = create(:published_news_article, title: title, document: document)
+  @edition = create(:published_news_article, title: title)
+  @edition.document.locked = true
+  @edition.document.save
 end
 
 And(/^the locked document is tagged to organisation "([^"]*)"$/) do |organisation_name|

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -10,6 +10,8 @@ module Whitehall
   class UnpublishableInstanceError < StandardError; end
 
   class PublishingApi
+    extend LockedDocumentConcern
+
     def self.publish(model_instance)
       assert_public_edition!(model_instance)
 
@@ -103,9 +105,7 @@ module Whitehall
     end
 
     def self.schedule_async(edition)
-      if edition.locked?
-        raise RuntimeError, "Cannot send a locked document to the Publishing API"
-      end
+      check_if_locked_document(edition: edition)
 
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
@@ -115,9 +115,7 @@ module Whitehall
     end
 
     def self.unschedule_async(edition)
-      if edition.locked?
-        raise RuntimeError, "Cannot send a locked document to the Publishing API"
-      end
+      check_if_locked_document(edition: edition)
 
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -103,6 +103,10 @@ module Whitehall
     end
 
     def self.schedule_async(edition)
+      if edition.locked?
+        raise RuntimeError, "Cannot send a locked document to the Publishing API"
+      end
+
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
@@ -111,6 +115,10 @@ module Whitehall
     end
 
     def self.unschedule_async(edition)
+      if edition.locked?
+        raise RuntimeError, "Cannot send a locked document to the Publishing API"
+      end
+
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -4,6 +4,10 @@ module Whitehall
   #
   class SearchIndex
     def self.add(instance)
+      if instance.is_a?(Edition) && instance.locked?
+        raise RuntimeError, "Cannot send a locked document to the Search API"
+      end
+
       # Note We delay the search index job to ensure that any transactions
       # around publishing will have had time to complete. Specifically,
       # EditionPublishingWorker publishes scheduled editions in a transaction

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -3,10 +3,10 @@ module Whitehall
   # Whitehall::SearchIndex.for returns a class that indexes content synchronously.
   #
   class SearchIndex
+    extend LockedDocumentConcern
+
     def self.add(instance)
-      if instance.is_a?(Edition) && instance.locked?
-        raise RuntimeError, "Cannot send a locked document to the Search API"
-      end
+      check_if_locked_document(edition: instance) if instance.is_a?(Edition)
 
       # Note We delay the search index job to ensure that any transactions
       # around publishing will have had time to complete. Specifically,

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -249,6 +249,13 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_equal 0, @edition.reload.attachments.size
   end
 
+  test "POST :create with an edition belonging to a locked document does not save the attachment" do
+    edition = create(:edition, document: build(:document, locked: true))
+    assert_raise LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      post :create, params: { edition_id: edition, attachment: valid_file_attachment_params }
+    end
+  end
+
   view_test "GET :edit renders the edit form" do
     attachment = create(:file_attachment, attachable: @edition)
     get :edit, params: { edition_id: @edition, id: attachment }

--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -57,7 +57,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
       alt_text: "some text",
     }
 
-    assert_raises "Cannot feature a locked document" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       post :create, params: { feature_list_id: feature_list.id, feature: params }
     end
   end

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -220,7 +220,7 @@ module ServiceListeners
       document = build(:document, locked: true)
       edition = build(:edition, document: document)
 
-      assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
         PublishingApiPusher.new(edition).push(event: "anything")
       end
     end

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -215,5 +215,14 @@ module ServiceListeners
 
       PublishingApiPusher.new(edition).push(event: 'update_draft')
     end
+
+    test "raises an error if an edition's document is locked" do
+      document = build(:document, locked: true)
+      edition = build(:edition, document: document)
+
+      assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+        PublishingApiPusher.new(edition).push(event: "anything")
+      end
+    end
   end
 end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -239,6 +239,15 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_equal timestamp, second_job[1]
   end
 
+  test ".schedule_async raises an error if the edition belongs to a locked document" do
+    document = create(:document, locked: true)
+    edition = build(:edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      Whitehall::PublishingApi.schedule_async(edition)
+    end
+  end
+
   test ".unschedule_async for a first edition served from the content store queues jobs to remove publish intents" do
     edition = create(:scheduled_publication)
 
@@ -274,6 +283,15 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
   end
 
+  test ".unschedule_async raises an error if the edition belongs to a locked document" do
+    document = create(:document, locked: true)
+    edition = build(:edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      Whitehall::PublishingApi.unschedule_async(edition)
+    end
+  end
+
   test ".save_draft publishes a draft edition" do
     draft_edition = create(:draft_case_study)
     payload = PublishingApiPresenters.presenter_for(draft_edition)
@@ -285,10 +303,10 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   end
 
   test ".publish_redirect_async publishes a redirect to the Publishing API" do
-    redirect_uuid = SecureRandom.uuid
+    document = create(:document)
     destination = "/government/people/milli-vanilli"
     redirect_request = stub_publishing_api_unpublish(
-      redirect_uuid,
+      document.content_id,
       body: {
         type: "redirect",
         alternative_path: destination,
@@ -298,17 +316,17 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     )
 
     Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_redirect_async(redirect_uuid, destination)
+      Whitehall::PublishingApi.publish_redirect_async(document.content_id, destination)
     end
 
     assert_requested redirect_request
   end
 
   test ".publish_gone_async publishes a gone to the Publishing API" do
-    gone_uuid = SecureRandom.uuid
+    document = create(:document)
 
     gone_request = stub_publishing_api_unpublish(
-      gone_uuid,
+      document.content_id,
       body: {
         type: "gone",
         locale: "en",
@@ -317,7 +335,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     )
 
     Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_gone_async(gone_uuid, nil, nil)
+      Whitehall::PublishingApi.publish_gone_async(document.content_id, nil, nil)
     end
 
     assert_requested gone_request

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -243,7 +243,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     document = create(:document, locked: true)
     edition = build(:edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       Whitehall::PublishingApi.schedule_async(edition)
     end
   end
@@ -287,7 +287,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     document = create(:document, locked: true)
     edition = build(:edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       Whitehall::PublishingApi.unschedule_async(edition)
     end
   end

--- a/test/unit/whitehall/search_index_test.rb
+++ b/test/unit/whitehall/search_index_test.rb
@@ -17,7 +17,7 @@ module Whitehall
 
     test 'SearchIndex.add does not queue a search index add job if a document is locked' do
       edition = create(:edition, document: build(:document, locked: true))
-      assert_raises RuntimeError, 'Cannot send a locked document to the Search API' do
+      assert_raises LockedDocumentConcern::LockedDocumentError, 'Cannot perform this operation on a locked document' do
         SearchIndex.add(edition)
       end
 

--- a/test/unit/whitehall/search_index_test.rb
+++ b/test/unit/whitehall/search_index_test.rb
@@ -6,13 +6,22 @@ module Whitehall
     end
 
     test 'SearchIndex.add queues a search index add job for 10 seconds time to allow any transactions to complete' do
-      searchable_thing = stub(class: SearchableClass, id: 'id')
+      searchable_thing = stub(class: SearchableClass, id: 'id', locked?: false)
 
       SearchIndex.add(searchable_thing)
       job = SearchIndexAddWorker.jobs.last
 
       assert_equal %w(SearchableClass id), job['args'].take(2)
       assert_equal 10.seconds.from_now.to_i, job['at']
+    end
+
+    test 'SearchIndex.add does not queue a search index add job if a document is locked' do
+      edition = create(:edition, document: build(:document, locked: true))
+      assert_raises RuntimeError, 'Cannot send a locked document to the Search API' do
+        SearchIndex.add(edition)
+      end
+
+      assert_empty SearchIndexAddWorker.jobs
     end
 
     test 'SearchIndex.delete queues a search index removal job for the instance based on its slug and rummager index' do

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
 
-class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
+class PublishingApiDiscardDraftWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   def setup
@@ -38,7 +38,7 @@ class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
     document = build(:document, locked: true)
     edition = create(:published_edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiDiscardDraftWorker.new.perform(edition.content_id, "en")
     end
   end

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -33,4 +33,13 @@ class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "raises an error if an edition's document is locked" do
+    document = build(:document, locked: true)
+    edition = create(:published_edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiDiscardDraftWorker.new.perform(edition.content_id, "en")
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -9,6 +9,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       published_edition: published_edition = build(:edition, id: 1),
       id: 1,
       pre_publication_edition: draft_edition = build(:edition, id: 2),
+      locked?: false,
     )
 
     Document.stubs(:find).returns(document)
@@ -42,6 +43,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       published_edition: build(:edition),
       id: 1,
       pre_publication_edition: build(:edition),
+      locked?: false,
     )
 
     Document.stubs(:find).returns(document)
@@ -96,6 +98,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       published_edition: published_edition = create(:withdrawn_edition, unpublishing: unpublishing),
       id: 1,
       pre_publication_edition: nil,
+      locked?: false,
     )
 
     Document.stubs(:find).returns(document)
@@ -125,6 +128,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       published_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
       id: 1,
       pre_publication_edition: nil,
+      locked?: false,
     )
 
     Document.stubs(:find).returns(document)
@@ -141,6 +145,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       published_edition: nil,
       id: 1,
       pre_publication_edition: nil,
+      locked?: false,
     )
 
     Document.stubs(:find).returns(document)
@@ -153,6 +158,14 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiUnpublishingWorker.stubs(:new).returns(raising_worker)
 
     assert_nothing_raised do
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+
+  test "raises an error if an edition's document is locked" do
+    document = create(:document, locked: true)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
       PublishingApiDocumentRepublishingWorker.new.perform(document.id)
     end
   end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -165,7 +165,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   test "raises an error if an edition's document is locked" do
     document = create(:document, locked: true)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiDocumentRepublishingWorker.new.perform(document.id)
     end
   end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -5,7 +5,8 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   setup do
-    @uuid = SecureRandom.uuid
+    document = create(:document)
+    @uuid = document.content_id
   end
 
   test "publishes a 'gone' item for the supplied content id" do
@@ -74,6 +75,14 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
         PublishingApiGoneWorker.new.perform(@uuid, "alternative_path", "*why?*", "de")
         assert_mock govukerror_notify
       end
+    end
+  end
+
+  test "raises an error if a document is locked" do
+    document = create(:document, locked: true)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiGoneWorker.new.perform(document.content_id, "alternative_path", "*why?*", "de")
     end
   end
 end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -81,7 +81,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
   test "raises an error if a document is locked" do
     document = create(:document, locked: true)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiGoneWorker.new.perform(document.content_id, "alternative_path", "*why?*", "de")
     end
   end

--- a/test/unit/workers/publishing_api_links_worker_test.rb
+++ b/test/unit/workers/publishing_api_links_worker_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class PublishingApiLinksWorkerTest < ActiveSupport::TestCase
+  test "raises an error if an edition's document is locked" do
+    document = create(:document, locked: true)
+    edition = create(:edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiLinksWorker.new.perform(edition.id)
+    end
+  end
+end

--- a/test/unit/workers/publishing_api_links_worker_test.rb
+++ b/test/unit/workers/publishing_api_links_worker_test.rb
@@ -5,7 +5,7 @@ class PublishingApiLinksWorkerTest < ActiveSupport::TestCase
     document = create(:document, locked: true)
     edition = create(:edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiLinksWorker.new.perform(edition.id)
     end
   end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -5,7 +5,8 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   setup do
-    @uuid = SecureRandom.uuid
+    document = create(:document)
+    @uuid = document.content_id
     @base_path = "/government/this-needs-redirecting.fr"
 
     @destination = "/government/has-been-redirected.fr"
@@ -74,6 +75,14 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
         PublishingApiRedirectWorker.new.perform(@uuid, @destination, "fr", true)
         assert_mock govukerror_notify
       end
+    end
+  end
+
+  test "raises an error if an edition's document is locked" do
+    document = create(:document, locked: true)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiRedirectWorker.new.perform(document.content_id, @destination, "fr", true)
     end
   end
 end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -81,7 +81,7 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
   test "raises an error if an edition's document is locked" do
     document = create(:document, locked: true)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiRedirectWorker.new.perform(document.content_id, @destination, "fr", true)
     end
   end

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -111,4 +111,13 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id, true)
   end
+
+  test "raises an error if an edition's document is locked" do
+    document = build(:document, locked: true)
+    edition = create(:unpublished_edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiUnpublishingWorker.new.perform(edition.unpublishing.id)
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -116,7 +116,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
     document = build(:document, locked: true)
     edition = create(:unpublished_edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiUnpublishingWorker.new.perform(edition.unpublishing.id)
     end
   end

--- a/test/unit/workers/publishing_api_vanish_worker_test.rb
+++ b/test/unit/workers/publishing_api_vanish_worker_test.rb
@@ -21,4 +21,12 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "an error if document is locked" do
+    document = create(:document, locked: true)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiVanishWorker.new.perform(document.content_id, "en")
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_vanish_worker_test.rb
+++ b/test/unit/workers/publishing_api_vanish_worker_test.rb
@@ -25,7 +25,7 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
   test "an error if document is locked" do
     document = create(:document, locked: true)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiVanishWorker.new.perform(document.content_id, "en")
     end
   end

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -23,4 +23,14 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "raises an error if the document is locked" do
+    document = create(:document, locked: true)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiWithdrawalWorker.new.perform(
+        document.content_id, "*why?*", "en"
+      )
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -27,7 +27,7 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
   test "raises an error if the document is locked" do
     document = create(:document, locked: true)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiWithdrawalWorker.new.perform(
         document.content_id, "*why?*", "en"
       )

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -119,7 +119,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     document = build(:document, locked: true)
     edition = create(:published_edition, document: document)
 
-    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiWorker.new.perform(edition.class.name, edition.id)
     end
   end

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -114,4 +114,13 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       .with(error, extra: { explanation: "The error code indicates that retrying this request will not help. This job is being aborted and will not be retried." })
     PublishingApiWorker.new.perform(organisation.class.name, organisation.id, nil, 'en')
   end
+
+  test "raises an error if an edition's document is locked" do
+    document = build(:document, locked: true)
+    edition = create(:published_edition, document: document)
+
+    assert_raises RuntimeError, "Cannot send a locked document to the Publishing API" do
+      PublishingApiWorker.new.perform(edition.class.name, edition.id)
+    end
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/QaZakMWe/1018-disable-whitehall-external-api-calls-on-a-migrated-document

This attempts to find places where Publishing API calls are made and raise an error if the document that is being changed is locked (pending migration to Content Publisher).  The initial plan was to focus on raising an error in the PublishingApiPusher as it seemed like a central place for handling Publishing API calls for editions, however it seems there are various workers being called from all sorts of different places in Whitehall, so it feels prudent to add checks for locked documents to these as well.

There are some controllers and services making calls directly to the Publishing API but it feels excessive at this point to add checks to all of them.  Instead, I propose adding in checks where necessary as we come across these calls during the course of the [work to lock documents in Whitehall](https://trello.com/c/tWSO1M1R/1020-lock-a-document-in-whitehall).

We also add a check before calling the SearchIndexAddWorker to prevent locked documents from being added to the search index via the Search API.  We've decided not to add this check before deleting the document as it's probably no bad thing to remove locked documents from the government index, as once they're in Content Publisher they get indexed into the govuk index via the Publishing API anyway.

API calls to Asset Manager are quite confusing in this application but we believe that the most important one to prevent in this context is for updating attachments.   