### PR TITLE
[WIP] Support non-Whitehall links in document collections

### DIFF
--- a/app/assets/javascripts/admin/document_group_ordering.js
+++ b/app/assets/javascripts/admin/document_group_ordering.js
@@ -49,7 +49,7 @@
     for(var i=0; i<this.documentGroups.length; i++) {
       postData.groups.push({
         id: this.documentGroups[i].groupID(),
-        document_ids: this.documentGroups[i].documentIDs(),
+        membership_ids: this.documentGroups[i].membershipIDs(),
         order: i
       });
     }
@@ -84,8 +84,8 @@
       return documentList.data('group-id');
     };
 
-    this.documentIDs = function documentIDs() {
-      return documentList.find("input[name='documents[]']").map(function(i, input) {
+    this.membershipIDs = function membershipIDs() {
+      return documentList.find("input[name='memberships[]']").map(function(i, input) {
         return input.value;
       }).toArray();
     };

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -20,6 +20,9 @@ class DocumentCollection < Edition
            dependent: :destroy,
            inverse_of: :document_collection
   has_many :documents, through: :groups
+  has_many :non_whitehall_links,
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :groups
   has_many :editions, through: :documents
 
   before_create :create_default_group
@@ -63,6 +66,10 @@ class DocumentCollection < Edition
 
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
+  def content_ids
+    groups.flat_map(&:content_ids)
   end
 
 private

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -19,11 +19,6 @@ class DocumentCollection < Edition
            class_name: 'DocumentCollectionGroup',
            dependent: :destroy,
            inverse_of: :document_collection
-  has_many :documents, through: :groups
-  has_many :non_whitehall_links,
-           class_name: 'DocumentCollectionNonWhitehallLink',
-           through: :groups
-  has_many :editions, through: :documents
 
   before_create :create_default_group
 
@@ -46,7 +41,7 @@ class DocumentCollection < Edition
   def indexable_content
     [
       Govspeak::Document.new(body).to_text,
-      groups.visible.map do |group|
+      groups.live.map do |group|
         [group.heading, Govspeak::Document.new(group.body).to_text]
       end
     ].flatten.join("\n")
@@ -54,14 +49,6 @@ class DocumentCollection < Edition
 
   def display_type
     "Collection"
-  end
-
-  def published_editions
-    editions.published.reorder(nil).in_reverse_chronological_order
-  end
-
-  def scheduled_editions
-    editions.scheduled
   end
 
   def rendering_app

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -16,18 +16,15 @@ class DocumentCollectionGroup < ApplicationRecord
            -> { order('document_collection_group_memberships.ordering') },
            through: :documents
 
+  scope :live, -> do
+    left_joins(:non_whitehall_links, documents: :editions)
+      .where("editions.state = 'published' OR document_collection_non_whitehall_links.id IS NOT NULL")
+  end
+
   validates :heading, presence: true, uniqueness: { scope: :document_collection_id }
   validates_associated :memberships
 
   before_create :assign_ordering
-
-  def set_document_ids_in_order!(document_ids)
-    self.document_ids = document_ids
-    self.save!
-    self.memberships.each do |membership|
-      membership.update_attribute(:ordering, document_ids.index(membership.document_id))
-    end
-  end
 
   def set_membership_ids_in_order!(membership_ids)
     self.membership_ids = membership_ids
@@ -37,26 +34,14 @@ class DocumentCollectionGroup < ApplicationRecord
     end
   end
 
-  def self.visible
-    includes(:editions).references(:editions).where(editions: { state: 'published' })
-  end
-
   def self.default_attributes
     { heading: 'Documents' }
   end
 
-  def published_editions
-    editions.published
-  end
-
-  def latest_editions
-    associations = { latest_edition: %i[organisations translations] }
-    editions = documents.includes(associations).map(&:latest_edition)
-    editions.compact
-  end
-
-  def visible?
-    published_editions.present? || non_whitehall_links.present?
+  def editable_members
+    memberships.filter do |member|
+      member.document&.latest_edition || member.non_whitehall_link
+    end
   end
 
   def dup
@@ -71,6 +56,10 @@ class DocumentCollectionGroup < ApplicationRecord
 
   def content_ids
     memberships.map(&:content_id)
+  end
+
+  def published_editions
+    editions.published
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -8,6 +8,10 @@ class DocumentCollectionGroup < ApplicationRecord
   has_many :documents,
            -> { order('document_collection_group_memberships.ordering') },
            through: :memberships
+  has_many :non_whitehall_links,
+           -> { order('document_collection_group_memberships.ordering') },
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :memberships
   has_many :editions,
            -> { order('document_collection_group_memberships.ordering') },
            through: :documents
@@ -44,7 +48,7 @@ class DocumentCollectionGroup < ApplicationRecord
   end
 
   def visible?
-    published_editions.present?
+    published_editions.present? || non_whitehall_links.present?
   end
 
   def dup
@@ -55,6 +59,10 @@ class DocumentCollectionGroup < ApplicationRecord
 
   def slug
     heading.parameterize
+  end
+
+  def content_ids
+    memberships.map(&:content_id)
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -29,6 +29,14 @@ class DocumentCollectionGroup < ApplicationRecord
     end
   end
 
+  def set_membership_ids_in_order!(membership_ids)
+    self.membership_ids = membership_ids
+    self.save!
+    self.memberships.each do |membership|
+      membership.update_attribute(:ordering, membership_ids.index(membership.id))
+    end
+  end
+
   def self.visible
     includes(:editions).references(:editions).where(editions: { state: 'published' })
   end

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -19,6 +19,10 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   validate :document_is_of_allowed_type, if: -> { document.present? }
   validate :presence_of_document_or_non_whitehall_link
 
+  def content_id
+    document&.content_id || non_whitehall_link&.content_id
+  end
+
 private
 
   def assign_ordering

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -2,16 +2,22 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   BANNED_DOCUMENT_TYPES = %w[DocumentCollection].freeze
   include LockedDocumentConcern
 
-  belongs_to :document, inverse_of: :document_collection_group_memberships
+  belongs_to :document,
+             inverse_of: :document_collection_group_memberships,
+             optional: true
+  belongs_to :non_whitehall_link,
+             class_name: 'DocumentCollectionNonWhitehallLink',
+             inverse_of: :document_collection_group_memberships,
+             optional: true
   belongs_to :document_collection_group, inverse_of: :memberships
 
   before_create :assign_ordering
 
-  before_save { check_if_locked_document(document: self.document) }
+  before_save { check_if_locked_document(document: document) if document }
 
-  validates :document, presence: true
   validates :document_collection_group, presence: true
   validate :document_is_of_allowed_type, if: -> { document.present? }
+  validate :presence_of_document_or_non_whitehall_link
 
 private
 
@@ -20,8 +26,18 @@ private
   end
 
   def document_is_of_allowed_type
-    if BANNED_DOCUMENT_TYPES.include? document.document_type
+    if document && BANNED_DOCUMENT_TYPES.include?(document.document_type)
       errors.add(:document, "cannot be a #{document.humanized_document_type}")
+    end
+  end
+
+  def presence_of_document_or_non_whitehall_link
+    if document && non_whitehall_link
+      errors.add(:base, "cannot be associated with a document and an non-whitehall link")
+    end
+
+    if !document && !non_whitehall_link
+      errors.add(:base, "must be associated with a document or an non-whitehall link")
     end
   end
 end

--- a/app/models/document_collection_non_whitehall_link.rb
+++ b/app/models/document_collection_non_whitehall_link.rb
@@ -3,6 +3,4 @@ class DocumentCollectionNonWhitehallLink < ApplicationRecord
            inverse_of: :non_whitehall_link,
            foreign_key: :non_whitehall_link_id,
            dependent: :destroy
-
-  # may want to validate base_path and content_id
 end

--- a/app/models/document_collection_non_whitehall_link.rb
+++ b/app/models/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+class DocumentCollectionNonWhitehallLink < ApplicationRecord
+  has_many :document_collection_group_memberships,
+           inverse_of: :non_whitehall_link,
+           foreign_key: :non_whitehall_link_id,
+           dependent: :destroy
+
+  # may want to validate base_path and content_id
+end

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -41,7 +41,7 @@ module PublishingApi
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )
-      links[:documents] = item.documents.pluck(:content_id).uniq
+      links[:documents] = item.content_ids.uniq
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 
@@ -70,7 +70,7 @@ module PublishingApi
         {
           title: group.heading,
           body: govspeak_renderer.govspeak_to_html(group.body),
-          documents: group.documents.collect(&:content_id)
+          documents: group.content_ids
         }
       end
     end

--- a/app/services/service_listeners/search_indexer.rb
+++ b/app/services/service_listeners/search_indexer.rb
@@ -16,7 +16,7 @@ module ServiceListeners
 
     def reindex_collection_documents
       if edition.is_a?(DocumentCollection)
-        edition.published_editions.each do |collected_edition|
+        edition.groups.flat_map(&:published_editions).each do |collected_edition|
           Whitehall::SearchIndex.add(collected_edition)
         end
       end

--- a/app/views/admin/document_collection_groups/_collection_document.html.erb
+++ b/app/views/admin/document_collection_groups/_collection_document.html.erb
@@ -1,18 +1,33 @@
-<%= content_tag_for(:li, edition, class: "document-row") do %>
-  <label>
-    <%= check_box_tag('documents[]', edition.document.id, false, class: 'checkbox', id: nil) %>
-    <%= edition.title %>
-  </label>
-  (<%= link_to 'view page', admin_edition_path(edition) %>)
-  <ul class="metadata list-inline text-muted">
-    <li>
-      Last changed: <%= public_time_for_edition(edition) %>
-    </li>
-    <li>
-      <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
-    </li>
-    <li>
-      <%= edition.display_type %>
-    </li>
-  </ul>
+<%= content_tag(:li, class: "document-row") do %>
+  <% if membership.non_whitehall_link %>
+    <% non_whitehall_link = membership.non_whitehall_link %>
+    <label>
+      <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
+      <%= non_whitehall_link.title %>
+    </label>
+    (<%= link_to 'view on GOV.UK', Plek.new.website_root + non_whitehall_link.base_path %>)
+    <ul class="metadata list-inline text-muted">
+      <li>
+        Document from: <%= non_whitehall_link.publishing_app.titleize %>
+      </li>
+    </ul>
+  <% else %>
+    <% edition = membership.document.latest_edition %>
+    <label>
+      <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
+      <%= edition.title %>
+    </label>
+    (<%= link_to 'view page', admin_edition_path(edition) %>)
+    <ul class="metadata list-inline text-muted">
+      <li>
+        Last changed: <%= public_time_for_edition(edition) %>
+      </li>
+      <li>
+        <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
+      </li>
+      <li>
+        <%= edition.display_type %>
+      </li>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/admin/document_collection_groups/_collection_size_warning.erb
+++ b/app/views/admin/document_collection_groups/_collection_size_warning.erb
@@ -1,4 +1,4 @@
-<% if @collection.documents.count > 50 %>
+<% if @collection.groups.sum { |g| g.editable_members.count } > 50 %>
   <div class="alert alert-info">
     If your collection contains over 50 documents it may be slow or impossible to update. Consider splitting the collection or using another format.
   </div>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -48,7 +48,7 @@
           </ul>
         </header>
         <div class="js-group-body">
-          <% if group.latest_editions.empty? %>
+          <% if group.editable_members.empty? %>
             <p class="no-content no-content-bordered js-document-group" data-group-id="<%= group.id %>">
               No documents in this group<br />
               Add documents by searching or dragging them from another group.
@@ -71,7 +71,7 @@
                 <% end %>
               </ul>
               <ol class="document-list js-document-group list-unstyled" data-group-id="<%= group.id %>">
-                <%= render partial: 'collection_document', collection: group.latest_editions, as: :edition, locals: { document_collection: @collection } %>
+                <%= render partial: 'collection_document', collection: group.editable_members, as: :membership, locals: { document_collection: @collection } %>
               </ol>
             <% end %>
           <% end %>

--- a/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
@@ -1,0 +1,11 @@
+class CreateDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :document_collection_non_whitehall_links do |t|
+      t.string :content_id, null: false
+      t.string :title, null: false
+      t.text :base_path, null: false
+      t.string :publishing_app, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
@@ -1,0 +1,7 @@
+class ReferenceDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :document_collection_group_memberships,
+                  :non_whitehall_link,
+                  index: { name: "index_document_collection_non_whitehall_link" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711112443) do
+ActiveRecord::Schema.define(version: 20190806120852) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -240,8 +240,10 @@ ActiveRecord::Schema.define(version: 20190711112443) do
     t.integer "ordering"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "non_whitehall_link_id"
     t.index ["document_collection_group_id", "ordering"], name: "index_dc_group_memberships_on_dc_group_id_and_ordering"
     t.index ["document_id"], name: "index_document_collection_group_memberships_on_document_id"
+    t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
   create_table "document_collection_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -252,6 +254,15 @@ ActiveRecord::Schema.define(version: 20190711112443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
+  end
+
+  create_table "document_collection_non_whitehall_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "content_id", null: false
+    t.string "title", null: false
+    t.text "base_path", null: false
+    t.string "publishing_app", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "document_sources", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/document_collection.rake
+++ b/lib/tasks/document_collection.rake
@@ -1,0 +1,11 @@
+namespace :document_collection do
+  desc "Add content published in a different GOV.UK app to a document collection group"
+  task :add_non_whitehall_link_to_group, %i[content_id group_id] => :environment do |_, args|
+    content_item = Services.publishing_api.get_content(args[:content_id])
+    group = DocumentCollectionGroup.find(args[:group_id])
+    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+      content_item.to_h.slice("content_id", "title", "base_path", "publishing_app")
+    )
+    group.non_whitehall_links << non_whitehall_link
+  end
+end

--- a/test/factories/document_collection_non_whitehall_link.rb
+++ b/test/factories/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :document_collection_non_whitehall_link do
+    content_id { SecureRandom.uuid }
+    base_path { "/vat-rates" }
+    title { "VAT Rates" }
+    publishing_app { "mainstream" }
+  end
+end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -40,11 +40,12 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     id_params.merge(commit: 'Move')
   end
 
-  view_test 'DELETE #destroy removes documents and redirects when Remove clicked' do
-    documents = [create(:publication), create(:publication)].map(&:document)
-    @group.documents << documents
-    assert_difference '@group.reload.documents.size', -1 do
-      delete :destroy, params: remove_params.merge(documents: [documents.first.id])
+  view_test 'DELETE #destroy removes memberships and redirects when Remove clicked' do
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
+    assert_difference '@group.reload.memberships.size', -1 do
+      delete :destroy, params: remove_params.merge(memberships: [memberships.first.id])
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
     assert_match %r[1 document removed], flash[:notice]
@@ -56,14 +57,15 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   end
 
   test 'DELETE #destroy moves documents and redirects when Move clicked' do
-    documents = [create(:publication), create(:publication)].map(&:document)
-    @group.documents << documents
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
     new_group = build(:document_collection_group)
     @collection.groups << new_group
-    assert_difference 'new_group.reload.documents.size', 1 do
-      assert_difference '@group.reload.documents.size', -1 do
+    assert_difference 'new_group.reload.memberships.size', 1 do
+      assert_difference '@group.reload.memberships.size', -1 do
         delete :destroy, params: move_params.merge(
-          documents: [documents.first.id],
+          memberships: [memberships.first.id],
           new_group_id: new_group.id
         )
       end

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -34,14 +34,14 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   view_test 'GET #index shows a warning if > 50 documents in collection' do
-    @group.documents = create_list(:document, 51)
+    @group.non_whitehall_links = create_list(:document_collection_non_whitehall_link, 51)
     get :index, params: { document_collection_id: @collection }
     assert_response :ok
     assert_select '.alert-info', text: /it may be slow or impossible to update/
   end
 
   view_test 'GET #index does not show a warning if <= 50 documents in collection' do
-    @group.documents = create_list(:document, 50)
+    @group.non_whitehall_links = create_list(:document_collection_non_whitehall_link, 50)
     get :index, params: { document_collection_id: @collection }
     assert_response :ok
     assert_select '.alert-info', false, text: /it may be slow or impossible to update/
@@ -124,42 +124,42 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   test "POST #update_memberships saves the order of group members" do
-    given_two_groups_with_documents
+    given_two_groups_with_memberships
     post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
-            @doc_1_2.id,
-            @doc_1_1.id
+          membership_ids: [
+            @member_1_2.id,
+            @member_1_1.id
           ],
           order: 0
         }
       }
     }
 
