### PR TITLE
Indicate locked documents on index page

### DIFF
--- a/app/assets/stylesheets/admin/views/_editions-index.scss
+++ b/app/assets/stylesheets/admin/views/_editions-index.scss
@@ -98,4 +98,8 @@
       width: 70px;
     }
   }
+
+  .migrated-notice {
+    text-align: center;
+  }
 }

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -66,6 +66,9 @@
             <% if edition.access_limited? %>
               <span class="access_limited label label-danger">limited access</span>
             <% end %>
+            <% if edition.locked? %>
+              <span class="label label-info">Moved to Content Publisher</span>
+            <% end %>
             <% if edition.link_check_reports.any? && edition.link_check_reports.last.completed? %>
               <% if edition.link_check_reports.last.broken_links.any? %>
                 <span class="has-broken-links label label-primary">has broken links</span>
@@ -74,10 +77,14 @@
               <% end %>
             <% end %>
           </td>
-          <td class="author"><%= linked_author(edition.last_author) %></td>
-          <td class="updated"><span title="<%= edition.updated_at %>"><%= time_ago_in_words edition.updated_at %> ago</span></td>
-          <% if viewing_all_active_editions? %>
-            <td class="state"><%= admin_edition_state_text(edition) %></td>
+          <% if edition.locked? %>
+            <td class="migrated-notice" colspan="3">Moved to Content Publisher</td>
+          <% else %>
+            <td class="author"><%= linked_author(edition.last_author) %></td>
+            <td class="updated"><span title="<%= edition.updated_at %>"><%= time_ago_in_words edition.updated_at %> ago</span></td>
+            <% if viewing_all_active_editions? %>
+              <td class="state"><%= admin_edition_state_text(edition) %></td>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/features/admin-locked-documents.feature
+++ b/features/admin-locked-documents.feature
@@ -3,15 +3,16 @@ Feature: Viewing locked documents
     Given a published locked document titled "A document that will be migrated"
     When I visit the list of published documents
     Then I should see the document "A document that will be migrated" in the list of published documents
+    And I can see that the document has been moved to Content Publisher
 
   Scenario: Published locked document admin page
     Given a published locked document titled "A document that will be migrated"
     When I visit the admin page for "A document that will be migrated"
     Then I can see that I cannot create a new draft
-    And I can see that the document has been moved to Content Publisher
+    And I can see that the document can be edited in Content Publisher
 
   Scenario: Draft locked document admin page
     Given a draft locked document titled "A document that will be migrated"
     When I visit the admin page for "A document that will be migrated"
     Then I can see that the document cannot be edited
-    And I can see that the document has been moved to Content Publisher
+    And I can see that the document can be edited in Content Publisher

--- a/features/step_definitions/admin_locked_documents_steps.rb
+++ b/features/step_definitions/admin_locked_documents_steps.rb
@@ -21,8 +21,16 @@ Then(/^I can see that the document cannot be edited$/) do
   refute page.has_link?("Edit draft", href: edit_link)
 end
 
-And(/^I can see that the document has been moved to Content Publisher$/) do
+And(/^I can see that the document can be edited in Content Publisher$/) do
   content_publisher_base_url = Plek.current.external_url_for('content-publisher')
   content_publisher_link = "#{content_publisher_base_url}/documents/#{@edition.content_id}:#{@edition.primary_locale}"
   assert page.has_link?("Edit in Content Publisher", href: content_publisher_link)
+end
+
+And(/^I can see that the document has been moved to Content Publisher$/) do
+  within record_css_selector(@edition) do
+    assert page.has_css?(".label-info", text: "Moved to Content Publisher")
+    last_cell = find("td:last-child")
+    assert last_cell.text, "Moved to Content Publisher"
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/QmVdXHrM/1026-disable-edit-in-the-whitehall-ui

We add a label to locked documents on the document index page to indicate that
it has been moved to Content Publisher. Once the document has been moved it
won't make sense to display the "Updated by", "Updated" and "State" values as
it won't be in sync with what is in Content Publisher, so we replace these with
another message about having been moved to Content Publisher.

<img width="1067" alt="Screen Shot 2019-08-16 at 11 40 58" src="https://user-images.githubusercontent.com/13434452/63162557-c4814680-c01a-11e9-89bb-39efc1c78dcd.png">