### PR TITLE
Send unwithdrawn editions to the Publishing API

### DIFF
--- a/app/services/edition_unwithdrawer.rb
+++ b/app/services/edition_unwithdrawer.rb
@@ -44,6 +44,7 @@ private
     force_publisher = EditionForcePublisher.new(unwithdrawn_edition)
     force_publisher.send(:prepare_edition)
     force_publisher.send(:fire_transition!)
+    force_publisher.send(:update_publishing_api!)
   end
 
   def user

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class EditionUnwithdrawerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
   setup do
     @edition = FactoryBot.create(:published_edition, state: "withdrawn")
     @user = FactoryBot.create(:user)
@@ -50,6 +52,12 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
     assert_equal edition.document, unwithdrawn_edition.document
     assert_equal @user, unwithdrawn_edition.editorial_remarks.first.author
     assert_equal "Unwithdrawn", unwithdrawn_edition.editorial_remarks.first.body
+  end
+
+  test "unwithdraw sends the new edition to the publishing-api" do
+    unwithdraw
+    assert_publishing_api_put_content(@edition.content_id)
+    assert_publishing_api_publish(@edition.content_id)
   end
 
   def unwithdraw(edition = nil)


### PR DESCRIPTION
Currently we only mark the edition as re-published in Whitehall without actually sending the edition to the Publishing API. This means that when users pressed "unwithdraw" they would have to manually publish the edition by pressing "force publish".

[Trello Card](https://trello.com/c/3jYLdax3/1293-5-investigate-being-unable-to-unwithdraw-whitehall-content)