### PR TITLE
Display alternative show page for locked documents

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -61,6 +61,7 @@
 // they relate to
 @import "views/_dashboard";
 @import "views/_edition_form";
+@import "views/_edition_show_locked";
 @import "views/_edition_show";
 @import "views/_editions-index";
 @import "views/_edition_edit_help";

--- a/app/assets/stylesheets/admin/views/_edition_show_locked.scss
+++ b/app/assets/stylesheets/admin/views/_edition_show_locked.scss
@@ -1,0 +1,10 @@
+.edition-show-locked {
+
+  .jumbotron-header {
+    font-size: 48px;
+  }
+
+  .jumbotron {
+    padding: 40px;
+  }
+}

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -43,7 +43,7 @@ class Admin::BaseController < ApplicationController
 
   def forbid_editing_of_locked_documents
     if @edition.locked?
-      redirect_to [:admin, @edition],
+      redirect_to show_locked_admin_edition_path(@edition),
                   alert: %{This document is locked and cannot be edited}
     end
   end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -2,7 +2,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
-  before_action :find_edition, only: %i[show edit update submit revise diff reject destroy]
+  before_action :find_edition, only: %i[show show_locked edit update submit revise diff reject destroy]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_edition, only: %i[new create]
@@ -27,7 +27,7 @@ class Admin::EditionsController < Admin::BaseController
     case action_name
     when 'index', 'topics'
       enforce_permission!(:see, edition_class || Edition)
-    when 'show'
+    when 'show', 'show_locked'
       enforce_permission!(:see, @edition)
     when 'new'
       enforce_permission!(:create, edition_class || Edition)
@@ -74,6 +74,11 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def show
+    if @edition.locked?
+      redirect_to show_locked_admin_edition_path(@edition)
+      return
+    end
+
     fetch_version_and_remark_trails
 
     @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
@@ -82,6 +87,8 @@ class Admin::EditionsController < Admin::BaseController
       @edition_world_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch_world_taxons
     end
   end
+
+  def show_locked; end
 
   def new; end
 

--- a/app/helpers/admin/content_publisher_routes_helper.rb
+++ b/app/helpers/admin/content_publisher_routes_helper.rb
@@ -1,0 +1,14 @@
+module Admin::ContentPublisherRoutesHelper
+  def content_publisher_document_summary_url(edition)
+    content_id = edition.content_id
+    locale = edition.primary_locale
+
+    "#{content_publisher_base_url}/documents/#{content_id}:#{locale}"
+  end
+
+private
+
+  def content_publisher_base_url
+    Plek.current.external_url_for('content-publisher')
+  end
+end

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -20,6 +20,19 @@ module Admin::EditionActionsHelper
             }
   end
 
+  def content_publisher_button(edition)
+    url = content_publisher_document_summary_url(edition)
+
+    link_to 'Edit in Content Publisher',
+            url,
+            class: 'btn btn-lg btn-primary public_version',
+            data: {
+              track_category: 'external-link-clicked',
+              track_action: url,
+              track_label: 'Edit in Content Publisher',
+            }
+  end
+
   def custom_track_dimensions(edition)
     {
       1 => public_document_path(edition),

--- a/app/views/admin/editions/show_locked.html.erb
+++ b/app/views/admin/editions/show_locked.html.erb
@@ -1,0 +1,36 @@
+<% page_title @edition.title, @edition.format_name %>
+<% page_class "edition-show-locked" %>
+
+<div class="row" data-module="track-button-click" data-track-category="button-pressed" data-track-action="<%= @edition.format_name.parameterize(separator: '-') %>-button">
+  <div class="col-md-8">
+    <div class="jumbotron">
+      <h1 class="jumbotron-header">Moved to Content Publisher</h1>
+      <p>This document has been moved from Whitehall to Content Publisher. Information about it in Whitehall may now be out of date.</p>
+      <p>You can now edit this document in Content Publisher.</p>
+      <%= content_publisher_button(@edition) %>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="page-header col-md-8">
+    <h1><%= @edition.title %></h1>
+    <p class="lead"><%= @edition.summary %></p>
+    <dl class="clearfix dl-horizontal">
+      <dt>Type of document:</dt>
+      <dd><%= edition_type(@edition) %></dd>
+      <dt>Organisations:</dt>
+      <dd><%= joined_list(@edition.organisations.map { |o| o.name }) %></dd>
+    </dl>
+    <% if @edition.non_english_edition? %>
+      <p><em>(This document is <%=@edition.primary_language_name %>-only)</em></p>
+    <% end %>
+  </div>
+  <div class="col-md-8 edition-metadata">
+    <section  >
+      <% if @edition.publicly_visible? %>
+        <%= link_to "View on website", public_document_url(@edition), class: 'btn btn-lg btn-primary public_version', target: '_blank' %>
+        <%= content_data_button(@edition) %>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,6 +309,7 @@ Whitehall::Application.routes.draw do
             post :unschedule, to: 'edition_workflow#unschedule'
             post :convert_to_draft, to: 'edition_workflow#convert_to_draft'
             get  :audit_trail, to: 'edition_audit_trail#index'
+            get  :show_locked, to: 'editions#show_locked'
           end
           resources :link_check_reports
           resource :unpublishing, controller: 'edition_unpublishing', only: %i[edit update]

--- a/features/admin-locked-documents.feature
+++ b/features/admin-locked-documents.feature
@@ -1,8 +1,17 @@
 Feature: Viewing locked documents
-  Background:
-    Given a document titled "A document that will be migrated"
-
   Scenario: Locked document appears on index page
-    And the document is locked
+    Given a published locked document titled "A document that will be migrated"
     When I visit the list of published documents
     Then I should see the document "A document that will be migrated" in the list of published documents
+
+  Scenario: Published locked document admin page
+    Given a published locked document titled "A document that will be migrated"
+    When I visit the admin page for "A document that will be migrated"
+    Then I can see that I cannot create a new draft
+    And I can see that the document has been moved to Content Publisher
+
+  Scenario: Draft locked document admin page
+    Given a draft locked document titled "A document that will be migrated"
+    When I visit the admin page for "A document that will be migrated"
+    Then I can see that the document cannot be edited
+    And I can see that the document has been moved to Content Publisher

--- a/features/step_definitions/admin_locked_documents_steps.rb
+++ b/features/step_definitions/admin_locked_documents_steps.rb
@@ -1,0 +1,28 @@
+Given(/^a published locked document titled "([^"]*)"$/) do |title|
+  @edition = create(:published_news_article, :with_locked_document, title: title)
+end
+
+Given(/^a draft locked document titled "([^"]*)"$/) do |title|
+  @edition = create(:draft_news_article, :with_locked_document, title: title)
+end
+
+When(/^I visit the admin page for "([^"]*)"$/) do |title|
+  @edition = Edition.find_by!(title: title)
+  visit admin_edition_path(@edition)
+end
+
+Then(/^I can see that I cannot create a new draft$/) do
+  new_draft_link = revise_admin_edition_path(@edition)
+  refute page.has_link?("Create new edition to edit", href: new_draft_link)
+end
+
+Then(/^I can see that the document cannot be edited$/) do
+  edit_link = edit_admin_edition_path(@edition)
+  refute page.has_link?("Edit draft", href: edit_link)
+end
+
+And(/^I can see that the document has been moved to Content Publisher$/) do
+  content_publisher_base_url = Plek.current.external_url_for('content-publisher')
+  content_publisher_link = "#{content_publisher_base_url}/documents/#{@edition.content_id}:#{@edition.primary_locale}"
+  assert page.has_link?("Edit in Content Publisher", href: content_publisher_link)
+end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -96,7 +96,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     post :create, params: { edition_id: edition.id, attachment: valid_file_attachment_params }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -114,7 +114,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     get :index, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -186,7 +186,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     delete :destroy, params: { edition_id: edition.id, id: attachment.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -254,7 +254,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     put :order, params: { edition_id: edition.id, order: {} }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -285,7 +285,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     get :new, params: { edition_id: edition, type: "file" }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -313,7 +313,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: edition.id, id: attachment }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -375,7 +375,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
       attachment: { title: "New title" },
     }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -472,7 +472,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     new_data = attachments.map { |a| [a.id.to_s, { title: a.title + '_' }] }
     put :update_many, params: { edition_id: edition, attachments: Hash[new_data] }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 

