### PR TITLE
Update how government works page

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -135,19 +135,21 @@ $govuk-typography-use-rem: false;
   @import "layouts/two_column_page";
 }
 
+
 // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
 // coming from static and the global styles set in `global/_links.scss`. This
 // can be removed when the style from static and Whitehall removed.
 #whitehall-wrapper {
-  a.govuk-link {
+  a.govuk-link{
+    text-decoration: underline;
     &:focus {
-      text-decoration: none;
       color: $govuk-focus-text-colour;
+      text-decoration: none;
     }
   }
 
   .gem-c-title__context-link,
   .gem-c-title__context-link:visited {
     color: #6f777b;
-    }
+  }
 }

--- a/app/assets/stylesheets/frontend/global/_links.scss
+++ b/app/assets/stylesheets/frontend/global/_links.scss
@@ -1,17 +1,20 @@
 a {
-  color: $link-colour;
+  color: $govuk-link-colour;
   text-decoration: none;
 
   &:visited {
-    color: $link-visited-colour
+    color: $govuk-link-visited-colour;
   }
+
   &:hover {
-    color: $link-hover-colour;
+    color: $govuk-link-hover-colour;
     text-decoration: underline;
   }
+
   &:active {
-    color: $link-active-colour
+    color: $govuk-link-active-colour;
   }
+
   &:focus {
     text-decoration: underline;
   }

--- a/app/assets/stylesheets/frontend/helpers/_change-notes.scss
+++ b/app/assets/stylesheets/frontend/helpers/_change-notes.scss
@@ -16,7 +16,7 @@
       text-decoration: underline;
     }
     &:active {
-      color: $link-active-colour
+      color: $govuk-link-active-colour;
     }
     &:focus {
       outline: none;

--- a/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
@@ -42,7 +42,7 @@
     dd {
       margin-top: 5px;
       @include bold-24;
-      // some bits of metadata are included inside of other tags which have a 
+      // some bits of metadata are included inside of other tags which have a
       // default style of font-weight: normal
       p, strong {
         font-weight: bold;
@@ -68,7 +68,7 @@
         color: $link-hover-colour;
       }
       &:active {
-        color: $link-active-colour;
+        color: $govuk-link-active-colour;
       }
     }
     .overlay {

--- a/app/assets/stylesheets/frontend/html-publication.scss
+++ b/app/assets/stylesheets/frontend/html-publication.scss
@@ -1,3 +1,7 @@
+$govuk-use-legacy-palette: true;
+$govuk-typography-use-rem: false;
+
+@import "govuk_publishing_components/all_components";
 
 // BASE STYLESHEET COMPILER
 

--- a/app/assets/stylesheets/frontend/styleguide/_typography.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_typography.scss
@@ -129,6 +129,6 @@
     text-decoration: underline;
   }
   a:active {
-    color: $link-active-colour;
+    color: $govuk-link-active-colour;
   }
 }

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -69,33 +69,41 @@
 
   .coalition {
     margin-top: $gutter;
+  }
 
