### PR TITLE
Update how gov work, embassies, world location, and past foreign sec pages

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -3,6 +3,8 @@
 $govuk-use-legacy-palette: true;
 $govuk-typography-use-rem: false;
 
+@import "govuk_publishing_components/all_components";
+
 // STYLEGUIDE
 // Mixins to be shared across gov.uk sites. Anything set in these
 // files can be used in the view files.
@@ -133,15 +135,14 @@ $govuk-typography-use-rem: false;
   @import "layouts/two_column_page";
 }
 
-@import "govuk_publishing_components/all_components";
 
 // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
 // coming from static and the global styles set in `global/_links.scss`. This
 // can be removed when the style from static and Whitehall removed.
 #whitehall-wrapper a.govuk-link{
-  text-decoration: none;
-
+  text-decoration: underline;
   &:focus {
     color: $govuk-focus-text-colour;
+    text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -136,13 +136,29 @@ $govuk-typography-use-rem: false;
 }
 
 
-// TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
-// coming from static and the global styles set in `global/_links.scss`. This
-// can be removed when the style from static and Whitehall removed.
-#whitehall-wrapper a.govuk-link{
-  text-decoration: underline;
-  &:focus {
-    color: $govuk-focus-text-colour;
+#whitehall-wrapper {
+  // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus`
+  // style coming from static and the global styles set in
+  // `global/_links.scss`. This can be removed when the style from static
+  // and Whitehall removed.
+  a.govuk-link{
+    text-decoration: underline;
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+      text-decoration: none;
+    }
+  }
+
+  // TODO: The title component uses `.govuk-link`, so a further override is
+  // needed. This can be removed when the global link styles are gone.
+  a.gem-c-title__context-link {
+    color: $govuk-secondary-text-colour;
     text-decoration: none;
+
+    &:hover {
+      color: $govuk-secondary-text-colour;
+      text-decoration: underline;
+    }
   }
 }

--- a/app/assets/stylesheets/frontend/global/_links.scss
+++ b/app/assets/stylesheets/frontend/global/_links.scss
@@ -1,17 +1,20 @@
 a {
-  color: $link-colour;
+  color: $govuk-link-colour;
   text-decoration: none;
 
   &:visited {
-    color: $link-visited-colour
+    color: $govuk-link-visited-colour;
   }
+
   &:hover {
-    color: $link-hover-colour;
+    color: $govuk-link-hover-colour;
     text-decoration: underline;
   }
+
   &:active {
-    color: $link-active-colour
+    color: $govuk-link-active-colour;
   }
+
   &:focus {
     text-decoration: underline;
   }

--- a/app/assets/stylesheets/frontend/helpers/_change-notes.scss
+++ b/app/assets/stylesheets/frontend/helpers/_change-notes.scss
@@ -16,7 +16,7 @@
       text-decoration: underline;
     }
     &:active {
-      color: $link-active-colour
+      color: $govuk-link-active-colour;
     }
     &:focus {
       outline: none;

--- a/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
@@ -42,7 +42,7 @@
     dd {
       margin-top: 5px;
       @include bold-24;
-      // some bits of metadata are included inside of other tags which have a 
+      // some bits of metadata are included inside of other tags which have a
       // default style of font-weight: normal
       p, strong {
         font-weight: bold;
@@ -68,7 +68,7 @@
         color: $link-hover-colour;
       }
       &:active {
-        color: $link-active-colour;
+        color: $govuk-link-active-colour;
       }
     }
     .overlay {

--- a/app/assets/stylesheets/frontend/html-publication.scss
+++ b/app/assets/stylesheets/frontend/html-publication.scss
@@ -1,3 +1,7 @@
+$govuk-use-legacy-palette: true;
+$govuk-typography-use-rem: false;
+
+@import "govuk_publishing_components/all_components";
 
 // BASE STYLESHEET COMPILER
 

--- a/app/assets/stylesheets/frontend/styleguide/_typography.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_typography.scss
@@ -129,6 +129,6 @@
     text-decoration: underline;
   }
   a:active {
-    color: $link-active-colour;
+    color: $govuk-link-active-colour;
   }
 }

--- a/app/assets/stylesheets/frontend/views/_get-involved.scss
+++ b/app/assets/stylesheets/frontend/views/_get-involved.scss
@@ -49,6 +49,27 @@
       }
     }
 
