### PR TITLE
Migration to change tribunals org type

### DIFF
--- a/db/data_migration/20190812093415_change_tribunal_org_type.rb
+++ b/db/data_migration/20190812093415_change_tribunal_org_type.rb
@@ -1,0 +1,9 @@
+orgs = Organisation.where(organisation_type_key: :tribunal_ndpb)
+
+orgs.each do |org|
+  puts "Changing #{org.name} old org type #{org.organisation_type_key}"
+
+  org.update_attributes!(organisation_type_key: :tribunal)
+
+  puts "#{org.name} new org type: #{org.organisation_type_key}"
+end


### PR DESCRIPTION
On the Organisations page on Signon, any organisation that has a tribunal type is labelled 'tribunal non-departmental public body'.

However, many organisations are tribunal bodies but are departmental public bodies (such as HMCTS). There is only one type tag available (non-DPB), so we should rename this type as 'Tribunal' to cover both types of organisations.

[trello](https://trello.com/c/KHXlOF6V/1191-change-organisation-type-tribunal-non-departmental-public-body-to-tribunal)