### PR TITLE
Updated language attributes for use in subscription component

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -40,6 +40,10 @@ module TranslationHelper
     end
   end
 
+  def t_locale(key, options = {})
+    t_fallback(key, options).presence
+  end
+
   def t_fallback(key, options = {})
     translation = I18n.t(key, options, locale: I18n.locale, fallback: false, default: "fallback")
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -122,8 +122,13 @@
           } %>
 
           <%= render "govuk_publishing_components/components/subscription-links", {
+            hide_heading: true,
             email_signup_link: email_signup_path(atom_feed_url_for(@person)),
-            feed_link: atom_feed_url_for(@person)
+            email_signup_link_text: t('feeds.get_email_alerts'),
+            email_signup_link_text_locale: t_locale('feeds.get_email_alerts'),
+            feed_link: atom_feed_url_for(@person),
+            feed_link_text: t('feeds.subscribe_to_feed'),
+            feed_link_text_locale: t_locale('feeds.subscribe_to_feed')
           } %>
 
           <%= render "govuk_publishing_components/components/document_list", items: @person.announcements %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -533,8 +533,11 @@ ar:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: أحدث المستجدات
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -288,8 +288,11 @@ az:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: sonuncu fəaliyyət
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -432,8 +432,11 @@ be:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Апошнія аднаўленні
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -335,8 +335,11 @@ bg:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Последна дейност
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -326,8 +326,11 @@ bn:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -381,8 +381,11 @@ cs:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Poslední aktivita
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -535,8 +535,11 @@ cy:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Gweithgaredd diweddaraf
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -326,8 +326,11 @@ da:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -330,8 +330,11 @@ de:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Zuletzt aktiv
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -329,8 +329,11 @@ dr:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: فعالیت اخیر
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -330,8 +330,11 @@ el:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Πρόσφατες ενημερώσεις
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,9 @@ en:
     feed: feed
     email: email
     latest_activity: Latest activity
+    get_email_alerts: Get email alerts
+    subscribe_to_feed: Subscribe to feed
+    view_feed: View feed
   latest_feed:
     no_updates: There are no updates yet.
     title: Latest

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -330,8 +330,11 @@ es-419:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Actividad más reciente
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -329,8 +329,11 @@ es:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Actividad reciente
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -334,8 +334,11 @@ et:
   feeds:
     email: e-post
     feed: uudisvoog
+    get_email_alerts:
     get_updates_to_this_list: Telli uudiskiri
     latest_activity: Viimased uudised
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -291,8 +291,11 @@ fa:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: آخرین تحولات
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -326,8 +326,11 @@ fi:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -330,8 +330,11 @@ fr:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Dernière mise à jour
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -428,8 +428,11 @@ gd:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -329,8 +329,11 @@ he:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: פעילות אחרונה
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -330,8 +330,11 @@ hi:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: नवीनतम गतिविधि
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -428,8 +428,11 @@ hr:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -330,8 +330,11 @@ hu:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Legfrissebb aktivitás
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -330,8 +330,11 @@ hy:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Վերջին գործողություն
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -291,8 +291,11 @@ id:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Aktivitas terbaru
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -326,8 +326,11 @@ is:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -329,8 +329,11 @@ it:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Attività recente
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -289,8 +289,11 @@ ja:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: 最新情報
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -288,8 +288,11 @@ ka:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -326,8 +326,11 @@ kk:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -289,8 +289,11 @@ ko:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: 최근 활동
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -380,8 +380,11 @@ lt:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Paskutinės naujienos
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -328,8 +328,11 @@ lv:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Jaunumi
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -288,8 +288,11 @@ ms:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -428,8 +428,11 @@ mt:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -326,8 +326,11 @@ nl:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -326,8 +326,11 @@
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -433,8 +433,11 @@ pl:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Najnowsza czynność
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -329,8 +329,11 @@ ps:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: اخیرنی فعالیت
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -329,8 +329,11 @@ pt:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Últimas atividades
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -383,8 +383,11 @@ ro:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Activiţăti recente
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -430,8 +430,11 @@ ru:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Реестр активности
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -328,8 +328,11 @@ si:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: අලුත්ම ක්‍රියාකාරකම්
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -377,8 +377,11 @@ sk:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -428,8 +428,11 @@ sl:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -331,8 +331,11 @@ so:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Waxqabadkii ugu dambeeyey
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -330,8 +330,11 @@ sq:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Aktiviteti me i fundit
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -432,8 +432,11 @@ sr:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: najnovije aktivnosti
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -326,8 +326,11 @@ sv:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -326,8 +326,11 @@ sw:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -331,8 +331,11 @@ ta:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: சமீபத்தைய நடவடிக்கை
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -289,8 +289,11 @@ th:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: กิจกรรมล่าสุด
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -326,8 +326,11 @@ tk:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity:
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -290,8 +290,11 @@ tr:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Son etkinlik
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -431,8 +431,11 @@ uk:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Останні новини
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -330,8 +330,11 @@ ur:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: تازہ ترین سرگرمیاں
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -329,8 +329,11 @@ uz:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Eng so'nggi faoliyat
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -291,8 +291,11 @@ vi:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: Hoạt động mới nhất
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -288,8 +288,11 @@ zh-hk:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: 最新的活動
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -288,8 +288,11 @@ zh-tw:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: 最新的活動
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -288,8 +288,11 @@ zh:
   feeds:
     email:
     feed:
+    get_email_alerts:
     get_updates_to_this_list:
     latest_activity: 最新活动
+    subscribe_to_feed:
+    view_feed:
   i18n:
     direction: ltr
   language_names:


### PR DESCRIPTION
 - Updated subscription component - which can now the locale passed into it to be used in the `lang` attribute
 - Added English translations for use in the subscription component; regenerated other translations
 - Subscription component hidden heading turned off to prevent duplicated out-of-order headings.