+    .count {
+
+      @include govuk-media-query($from: desktop) {
+        width: $half;
+      }
+
+      display: block;
+      margin: $gutter-half;
+      @include heading-80;
+      font-weight: bold;
+      text-decoration: none;
+
+      .context {
+        display: block;
+        @include core-16;
+        margin-top:0;
+        color: govuk-colour("black");
+      }
+
+  }
+
     section {
       @include core-19;
       @extend %contain-floats;
@@ -57,48 +78,6 @@
 
       h3, h4 {
         font-weight: bold;
-      }
-
-      dt, dd {
-        @include core-16;
-        display: block;
-      }
-      dt{
-        @include heading-80;
-        font-weight: bold;
-        margin: 0 0 (-$gutter-one-sixth) 0;
-        @include media(tablet) {
-          padding: 0;
-        }
-      }
-
-      .value {
-        @include heading-80;
-        font-weight: bold;
-        @include media(tablet) {
-          padding-bottom: 0;
-        }
-        &+ p {
-          @include core-16;
-          margin-top: -$gutter-one-sixth;
-        }
-      }
-
-      .values {
-        padding-top: $gutter-half;
-        dt, dd {
-          padding: 0 $gutter-half;
-          @include media(desktop) {
-            width: $half;
-          }
-        }
-        dt {
-          padding: 0 $gutter-half;
-          margin-top: $gutter-half;
-          @include media(tablet) {
-            margin: $gutter-half 0 (-$gutter-one-third);
-          }
-        }
       }
 
       .column {
@@ -120,6 +99,10 @@
           padding: $gutter-half $gutter-half 0;
           a {
             color: $white;
+
+            &:focus {
+              color: govuk-colour("black") !important;
+            }
           }
           h3 {
             @include heading-27;

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -1,4 +1,5 @@
 .historic-people-index {
+
   .clear-person {
     clear: both;
   }
@@ -11,20 +12,38 @@
       margin: 0 $gutter-half $gutter-half;
     }
 
-    .name {
-      @include core-19;
-      font-weight: bold;
-    }
     .term {
-      @include core-14;
-      color: $grey-1;
+      color: $govuk-secondary-text-colour;
     }
 
     .person-excerpt {
       .inner {
         .image-holder {
-          img {
-            max-width: $full-width;
+          box-sizing: border-box;
+
+          @include govuk-media-query($until: tablet) {
+            padding-right: govuk-spacing(3);
+          }
+
+          a {
+            background: govuk-colour("mid-grey", #b1b4b6);
+            height: 0;
+            overflow: hidden;
+            padding: 66% 0 0 0;
+            position: relative;
+
+            @include govuk-media-query($from: tablet) {
+              margin: 0 0 govuk-spacing(1) 0;
+            }
+
+            img {
+              max-width: $full-width;
+              position: absolute;
+              height: 100%;
+              width: 100%;
+              top: 0;
+              left: 0;
+            }
           }
         }
       }
@@ -36,28 +55,31 @@
   }
 
   .foreign-secretaries {
-    .heading, ol {
+
+    .inner {
+      padding: 0 govuk-spacing(3) govuk-spacing(1) 0;
+
+      @include govuk-media-query($from: tablet) {
+        padding-bottom: govuk-spacing(4);
+      }
+    }
+
+    .heading,
+    ol {
       @include media(tablet) {
         float: left;
         width: $one-quarter;
       }
     }
+
     ol {
       li {
         list-style: none;
+
         @include media(tablet) {
           float: left;
           width: $one-third;
         }
-        .inner {
-          padding: $gutter-half;
-          h4 {
-            font-weight: bold;
-          }
-        }
-      }
-      @include media(tablet) {
-        width: 75%; // There's no variable for this in the toolkit yet, needs updating when the toolkit gets updated
       }
     }
     .heading {
@@ -75,9 +97,7 @@
       }
     }
   }
-
 }
-
 
 
 .historic-people-show {
@@ -89,13 +109,6 @@
   }
 
   .person-info {
-
-    .name-title, .person-detail, .person-profile {
-      .inner {
-        padding: 0 $gutter-half;
-      }
-    }
-
     .person-profile {
       @include core-14;
       width: 218px;
@@ -103,13 +116,17 @@
       img {
         max-width: $full-width;
       }
+
       .info {
         background-color: $grey-3;
         padding-bottom: $gutter-half;
         margin-bottom: $gutter;
-        h3, p {
+
+        h3,
+        p {
           padding: 0 $gutter-half;
         }
+
         h3 {
           font-weight: bold;
           margin-top: $gutter-half;
@@ -147,12 +164,15 @@
     @include media(tablet) {
       position: relative;
       width: 75%;
+
       .person-profile {
         float: left;
         width: $one-third;
+
         img {
           width: $full-width;
         }
+
         .inner {
           padding: 0 $gutter-half;
         }

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -3,17 +3,6 @@
     clear:both;
   }
 
-  p, li{
-    @include ig-core-19;
-    a {
-      text-decoration: underline;
-    }
-  }
-
-  li {
-    margin-left: $gutter;
-  }
-
   .thirds-width-section,
   .halves-width-section {
     overflow:visible;
@@ -67,8 +56,7 @@
     margin-bottom: $gutter*2;
   }
 
-  .coalition {
-    margin-top: $gutter;
+  .feature-value {
 
     @include media(tablet) {
       margin-top: 0;
@@ -274,14 +262,6 @@
 
   p.small-print {
     @include ig-core-14;
-  }
-  h2.coalition {
-    border-color: black;
-  }
-  .coalition h3 {
-    border-color: black;
-    border-width: $gutter-one-sixth;
-    padding-top: $gutter - 9px;
   }
 
   hr.keyline {

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -57,33 +57,38 @@
   }
 
   .feature-value {
+    display: block;
+    padding-bottom: 0;
 
-    @include media(tablet) {
-      margin-top: 0;
+    .feature-value__count {
+      display: block;
+      font-size: 5em;
+      font-weight: bold;
+      line-height: 1;
     }
 
-    p{
-      background-color:$panel-colour;
-      padding:$gutter-half;
-      margin-top:-0.5em;
+    @include govuk-media-query($from: tablet, $until: 815px) {
+      &--small .feature-value__count {
+        font-size: 3.85em;
+      }
     }
+    }
+
+  .feature-value__caption {
+    color: inherit;
+    display: inline-block;
+    padding: 0 0.2em;
+    position: relative;
+    top: -0.5em;
   }
 
-  .feature-value{
-    font-size:5em;
-    padding-bottom:0;
-    margin:0 0 ($gutter-one-third * -1);
-    color:$grey-1;
-    font-weight: bold;
-    display:block;
-    line-height:1em;
-    a {
+  .feature-value__link {
+    color: $govuk-link-colour;
+    display: inline-block;
       text-decoration: none;
-      color: $black;
-      &:hover,
+
       &:focus {
-        text-decoration: underline;
-      }
+      @include govuk-focused-text;
     }
   }
 

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -1,15 +1,16 @@
 .inside_gov_how-gov-works {
-  .full-width-section{
-    clear:both;
+  .full-width-section {
+    clear: both;
   }
 
   .thirds-width-section,
   .halves-width-section {
-    overflow:visible;
-    clear:both;
-    margin-top:$gutter - $gutter-one-sixth;
-    margin-bottom:$gutter-two-thirds;
+    overflow: visible;
+    clear: both;
+    margin-top: $gutter - $gutter-one-sixth;
+    margin-bottom: $gutter-two-thirds;
     @extend %contain-floats;
+
     img {
       width: $full-width;
       height: auto;
@@ -20,8 +21,8 @@
     }
 
     @include media(tablet) {
-      margin-left:-$gutter-half;
-      margin-right:-$gutter-half;
+      margin-left: -$gutter-half;
+      margin-right: -$gutter-half;
 
       .inner-block {
         padding: 0 $gutter-half;
@@ -72,7 +73,7 @@
         font-size: 3.85em;
       }
     }
-    }
+  }
 
   .feature-value__caption {
     color: inherit;
@@ -85,17 +86,17 @@
   .feature-value__link {
     color: $govuk-link-colour;
     display: inline-block;
-      text-decoration: none;
+    text-decoration: none;
 
-      &:focus {
+    &:focus {
       @include govuk-focused-text;
     }
   }
 
   .feature-ministers {
-      text-align: center;
-      color: $secondary-text-colour;
-      padding: $gutter-half 0 $gutter;
+    text-align: center;
+    color: $secondary-text-colour;
+    padding: $gutter-half 0 $gutter;
 
     .feature-ministers__symbol,
     .feature-ministers__equals-wrapper {
@@ -109,7 +110,7 @@
       margin: 0.5em 0;
       padding: 0;
       text-align: center;
-        text-decoration: none;
+      text-decoration: none;
       vertical-align: middle;
       width: 5em;
 
@@ -127,7 +128,7 @@
       .caption {
         display: block;
         line-height: 1em;
-        }
+      }
 
       @include govuk-media-query($from: tablet) {
         border: 0.2em solid $inside-gov-secondary; // https://webaim.org/resources/contrastchecker/?fcolor=0B0C0C&bcolor=57DA95
@@ -136,23 +137,23 @@
         width: 9em;
         padding-top: 1.85em;
 
-          &:hover,
-          &:focus {
-            text-decoration: none;
-          }
+        &:hover,
+        &:focus {
+          text-decoration: none;
+        }
 
         &:hover {
           color: $govuk-link-hover-colour;
           background: govuk-colour("white");
           border-color: $govuk-link-hover-colour;
-      }
+        }
 
         &:focus {
           color: $govuk-focus-text-colour;
           background: $govuk-focus-colour;
           border-color: $govuk-focus-text-colour;
           outline: none;
-    }
+        }
 
         .count,
         .caption {
@@ -162,23 +163,23 @@
         .caption {
           display: inline-block;
           width: 6em;
+        }
       }
     }
-  }
 
     @include media(tablet) {
       .feature-ministers__symbol {
         margin: 0 1em;
         position: relative;
         top: 0.25em;
-  }
+      }
 
       .feature-ministers__item--invert {
         background-color: $inside-gov-secondary;
         border-color: $inside-gov-secondary;
+      }
     }
   }
-    }
 
   .ministers .caption {
     max-width: 26em;

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -52,8 +52,8 @@
     }
   }
 
-  .ministers{
-    margin-bottom: $gutter*2;
+  .ministers {
+    margin-bottom: $gutter * 2;
   }
 
   .feature-value {
@@ -87,173 +87,98 @@
     }
   }
 
-  .feature-caption {
-    @include ig-core-16;
-    display: block;
-    padding-bottom: $gutter;
-  }
-
-  .feature-ministers{
-    p {
+  .feature-ministers {
       text-align: center;
       color: $secondary-text-colour;
-      @include ig-core-48;
       padding: $gutter-half 0 $gutter;
+
+    .feature-ministers__symbol,
+    .feature-ministers__equals-wrapper {
+      display: inline-block;
     }
 
-    span.circle {
+    .feature-ministers__item {
+      box-sizing: border-box;
+      color: $govuk-text-colour;
       display: inline-block;
-      text-align: center;
+      margin: 0.5em 0;
       padding: 0;
-      vertical-align: middle;
-      width: 17%;
-      a {
+      text-align: center;
         text-decoration: none;
-        &:hover,
+      vertical-align: middle;
+      width: 5em;
+
+      @include govuk-media-query($until: tablet) {
+        &:hover {
+          color: $govuk-link-hover-colour;
+        }
+
         &:focus {
-          text-decoration: underline;
+          @include govuk-focused-text;
         }
       }
 
-      .count {
-        @include core-48;
-        position: relative;
-        top: $gutter-one-third;
-        padding: 0;
-        margin: 0 0 $gutter-one-sixth 0;
-
-        font-size: 1.9em;
-        font-weight: bold;
+      .count,
+      .caption {
         display: block;
         line-height: 1em;
-        a {
-          color:$black;
-        }
-      }
-
-      @include media(tablet) {
-        background-color:transparent;
-        border:0.1em solid $inside-gov-secondary;
-        width:3.8em;
-        height:3.8em;
-        -moz-border-radius: 2em;
-        -webkit-border-radius: 2em;
-        border-radius: 5em;
-
-        &:hover {
-          background-color: darken($inside-gov-secondary,10%);
-          border-color: darken($inside-gov-secondary,10%);
         }
 
-        a {
+      @include govuk-media-query($from: tablet) {
+        border: 0.2em solid $inside-gov-secondary; // https://webaim.org/resources/contrastchecker/?fcolor=0B0C0C&bcolor=57DA95
+        border-radius: 4.5em;
+        height: 9em;
+        width: 9em;
+        padding-top: 1.85em;
+
           &:hover,
           &:focus {
             text-decoration: none;
           }
-        }
-
-        .count{
-          padding-top: 0.35em;
-          font-size: 1.9em;
-          font-weight: bold;
-          width:100%;
-          text-align:center;
-        }
-      }
-
-      span{
-        color:black;
-        @include ig-core-16;
-        display: block;
-        padding: 0;
-        margin: 0;
-      }
-    }
-
-    @include media(tablet) {
-      span.invert {
-        background-color: $inside-gov-secondary;
-        border-color: $inside-gov-secondary;
 
         &:hover {
-          background-color: darken($inside-gov-secondary,10%);
-          border-color: darken($inside-gov-secondary,10%);
+          color: $govuk-link-hover-colour;
+          background: govuk-colour("white");
+          border-color: $govuk-link-hover-colour;
+      }
+
+        &:focus {
+          color: $govuk-focus-text-colour;
+          background: $govuk-focus-colour;
+          border-color: $govuk-focus-text-colour;
+          outline: none;
+    }
+
+        .count,
+        .caption {
+          text-align: center;
         }
 
-
-        .count a, .caption {
-          color: black;
-        }
+        .caption {
+          display: inline-block;
+          width: 6em;
       }
     }
   }
+
+    @include media(tablet) {
+      .feature-ministers__symbol {
+        margin: 0 1em;
+        position: relative;
+        top: 0.25em;
+  }
+
+      .feature-ministers__item--invert {
+        background-color: $inside-gov-secondary;
+        border-color: $inside-gov-secondary;
+    }
+  }
+    }
 
   .ministers .caption {
     max-width: 26em;
   }
 
-  h2 {
-    @include ig-core-36;
-    padding-bottom: 1px;
-    border-bottom: 5px solid black;
-    margin: $gutter 0 $gutter;
-    clear:both;
-
-    @include media(tablet) {
-      margin-top: $gutter*2;
-    }
-  }
-
-  h3 {
-    @include ig-core-27;
-    font-weight: bold;
-    margin: 0 0 $gutter-two-thirds;
-    width: $full-width;
-    &.with-gutter {
-      margin-top: $gutter-half;
-    }
-  }
-
-  .prime-minister,
-  .dep-prime-minister {
-    h3 {
-      @include ig-core-27;
-      font-weight: bold;
-    }
-  }
-
-  .depts-cont,
-  .gov-types {
-    h3 {
-      @include ig-core-19;
-      font-weight: bold;
-      margin-bottom: 0;
-    }
-  }
-
-  .gov-types, .ministers, .cabinet, .coalition {
-    h3{
-      border-top:1px solid $border-colour;
-      padding-top:$gutter - $gutter-one-sixth;
-    }
-  }
-
-  .ministers {
-    h3 {
-      margin-bottom: 0;
-      @include media(tablet) {
-        margin-bottom: $gutter-half;
-      }
-    }
-  }
-
-  h4 {
-    @include ig-core-19;
-    font-weight: bold;
-    &.with-gutter {
-      margin-top: $gutter-half;
-    }
-  }
   .block {
     float: none;
     display: block;
@@ -330,55 +255,4 @@
       }
     }
   }
-
-  @media (min-width: 640px) and (max-width: 760px) {
-    .feature-ministers {
-      p {
-        font-size: $gutter;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -10px;
-        @include ig-core-14;
-        line-height: 1;
-      }
-    }
-  }
-
-  @media (min-width: 761px) and (max-width: 980px) {
-    .feature-ministers {
-      p {
-        font-size: 35px;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -10px;
-        @include ig-core-14;
-        line-height: 1;
-      }
-    }
-  }
-
-  @media (min-width: 811px) and (max-width: 980px) {
-    .feature-ministers {
-      p {
-        font-size: 39px;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -5px;
-        @include ig-core-14;
-      }
-    }
-  }
-
 }

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -21,6 +21,7 @@ class EmbassyPresenter < SimpleDelegator
       link_to(
         organisation.name,
         worldwide_organisation_path(organisation.slug),
+        class: "govuk-link",
       )
     end
   end

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -2,6 +2,6 @@
 <% if offices.any? -%>
   <li>
     <h3><%= offices.first.contact.locality %></h3>
-    <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug)) %>
+    <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
   </li>
 <% end -%>

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: 'shared/heading',
               locals: { big: true,
                         heading: "Get involved" } %>
-    <p class="intro-paragraph">Find out how you can <a href="#engage-with-government">engage with government</a> directly, and <a href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
+    <p class="intro-paragraph">Find out how you can <a class="govuk-link" href="#engage-with-government">engage with government</a> directly, and <a class="govuk-link" href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
   </div>
 </header>
 
@@ -26,17 +26,17 @@
     </section>
     <section class="consultations">
       <div class="head-section">
-        <dl class="values">
-          <dt><%= link_to @open_consultation_count, publications_filter_path(:publication_filter_option => 'open-consultations') %>
-        </dt>
-          <dd>Open consultations</dd>
-          <dt><%=  link_to @closed_consultation_count, publications_filter_path(:publication_filter_option => 'closed-consultations') %></dt>
-          <dd>Closed consultations in the past 12 months</dd>
-          <% if false # this count not implemented yet %>
-            <dt><a href="#">29</a></dt>
-            <dd>Responses in the past 12 months</dd>
-          <% end %>
-        </dl>
+
+        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
+          <%= @open_consultation_count %>
+          <span class="context">Open consultations</span>
+        </a>
+
+        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
+          <%= @closed_consultation_count %>
+          <span class="context">Closed consultations in the past 12 months</span>
+        </a>
+
       </div>
       <div class="consultation-lists">
         <div class="consultation-closing-soon">
@@ -48,7 +48,7 @@
               <%= content_tag_for(:li, consultation, class: 'document-row') do %>
                 <h3><%= consultation.title %></h3>
                 <ul class="attributes">
-                  <li><%= link_to "Read and respond", public_document_path(consultation) %></li>
+                  <li><%= link_to "Read and respond", public_document_path(consultation), class: "govuk-link" %></li>
                 </ul>
               <% end %>
             <% end %>
@@ -61,16 +61,16 @@
               <ol class="document-list">
                 <% @recently_opened_consultations.each do |consultation| %>
                   <li class="document-row">
-                    <h3><%= link_to consultation.title, public_document_path(consultation) %></h3>
+                    <h3><%= link_to consultation.title, public_document_path(consultation), class: "govuk-link" %></h3>
                     <ul class="attributes">
                       <li><%= consultation.organisations.map(&:acronym).to_sentence %></li>
                       <li>Closes <%= consultation.date_microformat(:closing_at) %></li>
-                      <li><%= link_to "Read and respond", public_document_path(consultation) %></li>
+                      <li><%= link_to "Read and respond", public_document_path(consultation), class: "govuk-link", aria: {hidden: true} %></li>
                     </ul>
                   </li>
                 <% end %>
               </ol>
-              <p class="see-all"><%= link_to("Search all consultations", publications_path(publication_filter_option: "consultations")) %></p>
+              <p class="see-all"><%= link_to("Search all consultations", publications_path(publication_filter_option: "consultations"), class: "govuk-link" ) %></p>
             </div>
           </div>
           <div class="column">
@@ -79,11 +79,11 @@
               <ol class="document-list">
                 <% @recent_consultation_outcomes.each do |consultation| %>
                   <li class="document-row">
-                    <h3><%= link_to consultation.title, public_document_path(consultation) %></h3>
+                    <h3><%= link_to consultation.title, public_document_path(consultation), class: "govuk-link" %></h3>
                     <ul class="attributes">
                       <li><%= consultation.organisations.map(&:acronym).to_sentence %></li>
                       <li>Closed <%= consultation.date_microformat(:closing_at) %></li>
-                      <li><%= link_to "See the outcome", public_document_path(consultation) %></li>
+                      <li><%= link_to "See the outcome", public_document_path(consultation), class: "govuk-link", aria: {hidden: true}  %></li>
                     </ul>
                   </li>
                 <% end %>
@@ -100,7 +100,7 @@
       </div>
       <div class="column">
         <div class="content">
-          <p>You can <a href="https://petition.parliament.uk/" rel="external">create a petition</a> to influence government and Parliament. If the petition gets at least 100,000 online signatures, it will be considered for debate in the House of Commons.</p>
+          <p>You can <a class="govuk-link" href="https://petition.parliament.uk/" rel="external">create a petition</a> to influence government and Parliament. If the petition gets at least 100,000 online signatures, it will be considered for debate in the House of Commons.</p>
         </div>
       </div>
     </section>
@@ -112,14 +112,15 @@
       <div class="column">
         <div class="content">
           <p>For an instant way to interact with government departments, try their social media streams. These are listed under 'Follow us' on the department's home page. As well as access to blogs, audio, video and more, you can comment, debate and rate.</p>
-          <p class="see-all"><a href="/government/organisations/">See all government departments</a></p>
+          <p class="see-all"><a href="/government/organisations/" class="govuk-link">See all government departments</a></p>
           <p>Some active government blogs include:</p>
           <ul class="index-list">
-            <li><a href="https://history.blog.gov.uk" rel="external">History of Government</a></li>
-            <li><a href="https://quarterly.blog.gov.uk" rel="external">Civil Service Quarterly</a></li>
-            <li><a href="http://blogs.fco.gov.uk" rel="external">FCO bloggers</a></li>
-            <li><a href="https://gds.blog.gov.uk/" rel="external">Government Digital Service</a></li>
-            <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" rel="external">Head of the Civil Service</a></li>
+            <li><a href="https://history.blog.gov.uk" class="govuk-link" rel="external">History of Government</a></li>
+            <li><a href="https://quarterly.blog.gov.uk" class="govuk-link" rel="external">Civil Service Quarterly</a></li>
+            <li><a href="http://blogs.fco.gov.uk" class="govuk-link" rel="external">FCO bloggers</a></li>
+            <li><a href="https://gds.blog.gov.uk/" class="govuk-link" rel="external">Government Digital Service</a></li>
+            <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" class="govuk-link"
+             rel="external">Head of the Civil Service</a></li>
           </ul>
         </div>
       </div>
@@ -136,10 +137,10 @@
         <article<% if index % 3 == 0 %> class="article-clear"<% end %>>
           <div class="content">
             <span class="image-holder">
-              <%= link_to image_tag(take_part_page.image_url(:s300), alt: take_part_page.image_alt_text), take_part_page, title: take_part_page.title, class: 'img' %>
+              <%= link_to image_tag(take_part_page.image_url(:s300), alt: take_part_page.image_alt_text), take_part_page, title: take_part_page.title, class: 'img', tabindex: -1, aria: {hidden: true} %>
             </span>
             <div class="text">
-              <h3><%= link_to take_part_page.title, take_part_page %></h3>
+              <h3><%= link_to take_part_page.title, take_part_page, class: "govuk-link" %></h3>
               <p class="summary"><%= format_with_html_line_breaks(take_part_page.summary) %></p>
             </div>
           </div>
@@ -155,10 +156,10 @@
         <div class="content">
           <p>Many people are already volunteering, donating and contributing, both in the UK and abroad. If you&rsquo;d like to join them, but don&rsquo;t know where to start, here&rsquo;s a list of suggestions:</p>
           <ul class="index-list">
-            <li><a href="http://www.volunteerics.org/" rel="external">Join the International Citizen Service (18- to 25-year-olds)</a></li>
-            <li><a href="http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/" rel="external">Take part in your local Neighbourhood Watch</a></li>
-            <li><a href="/donating-to-charity">Make a donation to charity</a></li>
-            <li><a href="https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms" rel="external">Link up with a school overseas</a></li>
+            <li><a href="http://www.volunteerics.org/" class="govuk-link" rel="external">Join the International Citizen Service (18- to 25-year-olds)</a></li>
+            <li><a href="http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/" class="govuk-link" rel="external">Take part in your local Neighbourhood Watch</a></li>
+            <li><a href="/donating-to-charity" class="govuk-link">Make a donation to charity</a></li>
+            <li><a href="https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms" class="govuk-link" rel="external">Link up with a school overseas</a></li>
           </ul>
         </div>
       </div>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -3,18 +3,24 @@
 <% meta_description "In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out who runs government and how government is run, as well as learning about the history of government." %>
 
 <div id="how-government-works">
-  <header class="block headings-block">
-    <div class="inner-block floated-children">
-      <%= render partial: 'shared/heading',
-                locals: { big: true,
-                          heading: "How government works" } %>
-      <p class="intro-paragraph">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a href="#who-runs-government">who runs government</a> and <a href="#how-government-is-run">how government is run</a>, as well as learning about the <a href="#history-uk-government">history of government</a>.</p>
+  <header class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <%= render "govuk_publishing_components/components/title", {
+          title: "How government works",
+        } %>
+        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
+    </div>
     </div>
   </header>
 
   <div class="block">
     <div class="inner-block">
-      <h2 class="coalition" id="who-runs-government">Who runs government</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Who runs government",
+        id: "who-runs-government",
+        heading_level: 2,
+      } %>
       <div class="halves-width-section prime-minister">
         <div class="one-half">
           <div class="inner-block">
@@ -27,9 +33,11 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <h3>The Prime Minister</h3>
-            <p>The <a href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions. The Prime Minister also:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "The Prime Minister",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
               <li>oversees the operation of the Civil Service and government agencies</li>
               <li>appoints members of the government</li>
               <li>is the principal government figure in the House of Commons</li>
@@ -50,15 +58,20 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <h3>The Cabinet</h3>
-            <p>The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
-            <p><a href="/government/ministers">See who is in the Cabinet</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "The Cabinet",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
       </div>
 
       <div class="full-width-section ministers">
-          <h3>Ministers</h3>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Ministers",
+          heading_level: 3,
+        } %>
           <% if !@is_during_reshuffle %>
             <div class="feature-ministers">
               <p>
@@ -70,11 +83,19 @@
           <p><%= link_to "See full list of ministers", ministerial_roles_path %></p>
       </div>
 
-     <h2 id="how-government-is-run">How government is run</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How government is run",
+        id: "how-government-is-run",
+        heading_level: 2,
+        margin_bottom: 6,
+      } %>
       <div class="thirds-width-section depts">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Government departments and agencies</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Government departments and agencies",
+              heading_level: 3,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -98,13 +119,21 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h3>Government departments</h3>
-            <p>Some departments, like the <a href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Government departments",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p><a href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
-            <h3 class="with-gutter">Executive agencies</h3>
-            <p>These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Executive agencies",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p>An example is the <a href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
 
@@ -112,8 +141,12 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Other public bodies</h3>
-            <p>These have varying degrees of independence but are directly accountable to ministers. There are 4 types of non-departmental public bodies (NDPBs).</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Other public bodies",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p>Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
 
@@ -131,7 +164,11 @@
       <div class="thirds-width-section civil-service">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Civil Service</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Civil Service",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -154,14 +191,22 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Work for us</h4>
-            <p><a href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Work for us",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Work with us</h4>
-            <p><a href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Work with us",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -171,7 +216,11 @@
       <div class="thirds-width-section get-involved">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Get involved</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Get involved",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
 
@@ -183,15 +232,23 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Engage with government</h4>
-            <p>Interact with government through <a href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Engage with government",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Take part</h4>
-            <p><a href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Take part",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -201,7 +258,11 @@
       <div class="thirds-width-section legislation">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Legislation</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Legislation",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -213,8 +274,12 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Draft legislation</h4>
-            <p>White papers outline proposals for new laws. Green papers ask for public comments before the white paper is published.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Draft legislation",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
             <p>Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
           </div>
@@ -222,9 +287,12 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Acts of Parliament</h4>
-            <p>These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
-            <p><a href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Acts of Parliament",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -234,45 +302,49 @@
       <div class="thirds-width-section access-information">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Access to information</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Access to information",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Freedom of information</h4>
-            <p>The Freedom of Information Act gives you the right to ask any
-            public sector organisation for all the recorded information it has
-            on any subject. Anyone can make a request for information –
-            known as a Freedom of Information (or FOI) request.  There are no
-            restrictions on your age, nationality or where you live.</p>
-            <p><a href="/make-a-freedom-of-information-request">How to make a freedom of information request</a></p>
-            <p><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases') %></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Freedom of information",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
-            <h4 class="with-gutter">Statistics</h4>
-            <p>Government produces Official Statistics about most areas of
-            public life. Statistics are used by people inside and outside
-            government to make informed decisions and to measure the success of
-            government policies and services. <a
-              href="/government/statistics/how-national-and-official-statistics-are-assured">Find
-              out about the legislation</a> that governs the publication of UK
-            national and Official Statistics.</p>
-            <p><%= link_to "See statistics publications on GOV.UK", '/search/research-and-statistics' %></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Statistics",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-
-            <h4>Transparency</h4>
-            <p>The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Transparency",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
-            <p><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data') %></p>
-            <h4 class="with-gutter">Data</h4>
-            <p>Putting data in people’s hands can help them have more of a say in the reform of public services. On <a href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Data",
+              heading_level: 4,
+              margin_bott2m: 4,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -280,8 +352,11 @@
       <div class="thirds-width-section gov-types">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Devolved government</h3>
-            <p>In <a href="http://www.gov.scot/" rel="external">Scotland</a>, <a href="http://gov.wales/" rel="external">Wales</a> and <a href="https://www.northernireland.gov.uk/" rel="external">Northern
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Devolved government",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
             Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
             <p>Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
             <ul>
@@ -295,17 +370,20 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Local government</h3>
-            <p>Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
-            <p>In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
-            <p><a href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Local government",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Parliament</h3>
-            <p>Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Parliament",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
               <li>look at what the government is
               doing</li>
               <li>debate issues and pass new laws</li>
@@ -317,8 +395,12 @@
         </div>
       </div>
 
-
-      <h2 id="history-uk-government">History of government</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "History of government",
+        id: "history-uk-government",
+        heading_level: 2,
+        margin_bottom: 3,
+      } %>
       <div class="halves-width-section history">
         <div class="one-half">
           <div class="inner-block">

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -38,14 +38,24 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+
+            <p class="govuk-body">The <a class="govuk-link" href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
+
+            <p class="govuk-body">The Prime Minister also:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
               <li>oversees the operation of the Civil Service and government agencies</li>
               <li>appoints members of the government</li>
               <li>is the principal government figure in the House of Commons</li>
             </ul>
+
             <% if @prime_minister.present? %>
-              <p>The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister) %>.</p>
+              <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister), class: "govuk-link" %>.</p>
             <% end %>
-            <p><a href="/government/organisations/prime-ministers-office-10-downing-street">Read more about the Prime Minister's Office, 10 Downing Street</a></p>
+
+            <p class="govuk-body">
+              <%= link_to "Read more about the Prime Minister's Office, 10 Downing Street", "/government/organisations/prime-ministers-office-10-downing-street", class: "govuk-link" %>
+            </p>
           </div>
         </div>
       </div>
@@ -63,6 +73,10 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+
+            <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
           </div>
         </div>
       </div>
@@ -79,8 +93,10 @@
               </p>
             </div>
           <% end %>
-          <p class="caption">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
-          <p><%= link_to "See full list of ministers", ministerial_roles_path %></p>
+        
+        <p class="govuk-body">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
+        
+        <p class="govuk-body"><%= link_to "See full list of ministers", ministerial_roles_path, class: "govuk-link" %></p>
       </div>
 
       <%= render "govuk_publishing_components/components/heading", {
@@ -100,7 +116,7 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Departments and their agencies are responsible for putting government policy into practice.</p>
+            <p class="govuk-body">Departments and their agencies are responsible for putting government policy into practice.</p>
           </div>
         </div>
       </div>
@@ -126,7 +142,9 @@
               font_size: 19,
             } %>
 
-            <p><a href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
+            <p class="govuk-body">Some departments, like the <a class="govuk-link" href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a class="govuk-link" href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+
+            <p class="govuk-body"><a class="govuk-link" href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Executive agencies",
@@ -135,7 +153,9 @@
               font_size: 19,
             } %>
 
-            <p>An example is the <a href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
+            <p class="govuk-body">These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
+
+            <p class="govuk-body">An example is the <a class="govuk-link" href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a class="govuk-link" href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
 
           </div>
         </div>
@@ -148,13 +168,15 @@
               font_size: 19,
             } %>
 
-            <p>Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
+            <p class="govuk-body">These have varying degrees of independence but are directly accountable to ministers. There are 4 types of non-departmental public bodies (NDPBs).</p>
 
-            <p>Advisory NDPBs provide independent, expert advice to ministers - for example, the Committee on Standards in Public Life.</p>
+            <p class="govuk-body">Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
 
-            <p>Tribunal NDPBs are part of the justice system and have jurisdiction over a specific area of law - for example, the Competition Appeal Tribunal.</p>
+            <p class="govuk-body">Advisory NDPBs provide independent, expert advice to ministers - for example, the Committee on Standards in Public Life.</p>
 
-            <p>Independent monitoring boards are responsible for the running of prisons and treatment of prisoners - for example, Her Majesty's Inspectorate of Prisons.</p>
+            <p class="govuk-body">Tribunal NDPBs are part of the justice system and have jurisdiction over a specific area of law - for example, the Competition Appeal Tribunal.</p>
+
+            <p class="govuk-body">Independent monitoring boards are responsible for the running of prisons and treatment of prisoners - for example, Her Majesty's Inspectorate of Prisons.</p>
           </div>
         </div>
       </div>
@@ -173,15 +195,18 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-          <p>The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
-            <p>Around half of all civil servants provide services direct to the public, including:</p>
-            <ul>
+            <p class="govuk-body">The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
+            
+            <p class="govuk-body">Around half of all civil servants provide services direct to the public, including:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>paying benefits and pensions</li>
               <li>running employment services</li>
               <li>staffing prisons</li>
               <li>issuing driving licences</li>
             </ul>
-            <p>The <a href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
+            
+            <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
           </div>
         </div>
 
@@ -197,6 +222,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
         <div class="one-third">
@@ -207,6 +234,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
           </div>
         </div>
       </div>
@@ -226,7 +255,7 @@
 
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Read about ways to <a href="/government/get-involved">get involved</a>.</p>
+            <p class="govuk-body">Read about ways to <a class="govuk-link" href="/government/get-involved">get involved</a>.</p>
           </div>
         </div>
 
@@ -238,6 +267,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
           </div>
         </div>
 
@@ -249,6 +280,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
       </div>
@@ -267,8 +300,9 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
-            <p>They can include:</p>
+            <p class="govuk-body">Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
+            
+            <p class="govuk-body">They can include:</p>
           </div>
         </div>
 
@@ -281,7 +315,9 @@
               font_size: 19,
             } %>
 
-            <p>Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
+            <p class="govuk-body">White papers outline proposals for new laws. Green papers ask for public comments before the white paper is published.</p>
+
+            <p class="govuk-body">Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
           </div>
         </div>
 
@@ -293,6 +329,10 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
           </div>
         </div>
       </div>
@@ -318,12 +358,22 @@
               font_size: 19,
             } %>
 
+            <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
+            
+            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
+            
+            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
+
             <%= render "govuk_publishing_components/components/heading", {
               text: "Statistics",
               heading_level: 4,
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body">Government produces Official Statistics about most areas of public life. Statistics are used by people inside and outside government to make informed decisions and to measure the success of government policies and services. <%= link_to "Find out about the legislation", "/government/statistics/how-national-and-official-statistics-are-assured", class: "govuk-link" %> that governs the publication of UK national and Official Statistics.</p>
+            
+            <p class="govuk-body"><%= link_to "See statistics publications on GOV.UK", "/search/research-and-statistics", class: "govuk-link" %></p>
 
           </div>
         </div>
@@ -335,16 +385,25 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body">The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
+            
+            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
+            
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
               heading_level: 4,
               margin_bott2m: 4,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
       </div>
@@ -357,9 +416,12 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
-            <p>Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
-            <ul>
+            
+            <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
+            
+            <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>health</li>
               <li>education</li>
               <li>culture</li>
@@ -375,6 +437,12 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+            
+            <p class="govuk-body">Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
+            
+            <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
           </div>
         </div>
         <div class="one-third">
@@ -384,13 +452,18 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-              <li>look at what the government is
-              doing</li>
+
+            <p class="govuk-body">Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
+              <li>look at what the government is doing</li>
               <li>debate issues and pass new laws</li>
               <li>set taxes</li>
             </ul>
-            <p><a href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
-            <p>Read The Official Report at <a href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
+            
+            <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
           </div>
         </div>
       </div>
@@ -409,18 +482,14 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <p>Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a href="/government/history">history</a> section.</p>
-            <p>Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a href="/government/history#notable-people">notable people</a>. Learn more about historic <a href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
-            <p>You can also find links to <a href="/government/history#historical-research">historical research</a>, documents and records.</p>
+            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a class="govuk-link" href="/government/history">history</a> section.</p>
+
+            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a class="govuk-link" href="/government/history#notable-people">notable people</a>. Learn more about historic <a class="govuk-link" href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
+
+            <p class="govuk-body">You can also find links to <a class="govuk-link" href="/government/history#historical-research">historical research</a>, documents and records.</p>
           </div>
         </div>
       </div>
-
-
     </div>
   </div>
-
-
-
-
 </div>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -9,7 +9,7 @@
         <%= render "govuk_publishing_components/components/title", {
           title: "How government works",
         } %>
-        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
+        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <%= link_to("who runs government", "#who-runs-government", class: "govuk-link") %> and <%= link_to("how government is run", "#how-government-is-run", class: "govuk-link") %>, as well as learning about the <%= link_to("history of government", "#history-uk-government", class: "govuk-link") %>.</p>
       </div>
     </div>
   </header>
@@ -39,7 +39,7 @@
               margin_bottom: 5,
             } %>
 
-            <p class="govuk-body">The <a class="govuk-link" href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
+            <p class="govuk-body">The <%= link_to("Prime Minister", "/government/ministers/prime-minister", class: "govuk-link") %> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
 
             <p class="govuk-body">The Prime Minister also:</p>
 
@@ -76,7 +76,7 @@
 
             <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
+            <p class="govuk-body"><%= link_to("See who is in the Cabinet", "/government/ministers", class: "govuk-link") %></p>
           </div>
         </div>
       </div>
@@ -174,9 +174,9 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Some departments, like the <a class="govuk-link" href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a class="govuk-link" href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+            <p class="govuk-body">Some departments, like the <%= link_to "Ministry of Defence", "/government/organisations/ministry-of-defence", class: "govuk-link" %>, cover the  whole UK. Others don’t – the <%= link_to "Department for Work and Pensions", "/government/organisations/department-for-work-pensions", class: "govuk-link" %> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
+            <p class="govuk-body"><%= link_to "Non-ministerial departments", "/government/organisations#non_ministerial_departments", class: "govuk-link" %> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Executive agencies",
@@ -187,7 +187,7 @@
 
             <p class="govuk-body">These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
 
-            <p class="govuk-body">An example is the <a class="govuk-link" href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a class="govuk-link" href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
+            <p class="govuk-body">An example is the <%= link_to "Driver and Vehicle Licensing Agency", "/government/organisations/driver-and-vehicle-licensing-agency", class: "govuk-link" %> (overseen by the <%= link_to "Department for Transport", "/government/organisations/department-for-transport", class: "govuk-link" %>).</p>
 
           </div>
         </div>
@@ -238,7 +238,7 @@
               <li>issuing driving licences</li>
             </ul>
 
-            <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
+            <p class="govuk-body">The <%= link_to "Civil Service", "/government/organisations/civil-service", class: "govuk-link" %> is on GOV.UK.</p>
           </div>
         </div>
 
@@ -255,7 +255,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
+            <p class="govuk-body"><%= link_to "Find and apply", "https://civilservicejobs.service.gov.uk/", class: "govuk-link" %> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
         <div class="one-third">
@@ -267,7 +267,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
+            <p class="govuk-body"><%= link_to "Search Contracts Finder", "/contracts-finder/", class: "govuk-link" %> for any government contract over £10,000 and get details of all previous tenders.</p>
           </div>
         </div>
       </div>
@@ -287,7 +287,7 @@
 
         <div class="two-thirds">
           <div class="inner-block">
-            <p class="govuk-body">Read about ways to <a class="govuk-link" href="/government/get-involved">get involved</a>.</p>
+            <p class="govuk-body">Read about ways to <%= link_to "get involved", "/government/get-involved/", class: "govuk-link" %>.</p>
           </div>
         </div>
 
@@ -300,7 +300,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
+            <p class="govuk-body">Interact with government through <%= link_to "consultations and petitions", "/government/get-involved#engage-with-government", class: "govuk-link" %> to inform and influence the decisions it makes.</p>
           </div>
         </div>
 
@@ -313,7 +313,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
+            <p class="govuk-body"><%= link_to "Offer your skills and energy", "/government/get-involved#take-part", class: "govuk-link" %> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
       </div>
@@ -364,7 +364,7 @@
 
             <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
+            <p class="govuk-body"><%= link_to "Visit www.legislation.gov.uk", "https://www.legislation.gov.uk", class: "govuk-link", rel: "external" %></p>
           </div>
         </div>
       </div>
@@ -392,9 +392,9 @@
 
             <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
 
-            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: "govuk-link" %></p>
 
-            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: "govuk-link" %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Statistics",
@@ -426,7 +426,7 @@
               <li>how the government is doing against its objectives</li>
             </ul>
 
-            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: "govuk-link" %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
@@ -435,7 +435,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
+            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <%= link_to "data.gov.uk", "https://data.gov.uk/", class: "govuk-link", rel: "external" %> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
       </div>
@@ -449,7 +449,7 @@
               margin_bottom: 5,
             } %>
 
-            <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
+            <p class="govuk-body">In <%= link_to "Scotland", "https://www.gov.scot/", class: "govuk-link", rel: "external" %>, <%= link_to "Wales", "https://www.gov.wales/", class: "govuk-link", rel: "external" %> and <%= link_to "Northern Ireland", "https://www.northernireland.gov.uk/", class: "govuk-link", rel: "external" %>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
 
             <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
 
@@ -474,7 +474,7 @@
 
             <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
+            <p class="govuk-body"><%= link_to "Understand how your council works", "/understand-how-your-council-works/types-of-council/", class: "govuk-link" %></p>
           </div>
         </div>
         <div class="one-third">
@@ -493,9 +493,11 @@
               <li>set taxes</li>
             </ul>
 
-            <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
+            <p class="govuk-body">
+              <%= link_to "Find out about how Parliament works", "https://www.parliament.uk/", class: "govuk-link", rel: "external" %>
+            </p>
 
-            <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
+            <p class="govuk-body">Read The Official Report at <%= link_to "Hansard", "http://www.parliament.uk/business/publications/", class: "govuk-link", rel: "external" %></p>
           </div>
         </div>
       </div>
@@ -514,11 +516,11 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a class="govuk-link" href="/government/history">history</a> section.</p>
+            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <%= link_to "history", "/government/history/", class: "govuk-link" %> section.</p>
 
-            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a class="govuk-link" href="/government/history#notable-people">notable people</a>. Learn more about historic <a class="govuk-link" href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
+            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <%= link_to "notable people", "/government/history#notable-people", class: "govuk-link" %>. Learn more about historic <%= link_to "government buildings", "/government/history#government-buildings", class: "govuk-link" %> on Whitehall and around the UK.</p>
 
-            <p class="govuk-body">You can also find links to <a class="govuk-link" href="/government/history#historical-research">historical research</a>, documents and records.</p>
+            <p class="govuk-body">You can also find links to <%= link_to "historical research", "/government/history#historical-research", class: "govuk-link" %>, documents and records.</p>
           </div>
         </div>
       </div>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -88,9 +88,27 @@
         } %>
           <% if !@is_during_reshuffle %>
             <div class="feature-ministers">
-              <p>
-                <span class="circle prime-minister"><span class="count"><a href="/government/ministers/prime-minister">01</a></span> <span class="caption">Prime Minister</span></span> + <span class="circle cabinet-ministers"><span class="count"><a href="/government/ministers#cabinet-ministers"><%= @cabinet_minister_count %></a></span> <span class="caption">Cabinet ministers</span></span> + <span class="circle other-ministers"><span class="count"><a href="/government/ministers#ministers-by-department"><%= @other_minister_count %></a></span> <span class="caption">Other ministers</span></span> = <span class="circle invert all-ministers"><span class="count"><a href="/government/ministers"><%= @all_ministers_count %></a></span> <span class="caption">Total ministers</span></span>
-              </p>
+            <a href="/government/ministers/prime-minister" class="feature-ministers__item">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</span>
+              <span class="caption">Prime Minister</span>
+            </a>
+            <span class="feature-ministers__symbol">&#43;</span>
+            <a href="/government/ministers#cabinet-ministers" class="feature-ministers__item cabinet-ministers">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @cabinet_minister_count %></span>
+              <span class="caption">Cabinet ministers</span>
+            </a>
+            <span class="feature-ministers__symbol">&#43;</span>
+            <a href="/government/ministers#ministers-by-department" class="feature-ministers__item other-ministers">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @other_minister_count %></span>
+              <span class="caption">Other ministers</span>
+            </a>
+            <span class="feature-ministers__equals-wrapper">
+              <span class="feature-ministers__symbol">&#61;</span>
+              <a href="/government/ministers" class="feature-ministers__item feature-ministers__item--invert all-ministers">
+                <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @all_ministers_count %></span>
+                <span class="caption">Total ministers</span>
+              </a>
+            <span>
             </div>
           <% end %>
         

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -10,7 +10,7 @@
           title: "How government works",
         } %>
         <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
-    </div>
+      </div>
     </div>
   </header>
 
@@ -60,7 +60,7 @@
         </div>
       </div>
 
-        <div class="halves-width-section cabinet">
+      <div class="halves-width-section cabinet">
         <div class="one-half">
           <div class="inner-block">
             <%= image_tag 'how-gov-works/Cabinet_01.jpg', alt: 'The Cabinet' %>
@@ -75,7 +75,7 @@
             } %>
 
             <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
           </div>
         </div>