-    @include media(tablet) {
-      margin-top: 0;
+  .feature-value {
+    display: block;
+    padding-bottom: 0;
+
+    .feature-value__count {
+      display: block;
+      font-size: 5em;
+      font-weight: bold;
+      line-height: 1;
     }
 
-    p{
-      background-color:$panel-colour;
-      padding:$gutter-half;
-      margin-top:-0.5em;
+    @include govuk-media-query($from: tablet, $until: 815px) {
+      &--small .feature-value__count {
+        font-size: 3.85em;
+      }
     }
   }
 
-  .feature-value{
-    font-size:5em;
-    padding-bottom:0;
-    margin:0 0 ($gutter-one-third * -1);
-    color:$grey-1;
-    font-weight: bold;
-    display:block;
-    line-height:1em;
-    a {
+  .feature-value__caption {
+    color: inherit;
+    display: inline-block;
+    padding: 0 0.2em;
+    position: relative;
+    top: -0.5em;
+  }
+
+  .feature-value__link {
+    color: $govuk-link-colour;
+    display: inline-block;
       text-decoration: none;
-      color: $black;
-      &:hover,
+
       &:focus {
-        text-decoration: underline;
-      }
+      @include govuk-focused-text;
     }
   }
 

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -1,6 +1,6 @@
 .inside_gov_how-gov-works {
-  .full-width-section{
-    clear:both;
+  .full-width-section {
+    clear: both;
   }
 
   p, li{
@@ -16,11 +16,12 @@
 
   .thirds-width-section,
   .halves-width-section {
-    overflow:visible;
-    clear:both;
-    margin-top:$gutter - $gutter-one-sixth;
-    margin-bottom:$gutter-two-thirds;
+    overflow: visible;
+    clear: both;
+    margin-top: $gutter - $gutter-one-sixth;
+    margin-bottom: $gutter-two-thirds;
     @extend %contain-floats;
+
     img {
       width: $full-width;
       height: auto;
@@ -31,8 +32,8 @@
     }
 
     @include media(tablet) {
-      margin-left:-$gutter-half;
-      margin-right:-$gutter-half;
+      margin-left: -$gutter-half;
+      margin-right: -$gutter-half;
 
       .inner-block {
         padding: 0 $gutter-half;
@@ -100,17 +101,17 @@
   .feature-value__link {
     color: $govuk-link-colour;
     display: inline-block;
-      text-decoration: none;
+    text-decoration: none;
 
-      &:focus {
+    &:focus {
       @include govuk-focused-text;
     }
   }
 
   .feature-ministers {
-      text-align: center;
-      color: $secondary-text-colour;
-      padding: $gutter-half 0 $gutter;
+    text-align: center;
+    color: $secondary-text-colour;
+    padding: $gutter-half 0 $gutter;
 
     .feature-ministers__symbol,
     .feature-ministers__equals-wrapper {
@@ -124,7 +125,7 @@
       margin: 0.5em 0;
       padding: 0;
       text-align: center;
-        text-decoration: none;
+      text-decoration: none;
       vertical-align: middle;
       width: 5em;
 
@@ -142,7 +143,7 @@
       .caption {
         display: block;
         line-height: 1em;
-        }
+      }
 
       @include govuk-media-query($from: tablet) {
         border: 0.2em solid $inside-gov-secondary; // https://webaim.org/resources/contrastchecker/?fcolor=0B0C0C&bcolor=57DA95
@@ -151,23 +152,23 @@
         width: 9em;
         padding-top: 1.85em;
 
-          &:hover,
-          &:focus {
-            text-decoration: none;
-          }
+        &:hover,
+        &:focus {
+          text-decoration: none;
+        }
 
         &:hover {
           color: $govuk-link-hover-colour;
           background: govuk-colour("white");
           border-color: $govuk-link-hover-colour;
-      }
+        }
 
         &:focus {
           color: $govuk-focus-text-colour;
           background: $govuk-focus-colour;
           border-color: $govuk-focus-text-colour;
           outline: none;
-    }
+        }
 
         .count,
         .caption {
@@ -177,23 +178,23 @@
         .caption {
           display: inline-block;
           width: 6em;
+        }
       }
     }
-  }
 
     @include media(tablet) {
       .feature-ministers__symbol {
         margin: 0 1em;
         position: relative;
         top: 0.25em;
-  }
+      }
 
       .feature-ministers__item--invert {
         background-color: $inside-gov-secondary;
         border-color: $inside-gov-secondary;
+      }
     }
   }
-    }
 
   .ministers .caption {
     max-width: 26em;

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -63,8 +63,8 @@
     }
   }
 
-  .ministers{
-    margin-bottom: $gutter*2;
+  .ministers {
+    margin-bottom: $gutter * 2;
   }
 
   .coalition {
@@ -99,173 +99,98 @@
     }
   }
 
-  .feature-caption {
-    @include ig-core-16;
-    display: block;
-    padding-bottom: $gutter;
-  }
-
-  .feature-ministers{
-    p {
+  .feature-ministers {
       text-align: center;
       color: $secondary-text-colour;
-      @include ig-core-48;
       padding: $gutter-half 0 $gutter;
+
+    .feature-ministers__symbol,
+    .feature-ministers__equals-wrapper {
+      display: inline-block;
     }
 
-    span.circle {
+    .feature-ministers__item {
+      box-sizing: border-box;
+      color: $govuk-text-colour;
       display: inline-block;
-      text-align: center;
+      margin: 0.5em 0;
       padding: 0;
-      vertical-align: middle;
-      width: 17%;
-      a {
+      text-align: center;
         text-decoration: none;
-        &:hover,
+      vertical-align: middle;
+      width: 5em;
+
+      @include govuk-media-query($until: tablet) {
+        &:hover {
+          color: $govuk-link-hover-colour;
+        }
+
         &:focus {
-          text-decoration: underline;
+          @include govuk-focused-text;
         }
       }
 
-      .count {
-        @include core-48;
-        position: relative;
-        top: $gutter-one-third;
-        padding: 0;
-        margin: 0 0 $gutter-one-sixth 0;
-
-        font-size: 1.9em;
-        font-weight: bold;
+      .count,
+      .caption {
         display: block;
         line-height: 1em;
-        a {
-          color:$black;
-        }
-      }
-
-      @include media(tablet) {
-        background-color:transparent;
-        border:0.1em solid $inside-gov-secondary;
-        width:3.8em;
-        height:3.8em;
-        -moz-border-radius: 2em;
-        -webkit-border-radius: 2em;
-        border-radius: 5em;
-
-        &:hover {
-          background-color: darken($inside-gov-secondary,10%);
-          border-color: darken($inside-gov-secondary,10%);
         }
 
-        a {
+      @include govuk-media-query($from: tablet) {
+        border: 0.2em solid $inside-gov-secondary; // https://webaim.org/resources/contrastchecker/?fcolor=0B0C0C&bcolor=57DA95
+        border-radius: 4.5em;
+        height: 9em;
+        width: 9em;
+        padding-top: 1.85em;
+
           &:hover,
           &:focus {
             text-decoration: none;
           }
-        }
-
-        .count{
-          padding-top: 0.35em;
-          font-size: 1.9em;
-          font-weight: bold;
-          width:100%;
-          text-align:center;
-        }
-      }
-
-      span{
-        color:black;
-        @include ig-core-16;
-        display: block;
-        padding: 0;
-        margin: 0;
-      }
-    }
-
-    @include media(tablet) {
-      span.invert {
-        background-color: $inside-gov-secondary;
-        border-color: $inside-gov-secondary;
 
         &:hover {
-          background-color: darken($inside-gov-secondary,10%);
-          border-color: darken($inside-gov-secondary,10%);
+          color: $govuk-link-hover-colour;
+          background: govuk-colour("white");
+          border-color: $govuk-link-hover-colour;
+      }
+
+        &:focus {
+          color: $govuk-focus-text-colour;
+          background: $govuk-focus-colour;
+          border-color: $govuk-focus-text-colour;
+          outline: none;
+    }
+
+        .count,
+        .caption {
+          text-align: center;
         }
 
-
-        .count a, .caption {
-          color: black;
-        }
+        .caption {
+          display: inline-block;
+          width: 6em;
       }
     }
   }
+
+    @include media(tablet) {
+      .feature-ministers__symbol {
+        margin: 0 1em;
+        position: relative;
+        top: 0.25em;
+  }
+
+      .feature-ministers__item--invert {
+        background-color: $inside-gov-secondary;
+        border-color: $inside-gov-secondary;
+    }
+  }
+    }
 
   .ministers .caption {
     max-width: 26em;
   }
 
-  h2 {
-    @include ig-core-36;
-    padding-bottom: 1px;
-    border-bottom: 5px solid black;
-    margin: $gutter 0 $gutter;
-    clear:both;
-
-    @include media(tablet) {
-      margin-top: $gutter*2;
-    }
-  }
-
-  h3 {
-    @include ig-core-27;
-    font-weight: bold;
-    margin: 0 0 $gutter-two-thirds;
-    width: $full-width;
-    &.with-gutter {
-      margin-top: $gutter-half;
-    }
-  }
-
-  .prime-minister,
-  .dep-prime-minister {
-    h3 {
-      @include ig-core-27;
-      font-weight: bold;
-    }
-  }
-
-  .depts-cont,
-  .gov-types {
-    h3 {
-      @include ig-core-19;
-      font-weight: bold;
-      margin-bottom: 0;
-    }
-  }
-
-  .gov-types, .ministers, .cabinet, .coalition {
-    h3{
-      border-top:1px solid $border-colour;
-      padding-top:$gutter - $gutter-one-sixth;
-    }
-  }
-
-  .ministers {
-    h3 {
-      margin-bottom: 0;
-      @include media(tablet) {
-        margin-bottom: $gutter-half;
-      }
-    }
-  }
-
-  h4 {
-    @include ig-core-19;
-    font-weight: bold;
-    &.with-gutter {
-      margin-top: $gutter-half;
-    }
-  }
   .block {
     float: none;
     display: block;
@@ -350,55 +275,4 @@
       }
     }
   }
-
-  @media (min-width: 640px) and (max-width: 760px) {
-    .feature-ministers {
-      p {
-        font-size: $gutter;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -10px;
-        @include ig-core-14;
-        line-height: 1;
-      }
-    }
-  }
-
-  @media (min-width: 761px) and (max-width: 980px) {
-    .feature-ministers {
-      p {
-        font-size: 35px;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -10px;
-        @include ig-core-14;
-        line-height: 1;
-      }
-    }
-  }
-
-  @media (min-width: 811px) and (max-width: 980px) {
-    .feature-ministers {
-      p {
-        font-size: 39px;
-      }
-      span.circle .count {
-        top: $gutter-one-sixth;
-      }
-      span.circle .caption {
-        position: relative;
-        top: -5px;
-        @include ig-core-14;
-      }
-    }
-  }
-
 }

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -3,18 +3,24 @@
 <% meta_description "In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out who runs government and how government is run, as well as learning about the history of government." %>
 
 <div id="how-government-works">
-  <header class="block headings-block">
-    <div class="inner-block floated-children">
-      <%= render partial: 'shared/heading',
-                locals: { big: true,
-                          heading: "How government works" } %>
-      <p class="intro-paragraph">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a href="#who-runs-government">who runs government</a> and <a href="#how-government-is-run">how government is run</a>, as well as learning about the <a href="#history-uk-government">history of government</a>.</p>
+  <header class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <%= render "govuk_publishing_components/components/title", {
+          title: "How government works",
+        } %>
+        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
+    </div>
     </div>
   </header>
 
   <div class="block">
     <div class="inner-block">
-      <h2 class="coalition" id="who-runs-government">Who runs government</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Who runs government",
+        id: "who-runs-government",
+        heading_level: 2,
+      } %>
       <div class="halves-width-section prime-minister">
         <div class="one-half">
           <div class="inner-block">
@@ -27,9 +33,11 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <h3>The Prime Minister</h3>
-            <p>The <a href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions. The Prime Minister also:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "The Prime Minister",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
               <li>oversees the operation of the Civil Service and government agencies</li>
               <li>appoints members of the government</li>
               <li>is the principal government figure in the House of Commons</li>
@@ -50,15 +58,20 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <h3>The Cabinet</h3>
-            <p>The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
-            <p><a href="/government/ministers">See who is in the Cabinet</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "The Cabinet",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
       </div>
 
       <div class="full-width-section ministers">
-          <h3>Ministers</h3>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Ministers",
+          heading_level: 3,
+        } %>
           <% if !@is_during_reshuffle %>
             <div class="feature-ministers">
               <p>
@@ -70,11 +83,19 @@
           <p><%= link_to "See full list of ministers", ministerial_roles_path %></p>
       </div>
 
-     <h2 id="how-government-is-run">How government is run</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How government is run",
+        id: "how-government-is-run",
+        heading_level: 2,
+        margin_bottom: 6,
+      } %>
       <div class="thirds-width-section depts">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Government departments and agencies</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Government departments and agencies",
+              heading_level: 3,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -98,13 +119,21 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h3>Government departments</h3>
-            <p>Some departments, like the <a href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Government departments",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p><a href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
-            <h3 class="with-gutter">Executive agencies</h3>
-            <p>These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Executive agencies",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p>An example is the <a href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
 
@@ -112,8 +141,12 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Other public bodies</h3>
-            <p>These have varying degrees of independence but are directly accountable to ministers. There are 4 types of non-departmental public bodies (NDPBs).</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Other public bodies",
+              heading_level: 3,
+              margin_bottom: 3,
+              font_size: 19,
+            } %>
 
             <p>Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
 
@@ -131,7 +164,11 @@
       <div class="thirds-width-section civil-service">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Civil Service</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Civil Service",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -154,14 +191,22 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Work for us</h4>
-            <p><a href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Work for us",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Work with us</h4>
-            <p><a href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Work with us",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -171,7 +216,11 @@
       <div class="thirds-width-section get-involved">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Get involved</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Get involved",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
 
@@ -183,15 +232,23 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Engage with government</h4>
-            <p>Interact with government through <a href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Engage with government",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Take part</h4>
-            <p><a href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Take part",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -201,7 +258,11 @@
       <div class="thirds-width-section legislation">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Legislation</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Legislation",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="two-thirds">
@@ -213,8 +274,12 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Draft legislation</h4>
-            <p>White papers outline proposals for new laws. Green papers ask for public comments before the white paper is published.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Draft legislation",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
             <p>Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
           </div>
@@ -222,9 +287,12 @@
 
         <div class="one-third">
           <div class="inner-block">
-            <h4>Acts of Parliament</h4>
-            <p>These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
-            <p><a href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Acts of Parliament",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -234,45 +302,49 @@
       <div class="thirds-width-section access-information">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Access to information</h3>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Access to information",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h4>Freedom of information</h4>
-            <p>The Freedom of Information Act gives you the right to ask any
-            public sector organisation for all the recorded information it has
-            on any subject. Anyone can make a request for information –
-            known as a Freedom of Information (or FOI) request.  There are no
-            restrictions on your age, nationality or where you live.</p>
-            <p><a href="/make-a-freedom-of-information-request">How to make a freedom of information request</a></p>
-            <p><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases') %></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Freedom of information",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
-            <h4 class="with-gutter">Statistics</h4>
-            <p>Government produces Official Statistics about most areas of
-            public life. Statistics are used by people inside and outside
-            government to make informed decisions and to measure the success of
-            government policies and services. <a
-              href="/government/statistics/how-national-and-official-statistics-are-assured">Find
-              out about the legislation</a> that governs the publication of UK
-            national and Official Statistics.</p>
-            <p><%= link_to "See statistics publications on GOV.UK", '/search/research-and-statistics' %></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Statistics",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
 
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-
-            <h4>Transparency</h4>
-            <p>The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Transparency",
+              heading_level: 4,
+              margin_bottom: 2,
+              font_size: 19,
+            } %>
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
-            <p><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data') %></p>
-            <h4 class="with-gutter">Data</h4>
-            <p>Putting data in people’s hands can help them have more of a say in the reform of public services. On <a href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Data",
+              heading_level: 4,
+              margin_bott2m: 4,
+              font_size: 19,
+            } %>
           </div>
         </div>
       </div>
@@ -280,8 +352,11 @@
       <div class="thirds-width-section gov-types">
         <div class="one-third">
           <div class="inner-block">
-            <h3>Devolved government</h3>
-            <p>In <a href="http://www.gov.scot/" rel="external">Scotland</a>, <a href="http://gov.wales/" rel="external">Wales</a> and <a href="https://www.northernireland.gov.uk/" rel="external">Northern
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Devolved government",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
             Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
             <p>Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
             <ul>
@@ -295,17 +370,20 @@
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Local government</h3>
-            <p>Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
-            <p>In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
-            <p><a href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Local government",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
           </div>
         </div>
         <div class="one-third">
           <div class="inner-block">
-            <h3>Parliament</h3>
-            <p>Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
-            <ul>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Parliament",
+              heading_level: 3,
+              margin_bottom: 5,
+            } %>
               <li>look at what the government is
               doing</li>
               <li>debate issues and pass new laws</li>