-    assert_equal [@doc_1_2, @doc_1_1], @group_1.reload.documents
+    assert_equal [@member_1_2, @member_1_1], @group_1.reload.memberships
   end
 
   test "POST #update_memberships saves the order of groups" do
-    given_two_groups_with_documents
+    given_two_groups_with_memberships
     post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
-            @doc_1_1.id,
-            @doc_1_2.id
+          membership_ids: [
+            @member_1_1.id,
+            @member_1_2.id
           ],
           order: 1
         },
         1 => {
           id: @group_2.id,
-          document_ids: [
-            @doc_2_1.id,
-            @doc_2_2.id
+          membership_ids: [
+            @member_2_1.id,
+            @member_2_2.id
           ],
           order: 0
         }
@@ -171,64 +171,64 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   test "POST #update_memberships should cope with duplicate documents in group" do
-    given_two_groups_with_documents
+    given_two_groups_with_memberships
     post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
-            @doc_1_1.id,
-            @doc_1_1.id
+          membership_ids: [
+            @member_1_1.id,
+            @member_1_1.id
           ],
           order: 0
         }
       }
     }
 
-    assert_equal [@doc_1_1], @group_1.reload.documents
+    assert_equal [@member_1_1], @group_1.reload.memberships
   end
 
   test "POST #update_memberships should support moving memberships between groups" do
