### PR TITLE
Add more attachment data to document export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -27,6 +27,9 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       if association == :images
         edition_images = edition.public_send(association)
         output[:associations][association] = complete_images_hash(edition_images)
+      elsif association == :attachments
+        edition_attachments = edition.public_send(association)
+        output[:associations][association] = complete_attachments_hash(edition_attachments)
       else
         output[:associations][association] = edition.public_send(association)
       end
@@ -43,6 +46,14 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   def complete_images_hash(edition_images)
     edition_images.map do |image|
       image.as_json(methods: :url)
+    end
+  end
+
+  def complete_attachments_hash(edition_attachments)
+    edition_attachments.map do |attachment|
+      attachment.as_json(include: :attachment_data, methods: %i[url type]).tap do |json|
+        json.merge!("govspeak_content" => attachment.govspeak_content.as_json) if attachment.respond_to?(:govspeak_content)
+      end
     end
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -49,6 +49,37 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal image.image_data.file_url, images.first['url']
   end
 
+  test "appends expected attachment data to the file attachment response hash" do
+    publication_file = create(:publication, :with_command_paper)
+
+    result = DocumentExportPresenter.new(publication_file.document).as_json
+    attachments = result[:editions].first[:associations][:attachments]
+
+    assert_equal publication_file.attachments.first.url, attachments.first['url']
+    assert_equal "FileAttachment", attachments.first['type']
+    assert_equal publication_file.attachments.first.attachment_data.as_json, attachments.first['attachment_data']
+  end
+
+  test "exports expected data with the external attachment response hash" do
+    publication_external = create(:publication, :with_external_attachment)
+
+    result = DocumentExportPresenter.new(publication_external.document).as_json
+    attachments = result[:editions].first[:associations][:attachments]
+
+    assert_equal publication_external.attachments.first.url, attachments.first['url']
+    assert_equal "ExternalAttachment", attachments.first['type']
+  end
+
+  test "appends expected govspeak data to the html attachment response hash" do
+    publication_html = create(:publication)
+
+    result = DocumentExportPresenter.new(publication_html.document).as_json
+    attachments = result[:editions].first[:associations][:attachments]
+
+    assert_equal "HtmlAttachment", attachments.first['type']
+    assert_equal publication_html.attachments.first.govspeak_content.as_json, attachments.first['govspeak_content']
+  end
+
   test "returns government information about an edition" do
     edition = create(:edition)
 


### PR DESCRIPTION
To facilitate the export of documents from Whitehall to Content
Publisher we need as much detail as relevant in our export.

This commit

- Ensures we are exporting all the data relevant to any given
attachment assigned to an edition by adding the export via association
of both the base attachment and its own relevant data object where
applicable (govspeak for HTML, attachment_data chunk for others).

- Includes tests to that affect.

https://trello.com/c/KOiNK5J2/1070-add-more-attachment-data-to-document-export