@@ -317,8 +395,12 @@
         </div>
       </div>
 
-
-      <h2 id="history-uk-government">History of government</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "History of government",
+        id: "history-uk-government",
+        heading_level: 2,
+        margin_bottom: 3,
+      } %>
       <div class="halves-width-section history">
         <div class="one-half">
           <div class="inner-block">

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -38,14 +38,24 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+
+            <p class="govuk-body">The <a class="govuk-link" href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
+
+            <p class="govuk-body">The Prime Minister also:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
               <li>oversees the operation of the Civil Service and government agencies</li>
               <li>appoints members of the government</li>
               <li>is the principal government figure in the House of Commons</li>
             </ul>
+
             <% if @prime_minister.present? %>
-              <p>The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister) %>.</p>
+              <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister), class: "govuk-link" %>.</p>
             <% end %>
-            <p><a href="/government/organisations/prime-ministers-office-10-downing-street">Read more about the Prime Minister's Office, 10 Downing Street</a></p>
+
+            <p class="govuk-body">
+              <%= link_to "Read more about the Prime Minister's Office, 10 Downing Street", "/government/organisations/prime-ministers-office-10-downing-street", class: "govuk-link" %>
+            </p>
           </div>
         </div>
       </div>
@@ -63,6 +73,10 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+
+            <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
           </div>
         </div>
       </div>
