### PR TITLE
Update the ministerial ordering without involving the Publishing API

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -36,7 +36,7 @@ private
     return unless params.include?(:organisation)
 
     params[:organisation].each_pair do |id, org_params|
-      Organisation.find(id).update_attributes(
+      Organisation.where(id: id).update_all(
         ministerial_ordering: org_params["ordering"]
       )
     end


### PR DESCRIPTION
Or any of the other hooks on the model. This data currently only
affects Whitehall and pages rendered by Whitehall Frontend, so we
don't need to involve the Publishing API.

Currently, it can take ~40 seconds to update every organisation, which
means the user sees a timeout error.