### PR TITLE
Report on non-accessible attachments by organisation

### DIFF
--- a/lib/reports/organisation_attachments_report.rb
+++ b/lib/reports/organisation_attachments_report.rb
@@ -1,0 +1,61 @@
+module Reports
+  class OrganisationAttachmentsReport
+    def initialize(organisation_slug)
+      @organisation_slug = organisation_slug
+    end
+
+    def report
+      path = "#{Rails.root}/tmp/#{@organisation_slug}-attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv"
+      csv_headers = ["Attachment title", "Attachment path", "File type", "Accessible", "Content type", "Content URL", "Publication date", "Last amended date"]
+
+      CSV.open(path, "wb", headers: csv_headers, write_headers: true) do |csv|
+        organisation_id = Organisation.where(slug: @organisation_slug, govuk_status: 'live').limit(1).pluck(:id).first
+
+        editions = get_editions_by_organisation(organisation_id)
+
+        puts "Found #{editions.count} editions containing attachments with organisation '#{@organisation_slug}'"
+
+        editions.each do |edition|
+          edition.attachments.each do |attachment|
+            if attachment.accessible == false
+              csv << [
+                attachment.title,
+                attachment.url,
+                attachment.content_type,
+                attachment.accessible,
+                edition.type,
+                "/government/publications/#{edition.slug}",
+                edition.first_published_at,
+                attachment.updated_at
+              ]
+            end
+          end
+          print(".")
+        end
+      end
+      puts "Finished! Report available at #{path}"
+    end
+
+    private
+
+    attr_reader :organisation_slug
+
+    def get_editions_by_organisation(organisation_id)
+      Edition.find_by_sql([
+        "SELECT e.*
+         FROM editions e
+         JOIN edition_organisations eo ON eo.edition_id = e.id AND eo.organisation_id = ? AND eo.lead = TRUE
+         WHERE e.state = 'published'
+         AND e.state != 'deleted'
+         AND EXISTS(
+           SELECT a.id
+           FROM attachments a
+           WHERE a.attachable_type = 'Edition'
+           AND a.attachable_id = e.id
+           AND a.attachment_data_id IS NOT NULL
+         )
+         ORDER BY e.created_at DESC", organisation_id
+      ])
+    end
+  end
+end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -87,6 +87,13 @@ namespace :reporting do
     Reports::DraftPublicationsReport.new(args[:start_date], args[:end_date]).report
   end
 
+  desc "A CSV report of non-accessible attachments uploads published by the given organisation"
+  task :organisation_attachments_report, %i[organisation_slug] => :environment do |_t, args|
+    raise "Missing organisation slug" unless args[:organisation_slug].present?
+
+    Reports::OrganisationAttachmentsReport.new(args[:organisation_slug]).report
+  end
+
   desc "A CSV report of all documents published by the given organisation"
   task organisation_documents: :environment do
     options = opts_from_environment(:organisation_slug)


### PR DESCRIPTION
As part of meeting the new accessibility regulations, organisations
need to be more transparent on how accessible their content is on
GOV.UK. This includes reviewing their attachments that are not
accessible, and the steps they will take to improve them.

This rake task generates a CSV report containing information about
all published non-accessible attachments that belong to the specified
organisation. This should help organisations determine the amount
of work required.

Trello card: https://trello.com/c/BSfJQeUu/1162-report-listing-nonaccessible-attachments-on-govuk