### PR TITLE
Redirect American Samoa news page

### DIFF
--- a/db/data_migration/20190725152632_redirect_american_samoa_news.rb
+++ b/db/data_migration/20190725152632_redirect_american_samoa_news.rb
@@ -1,0 +1,10 @@
+american_samoa = WorldLocation.find_by(slug: "american-samoa")
+base_path = "/world/american-samoa/news"
+destination = "/world/usa/news"
+
+puts "Unpublishing #{base_path} and redirecting to #{destination}"
+Services.publishing_api.unpublish(
+  american_samoa.news_page_content_id,
+  type: "redirect",
+  alternative_path: destination,
+)


### PR DESCRIPTION
American Samoa is an Overseas Territory of the United Sates. For all
other Overseas Territories of the United Sates, we don't have specific
pages or Taxons in GOV.UK.

This is part of the work I'm doing to remove specific American Samoa
pages and redirect them to the corresponding USA pages. This commit
creates a data migration to redirect
https://www.gov.uk/world/american-samoa/news
to
https://www.gov.uk/world/usa/news.
Once this is merged, this will need to be run:
https://deploy.integration.publishing.service.gov.uk/job/Run_Whitehall_Data_Migrations/

Trello card:
https://trello.com/c/VHoxXkyC/1136-remove-and-redirect-american-samoa-pages