### PR TITLE
Align previous chancellors list

### DIFF
--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -117,7 +117,7 @@
         <h3>Foreign Secretaries <span>1782 to present</span></h3>
       </div>
       <ol>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name"><a href="/government/people/dominic-raab">Dominic Raab</a></h4>
             <p class="term">2019 to present</p>
@@ -135,13 +135,13 @@
             <p class="term">2016 to 2018</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Philip Hammond</h4>
             <p class="term">2014 to 2016</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">William Hague</h4>
             <p class="term">2010 to 2014</p>
@@ -153,13 +153,13 @@
             <p class="term">2007 to 2010</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Margaret Beckett</h4>
             <p class="term">2006 to 2007</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Jack Straw</h4>
             <p class="term">2001 to 2006</p>
@@ -171,13 +171,13 @@
             <p class="term">1997 to 2001</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Malcolm Rifkind</h4>
             <p class="term">1995 to 1997</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Douglas Hurd, Lord Hurd of Westwell</h4>
             <p class="term">1989 to 1995</p>
@@ -189,13 +189,13 @@
             <p class="term">1989</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Geoffrey Howe, Lord Howe of Aberavon</h4>
             <p class="term">1983 to 1989</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Francis Pym, Lord Pym of Sandy</h4>
             <p class="term">1982 to 1983</p>
@@ -207,13 +207,13 @@
             <p class="term">1979 to 1982</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Dr David Owen, Lord Owen of the City of Plymouth</h4>
             <p class="term">1977 to 1979</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Anthony Crosland</h4>
             <p class="term">1976 to 1977</p>
@@ -225,13 +225,13 @@
             <p class="term">1974 to 1976</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
             <p class="term">1970 to 1974</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
             <p class="term">1968 to 1970</p>
@@ -243,13 +243,13 @@
             <p class="term">1966 to 1968</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
             <p class="term">1965 to 1966</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Patrick Gordon-Walker, Lord Gordon-Walker of Leyton</h4>
             <p class="term">1964 to 1965</p>
@@ -261,13 +261,13 @@
             <p class="term">1963 to 1964</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
             <p class="term">1960 to 1963</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">John Selwyn Brooke Lloyd, Lord Selwyn-Lloyd</h4>
             <p class="term">1955 to 1960</p>
@@ -279,13 +279,13 @@
             <p class="term">1955</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
             <p class="term">1951 to 1955</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Herbert Morrison, Lord Morrison of Lambeth</h4>
             <p class="term">1951</p>
@@ -297,13 +297,13 @@
             <p class="term">1945 to 1951</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
             <p class="term">1940 to 1945</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount Halifax</a></h4>
             <p class="term">1938 to 1940</p>
@@ -315,13 +315,13 @@
             <p class="term">1935 to 1938</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Sir Samuel Hoare, Viscount Templewood</h4>
             <p class="term">1935</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Sir John Simon, Viscount Simon</h4>
             <p class="term">1931 to 1935</p>
@@ -333,13 +333,13 @@
             <p class="term">1931</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Arthur Henderson</h4>
             <p class="term">1929 to 1931</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h4>
             <p class="term">1924 to 1929</p>
@@ -351,13 +351,13 @@
             <p class="term">1924</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name"><a href="past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h4>
             <p class="term">1919 to 1924</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Arthur James Balfour, Earl of Balfour</h4>
             <p class="term">1916 to 1919</p>
@@ -369,13 +369,13 @@
             <p class="term">1905 to 1916</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h4>
             <p class="term">1900 to 1905</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
             <p class="term">1895 to 1900</p>
@@ -387,13 +387,13 @@
             <p class="term">1894 to 1895</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
             <p class="term">1892 to 1894</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
             <p class="term">1897 to 1892</p>
@@ -405,13 +405,13 @@
             <p class="term">1886 to 1887</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
             <p class="term">1886</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
             <p class="term">1885 to 1886</p>
@@ -423,13 +423,13 @@
             <p class="term">1880 to 1885</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
             <p class="term">1878 to 1880</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
             <p class="term">1874 to 1878</p>
@@ -441,13 +441,13 @@
             <p class="term">1870 to 1874</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">George Villiers, Earl of Clarendon</h4>
             <p class="term">1868 to 1870</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
             <p class="term">1866 to 1868</p>
@@ -459,13 +459,13 @@
             <p class="term">1865 to 1866</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Lord John Russell, Earl Russell</h4>
             <p class="term">1859 to 1865</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">James Harris, Earl of Malmesbury</h4>
             <p class="term">1858 to 1859</p>
@@ -477,13 +477,13 @@
             <p class="term">1853 to 1858</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Lord John Russell, Earl Russell</h4>
             <p class="term">1852 to 1853</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">James Harris, Earl of Malmesbury</h4>
             <p class="term">1852</p>
@@ -495,13 +495,13 @@
             <p class="term">1851 to 1852</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
             <p class="term">1846 to 1851</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h4>
             <p class="term">1841 to 1846</p>
@@ -513,13 +513,13 @@
             <p class="term">1835 to 1841</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Arthur Wellesley, Duke of Wellington</h4>
             <p class="term">1834 to 1835</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
             <p class="term">1830 to 1834</p>
@@ -531,13 +531,13 @@
             <p class="term">1828 to 1830</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">John William Ward, Viscount Dudley and Ward</h4>
             <p class="term">1827 to 1828</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">George Canning</h4>
             <p class="term">1822 to 1827</p>
@@ -549,13 +549,13 @@
             <p class="term">1812 to 1822</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Richard Wellesley, Marquess Wellesley</h4>
             <p class="term">1809 to 1812</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Henry Bathurst, Earl Bathurst</h4>
             <p class="term">1809</p>
@@ -567,13 +567,13 @@
             <p class="term">1807 to 1809</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Charles Grey, Lord Howick</h4>
             <p class="term">1806 to 1807</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
             <p class="term">1806</p>
@@ -585,13 +585,13 @@
             <p class="term">1805 to 1806</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Dudley Ryder, Lord Harrowby</h4>
             <p class="term">1804</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">Robert Banks Jenkinson, Lord Hawkesbury</h4>
             <p class="term">1801 to 1804</p>
@@ -603,13 +603,13 @@
             <p class="term">1791 to 1801</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Francis Godolphin Osborne, Marquess of Carmarthen</h4>
             <p class="term">1783 to 1791</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name">George Nugent Temple Grenville, Earl Temple</h4>
             <p class="term">1783</p>
@@ -621,13 +621,13 @@
             <p class="term">1783</p>
           </div>
         </li>
-        <li>
+        <li class="clear-person">
           <div class="inner">
             <h4 class="name">Thomas Robinson, Lord Grantham</h4>
             <p class="term">1782 to 1783</p>
           </div>
         </li>
-        <li class="clear-person">
+        <li>
           <div class="inner">
             <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
             <p class="term">1782</p>


### PR DESCRIPTION
This will display them in lines of three.

Trello card: https://trello.com/c/f12zlzdi/1144-update-former-foreign-secretaries-page-content-requests

# Before

<img width="988" alt="Screen Shot 2019-07-29 at 16 07 23" src="https://user-images.githubusercontent.com/14851208/62063012-04c28580-b222-11e9-8dba-44ae48517324.png">

# After

<img width="936" alt="Screen Shot 2019-07-29 at 16 42 50" src="https://user-images.githubusercontent.com/14851208/62063028-0ab86680-b222-11e9-9523-4c4c1ff93de4.png">
