### PR TITLE
Redirect the-highway-code-road-markings to correct page

### DIFF
--- a/db/data_migration/20190819114211_redirect_the_high_way.rb
+++ b/db/data_migration/20190819114211_redirect_the_high_way.rb
@@ -1,0 +1,3 @@
+content_id = "a8ac1c77-772b-4343-8942-941236833aed"
+redirect_path = "/guidance/the-highway-code/road-markings"
+PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en", true)


### PR DESCRIPTION
This placeholder https://www.gov.uk/government/publications/the-highway-code-road-markings should redirect to the live version: https://www.gov.uk/guidance/the-highway-code/road-markings

Zendesk: https://govuk.zendesk.com/agent/tickets/3772899