### PR TITLE
Disable Whitehall DB operations on a document when locked

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,6 +4,7 @@ class Document < ApplicationRecord
   extend FriendlyId
 
   include Document::Needs
+  include LockedDocumentConcern
 
   friendly_id :sluggable_string, use: :scoped, scope: :document_type
 
@@ -38,6 +39,8 @@ class Document < ApplicationRecord
   has_many :document_collection_groups, through: :document_collection_group_memberships
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document, dependent: :destroy
+
+  before_save { check_if_locked_document(document: self) unless locked_changed? }
 
   validates_presence_of :content_id
 

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -1,10 +1,13 @@
 class DocumentCollectionGroupMembership < ApplicationRecord
   BANNED_DOCUMENT_TYPES = %w[DocumentCollection].freeze
+  include LockedDocumentConcern
 
   belongs_to :document, inverse_of: :document_collection_group_memberships
   belongs_to :document_collection_group, inverse_of: :memberships
 
   before_create :assign_ordering
+
+  before_save { check_if_locked_document(document: self.document) }
 
   validates :document, presence: true
   validates :document_collection_group, presence: true

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -31,6 +31,7 @@ class Edition < ApplicationRecord
   extend Edition::FindableByWorldwideOrganisation
 
   include Searchable
+  include LockedDocumentConcern
 
   has_many :editorial_remarks, dependent: :destroy
   has_many :edition_authors, dependent: :destroy
@@ -92,6 +93,7 @@ class Edition < ApplicationRecord
 
   # @!group Callbacks
   before_save :set_public_timestamp
+  before_save { check_if_locked_document(edition: self) }
   # @!endgroup
 
   class UnmodifiableValidator < ActiveModel::Validator

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,8 +1,11 @@
 class Feature < ApplicationRecord
+  include LockedDocumentConcern
   belongs_to :document
   belongs_to :topical_event
   belongs_to :offsite_link
   belongs_to :feature_list
+
+  before_save { check_if_locked_document(document: self.document) }
 
   after_save :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api

--- a/features/admin-locked-documents.feature
+++ b/features/admin-locked-documents.feature
@@ -1,7 +1,8 @@
 Feature: Viewing locked documents
   Background:
-    Given a locked document titled "A document that will be migrated"
+    Given a document titled "A document that will be migrated"
 
   Scenario: Locked document appears on index page
+    And the document is locked
     When I visit the list of published documents
     Then I should see the document "A document that will be migrated" in the list of published documents

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -27,7 +27,8 @@ Feature: Grouping documents into a collection
 
   @javascript
   Scenario:
-    Given a locked document titled "Wimbledon wombats and where to find them"
+    Given a document titled "Wimbledon wombats and where to find them"
+    And the document is locked
     When I draft a new document collection called "Wildlife of Wimbledon Common"
     And I search for "Wimbledon wombats and where to find them" to add it to the document collection
     Then the document does not appear in the search results

--- a/features/featuring-locked-documents.feature
+++ b/features/featuring-locked-documents.feature
@@ -1,25 +1,28 @@
 Feature: Featuring locked documents
 
 Background:
-  Given a locked document titled "Quidditch World Cups comes to Hogsmeade"
+  Given a document titled "Quidditch World Cups comes to Hogsmeade"
 
 Scenario: Featuring a locked document on an organisation page
   Given the organisation "Department of Magical Games and Sports" exists
-  And the locked document is tagged to organisation "Department of Magical Games and Sports"
+  And the document is tagged to organisation "Department of Magical Games and Sports"
+  And the document is locked
   When I visit the organisation admin page for "Department of Magical Games and Sports"
   And I search for a document titled "Quidditch World Cups comes to Hogsmeade" in the list of featurable documents
   Then I cannot see the document in the list of featurable documents
 
 Scenario: Featuring a locked document on a world location page
   Given a world location "Hogsmeade" exists
-  And the locked document is tagged to the world location "Hogsmeade"
+  And the document is tagged to the world location "Hogsmeade"
+  And the document is locked
   When I visit the world location admin page for "Hogsmeade"
   And I search for a document titled "Quidditch World Cups comes to Hogsmeade" in the list of featurable documents
   Then I cannot see the document in the list of featurable documents
 
 Scenario: Featuring a locked document on a topical event page
   Given a topical event called "Quidditch World Cup" with description "Sporting event"
