### PR TITLE
Use memberships as basis for collection ordering

### DIFF
--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -26,7 +26,8 @@ class DocumentCollectionGroupMembership < ApplicationRecord
 private
 
   def assign_ordering
-    self.ordering = document_collection_group.documents.size + 1
+    memberships = document_collection_group.memberships
+    self.ordering = memberships.size + (memberships.include?(self) ? 0 : 1)
   end
 
   def document_is_of_allowed_type


### PR DESCRIPTION
Now that collections contain both documents and non-Whitehall links this
count is incorrect, this meant that items added were appearing in an
unexpected location. Switching to memberships covers both of these types
and corrects the issue.