@@ -86,8 +86,8 @@
           text: "Ministers",
           heading_level: 3,
         } %>
-          <% if !@is_during_reshuffle %>
-            <div class="feature-ministers">
+        <% if !@is_during_reshuffle %>
+          <div class="feature-ministers">
             <a href="/government/ministers/prime-minister" class="feature-ministers__item">
               <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</span>
               <span class="caption">Prime Minister</span>
@@ -109,11 +109,11 @@
                 <span class="caption">Total ministers</span>
               </a>
             <span>
-            </div>
-          <% end %>
-        
+          </div>
+        <% end %>
+
         <p class="govuk-body">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
-        
+
         <p class="govuk-body"><%= link_to "See full list of ministers", ministerial_roles_path, class: "govuk-link" %></p>
       </div>
 
@@ -142,12 +142,26 @@
       <div class="thirds-width-section depts-cont">
         <div class="one-third">
           <div class="inner-block">
-            <p><span class="feature-value"><%= link_to @ministerial_department_count, organisations_path(anchor: 'departments') %></span>
-              <span class="feature-caption">Ministerial departments</span>
-              <span class="feature-value"><a href="/government/organisations#non-ministerial-departments"><%= @non_ministerial_department_count %></a></span>
-              <span class="feature-caption">Non-ministerial departments</span>
-              <span class="feature-value"><a href="/government/organisations#agencies-and-government-bodies">300+</a></span>
-              <span class="feature-caption">Agencies &amp; other public bodies</span></p>
+            <ul class="govuk-list">
+              <li class="feature-value">
+                <a href="<%= organisations_path(anchor: 'departments') %>" class="feature-value__link">
+                  <span class="feature-value__count"><%= @ministerial_department_count %></span>
+                  <span class="feature-value__caption govuk-body-s">Ministerial departments</span>
+                </a>
+              </li>
+              <li class="feature-value">
+                <a href="<%= organisations_path(anchor: 'non-ministerial-departments') %>" class="feature-value__link">
+                  <span class="feature-value__count"><%= @non_ministerial_department_count %></span>
+                  <span class="feature-value__caption govuk-body-s">Non-ministerial departments</span>
+                </a>
+              </li>
+              <li class="feature-value feature-value--small">
+                <a href="<%= organisations_path(anchor: 'agencies-and-government-bodies') %>" class="feature-value__link">
+                  <span class="feature-value__count">300+</span>
+                  <span class="feature-value__caption govuk-body-s">Agencies &amp; other public bodies</span>
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
 
