### PR TITLE
Add government information to each edition

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -32,7 +32,9 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
         output[:associations][association] = edition.public_send(association)
       end
     end
-    output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.body))
+
+    output[:government] = edition.government
+    output[:whitehall_admin_links] = resolve_whitehall_admin_links(edition.body)
     if edition.withdrawn?
       output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
     end

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -18,9 +18,8 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
   def edition_associations(edition)
     output = {
-               "edition": edition,
-               "associations": {},
-               "whitehall_admin_links": []
+               edition: edition,
+               associations: {}
              }
 
     associations = edition.class.reflect_on_all_associations.map(&:name)
@@ -49,7 +48,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
   def resolve_whitehall_admin_links(body)
     whitehall_admin_links(body).map do |link|
-      { "whitehall_admin_url": link, "public_url": public_url_for_admin_link(link) }
+      { whitehall_admin_url: link, public_url: public_url_for_admin_link(link) }
     end
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -48,4 +48,11 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
     assert_equal image.image_data.file_url, images.first['url']
   end
+
+  test "returns government information about an edition" do
+    edition = create(:edition)
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    assert_equal edition.government, result[:editions].first[:government]
+  end
 end


### PR DESCRIPTION
This PR adds which government was associated with each edition of a document. The political boolean doesn't need to be added as it's already present on the data exported from the edition.

Trello:
https://trello.com/c/1uhpv9pA/1038-add-government-field-to-document-export