### PR TITLE
Redirect edit pages for locked documents

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -1,6 +1,7 @@
 class Admin::AttachmentsController < Admin::BaseController
   before_action :limit_attachable_access, if: :attachable_is_an_edition?
   before_action :check_attachable_allows_attachment_type
+  before_action :forbid_editing_of_locked_documents, if: :attachable_is_an_edition?
 
   rescue_from Mysql2::Error, with: :handle_duplicate_key_errors_caused_by_double_create_requests
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -41,6 +41,13 @@ class Admin::BaseController < ApplicationController
     end
   end
 
+  def forbid_editing_of_locked_documents
+    if @edition.locked?
+      redirect_to [:admin, @edition],
+                  alert: %{This document is locked and cannot be edited}
+    end
+  end
+
 private
 
   def forbidden!

--- a/app/controllers/admin/document_sources_controller.rb
+++ b/app/controllers/admin/document_sources_controller.rb
@@ -1,6 +1,7 @@
 class Admin::DocumentSourcesController < Admin::BaseController
   before_action :require_import_permission!
   before_action :find_edition
+  before_action :forbid_editing_of_locked_documents
 
   def update
     @document_sources = params[:document_sources]

--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -2,7 +2,7 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
-
+  before_action :forbid_editing_of_locked_documents
 
   def edit
     @path = get_path

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -2,6 +2,7 @@ class Admin::EditionTagsController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
+  before_action :forbid_editing_of_locked_documents
 
   def edit
     @topic_taxonomy = Taxonomy::TopicTaxonomy.new

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -1,6 +1,8 @@
 class Admin::EditionTranslationsController < Admin::BaseController
   include TranslationControllerConcern
 
+  before_action :forbid_editing_of_locked_documents
+
   def update
     @translated_edition.change_note = 'Added translation' unless @translated_edition.change_note.present?
     super

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -23,13 +23,6 @@ class Admin::EditionsController < Admin::BaseController
     end
   end
 
-  def forbid_editing_of_locked_documents
-    if @edition.locked?
-      redirect_to [:admin, @edition],
-                  alert: %{This document is locked and cannot be edited}
-    end
-  end
-
   def enforce_permissions!
     case action_name
     when 'index', 'topics'

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -14,11 +14,19 @@ class Admin::EditionsController < Admin::BaseController
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :deduplicate_specialist_sectors, only: %i[create update]
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update submit destory revise]
+  before_action :forbid_editing_of_locked_documents, only: %i[edit update revise destroy]
 
   def forbid_editing_of_historic_content!
     unless can?(:modify, @edition)
       redirect_to [:admin, @edition],
                   alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please <a href="https://support.publishing.service.gov.uk/content_change_request/new">contact GDS</a> if you need to change it.}
+    end
+  end
+
+  def forbid_editing_of_locked_documents
+    if @edition.locked?
+      redirect_to [:admin, @edition],
+                  alert: %{This document is locked and cannot be edited}
     end
   end
 

--- a/app/controllers/admin/editorial_remarks_controller.rb
+++ b/app/controllers/admin/editorial_remarks_controller.rb
@@ -2,6 +2,7 @@ class Admin::EditorialRemarksController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
+  before_action :forbid_editing_of_locked_documents
 
   def enforce_permissions!
     enforce_permission!(:make_editorial_remark, @edition)

--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -1,16 +1,20 @@
 class Admin::NeedsController < Admin::BaseController
-  def edit
-    @document = Document.find_by(content_id: params[:content_id])
-    @edition = @document.latest_edition
-  end
+  before_action :find_latest_edition
+  before_action :forbid_editing_of_locked_documents
+
+  def edit; end
 
   def update
-    document = Document.find_by(content_id: params[:content_id])
-    edition = document.latest_edition
+    @document.need_ids = params[:need_ids] || []
+    @document.patch_meets_user_needs_links
 
-    document.need_ids = params[:need_ids] || []
-    document.patch_meets_user_needs_links
+    redirect_to admin_edition_path(@edition)
+  end
 
-    redirect_to admin_edition_path(edition)
+private
+
+  def find_latest_edition
+    @document = Document.find_by(content_id: params[:content_id])
+    @edition = @document.latest_edition
   end
 end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -91,6 +91,15 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_redirected_to admin_edition_attachments_url(attachable)
   end
 
+  test "POST :create should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    post :create, params: { edition_id: edition.id, attachment: valid_file_attachment_params }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   view_test 'GET :index shows html attachments' do
     create(:html_attachment, title: 'An HTML attachment', attachable: @edition)
 
@@ -98,6 +107,15 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_select '.existing-attachments li strong', text: 'An HTML attachment'
+  end
+
+  test "GET :index should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :index, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
   test 'POST :create handles html attachments when attachable allows them' do