@@ -214,16 +228,16 @@
         <div class="two-thirds">
           <div class="inner-block">
             <p class="govuk-body">The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
-            
+
             <p class="govuk-body">Around half of all civil servants provide services direct to the public, including:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>paying benefits and pensions</li>
               <li>running employment services</li>
               <li>staffing prisons</li>
               <li>issuing driving licences</li>
             </ul>
-            
+
             <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
           </div>
         </div>
@@ -240,7 +254,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
@@ -285,7 +299,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
           </div>
         </div>
@@ -298,7 +312,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
@@ -319,7 +333,7 @@
         <div class="two-thirds">
           <div class="inner-block">
             <p class="govuk-body">Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
-            
+
             <p class="govuk-body">They can include:</p>
           </div>
         </div>
@@ -347,9 +361,9 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
           </div>
         </div>
@@ -377,9 +391,9 @@
             } %>
 
             <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
-            
+
             <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
-            
+
             <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
@@ -390,7 +404,7 @@
             } %>
 
             <p class="govuk-body">Government produces Official Statistics about most areas of public life. Statistics are used by people inside and outside government to make informed decisions and to measure the success of government policies and services. <%= link_to "Find out about the legislation", "/government/statistics/how-national-and-official-statistics-are-assured", class: "govuk-link" %> that governs the publication of UK national and Official Statistics.</p>