--- a/test/functional/admin/document_sources_controller_test.rb
+++ b/test/functional/admin/document_sources_controller_test.rb
@@ -64,7 +64,7 @@ http://woo.example.com} }
 
     put :update, params: { edition_id: edition.id, document_sources: "http://woo.example.com" }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -204,7 +204,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     put :update, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -213,7 +213,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -20,7 +20,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
     post :create, params: { edition_id: edition.id, translation_locale: 'en' }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -88,7 +88,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: edition.id, id: "cy" }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -150,7 +150,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
     put :update, params: { edition_id: edition.id, id: "cy", edition: { title: "title" } }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -225,7 +225,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
     delete :destroy, params: { edition_id: edition.id, id: "fr" }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -293,7 +293,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
     post :revise, params: { id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
   end
 
 private

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -65,7 +65,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
 
     post :create, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -74,7 +74,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
 
     get :new, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end

--- a/test/functional/admin/needs_controller_test.rb
+++ b/test/functional/admin/needs_controller_test.rb
@@ -53,7 +53,7 @@ class Admin::NeedsControllerTest < ActionController::TestCase
 
     post :update, params: { content_id: document.content_id, document_sources: "http://woo.example.com" }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -63,7 +63,7 @@ class Admin::NeedsControllerTest < ActionController::TestCase
 
     get :edit, params: { content_id: document.content_id, edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -45,21 +45,21 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
     edition = create(:news_article, :with_locked_document)
     get :edit, params: { id: edition }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
   end
 
   test "update should redirect to index page if document is locked" do
     edition = create(:news_article, :with_locked_document)
     put :update, params: { id: edition }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
   end
 
   test "destroy should redirect to index page if document is locked" do
     edition = create(:news_article, :with_locked_document)
     delete :destroy, params: { id: edition }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
   end
 
 private

--- a/test/functional/edition_legacy_associations_controller_test.rb
+++ b/test/functional/edition_legacy_associations_controller_test.rb
@@ -135,7 +135,7 @@ class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCas
 
     put :update, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 
@@ -144,7 +144,7 @@ class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCas
 
     get :edit, params: { edition_id: edition.id }
 
-    assert_redirected_to admin_news_article_path(edition)
+    assert_redirected_to show_locked_admin_edition_path(edition)
     assert_equal "This document is locked and cannot be edited", flash[:alert]
   end
 end


### PR DESCRIPTION
For https://trello.com/c/QmVdXHrM/1026-disable-edit-in-the-whitehall-ui

We don't want users to be able to edit locked documents, so when they navigate
to a show page for a locked document we display a stripped-back version without
navigation to pages where the document could be edited. Instead we display only
key metadata, a notice explaining that the document has been moved to Content
Publisher, and a link to the document in Content Publisher.