### PR TITLE
Mark World News untranslated text as english

### DIFF
--- a/app/views/shared/_featured.html.erb
+++ b/app/views/shared/_featured.html.erb
@@ -27,9 +27,9 @@
             <%= absolute_date(feature.time_stamp) %>
           <% else %>
             <% if feature.time_stamp %>
-              <%= absolute_date(feature.time_stamp) %> &mdash; <%= t_display_type feature %>
+              <%= absolute_date(feature.time_stamp) %><span <%= t_lang('document.type.' + feature.display_type_key, {count: 1}) %> > &mdash; <%= t_display_type feature %></span>
             <% else %>
-              <%= t_display_type feature %>
+              <span <%= t_lang('document.type.' + feature.display_type_key, {count: 1}) %> ><%= t_display_type feature %></span>
             <% end %>
           <% end %>
         </p>

--- a/app/views/shared/_featured_links.html.erb
+++ b/app/views/shared/_featured_links.html.erb
@@ -1,5 +1,8 @@
-<%= content_tag_if_not_empty(:ul, class: 'featured-links') do %>
-  <% links.each do |link| %>
-    <li><%= link_to link.title, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
-  <% end %>
+<% if links %>
+  <ul class="featured-links" <%= lang if local_assigns[:lang] %> >
+    <% links.each do |link| %>
+      <li><%= link_to link.title, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
+    <% end %>
+  </ul>
 <% end %>
+

--- a/app/views/shared/_list_description.html.erb
+++ b/app/views/shared/_list_description.html.erb
@@ -20,7 +20,7 @@
       </h2>
       <ul class="attributes">
         <li class="publication-date"><%= edition.display_date_microformat %></li>
-        <li class="document-type"><%= t_display_type(edition) %></li>
+        <li class="document-type" <%= t_lang('document.type.' + edition.display_type_key, {count: 1}) %>><%= t_display_type(edition) %></li>
       </ul>
     <% end %>
   <% end %>

--- a/app/views/shared/_list_description_for_rummager_list.html.erb
+++ b/app/views/shared/_list_description_for_rummager_list.html.erb
@@ -20,7 +20,7 @@
       </h2>
       <ul class="attributes">
         <li class="publication-date"><%= edition.display_date_microformat %></li>
-        <li class="document-type"><%= edition.display_type %></li>
+        <li class="document-type" lang="en"><%= edition.display_type %></li>
       </ul>
     </li>
   <% end %>

--- a/app/views/shared/_recently_updated_documents.html.erb
+++ b/app/views/shared/_recently_updated_documents.html.erb
@@ -7,7 +7,7 @@
           <%= published_or_updated(document) %>
           <%= absolute_date(document.public_timestamp, class: 'published-at') %>
         </li>
-        <li class="display-type"><%= t_display_type(document) %></li>
+        <li class="display-type" <%= t_lang('document.type.' + document.display_type_key, {count: 1}) %>  ><%= t_display_type(document) %></li>
       </ul>
     <% end %>
   <% end %>

--- a/app/views/shared/_recently_updated_documents_from_rummager.html.erb
+++ b/app/views/shared/_recently_updated_documents_from_rummager.html.erb
@@ -6,7 +6,7 @@
         <li class="published-date">
           <%= document.publication_date %>
         </li>
-        <li class="display-type"><%= t_display_type(document) %></li>
+        <li class="display-type" <%= t_lang('document.type.' + document.display_type_key, {count: 1}) %> ><%= t_display_type(document) %></li>
       </ul>
     </li>
   <% end %>

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -12,7 +12,8 @@
       <aside class="heading-extra">
         <div class="inner-heading">
           <%= render 'shared/available_languages', object: @world_location %>
-          <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set %>
+          <% lang = "lang=en" unless I18n.locale.eql?(:en) %>
+          <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set, lang: lang %>
         </div>
       </aside>
     </div>

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -339,7 +339,6 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
   view_test "should show featured links if there are some" do
     with_stubbed_rummager(@rummager, true) do
       @rummager.expects(:search).returns('results' => []).twice
-
       featured_link = create(:featured_link, linkable: @world_location)
 
       get :index, params: { world_location_id: @world_location }
@@ -348,5 +347,25 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
         assert_select "a[href='#{featured_link.url}']", text: featured_link.title
       end
     end
+  end
+
+  view_test "does not set lang=en on featured links for english pages" do
+    with_stubbed_rummager(@rummager, true) do
+      @rummager.expects(:search).returns('results' => []).twice
+      create(:featured_link, linkable: @world_location)
+
+      get :index, params: { world_location_id: @world_location }
+
+      assert_select '.featured-links[lang=en]', false, "English world location pages should not set lang=en on featured links"
+    end
+  end
+
+  view_test "sets lang=en on featured links for translated pages" do
+    create(:published_publication, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_publication, world_locations: [@translated_world_location])
+
+    get :index, params: { world_location_id: @translated_world_location, locale: 'fr' }
+
+    assert_select '.featured-links[lang=en]'
   end
 end


### PR DESCRIPTION
## What
Mark up untranslated text on non-english pages with `lang=en`. This includes:

- Featured links
- Document types, within document lists (Our Documents; Latest) and under images in featured documents

## Why
Featured links on world news pages are specified within Whitehall Publisher and there is no current way of providing translations for these links. Therefore, on translated (non-english) pages, these links continue to display as english. We need to identify these links as English so screenreaders don't try to read them out in the translated language.

Document type translations are stored within locale files, but we don't have translations for everything in every language. In these cases, we fallback to English. We should mark up this text as `lang=en` when we fall back.

### View in Whitehall where featured links are added
<img width="767" alt="Screen Shot 2019-07-31 at 13 30 33" src="https://user-images.githubusercontent.com/29889908/62216781-547b8b00-b3a1-11e9-8012-247a3496b27b.png">

## Changes: Featured Links

<img width="345" alt="Screen Shot 2019-07-31 at 14 42 51" src="https://user-images.githubusercontent.com/29889908/62216924-93a9dc00-b3a1-11e9-9c0b-9424759be52d.png">

### Before
<img width="241" alt="Screen Shot 2019-07-31 at 14 43 17" src="https://user-images.githubusercontent.com/29889908/62216915-90165500-b3a1-11e9-9102-c91307538768.png">

### After
<img width="312" alt="Screen Shot 2019-07-31 at 14 43 04" src="https://user-images.githubusercontent.com/29889908/62216930-960c3600-b3a1-11e9-9f19-120a35cc3a2c.png">

## Changes: Document Type
<img width="320" alt="Screen Shot 2019-07-31 at 15 30 40" src="https://user-images.githubusercontent.com/29889908/62220615-3b2a0d00-b3a8-11e9-90a3-bb6d69a49b16.png">

### Before
<img width="410" alt="Screen Shot 2019-07-31 at 15 31 05" src="https://user-images.githubusercontent.com/29889908/62220623-3feec100-b3a8-11e9-88a0-1ac3fb8b7ae8.png">

### After
<img width="470" alt="Screen Shot 2019-07-31 at 15 30 51" src="https://user-images.githubusercontent.com/29889908/62220635-45e4a200-b3a8-11e9-85e4-a3e9ce2766e2.png">

## Example Pages

- https://www.gov.uk/world/afghanistan/news.dr
- https://www.gov.uk/world/spain/news.es