### PR TITLE
Exclude tmp/ from being searched by rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   Exclude:
+    - 'tmp/**/*'
     - 'db/schema.rb'
     - 'lib/tasks/cucumber.rake'
 


### PR DESCRIPTION
This was causing problems when I was running `govuk-lint-ruby` as
rubocop was checking in all my local tmp files.