@@ -162,6 +180,16 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert Attachment.find(attachment.id).deleted?, 'attachment should have been deleted'
   end
 
+  test "DELETE :destroy should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    attachment = create(:file_attachment, attachable: edition)
+
+    delete :destroy, params: { edition_id: edition.id, id: attachment.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   view_test 'GET :index shows external attachments' do
     create(:external_attachment, title: 'An external attachment', attachable: @edition)
 
@@ -221,6 +249,15 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  test "PUT :order should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    put :order, params: { edition_id: edition.id, order: {} }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   test "GET :new raises an exception with an unknown parent type" do
     assert_raise(ActiveRecord::RecordNotFound) {
       get :new, params: { edition_id: 123 }
@@ -243,17 +280,19 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "option[value='#{Attachment.parliamentary_sessions.first}']"
   end
 
+  test "GET :new should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :new, params: { edition_id: edition, type: "file" }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new
     assert_equal 0, @edition.reload.attachments.size
-  end
-
-  test "POST :create with an edition belonging to a locked document does not save the attachment" do
-    edition = create(:unpublished_edition, :with_locked_document)
-    assert_raise LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
-      post :create, params: { edition_id: edition, attachment: valid_file_attachment_params }
-    end
   end
 
   view_test "GET :edit renders the edit form" do
@@ -266,6 +305,16 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     attachment = create(:file_attachment, attachable: @edition, attachment_data: create(:attachment_data))
     get :edit, params: { edition_id: @edition, id: attachment }
     assert_select "input[type=file]"
+  end
+
+  test "GET :edit should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    attachment = create(:file_attachment, attachable: edition, attachment_data: create(:attachment_data))
+
+    get :edit, params: { edition_id: edition.id, id: attachment }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
   test "PUT :update for HTML attachment updates the attachment" do
@@ -314,6 +363,20 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
         title: 'New title'
       }
     }
+  end
+
+  test "PUT :update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    attachment = create(:file_attachment, attachable: edition)
+
+    put :update, params: {
+      edition_id: edition.id,
+      id: attachment,
+      attachment: { title: "New title" },
+    }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
   test 'PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager' do
@@ -395,6 +458,22 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     @edition.reload.attachments.each do |attachment|
       assert_match(/.+_$/, attachment.title)
     end
+  end
+
+  test "PUT :update_many should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    files = Dir.glob(Rails.root.join('test', 'fixtures', '*.csv')).take(4)
+
+    files.each_with_index do |f, i|
+      create(:file_attachment, title: "attachment_#{i}", attachable: edition, file: File.open(f))
+    end
+    attachments = edition.reload.attachments
+
+    new_data = attachments.map { |a| [a.id.to_s, { title: a.title + '_' }] }
+    put :update_many, params: { edition_id: edition, attachments: Hash[new_data] }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
   test "update_many returns validation errors in JSON" do

--- a/test/functional/admin/document_sources_controller_test.rb
+++ b/test/functional/admin/document_sources_controller_test.rb
@@ -58,4 +58,13 @@ http://woo.example.com} }
     assert_equal ["http://www.example.com", "http://woo.example.com"], edition.document.document_sources.map(&:url)
     assert_redirected_to admin_publication_path(edition, anchor: 'document-sources')
   end
+
+  test "update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    put :update, params: { edition_id: edition.id, document_sources: "http://woo.example.com" }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
 end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -198,4 +198,22 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
       previous_version: "1"
     )
   end
+
+  test "#update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    put :update, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
+  test "#edit should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :edit, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
 end

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -15,6 +15,15 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     assert_redirected_to @controller.edit_admin_edition_translation_path(edition, id: 'fr')
   end
 
+  test 'create should redirect to the document show page if the document is locked' do
+    edition = create(:news_article, :with_locked_document)
+
+    post :create, params: { edition_id: edition.id, translation_locale: 'en' }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   view_test 'edit indicates which language we are adding a translation for' do
     edition = create(:edition, title: 'english-title')
 
@@ -74,6 +83,15 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     refute_select "input#edition_title"
   end
 
+  test "edit should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :edit, params: { edition_id: edition.id, id: "cy" }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   test "update creates a translation for an edition that's yet to be published, and redirect back to the edition admin page" do
     edition = create(:draft_edition)
 
@@ -125,6 +143,15 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     edition.reload
 
     assert_equal 'manually-added-change-note', edition.change_note
+  end
+
+  test "update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    put :update, params: { edition_id: edition.id, id: "cy", edition: { title: "title" } }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
   view_test 'update renders the form again, with errors, if the translation is invalid' do
