### PR TITLE
Set a meaningful user agent when talking to the Search API

### DIFF
--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -97,6 +97,7 @@ module Whitehall
             *args,
             content_type: :json,
             accept: :json,
+            user_agent: "whitehall (rummageable)",
             authorization: "Bearer #{ENV['RUMMAGER_BEARER_TOKEN'] || 'example'}",
           )
         end

--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -92,7 +92,13 @@ module Whitehall
         response = nil
         log_request(method, *args)
         call_time = Benchmark.realtime do
-          response = RestClient.send(method, *args, content_type: :json, accept: :json, authorization: "Bearer #{ENV['RUMMAGER_BEARER_TOKEN'] || 'example'}")
+          response = RestClient.send(
+            method,
+            *args,
+            content_type: :json,
+            accept: :json,
+            authorization: "Bearer #{ENV['RUMMAGER_BEARER_TOKEN'] || 'example'}",
+          )
         end
         log_response(method, call_time, response, *args)
         response


### PR DESCRIPTION
Otherwise the user agent doesn't mention Whitehall, making it harder
when looking at logs of requests to identify the source.