### PR TITLE
Fix current role h2 on people pages

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -68,7 +68,7 @@
       <div class="current-roles" id="current-roles">
         <% @person.current_role_appointments.each do |appointment| %>
           <%= content_tag_for :section, appointment, class: "role" do %>
-            <h2 id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h2>
+            <h2 class="gem-c-heading" id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h2>
             <%= appointment.role.responsibilities %>
             <div class="read-more">
               <% if appointment.role.ministerial? %>


### PR DESCRIPTION
The styles on this look a bit broken at present.  Adding "gem-c-heading" as per the other h2's on the page make it look a bit better. This is on people pages like https://www.gov.uk/government/people/michael-gove#current-roles

## Before
<img width="681" alt="Screenshot 2019-08-12 13 15 42" src="https://user-images.githubusercontent.com/773037/62864353-63e4c780-bd03-11e9-9ab8-a536828b55fb.png">


## After
<img width="730" alt="Screenshot 2019-08-12 13 15 31" src="https://user-images.githubusercontent.com/773037/62864356-66dfb800-bd03-11e9-8b46-1b8d4253dcbf.png">