-            
+
             <p class="govuk-body"><%= link_to "See statistics publications on GOV.UK", "/search/research-and-statistics", class: "govuk-link" %></p>
 
           </div>
@@ -405,22 +419,22 @@
             } %>
 
             <p class="govuk-body">The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
-            
+
             <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
-            
+
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
               heading_level: 4,
               margin_bott2m: 4,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
@@ -434,11 +448,11 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            
+
             <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
-            
+
             <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>health</li>
               <li>education</li>
@@ -455,11 +469,11 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            
+
             <p class="govuk-body">Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
-            
+
             <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
           </div>
         </div>
@@ -472,15 +486,15 @@
             } %>
 
             <p class="govuk-body">Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>look at what the government is doing</li>
               <li>debate issues and pass new laws</li>
               <li>set taxes</li>
             </ul>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
-            
+
             <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
           </div>
         </div>

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -1,639 +1,691 @@
 <% page_title "Past Foreign Secretaries" %>
-<% page_class "historic-people-index" %>
+<% page_class "historic-people-index govuk-width-container" %>
 
-<header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', histories_path),
-                        heading: "Past Foreign Secretaries",
-                        big: true } %>
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: "History",
+        href: histories_path,
+      },
+      title: "Past Foreign Secretaries"
+    } %>
   </div>
 </header>
 
