### PR TITLE
Migrate all orgs to tribunal type

### DIFF
--- a/db/migrate/20190911141806_change_tribunals_organisation_type.rb
+++ b/db/migrate/20190911141806_change_tribunals_organisation_type.rb
@@ -1,0 +1,7 @@
+class ChangeTribunalsOrganisationType < ActiveRecord::Migration[5.1]
+  def change
+    Organisation
+      .where(organisation_type_key: :tribunal_ndpb)
+      .update_all(organisation_type_key: :tribunal)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190816161334) do
+ActiveRecord::Schema.define(version: 20190911141806) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"


### PR DESCRIPTION
Any organisation that has a tribunal type is labelled 'tribunal non-departmental public body'.

However, many organisations are tribunal bodies but are departmental
public bodies (such as HMCTS).

[Trello](https://trello.com/c/KHXlOF6V/1191-change-organisation-type-tribunal-non-departmental-public-body-to-tribunal)