### PR TITLE
Mark up mixed languages on Worldwide Organisation pages

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -17,6 +17,10 @@ module TranslationHelper
     t("see_all.#{type}")
   end
 
+  def t_lang_translated_locales(object)
+    "lang=en" unless object.translated_locales.include?(I18n.locale)
+  end
+
   def t_delivery_title(document)
     if document.delivered_by_minister?
       t("document.speech.#{document.speech_type.owner_key_group}.minister")

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -115,6 +115,10 @@ class CorporateInformationPage < Edition
     corporate_information_page_type.title(owning_organisation)
   end
 
+  def title_lang
+    corporate_information_page_type.title_lang(owning_organisation)
+  end
+
   def self.by_menu_heading(menu_heading)
     type_ids = CorporateInformationPageType.by_menu_heading(menu_heading).map(&:id)
     where(corporate_information_page_type_id: type_ids)

--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -1,5 +1,6 @@
 class CorporateInformationPageType
   include ActiveRecordLikeInterface
+  include TranslationHelper
 
   attr_accessor :id, :title_template, :slug, :menu_heading
 
@@ -16,13 +17,13 @@ class CorporateInformationPageType
   end
 
   def title(organisation)
-    organisation_name = if organisation.respond_to?(:acronym) && organisation.acronym.present?
-                          organisation.acronym
-                        else
-                          organisation.name
-                        end
     translation_key = slug.tr('-', '_')
