### PR TITLE
Add display date to stats announcement searchable

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -76,6 +76,7 @@ class StatisticsAnnouncement < ApplicationRecord
               title: :title,
               link: :public_path,
               description: :summary,
+              display_date: :display_date,
               display_type: :display_type,
               slug: :slug,
               organisations: :organisations_slugs,


### PR DESCRIPTION
We want to expose the statistics announcement release date in the research and statistics finder.  This can apparently be approximate for things that are provisional.  Using the display date will solve this problem for us.

The display_date field is currently embedded in the metadata field which makes it hard for finders to access.  By promoting it to the top level of the search item we can more readily use it.

I haven't removed it from the metadata field yet because we may have external users of the search-api that rely upon it.  We'll think about managing this process in future.

https://trello.com/c/zucpgkPW/966-update-statistics-announcements-finder-to-use-provisional-dates