### PR TITLE
Fix presenting roles to the Publishing API

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -59,8 +59,8 @@ module PublishingApi
     def details
       {
         body: body,
-        attends_cabinet_type: item.attends_cabinet_type,
-        role_payment_type: item.role_payment_type,
+        attends_cabinet_type: item.attends_cabinet_type&.name,
+        role_payment_type: item.role_payment_type&.name,
         supports_historical_accounts: item.supports_historical_accounts,
       }
     end


### PR DESCRIPTION
The string representation of the RoleAttendsCabinetType was being sent
to the Publishing API, with the id. But the thing that needs to be
sent is just the name.