### PR TITLE
Use membership ID's 

### DIFF
--- a/app/assets/javascripts/admin/document_group_ordering.js
+++ b/app/assets/javascripts/admin/document_group_ordering.js
@@ -49,7 +49,7 @@
     for(var i=0; i<this.documentGroups.length; i++) {
       postData.groups.push({
         id: this.documentGroups[i].groupID(),
-        document_ids: this.documentGroups[i].documentIDs(),
+        membership_ids: this.documentGroups[i].membershipIDs(),
         order: i
       });
     }
@@ -84,8 +84,8 @@
       return documentList.data('group-id');
     };
 
-    this.documentIDs = function documentIDs() {
-      return documentList.find("input[name='documents[]']").map(function(i, input) {
+    this.membershipIDs = function membershipIDs() {
+      return documentList.find("input[name='memberships[]']").map(function(i, input) {
         return input.value;
       }).toArray();
     };

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -40,7 +40,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
     params[:groups].each_pair do |_key, group_params|
       group = @collection.groups.find(group_params[:id])
       group.ordering = group_params[:order]
-      group.set_document_ids_in_order! group_params.fetch(:document_ids, []).map(&:to_i).uniq
+      group.set_membership_ids_in_order! group_params.fetch(:membership_ids, []).map(&:to_i).uniq
     end
     respond_to do |format|
       format.html { render :index }

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -20,6 +20,9 @@ class DocumentCollection < Edition
            dependent: :destroy,
            inverse_of: :document_collection
   has_many :documents, through: :groups
+  has_many :non_whitehall_links,
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :groups
   has_many :editions, through: :documents
 
   before_create :create_default_group
@@ -63,6 +66,10 @@ class DocumentCollection < Edition
 
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
+  def content_ids
+    groups.flat_map(&:content_ids)
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -8,6 +8,10 @@ class DocumentCollectionGroup < ApplicationRecord
   has_many :documents,
            -> { order('document_collection_group_memberships.ordering') },
            through: :memberships
+  has_many :non_whitehall_links,
+           -> { order('document_collection_group_memberships.ordering') },
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :memberships
   has_many :editions,
            -> { order('document_collection_group_memberships.ordering') },
            through: :documents
@@ -44,7 +48,7 @@ class DocumentCollectionGroup < ApplicationRecord
   end
 
   def visible?
-    published_editions.present?
+    published_editions.present? || non_whitehall_links.present?
   end
 
   def dup
@@ -55,6 +59,10 @@ class DocumentCollectionGroup < ApplicationRecord
 
   def slug
     heading.parameterize
+  end
+
+  def content_ids
+    memberships.map(&:content_id)
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -29,6 +29,14 @@ class DocumentCollectionGroup < ApplicationRecord
     end
   end
 
+  def set_membership_ids_in_order!(membership_ids)
+    self.membership_ids = membership_ids
+    self.save!
+    self.memberships.each do |membership|
+      membership.update_attribute(:ordering, membership_ids.index(membership.id))
+    end
+  end
+
   def self.visible
     includes(:editions).references(:editions).where(editions: { state: 'published' })
   end

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -3,8 +3,7 @@ class DocumentCollectionGroup < ApplicationRecord
   has_many :memberships,
            -> { order('document_collection_group_memberships.ordering') },
            class_name: 'DocumentCollectionGroupMembership',
-           inverse_of: :document_collection_group,
-           dependent: :destroy
+           inverse_of: :document_collection_group
   has_many :documents,
            -> { order('document_collection_group_memberships.ordering') },
            through: :memberships

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -19,6 +19,10 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   validate :document_is_of_allowed_type, if: -> { document.present? }
   validate :presence_of_document_or_non_whitehall_link
 
+  def content_id
+    document&.content_id || non_whitehall_link&.content_id
+  end
+
 private
 
   def assign_ordering

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -2,16 +2,22 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   BANNED_DOCUMENT_TYPES = %w[DocumentCollection].freeze
   include LockedDocumentConcern
 
-  belongs_to :document, inverse_of: :document_collection_group_memberships
+  belongs_to :document,
+             inverse_of: :document_collection_group_memberships,
+             optional: true
+  belongs_to :non_whitehall_link,
+             class_name: 'DocumentCollectionNonWhitehallLink',
+             inverse_of: :document_collection_group_memberships,
+             optional: true
   belongs_to :document_collection_group, inverse_of: :memberships
 
   before_create :assign_ordering
 
-  before_save { check_if_locked_document(document: self.document) }
+  before_save { check_if_locked_document(document: document) if document }
 
-  validates :document, presence: true
   validates :document_collection_group, presence: true
   validate :document_is_of_allowed_type, if: -> { document.present? }
+  validate :presence_of_document_or_non_whitehall_link
 
 private
 
@@ -20,8 +26,18 @@ private
   end
 
   def document_is_of_allowed_type
-    if BANNED_DOCUMENT_TYPES.include? document.document_type
+    if document && BANNED_DOCUMENT_TYPES.include?(document.document_type)
       errors.add(:document, "cannot be a #{document.humanized_document_type}")
+    end
+  end
+
+  def presence_of_document_or_non_whitehall_link
+    if document && non_whitehall_link
+      errors.add(:base, "cannot be associated with a document and an non-whitehall link")
+    end
+
+    if !document && !non_whitehall_link
+      errors.add(:base, "must be associated with a document or an non-whitehall link")
     end
   end
 end

--- a/app/models/document_collection_non_whitehall_link.rb
+++ b/app/models/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+class DocumentCollectionNonWhitehallLink < ApplicationRecord
+  has_many :document_collection_group_memberships,
+           inverse_of: :non_whitehall_link,
+           foreign_key: :non_whitehall_link_id,
+           dependent: :destroy
+
+  # may want to validate base_path and content_id
+end

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -41,7 +41,7 @@ module PublishingApi
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )
-      links[:documents] = item.documents.pluck(:content_id).uniq
+      links[:documents] = item.content_ids.uniq
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 
@@ -70,7 +70,7 @@ module PublishingApi
         {
           title: group.heading,
           body: govspeak_renderer.govspeak_to_html(group.body),
-          documents: group.documents.collect(&:content_id)
+          documents: group.content_ids
         }
       end
     end

--- a/app/views/admin/document_collection_groups/_collection_document.html.erb
+++ b/app/views/admin/document_collection_groups/_collection_document.html.erb
@@ -1,18 +1,23 @@
-<%= content_tag_for(:li, edition, class: "document-row") do %>
-  <label>
-    <%= check_box_tag('documents[]', edition.document.id, false, class: 'checkbox', id: nil) %>
-    <%= edition.title %>
-  </label>
-  (<%= link_to 'view page', admin_edition_path(edition) %>)
-  <ul class="metadata list-inline text-muted">
-    <li>
-      Last changed: <%= public_time_for_edition(edition) %>
-    </li>
-    <li>
-      <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
-    </li>
-    <li>
-      <%= edition.display_type %>
-    </li>
-  </ul>
+<%= content_tag(:li, class: "document-row") do %>
+  <% if membership.non_whitehall_link %>
+
+  <% else %>
+    <% edition = membership.document.latest_edition %>
+    <label>
+      <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
+      <%= edition.title %>
+    </label>
+    (<%= link_to 'view page', admin_edition_path(edition) %>)
+    <ul class="metadata list-inline text-muted">
+      <li>
+        Last changed: <%= public_time_for_edition(edition) %>
+      </li>
+      <li>
+        <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
+      </li>
+      <li>
+        <%= edition.display_type %>
+      </li>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -71,7 +71,7 @@
                 <% end %>
               </ul>
               <ol class="document-list js-document-group list-unstyled" data-group-id="<%= group.id %>">
-                <%= render partial: 'collection_document', collection: group.latest_editions, as: :edition, locals: { document_collection: @collection } %>
+                <%= render partial: 'collection_document', collection: group.memberships, as: :membership, locals: { document_collection: @collection } %>
               </ol>
             <% end %>
           <% end %>

--- a/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
@@ -1,0 +1,11 @@
+class CreateDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :document_collection_non_whitehall_links do |t|
+      t.string :content_id, null: false
+      t.string :title, null: false
+      t.text :base_path, null: false
+      t.string :publishing_app, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
@@ -1,0 +1,7 @@
+class ReferenceDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :document_collection_group_memberships,
+                  :non_whitehall_link,
+                  index: { name: "index_document_collection_non_whitehall_link" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711112443) do
+ActiveRecord::Schema.define(version: 20190806120852) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -240,8 +240,10 @@ ActiveRecord::Schema.define(version: 20190711112443) do
     t.integer "ordering"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "non_whitehall_link_id"
     t.index ["document_collection_group_id", "ordering"], name: "index_dc_group_memberships_on_dc_group_id_and_ordering"
     t.index ["document_id"], name: "index_document_collection_group_memberships_on_document_id"
+    t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
   create_table "document_collection_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -252,6 +254,15 @@ ActiveRecord::Schema.define(version: 20190711112443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
+  end
+
+  create_table "document_collection_non_whitehall_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "content_id", null: false
+    t.string "title", null: false
+    t.text "base_path", null: false
+    t.string "publishing_app", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "document_sources", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/test/factories/document_collection_non_whitehall_link.rb
+++ b/test/factories/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :document_collection_non_whitehall_link do
+    content_id { SecureRandom.uuid }
+    base_path { "/vat-rates" }
+    title { "VAT Rates" }
+    publishing_app { "mainstream" }
+  end
+end

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -186,7 +186,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
       }
     }
 
