### PR TITLE
Add document type to Whitehall document export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -32,6 +32,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       end
     end
 
+    provide_doctype_information(edition, output)
     output[:government] = edition.government
     output[:whitehall_admin_links] = resolve_whitehall_admin_links(edition.body)
     if edition.withdrawn?
@@ -43,6 +44,12 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   def complete_images_hash(edition_images)
     edition_images.map do |image|
       image.as_json(methods: :url)
+    end
+  end
+
+  def provide_doctype_information(edition, output)
+    %i[news_article_type publication_type corporate_information_page_type speech_type].each do |type|
+      output[type] = edition.public_send(type)&.key if edition.respond_to?(type)
     end
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -49,9 +49,31 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal image.image_data.file_url, images.first['url']
   end
 
+  test "appends the editions document type key to the response" do
+    news = create(:news_article)
+    publication = create(:publication)
+    speech = create(:speech)
+    corp_info = create(:corporate_information_page)
+
+    news_result = DocumentExportPresenter.new(news.document).as_json
+    doctype_data = news_result[:editions].first[:news_article_type]
+    assert_equal news.news_article_type.key, doctype_data
+
+    pub_result = DocumentExportPresenter.new(publication.document).as_json
+    doctype_data = pub_result[:editions].first[:publication_type]
+    assert_equal publication.publication_type.key, doctype_data
+
+    speech_result = DocumentExportPresenter.new(speech.document).as_json
+    doctype_data = speech_result[:editions].first[:speech_type]
+    assert_equal speech.speech_type.key, doctype_data
+
+    corp_result = DocumentExportPresenter.new(corp_info.document).as_json
+    doctype_data = corp_result[:editions].first[:corporate_information_page_type]
+    assert_equal corp_info.corporate_information_page_type.key, doctype_data
+  end
+
   test "returns government information about an edition" do
     edition = create(:edition)
-
     result = DocumentExportPresenter.new(edition.document).as_json
     assert_equal edition.government, result[:editions].first[:government]
   end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -73,8 +73,10 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
   end
 
   test "returns government information about an edition" do
+    current_government = create(:current_government)
     edition = create(:edition)
     result = DocumentExportPresenter.new(edition.document).as_json
     assert_equal edition.government, result[:editions].first[:government]
+    assert_equal current_government, result[:editions].first[:government]
   end
 end


### PR DESCRIPTION
In order to correctly handle migration we need to ensure that we get
the mapped value for a document type from the API export instead of
just the type ID, as Content Publisher has no knowledge of the
mappings used by Whitehall.

This commit
- Introduces a check to append the required data for corporate
information, speeches, publications and news stories to the API
export for each edition where relevant.
- Introduces a test to this affect
- Fixes an exporter test that was not failing, but was passing
with the wrong comparison (it was comparing two nils, which are
still equal but not what was intended by the test).

https://trello.com/c/Z1yHfuJw/1092-add-document-type-to-whitehall-document-export