-    given_two_groups_with_documents
+    given_two_groups_with_memberships
     post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
-            @doc_1_1.id
+          membership_ids: [
+            @member_1_1.id
           ],
           order: 0
         },
         1 => {
           id: @group_2.id,
-          document_ids: [
-            @doc_1_2.id,
-            @doc_2_1.id,
-            @doc_2_2.id
+          membership_ids: [
+            @member_1_2.id,
+            @member_2_1.id,
+            @member_2_2.id
           ],
           order: 1
         }
       }
     }
 
-    assert @group_2.reload.documents.include?(@doc_1_2)
+    assert @group_2.reload.memberships.include?(@member_1_2)
   end
 
   test "POST #update_memberships should handle empty groups" do
-    given_two_groups_with_documents
+    given_two_groups_with_memberships
 
     post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
-            @doc_1_1.id,
-            @doc_1_2.id,
-            @doc_2_1.id,
-            @doc_2_2.id
+          membership_ids: [
+            @member_1_1.id,
+            @member_1_2.id,
+            @member_2_1.id,
+            @member_2_2.id
           ],
           order: 0
         },
@@ -240,18 +240,18 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
-    assert_equal [@doc_1_1, @doc_1_2, @doc_2_1, @doc_2_2], @group_1.reload.documents
-    assert_empty @group_2.reload.documents
+    assert_equal [@member_1_1, @member_1_2, @member_2_1, @member_2_2], @group_1.reload.memberships
+    assert_empty @group_2.reload.memberships
   end
 
