### PR TITLE
Update world pages

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -21,6 +21,7 @@ class EmbassyPresenter < SimpleDelegator
       link_to(
         organisation.name,
         worldwide_organisation_path(organisation.slug),
+        class: "govuk-link",
       )
     end
   end

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -2,6 +2,6 @@
 <% if offices.any? -%>
   <li>
     <h3><%= offices.first.contact.locality %></h3>
-    <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug)) %>
+    <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
   </li>
 <% end -%>

--- a/app/views/world_locations/_world_location.html.erb
+++ b/app/views/world_locations/_world_location.html.erb
@@ -1,7 +1,7 @@
 <% options ||= {} %>
 <%= content_tag_for(:li, world_location, options) do %>
   <% if world_location.active? %>
-    <%= link_to world_location.name, world_location_path(world_location), class: 'location-link' %>
+    <%= link_to world_location.name, world_location_path(world_location), class: 'location-link govuk-link' %>
   <% else %>
     <span class="location-link"><%= world_location.name %></span>
   <% end %>


### PR DESCRIPTION
Adds new focus state to links on the [embassies pages](https://www.gov.uk/world/embassies).

Where required, the markup has been made more accessible - **but this isn't a complete move towards using all of GOV.UK Frontend** - we are aware that plenty more improvements could be made.

Part of https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on

## Significant changes before / after 
### [Embassies](https://www.gov.uk/government/world/embassies):

Before:
![Screen Shot 2019-10-10 at 11 35 43](https://user-images.githubusercontent.com/31649453/66561901-53f63200-eb52-11e9-911d-cc20c1489cfc.png)

After:
![Screen Shot 2019-10-10 at 11 37 07](https://user-images.githubusercontent.com/31649453/66561902-53f63200-eb52-11e9-8c69-64d6dec2670e.png)