### PR TITLE
Update Statistics links

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -1,4 +1,5 @@
-# Statistics Announcements can be found at https://www.gov.uk/government/statistics/announcements
+# Statistics Announcements can be found at
+# https://www.gov.uk/search/research-and-statistics?content_store_document_type=upcoming_statistics
 #
 # They are used to announce the publication of official statistics. Some info
 # can be found in the Wiki - https://gov-uk.atlassian.net/wiki/display/GOVUK/Statistics.

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -256,7 +256,7 @@
               href="/government/statistics/how-national-and-official-statistics-are-assured">Find
               out about the legislation</a> that governs the publication of UK
             national and Official Statistics.</p>
-            <p><%= link_to "See statistics publications on GOV.UK", '/government/statistics' %></p>
+            <p><%= link_to "See statistics publications on GOV.UK", '/search/research-and-statistics' %></p>
 
           </div>
         </div>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -6,7 +6,7 @@
       <li><%= main_navigation_link_to 'How government works', how_government_works_path %></li>
       <li><%= main_navigation_link_to "Get involved", get_involved_path %></li>
       <li class="clear-child"><a href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">Consultations</a></li>
-      <li><%= main_navigation_link_to "Statistics", statistics_path %></li>
+      <li><a href="/search/research-and-statistics">Statistics</a></li>
       <li><a href="/news-and-communications">News and communications</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
To point to the new specialist finder at search/research-and-statistics

https://trello.com/c/CAtBdn4k/510-change-whitehall-header-link-to-stats-finder-s