### PR TITLE
[WIP]Add tribunal org type

### DIFF
--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -6,6 +6,7 @@ class OrganisationType
     executive_agency:            { name: "Executive agency",                       analytics_prefix: "EA", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     executive_ndpb:              { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     advisory_ndpb:               { name: "Advisory non-departmental public body",  analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
+    tribunal:                    { name: "Tribunal",                               analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     tribunal_ndpb:               { name: "Tribunal non-departmental public body",  analytics_prefix: "PB", agency_or_public_body: true,  non_departmental_public_body: true, allowed_promotional: false },
     public_corporation:          { name: "Public corporation",                     analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     independent_monitoring_body: { name: "Independent monitoring body",            analytics_prefix: "IM", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
@@ -25,6 +26,7 @@ class OrganisationType
     executive_ndpb
     advisory_ndpb
     tribunal_ndpb
+    tribunal
     public_corporation
     independent_monitoring_body
     adhoc_advisory_group
@@ -86,6 +88,10 @@ class OrganisationType
 
   def self.tribunal_ndpb
     get :tribunal_ndpb
+  end
+
+  def self.tribunal
+    get :tribunal
   end
 
   def self.public_corporation
@@ -170,6 +176,10 @@ class OrganisationType
 
   def tribunal_ndpb?
     key == :tribunal_ndpb
+  end
+
+  def tribunal?
+    key == :tribunal
   end
 
   def public_corporation?

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
   end
 
   factory :hmcts_tribunal, parent: :organisation do
-    organisation_type_key { :tribunal_ndpb }
+    organisation_type_key { :tribunal }
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
     parent_organisations {

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -316,6 +316,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_relationship_type_is_described_as(:executive_ndpb, '{this_org_name} is an executive non-departmental public body, sponsored by the {parent_org_name}.')
     assert_relationship_type_is_described_as(:advisory_ndpb, '{this_org_name} is an advisory non-departmental public body, sponsored by the {parent_org_name}.')
     assert_relationship_type_is_described_as(:tribunal_ndpb, '{this_org_name} is a tribunal non-departmental public body, sponsored by the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:tribunal, '{this_org_name} is a tribunal of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:public_corporation, '{this_org_name} is a public corporation of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:independent_monitoring_body, '{this_org_name} is an independent monitoring body of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:other, '{this_org_name} works with the {parent_org_name}.')

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -79,7 +79,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
   class HMCTSOrganisationTests < ActiveSupport::TestCase
     def setup
       @other_org = create(:organisation)
-      @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb,
+      @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal,
         name: "Copyright Tribunal", parent_organisations: [@other_org])
       @multiple_parent_child_org = create(:organisation, parent_organisations: [@other_org, @copyright_tribunal])
       @court = create(:court)
@@ -134,7 +134,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
     _child_org_4 = create(:closed_organisation, parent_organisations: [parent_org_1])
     _child_org_5 = create(:court, parent_organisations: [parent_org_1])
-    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal_ndpb)
+    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal)
 
     assert_equal [child_org_3, child_org_1, child_org_6], parent_org_1.supporting_bodies
   end
@@ -178,7 +178,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
 
   test "#hmcts_tribunal? should be true if it's an HMCTS tribunal only" do
     hmcts_tribunal = create(:hmcts_tribunal)
-    tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb)
+    tribunal = create(:organisation, organisation_type_key: :tribunal)
     hmcts_child = create(:organisation,
                          parent_organisations: [Organisation.find_by(slug: "hm-courts-and-tribunals-service")])
 

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -66,6 +66,7 @@ class OrganisationTypeTest < ActiveSupport::TestCase
         executive_ndpb
         advisory_ndpb
         tribunal_ndpb
+        tribunal
         public_corporation
         independent_monitoring_body
         adhoc_advisory_group

--- a/test/unit/presenters/organisations_index_presenter_test.rb
+++ b/test/unit/presenters/organisations_index_presenter_test.rb
@@ -10,6 +10,7 @@ class OrganisationsIndexPresenterTest < ActiveSupport::TestCase
       executive_ndpb:              build(:organisation, organisation_type_key: :executive_ndpb),
       advisory_ndpb:               build(:organisation, organisation_type_key: :advisory_ndpb),
       tribunal_ndpb:               build(:organisation, organisation_type_key: :tribunal_ndpb),
+      tribunal:                    build(:organisation, organisation_type_key: :tribunal),
       public_corporation:          build(:organisation, organisation_type_key: :public_corporation),
       independent_monitoring_body: build(:organisation, organisation_type_key: :independent_monitoring_body),
       adhoc_advisory_group:        build(:organisation, organisation_type_key: :adhoc_advisory_group),


### PR DESCRIPTION
Not all organisations that are of type 'Tribunal non-departmental public body' are actually non-departmental. Some of them are in fact
departmental. Changing this type to be just 'Tribunal' will reflect this
more accurately.

Trello card:
https://trello.com/c/KHXlOF6V/1191-change-organisation-type-tribunal-non-departmental-public-body-to-tribunal