-  And the locked document is tagged to the topical event "Quidditch World Cup"
+  And the document is tagged to the topical event "Quidditch World Cup"
+  And the document is locked
   And I visit the topical event admin page for "Quidditch World Cup"
   And I search for a document titled "Locked document" in the list of featurable documents
   Then I cannot see the document in the list of featurable documents

--- a/features/step_definitions/featuring_locked_documents_steps.rb
+++ b/features/step_definitions/featuring_locked_documents_steps.rb
@@ -1,10 +1,8 @@
-Given(/^a locked document titled "([^"]*)"$/) do |title|
+Given(/^a document titled "([^"]*)"$/) do |title|
   @edition = create(:published_news_article, title: title)
-  @edition.document.locked = true
-  @edition.document.save
 end
 
-And(/^the locked document is tagged to organisation "([^"]*)"$/) do |organisation_name|
+And(/^the document is tagged to organisation "([^"]*)"$/) do |organisation_name|
   organisation = Organisation.find_by(name: organisation_name)
   @edition.organisations = [organisation]
   @edition.save
@@ -22,7 +20,7 @@ Then(/^I cannot see the document in the list of featurable documents$/) do
   end
 end
 
-And(/^the locked document is tagged to the world location "([^"]*)"$/) do |world_location_name|
+And(/^the document is tagged to the world location "([^"]*)"$/) do |world_location_name|
   world_location = WorldLocation.find_by!(name: world_location_name)
   @edition.world_locations = [world_location]
   @edition.save
@@ -33,7 +31,7 @@ And(/^I visit the world location admin page for "([^"]*)"$/) do |world_location_
   visit admin_world_location_path(world_location)
 end
 
-And(/^the locked document is tagged to the topical event "([^"]*)"$/) do |topical_event_name|
+And(/^the document is tagged to the topical event "([^"]*)"$/) do |topical_event_name|
   topical_event = TopicalEvent.find_by(name: topical_event_name)
   @edition.topical_events = [topical_event]
   @edition.save
@@ -42,4 +40,9 @@ end
 And(/^I visit the topical event admin page for "([^"]*)"$/) do |topical_event_name|
   topical_event = TopicalEvent.find_by!(name: topical_event_name)
   visit admin_topical_event_classification_featurings_path(topical_event)
+end
+
+And(/^the document is locked/) do
+  @edition.document.locked = true
+  @edition.document.save
 end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -161,6 +161,12 @@ FactoryBot.define do
         edition.unpublishing = build(:withdrawn_unpublishing, edition: edition)
       end
     end
+
+    trait(:with_locked_document) do
+      after(:create) do |edition|
+        edition.document.update(locked: true)
+      end
+    end
   end
 
   factory :announcement, parent: :edition, class: Announcement, traits: %i[with_organisations with_topics]

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -250,7 +250,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create with an edition belonging to a locked document does not save the attachment" do
-    edition = create(:edition, document: build(:document, locked: true))
+    edition = create(:unpublished_edition, :with_locked_document)
     assert_raise LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       post :create, params: { edition_id: edition, attachment: valid_file_attachment_params }
     end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -335,15 +335,13 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "should exclude locked documents" do
-    document = create(:document, locked: true)
-    edition = create(:edition, :published, document: document)
+    edition = create(:unpublished_edition, :with_locked_document)
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
     refute_includes filter.editions, edition
   end
 
   test "should include locked document if 'include_locked_documents' flag is set" do
-    document = create(:document, locked: true)
-    edition = create(:edition, :published, document: document)
+    edition = create(:unpublished_edition, :with_locked_document)
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2, include_locked_documents: true)
     assert_includes filter.editions, edition
   end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -238,4 +238,12 @@ class DocumentTest < ActiveSupport::TestCase
 
     assert_equal document.patch_meets_user_needs_links, "Links updated"
   end
+
+  test 'should raise an exception when attempting to modify a locked document' do
+    document = create(:document, locked: true)
+    document.id = 42
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      document.save
+    end
+  end
 end

