### PR TITLE
Support non-Whitehall links in document collections

### DIFF
--- a/app/assets/javascripts/admin/document_group_ordering.js
+++ b/app/assets/javascripts/admin/document_group_ordering.js
@@ -49,7 +49,7 @@
     for(var i=0; i<this.documentGroups.length; i++) {
       postData.groups.push({
         id: this.documentGroups[i].groupID(),
-        document_ids: this.documentGroups[i].documentIDs(),
+        membership_ids: this.documentGroups[i].membershipIDs(),
         order: i
       });
     }
@@ -84,8 +84,8 @@
       return documentList.data('group-id');
     };
 
-    this.documentIDs = function documentIDs() {
-      return documentList.find("input[name='documents[]']").map(function(i, input) {
+    this.membershipIDs = function membershipIDs() {
+      return documentList.find("input[name='memberships[]']").map(function(i, input) {
         return input.value;
       }).toArray();
     };

--- a/app/assets/stylesheets/admin/helpers/_document_finder.scss
+++ b/app/assets/stylesheets/admin/helpers/_document_finder.scss
@@ -1,5 +1,5 @@
-#document-finder {
-  margin: $gutter 0;
+.document-finder {
+  margin: $gutter/2 0;
   position: relative;
 
   h2 {
@@ -13,13 +13,20 @@
   $spacing: 0.5em;
 
   input#title,
+  input#url,
   select {
     margin: 0 $spacing;
   }
+  input#url,
 
   input#title {
     width: 25%;
     margin-right: 0.1em;
+  }
+
+  input#url {
+    width: 40%;
+    margin-right: 0.5em;
   }
 
   .document-finder-fields {

--- a/app/assets/stylesheets/admin/views/_document_collection_groups.scss
+++ b/app/assets/stylesheets/admin/views/_document_collection_groups.scss
@@ -1,5 +1,21 @@
 .document-collection-groups {
   &.index {
+    .non-whitehall-disclosure {
+      margin-bottom: $gutter/2;
+
+      summary {
+        font-weight: bold;
+        margin-bottom: $gutter/2;
+        @include border-radius(3px);
+        border: 1px solid transparent;
+      }
+
+      summary:focus {
+        border-color: #66afe9;
+        outline: 0;
+        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+      }
+    }
 
     .reorder-buttons {
       button {

--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -1,9 +1,9 @@
 class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseController
   before_action :load_document_collection
   before_action :load_document_collection_group
-  before_action :find_document, only: :create
+  before_action :find_document, only: :create_whitehall_member
 
-  def create
+  def create_whitehall_member
     membership = DocumentCollectionGroupMembership.new(document: @document, document_collection_group: @group)
     if membership.save
       redirect_to admin_document_collection_groups_path(@collection),
@@ -11,6 +11,20 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
     else
       redirect_to admin_document_collection_groups_path(@collection),
                   alert: membership.errors.full_messages.join(". ") + '.'
+    end
+  end
+
+  def create_non_whitehall_member
+    govuk_link = DocumentCollectionNonWhitehallLink::GovukUrl.new(url: params[:url],
+                                                                  document_collection_group: @group)
+    if govuk_link.save
+      redirect_to admin_document_collection_groups_path(@collection),
+                  notice: "'#{govuk_link.title}' added to '#{@group.heading}'"
+    else
+      flash[:url] = params[:url]
+      flash[:open_non_whitehall] = true
+      redirect_to admin_document_collection_groups_path(@collection),
+                  alert: govuk_link.errors.full_messages.join(". ") + '.'
     end
   end
 

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -20,6 +20,9 @@ class DocumentCollection < Edition
            dependent: :destroy,
            inverse_of: :document_collection
   has_many :documents, through: :groups
+  has_many :non_whitehall_links,
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :groups
   has_many :editions, through: :documents
 
   before_create :create_default_group
@@ -63,6 +66,10 @@ class DocumentCollection < Edition
 
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
+  def content_ids
+    groups.flat_map(&:content_ids)
   end
 
 private

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -19,11 +19,6 @@ class DocumentCollection < Edition
            class_name: 'DocumentCollectionGroup',
            dependent: :destroy,
            inverse_of: :document_collection
-  has_many :documents, through: :groups
-  has_many :non_whitehall_links,
-           class_name: 'DocumentCollectionNonWhitehallLink',
-           through: :groups
-  has_many :editions, through: :documents
 
   before_create :create_default_group
 
@@ -46,7 +41,7 @@ class DocumentCollection < Edition
   def indexable_content
     [
       Govspeak::Document.new(body).to_text,
-      groups.visible.map do |group|
+      groups.live.map do |group|
         [group.heading, Govspeak::Document.new(group.body).to_text]
       end
     ].flatten.join("\n")
@@ -54,14 +49,6 @@ class DocumentCollection < Edition
 
   def display_type
     "Collection"
-  end
-
-  def published_editions
-    editions.published.reorder(nil).in_reverse_chronological_order
-  end
-
-  def scheduled_editions
-    editions.scheduled
   end
 
   def rendering_app

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -16,18 +16,15 @@ class DocumentCollectionGroup < ApplicationRecord
            -> { order('document_collection_group_memberships.ordering') },
            through: :documents
 
+  scope :live, -> do
+    left_joins(:non_whitehall_links, documents: :editions)
+      .where("editions.state = 'published' OR document_collection_non_whitehall_links.id IS NOT NULL")
+  end
+
   validates :heading, presence: true, uniqueness: { scope: :document_collection_id }
   validates_associated :memberships
 
   before_create :assign_ordering
-
-  def set_document_ids_in_order!(document_ids)
-    self.document_ids = document_ids
-    self.save!
-    self.memberships.each do |membership|
-      membership.update_attribute(:ordering, document_ids.index(membership.document_id))
-    end
-  end
 
   def set_membership_ids_in_order!(membership_ids)
     self.membership_ids = membership_ids
@@ -37,26 +34,14 @@ class DocumentCollectionGroup < ApplicationRecord
     end
   end
 
-  def self.visible
-    includes(:editions).references(:editions).where(editions: { state: 'published' })
-  end
-
   def self.default_attributes
     { heading: 'Documents' }
   end
 
-  def published_editions
-    editions.published
-  end
-
-  def latest_editions
-    associations = { latest_edition: %i[organisations translations] }
-    editions = documents.includes(associations).map(&:latest_edition)
-    editions.compact
-  end
-
-  def visible?
-    published_editions.present? || non_whitehall_links.present?
+  def editable_members
+    memberships.filter do |member|
+      member.document&.latest_edition || member.non_whitehall_link
+    end
   end
 
   def dup
@@ -71,6 +56,10 @@ class DocumentCollectionGroup < ApplicationRecord
 
   def content_ids
     memberships.map(&:content_id)
+  end
+
+  def published_editions
+    editions.published
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -8,6 +8,10 @@ class DocumentCollectionGroup < ApplicationRecord
   has_many :documents,
            -> { order('document_collection_group_memberships.ordering') },
            through: :memberships
+  has_many :non_whitehall_links,
+           -> { order('document_collection_group_memberships.ordering') },
+           class_name: 'DocumentCollectionNonWhitehallLink',
+           through: :memberships
   has_many :editions,
            -> { order('document_collection_group_memberships.ordering') },
            through: :documents
@@ -44,7 +48,7 @@ class DocumentCollectionGroup < ApplicationRecord
   end
 
   def visible?
-    published_editions.present?
+    published_editions.present? || non_whitehall_links.present?
   end
 
   def dup
@@ -55,6 +59,10 @@ class DocumentCollectionGroup < ApplicationRecord
 
   def slug
     heading.parameterize
+  end
+
+  def content_ids
+    memberships.map(&:content_id)
   end
 
 private

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -29,6 +29,14 @@ class DocumentCollectionGroup < ApplicationRecord
     end
   end
 
+  def set_membership_ids_in_order!(membership_ids)
+    self.membership_ids = membership_ids
+    self.save!
+    self.memberships.each do |membership|
+      membership.update_attribute(:ordering, membership_ids.index(membership.id))
+    end
+  end
+
   def self.visible
     includes(:editions).references(:editions).where(editions: { state: 'published' })
   end

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -19,6 +19,10 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   validate :document_is_of_allowed_type, if: -> { document.present? }
   validate :presence_of_document_or_non_whitehall_link
 
+  def content_id
+    document&.content_id || non_whitehall_link&.content_id
+  end
+
 private
 
   def assign_ordering

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -2,16 +2,22 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   BANNED_DOCUMENT_TYPES = %w[DocumentCollection].freeze
   include LockedDocumentConcern
 
-  belongs_to :document, inverse_of: :document_collection_group_memberships
+  belongs_to :document,
+             inverse_of: :document_collection_group_memberships,
+             optional: true
+  belongs_to :non_whitehall_link,
+             class_name: 'DocumentCollectionNonWhitehallLink',
+             inverse_of: :document_collection_group_memberships,
+             optional: true
   belongs_to :document_collection_group, inverse_of: :memberships
 
   before_create :assign_ordering
 
-  before_save { check_if_locked_document(document: self.document) }
+  before_save { check_if_locked_document(document: document) if document }
 
-  validates :document, presence: true
   validates :document_collection_group, presence: true
   validate :document_is_of_allowed_type, if: -> { document.present? }
+  validate :presence_of_document_or_non_whitehall_link
 
 private
 
@@ -20,8 +26,18 @@ private
   end
 
   def document_is_of_allowed_type
-    if BANNED_DOCUMENT_TYPES.include? document.document_type
+    if document && BANNED_DOCUMENT_TYPES.include?(document.document_type)
       errors.add(:document, "cannot be a #{document.humanized_document_type}")
+    end
+  end
+
+  def presence_of_document_or_non_whitehall_link
+    if document && non_whitehall_link
+      errors.add(:base, "cannot be associated with a document and a non-whitehall link")
+    end
+
+    if !document && !non_whitehall_link
+      errors.add(:base, "must be associated with a document or a non-whitehall link")
     end
   end
 end

--- a/app/models/document_collection_non_whitehall_link.rb
+++ b/app/models/document_collection_non_whitehall_link.rb
@@ -3,6 +3,4 @@ class DocumentCollectionNonWhitehallLink < ApplicationRecord
            inverse_of: :non_whitehall_link,
            foreign_key: :non_whitehall_link_id,
            dependent: :destroy
-
-  # may want to validate base_path and content_id
 end

--- a/app/models/document_collection_non_whitehall_link.rb
+++ b/app/models/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+class DocumentCollectionNonWhitehallLink < ApplicationRecord
+  has_many :document_collection_group_memberships,
+           inverse_of: :non_whitehall_link,
+           foreign_key: :non_whitehall_link_id,
+           dependent: :destroy
+
+  # may want to validate base_path and content_id
+end

--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -1,0 +1,56 @@
+class DocumentCollectionNonWhitehallLink::GovukUrl
+  include ActiveModel::Validations
+
+  attr_reader :url, :document_collection_group, :content_item
+
+  validates_presence_of :url
+  validates_presence_of :document_collection_group
+  validate :linkable_govuk_url
+
+  def initialize(url:, document_collection_group:)
+    @url = url
+    @document_collection_group = document_collection_group
+  end
+
+  def save
+    return unless valid?
+
+    non_whitehall_link = DocumentCollectionNonWhitehallLink.create!(
+      content_item.slice("base_path", "content_id", "publishing_app", "title")
+    )
+
+    document_collection_group.memberships.create!(non_whitehall_link: non_whitehall_link)
+  end
+
+  def title
+    content_item["title"]
+  end
+
+private
+
+  def linkable_govuk_url
+    return unless url.present?
+
+    parsed_url = URI.parse(url)
+
+    unless parsed_url.host =~ /(publishing.service|www).gov.uk\Z/
+      errors.add(:url, 'must be a valid GOV.UK URL')
+      return
+    end
+
+    content_id = Services.publishing_api.lookup_content_id(base_path: parsed_url.path,
+                                                           with_drafts: true)
+    unless content_id
+      errors.add(:url, 'must reference a GOV.UK page')
+      return
+    end
+
+    @content_item = Services.publishing_api.get_content(content_id).to_h
+  rescue URI::InvalidURIError
+    errors.add(:url, 'must be a valid GOV.UK URL')
+  rescue GdsApi::HTTPNotFound
+    errors.add(:url, 'must reference a GOV.UK page')
+  rescue GdsApi::HTTPIntermittentServerError
+    errors.add(:base, 'Link lookup failed, please try again later')
+  end
+end

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -41,7 +41,7 @@ module PublishingApi
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )
-      links[:documents] = item.documents.pluck(:content_id).uniq
+      links[:documents] = item.content_ids.uniq
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 
@@ -70,7 +70,7 @@ module PublishingApi
         {
           title: group.heading,
           body: govspeak_renderer.govspeak_to_html(group.body),
-          documents: group.documents.collect(&:content_id)
+          documents: group.content_ids
         }
       end
     end

--- a/app/services/service_listeners/search_indexer.rb
+++ b/app/services/service_listeners/search_indexer.rb
@@ -16,7 +16,7 @@ module ServiceListeners
 
     def reindex_collection_documents
       if edition.is_a?(DocumentCollection)
-        edition.published_editions.each do |collected_edition|
+        edition.groups.flat_map(&:published_editions).each do |collected_edition|
           Whitehall::SearchIndex.add(collected_edition)
         end
       end

--- a/app/views/admin/document_collection_groups/_collection_document.html.erb
+++ b/app/views/admin/document_collection_groups/_collection_document.html.erb
@@ -1,18 +1,33 @@
-<%= content_tag_for(:li, edition, class: "document-row") do %>
-  <label>
-    <%= check_box_tag('documents[]', edition.document.id, false, class: 'checkbox', id: nil) %>
-    <%= edition.title %>
-  </label>
-  (<%= link_to 'view page', admin_edition_path(edition) %>)
-  <ul class="metadata list-inline text-muted">
-    <li>
-      Last changed: <%= public_time_for_edition(edition) %>
-    </li>
-    <li>
-      <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
-    </li>
-    <li>
-      <%= edition.display_type %>
-    </li>
-  </ul>
+<%= content_tag(:li, class: "document-row") do %>
+  <% if membership.non_whitehall_link %>
+    <% non_whitehall_link = membership.non_whitehall_link %>
+    <label>
+      <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
+      <%= non_whitehall_link.title %>
+    </label>
+    (<%= link_to 'view on GOV.UK', Plek.new.website_root + non_whitehall_link.base_path %>)
+    <ul class="metadata list-inline text-muted">
+      <li>
+        Document from: <%= non_whitehall_link.publishing_app.titleize %>
+      </li>
+    </ul>
+  <% else %>
+    <% edition = membership.document.latest_edition %>
+    <label>
+      <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
+      <%= edition.title %>
+    </label>
+    (<%= link_to 'view page', admin_edition_path(edition) %>)
+    <ul class="metadata list-inline text-muted">
+      <li>
+        Last changed: <%= public_time_for_edition(edition) %>
+      </li>
+      <li>
+        <%= edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe %>
+      </li>
+      <li>
+        <%= edition.display_type %>
+      </li>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/admin/document_collection_groups/_collection_size_warning.erb
+++ b/app/views/admin/document_collection_groups/_collection_size_warning.erb
@@ -1,4 +1,4 @@
-<% if @collection.documents.count > 50 %>
+<% if @collection.groups.sum { |g| g.editable_members.count } > 50 %>
   <div class="alert alert-info">
     If your collection contains over 50 documents it may be slow or impossible to update. Consider splitting the collection or using another format.
   </div>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -48,7 +48,7 @@
           </ul>
         </header>
         <div class="js-group-body">
-          <% if group.latest_editions.empty? %>
+          <% if group.editable_members.empty? %>
             <p class="no-content no-content-bordered js-document-group" data-group-id="<%= group.id %>">
               No documents in this group<br />
               Add documents by searching or dragging them from another group.
@@ -71,7 +71,7 @@
                 <% end %>
               </ul>
               <ol class="document-list js-document-group list-unstyled" data-group-id="<%= group.id %>">
-                <%= render partial: 'collection_document', collection: group.latest_editions, as: :edition, locals: { document_collection: @collection } %>
+                <%= render partial: 'collection_document', collection: group.editable_members, as: :membership, locals: { document_collection: @collection } %>
               </ol>
             <% end %>
           <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -7,10 +7,10 @@
 <h1><%= @collection.title %></h1>
 
 <%= edition_editing_tabs(@collection) do %>
-  <%= form_tag admin_document_collection_new_member_path(@collection), class: 'document-finder' do %>
+  <%= render partial: 'collection_size_warning' %>
+  <%= form_tag admin_document_collection_new_whitehall_member_path(@collection) do %>
     <h2>Add document to a group</h2>
-    <%= render partial: 'collection_size_warning' %>
-    <div id="document-finder" class="form-inline well remove-top-margin">
+    <div id="document-finder" class="document-finder form-inline well remove-top-margin">
       <label for="title">Add</label>
       <div class="document-finder-fields">
         <%= search_field_tag :title, '', placeholder: 'Title or slug&hellip;'.html_safe, results: 5, autosave: 'unique', autofocus: true, class: 'form-control input-sm' %>
@@ -27,6 +27,23 @@
       <%= hidden_field_tag :document_id %>
     </div>
   <% end %>
+
+  <details class="non-whitehall-disclosure"<% if flash[:open_non_whitehall] %> open<% end %>>
+    <summary>
+      Add GOV.UK content created outside of Whitehall to a group
+    </summary>
+    <%= form_tag admin_document_collection_new_non_whitehall_member_path(@collection), class: 'document-finder' do %>
+      <div class="document-finder form-inline well remove-top-margin">
+        <label for="url">Add</label>
+        <%= text_field_tag :url, flash[:url], placeholder: 'GOV.UK URL', class: 'form-control input-sm' %>
+        to the
+        <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :heading, session[:document_collection_selected_group_id]), class: 'form-control input-sm' %>
+        group
+        <%= submit_tag 'Add', class: 'btn btn-sm btn-info' %>
+      </div>
+    <% end %>
+  </details>
+
   <div class="js-group-container">
     <div class="reorder-buttons">
       <%= button_tag 'Reorder groups', class: 'btn btn-sm btn-info js-reorder' %><%= button_tag 'Finish reordering', class: 'btn btn-sm btn-success js-finish-reorder' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,9 +204,8 @@ Whitehall::Application.routes.draw do
                                                         path: 'members',
                                                         only: [:destroy]
           end
-          resource :document_collection_group_membership, as: :new_member,
-                                                      path: 'members',
-                                                      only: [:create]
+          post 'whitehall-member' => 'document_collection_group_memberships#create_whitehall_member', as: :new_whitehall_member
+          post 'non-whitehall-member' => 'document_collection_group_memberships#create_non_whitehall_member', as: :new_non_whitehall_member
           post 'groups/update_memberships' => 'document_collection_groups#update_memberships', as: :update_group_memberships
         end
         resources :organisations do

--- a/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806104923_create_document_collection_non_whitehall_links.rb
@@ -1,0 +1,11 @@
+class CreateDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :document_collection_non_whitehall_links do |t|
+      t.string :content_id, null: false
+      t.string :title, null: false
+      t.text :base_path, null: false
+      t.string :publishing_app, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
+++ b/db/migrate/20190806120852_reference_document_collection_non_whitehall_links.rb
@@ -1,0 +1,7 @@
+class ReferenceDocumentCollectionNonWhitehallLinks < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :document_collection_group_memberships,
+                  :non_whitehall_link,
+                  index: { name: "index_document_collection_non_whitehall_link" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,8 +240,10 @@ ActiveRecord::Schema.define(version: 20190816161334) do
     t.integer "ordering"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "non_whitehall_link_id"
     t.index ["document_collection_group_id", "ordering"], name: "index_dc_group_memberships_on_dc_group_id_and_ordering"
     t.index ["document_id"], name: "index_document_collection_group_memberships_on_document_id"
+    t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
   create_table "document_collection_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -252,6 +254,15 @@ ActiveRecord::Schema.define(version: 20190816161334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
+  end
+
+  create_table "document_collection_non_whitehall_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "content_id", null: false
+    t.string "title", null: false
+    t.text "base_path", null: false
+    t.string "publishing_app", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "document_sources", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -15,6 +15,12 @@ Feature: Grouping documents into a collection
     Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
 
   @javascript
+  Scenario: Admin creates a document collection with non whitehall links.
+    Given a document collection "Some super collection" exists
+    And I add the non whitehall url "https://www.gov.uk/king-content-publisher" for "King Content Publisher" to the document collection
+    Then I can see in the admin that "King Content Publisher" is part of the document collection
+
+  @javascript
   Scenario: Removing documents from a collection
     Given a published publication called "May 2012 Update" in a published document collection
     When I redraft the document collection and remove "May 2012 Update" from it

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -20,6 +20,33 @@ When(/^I draft a new document collection called "(.*?)"$/) do |title|
   @document_collection = DocumentCollection.find_by!(title: title)
 end
 
+When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
+  visit admin_document_collection_path(@document_collection)
+  click_on "Edit draft"
+  click_on "Collection documents"
+
+  base_path = URI.parse(url).path
+  content_id = SecureRandom.uuid
+
+  stub_publishing_api_has_lookups(base_path => content_id)
+  res = stub_publishing_api_has_item(
+    content_id: content_id,
+    base_path: base_path,
+    publishing_app: "content-publisher",
+    title: title
+  )
+
+  within '.non-whitehall-disclosure' do
+    find('summary').click
+    fill_in 'url', with: url
+    click_on 'Add'
+  end
+
+  within 'section.group' do
+    assert page.has_content? title
+  end
+end
+
 When(/^I add the document "(.*?)" to the document collection$/) do |document_title|
   doc_edition = Edition.find_by!(title: document_title)
   refute @document_collection.nil?, "No document collection to act on."

--- a/test/factories/document_collection_non_whitehall_link.rb
+++ b/test/factories/document_collection_non_whitehall_link.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :document_collection_non_whitehall_link do
+    content_id { SecureRandom.uuid }
+    base_path { "/vat-rates" }
+    title { "VAT Rates" }
+    publishing_app { "mainstream" }
+  end
+end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -40,11 +40,12 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     id_params.merge(commit: 'Move')
   end
 
-  view_test 'DELETE #destroy removes documents and redirects when Remove clicked' do
-    documents = [create(:publication), create(:publication)].map(&:document)
-    @group.documents << documents
-    assert_difference '@group.reload.documents.size', -1 do
-      delete :destroy, params: remove_params.merge(documents: [documents.first.id])
+  view_test 'DELETE #destroy removes memberships and redirects when Remove clicked' do
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
+    assert_difference '@group.reload.memberships.size', -1 do
+      delete :destroy, params: remove_params.merge(memberships: [memberships.first.id])
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
     assert_match %r[1 document removed], flash[:notice]
@@ -56,14 +57,15 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   end
 
   test 'DELETE #destroy moves documents and redirects when Move clicked' do
-    documents = [create(:publication), create(:publication)].map(&:document)
-    @group.documents << documents
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
     new_group = build(:document_collection_group)
     @collection.groups << new_group
-    assert_difference 'new_group.reload.documents.size', 1 do
-      assert_difference '@group.reload.documents.size', -1 do
+    assert_difference 'new_group.reload.memberships.size', 1 do
+      assert_difference '@group.reload.memberships.size', -1 do
         delete :destroy, params: move_params.merge(
-          documents: [documents.first.id],
+          memberships: [memberships.first.id],
           new_group_id: new_group.id
         )
       end

--- a/test/unit/models/document_collection_group_membership_test.rb
+++ b/test/unit/models/document_collection_group_membership_test.rb
@@ -8,8 +8,14 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
     assert_equal [1, 2], group.memberships.reload.map(&:ordering)
   end
 
-  test 'is invalid without a document' do
-    refute build(:document_collection_group_membership, document: nil).valid?
+  test 'is invalid without a document or a non-whitehall link' do
+    refute build(:document_collection_group_membership, document: nil, non_whitehall_link: nil).valid?
+  end
+
+  test 'is invalid with both a document and a external link' do
+    refute build(:document_collection_group_membership,
+                 document: build(:document),
+                 non_whitehall_link: build(:document_collection_non_whitehall_link)).valid?
   end
 
   test 'is invalid without a document_collection_group' do

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -29,6 +29,28 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
   end
 
+  test "#set_membership_ids_in_order! should associate documents and set their\
+        membership's ordering to the position of the membership id in the passed in array" do
+    group = build(:document_collection_group)
+
+    membership_1 = create(:document_collection_group_membership)
+    membership_2 = create(:document_collection_group_membership)
+    membership_3 = create(:document_collection_group_membership)
+
+    group.memberships << membership_1
+    group.memberships << membership_2
+    group.memberships << membership_3
+
+    group.set_membership_ids_in_order! [membership_3.id, membership_1.id]
+
+    assert group.memberships.include? membership_1
+    assert group.memberships.include? membership_3
+    refute group.memberships.include? membership_2
+
+    assert_equal 0, group.memberships.find(membership_3.id).ordering
+    assert_equal 1, group.memberships.find(membership_1.id).ordering
+  end
+
   test '::published_editions should list published editions ordered by membership ordering' do
     group = create(:document_collection_group)
     published_1 = create(:published_publication)

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -8,27 +8,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal [1, 2], series.groups.reload.map(&:ordering)
   end
 
-  test "#set_document_ids_in_order! should associate documents and set their\
-        membership's ordering to the position of the document id in the passed in array" do
-    group = build(:document_collection_group)
-
-    doc_1 = create(:document)
-    doc_2 = create(:document)
-    doc_3 = create(:document)
-
-    group.documents << doc_1
-    group.documents << doc_2
-
-    group.set_document_ids_in_order! [doc_3.id, doc_1.id]
-
-    assert group.documents.include? doc_1
-    assert group.documents.include? doc_3
-    refute group.documents.include? doc_2
-
-    assert_equal 0, group.memberships.find_by(document_id: doc_3.id).ordering
-    assert_equal 1, group.memberships.find_by(document_id: doc_1.id).ordering
-  end
-
   test "#set_membership_ids_in_order! should associate documents and set their\
         membership's ordering to the position of the membership id in the passed in array" do
     group = build(:document_collection_group)
@@ -49,28 +28,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
 
     assert_equal 0, group.memberships.find(membership_3.id).ordering
     assert_equal 1, group.memberships.find(membership_1.id).ordering
-  end
-
-  test '::published_editions should list published editions ordered by membership ordering' do
-    group = create(:document_collection_group)
-    published_1 = create(:published_publication)
-    published_2 = create(:published_publication)
-    draft = create(:draft_publication)
-
-    group.set_document_ids_in_order! [draft.document.id, published_2.document.id, published_1.document.id]
-
-    assert_equal [published_2, published_1], group.published_editions
-  end
-
-  test '::latest_editions should list latest editions for each document ordered by membership ordering' do
-    group = create(:document_collection_group)
-    draft = create(:draft_publication)
-    published_1 = create(:published_publication)
-    published_2 = create(:published_publication)
-
-    group.set_document_ids_in_order! [published_1.document.id, draft.document.id, published_2.document.id]
-
-    assert_equal [published_1, draft, published_2], group.latest_editions
   end
 
   test '#dup should also clone document memberships' do
@@ -95,22 +52,6 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
   test '#slug generates slugs of the heading' do
     group = create(:document_collection_group, heading: 'Foo bar')
     assert_equal group.slug, 'foo-bar'
-  end
-
-  test '#visible? should be true if only non-whitehall links are present' do
-    group = create(:document_collection_group, non_whitehall_links: [
-      build(:document_collection_non_whitehall_link),
-    ])
-
-    assert group.visible?
-  end
-
-  test '#visible? should be false if only non-published editions are present' do
-    group = create(:document_collection_group, documents: [
-      create(:draft_edition).document,
-    ])
-
-    refute group.visible?
   end
 
   test '#content_ids contain document and non-whitehall links in order' do

--- a/test/unit/models/document_collection_non_whitehall_link/govuk_url_test.rb
+++ b/test/unit/models/document_collection_non_whitehall_link/govuk_url_test.rb
@@ -1,0 +1,131 @@
+require 'test_helper'
+
+class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
+  setup do
+    @content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/test" => @content_id)
+    stub_publishing_api_has_item(content_id: @content_id,
+                                 title: "Test",
+                                 base_path: "/test",
+                                 publishing_app: "content-publisher")
+  end
+
+  test 'should be valid without a GOV.UK url that Publishing API knows' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/test",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    assert url.valid?
+  end
+
+  test 'should be valid when an integration GOV.UK url is used' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://integration.publishing.service.gov.uk/test",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    assert url.valid?
+  end
+
+  test 'should be invalid without a url' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: nil,
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+  end
+
+  test 'should be invalid without a document collection group' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/test",
+      document_collection_group: nil,
+    )
+
+    refute url.valid?
+  end
+
+  test 'should be invalid when an invalid URL is used' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "invalid URL",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+    assert url.errors.full_messages.include?('Url must be a valid GOV.UK URL')
+  end
+
+  test 'should be invalid when a non-GOV.UK URL is used' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.google.com/test",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+    assert url.errors.full_messages.include?('Url must be a valid GOV.UK URL')
+  end
+
+  test 'should be invalid when a GOV.UK URL that isn\'t in the Publishing API' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/different-path",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+    assert url.errors.full_messages.include?('Url must reference a GOV.UK page')
+  end
+
+  test 'should be invalid when Publishing API returns a 404' do
+    stub_any_publishing_api_call_to_return_not_found
+
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/test",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+    assert url.errors.full_messages.include?('Url must reference a GOV.UK page')
+  end
+
+  test 'should be invalid when Publishing API is down' do
+    stub_publishing_api_isnt_available
+
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/test",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    refute url.valid?
+    assert url.errors.full_messages.include?('Link lookup failed, please try again later')
+  end
+
+  test '#save should create a document collection group membership' do
+    group = create(:document_collection_group)
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/test",
+      document_collection_group: group,
+    )
+
+    assert_difference -> { group.memberships.size }, 1 do
+      url.save
+    end
+
+    non_whitehall_link = group.memberships.last.non_whitehall_link
+
+    assert_equal non_whitehall_link.as_json(only: %w[base_path content_id publishing_app title]),
+                 "base_path" => "/test",
+                 "content_id" => @content_id,
+                 "publishing_app" => "content-publisher",
+                 "title" => "Test"
+  end
+
+  test '#save return nil when it is invalid' do
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: nil,
+      document_collection_group: nil,
+    )
+
+    assert_nil url.save
+  end
+end

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -16,19 +16,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal [groups[1], groups[0], groups[2]], doc_collection.reload.groups
   end
 
-  test "editions lists all editions associated through the document collection groups" do
-    doc_collection = create(:document_collection)
-
-    pub_1 = create(:publication)
-    pub_2 = create(:publication)
-
-    create(:document_collection_group, document_collection: doc_collection, documents: [pub_1.document])
-    create(:document_collection_group, document_collection: doc_collection, documents: [pub_2.document])
-
-    assert doc_collection.editions.include? pub_1
-    assert doc_collection.editions.include? pub_2
-  end
-
   should_validate_with_safe_html_validator
 
   test "it should be invalid without a title" do
@@ -119,27 +106,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
   test 'indexes the summary as description' do
     collection = create(:document_collection, summary: 'a summary')
     assert_match 'a summary', collection.search_index['description']
-  end
-
-  test 'published_editions returns published editions from collection in reverse chronological order' do
-    collection = create(:document_collection, :with_group)
-    draft = create(:draft_publication)
-    old = create(:published_publication, first_published_at: 2.days.ago)
-    new = create(:published_publication, first_published_at: 1.day.ago)
-    group = collection.groups.first
-    group.documents = [draft.document, old.document, new.document]
-
-    assert_equal [new, old], collection.published_editions
-  end
-
-  test 'scheduled_editions returns editions that are scheduled for publishing in the collection' do
-    collection = create(:document_collection, :with_group)
-    publication = create(:published_publication, first_published_at: 2.days.ago)
-    scheduled_publication = create(:scheduled_publication)
-    group = collection.groups.first
-    group.documents = [scheduled_publication.document, publication.document]
-
-    assert_equal [scheduled_publication], collection.scheduled_editions
   end
 
   test 'specifies the rendering app as government frontend' do

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -146,4 +146,16 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     document_collection = DocumentCollection.new
     assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
   end
+
+  test '#content_ids returns content_ids from each group' do
+    doc = create(:published_news_article).document
+    non_whitehall_link = create(:document_collection_non_whitehall_link)
+    groups = [
+      build(:document_collection_group, documents: [doc]),
+      build(:document_collection_group, non_whitehall_links: [non_whitehall_link]),
+    ]
+    doc_collection = create(:document_collection, groups: groups)
+
+    assert_equal doc_collection.content_ids, [doc.content_id, non_whitehall_link.content_id]
+  end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -95,24 +95,10 @@ class PublishingApi::DocumentCollectionPresenterGroupTest < ActiveSupport::TestC
     group_one = document_collection.groups.first
     group_two = document_collection.groups.second
 
-    group_one.stubs(:documents).returns(
-      [
-        stub(content_id: "aaa"),
-        stub(content_id: "bbb"),
-      ]
-    )
-    group_two.stubs(:documents).returns(
-      [
-        stub(content_id: "fff"),
-        stub(content_id: "eee"),
-      ]
-    )
-    group_one.stubs(:heading).returns(
-      "Group 1"
-    )
-    group_two.stubs(:heading).returns(
-      "Group 2"
-    )
+    group_one.stubs(:content_ids).returns(%w(aaa bbb))
+    group_two.stubs(:content_ids).returns(%w(fff eee))
+    group_one.stubs(:heading).returns("Group 1")
+    group_two.stubs(:heading).returns("Group 2")
 
     presenter = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -143,9 +129,7 @@ end
 class PublishingApi::DocumentCollectionPresenterDocumentLinksTestCase < ActiveSupport::TestCase
   setup do
     document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).with(:content_id).returns(%w(faf afa))
-    document_collection.stubs(:documents).returns(documents)
+    document_collection.stubs(:content_ids).returns(%w(faf afa))
 
     @presented_links = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -286,9 +270,7 @@ end
 class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)
-    documents = mock('documents')
-    documents.expects(:pluck).twice.with(:content_id).returns(%w(test test ers))
-    @document_collection.stubs(:documents).returns(documents)
+    @document_collection.stubs(:content_ids).returns(%w(test test ers))
     presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
     @presented_edition_links = presented_document_collection.content[:links]
     @presented_links = presented_document_collection.links

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -226,7 +226,7 @@ class PublishingApi::PublishedDocumentCollectionPresenterEditionLinksTest < Acti
 
   test "it presents the documents content_ids as links, documents" do
     assert_equal(
-      @document_collection.documents.map(&:content_id),
+      @document_collection.content_ids,
       @presented_links[:documents]
     )
   end


### PR DESCRIPTION
Trello: https://trello.com/c/VdQtNZeV/1122-spike-making-content-publisher-documents-show-up-in-whitehall-document-collections

This adds the ability to add content created in other publishing applications to a Whitehall document collection. Which resolves a problem Content Publisher publishers have faced. The solution to this is a rather quick and dirty one that allows a document collection group to have a membership with either a Whitehall document or a GOV.UK content_id, had more time been available it'd have been good to replace the document collection approach in Whitehall to be one powered entirely by the Publishing API.

The user interface for this is like so:

![Aug-14-2019 12-12-27](https://user-images.githubusercontent.com/282717/63016917-ce753f00-be8c-11e9-8d35-82b72ea00afb.gif)

And will appear on GOV.UK like this:

<img width="700" alt="Screen Shot 2019-08-14 at 12 09 58" src="https://user-images.githubusercontent.com/282717/63016814-90781b00-be8c-11e9-93e8-3dc43fb279da.png">

More details in the individual commits.

Despite the commit history this also represents works by @1pretz1, @Tetrino and @JonathanHallam 