### PR TITLE
Allow a single HTML Attachment to be redirected

### DIFF
--- a/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
+++ b/lib/data_hygiene/publishing_api_html_attachment_redirector.rb
@@ -7,7 +7,9 @@ module DataHygiene
     end
 
     def call
-      raise DataHygiene::EditionNotUnpublished.new unless unpublished_or_withdrawn
+      if document
+        raise DataHygiene::EditionNotUnpublished.new unless unpublished_or_withdrawn
+      end
       raise DataHygiene::HTMLAttachmentsNotFound.new unless html_attachments.any?
       return dry_run_results if dry_run
 
@@ -37,7 +39,11 @@ module DataHygiene
     end
 
     def html_attachments
-      @html_attachments ||= last_edition.html_attachments
+      @html_attachments ||= document ? last_edition.html_attachments : [html_attachment]
+    end
+
+    def html_attachment
+      @html_attachment ||= HtmlAttachment.find_by(content_id: content_id)
     end
 
     def dry_run_results


### PR DESCRIPTION
This adapts the PublishingApiHtmlRedirector to accept a single HtmlAttachment
and redirect it. This is useful in cases where an HtmlAttachment has become
orphaned from an edition and so cannot be redirected using the rake task in its
current form.