-<div class="block featured-profiles">
-  <div class="inner-block floated-children">
-    <h2 class="profiles">Selection of profiles</h2>
+<div class="govuk-grid-row featured-profiles">
+  <div class="govuk-grid-column-full floated-children">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Selection of profiles",
+      heading_level: 2,
+    } %>
+  </div>
+  <div class="govuk-grid-column-full govuk-!-padding-0 floated-children">
     <ol>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-wood" class="img"><%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax' %></a>
+            <a href="/government/history/past-foreign-secretaries/edward-wood" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount&nbsp;Halifax</a></h3>
-          <p class="term">1938 to 1940</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/edward-wood" class="govuk-link">
+              Edward Frederick Lindley Wood, Viscount Halifax
+            </a>
+          </h3>
+          <p class="govuk-body-s term">1938 to 1940</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="img"><%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain' %></a>
+            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h3>
-          <p class="term">1924 to 1929</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="govuk-link">Sir Austen Chamberlain</a>
+          </h3>
+          <p class="govuk-body-s term">1924 to 1929</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-curzon" class="img"><%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-curzon" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h3>
-          <p class="term">1919 to 1924</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-curzon" class="govuk-link">George Nathaniel Curzon, Marquess of Kedleston</a>
+          </h3>
+          <p class="govuk-body-s term">1919 to 1924</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-grey" class="img"><%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon' %></a>
+            <a href="/government/history/past-foreign-secretaries/edward-grey" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of&nbsp;Fallodon</a></h3>
-          <p class="term">1905 to 1916</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/edward-grey" class="govuk-link">Sir Edward Grey, Viscount Grey of Fallodon</a>
+          </h3>
+          <p class="govuk-body-s term">1905 to 1916</p>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne' %></a>
+            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h3>
-          <p class="term">1900 to 1905</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="govuk-link">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a>
+          </h3>
+          <p class="govuk-body-s term">1900 to 1905</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="img"><%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury' %></a>
+            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h3>
-          <p class="term">1878 to 1880, 1885 to 1886,<br />
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="govuk-link">Robert Cecil, Marquess of Salisbury</a>
+          </h3>
+          <p class="govuk-body-s term">1878 to 1880, 1885 to 1886,<br />
             1887 to 1892 and 1895 to 1900</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gower" class="img"><%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-gower" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h3>
-          <p class="term">1851 to 1852, 1870 to 1874<br />
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-gower" class="govuk-link">George Leveson Gower, Earl Granville</a>
+          </h3>
+          <p class="govuk-body-s term">1851 to 1852, 1870 to 1874<br />
             and 1880 to 1885</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gordon" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-gordon" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h3>
-          <p class="term">1828 to 1830 and 1841 to 1846</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-gordon" class="govuk-link">George Hamilton Gordon, Earl of Aberdeen</a>
+          </h3>
+          <p class="govuk-body-s term">1828 to 1830 and 1841 to 1846</p>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/charles-fox" class="img"><%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox' %></a>
+            <a href="/government/history/past-foreign-secretaries/charles-fox" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h3>
-          <p class="term">1782, 1783 and 1806</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/charles-fox" class="govuk-link">Charles James Fox</a>
+          </h3>
+          <p class="govuk-body-s term">1782, 1783 and 1806</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/william-grenville" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville' %></a>
+            <a href="/government/history/past-foreign-secretaries/william-grenville" class="img" aria-hidden="true" tabindex="-1">
+              <%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord&nbsp;Grenville</a></h3>
-          <p class="term">1791 to 1801</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/william-grenville" class="govuk-link">William Wyndham Grenville, Lord Grenville</a>
+          </h3>
+          <p class="govuk-body-s term">1791 to 1801</p>
         </div>
       </li>
     </ol>
   </div>
 </div>
 
