### PR TITLE
Update mysql set up instructions in readme

### DIFF
--- a/docs/detailed_setup_guide.md
+++ b/docs/detailed_setup_guide.md
@@ -25,8 +25,9 @@ The database.yml for this project is checked into source control so
 you'll need a local user with credentials that match those in
 database.yml.
 
-```
-mysql> grant all on `whitehall\_%`.* to whitehall@localhost identified by 'whitehall';
+```sql
+mysql> CREATE USER 'whitehall'@'localhost' IDENTIFIED BY 'whitehall';
+mysql> GRANT ALL ON `whitehall\_%`.* TO 'whitehall'@'localhost';
 ```
 
 ### Preparing the app
@@ -60,4 +61,3 @@ Once that is imported upgrade your import to the latest schema version with
 ```
 $ bundle exec rake db:setup
 ```
-


### PR DESCRIPTION
The commands to set up the whitehall user are out of date. The mysql documentation for v 8.0 states that you must first CREATE USER, and then GRANT access.

Ref: https://dev.mysql.com/doc/refman/8.0/en/grant.html

