### PR TITLE
Stop image link in attachment block from being tab-able

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -2,7 +2,7 @@
   published_on ||= ""
   help_block_id = "attachment-#{attachment.id}-accessibility-help"
   help_block_toggle_id = "attachment-#{attachment.id}-accessibility-request"
-  thumbnail_link_options = { "aria-hidden" => true, class: 'thumbnail' }
+  thumbnail_link_options = { "aria-hidden" => true, class: 'thumbnail', tabindex: '-1'}
 
   title_link_options = {}
   title_link_options['rel'] = 'external' if attachment.external?

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -38,7 +38,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
           policies: %w[2012-olympic-and-paralympic-legacy],
           topics: []
         },
-        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
+        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
         first_public_at: publication.first_public_at,
         change_history: [
           { public_timestamp: publication.public_timestamp, note: 'change-note' }.as_json


### PR DESCRIPTION
The attachment component had the same link for the document thumbnail and for the document title. The thumbnail link focus state is non-existent, so people that use a keyboard to navigate around the page couldn't tell where the focus was. 

To fix this the `tabindex` on the thumbnail link has been set to `-1` to prevent keyboard navigation of duplicate link.

Trello card: https://trello.com/c/W3UJPgdZ/62-2-fix-focus-state-for-attachment-icons

![image](https://user-images.githubusercontent.com/1732331/63774483-40aa4280-c8d5-11e9-85aa-8edf94c61c1f.png)

Code before:
```html
<div class="attachment-thumb">
  <a aria-hidden="true" class="thumbnail" href="https://example.com/document.pdf">
    <img alt="" src="https://example.com/document.png">
  </a>
</div>
```

Code after:
```html
<div class="attachment-thumb">
  <a aria-hidden="true" class="thumbnail" tabindex="-1" href="https://example.com/document.pdf">
    <img alt="" src="https://example.com/document.png">
  </a>
</div>
```

