### PR TITLE
Hide sub heading on ministers page during reshuffle

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -7,7 +7,9 @@
               locals: { big: true,
                         heading: "Ministers" } %>
 
-    <p class="intro-paragraph">Read biographies and responsibilities of <a href="#cabinet-ministers">Cabinet ministers</a> and all <a href="#ministers-by-department">ministers by department</a>, as well as the <a href="#whips">whips</a> who help co-ordinate parliamentary business.</p>
+    <% unless @is_during_reshuffle %>
+      <p class="intro-paragraph">Read biographies and responsibilities of <a href="#cabinet-ministers">Cabinet ministers</a> and all <a href="#ministers-by-department">ministers by department</a>, as well as the <a href="#whips">whips</a> who help co-ordinate parliamentary business.</p>
+    <% end %>
   </div>
 </header>
 


### PR DESCRIPTION
This commit hides the sub-heading on the ministers page during a reshuffle since the links don't lead anywhere.

Before:

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/444232/61857127-6e0d6600-aebb-11e9-945d-fd231ba893f9.png">

After:

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/444232/61857135-71a0ed00-aebb-11e9-8515-580306509efd.png">
