### PR TITLE
Add help text for House of Commons reference fields

### DIFF
--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="paper-number clearfix">
-  <%= form.text_field :hoc_paper_number, label_text: 'House of Commons paper number', class: 'input-md-3' %>
-  <%= form.check_box :unnumbered_hoc_paper, label_text: 'Unnumbered act paper' %>
+  <%= form.text_field :hoc_paper_number,
+                      label_text: "House of Commons paper number",
+                      class: 'input-md-3' %>
+
+  <%= form.check_box :unnumbered_hoc_paper,
+                     label_text: "Unnumbered act paper" %>
 
   <p class="help-block">
     Fill in the command and House of Commons boxes to publish an official
@@ -10,7 +14,11 @@
 
 <div class="form-group">
   <%= form.label :parliamentary_session %>
-  <%= form.select :parliamentary_session, Attachment.parliamentary_sessions, {include_blank: true}, {class: 'form-control input-md-3'} %>
+
+  <%= form.select :parliamentary_session,
+                  Attachment.parliamentary_sessions,
+                  { include_blank: true },
+                  { class: "form-control input-md-3" } %>
 
   <p class="help-block">Choose the right Parliamentary session.</p>
 </div>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,8 +1,16 @@
 <div class="paper-number clearfix">
   <%= form.text_field :hoc_paper_number, label_text: 'House of Commons paper number', class: 'input-md-3' %>
-  <%= form.check_box :unnumbered_hoc_paper, label_text: 'Unnumbered' %>
+  <%= form.check_box :unnumbered_hoc_paper, label_text: 'Unnumbered act paper' %>
+
+  <p class="help-block">
+    Fill in the command and House of Commons boxes to publish an official
+    document which will appear in the list of official documents.
+  </p>
 </div>
+
 <div class="form-group">
   <%= form.label :parliamentary_session %>
   <%= form.select :parliamentary_session, Attachment.parliamentary_sessions, {include_blank: true}, {class: 'form-control input-md-3'} %>
+
+  <p class="help-block">Choose the right Parliamentary session.</p>
 </div>


### PR DESCRIPTION
Plenty of documents get published incorrectly. They should be marked as official documents but aren't. This is controlled by data put into the form fields above. The GOV.UK guidance team met with someone from the National Archives about this problem and decided these changes would help publishers make more informed decisions.

<img width="741" alt="Screen Shot 2019-08-15 at 10 27 37" src="https://user-images.githubusercontent.com/510498/63086232-5750b100-bf47-11e9-91be-0a2b9dabcdff.png">

[Trello Card](https://trello.com/c/b9uhwK8O/1195-changes-to-official-documents-attachments-info-in-whitehall)