### PR TITLE
Allow organisations in subscriptions

### DIFF
--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -81,6 +81,7 @@ class UrlToSubscriberListCriteria
     def self.content_id(key, slug)
       lookup_map = {
         "world_locations" => WorldLocation,
+        "organisations" => Organisation,
         "roles" => Role,
         "people" => Person,
         "topical_events" => Classification


### PR DESCRIPTION
This was removed as part of [redirecting organisation subscriptions to email alert frontend](https://github.com/alphagov/whitehall/pull/4986), however the [organisation property is still used](https://github.com/alphagov/whitehall/blob/12fffbb11b7d161adf3406eec742cb804ea84982/lib/url_to_subscriber_list_criteria.rb#L61) in other subscriptions like:

https://www.gov.uk/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications.atom%3Fdepartments%255B%255D%3Deducation-and-skills-funding-agency%26publication_filter_option%3Dcorrespondence

These paths are currently sending errors to sentry:
https://sentry.io/organizations/govuk/issues/1169351678/?project=202259&query=url%3A%22https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Femail-signup%22&statsPeriod=14d

with an error like:

```
UrlToSubscriberListCriteria::StaticData::UnknownStaticDataKey
organisations
.../lib/url_to_subscriber_list_criteria.rb:89:in `content_id'
.../lib/url_to_subscriber_list_criteria.rb:75:in `lookup_content_id'
.../lib/url_to_subscriber_list_criteria.rb:50:in `block (2 levels) in map_url_to_hash'
.../lib/url_to_subscriber_list_criteria.rb:50:in `map'
.../lib/url_to_subscriber_list_criteria.rb:50:in `block in map_url_to_hash'
.../lib/url_to_subscriber_list_criteria.rb:46:in `each'
.../lib/url_to_subscriber_list_criteria.rb:46:in `each_with_object'
.../lib/url_to_subscriber_list_criteria.rb:46:in `map_url_to_hash'
.../lib/url_to_subscriber_list_criteria.rb:14:in `convert'
.../app/models/email_signup.rb:27:in `criteria'
.../app/models/email_signup.rb:23:in `ensure_subscriber_list_exists'
.../app/models/email_signup.rb:16:in `save'
.../app/controllers/email_signups_controller.rb:15:in `create'
```

I think if we add organisation back here, then the remaining things will continue to work until we retire them too. 