### PR TITLE
Add Philip Hammond to previous chancellors list

### DIFF
--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -15,6 +15,10 @@
       <h2 class="profiles">20th &amp; 21st centuries</h2>
       <ol>
         <li class="person person-excerpt"><div class="inner">
+          <h3 class="name">Philip Hammond</h3>
+          <p class="term">2016 to 2019</p>
+        </div></li>
+        <li class="person person-excerpt"><div class="inner">
           <h3 class="name">George Osborne</h3>
           <p class="term">2010 to 2016</p>
         </div></li>


### PR DESCRIPTION
This adds the Philip Hammond to 
https://www.gov.uk/government/history/past-chancellors

Trello card: 
https://trello.com/c/Ze0BwcRz/1143-update-former-chancellors-page-content-requests