### PR TITLE
Allow display_date as a searchable field

### DIFF
--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -12,6 +12,7 @@ module Searchable
     :content_id,
     :content_store_document_type,
     :description,
+    :display_date,
     :display_type,
     :detailed_format,
     :end_date,

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -60,6 +60,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       'organisations' => announcement.organisations.map(&:slug),
       'policy_areas' => announcement.topics.map(&:slug),
       'public_timestamp' => announcement.updated_at,
+      'display_date' => announcement.display_date,
       'display_type' => announcement.display_type,
       'slug' => announcement.slug,
       'release_timestamp' => announcement.release_date,


### PR DESCRIPTION
This was added to statistics_announcements but needs to be presented to search-api.

https://trello.com/c/zucpgkPW/966-update-statistics-announcements-finder-to-use-provisional-dates