### PR TITLE
Update focus states for Get Involved page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_get-involved.scss
+++ b/app/assets/stylesheets/frontend/views/_get-involved.scss
@@ -49,6 +49,27 @@
       }
     }
 
+    .count {
+
+      @include govuk-media-query($from: desktop) {
+        width: $half;
+      }
+
+      display: block;
+      margin: $gutter-half;
+      @include heading-80;
+      font-weight: bold;
+      text-decoration: none;
+
+      .context {
+        display: block;
+        @include core-16;
+        margin-top:0;
+        color: govuk-colour("black");
+      }
+
+  }
+
     section {
       @include core-19;
       @extend %contain-floats;
@@ -57,48 +78,6 @@
 
       h3, h4 {
         font-weight: bold;
-      }
-
-      dt, dd {
-        @include core-16;
-        display: block;
-      }
-      dt{
-        @include heading-80;
-        font-weight: bold;
-        margin: 0 0 (-$gutter-one-sixth) 0;
-        @include media(tablet) {
-          padding: 0;
-        }
-      }
-
-      .value {
-        @include heading-80;
-        font-weight: bold;
-        @include media(tablet) {
-          padding-bottom: 0;
-        }
-        &+ p {
-          @include core-16;
-          margin-top: -$gutter-one-sixth;
-        }
-      }
-
-      .values {
-        padding-top: $gutter-half;
-        dt, dd {
-          padding: 0 $gutter-half;
-          @include media(desktop) {
-            width: $half;
-          }
-        }
-        dt {
-          padding: 0 $gutter-half;
-          margin-top: $gutter-half;
-          @include media(tablet) {
-            margin: $gutter-half 0 (-$gutter-one-third);
-          }
-        }
       }
 
       .column {
@@ -114,13 +93,10 @@
           width: $two-thirds;
         }
         .consultation-closing-soon {
-          color: $white;
+          color: govuk-colour("white");
           background-color: $inside-gov-brand;
           margin: $gutter $gutter-half;
           padding: $gutter-half $gutter-half 0;
-          a {
-            color: $white;
-          }
           h3 {
             @include heading-27;
             font-weight: bold;
@@ -134,17 +110,23 @@
 
             h3 {
               @include core-19;
-              border-bottom: 1px solid $white;
+              border-bottom: 1px solid govuk-colour("white");
               padding-bottom: $gutter-one-third;
               font-weight: normal;
             }
             .attributes {
               @extend %contain-floats;
               margin-top: $gutter-one-third;
+
               li {
                 @include core-19;
+
                 a {
-                  color: $white;
+                  color: govuk-colour("white");
+
+                  &:link:focus {
+                    color: $govuk-focus-text-colour;
+                  }
                 }
               }
             }
@@ -238,7 +220,7 @@
 
     .keyline {
       clear: both;
-      border: solid $border-colour;
+      border: solid $govuk-border-colour;
       border-width: 0 0 1px;
       margin: 0 $gutter-half $gutter;
       padding-top: $gutter;

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: 'shared/heading',
               locals: { big: true,
                         heading: "Get involved" } %>
-    <p class="intro-paragraph">Find out how you can <a href="#engage-with-government">engage with government</a> directly, and <a href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
+    <p class="intro-paragraph">Find out how you can <a class="govuk-link" href="#engage-with-government">engage with government</a> directly, and <a class="govuk-link" href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
   </div>
 </header>
 
@@ -26,17 +26,17 @@
     </section>
     <section class="consultations">
       <div class="head-section">
-        <dl class="values">
-          <dt><%= link_to @open_consultation_count, publications_filter_path(:publication_filter_option => 'open-consultations') %>
-        </dt>
-          <dd>Open consultations</dd>
-          <dt><%=  link_to @closed_consultation_count, publications_filter_path(:publication_filter_option => 'closed-consultations') %></dt>
-          <dd>Closed consultations in the past 12 months</dd>
-          <% if false # this count not implemented yet %>
-            <dt><a href="#">29</a></dt>
-            <dd>Responses in the past 12 months</dd>
-          <% end %>
-        </dl>
+
+        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
+          <%= @open_consultation_count %>
+          <span class="context">Open consultations</span>
+        </a>
+
+        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
+          <%= @closed_consultation_count %>
+          <span class="context">Closed consultations in the past 12 months</span>
+        </a>
+
       </div>
       <div class="consultation-lists">
         <div class="consultation-closing-soon">
@@ -48,7 +48,7 @@
               <%= content_tag_for(:li, consultation, class: 'document-row') do %>
                 <h3><%= consultation.title %></h3>
                 <ul class="attributes">
-                  <li><%= link_to "Read and respond", public_document_path(consultation) %></li>
+                  <li><%= link_to "Read and respond", public_document_path(consultation), class: "govuk-link" %></li>
                 </ul>
               <% end %>
             <% end %>
@@ -61,16 +61,16 @@
               <ol class="document-list">
                 <% @recently_opened_consultations.each do |consultation| %>
                   <li class="document-row">
-                    <h3><%= link_to consultation.title, public_document_path(consultation) %></h3>
+                    <h3><%= link_to consultation.title, public_document_path(consultation), class: "govuk-link" %></h3>
                     <ul class="attributes">
                       <li><%= consultation.organisations.map(&:acronym).to_sentence %></li>
                       <li>Closes <%= consultation.date_microformat(:closing_at) %></li>
-                      <li><%= link_to "Read and respond", public_document_path(consultation) %></li>
+                      <li><%= link_to "Read and respond", public_document_path(consultation), class: "govuk-link", aria: {hidden: true} %></li>
                     </ul>
                   </li>
                 <% end %>
               </ol>
-              <p class="see-all"><%= link_to("Search all consultations", publications_path(publication_filter_option: "consultations")) %></p>
+              <p class="see-all"><%= link_to("Search all consultations", publications_path(publication_filter_option: "consultations"), class: "govuk-link" ) %></p>
             </div>
           </div>
           <div class="column">
@@ -79,11 +79,11 @@
               <ol class="document-list">
                 <% @recent_consultation_outcomes.each do |consultation| %>
                   <li class="document-row">
-                    <h3><%= link_to consultation.title, public_document_path(consultation) %></h3>
+                    <h3><%= link_to consultation.title, public_document_path(consultation), class: "govuk-link" %></h3>
                     <ul class="attributes">
                       <li><%= consultation.organisations.map(&:acronym).to_sentence %></li>
                       <li>Closed <%= consultation.date_microformat(:closing_at) %></li>
-                      <li><%= link_to "See the outcome", public_document_path(consultation) %></li>
+                      <li><%= link_to "See the outcome", public_document_path(consultation), class: "govuk-link", aria: {hidden: true}  %></li>
                     </ul>
                   </li>
                 <% end %>
@@ -100,7 +100,7 @@
       </div>
       <div class="column">
         <div class="content">
-          <p>You can <a href="https://petition.parliament.uk/" rel="external">create a petition</a> to influence government and Parliament. If the petition gets at least 100,000 online signatures, it will be considered for debate in the House of Commons.</p>
+          <p>You can <a class="govuk-link" href="https://petition.parliament.uk/" rel="external">create a petition</a> to influence government and Parliament. If the petition gets at least 100,000 online signatures, it will be considered for debate in the House of Commons.</p>
         </div>
       </div>
     </section>
@@ -112,14 +112,15 @@
       <div class="column">
         <div class="content">
           <p>For an instant way to interact with government departments, try their social media streams. These are listed under 'Follow us' on the department's home page. As well as access to blogs, audio, video and more, you can comment, debate and rate.</p>
-          <p class="see-all"><a href="/government/organisations/">See all government departments</a></p>
+          <p class="see-all"><a href="/government/organisations/" class="govuk-link">See all government departments</a></p>
           <p>Some active government blogs include:</p>
           <ul class="index-list">
-            <li><a href="https://history.blog.gov.uk" rel="external">History of Government</a></li>
-            <li><a href="https://quarterly.blog.gov.uk" rel="external">Civil Service Quarterly</a></li>
-            <li><a href="http://blogs.fco.gov.uk" rel="external">FCO bloggers</a></li>
-            <li><a href="https://gds.blog.gov.uk/" rel="external">Government Digital Service</a></li>
-            <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" rel="external">Head of the Civil Service</a></li>
+            <li><a href="https://history.blog.gov.uk" class="govuk-link" rel="external">History of Government</a></li>
+            <li><a href="https://quarterly.blog.gov.uk" class="govuk-link" rel="external">Civil Service Quarterly</a></li>
+            <li><a href="http://blogs.fco.gov.uk" class="govuk-link" rel="external">FCO bloggers</a></li>
+            <li><a href="https://gds.blog.gov.uk/" class="govuk-link" rel="external">Government Digital Service</a></li>
+            <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" class="govuk-link"
+             rel="external">Head of the Civil Service</a></li>
           </ul>
         </div>
       </div>
@@ -136,10 +137,10 @@
         <article<% if index % 3 == 0 %> class="article-clear"<% end %>>
           <div class="content">
             <span class="image-holder">
-              <%= link_to image_tag(take_part_page.image_url(:s300), alt: take_part_page.image_alt_text), take_part_page, title: take_part_page.title, class: 'img' %>
+              <%= link_to image_tag(take_part_page.image_url(:s300), alt: take_part_page.image_alt_text), take_part_page, title: take_part_page.title, class: 'img', tabindex: -1, aria: {hidden: true} %>
             </span>
             <div class="text">
-              <h3><%= link_to take_part_page.title, take_part_page %></h3>
+              <h3><%= link_to take_part_page.title, take_part_page, class: "govuk-link" %></h3>
               <p class="summary"><%= format_with_html_line_breaks(take_part_page.summary) %></p>
             </div>
           </div>
@@ -155,10 +156,10 @@
         <div class="content">
           <p>Many people are already volunteering, donating and contributing, both in the UK and abroad. If you&rsquo;d like to join them, but don&rsquo;t know where to start, here&rsquo;s a list of suggestions:</p>
           <ul class="index-list">
-            <li><a href="http://www.volunteerics.org/" rel="external">Join the International Citizen Service (18- to 25-year-olds)</a></li>
-            <li><a href="http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/" rel="external">Take part in your local Neighbourhood Watch</a></li>
-            <li><a href="/donating-to-charity">Make a donation to charity</a></li>
-            <li><a href="https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms" rel="external">Link up with a school overseas</a></li>
+            <li><a href="http://www.volunteerics.org/" class="govuk-link" rel="external">Join the International Citizen Service (18- to 25-year-olds)</a></li>
+            <li><a href="http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/" class="govuk-link" rel="external">Take part in your local Neighbourhood Watch</a></li>
+            <li><a href="/donating-to-charity" class="govuk-link">Make a donation to charity</a></li>
+            <li><a href="https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms" class="govuk-link" rel="external">Link up with a school overseas</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
- Adds govuk-link class to links
- Overrides colours where necessary
- Removes repetitive links from tab order and assistive tech
- Reworks large links to consultations to contextualise them

Part of https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on