### PR TITLE
Add new statistics_published state to Statistics Announcements

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -212,7 +212,7 @@ class StatisticsAnnouncement < ApplicationRecord
   end
 
   def statistics_published?
-    publication.first_published_at.present?
+    publication.first_published_at.present? if publication
   end
 
   def requires_redirect?

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -200,6 +200,8 @@ class StatisticsAnnouncement < ApplicationRecord
       'cancelled'
     elsif confirmed?
       'confirmed'
+    elsif statistics_published?
+      'statistics_published'
     else
       'provisional'
     end
@@ -207,6 +209,10 @@ class StatisticsAnnouncement < ApplicationRecord
 
   def unpublished?
     publishing_state == "unpublished"
+  end
+
+  def statistics_published?
+    publication.first_published_at.present?
   end
 
   def requires_redirect?

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -43,6 +43,10 @@ FactoryBot.define do
     redirect_url { "https://www.test.gov.uk/government/sparkle" }
   end
 
+  factory :statistics_announcement_with_published_stats, parent: :statistics_announcement do
+    publication { FactoryBot.build :published_statistics }
+  end
+
   factory :statistics_announcement_requiring_redirect,
           parent: :unpublished_statistics_announcement do
   end

--- a/test/unit/models/frontend/statistics_announcement_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_test.rb
@@ -32,6 +32,11 @@ class Frontend::StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal "March 12 2015 (cancelled)", announcement.display_date_with_status
   end
 
+  test "#disply_date_with_status appends (statistics_published) to published announcements" do
+    announcement = build_announcement(display_date: "March 12 2015", state: "statistics_published")
+    assert_equal "March 12 2015 (statistics_published)", announcement.display_date_with_status
+  end
+
   test "it identifies by its slug" do
     assert_equal 'a-slug', build_announcement(slug: 'a-slug').to_param
   end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -178,6 +178,13 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal "confirmed", announcement.state
   end
 
+  test 'an announcement with published statistics is in a "statistics_published" state' do
+    announcement = build(:statistics_announcement,
+                         current_release_date: build(:statistics_announcement_date, statistics_published: true))
+
+    assert_equal "statistics_published", announcement.state
+  end
+
   test 'cannot cancel without a reason' do
     announcement = create(:statistics_announcement)
 

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -179,8 +179,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test 'an announcement with published statistics is in a "statistics_published" state' do
-    announcement = build(:statistics_announcement,
-                         current_release_date: build(:statistics_announcement_date, statistics_published: true))
+    announcement = build(:statistics_announcement_with_published_stats)
 
     assert_equal "statistics_published", announcement.state
   end


### PR DESCRIPTION
https://trello.com/c/TRKpC1SC/935-users-cant-find-cancelled-statistics-releases