@@ -79,8 +93,10 @@
               </p>
             </div>
           <% end %>
-          <p class="caption">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
-          <p><%= link_to "See full list of ministers", ministerial_roles_path %></p>
+        
+        <p class="govuk-body">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
+        
+        <p class="govuk-body"><%= link_to "See full list of ministers", ministerial_roles_path, class: "govuk-link" %></p>
       </div>
 
       <%= render "govuk_publishing_components/components/heading", {
@@ -100,7 +116,7 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Departments and their agencies are responsible for putting government policy into practice.</p>
+            <p class="govuk-body">Departments and their agencies are responsible for putting government policy into practice.</p>
           </div>
         </div>
       </div>
@@ -126,7 +142,9 @@
               font_size: 19,
             } %>
 
-            <p><a href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
+            <p class="govuk-body">Some departments, like the <a class="govuk-link" href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a class="govuk-link" href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+
+            <p class="govuk-body"><a class="govuk-link" href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Executive agencies",
@@ -135,7 +153,9 @@
               font_size: 19,
             } %>
 
-            <p>An example is the <a href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
+            <p class="govuk-body">These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
+
+            <p class="govuk-body">An example is the <a class="govuk-link" href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a class="govuk-link" href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
 
           </div>
         </div>
@@ -148,13 +168,15 @@
               font_size: 19,
             } %>
 
-            <p>Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
+            <p class="govuk-body">These have varying degrees of independence but are directly accountable to ministers. There are 4 types of non-departmental public bodies (NDPBs).</p>
 
-            <p>Advisory NDPBs provide independent, expert advice to ministers - for example, the Committee on Standards in Public Life.</p>
+            <p class="govuk-body">Executive NDPBs do work for the government in specific areas - for example, the Environment Agency.</p>
 
-            <p>Tribunal NDPBs are part of the justice system and have jurisdiction over a specific area of law - for example, the Competition Appeal Tribunal.</p>
+            <p class="govuk-body">Advisory NDPBs provide independent, expert advice to ministers - for example, the Committee on Standards in Public Life.</p>
 
-            <p>Independent monitoring boards are responsible for the running of prisons and treatment of prisoners - for example, Her Majesty's Inspectorate of Prisons.</p>
+            <p class="govuk-body">Tribunal NDPBs are part of the justice system and have jurisdiction over a specific area of law - for example, the Competition Appeal Tribunal.</p>
+
+            <p class="govuk-body">Independent monitoring boards are responsible for the running of prisons and treatment of prisoners - for example, Her Majesty's Inspectorate of Prisons.</p>
           </div>
         </div>
       </div>
@@ -173,15 +195,18 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-          <p>The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
-            <p>Around half of all civil servants provide services direct to the public, including:</p>
-            <ul>
+            <p class="govuk-body">The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
+            
+            <p class="govuk-body">Around half of all civil servants provide services direct to the public, including:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>paying benefits and pensions</li>
               <li>running employment services</li>
               <li>staffing prisons</li>
               <li>issuing driving licences</li>
             </ul>
