### PR TITLE
Redirect how-to-make-a-right-to-rent-check-a-3-step-guide

### DIFF
--- a/db/data_migration/20191001120013_redirect_right_to_rent_3_step.rb
+++ b/db/data_migration/20191001120013_redirect_right_to_rent_3_step.rb
@@ -1,0 +1,3 @@
+content_id = "73c5fd84-e356-4d8e-98cc-bbe82d73a7c7"
+redirect_path = "/check-tenant-right-to-rent-documents"
+PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en", true)


### PR DESCRIPTION
The URL
https://www.gov.uk/government/publications/how-to-make-a-right-to-rent-check-a-3-step-guide
should be unpublished and redirected to
https://www.gov.uk/check-tenant-right-to-rent-documents

This is a data migration to make that happen.

Zendesk: https://govuk.zendesk.com/agent/tickets/3816868