### PR TITLE
the allow_draft parameter in PublishingApiRedirectWorker should be false

### DIFF
--- a/db/data_migration/20191001120013_redirect_right_to_rent_3_step.rb
+++ b/db/data_migration/20191001120013_redirect_right_to_rent_3_step.rb
@@ -1,3 +1,3 @@
 content_id = "73c5fd84-e356-4d8e-98cc-bbe82d73a7c7"
 redirect_path = "/check-tenant-right-to-rent-documents"
-PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en", true)
+PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en", false)


### PR DESCRIPTION
This data migration has not been run yet on production, so merging this
should be fine.

fixes pr: https://github.com/alphagov/whitehall/pull/5057