-            <p>The <a href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
+            
+            <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
           </div>
         </div>
 
@@ -197,6 +222,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
         <div class="one-third">
@@ -207,6 +234,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
           </div>
         </div>
       </div>
@@ -226,7 +255,7 @@
 
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Read about ways to <a href="/government/get-involved">get involved</a>.</p>
+            <p class="govuk-body">Read about ways to <a class="govuk-link" href="/government/get-involved">get involved</a>.</p>
           </div>
         </div>
 
@@ -238,6 +267,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
           </div>
         </div>
 
@@ -249,6 +280,8 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
       </div>
@@ -267,8 +300,9 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
-            <p>They can include:</p>
+            <p class="govuk-body">Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
+            
+            <p class="govuk-body">They can include:</p>
           </div>
         </div>
 
@@ -281,7 +315,9 @@
               font_size: 19,
             } %>
 
-            <p>Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
+            <p class="govuk-body">White papers outline proposals for new laws. Green papers ask for public comments before the white paper is published.</p>
+
+            <p class="govuk-body">Bills are proposals for new laws or changes to existing ones. Once agreed by Parliament, they have to be approved by The Queen before becoming law.</p>
           </div>
         </div>
 
@@ -293,6 +329,10 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
           </div>
         </div>
       </div>
@@ -318,12 +358,22 @@
               font_size: 19,
             } %>
 
+            <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
+            
+            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
+            
+            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
+
             <%= render "govuk_publishing_components/components/heading", {
               text: "Statistics",
               heading_level: 4,
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body">Government produces Official Statistics about most areas of public life. Statistics are used by people inside and outside government to make informed decisions and to measure the success of government policies and services. <%= link_to "Find out about the legislation", "/government/statistics/how-national-and-official-statistics-are-assured", class: "govuk-link" %> that governs the publication of UK national and Official Statistics.</p>
+            
+            <p class="govuk-body"><%= link_to "See statistics publications on GOV.UK", "/search/research-and-statistics", class: "govuk-link" %></p>
 
           </div>
         </div>
@@ -335,16 +385,25 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
+
+            <p class="govuk-body">The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
+            
+            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
+            
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
               heading_level: 4,
               margin_bott2m: 4,
               font_size: 19,
             } %>
+            
+            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
       </div>
@@ -357,9 +416,12 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
-            <p>Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
-            <ul>
+            
+            <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
+            
+            <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
               <li>health</li>
               <li>education</li>
               <li>culture</li>
@@ -375,6 +437,12 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
+            
+            <p class="govuk-body">Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
+            
+            <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
           </div>
         </div>
         <div class="one-third">
@@ -384,13 +452,18 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-              <li>look at what the government is
-              doing</li>
+
+            <p class="govuk-body">Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
+            
+            <ul class="govuk-list govuk-list--bullet">
+              <li>look at what the government is doing</li>
               <li>debate issues and pass new laws</li>
               <li>set taxes</li>
             </ul>
-            <p><a href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
-            <p>Read The Official Report at <a href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
+            
+            <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
+            
+            <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
           </div>
         </div>
       </div>
@@ -409,18 +482,14 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <p>Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a href="/government/history">history</a> section.</p>
-            <p>Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a href="/government/history#notable-people">notable people</a>. Learn more about historic <a href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
-            <p>You can also find links to <a href="/government/history#historical-research">historical research</a>, documents and records.</p>
+            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a class="govuk-link" href="/government/history">history</a> section.</p>
+
+            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a class="govuk-link" href="/government/history#notable-people">notable people</a>. Learn more about historic <a class="govuk-link" href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
+
+            <p class="govuk-body">You can also find links to <a class="govuk-link" href="/government/history#historical-research">historical research</a>, documents and records.</p>
           </div>
         </div>
       </div>
-
-
     </div>
   </div>
-
-
-
-
 </div>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -9,7 +9,7 @@
         <%= render "govuk_publishing_components/components/title", {
           title: "How government works",
         } %>
-        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
+        <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <%= link_to("who runs government", "#who-runs-government", class: "govuk-link") %> and <%= link_to("how government is run", "#how-government-is-run", class: "govuk-link") %>, as well as learning about the <%= link_to("history of government", "#history-uk-government", class: "govuk-link") %>.</p>
       </div>
     </div>
   </header>
@@ -39,7 +39,7 @@
               margin_bottom: 5,
             } %>
 
-            <p class="govuk-body">The <a class="govuk-link" href="/government/ministers/prime-minister">Prime Minister</a> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
+            <p class="govuk-body">The <%= link_to("Prime Minister", "/government/ministers/prime-minister", class: "govuk-link") %> is the leader of Her Majesty’s Government and is ultimately responsible for all policy and decisions.</p>
 
             <p class="govuk-body">The Prime Minister also:</p>
 
@@ -76,7 +76,7 @@
 
             <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
+            <p class="govuk-body"><%= link_to("See who is in the Cabinet", "/government/ministers", class: "govuk-link") %></p>
           </div>
         </div>
       </div>
@@ -174,9 +174,9 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Some departments, like the <a class="govuk-link" href="/government/organisations/ministry-of-defence">Ministry of Defence</a>, cover the  whole UK. Others don’t – the <a class="govuk-link" href="/government/organisations/department-for-work-pensions">Department for Work and Pensions</a> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
+            <p class="govuk-body">Some departments, like the <%= link_to "Ministry of Defence", "/government/organisations/ministry-of-defence", class: "govuk-link" %>, cover the  whole UK. Others don’t – the <%= link_to "Department for Work and Pensions", "/government/organisations/department-for-work-pensions", class: "govuk-link" %> doesn't cover Northern Ireland. This is because some aspects of government are devolved to Scotland, Wales and Northern Ireland.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/organisations#non-ministerial-departments">Non-ministerial departments</a> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
+            <p class="govuk-body"><%= link_to "Non-ministerial departments", "/government/organisations#non_ministerial_departments", class: "govuk-link" %> are headed by senior civil servants and not ministers. They usually have a regulatory or inspection function like the Charity Commission.</p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Executive agencies",
@@ -187,7 +187,7 @@
 
             <p class="govuk-body">These are part of government departments and usually provide government services rather than decide policy - which is done by the department that oversees the agency.</p>
 
