### PR TITLE
Fix 'See All' links

### DIFF
--- a/app/views/shared/_document_list_from_rummager.html.erb
+++ b/app/views/shared/_document_list_from_rummager.html.erb
@@ -2,6 +2,7 @@
    heading ||= type.to_s.humanize
    filter_option = (heading == "Publications") ? "all" : heading.downcase
    world_location_news ||= "0"
+   see_all_text ||= "See all #{heading.downcase}"
    filter_type = @classification || @world_location || @topical_event
 %>
 <section id="<%= heading.downcase.parameterize %>" class="document-block">
@@ -19,7 +20,7 @@
     %>
     <%=
       link_to(
-        "See all #{heading.downcase}",
+        see_all_text,
         see_more_url,
         data: {
           track_category: 'navPolicyAreaLinkClicked',

--- a/app/views/shared/_recently_updated.html.erb
+++ b/app/views/shared/_recently_updated.html.erb
@@ -15,8 +15,8 @@
     <% end %>
     <%= render 'shared/feeds', atom_url: atom_url %>
     <% if local_assigns[:see_all_link] %>
-      <p class="see-all">
-        <%= link_to 'See all', see_all_link %>
+      <p class="see-all" <%= t_lang('document.see_all') %> >
+        <%= link_to t('document.see_all'), see_all_link %>
       </p>
     <% end %>
   </div>

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -62,6 +62,7 @@
               documents_count: @announcements.count,
               heading: t('world_location.headings.announcements'),
               world_location_news: "1",
+              see_all_text: t_see_all_our(:announcement)
             } %>
           </div>
         <% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -343,6 +343,7 @@ ar:
       updated:
     published: نشر
     read: اقرأ %{title} المقال
+    see_all:
     speech:
       author_title:
         minister: وزير

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -124,6 +124,7 @@ az:
       part_of:
     published: dərc olunub
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -249,6 +249,7 @@ be:
       updated:
     published: Апублікаваны
     read: Чытаць %{title} артыкул
+    see_all:
     speech:
       author_title:
         minister: Міністр

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -155,6 +155,7 @@ bg:
       updated:
     published: Публикувано
     read: 'Прочетете статията %{title} '
+    see_all:
     speech:
       author_title:
         minister: Министър

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -155,6 +155,7 @@ bn:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -202,6 +202,7 @@ cs:
       updated:
     published: Publikováno
     read: Čtěte %{title}
+    see_all:
     speech:
       author_title:
         minister: Minister

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -343,6 +343,7 @@ cy:
       updated:
     published: Cyhoeddwyd
     read: Darllenwch yr erthygl %{title}
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -155,6 +155,7 @@ da:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -155,6 +155,7 @@ de:
       updated:
     published: Veröffentlicht
     read: Artikel lesen %{title}
+    see_all:
     speech:
       author_title:
         minister: Minister

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -155,6 +155,7 @@ dr:
       updated:
     published: نشر شده
     read: مقاله %{title} را بخوانید
+    see_all:
     speech:
       author_title:
         minister: وزیر

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -155,6 +155,7 @@ el:
       updated:
     published: Δημοσιευμένο
     read: Διαβάστε το άρθρο  %{title}
+    see_all:
     speech:
       author_title:
         minister: Υπουργός

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
       storage_units:
          format: ! '%n%u'
   document:
+    see_all: "See all"
     published: published
     contents: Contents
     headings:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -155,6 +155,7 @@ es-419:
       updated:
     published: publicado
     read: Lea el artículo %{title}
+    see_all:
     speech:
       author_title:
         minister: Ministro

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -155,6 +155,7 @@ es:
       updated:
     published: Publicado
     read: Leer el artículo
+    see_all:
     speech:
       author_title:
         minister: Ministro

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -155,6 +155,7 @@ et:
       updated: Täiendatud
     published: avaldatud
     read: 'Lugege artiklit: %{title} '
+    see_all:
     speech:
       author_title:
         minister: Minister

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -126,6 +126,7 @@ fa:
       part_of:
     published: منتشر شده
     read: مقاله  %{title} را بخوانید
+    see_all:
     speech:
       author_title:
         minister: معاون وزیر

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -155,6 +155,7 @@ fi:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -155,6 +155,7 @@ fr:
       updated:
     published: publié
     read: Lire l'article intitulé %{title}
+    see_all:
     speech:
       author_title:
         minister: Ministre

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -249,6 +249,7 @@ gd:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -155,6 +155,7 @@ he:
       updated:
     published: פורסם
     read: קראו את מאמר %{title}
+    see_all:
     speech:
       author_title:
         minister: שר

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -155,6 +155,7 @@ hi:
       updated:
     published: प्रकाशित
     read: पढ़ें %{title} लेख
+    see_all:
     speech:
       author_title:
         minister: मंत्री

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -249,6 +249,7 @@ hr:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -155,6 +155,7 @@ hu:
       updated:
     published: közzététel dátuma
     read: 'Olvassa el a következő cikket: %{title}'
+    see_all:
     speech:
       author_title:
         minister: Miniszter

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -155,6 +155,7 @@ hy:
       updated:
     published: հրապարակված
     read: Կարդացեք  %{title} հոդվածը
+    see_all:
     speech:
       author_title:
         minister: Նախարար

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -126,6 +126,7 @@ id:
       part_of:
     published: Diterbitkan
     read: Baca artikel %{title}
+    see_all:
     speech:
       author_title:
         minister: Menteri

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -155,6 +155,7 @@ is:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -155,6 +155,7 @@ it:
       updated:
     published: pubblicato
     read: Leggi l'articolo %{title}
+    see_all:
     speech:
       author_title:
         minister: Ministro

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -125,6 +125,7 @@ ja:
       part_of:
     published: 掲載日
     read: "%{title} の記事を読む"
+    see_all:
     speech:
       author_title:
         minister: 大臣

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -124,6 +124,7 @@ ka:
       part_of:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -155,6 +155,7 @@ kk:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -125,6 +125,7 @@ ko:
       part_of:
     published: 발행
     read: "%{title} 기사를 확인하세요"
+    see_all:
     speech:
       author_title:
         minister: 장관

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -202,6 +202,7 @@ lt:
       updated:
     published: publikuota
     read: 'Skaitykite straipsnį %{title} '
+    see_all:
     speech:
       author_title:
         minister: Ministras

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -155,6 +155,7 @@ lv:
       updated:
     published: publicēts
     read: Lasīt %{title} rakstu
+    see_all:
     speech:
       author_title:
         minister: Ministrs

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -124,6 +124,7 @@ ms:
       part_of:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -249,6 +249,7 @@ mt:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -155,6 +155,7 @@ nl:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -155,6 +155,7 @@
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -249,6 +249,7 @@ pl:
       updated:
     published: opublikowano
     read: Przeczytaj %{title} artykuł
+    see_all:
     speech:
       author_title:
         minister: Minister

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -155,6 +155,7 @@ ps:
       updated:
     published: خپور شوی
     read: دا مضمون ووایاست %{title}
+    see_all:
     speech:
       author_title:
         minister: وزیر

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -155,6 +155,7 @@ pt:
       updated:
     published: publicado
     read: Leia o %{title} artigo
+    see_all:
     speech:
       author_title:
         minister: Ministro

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -202,6 +202,7 @@ ro:
       updated:
     published: Data publicării
     read: 'Citește articolul %{title} '
+    see_all:
     speech:
       author_title:
         minister: 'Ministru '

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -249,6 +249,7 @@ ru:
       updated:
     published: Опубликовано
     read: Прочитать статью %{title}
+    see_all:
     speech:
       author_title:
         minister: Министр

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -155,6 +155,7 @@ si:
       updated:
     published: පල කරන ලදී
     read: ලිපිය  %{title} කියවන්න
+    see_all:
     speech:
       author_title:
         minister: අමාත්‍යවරයා

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -202,6 +202,7 @@ sk:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -249,6 +249,7 @@ sl:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -155,6 +155,7 @@ so:
       updated:
     published: La-daabacay/nashriyey
     read: Akhri maqaalka %{title}
+    see_all:
     speech:
       author_title:
         minister: Wasiir

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -155,6 +155,7 @@ sq:
       updated:
     published: publikuar
     read: 'Lexo %{title} '
+    see_all:
     speech:
       author_title:
         minister: Minister

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -249,6 +249,7 @@ sr:
       updated:
     published: objavljeno
     read: Pročitajte %{title}
+    see_all:
     speech:
       author_title:
         minister: Ministar

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -155,6 +155,7 @@ sv:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -155,6 +155,7 @@ sw:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -155,6 +155,7 @@ ta:
       updated:
     published: பிரசுரிக்கப்பட்டது
     read: கட்டுரையின் %{title} வாசிக்கவும்
+    see_all:
     speech:
       author_title:
         minister: அமைச்சர்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -125,6 +125,7 @@ th:
       part_of:
     published: ตีพิมพ์
     read: อ่าน%{title}บทความ
+    see_all:
     speech:
       author_title:
         minister: รัฐมนตรี

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -155,6 +155,7 @@ tk:
       updated:
     published:
     read:
+    see_all:
     speech:
       author_title:
         minister:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -126,6 +126,7 @@ tr:
       part_of:
     published: Yayında
     read: "%{title} makalesini okuyunuz"
+    see_all:
     speech:
       author_title:
         minister: Bakan

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -249,6 +249,7 @@ uk:
       updated:
     published: опубліковано
     read: Читати %{title} статтю
+    see_all:
     speech:
       author_title:
         minister: Міністр

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -155,6 +155,7 @@ ur:
       updated:
     published: شائع شدہ
     read: پڑھئیے {title}% مضمون
+    see_all:
     speech:
       author_title:
         minister: وزیر

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -155,6 +155,7 @@ uz:
       updated:
     published: nashr qilindi
     read: Maqolani o'qish %{title}
+    see_all:
     speech:
       author_title:
         minister: Vazir

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -126,6 +126,7 @@ vi:
       part_of:
     published: Đã xuất bản
     read: Đọc bài có  %{title}
+    see_all:
     speech:
       author_title:
         minister: Thứ trưởng

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -124,6 +124,7 @@ zh-hk:
       part_of:
     published: 已發布
     read: 閱讀%{title}文章
+    see_all:
     speech:
       author_title:
         minister: 大臣

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -124,6 +124,7 @@ zh-tw:
       part_of:
     published: 發行
     read: 閱讀%{title}文章
+    see_all:
     speech:
       author_title:
         minister: 部長

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -124,6 +124,7 @@ zh:
       part_of:
     published: 已发布
     read: 阅读%{title}文章
+    see_all:
     speech:
       author_title:
         minister: 首相/大臣/秘书

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -285,6 +285,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
 
     assert_select ".type", "World location news"
     assert_select "#publications .see-all a", /Voir toutes nos publications/
+    assert_select ".see-all a", /Voir toutes nos annonces/
   end
 
   test "should only display translated announcements when requested for a locale" do


### PR DESCRIPTION
## What
Fixing the "see all" links on pages so they are fully translated properly when the page is translated into another language.

## Why
"See all announcements" was being translated to "See all [announcements in current language]" rather than the full translation that actually existed for "See all announcements". Other groups of documents had the ability to be translated and a translation for announcements existed, it just wasn't being used. This was resulting in mixed languages.

## See all announcements
### Before
<img width="494" alt="Screen Shot 2019-07-31 at 16 24 12" src="https://user-images.githubusercontent.com/29889908/62225106-b80cb500-b3af-11e9-89ac-dfc556959cbd.png">

### After
<img width="492" alt="Screen Shot 2019-07-31 at 16 23 59" src="https://user-images.githubusercontent.com/29889908/62225123-c1961d00-b3af-11e9-9a24-09130b7e9d36.png">

## See all
<img width="662" alt="Screen Shot 2019-07-31 at 16 34 29" src="https://user-images.githubusercontent.com/29889908/62226291-e25f7200-b3b1-11e9-81a1-7e065ad74498.png">

### Before
<img width="523" alt="Screen Shot 2019-07-31 at 16 38 25" src="https://user-images.githubusercontent.com/29889908/62226290-df648180-b3b1-11e9-9647-840bb1988ef7.png">

### After
<img width="526" alt="Screen Shot 2019-07-31 at 16 38 12" src="https://user-images.githubusercontent.com/29889908/62226275-da073700-b3b1-11e9-9c8f-7c677e31cb47.png">

## Example Pages

- https://www.gov.uk/world/afghanistan/news.dr
- https://www.gov.uk/world/spain/news.es