-  def given_two_groups_with_documents
+  def given_two_groups_with_memberships
     @group_1 = build(:document_collection_group)
     @group_2 = build(:document_collection_group)
     @collection.update_attribute :groups, [@group_1, @group_2]
 
-    @group_1.documents << @doc_1_1 = create(:document)
-    @group_1.documents << @doc_1_2 = create(:document)
-    @group_2.documents << @doc_2_1 = create(:document)
-    @group_2.documents << @doc_2_2 = create(:document)
+    @group_1.memberships << @member_1_1 = create(:document_collection_group_membership)
+    @group_1.memberships << @member_1_2 = create(:document_collection_group_membership)
+    @group_2.memberships << @member_2_1 = create(:document_collection_group_membership)
+    @group_2.memberships << @member_2_2 = create(:document_collection_group_membership)
   end
 end

--- a/test/unit/models/document_collection_group_membership_test.rb
+++ b/test/unit/models/document_collection_group_membership_test.rb
@@ -8,8 +8,14 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
     assert_equal [1, 2], group.memberships.reload.map(&:ordering)
   end
 
-  test 'is invalid without a document' do
-    refute build(:document_collection_group_membership, document: nil).valid?
+  test 'is invalid without a document or a non-whitehall link' do
+    refute build(:document_collection_group_membership, document: nil, non_whitehall_link: nil).valid?
+  end
+
+  test 'is invalid with both a document and a external link' do
+    refute build(:document_collection_group_membership,
+                 document: build(:document),
+                 non_whitehall_link: build(:document_collection_non_whitehall_link)).valid?
   end
 
   test 'is invalid without a document_collection_group' do

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -29,6 +29,28 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
   end
 