-            <p class="govuk-body">An example is the <a class="govuk-link" href="/government/organisations/driver-and-vehicle-licensing-agency">Driver and Vehicle Licensing Agency</a> (overseen by the <a class="govuk-link" href="/government/organisations/department-for-transport">Department for Transport</a>).</p>
+            <p class="govuk-body">An example is the <%= link_to "Driver and Vehicle Licensing Agency", "/government/organisations/driver-and-vehicle-licensing-agency", class: "govuk-link" %> (overseen by the <%= link_to "Department for Transport", "/government/organisations/department-for-transport", class: "govuk-link" %>).</p>
 
           </div>
         </div>
@@ -238,7 +238,7 @@
               <li>issuing driving licences</li>
             </ul>
 
-            <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
+            <p class="govuk-body">The <%= link_to "Civil Service", "/government/organisations/civil-service", class: "govuk-link" %> is on GOV.UK.</p>
           </div>
         </div>
 
@@ -255,7 +255,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
+            <p class="govuk-body"><%= link_to "Find and apply", "https://civilservicejobs.service.gov.uk/", class: "govuk-link" %> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
         <div class="one-third">
@@ -267,7 +267,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/contracts-finder">Search Contracts Finder</a> for any government contract over £10,000 and get details of all previous tenders.</p>
+            <p class="govuk-body"><%= link_to "Search Contracts Finder", "/contracts-finder/", class: "govuk-link" %> for any government contract over £10,000 and get details of all previous tenders.</p>
           </div>
         </div>
       </div>
@@ -287,7 +287,7 @@
 
         <div class="two-thirds">
           <div class="inner-block">
-            <p class="govuk-body">Read about ways to <a class="govuk-link" href="/government/get-involved">get involved</a>.</p>
+            <p class="govuk-body">Read about ways to <%= link_to "get involved", "/government/get-involved/", class: "govuk-link" %>.</p>
           </div>
         </div>
 
@@ -300,7 +300,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
+            <p class="govuk-body">Interact with government through <%= link_to "consultations and petitions", "/government/get-involved#engage-with-government", class: "govuk-link" %> to inform and influence the decisions it makes.</p>
           </div>
         </div>
 
@@ -313,7 +313,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
+            <p class="govuk-body"><%= link_to "Offer your skills and energy", "/government/get-involved#take-part", class: "govuk-link" %> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
       </div>
@@ -364,7 +364,7 @@
 
             <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
+            <p class="govuk-body"><%= link_to "Visit www.legislation.gov.uk", "https://www.legislation.gov.uk", class: "govuk-link", rel: "external" %></p>
           </div>
         </div>
       </div>
@@ -392,9 +392,9 @@
 
             <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
 
-            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: "govuk-link" %></p>
 
-            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: "govuk-link" %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Statistics",
@@ -426,7 +426,7 @@
               <li>how the government is doing against its objectives</li>
             </ul>
 
-            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
+            <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: "govuk-link" %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
@@ -435,7 +435,7 @@
               font_size: 19,
             } %>
 
-            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
+            <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <%= link_to "data.gov.uk", "https://data.gov.uk/", class: "govuk-link", rel: "external" %> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
       </div>
@@ -449,7 +449,7 @@
               margin_bottom: 5,
             } %>
 
-            <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
+            <p class="govuk-body">In <%= link_to "Scotland", "https://www.gov.scot/", class: "govuk-link", rel: "external" %>, <%= link_to "Wales", "https://www.gov.wales/", class: "govuk-link", rel: "external" %> and <%= link_to "Northern Ireland", "https://www.northernireland.gov.uk/", class: "govuk-link", rel: "external" %>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
 
             <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
 
@@ -474,7 +474,7 @@
 
             <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
 
-            <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
+            <p class="govuk-body"><%= link_to "Understand how your council works", "/understand-how-your-council-works/types-of-council/", class: "govuk-link" %></p>
           </div>
         </div>
         <div class="one-third">
@@ -493,9 +493,11 @@
               <li>set taxes</li>
             </ul>
 
-            <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
+            <p class="govuk-body">
+              <%= link_to "Find out about how Parliament works", "https://www.parliament.uk/", class: "govuk-link", rel: "external" %>
+            </p>
 
-            <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
+            <p class="govuk-body">Read The Official Report at <%= link_to "Hansard", "http://www.parliament.uk/business/publications/", class: "govuk-link", rel: "external" %></p>
           </div>
         </div>
       </div>
@@ -514,11 +516,11 @@
         </div>
         <div class="one-half">
           <div class="inner-block">
-            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <a class="govuk-link" href="/government/history">history</a> section.</p>
+            <p class="govuk-body">Britain has one of the oldest governments in the world. Find out more about how it has worked and who has shaped it in the <%= link_to "history", "/government/history/", class: "govuk-link" %> section.</p>
 
-            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <a class="govuk-link" href="/government/history#notable-people">notable people</a>. Learn more about historic <a class="govuk-link" href="/government/history#government-buildings">government buildings</a> on Whitehall and around the UK.</p>
+            <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <%= link_to "notable people", "/government/history#notable-people", class: "govuk-link" %>. Learn more about historic <%= link_to "government buildings", "/government/history#government-buildings", class: "govuk-link" %> on Whitehall and around the UK.</p>
 
-            <p class="govuk-body">You can also find links to <a class="govuk-link" href="/government/history#historical-research">historical research</a>, documents and records.</p>
+            <p class="govuk-body">You can also find links to <%= link_to "historical research", "/government/history#historical-research", class: "govuk-link" %>, documents and records.</p>
           </div>
         </div>
       </div>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -88,9 +88,27 @@
         } %>
           <% if !@is_during_reshuffle %>
             <div class="feature-ministers">
