### PR TITLE
Lazy load profile images for past prime ministers

### DIFF
--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -80,7 +80,7 @@ class PersonPresenter < Whitehall::Decorators::Decorator
 
   def image
     if (img = image_url(:s216))
-      context.image_tag img, alt: name
+      context.image_tag img, alt: name, loading: "lazy"
     end
   end
 end


### PR DESCRIPTION
### What
This PR updates the `person` presenter to lazy load profile images.

### Why
Chrome shipped lazy loading support in version 76. The 'Past Prime Ministers' page is a good use case for this feature having 76 profile images that could be saved from being downloaded straight away. This attribute doesn't harm any browser and improves experience for users of Chrome 76 and further. The standard is awaiting implementation from other major players so this change will hopefully have more reach in future.