-    assert_equal [@doc_1_1], @group_1.reload.documents
+    assert_equal [@doc_1_1], @group_1.reload.memberships
   end
 
   test "POST #update_memberships should support moving memberships between groups" do
@@ -213,7 +213,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
       }
     }
 
-    assert @group_2.reload.documents.include?(@doc_1_2)
+    assert @group_2.reload.memberships.include?(@doc_1_2)
   end
 
   test "POST #update_memberships should handle empty groups" do
@@ -224,7 +224,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
       groups: {
         0 => {
           id: @group_1.id,
-          document_ids: [
+          membership_ids: [
             @doc_1_1.id,
             @doc_1_2.id,
             @doc_2_1.id,
@@ -240,7 +240,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
-    assert_equal [@doc_1_1, @doc_1_2, @doc_2_1, @doc_2_2], @group_1.reload.documents
+    assert_equal [@doc_1_1, @doc_1_2, @doc_2_1, @doc_2_2], @group_1.reload.memberships
     assert_empty @group_2.reload.documents
   end
 
@@ -249,9 +249,9 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     @group_2 = build(:document_collection_group)
     @collection.update_attribute :groups, [@group_1, @group_2]
 
-    @group_1.documents << @doc_1_1 = create(:document)
-    @group_1.documents << @doc_1_2 = create(:document)
-    @group_2.documents << @doc_2_1 = create(:document)
-    @group_2.documents << @doc_2_2 = create(:document)
+    @group_1.memberships << @doc_1_1 = create(:document_collection_group_membership)
+    @group_1.memberships << @doc_1_2 = create(:document_collection_group_membership)
+    @group_2.memberships << @doc_2_1 = create(:document_collection_group_membership)
+    @group_2.memberships << @doc_2_2 = create(:document_collection_group_membership)
   end
 end

--- a/test/unit/models/document_collection_group_membership_test.rb
+++ b/test/unit/models/document_collection_group_membership_test.rb
@@ -8,8 +8,14 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
     assert_equal [1, 2], group.memberships.reload.map(&:ordering)
   end
 
-  test 'is invalid without a document' do
-    refute build(:document_collection_group_membership, document: nil).valid?
+  test 'is invalid without a document or a non-whitehall link' do
+    refute build(:document_collection_group_membership, document: nil, non_whitehall_link: nil).valid?
+  end
+
+  test 'is invalid with both a document and a external link' do
+    refute build(:document_collection_group_membership,
+                 document: build(:document),
+                 non_whitehall_link: build(:document_collection_non_whitehall_link)).valid?
   end
 
   test 'is invalid without a document_collection_group' do

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -8,27 +8,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal [1, 2], series.groups.reload.map(&:ordering)
   end
 
-  test "#set_document_ids_in_order! should associate documents and set their\
-        membership's ordering to the position of the document id in the passed in array" do
-    group = build(:document_collection_group)
-
-    doc_1 = create(:document)
-    doc_2 = create(:document)
-    doc_3 = create(:document)
-
-    group.documents << doc_1
-    group.documents << doc_2
-
-    group.set_document_ids_in_order! [doc_3.id, doc_1.id]
-
-    assert group.documents.include? doc_1
-    assert group.documents.include? doc_3
-    refute group.documents.include? doc_2
-
-    assert_equal 0, group.memberships.find_by(document_id: doc_3.id).ordering
-    assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
-  end
-
   test "#set_membership_ids_in_order! should associate documents and set their\
         membership's ordering to the position of the membership id in the passed in array" do
     group = build(:document_collection_group)

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -29,6 +29,28 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
   end
 
+  test "#set_membership_ids_in_order! should associate documents and set their\
+        membership's ordering to the position of the membership id in the passed in array" do
+    group = build(:document_collection_group)
+
+    membership_1 = create(:document_collection_group_membership)
+    membership_2 = create(:document_collection_group_membership)
+    membership_3 = create(:document_collection_group_membership)
+
+    group.memberships << membership_1
+    group.memberships << membership_2
+    group.memberships << membership_3
+
+    group.set_membership_ids_in_order! [membership_3.id, membership_1.id]
+
+    assert group.memberships.include? membership_1
+    assert group.memberships.include? membership_3
+    refute group.memberships.include? membership_2
+
+    assert_equal 0, group.memberships.find(membership_3.id).ordering
+    assert_equal 1, group.memberships.find(membership_1.id).ordering
+  end
+
   test '::published_editions should list published editions ordered by membership ordering' do
     group = create(:document_collection_group)
     published_1 = create(:published_publication)

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -146,4 +146,16 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     document_collection = DocumentCollection.new
     assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
   end
+
+  test '#content_ids returns content_ids from each group' do
+    doc = create(:published_news_article).document
+    non_whitehall_link = create(:document_collection_non_whitehall_link)
+    groups = [
+      build(:document_collection_group, documents: [doc]),
+      build(:document_collection_group, non_whitehall_links: [non_whitehall_link]),
+    ]
+    doc_collection = create(:document_collection, groups: groups)
+
+    assert_equal doc_collection.content_ids, [doc.content_id, non_whitehall_link.content_id]
+  end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -95,24 +95,10 @@ class PublishingApi::DocumentCollectionPresenterGroupTest < ActiveSupport::TestC
     group_one = document_collection.groups.first
     group_two = document_collection.groups.second
 
-    group_one.stubs(:documents).returns(
-      [
-        stub(content_id: "aaa"),
-        stub(content_id: "bbb"),
-      ]
-    )
-    group_two.stubs(:documents).returns(
-      [
-        stub(content_id: "fff"),
-        stub(content_id: "eee"),
-      ]
-    )
-    group_one.stubs(:heading).returns(
-      "Group 1"
-    )
-    group_two.stubs(:heading).returns(
-      "Group 2"
-    )
+    group_one.stubs(:content_ids).returns(%w(aaa bbb))
+    group_two.stubs(:content_ids).returns(%w(fff eee))
+    group_one.stubs(:heading).returns("Group 1")
+    group_two.stubs(:heading).returns("Group 2")
 
     presenter = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -143,9 +129,7 @@ end
 class PublishingApi::DocumentCollectionPresenterDocumentLinksTestCase < ActiveSupport::TestCase
   setup do
     document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).with(:content_id).returns(%w(faf afa))
-    document_collection.stubs(:documents).returns(documents)
+    document_collection.stubs(:content_ids).returns(%w(faf afa))
 
     @presented_links = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -286,9 +270,7 @@ end
 class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).twice.with(:content_id).returns(%w(test test ers))
-    @document_collection.stubs(:documents).returns(documents)
+    @document_collection.stubs(:content_ids).returns(%w(test test ers))
     presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
     @presented_edition_links = presented_document_collection.content[:links]
     @presented_links = presented_document_collection.links


### PR DESCRIPTION
Part of https://trello.com/c/VdQtNZeV/1122-spike-making-content-publisher-documents-show-up-in-whitehall-document-collections

Moves to using membership ID's rather than document ID's as a means of tracking the group of a document. This will make it easier to show content publisher documents in whitehall. 

Whilst this appears to work testing manually, as it stands a few tests are failing, I suspect that a couple just need some variables renaming but that one may be a more major change.