### PR TITLE
Add data migration to change speech role appointment

### DIFF
--- a/db/data_migration/20191015101540_remove_role_appointment_from_speech.rb
+++ b/db/data_migration/20191015101540_remove_role_appointment_from_speech.rb
@@ -1,0 +1,11 @@
+# Zendesk ticket https://govuk.zendesk.com/agent/tickets/3816861
+# Need to unlink the speech from the role appointment and link
+# to the minister's new role
+# Because the speech is superseded and would raise the validation
+# "cannot be modified when edition is in the superseded state"
+# it must be saved without running the validations but should
+# not result in the record being invalid afterwards
+
+speech = Speech.find(995407)
+speech.role_appointment_id = 5815
+speech.save(validate: false)


### PR DESCRIPTION
Zendesk ticket https://govuk.zendesk.com/agent/tickets/3816861
Need to unlike the speech from the role appointment
and set to another