@@ -191,5 +218,14 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
       assert_publishing_api_discard_draft(edition.content_id, locale: 'fr')
     end
+  end
+
+  test "destroy should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    delete :destroy, params: { edition_id: edition.id, id: "fr" }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -47,6 +47,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'publish redirects back to the edition with an error message if document is locked' do
+    post :publish, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to publish this edition because it is locked.", flash[:alert]
+  end
+
   test 'GET #confirm_force_publish renders force publishing form'do
     stub_publishing_api_links_with_taxons(draft_edition.content_id, %w[a-taxon-content-id])
     get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }
@@ -61,6 +68,14 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
     assert_response :redirect
+  end
+
+  test 'GET #confirm_force_publish redirects back to the edition with an error message if document is locked' do
+    stub_publishing_api_links_with_taxons(locked_edition.content_id, %w[a-taxon-content-id])
+    get :confirm_force_publish, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to force publish this edition because it is locked.", flash[:alert]
   end
 
   test 'POST #force_publish force publishes the edition' do
@@ -78,6 +93,16 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_redirected_to admin_publication_path(draft_edition)
     assert_equal 'You cannot force publish a document without a reason', flash[:alert]
     assert draft_edition.reload.draft?
+  end
+
+  test 'POST #force_publish redirects back to the edition with an error message if document is locked' do
+    stub_publishing_api_links_with_taxons(locked_edition.content_id, %w[a-taxon-content-id])
+    stub_publishing_api_registration_for(locked_edition)
+
+    post :force_publish, params: { id: locked_edition, lock_version: locked_edition.lock_version, reason: 'Urgent change' }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to force publish this edition because it is locked.", flash[:alert]
   end
 
   test 'schedule schedules the given edition on behalf of the current user' do
@@ -114,6 +139,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'schedule redirects back to the edition with an error message if document is locked' do
+    post :schedule, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to schedule this edition because it is locked.", flash[:alert]
+  end
+
   test 'POST :force_schedule force schedules the edition' do
     draft_edition.update_attribute(:scheduled_publication, 1.day.from_now)
     post :force_schedule, params: { id: draft_edition, lock_version: draft_edition.lock_version }
@@ -121,6 +153,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_redirected_to admin_editions_path(state: :scheduled)
     assert draft_edition.reload.scheduled?
     assert draft_edition.force_published?
+  end
+
+  test 'POST :force_schedule redirects back to the edition with an error message if document is locked' do
+    post :force_schedule, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to force schedule this edition because it is locked.", flash[:alert]
   end
 
   test 'unschedule unschedules the given edition on behalf of the current user' do
@@ -142,6 +181,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
 
     assert_response :unprocessable_entity
     assert_equal 'All workflow actions require a lock version', response.body
+  end
+
+  test 'unschedule redirects back to the edition with an error message if document is locked' do
+    post :unschedule, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to unschedule this edition because it is locked.", flash[:alert]
   end
 
   test 'submit submits the edition' do
@@ -178,6 +224,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'submit redirects back to the edition with an error message if document is locked' do
+    post :submit, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to submit this edition because it is locked.", flash[:alert]
+  end
+
   test 'reject redirects to the new editorial remark page to explain why the edition has been rejected' do
     submitted_publication = create(:submitted_publication)
     post :reject, params: { id: submitted_publication, lock_version: submitted_publication.lock_version }
@@ -200,6 +253,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'reject redirects back to the edition with an error message if document is locked' do
+    post :reject, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to reject this edition because it is locked.", flash[:alert]
+  end
+
   test 'approve_retrospectively marks the document as having been approved retrospectively and redirects back to he edition' do
     editor = create(:departmental_editor)
     acting_as(editor) { force_publish(draft_edition) }
@@ -216,6 +276,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'approve_retrospectively redirects back to the edition with an error message if document is locked' do
+    post :approve_retrospectively, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to retrospectively approve this edition because it is locked.", flash[:alert]
+  end
+
   test "confirm_unpublish loads the edition and renders the confirm page" do
     login_as(create(:managing_editor))
     publication = create(:published_publication)
@@ -224,6 +291,14 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_response :success
     assert_template :confirm_unpublish
     assert_equal publication, assigns(:edition)
+  end
+
+  test 'confirm_unpublish redirects back to the edition with an error message if document is locked' do
+    login_as create(:managing_editor)
+    get :confirm_unpublish, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to unpublish this edition because it is locked.", flash[:alert]
   end
 
   test 'unpublish is forbidden to non-Managing editors editors' do
@@ -278,6 +353,14 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'All workflow actions require a lock version', response.body
   end
 