+  test "#set_membership_ids_in_order! should associate documents and set their\
+        membership's ordering to the position of the membership id in the passed in array" do
+    group = build(:document_collection_group)
+
+    membership_1 = create(:document_collection_group_membership)
+    membership_2 = create(:document_collection_group_membership)
+    membership_3 = create(:document_collection_group_membership)
+
+    group.memberships << membership_1
+    group.memberships << membership_2
+    group.memberships << membership_3
+
+    group.set_membership_ids_in_order! [membership_3.id, membership_1.id]
+
+    assert group.memberships.include? membership_1
+    assert group.memberships.include? membership_3
+    refute group.memberships.include? membership_2
+
+    assert_equal 0, group.memberships.find(membership_3.id).ordering
+    assert_equal 1, group.memberships.find(membership_1.id).ordering
+  end
+
   test '::published_editions should list published editions ordered by membership ordering' do
     group = create(:document_collection_group)
     published_1 = create(:published_publication)

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -8,27 +8,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal [1, 2], series.groups.reload.map(&:ordering)
   end
 
-  test "#set_document_ids_in_order! should associate documents and set their\
-        membership's ordering to the position of the document id in the passed in array" do
-    group = build(:document_collection_group)
-
-    doc_1 = create(:document)
-    doc_2 = create(:document)
-    doc_3 = create(:document)
-
-    group.documents << doc_1
-    group.documents << doc_2
-
-    group.set_document_ids_in_order! [doc_3.id, doc_1.id]
-
-    assert group.documents.include? doc_1
-    assert group.documents.include? doc_3
-    refute group.documents.include? doc_2
-
-    assert_equal 0, group.memberships.find_by(document_id: doc_3.id).ordering
-    assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
-  end
-
   test "#set_membership_ids_in_order! should associate documents and set their\
         membership's ordering to the position of the membership id in the passed in array" do
     group = build(:document_collection_group)
