### PR TITLE
Unlink people translations from roles

### DIFF
--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -6,11 +6,7 @@ class PersonPresenter < Whitehall::Decorators::Decorator
   end
 
   def translated_locales
-    initial_locales = model.translated_locales
-    roles = model.current_role_appointments.map(&:role)
-    roles.reduce(initial_locales) do |locales, role|
-      locales & role.translated_locales
-    end
+    model.translated_locales
   end
 
   def current_role_appointments

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -68,18 +68,16 @@
       <div class="current-roles" id="current-roles">
         <% @person.current_role_appointments.each do |appointment| %>
           <%= content_tag_for :section, appointment, class: "role" do %>
-            <h2 class="gem-c-heading" id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h2>
-            <%= appointment.role.responsibilities %>
+            <h2 class="gem-c-heading" id="<%= appointment.role.name.parameterize%>" <%= t_lang_translated_locales(appointment.role) %> ><%= appointment.role.name %></h2>
+            <div <%= t_lang_translated_locales(appointment.role) %> ><%= appointment.role.responsibilities %></div>
             <div class="read-more">
               <% if appointment.role.ministerial? %>
                 <%= link_to t('roles.read_more'), appointment.role %>
               <% end %>
               <% if appointment.role.worldwide? %>
-                <%= render partial: 'organisations/organisations_name_list',
-                           locals: { organisations: appointment.role.worldwide_organisations } %>
+                <%= render partial: 'organisations/organisations_name_list', locals: { organisations: appointment.role.worldwide_organisations } %>
               <% else %>
-                <%= render  partial: 'organisations/organisations_name_list',
-                            locals: { organisations: appointment.role.organisations } %>
+                <%= render  partial: 'organisations/organisations_name_list', locals: { organisations: appointment.role.organisations } %>
               <% end %>
             </div>
           <% end %>
@@ -94,8 +92,8 @@
           <ol class="document-list">
             <% @person.previous_role_appointments.each do |appointment| %>
               <%= content_tag_for :li, appointment, class: "document-row" do %>
-                <h3><%= appointment.role_link %></h3>
-                <ul class="attributes">
+                <h3 <%= t_lang_translated_locales(appointment.role) %>><%= appointment.role_link %></h3>
+                <ul class="attributes" <%= t_lang_translated_locales(appointment.role) %>>
                   <li class="date"><%= appointment.date_range %></li>
                 </ul>
               <% end %>

--- a/test/unit/presenters/person_presenter_test.rb
+++ b/test/unit/presenters/person_presenter_test.rb
@@ -49,7 +49,7 @@ class PersonPresenterTest < ActionView::TestCase
     refute @presenter.available_in_multiple_languages?
   end
 
-  test "is not available in multiple languages if any current role is not available in multiple languages" do
+  test "is available in multiple languages" do
     role_1 = stub_translatable_record(:role_without_organisations)
     role_1.stubs(:translated_locales).returns([:en])
     role_2 = stub_translatable_record(:role_without_organisations)
@@ -60,22 +60,7 @@ class PersonPresenterTest < ActionView::TestCase
     @person.stubs(:current_role_appointments).returns([role_appointment_1, role_appointment_2])
     @person.stubs(:translated_locales).returns(%i[en es])
 
-    assert_equal [:en], @presenter.translated_locales
-    refute @presenter.available_in_multiple_languages?
-  end
-
-  test "is available in multiple languages if person and all current roles are available in the same multiple languages" do
-    role_1 = stub_translatable_record(:role_without_organisations)
-    role_1.stubs(:translated_locales).returns(%i[en es de it])
-    role_2 = stub_translatable_record(:role_without_organisations)
-    role_2.stubs(:translated_locales).returns(%i[en fr de it])
-    role_appointment_1 = stub_record(:role_appointment, role: role_1, person: @person)
-    role_appointment_2 = stub_record(:role_appointment, role: role_2, person: @person)
-
-    @person.stubs(:current_role_appointments).returns([role_appointment_1, role_appointment_2])
-    @person.stubs(:translated_locales).returns(%i[en fr es it])
-
-    assert_equal %i[en it], @presenter.translated_locales
+    assert_equal %i(en es), @presenter.translated_locales
     assert @presenter.available_in_multiple_languages?
   end
 end


### PR DESCRIPTION
The current logic in Whitehall is to only show the available translations where: 1) translations for the person are present AND 2) translations for every role they have are present.

For reference, [this is the commit where the code was added for translations](https://github.com/alphagov/whitehall/commit/4dd466918202d848827377911b1bb16cebf0c75e), which states: "the translated name & responsibilities will show up on the locale-specific version of the public-facing person page, as long as both the person and *all* their current roles have translations into a given locale."

I'm not sure why the two need to be linked, and it's confusing when translations are present in Whitehall but don't appear on the live site.

## Before
<img width="897" alt="Screen Shot 2019-09-13 at 17 03 24" src="https://user-images.githubusercontent.com/29889908/64877021-6ca12400-d648-11e9-84be-715b914ecd43.png">

## After
<img width="914" alt="Screen Shot 2019-09-13 at 17 07 38" src="https://user-images.githubusercontent.com/29889908/64877313-0bc61b80-d649-11e9-87c5-f5feeb5b1cbe.png">

Example pages: 
 - /government/people/kirsty-cooper.cy
 - /government/people/alun-cairns-mp.cy