### PR TITLE
Change Organisation Type to "Tribunal"

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -31,7 +31,7 @@ module Organisation::OrganisationTypeConcern
     scope :hmcts_tribunals, -> {
       hmcts_id = Organisation.unscoped.where(slug: "hm-courts-and-tribunals-service").ids.first
       joins(:parent_organisational_relationships).
-        where(organisation_type_key: :tribunal_ndpb).
+        where(organisation_type_key: :tribunal).
         where("organisational_relationships.parent_organisation_id" => hmcts_id)
     }
 
@@ -44,7 +44,7 @@ module Organisation::OrganisationTypeConcern
           where("NOT (parent_organisational_relationships.parent_organisation_id = ? AND
                 organisations.organisation_type_key = ?) OR
                 parent_organisational_relationships.child_organisation_id IS NULL",
-                hmcts_id, :tribunal_ndpb)
+                hmcts_id, :tribunal)
       end
     }
 
@@ -85,7 +85,7 @@ module Organisation::OrganisationTypeConcern
   end
 
   def hmcts_tribunal?
-    organisation_type_key == :tribunal_ndpb &&
+    organisation_type_key == :tribunal &&
       parent_organisations.pluck(:slug).include?("hm-courts-and-tribunals-service")
   end
 

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -6,7 +6,7 @@ class OrganisationType
     executive_agency:            { name: "Executive agency",                       analytics_prefix: "EA", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     executive_ndpb:              { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     advisory_ndpb:               { name: "Advisory non-departmental public body",  analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
-    tribunal_ndpb:               { name: "Tribunal non-departmental public body",  analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
+    tribunal:                    { name: "Tribunal",                               analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     public_corporation:          { name: "Public corporation",                     analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     independent_monitoring_body: { name: "Independent monitoring body",            analytics_prefix: "IM", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     adhoc_advisory_group:        { name: "Ad-hoc advisory group",                  analytics_prefix: "AG", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
@@ -24,7 +24,7 @@ class OrganisationType
     executive_agency
     executive_ndpb
     advisory_ndpb
-    tribunal_ndpb
+    tribunal
     public_corporation
     independent_monitoring_body
     adhoc_advisory_group
@@ -84,8 +84,8 @@ class OrganisationType
     get :advisory_ndpb
   end
 
-  def self.tribunal_ndpb
-    get :tribunal_ndpb
+  def self.tribunal
+    get :tribunal
   end
 
   def self.public_corporation
@@ -168,8 +168,8 @@ class OrganisationType
     key == :advisory_ndpb
   end
 
-  def tribunal_ndpb?
-    key == :tribunal_ndpb
+  def tribunal?
+    key == :tribunal
   end
 
   def public_corporation?

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -6,7 +6,7 @@ class OrganisationType
     executive_agency:            { name: "Executive agency",                       analytics_prefix: "EA", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     executive_ndpb:              { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     advisory_ndpb:               { name: "Advisory non-departmental public body",  analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
-    tribunal:                    { name: "Tribunal",                               analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
+    tribunal:                    { name: "Tribunal",                               analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     public_corporation:          { name: "Public corporation",                     analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     independent_monitoring_body: { name: "Independent monitoring body",            analytics_prefix: "IM", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     adhoc_advisory_group:        { name: "Ad-hoc advisory group",                  analytics_prefix: "AG", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },

--- a/db/migrate/20190813142450_change_tribunal_org_type.rb
+++ b/db/migrate/20190813142450_change_tribunal_org_type.rb
@@ -1,0 +1,7 @@
+class ChangeTribunalOrgType < ActiveRecord::Migration[5.1]
+  def change
+    Organisation
+      .where(organisation_type_key: :tribunal_ndpb)
+      .update_all(organisation_type_key: :tribunal)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711112443) do
+ActiveRecord::Schema.define(version: 20190813142450) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
   end
 
   factory :hmcts_tribunal, parent: :organisation do
-    organisation_type_key { :tribunal_ndpb }
+    organisation_type_key { :tribunal }
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
     parent_organisations {

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -315,7 +315,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_relationship_type_is_described_as(:executive_agency, '{this_org_name} is an executive agency, sponsored by the {parent_org_name}.')
     assert_relationship_type_is_described_as(:executive_ndpb, '{this_org_name} is an executive non-departmental public body, sponsored by the {parent_org_name}.')
     assert_relationship_type_is_described_as(:advisory_ndpb, '{this_org_name} is an advisory non-departmental public body, sponsored by the {parent_org_name}.')
-    assert_relationship_type_is_described_as(:tribunal_ndpb, '{this_org_name} is a tribunal non-departmental public body, sponsored by the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:tribunal, '{this_org_name} is a tribunal of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:public_corporation, '{this_org_name} is a public corporation of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:independent_monitoring_body, '{this_org_name} is an independent monitoring body of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:other, '{this_org_name} works with the {parent_org_name}.')

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -79,7 +79,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
   class HMCTSOrganisationTests < ActiveSupport::TestCase
     def setup
       @other_org = create(:organisation)
-      @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb,
+      @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal,
         name: "Copyright Tribunal", parent_organisations: [@other_org])
       @multiple_parent_child_org = create(:organisation, parent_organisations: [@other_org, @copyright_tribunal])
       @court = create(:court)
@@ -134,7 +134,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
     _child_org_4 = create(:closed_organisation, parent_organisations: [parent_org_1])
     _child_org_5 = create(:court, parent_organisations: [parent_org_1])
-    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal_ndpb)
+    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal)
 
     assert_equal [child_org_3, child_org_1, child_org_6], parent_org_1.supporting_bodies
   end
@@ -178,7 +178,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
 
   test "#hmcts_tribunal? should be true if it's an HMCTS tribunal only" do
     hmcts_tribunal = create(:hmcts_tribunal)
-    tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb)
+    tribunal = create(:organisation, organisation_type_key: :tribunal)
     hmcts_child = create(:organisation,
                          parent_organisations: [Organisation.find_by(slug: "hm-courts-and-tribunals-service")])
 

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -65,7 +65,7 @@ class OrganisationTypeTest < ActiveSupport::TestCase
         executive_agency
         executive_ndpb
         advisory_ndpb
-        tribunal_ndpb
+        tribunal
         public_corporation
         independent_monitoring_body
         adhoc_advisory_group

--- a/test/unit/presenters/organisations_index_presenter_test.rb
+++ b/test/unit/presenters/organisations_index_presenter_test.rb
@@ -9,7 +9,7 @@ class OrganisationsIndexPresenterTest < ActiveSupport::TestCase
       executive_agency:            build(:organisation, organisation_type_key: :executive_agency),
       executive_ndpb:              build(:organisation, organisation_type_key: :executive_ndpb),
       advisory_ndpb:               build(:organisation, organisation_type_key: :advisory_ndpb),
-      tribunal_ndpb:               build(:organisation, organisation_type_key: :tribunal_ndpb),
+      tribunal:                    build(:organisation, organisation_type_key: :tribunal),
       public_corporation:          build(:organisation, organisation_type_key: :public_corporation),
       independent_monitoring_body: build(:organisation, organisation_type_key: :independent_monitoring_body),
       adhoc_advisory_group:        build(:organisation, organisation_type_key: :adhoc_advisory_group),


### PR DESCRIPTION
Not all organisations that are of type 'Tribunal non-departmental public
body' are actually non-departmental. Some of them are in fact
departmental. Changing this type to be just 'Tribunal' will reflect this
more accurately.

Trello card: https://trello.com/c/KHXlOF6V/1191-change-organisation-type-tribunal-non-departmental-public-body-to-tribunal