@@ -49,28 +28,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
 
     assert_equal 0, group.memberships.find(membership_3.id).ordering
     assert_equal 1, group.memberships.find(membership_1.id).ordering
-  end
-
-  test '::published_editions should list published editions ordered by membership ordering' do
-    group = create(:document_collection_group)
-    published_1 = create(:published_publication)
-    published_2 = create(:published_publication)
-    draft = create(:draft_publication)
-
-    group.set_document_ids_in_order! [draft.document.id, published_2.document.id, published_1.document.id]
-
-    assert_equal [published_2, published_1], group.published_editions
-  end
-
-  test '::latest_editions should list latest editions for each document ordered by membership ordering' do
-    group = create(:document_collection_group)
-    draft = create(:draft_publication)
-    published_1 = create(:published_publication)
-    published_2 = create(:published_publication)
-
-    group.set_document_ids_in_order! [published_1.document.id, draft.document.id, published_2.document.id]
-
-    assert_equal [published_1, draft, published_2], group.latest_editions
   end
 
   test '#dup should also clone document memberships' do
@@ -95,22 +52,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
   test '#slug generates slugs of the heading' do
     group = create(:document_collection_group, heading: 'Foo bar')
     assert_equal group.slug, 'foo-bar'
-  end
-
-  test '#visible? should be true if only non-whitehall links are present' do
-    group = create(:document_collection_group, non_whitehall_links: [
-      build(:document_collection_non_whitehall_link),
-    ])
-
-    assert group.visible?
-  end
-
-  test '#visible? should be false if only non-published editions are present' do
-    group = create(:document_collection_group, documents: [
-      create(:draft_edition).document,
-    ])
-
-    refute group.visible?
   end
 
   test '#content_ids contain document and non-whitehall links in order' do

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -16,19 +16,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal [groups[1], groups[0], groups[2]], doc_collection.reload.groups
   end
 
-  test "editions lists all editions associated through the document collection groups" do
-    doc_collection = create(:document_collection)
-
-    pub_1 = create(:publication)
-    pub_2 = create(:publication)
-
-    create(:document_collection_group, document_collection: doc_collection, documents: [pub_1.document])
-    create(:document_collection_group, document_collection: doc_collection, documents: [pub_2.document])
-
-    assert doc_collection.editions.include? pub_1
-    assert doc_collection.editions.include? pub_2
-  end
-
   should_validate_with_safe_html_validator
 
   test "it should be invalid without a title" do
@@ -119,27 +106,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
   test 'indexes the summary as description' do
     collection = create(:document_collection, summary: 'a summary')
     assert_match 'a summary', collection.search_index['description']