-              <p>
-                <span class="circle prime-minister"><span class="count"><a href="/government/ministers/prime-minister">01</a></span> <span class="caption">Prime Minister</span></span> + <span class="circle cabinet-ministers"><span class="count"><a href="/government/ministers#cabinet-ministers"><%= @cabinet_minister_count %></a></span> <span class="caption">Cabinet ministers</span></span> + <span class="circle other-ministers"><span class="count"><a href="/government/ministers#ministers-by-department"><%= @other_minister_count %></a></span> <span class="caption">Other ministers</span></span> = <span class="circle invert all-ministers"><span class="count"><a href="/government/ministers"><%= @all_ministers_count %></a></span> <span class="caption">Total ministers</span></span>
-              </p>
+            <a href="/government/ministers/prime-minister" class="feature-ministers__item">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</span>
+              <span class="caption">Prime Minister</span>
+            </a>
+            <span class="feature-ministers__symbol">&#43;</span>
+            <a href="/government/ministers#cabinet-ministers" class="feature-ministers__item cabinet-ministers">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @cabinet_minister_count %></span>
+              <span class="caption">Cabinet ministers</span>
+            </a>
+            <span class="feature-ministers__symbol">&#43;</span>
+            <a href="/government/ministers#ministers-by-department" class="feature-ministers__item other-ministers">
+              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @other_minister_count %></span>
+              <span class="caption">Other ministers</span>
+            </a>
+            <span class="feature-ministers__equals-wrapper">
+              <span class="feature-ministers__symbol">&#61;</span>
+              <a href="/government/ministers" class="feature-ministers__item feature-ministers__item--invert all-ministers">
+                <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @all_ministers_count %></span>
+                <span class="caption">Total ministers</span>
+              </a>
+            <span>
             </div>
           <% end %>
         

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -10,7 +10,7 @@
           title: "How government works",
         } %>
         <p class="govuk-body-l">In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out <a class="govuk-link" href="#who-runs-government">who runs government</a> and <a class="govuk-link" href="#how-government-is-run">how government is run</a>, as well as learning about the <a class="govuk-link" href="#history-uk-government">history of government</a>.</p>
-    </div>
+      </div>
     </div>
   </header>
 
@@ -60,7 +60,7 @@
         </div>
       </div>
 
-        <div class="halves-width-section cabinet">
+      <div class="halves-width-section cabinet">
         <div class="one-half">
           <div class="inner-block">
             <%= image_tag 'how-gov-works/Cabinet_01.jpg', alt: 'The Cabinet' %>
@@ -75,7 +75,7 @@
             } %>
 
             <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="/government/ministers">See who is in the Cabinet</a></p>
           </div>
         </div>
@@ -86,8 +86,8 @@
           text: "Ministers",
           heading_level: 3,
         } %>
-          <% if !@is_during_reshuffle %>
-            <div class="feature-ministers">
+        <% if !@is_during_reshuffle %>
+          <div class="feature-ministers">
             <a href="/government/ministers/prime-minister" class="feature-ministers__item">
               <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</span>
               <span class="caption">Prime Minister</span>
@@ -109,11 +109,11 @@
                 <span class="caption">Total ministers</span>
               </a>
             <span>
-            </div>
-          <% end %>
-        
+          </div>
+        <% end %>
+
         <p class="govuk-body">Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.</p>
-        
+
         <p class="govuk-body"><%= link_to "See full list of ministers", ministerial_roles_path, class: "govuk-link" %></p>
       </div>
 
@@ -142,12 +142,26 @@
       <div class="thirds-width-section depts-cont">
         <div class="one-third">
           <div class="inner-block">
-            <p><span class="feature-value"><%= link_to @ministerial_department_count, organisations_path(anchor: 'departments') %></span>
-              <span class="feature-caption">Ministerial departments</span>
-              <span class="feature-value"><a href="/government/organisations#non-ministerial-departments"><%= @non_ministerial_department_count %></a></span>
-              <span class="feature-caption">Non-ministerial departments</span>
-              <span class="feature-value"><a href="/government/organisations#agencies-and-government-bodies">300+</a></span>
-              <span class="feature-caption">Agencies &amp; other public bodies</span></p>
+            <ul class="govuk-list">
+              <li class="feature-value">
+                <a href="<%= organisations_path(anchor: 'departments') %>" class="feature-value__link">
+                  <span class="feature-value__count"><%= @ministerial_department_count %></span>
+                  <span class="feature-value__caption govuk-body-s">Ministerial departments</span>
+                </a>
+              </li>
+              <li class="feature-value">
+                <a href="<%= organisations_path(anchor: 'non-ministerial-departments') %>" class="feature-value__link">
+                  <span class="feature-value__count"><%= @non_ministerial_department_count %></span>
+                  <span class="feature-value__caption govuk-body-s">Non-ministerial departments</span>
+                </a>
+              </li>
+              <li class="feature-value feature-value--small">
+                <a href="<%= organisations_path(anchor: 'agencies-and-government-bodies') %>" class="feature-value__link">
+                  <span class="feature-value__count">300+</span>
+                  <span class="feature-value__caption govuk-body-s">Agencies &amp; other public bodies</span>
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
 
@@ -214,16 +228,16 @@
         <div class="two-thirds">
           <div class="inner-block">
             <p class="govuk-body">The Civil Service does the practical and administrative work of government. It is co-ordinated and managed by the Prime Minister, in their role as Minister for the Civil Service.</p>
-            
+
             <p class="govuk-body">Around half of all civil servants provide services direct to the public, including:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>paying benefits and pensions</li>
               <li>running employment services</li>
               <li>staffing prisons</li>
               <li>issuing driving licences</li>
             </ul>
-            
+
             <p class="govuk-body">The <a class="govuk-link" href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
           </div>
         </div>
@@ -240,7 +254,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
@@ -285,7 +299,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">Interact with government through <a class="govuk-link" href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
           </div>
         </div>
@@ -298,7 +312,7 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
@@ -319,7 +333,7 @@
         <div class="two-thirds">
           <div class="inner-block">
             <p class="govuk-body">Laws go through several stages before they are passed by Parliament. The House of Commons and the House of Lords work together to make them.</p>
-            
+
             <p class="govuk-body">They can include:</p>
           </div>
         </div>
@@ -347,9 +361,9 @@
               margin_bottom: 2,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">These are bills which have been approved by the Commons, the Lords, and The Queen. The relevant government department is responsible for putting the act into practice.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="http://www.legislation.gov.uk" rel="external">Visit www.legislation.gov.uk</a></p>
           </div>
         </div>