-<div class="block">
-  <div class="inner-block floated-children foreign-secretaries">
-    <section>
-      <div class="heading">
-        <h3>Foreign Secretaries <span>1782 to present</span></h3>
-      </div>
-      <ol>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/people/dominic-raab">Dominic Raab</a></h4>
-            <p class="term">2019 to present</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Jeremy Hunt</h4>
-            <p class="term">2018 to 2019</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Boris Johnson</h4>
-            <p class="term">2016 to 2018</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Philip Hammond</h4>
-            <p class="term">2014 to 2016</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">William Hague</h4>
-            <p class="term">2010 to 2014</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">David Miliband</h4>
-            <p class="term">2007 to 2010</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Margaret Beckett</h4>
-            <p class="term">2006 to 2007</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Jack Straw</h4>
-            <p class="term">2001 to 2006</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robin Cook</h4>
-            <p class="term">1997 to 2001</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Malcolm Rifkind</h4>
-            <p class="term">1995 to 1997</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Douglas Hurd, Lord Hurd of Westwell</h4>
-            <p class="term">1989 to 1995</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir John Major</h4>
-            <p class="term">1989</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Geoffrey Howe, Lord Howe of Aberavon</h4>
-            <p class="term">1983 to 1989</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Francis Pym, Lord Pym of Sandy</h4>
-            <p class="term">1982 to 1983</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Peter Carrington, Baron Carrington</h4>
-            <p class="term">1979 to 1982</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Dr David Owen, Lord Owen of the City of Plymouth</h4>
-            <p class="term">1977 to 1979</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Anthony Crosland</h4>
-            <p class="term">1976 to 1977</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Callaghan, Lord Callaghan of Cardiff</h4>
-            <p class="term">1974 to 1976</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
-            <p class="term">1970 to 1974</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
-            <p class="term">1968 to 1970</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Brown, Lord George-Brown of Jevington</h4>
-            <p class="term">1966 to 1968</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
-            <p class="term">1965 to 1966</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Patrick Gordon-Walker, Lord Gordon-Walker of Leyton</h4>
-            <p class="term">1964 to 1965</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Richard Austen Butler, Lord Butler of Saffron Walden</h4>
-            <p class="term">1963 to 1964</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
-            <p class="term">1960 to 1963</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">John Selwyn Brooke Lloyd, Lord Selwyn-Lloyd</h4>
-            <p class="term">1955 to 1960</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Harold Macmillan, Earl of Stockton</h4>
-            <p class="term">1955</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1951 to 1955</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Herbert Morrison, Lord Morrison of Lambeth</h4>
-            <p class="term">1951</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Ernest Bevin</h4>
-            <p class="term">1945 to 1951</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1940 to 1945</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount Halifax</a></h4>
-            <p class="term">1938 to 1940</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1935 to 1938</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Samuel Hoare, Viscount Templewood</h4>
-            <p class="term">1935</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir John Simon, Viscount Simon</h4>
-            <p class="term">1931 to 1935</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Rufus Isaacs, Marquess of Reading</h4>
-            <p class="term">1931</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Arthur Henderson</h4>
-            <p class="term">1929 to 1931</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h4>
-            <p class="term">1924 to 1929</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Ramsay MacDonald</h4>
-            <p class="term">1924</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h4>
-            <p class="term">1919 to 1924</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Arthur James Balfour, Earl of Balfour</h4>
-            <p class="term">1916 to 1919</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of Fallodon</a></h4>
-            <p class="term">1905 to 1916</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h4>
-            <p class="term">1900 to 1905</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1895 to 1900</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">John Wodehouse, Earl of Kimberley</h4>
-            <p class="term">1894 to 1895</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
-            <p class="term">1892 to 1894</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1897 to 1892</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Stafford Northcote, Earl of Iddesleigh</h4>
-            <p class="term">1886 to 1887</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
-            <p class="term">1886</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1885 to 1886</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1880 to 1885</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1878 to 1880</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
-            <p class="term">1874 to 1878</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1870 to 1874</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1868 to 1870</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
-            <p class="term">1866 to 1868</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1865 to 1866</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Lord John Russell, Earl Russell</h4>
-            <p class="term">1859 to 1865</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Harris, Earl of Malmesbury</h4>
-            <p class="term">1858 to 1859</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1853 to 1858</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Lord John Russell, Earl Russell</h4>
-            <p class="term">1852 to 1853</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Harris, Earl of Malmesbury</h4>
-            <p class="term">1852</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1851 to 1852</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1846 to 1851</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h4>
-            <p class="term">1841 to 1846</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1835 to 1841</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Arthur Wellesley, Duke of Wellington</h4>
-            <p class="term">1834 to 1835</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1830 to 1834</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h4>
-            <p class="term">1828 to 1830</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">John William Ward, Viscount Dudley and Ward</h4>
-            <p class="term">1827 to 1828</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Canning</h4>
-            <p class="term">1822 to 1827</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robert Stewart, Viscount Castlereagh</h4>
-            <p class="term">1812 to 1822</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Richard Wellesley, Marquess Wellesley</h4>
-            <p class="term">1809 to 1812</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry Bathurst, Earl Bathurst</h4>
-            <p class="term">1809</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Canning</h4>
-            <p class="term">1807 to 1809</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Charles Grey, Lord Howick</h4>
-            <p class="term">1806 to 1807</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1806</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry Phipps, Lord Mulgrave</h4>
-            <p class="term">1805 to 1806</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Dudley Ryder, Lord Harrowby</h4>
-            <p class="term">1804</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robert Banks Jenkinson, Lord Hawkesbury</h4>
-            <p class="term">1801 to 1804</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord&nbsp;Grenville</a></h4>
-            <p class="term">1791 to 1801</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Francis Godolphin Osborne, Marquess of Carmarthen</h4>
-            <p class="term">1783 to 1791</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Nugent Temple Grenville, Earl Temple</h4>
-            <p class="term">1783</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1783</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Thomas Robinson, Lord Grantham</h4>
-            <p class="term">1782 to 1783</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1782</p>
-          </div>
-        </li>
-      </ol>
-    </section>
+<section class="govuk-grid-row foreign-secretaries">
+  <header class="govuk-grid-column-one-quarter">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Foreign Secretaries",
+      heading_level: 3,
+    } %>
+    <p class="govuk-body">1782 to present</p>
+  </header>
+  <div class="govuk-grid-column-three-quarters">
+    <ol class="govuk-!-width-full">
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/people/dominic-raab" class="govuk-link">Dominic Raab</a></h4>
+          <p class="govuk-body-s">2019 to present</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Jeremy Hunt</h4>
+          <p class="govuk-body-s">2018 to 2019</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Boris Johnson</h4>
+          <p class="govuk-body-s">2016 to 2018</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Philip Hammond</h4>
+          <p class="govuk-body-s">2014 to 2016</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">William Hague</h4>
+          <p class="govuk-body-s">2010 to 2014</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">David Miliband</h4>
+          <p class="govuk-body-s">2007 to 2010</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Margaret Beckett</h4>
+          <p class="govuk-body-s">2006 to 2007</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Jack Straw</h4>
+          <p class="govuk-body-s">2001 to 2006</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Robin Cook</h4>
+          <p class="govuk-body-s">1997 to 2001</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Malcolm Rifkind</h4>
+          <p class="govuk-body-s">1995 to 1997</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Douglas Hurd, Lord Hurd of Westwell</h4>
+          <p class="govuk-body-s">1989 to 1995</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir John Major</h4>
+          <p class="govuk-body-s">1989</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Geoffrey Howe, Lord Howe of Aberavon</h4>
+          <p class="govuk-body-s">1983 to 1989</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Francis Pym, Lord Pym of Sandy</h4>
+          <p class="govuk-body-s">1982 to 1983</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Lord Peter Carrington, Baron Carrington</h4>
+          <p class="govuk-body-s">1979 to 1982</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Dr David Owen, Lord Owen of the City of Plymouth</h4>
+          <p class="govuk-body-s">1977 to 1979</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Anthony Crosland</h4>
+          <p class="govuk-body-s">1976 to 1977</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">James Callaghan, Lord Callaghan of Cardiff</h4>
+          <p class="govuk-body-s">1974 to 1976</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
+          <p class="govuk-body-s">1970 to 1974</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Michael Stewart, Lord Stewart of Fulham</h4>
+          <p class="govuk-body-s">1968 to 1970</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Brown, Lord George-Brown of Jevington</h4>
+          <p class="govuk-body-s">1966 to 1968</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Michael Stewart, Lord Stewart of Fulham</h4>
+          <p class="govuk-body-s">1965 to 1966</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Patrick Gordon-Walker, Lord Gordon-Walker of Leyton</h4>
+          <p class="govuk-body-s">1964 to 1965</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Richard Austen Butler, Lord Butler of Saffron Walden</h4>
+          <p class="govuk-body-s">1963 to 1964</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
+          <p class="govuk-body-s">1960 to 1963</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">John Selwyn Brooke Lloyd, Lord Selwyn-Lloyd</h4>
+          <p class="govuk-body-s">1955 to 1960</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Harold Macmillan, Earl of Stockton</h4>
+          <p class="govuk-body-s">1955</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Anthony Eden, Earl of Avon</h4>
+          <p class="govuk-body-s">1951 to 1955</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Herbert Morrison, Lord Morrison of Lambeth</h4>
+          <p class="govuk-body-s">1951</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Ernest Bevin</h4>
+          <p class="govuk-body-s">1945 to 1951</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Anthony Eden, Earl of Avon</h4>
+          <p class="govuk-body-s">1940 to 1945</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/edward-wood" class="govuk-link">Edward Frederick Lindley Wood, Viscount Halifax</a></h4>
+          <p class="govuk-body-s">1938 to 1940</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Anthony Eden, Earl of Avon</h4>
+          <p class="govuk-body-s">1935 to 1938</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir Samuel Hoare, Viscount Templewood</h4>
+          <p class="govuk-body-s">1935</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Sir John Simon, Viscount Simon</h4>
+          <p class="govuk-body-s">1931 to 1935</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Rufus Isaacs, Marquess of Reading</h4>
+          <p class="govuk-body-s">1931</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Arthur Henderson</h4>
+          <p class="govuk-body-s">1929 to 1931</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="govuk-link">Sir Austen Chamberlain</a></h4>
+          <p class="govuk-body-s">1924 to 1929</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">James Ramsay MacDonald</h4>
+          <p class="govuk-body-s">1924</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="past-foreign-secretaries/george-curzon" class="govuk-link">George Nathaniel Curzon, Marquess of Kedleston</a></h4>
+          <p class="govuk-body-s">1919 to 1924</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Arthur James Balfour, Earl of Balfour</h4>
+          <p class="govuk-body-s">1916 to 1919</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/edward-grey" class="govuk-link">Sir Edward Grey, Viscount Grey of Fallodon</a></h4>
+          <p class="govuk-body-s">1905 to 1916</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="govuk-link">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h4>
+          <p class="govuk-body-s">1900 to 1905</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/robert-cecil" class="govuk-link">Robert Cecil, Marquess of Salisbury</a></h4>
+          <p class="govuk-body-s">1895 to 1900</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">John Wodehouse, Earl of Kimberley</h4>
+          <p class="govuk-body-s">1894 to 1895</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Archibald Primrose, Earl of Rosebery</h4>
+          <p class="govuk-body-s">1892 to 1894</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/robert-cecil" class="govuk-link">Robert Cecil, Marquess of Salisbury</a></h4>
+          <p class="govuk-body-s">1897 to 1892</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Stafford Northcote, Earl of Iddesleigh</h4>
+          <p class="govuk-body-s">1886 to 1887</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Archibald Primrose, Earl of Rosebery</h4>
+          <p class="govuk-body-s">1886</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/robert-cecil" class="govuk-link">Robert Cecil, Marquess of Salisbury</a></h4>
+          <p class="govuk-body-s">1885 to 1886</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/george-gower" class="govuk-link">George Leveson Gower, Earl Granville</a></h4>
+          <p class="govuk-body-s">1880 to 1885</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/robert-cecil" class="govuk-link">Robert Cecil, Marquess of Salisbury</a></h4>
+          <p class="govuk-body-s">1878 to 1880</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Lord Edward Stanley, Earl of Derby</h4>
+          <p class="govuk-body-s">1874 to 1878</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/george-gower" class="govuk-link">George Leveson Gower, Earl Granville</a></h4>
+          <p class="govuk-body-s">1870 to 1874</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Villiers, Earl of Clarendon</h4>
+          <p class="govuk-body-s">1868 to 1870</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Lord Edward Stanley, Earl of Derby</h4>
+          <p class="govuk-body-s">1866 to 1868</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Villiers, Earl of Clarendon</h4>
+          <p class="govuk-body-s">1865 to 1866</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Lord John Russell, Earl Russell</h4>
+          <p class="govuk-body-s">1859 to 1865</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">James Harris, Earl of Malmesbury</h4>
+          <p class="govuk-body-s">1858 to 1859</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Villiers, Earl of Clarendon</h4>
+          <p class="govuk-body-s">1853 to 1858</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Lord John Russell, Earl Russell</h4>
+          <p class="govuk-body-s">1852 to 1853</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">James Harris, Earl of Malmesbury</h4>
+          <p class="govuk-body-s">1852</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/george-gower" class="govuk-link">George Leveson Gower, Earl Granville</a></h4>
+          <p class="govuk-body-s">1851 to 1852</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Henry John Temple, Viscount Palmerston</h4>
+          <p class="govuk-body-s">1846 to 1851</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/george-gordon" class="govuk-link">George Hamilton Gordon, Earl of Aberdeen</a></h4>
+          <p class="govuk-body-s">1841 to 1846</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Henry John Temple, Viscount Palmerston</h4>
+          <p class="govuk-body-s">1835 to 1841</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Arthur Wellesley, Duke of Wellington</h4>
+          <p class="govuk-body-s">1834 to 1835</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Henry John Temple, Viscount Palmerston</h4>
+          <p class="govuk-body-s">1830 to 1834</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/george-gordon" class="govuk-link">George Hamilton Gordon, Earl of Aberdeen</a></h4>
+          <p class="govuk-body-s">1828 to 1830</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">John William Ward, Viscount Dudley and Ward</h4>
+          <p class="govuk-body-s">1827 to 1828</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Canning</h4>
+          <p class="govuk-body-s">1822 to 1827</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Robert Stewart, Viscount Castlereagh</h4>
+          <p class="govuk-body-s">1812 to 1822</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Richard Wellesley, Marquess Wellesley</h4>
+          <p class="govuk-body-s">1809 to 1812</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Henry Bathurst, Earl Bathurst</h4>
+          <p class="govuk-body-s">1809</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Canning</h4>
+          <p class="govuk-body-s">1807 to 1809</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Charles Grey, Lord Howick</h4>
+          <p class="govuk-body-s">1806 to 1807</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/charles-fox" class="govuk-link">Charles James Fox</a></h4>
+          <p class="govuk-body-s">1806</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Henry Phipps, Lord Mulgrave</h4>
+          <p class="govuk-body-s">1805 to 1806</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Dudley Ryder, Lord Harrowby</h4>
+          <p class="govuk-body-s">1804</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Robert Banks Jenkinson, Lord Hawkesbury</h4>
+          <p class="govuk-body-s">1801 to 1804</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/william-grenville" class="govuk-link">William Wyndham Grenville, Lord Grenville</a></h4>
+          <p class="govuk-body-s">1791 to 1801</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Francis Godolphin Osborne, Marquess of Carmarthen</h4>
+          <p class="govuk-body-s">1783 to 1791</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">George Nugent Temple Grenville, Earl Temple</h4>
+          <p class="govuk-body-s">1783</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/charles-fox" class="govuk-link">Charles James Fox</a></h4>
+          <p class="govuk-body-s">1783</p>
+        </div>
+      </li>
+      <li class="clear-person">
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Thomas Robinson, Lord Grantham</h4>
+          <p class="govuk-body-s">1782 to 1783</p>
+        </div>
+      </li>
+      <li>
+        <div class="inner">
+          <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"><a href="/government/history/past-foreign-secretaries/charles-fox" class="govuk-link">Charles James Fox</a></h4>
+          <p class="govuk-body-s">1782</p>
+        </div>
+      </li>
+    </ol>
   </div>