-    I18n.t("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name)
+    I18n.t("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name(organisation))
+  end
+
+  def title_lang(organisation)
+    translation_key = slug.tr('-', '_')
+    t_lang("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name(organisation))
   end
 
   def self.by_menu_heading(menu_heading)
@@ -96,4 +97,14 @@ class CorporateInformationPageType
   AccessibleDocumentsPolicy = create(
     id: 21, slug: 'accessible-documents-policy', menu_heading: :our_information
   )
+
+private
+
+  def organisation_name(organisation)
+    if organisation.respond_to?(:acronym) && organisation.acronym.present?
+      organisation.acronym
+    else
+      organisation.name
+    end
+  end
 end

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -9,7 +9,7 @@
   extra_class << 'postal-address' if contact.has_postal_address?
 %>
 <%= content_tag_for(:div, contact, class: extra_class.join(' ')) do %>
-  <div class="content">
+  <div class="content" <%= lang if local_assigns[:lang] %> >
     <% unless local_assigns[:hide_title] %><%= content_tag heading_tag, contact.title %><% end %>
 
     <div class="vcard contact-inner">

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -45,7 +45,11 @@
       <% end %>
 
       <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
-        <%= link_to 'Access and opening times', [contact.worldwide_organisation, contact], class: "url" %>
+        <%
+          fallback = t_fallback('contact.access_and_opening_times')
+          lang = fallback if fallback && fallback != I18n.locale
+        %>
+        <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "url", lang: lang %>
       <% end %>
     </div>
   </div>

--- a/app/views/worldwide_organisations/_corporate_information.html.erb
+++ b/app/views/worldwide_organisations/_corporate_information.html.erb
@@ -7,12 +7,12 @@
         <ul>
           <% organisation.corporate_information_pages.published.by_menu_heading(:our_information).each do |corporate_information_page| %>
             <% corporate_information_page.extend(UseSlugAsParam) %>
-            <li><%= link_to corporate_information_page.title, [organisation, corporate_information_page] %></li>
+            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page] %></li>
           <% end %>
 
           <% organisation.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |corporate_information_page| %>
             <% corporate_information_page.extend(UseSlugAsParam) %>
-            <li><%= link_to corporate_information_page.title, [organisation, corporate_information_page]%></li>
+            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page]%></li>
           <% end %>
         </ul>
       </nav>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -58,8 +58,11 @@
   <section class="block contact-us" id="contact-us">
     <div class="inner-block floated-children">
       <h1 class="keyline-header"><%= t('worldwide_organisation.headings.contact_us' ) %></h1>
-      <%= render partial: 'contacts/contact', locals: {contact: @main_office, is_main: true} %>
-      <%= render partial: 'contacts/contact', collection: @home_page_offices %>
+      <%= render partial: 'contacts/contact', locals: {contact: @main_office, is_main: true, lang: t_lang_translated_locales(@main_office.contact) } %>
+
+      <% @home_page_offices.each do |home_page_office| %>
+        <%= render partial: 'contacts/contact', locals: { contact: home_page_office, lang:  t_lang_translated_locales(home_page_office.contact) } %>
+      <% end %>
     </div>
   </section>
 <% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -485,6 +485,7 @@ ar:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: نموذج اتصال
     email: بريد إلكتروني
   corporate_information_page:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -74,6 +74,7 @@ az:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Əlaqə vasitəsi
     email: elektron poçt
   corporate_information_page:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -383,6 +383,7 @@ be:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Кантактная форма
     email: Электронная пошта
   corporate_information_page:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -287,6 +287,7 @@ bg:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Контактна форма
     email: И-мейл
   corporate_information_page:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -279,6 +279,7 @@ bn:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -334,6 +334,7 @@ cs:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Kontaktní formulář
     email: Email
   corporate_information_page:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -486,6 +486,7 @@ cy:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Ffurflen cysylltu
     email: E-bost
   corporate_information_page:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -279,6 +279,7 @@ da:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -282,6 +282,7 @@ de:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Kontaktformular
     email: E-Mail
   corporate_information_page:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -281,6 +281,7 @@ dr:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: فارم تماس
     email: ایمیل
   corporate_information_page:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -283,6 +283,7 @@ el:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Φόρμα επικοινωνίας
     email: Email
   corporate_information_page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,6 +350,7 @@ en:
   contact:
     email: Email
     contact_form: Contact form
+    access_and_opening_times: Access and opening times
   read_more: Read more
   change_notes:
     page_history: History

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -282,6 +282,7 @@ es-419:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formulario de contacto
     email: Correo electrónico
   corporate_information_page:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -282,6 +282,7 @@ es:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formulario de contacto
     email: Email
   corporate_information_page:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -283,6 +283,7 @@ et:
     see_all_updates: Vaadake kõiki täiendusi
     updated_at: Viimane täiendus
   contact:
+    access_and_opening_times:
     contact_form: Võtke ühendust
     email: E-post
   corporate_information_page:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -76,6 +76,7 @@ fa:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: فرم ارتباط
     email: ایمیل
   corporate_information_page:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -279,6 +279,7 @@ fi:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -282,6 +282,7 @@ fr:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formulaire de contact
     email: Email
   corporate_information_page:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -381,6 +381,7 @@ gd:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -282,6 +282,7 @@ he:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: טופס יצירת קשר
     email: דואר אלקטרוני
   corporate_information_page:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -282,6 +282,7 @@ hi:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: संपर्क प्रपत्र
     email: ईमेल
   corporate_information_page:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -381,6 +381,7 @@ hr:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -282,6 +282,7 @@ hu:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Kapcsolati űrlap
     email: E-mail
   corporate_information_page:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -282,6 +282,7 @@ hy:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Կապի միջոց
     email: Էլելտրոնային հասցե
   corporate_information_page:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -76,6 +76,7 @@ id:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formulir kontak
     email: Email
   corporate_information_page:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -279,6 +279,7 @@ is:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -282,6 +282,7 @@ it:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Contattaci
     email: Email
   corporate_information_page:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -75,6 +75,7 @@ ja:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: 連絡フォーム
     email: Email
   corporate_information_page:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -74,6 +74,7 @@ ka:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -279,6 +279,7 @@ kk:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -75,6 +75,7 @@ ko:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: 콘택트 폼
     email: 이메일
   corporate_information_page:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -332,6 +332,7 @@ lt:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Parašykite mums
     email: El.paštas
   corporate_information_page:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -281,6 +281,7 @@ lv:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Saziņas forma
     email: E-pasts
   corporate_information_page:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -74,6 +74,7 @@ ms:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -381,6 +381,7 @@ mt:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -279,6 +279,7 @@ nl:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -279,6 +279,7 @@
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -385,6 +385,7 @@ pl:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formularz kontaktowy
     email: Email
   corporate_information_page:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -281,6 +281,7 @@ ps:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: د اړیکوپاڼه
     email: برښنالیک
   corporate_information_page:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -281,6 +281,7 @@ pt:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formulário de contato
     email: E-mail
   corporate_information_page:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -336,6 +336,7 @@ ro:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Formular de contact
     email: Email
   corporate_information_page:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -382,6 +382,7 @@ ru:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Контактная форма
     email: Электронный адрес
   corporate_information_page:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -281,6 +281,7 @@ si:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: තොරතුරු පෝරමය
     email: විද්‍යුත් තැපැල්
   corporate_information_page:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -330,6 +330,7 @@ sk:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -381,6 +381,7 @@ sl:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -283,6 +283,7 @@ so:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Foom cinwaan
     email: E-mail
   corporate_information_page:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -282,6 +282,7 @@ sq:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Forme kontakti
     email: Email
   corporate_information_page:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -384,6 +384,7 @@ sr:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: formular za kontakt
     email: e-mail
   corporate_information_page:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -279,6 +279,7 @@ sv:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -279,6 +279,7 @@ sw:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -283,6 +283,7 @@ ta:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: தொடர்புகொள்ளல் படிவம்
     email: மின்னஞ்சல்
   corporate_information_page:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -75,6 +75,7 @@ th:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: แบบฟอร์มการติดต่อ
     email: อีเมล์
   corporate_information_page:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -279,6 +279,7 @@ tk:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
   corporate_information_page:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -76,6 +76,7 @@ tr:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: İletişim Formu
     email: E-posta
   corporate_information_page:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -383,6 +383,7 @@ uk:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Форма зворотнього зв'язку
     email: Електронна пошта
   corporate_information_page:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -282,6 +282,7 @@ ur:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: کانٹیکٹ فارم
     email: ای میل
   corporate_information_page:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -281,6 +281,7 @@ uz:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Aloqa uchun
     email: Elektron manzil
   corporate_information_page:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -76,6 +76,7 @@ vi:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: Mẫu liên hệ
     email: Email
   corporate_information_page:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -74,6 +74,7 @@ zh-hk:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: 聯絡資料表
     email: 電子郵件
   corporate_information_page:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -74,6 +74,7 @@ zh-tw:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: 聯絡資料表
     email: 電子郵件
   corporate_information_page:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -74,6 +74,7 @@ zh:
     see_all_updates:
     updated_at:
   contact:
+    access_and_opening_times:
     contact_form: 联系表格
     email: 邮件
   corporate_information_page:

--- a/test/unit/helpers/translation_helper_test.rb
+++ b/test/unit/helpers/translation_helper_test.rb
@@ -3,8 +3,12 @@
 require 'test_helper'
 
 class TranslationHelperTest < ActionView::TestCase
+  include TranslatableModel
+
   setup do
     @document = stub('document', display_type_key: 'stub')
+    @model = stub('model')
+    @model.extend(TranslatableModel)
   end
 
   teardown do
@@ -122,6 +126,22 @@ class TranslationHelperTest < ActionView::TestCase
 
     I18n.with_locale(:de) do
       assert_equal "lang=en", t_lang("document.one")
+    end
+  end
+
+  test "t_lang_translated_locales returns lang=en if translation does not exist" do
+    @model.stubs(:translated_locales).returns(%i(en es de))
+
+    I18n.with_locale(:fr) do
+      assert_equal "lang=en", t_lang_translated_locales(@model)
+    end
+  end
+
+  test "t_lang_translated_locales returns nil if translation does exist" do
+    @model.stubs(:translated_locales).returns(%i(en es de))
+
+    I18n.with_locale(:de) do
+      assert_nil t_lang_translated_locales(@model)
     end
   end
 end

--- a/test/unit/models/corporate_information_page_type_test.rb
+++ b/test/unit/models/corporate_information_page_type_test.rb
@@ -30,6 +30,19 @@ class CorporateInformationPageTypeTest < ActiveSupport::TestCase
     assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
   end
 
+  test '.title_lang returns lang=en if the title translation does not exist' do
+    @organisation.acronym = ''
+    corporate_information_page = create(
+      :corporate_information_page,
+      corporate_information_page_type: @corporate_information_page_type,
+      organisation: @organisation
+    )
+
+    I18n.with_locale(:de) do
+      assert_equal "lang=en", corporate_information_page.title_lang
+    end
+  end
+
   test '.title uses the organisation\'s name when the acronym is empty' do
     @organisation.acronym = ''
     corporate_information_page = create(


### PR DESCRIPTION
## What
This fixes various issues with mixed languages on worldwide organisation pages:

1. **Contact Information.** Not all organisations have translations for their contact information. This PR uses `translated_locale` to compare the available translations for each worldwide office with the translation we are trying to fetch. If it doesn't exist, we know the default locale (:en) is used, so we add `lang=en` to the contact information wrapper.

2. **Access and Opening Times link.** This was previously hardcoded in English. This PR switches to using a locale file, so the string can be translated in future. It uses the `t_lang` and `t_fallback` method introduced in https://github.com/alphagov/whitehall/pull/4929 to detect if the fallback language is being used (all the time, at the moment, as we have no other translations) and adds `lang=en` accordingly.

3. **Corporate Information section.** It is possible for a content designer to add translations for these pages in Whitehall publisher. However, it doesn't seem possible to provide translations for the page titles themselves - these are instead provided within locale files. This PR adds methods to the corporate information page models to check which locale is being used (again, relying on the `t_lang` method introduced in https://github.com/alphagov/whitehall/pull/4929 and adds `lang=en` accordingly.

## Why
Having multiple languages on one page is confusing for screen reader users as screen-readers will read them out incorrectly. We want to mark up the untranslated sections of the page so they are made obvious to screen readers.

## Changes
### Worldwide office / contact section
<img width="758" alt="Screen Shot 2019-07-26 at 15 46 22" src="https://user-images.githubusercontent.com/29889908/61960024-97fa8180-afbc-11e9-9624-818e777cb849.png">

**Before:**

<img width="576" alt="Screen Shot 2019-07-26 at 15 45 40" src="https://user-images.githubusercontent.com/29889908/61959975-7ac5b300-afbc-11e9-967e-d9320bc3f434.png">

**After**:
<img width="577" alt="Screen Shot 2019-07-26 at 15 43 49" src="https://user-images.githubusercontent.com/29889908/61960039-9e88f900-afbc-11e9-8dec-79754f2f3af0.png">

### Access and Opening Times link
<img width="284" alt="Screen Shot 2019-07-26 at 15 50 59" src="https://user-images.githubusercontent.com/29889908/61960351-31c22e80-afbd-11e9-8542-844fd716f3f6.png">

**Before:**
<img width="876" alt="Screen Shot 2019-07-26 at 15 51 28" src="https://user-images.githubusercontent.com/29889908/61960392-4272a480-afbd-11e9-94ab-f7f197841f20.png">

**After:**
<img width="995" alt="Screen Shot 2019-07-29 at 10 14 06" src="https://user-images.githubusercontent.com/29889908/62036416-ad082800-b1e9-11e9-8dc2-c7586feca3ee.png">

### Corporate Information Page links
<img width="734" alt="Screen Shot 2019-07-26 at 15 47 59" src="https://user-images.githubusercontent.com/29889908/61960090-c37d6c00-afbc-11e9-936c-cec982d42c4a.png">

**Before:**
<img width="130" alt="Screen Shot 2019-07-26 at 15 48 23" src="https://user-images.githubusercontent.com/29889908/61960124-d1cb8800-afbc-11e9-9aec-b8eef73bffb6.png">

**After:**
<img width="169" alt="Screen Shot 2019-07-26 at 15 44 26" src="https://user-images.githubusercontent.com/29889908/61960129-d5f7a580-afbc-11e9-9417-5532ef7a5221.png">

## Links:

- [Translated page with mixed languages](https://www.gov.uk/world/organisations/british-embassy-seoul.ko)
- [Translated page with translated contact information](https://www.gov.uk/world/organisations/british-embassy-bangkok.th)