+  test 'unpublish redirects back to the edition with an error message if document is locked' do
+    login_as create(:managing_editor)
+    post :unpublish, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to unpublish this edition because it is locked.", flash[:alert]
+  end
+
   test 'convert_to_draft turns the given edition into a draft and redirects back to the imported editions page' do
     imported_edition = create(:imported_edition)
     post :convert_to_draft, params: { id: imported_edition, lock_version: imported_edition.lock_version }
@@ -291,6 +374,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
 
     assert_response :unprocessable_entity
     assert_equal 'All workflow actions require a lock version', response.body
+  end
+
+  test 'convert_to_draft redirects back to the edition with an error message if document is locked' do
+    post :convert_to_draft, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to convert this imported edition to a draft because it is locked.", flash[:alert]
   end
 
   test "should prevent access to inaccessible editions" do
@@ -318,6 +408,21 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'unwithdraw redirects back to the edition with an error message if document is locked' do
+    post :unwithdraw, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to unwithdraw this edition because it is locked.", flash[:alert]
+  end
+
+  test 'confirm_unwithdraw redirects back to the edition with an error message if document is locked' do
+    stub_publishing_api_links_with_taxons(locked_edition.content_id, %w[a-taxon-content-id])
+    get :confirm_unwithdraw, params: { id: locked_edition, lock_version: locked_edition.lock_version }
+
+    assert_redirected_to admin_news_article_path(locked_edition)
+    assert_equal "Unable to unwithdraw this edition because it is locked.", flash[:alert]
+  end
+
 private
 
   def submitted_edition(options = {})
@@ -338,5 +443,9 @@ private
 
   def withdrawn_edition
     @withdrawn_edition ||= create(:withdrawn_edition, major_change_published_at: Time.zone.now)
+  end
+
+  def locked_edition
+    @locked_edition ||= create(:news_article, :with_locked_document)
   end
 end

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -286,6 +286,16 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_equal "The document list is too large for export", flash[:alert]
   end
 
+  test "revise should redirect to index page if document is locked" do
+    edition = create(:published_news_article)
+    edition.document.locked = true
+    edition.document.save
+
+    post :revise, params: { id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+  end
+
 private
 
   def stub_edition_filter(attributes = {})

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -59,4 +59,22 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
     get :create, params: { edition_id: protected_edition.id }
     assert_response :forbidden
   end
+
+  test "#create should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    post :create, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
+  test "#new should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :new, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
 end

--- a/test/functional/admin/needs_controller_test.rb
+++ b/test/functional/admin/needs_controller_test.rb
@@ -47,6 +47,26 @@ class Admin::NeedsControllerTest < ActionController::TestCase
     assert_requested patch_links_request
   end
 
+  test "update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    document = edition.document
+
+    post :update, params: { content_id: document.content_id, document_sources: "http://woo.example.com" }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
+  test "edit should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    document = edition.document
+
+    get :edit, params: { content_id: document.content_id, edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
   view_test "should be possible to update needs for a published edition" do
     edition = create(:edition_with_document)
     document = edition.document

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -41,6 +41,27 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
     assert_select ".page-header .lead", text: "a-simple-summary"
   end
 
+  test "edit should redirect to index page if document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    get :edit, params: { id: edition }
+
+    assert_redirected_to admin_news_article_path(edition)
+  end
+
+  test "update should redirect to index page if document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    put :update, params: { id: edition }
+
+    assert_redirected_to admin_news_article_path(edition)
+  end
+
+  test "destroy should redirect to index page if document is locked" do
+    edition = create(:news_article, :with_locked_document)
+    delete :destroy, params: { id: edition }
+
+    assert_redirected_to admin_news_article_path(edition)
+  end
+
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/edition_legacy_associations_controller_test.rb
+++ b/test/functional/edition_legacy_associations_controller_test.rb
@@ -129,4 +129,22 @@ class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCas
     assert_nil @edition.primary_specialist_sector_tag
     assert_equal [], @edition.secondary_specialist_sector_tags
   end
+
+  test "#update should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    put :update, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
+
+  test "#edit should redirect to the document show page if the document is locked" do
+    edition = create(:news_article, :with_locked_document)
+
+    get :edit, params: { edition_id: edition.id }
+
+    assert_redirected_to admin_news_article_path(edition)
+    assert_equal "This document is locked and cannot be edited", flash[:alert]
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/QmVdXHrM/1026-disable-edit-in-the-whitehall-ui

Since we don't want locked documents to be edited in any way, in this PR we add a before hook to redirect any requests that could lead to a locked document being edited to the document's show page.  A follow-up PR will deal with preventing users from being able to navigate to edit pages via the UI, but this focuses on the rare occasions that a user may land on an edit page (e.g. via a bookmark) or somehow make a request to edit a locked document and its associations.