-  end
-
-  test 'published_editions returns published editions from collection in reverse chronological order' do
-    collection = create(:document_collection, :with_group)
-    draft = create(:draft_publication)
-    old = create(:published_publication, first_published_at: 2.days.ago)
-    new = create(:published_publication, first_published_at: 1.day.ago)
-    group = collection.groups.first
-    group.documents = [draft.document, old.document, new.document]
-
-    assert_equal [new, old], collection.published_editions
-  end
-
-  test 'scheduled_editions returns editions that are scheduled for publishing in the collection' do
-    collection = create(:document_collection, :with_group)
-    publication = create(:published_publication, first_published_at: 2.days.ago)
-    scheduled_publication = create(:scheduled_publication)
-    group = collection.groups.first
-    group.documents = [scheduled_publication.document, publication.document]
-
-    assert_equal [scheduled_publication], collection.scheduled_editions
   end
 
   test 'specifies the rendering app as government frontend' do

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -146,4 +146,16 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     document_collection = DocumentCollection.new
     assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
   end
+
+  test '#content_ids returns content_ids from each group' do
+    doc = create(:published_news_article).document
+    non_whitehall_link = create(:document_collection_non_whitehall_link)
+    groups = [
+      build(:document_collection_group, documents: [doc]),
+      build(:document_collection_group, non_whitehall_links: [non_whitehall_link]),
+    ]
+    doc_collection = create(:document_collection, groups: groups)
+
+    assert_equal doc_collection.content_ids, [doc.content_id, non_whitehall_link.content_id]
+  end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -95,24 +95,10 @@ class PublishingApi::DocumentCollectionPresenterGroupTest < ActiveSupport::TestC
     group_one = document_collection.groups.first
     group_two = document_collection.groups.second
 
-    group_one.stubs(:documents).returns(
-      [
-        stub(content_id: "aaa"),
-        stub(content_id: "bbb"),
-      ]
-    )
-    group_two.stubs(:documents).returns(
-      [
-        stub(content_id: "fff"),
-        stub(content_id: "eee"),
-      ]
-    )
-    group_one.stubs(:heading).returns(
-      "Group 1"
-    )
-    group_two.stubs(:heading).returns(
-      "Group 2"
-    )
+    group_one.stubs(:content_ids).returns(%w(aaa bbb))
+    group_two.stubs(:content_ids).returns(%w(fff eee))
+    group_one.stubs(:heading).returns("Group 1")
+    group_two.stubs(:heading).returns("Group 2")
 
     presenter = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -143,9 +129,7 @@ end
 class PublishingApi::DocumentCollectionPresenterDocumentLinksTestCase < ActiveSupport::TestCase
   setup do
     document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).with(:content_id).returns(%w(faf afa))
-    document_collection.stubs(:documents).returns(documents)
+    document_collection.stubs(:content_ids).returns(%w(faf afa))
 
     @presented_links = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -286,9 +270,7 @@ end
 class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).twice.with(:content_id).returns(%w(test test ers))
-    @document_collection.stubs(:documents).returns(documents)
+    @document_collection.stubs(:content_ids).returns(%w(test test ers))
     presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
     @presented_edition_links = presented_document_collection.content[:links]
     @presented_links = presented_document_collection.links

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -226,7 +226,7 @@ class PublishingApi::PublishedDocumentCollectionPresenterEditionLinksTest < Acti
 
   test "it presents the documents content_ids as links, documents" do
     assert_equal(
-      @document_collection.documents.map(&:content_id),
+      @document_collection.content_ids,
       @presented_links[:documents]
     )
   end

