### PR TITLE
Fix changing the timeout for the Publishing API client

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -4,19 +4,11 @@ require "gds_api/email_alert_api"
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.find("publishing-api"),
-      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
-      timeout: 20,
-    )
+    @publishing_api ||= publishing_api_client_with_timeout(20)
   end
 
   def self.publishing_api_with_low_timeout
-    @publishing_api_with_low_timeout ||= begin
-      publishing_api.dup.tap do |client|
-        client.options[:timeout] = 1
-      end
-    end
+    @publishing_api_with_low_timeout ||= publishing_api_client_with_timeout(1)
   end
 
   def self.asset_manager
@@ -30,6 +22,14 @@ module Services
     @email_alert_api ||= GdsApi::EmailAlertApi.new(
       Plek.find("email-alert-api"),
       bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "gazorpazorp")
+    )
+  end
+
+  def self.publishing_api_client_with_timeout(timeout)
+    GdsApi::PublishingApiV2.new(
+      Plek.find("publishing-api"),
+      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
+      timeout: timeout,
     )
   end
 end


### PR DESCRIPTION
Calling the publishing_api_with_low_timeout function would cause the
Publishing API client timeout to be set to 1, which would break parts
of Whitehall that talk to the Publishing API, casuing it to "hang up"
after a second.

Rather than using `.dup`, just make it a parameter to a new function,
and call that in both places.