### PR TITLE
Redirect html attachments to edition

### DIFF
--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -121,10 +121,11 @@ private
   def content_ids_to_remove
     return Set[] unless previous_edition
 
+    deleted_content_ids = deleted_html_attachments.map(&:content_id).to_set
     old_content_ids = previous_html_attachments.map(&:content_id).to_set
     new_content_ids = current_html_attachments.map(&:content_id).to_set
 
-    old_content_ids - new_content_ids
+    deleted_content_ids + old_content_ids - new_content_ids
   end
 
   def deleted_html_attachments


### PR DESCRIPTION
Currently deleting an html attachment in Whitehall Admin sets it's `deleted` property to `true` and prevents it from appearing in the admin panel for the appropriate edition.

However, any published html attachments that are deleted on a subsequent edition, although no longer linked to, are still available at the original url.

This PR ensures that, when an edition is published, any `deleted` html attachments are also redirected in the publishing-api.

[trello](https://trello.com/c/9sZESuhp/1198-5-published-html-attachments-not-being-redirected-or-removed-when-deleted)