--- a/test/unit/edition/images_test.rb
+++ b/test/unit/edition/images_test.rb
@@ -83,6 +83,7 @@ class Edition::ImagesTest < ActiveSupport::TestCase
     published_edition = EditionWithImages.new(
       valid_edition_attributes.merge(
         state: 'published',
+        document: create(:document),
         major_change_published_at: Time.zone.now,
         first_published_at: Time.zone.now,
         images_attributes: [{

--- a/test/unit/edition/validation_test.rb
+++ b/test/unit/edition/validation_test.rb
@@ -161,4 +161,19 @@ class Edition::ValidationTest < ActiveSupport::TestCase
     edition.supporting_organisations = [organisation_1]
     assert edition.valid?
   end
+
+  test 'should raise an exception when attempting to modify an edition of a locked document' do
+    edition = create(:unpublished_edition, :with_locked_document)
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      edition.title = "hello world"
+      edition.save
+    end
+  end
+
+  test 'should raise an exception when attempting to create an edition for a locked document' do
+    document = create(:document, locked: true)
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      create(:edition, document: document)
+    end
+  end
 end

--- a/test/unit/feature_test.rb
+++ b/test/unit/feature_test.rb
@@ -36,4 +36,10 @@ class FeatureTest < ActiveSupport::TestCase
     assert feature.end!
     assert_equal Time.zone.now, feature.reload.ended_at
   end
+
+  test 'should raise an exception when attempting to feature a locked document' do
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      create(:feature, document: create(:document, locked: true))
+    end
+  end
 end

--- a/test/unit/models/document_collection_group_membership_test.rb
+++ b/test/unit/models/document_collection_group_membership_test.rb
@@ -20,4 +20,11 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
     membership = build(:document_collection_group_membership, document: create(:document_collection).document)
     refute membership.valid?
   end
+
+  test 'should raise an exception when attempting to add a locked document to a collection' do
+    document = create(:document, locked: true)
+    assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
+      create(:document_collection_group_membership, document: document)
+    end
+  end
 end

--- a/test/unit/whitehall/search_index_test.rb
+++ b/test/unit/whitehall/search_index_test.rb
@@ -16,7 +16,7 @@ module Whitehall
     end
 
     test 'SearchIndex.add does not queue a search index add job if a document is locked' do
-      edition = create(:edition, document: build(:document, locked: true))
+      edition = create(:unpublished_edition, :with_locked_document)
       assert_raises LockedDocumentConcern::LockedDocumentError, 'Cannot perform this operation on a locked document' do
         SearchIndex.add(edition)
       end

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -35,9 +35,7 @@ class PublishingApiDiscardDraftWorkerTest < ActiveSupport::TestCase
   end
 
   test "raises an error if an edition's document is locked" do
-    document = build(:document, locked: true)
-    edition = create(:published_edition, document: document)
-
+    edition = create(:unpublished_edition, :with_locked_document)
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiDiscardDraftWorker.new.perform(edition.content_id, "en")
     end

--- a/test/unit/workers/publishing_api_links_worker_test.rb
+++ b/test/unit/workers/publishing_api_links_worker_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class PublishingApiLinksWorkerTest < ActiveSupport::TestCase
   test "raises an error if an edition's document is locked" do
-    document = create(:document, locked: true)
-    edition = create(:edition, document: document)
-
+    edition = create(:unpublished_edition, :with_locked_document)
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiLinksWorker.new.perform(edition.id)
     end

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -113,9 +113,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
   end
 
   test "raises an error if an edition's document is locked" do
-    document = build(:document, locked: true)
-    edition = create(:unpublished_edition, document: document)
-
+    edition = create(:unpublished_edition, :with_locked_document)
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiUnpublishingWorker.new.perform(edition.unpublishing.id)
     end

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -116,9 +116,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
   end
 
   test "raises an error if an edition's document is locked" do
-    document = build(:document, locked: true)
-    edition = create(:published_edition, document: document)
-
+    edition = create(:unpublished_edition, :with_locked_document)
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiWorker.new.perform(edition.class.name, edition.id)
     end


### PR DESCRIPTION
When a document has been migrated it is locked on Whitehall side.
This commit takes steps to ensure that when locked, the user
cannot edit the document at a database level even if UI functionality
is exposed to allow it.

This commit:
- Adds a locking check on Feature, Document, Edition and
DocumentCollectionGroupMembership as a before_* step based on
the behaviour that could occur in that class (validation or update).
- Adds model tests for the above that ensures the expected behaviour.
- Modifies the way editions are created for existing document lock
tests such that they work with the new behaviour for edition lock checks.

This commit uses the new LockedDocumentConcern created for this purpose,
but relies on untidy logic to work around the issues with class vs
instance methods when passing the required objects to the concern.

Trello card: https://trello.com/c/iSEv8w6b/1027-disable-whitehall-db-operations-on-a-document-when-locked