### PR TITLE
Add a missing worldwide organisation edition association

### DIFF
--- a/db/data_migration/20190829094318_british_high_commission_port_vanatu.rb
+++ b/db/data_migration/20190829094318_british_high_commission_port_vanatu.rb
@@ -1,0 +1,4 @@
+org = WorldwideOrganisation.find_by!(slug: 'british-high-commission-vanuatu')
+ed = CorporateInformationPage.find(981490)
+
+EditionWorldwideOrganisation.create(edition: ed, worldwide_organisation: org)


### PR DESCRIPTION
Corporate information pages are supposed to have an associated
organisation or worldwide organisation.  This edition somehow doesn't
have one, so anything which tries to use the edition is throwing an
error.  For example, this page gives an error:

https://whitehall-admin.publishing.service.gov.uk/government/admin/organisations/government-digital-service/corporate_information_pages/981490

Draft and force-published are displayed on the whitehall-admin
homepage, so this data inconsistency is preventing at least one person
from logging in:

https://govuk.zendesk.com/agent/tickets/3767509

---

I've manually applied this fix in integration, and the edit page in integration now works.