### PR TITLE
Revert commit to update email address

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -459,7 +459,7 @@ cy:
     view_all: Gwelir holl datganiadau
   attachment:
     accessibility:
-      full_help_html: Os ydych yn defnyddio technoleg gynorthwyol (megis darllenydd sgrin) ac mae angen fersiwn o’r ddogfen hon arnoch mewn fformat mwy hygyrch, anfonwch e-bost i gwasanaeth.cymraeg@hmrc.gsi.gov.uk. Rhowch wybod i ni pa fformat sydd ei angen arnoch. Bydd o gymorth i ni os nodwch pa dechnoleg gynorthwyol yr ydych yn ei defnyddio.
+      full_help_html: Os ydych yn defnyddio technoleg gynorthwyol (megis darllenydd sgrin) ac mae angen fersiwn o’r ddogfen hon arnoch mewn fformat mwy hygyrch, anfonwch e-bost i %{email}. Rhowch wybod i ni pa fformat sydd ei angen arnoch. Bydd o gymorth i ni os nodwch pa dechnoleg gynorthwyol yr ydych yn ei defnyddio.
       heading: Efallai na fydd y ffeil hon yn addas ar gyfer defnyddwyr technoleg
         gynorthwyol
       request_a_different_format: Gwneud cais am fformat gwahanol.


### PR DESCRIPTION
...in Welsh translation

Reverts https://github.com/alphagov/whitehall/pull/5016

Having tested this on `integration` I naively assumed it would turn
into a hyperlink in it's html.

Before:
![Screen Shot 2019-09-05 at 16 44 32](https://user-images.githubusercontent.com/19667619/64357488-9fba3680-cffc-11e9-9717-93ab2d58a216.png)

After:
![Screen Shot 2019-09-05 at 16 44 45](https://user-images.githubusercontent.com/19667619/64357500-a5178100-cffc-11e9-8bf6-cc2a80768e17.png)
