### PR TITLE
Revert "Bump webmock from 3.7.4 to 3.7.5"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,7 +546,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webmock (3.7.5)
+    webmock (3.7.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
Reverts alphagov/whitehall#5036

For some reason this broke [`master`](https://ci.integration.publishing.service.gov.uk/job/whitehall/job/master/14267/console) 