--- a/test/unit/tasks/add_non_whitehall_link_to_group_test.rb
+++ b/test/unit/tasks/add_non_whitehall_link_to_group_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'rake'
+
+class AddNonWhitehallLinkToGroupTest < ActiveSupport::TestCase
+  setup do
+    Rake.application.rake_require 'tasks/document_collection'
+    Rake::Task.define_task(:environment)
+    Rake::Task['document_collection:add_non_whitehall_link_to_group'].reenable
+  end
+
+  test 'it should add a non-whitehall link to a group' do
+    content_id = SecureRandom.uuid
+    group = create(:document_collection_group, heading: 'Foo bar')
+    stub_publishing_api_has_item(content_id: content_id,
+                                 title: 'Vat Rates',
+                                 base_path: '/vat-rates',
+                                 publishing_app: 'content-publisher')
+
+    Rake.application.invoke_task "document_collection:add_non_whitehall_link_to_group[#{content_id}, #{group.id}]"
+
+    assert_equal 1, group.non_whitehall_links.count
+    non_whitehall_link = group.non_whitehall_links.first
+    assert_equal [content_id, 'Vat Rates', '/vat-rates', 'content-publisher'],
+                 non_whitehall_link.as_json.values_at("content_id", "title", "base_path", "publishing_app")
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/VdQtNZeV/1122-spike-making-content-publisher-documents-show-up-in-whitehall-document-collections

This is rather rapid attempt at trying to make the document collections feature in Whitehall support links to GOV.UK content that does not originate from Whitehall. Ideally this whole feature should be powered by Publishing API data so that content from all publishing applications is treated equally.

To do this a `DocumentCollectionGroupMembership` has been changed from requiring an association to a `Document` to supporting an association to either a `Document` or a `DocumentCollectionNonWhitehallLink`. A `DocumentCollectionNonWhitehallLink` contains data that can be populated from the Publishing API: `base_path`, `title`, `publishing_app` and `content_id`. `content_id` is the only value that is needed for presenting the `DocumentCollection` to the Publishing API (and this code caters for this) the other fields are intended for the user interface. There is an expected risk that the data in these fields may fall out of date.

I envision this as eventually allowing a user to enter a GOV.UK URL in a progressively disclosed form to add to the group. For example:

<img width="1175" alt="Screen Shot 2019-08-08 at 10 06 30" src="https://user-images.githubusercontent.com/282717/62690196-3545b480-b9c4-11e9-9c7d-362e4c1e4e5a.png">

The next steps I see for this are:

## 1. Allow showing, moving and removing a non-Whitehall link in the UI for a document collection.

This focuses on altering the rendering of the document collection view to show memberships of groups rather than documents. A view will need to be created to allow showing a non-Whitehall link. The form parameters will need to be altered from working with [documents](https://github.com/alphagov/whitehall/blob/374ee2ec2ed0964e93243924ff1f76488ba94cf8/app/views/admin/document_collection_groups/_collection_document.html.erb) to working with memberships so that [set_document_ids_in_order](https://github.com/alphagov/whitehall/blob/374ee2ec2ed0964e93243924ff1f76488ba94cf8/app/controllers/admin/document_collection_groups_controller.rb#L43) can be replaced with [set_membership_ids_in_order](https://github.com/alphagov/whitehall/compare/document-collections?expand=1#diff-f5360a4fd8e851e1448380058b2dae6eR32). 

I anticipate the view looking something like this: 

<img width="1162" alt="Screen Shot 2019-08-08 at 10 01 43" src="https://user-images.githubusercontent.com/282717/62689888-8e611880-b9c3-11e9-8223-cd429658e596.png">

Note this does not include adding the document to the collection which is a bigger task.

## 2. Provide means of a Rake task to create these 

I'd anticipate there being a rake task that would allow adding items to a group as a faster means of allowing this feature to ship, meaning this could be done as a developer task initially until we have availability to build the UI.

I'd expect the task to be something like: `document_collection:add_non_whitehall_link_to_group[<content_id>, <document_collection_group_id>]`.

The task should look up the `DocumentCollectionGroup` for the id and check whether that is part of an editable document collection, if not abort.

It should then look up the [content item in the Publishing API](https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2content) for the content_id and, assuming one exists, create a `DocumentCollectionNonWhitehallLink` with the data and save that to the `DocumentCollectionGroup`.

## 3.Allow ability to add to collection via Whitehall UI

This would allow a progressively disclosed form that allows adding a GOV.UK URL to a document collection group.

This would need means to validate the URL. It should determine the user input is a valid URL and that this a GOV.UK URL. Assuming those checks pass it should extract the path of the URL and use [Publishing API lookup-by-base-path](https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-lookup-by-base-path) to get the content_id and [Publishing API get content](https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2content) to look up the data. This would then be used to create the `DocumentCollectionNonWhitehallLink`.

What is unclear to me at this point is how we would render validate errors to the user and what class/model would be used to perform the validation.

/cc @Tetrino @JonathanHallam 