### PR TITLE
Fix ordering approach for DocumentCollectionGroupMembership

### DIFF
--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -27,7 +27,12 @@ private
 
   def assign_ordering
     memberships = document_collection_group.memberships
-    self.ordering = memberships.size + (memberships.include?(self) ? 0 : 1)
+    self.ordering = if memberships.include?(self)
+                      memberships.index(self)
+                    else
+                      maximum = memberships.maximum(:ordering)
+                      maximum.nil? ? 0 : maximum + 1
+                    end
   end
 
   def document_is_of_allowed_type

--- a/test/unit/models/document_collection_group_membership_test.rb
+++ b/test/unit/models/document_collection_group_membership_test.rb
@@ -5,7 +5,42 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
     group = create(:document_collection_group, document_collection: build(:document_collection))
     documents = [build(:document), build(:document)]
     group.documents = documents
-    assert_equal [1, 2], group.memberships.reload.map(&:ordering)
+    assert_equal [0, 1], group.memberships.reload.map(&:ordering)
+  end
+
+  test 'it uses the ordering of the membership to set ordering' do
+    membership = build(:document_collection_group_membership)
+    group = create(:document_collection_group)
+    group.memberships = [
+      build(:document_collection_group_membership),
+      build(:document_collection_group_membership),
+      membership,
+      build(:document_collection_group_membership),
+    ]
+
+    membership.save
+    assert_equal 2, membership.ordering
+  end
+
+  test 'it is given an automatic ordering of the last item' do
+    group = create(:document_collection_group, memberships: [
+      build(:document_collection_group_membership),
+      build(:document_collection_group_membership),
+    ])
+
+    membership = create(:document_collection_group_membership,
+                        document_collection_group: group)
+    assert_equal 2, membership.ordering
+  end
+
+  test 'it adapts the auto ordering if the last item has a weird ordering' do
+    weird_membership = build(:document_collection_group_membership)
+    group = create(:document_collection_group, memberships: [weird_membership])
+    weird_membership.update!(ordering: 6)
+
+    membership = create(:document_collection_group_membership,
+                        document_collection_group: group)
+    assert_equal 7, membership.ordering
   end
 
   test 'is invalid without a document or a non-whitehall link' do


### PR DESCRIPTION
This resolves a bug where copying a list of document collection group
memberships led to every item to having the same ordering (the maximum
value) which meant that all ordering was lost.

Instead this uses the index in the membership if it is available
otherwise it works out the maximum one.