@@ -377,9 +391,9 @@
             } %>
 
             <p class="govuk-body">The Freedom of Information Act gives you the right to ask any public sector organisation for all the recorded information it has on any subject. Anyone can make a request for information – known as a Freedom of Information (or FOI) request.  There are no restrictions on your age, nationality or where you live.</p>
-            
+
             <p class="govuk-body"><%= link_to "How to make a freedom of information request", "/make-a-freedom-of-information-request", class: 'govuk-link' %></p>
-            
+
             <p class="govuk-body"><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases'), class: 'govuk-link' %></p>
 
             <%= render "govuk_publishing_components/components/heading", {
@@ -390,7 +404,7 @@
             } %>
 
             <p class="govuk-body">Government produces Official Statistics about most areas of public life. Statistics are used by people inside and outside government to make informed decisions and to measure the success of government policies and services. <%= link_to "Find out about the legislation", "/government/statistics/how-national-and-official-statistics-are-assured", class: "govuk-link" %> that governs the publication of UK national and Official Statistics.</p>
-            
+
             <p class="govuk-body"><%= link_to "See statistics publications on GOV.UK", "/search/research-and-statistics", class: "govuk-link" %></p>
 
           </div>
@@ -405,22 +419,22 @@
             } %>
 
             <p class="govuk-body">The government publishes information about how government works to allow you to make politicians, public services and public organisations more accountable. We are committed to publishing information about:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>how much public money has been spent on what</li>
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
-            
+
             <p class="govuk-body"><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data'), class: 'govuk-link' %></p>
-            
+
             <%= render "govuk_publishing_components/components/heading", {
               text: "Data",
               heading_level: 4,
               margin_bott2m: 4,
               font_size: 19,
             } %>
-            
+
             <p class="govuk-body">Putting data in people’s hands can help them have more of a say in the reform of public services. On <a class="govuk-link" href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
@@ -434,11 +448,11 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            
+
             <p class="govuk-body">In <a class="govuk-link" href="https://www.gov.scot/" rel="external">Scotland</a>, <a class="govuk-link" href="https://gov.wales/" rel="external">Wales</a> and <a class="govuk-link" href="https://www.northernireland.gov.uk/" rel="external">Northern Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
-            
+
             <p class="govuk-body">Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>health</li>
               <li>education</li>
@@ -455,11 +469,11 @@
               heading_level: 3,
               margin_bottom: 5,
             } %>
-            
+
             <p class="govuk-body">Councils make and carry out decisions on local services. Many parts of England have 2 tiers of local government: county councils and district, borough or city councils.</p>
-            
+
             <p class="govuk-body">In some parts of the country, there’s just one tier of local government providing all the functions, known as a ‘unitary authority’. This can be a city, borough or county council – or it may just be called ‘council’. As well as these, many areas also have parish or town councils.</p>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/understand-how-your-council-works/types-of-council">Understand how your council works</a></p>
           </div>
         </div>
@@ -472,15 +486,15 @@
             } %>
 
             <p class="govuk-body">Parliament is separate from government. Made up of the House of Commons and the House of Lords, its role is to:</p>
-            
+
             <ul class="govuk-list govuk-list--bullet">
               <li>look at what the government is doing</li>
               <li>debate issues and pass new laws</li>
               <li>set taxes</li>
             </ul>
-            
+
             <p class="govuk-body"><a class="govuk-link" href="http://www.parliament.uk/" rel="external">Find out about how Parliament works</a></p>
-            
+
             <p class="govuk-body">Read The Official Report at <a class="govuk-link" href="http://www.parliament.uk/business/publications/" rel="external">Hansard</a></p>
           </div>
         </div>


### PR DESCRIPTION
* Updates the links to have the new focus state
* Updates Sass to use variables from GOV.UK Frontend (via GOV.UK Publishing Components gem)
* Switches app components to gem components
* Replaces `<a href...` with `<%= link_to...` where possible
* Updates ministers circle feature to not break on medium sized screens
* Adds context to the links in the ministers circle feature so they're more readable by assistive tech
* Remove mysterious leading zero from the Prime Minister circle
* Updates the department numbers to stop it overlapping with the rest of the page
* Makes sure that the links in the department numbers make sense on their own so they're more readable

Live page: https://www.gov.uk/government/how-government-works

# Visual differences

## Ministers circle feature before

Showing layout glitch:
<img width="601" alt="Screen Shot 2019-10-10 at 11 42 23" src="https://user-images.githubusercontent.com/1732331/67856911-82da4500-fb0d-11e9-908b-c05357160fed.png">

Small screens with focus state, hover state, no state, no state:
<img width="461" alt="Screen Shot 2019-10-10 at 11 43 06" src="https://user-images.githubusercontent.com/1732331/67856943-94bbe800-fb0d-11e9-97f5-e9855825df56.png">

Focus state, hover state, no state, no state (total has different styles):
<img width="980" alt="Screen Shot 2019-10-10 at 11 46 26" src="https://user-images.githubusercontent.com/1732331/67857189-098f2200-fb0e-11e9-93c8-adb07fb99b68.png">

## Ministers circle feature after

Focus state, hover state, no state, no state (total has different styles):
<img width="998" alt="Screen Shot 2019-10-10 at 11 48 39" src="https://user-images.githubusercontent.com/1732331/67857325-62f75100-fb0e-11e9-9807-c84c919253a5.png">

Small screens with focus state, hover state, no state, no state:
<img width="451" alt="Screen Shot 2019-10-10 at 11 42 57" src="https://user-images.githubusercontent.com/1732331/67857354-7d312f00-fb0e-11e9-833f-26d2180c952a.png">

## Department numbers before
Layout glitch and hover state:
<img width="523" alt="Screen Shot 2019-10-10 at 11 41 41" src="https://user-images.githubusercontent.com/1732331/67857424-a6ea5600-fb0e-11e9-91c5-31025ce9e894.png">

## Department numbers after
`300+` reduced in size, and new hover state:
<img width="475" alt="Screen Shot 2019-10-10 at 13 03 12" src="https://user-images.githubusercontent.com/1732331/67857506-e3b64d00-fb0e-11e9-8741-c0ad79cb4a82.png">





Part of https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on