-</div>
+</section>

--- a/app/views/world_locations/_world_location.html.erb
+++ b/app/views/world_locations/_world_location.html.erb
@@ -1,7 +1,7 @@
 <% options ||= {} %>
 <%= content_tag_for(:li, world_location, options) do %>
   <% if world_location.active? %>
-    <%= link_to world_location.name, world_location_path(world_location), class: 'location-link' %>
+    <%= link_to world_location.name, world_location_path(world_location), class: 'location-link govuk-link' %>
   <% else %>
     <span class="location-link"><%= world_location.name %></span>
   <% end %>


### PR DESCRIPTION
This is the work towards moving pages that Whitehall renders towards reaching WCAG 2.1. The main aim is the new focus states that come from version 3 of GOV.UK Frontend. 

Where required, the markup has been made more accessible - **but this isn't a complete move towards using all of GOV.UK Frontend** - we are aware that plenty more improvements could be made.

🗃 [Trello card](https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on)

This pull request covers these pages:
 - [Get Involved](https://www.gov.uk/government/get-involved)
 - [Embassies](https://www.gov.uk/government/world/embassies)
 - [How government works](https://www.gov.uk/government/how-government-works)
 - [Past Foreign Secretaries](https://www.gov.uk/government/history/past-foreign-secretaries)

## Significant changes before / after 

### [Get Involved](https://www.gov.uk/government/get-involved)
Open/Closed consultations large link before:
![Screen Shot 2019-10-10 at 11 23 37](https://user-images.githubusercontent.com/31649453/66561086-b1897f00-eb50-11e9-8c6b-0e6fb3f006f8.png)

Open/Closed consultations large link after:
![Screen Shot 2019-10-10 at 11 23 56](https://user-images.githubusercontent.com/31649453/66561088-b1897f00-eb50-11e9-9cd1-85088b39d7f2.png)

### [Embassies](https://www.gov.uk/government/world/embassies):

Before:
![Screen Shot 2019-10-10 at 11 35 43](https://user-images.githubusercontent.com/31649453/66561901-53f63200-eb52-11e9-911d-cc20c1489cfc.png)

After:
![Screen Shot 2019-10-10 at 11 37 07](https://user-images.githubusercontent.com/31649453/66561902-53f63200-eb52-11e9-8c69-64d6dec2670e.png)

### [How government works](https://www.gov.uk/government/how-government-works)

Minister circles before:
The difference is appearance is because of the difference in states and styles:
(focus state) (hover state) (normal state) (inverted style)

<img width="461" alt="" src="https://user-images.githubusercontent.com/1732331/66562397-805e7e00-eb53-11e9-9ec7-1b85d6cef7b8.png">
<img width="980" alt="Screen Shot 2019-10-10 at 11 46 26" src="https://user-images.githubusercontent.com/1732331/66562461-9ec47980-eb53-11e9-9fca-d8fa4e636102.png">

Minister circles after:
<img width="451" alt="Screen Shot 2019-10-10 at 11 42 57" src="https://user-images.githubusercontent.com/1732331/66562553-ce738180-eb53-11e9-96d7-5db5a700887a.png">
<img width="998" alt="Screen Shot 2019-10-10 at 11 48 39" src="https://user-images.githubusercontent.com/1732331/66562625-f367f480-eb53-11e9-912d-c7751b968dd0.png">

---

Government departments and agencies numbers before:
<img width="523" alt="Screen Shot 2019-10-10 at 11 41 41" src="https://user-images.githubusercontent.com/1732331/66562734-28744700-eb54-11e9-98ed-ffe7ad9b4096.png">

Government departments and agencies numbers after:
<img width="475" alt="Screen Shot 2019-10-10 at 13 03 12" src="https://user-images.githubusercontent.com/1732331/66567074-61b1b480-eb5e-11e9-9675-cca96248ea52.png">


---
### [Past Foreign Secretaries](https://www.gov.uk/government/history/past-foreign-secretaries)

Notable Foreign Secretaries before:

Two focusable links present.
<img width="249" alt="Screen Shot 2019-10-10 at 12 01 56" src="https://user-images.githubusercontent.com/1732331/66563741-607c8980-eb56-11e9-9363-1b95576160a2.png">
<img width="249" alt="Screen Shot 2019-10-10 at 12 04 23" src="https://user-images.githubusercontent.com/1732331/66563751-64a8a700-eb56-11e9-938d-bf16bcb65f7d.png">


Notable Foreign Secretaries after:

Image link now `aria-hidden="true"` and `tabindex="-1"`.
<img width="241" alt="Screen Shot 2019-10-10 at 12 03 58" src="https://user-images.githubusercontent.com/1732331/66563799-768a4a00-eb56-11e9-9cb0-b07ed8b4b697.png">

