### PR TITLE
Update past Foreign Secretaries pages

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -138,10 +138,16 @@ $govuk-typography-use-rem: false;
 // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
 // coming from static and the global styles set in `global/_links.scss`. This
 // can be removed when the style from static and Whitehall removed.
-#whitehall-wrapper a.govuk-link{
-  text-decoration: none;
-
-  &:focus {
-    color: $govuk-focus-text-colour;
+#whitehall-wrapper {
+  a.govuk-link {
+    &:focus {
+      text-decoration: none;
+      color: $govuk-focus-text-colour;
+    }
   }
+
+  .gem-c-title__context-link,
+  .gem-c-title__context-link:visited {
+    color: #6f777b;
+    }
 }

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -3,6 +3,8 @@
 $govuk-use-legacy-palette: true;
 $govuk-typography-use-rem: false;
 
+@import "govuk_publishing_components/all_components";
+
 // STYLEGUIDE
 // Mixins to be shared across gov.uk sites. Anything set in these
 // files can be used in the view files.
@@ -132,8 +134,6 @@ $govuk-typography-use-rem: false;
 #whitehall-wrapper {
   @import "layouts/two_column_page";
 }
-
-@import "govuk_publishing_components/all_components";
 
 // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
 // coming from static and the global styles set in `global/_links.scss`. This

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -40,15 +40,6 @@
   }
 
   .foreign-secretaries {
-    ol {
-      li {
-        list-style: none;
-        @include media(tablet) {
-          float: left;
-          width: $one-third;
-        }
-      }
-    }
     .heading {
       h3 {
         @include heading-36;

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -35,7 +35,7 @@
     }
 
     @include media(tablet) {
-      margin-bottom: $gutter * 2;
+      margin-bottom: $gutter*2;
     }
   }
 
@@ -77,6 +77,7 @@
   }
 
   .person-info {
+
     .name-title, .person-detail, .person-profile {
       .inner {
         padding: 0 $gutter-half;
@@ -90,17 +91,13 @@
       img {
         max-width: $full-width;
       }
-
       .info {
         background-color: $grey-3;
         padding-bottom: $gutter-half;
         margin-bottom: $gutter;
-
-        h3,
-        p {
+        h3, p {
           padding: 0 $gutter-half;
         }
-
         h3 {
           font-weight: bold;
           margin-top: $gutter-half;

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -35,7 +35,7 @@
     }
 
     @include media(tablet) {
-      margin-bottom: $gutter*2;
+      margin-bottom: $gutter * 2;
     }
   }
 
@@ -47,8 +47,8 @@
           float: left;
           width: $one-third;
         }
-          }
-        }
+      }
+    }
     .heading {
       h3 {
         @include heading-36;
@@ -77,7 +77,6 @@
   }
 
   .person-info {
-
     .name-title, .person-detail, .person-profile {
       .inner {
         padding: 0 $gutter-half;
@@ -91,13 +90,17 @@
       img {
         max-width: $full-width;
       }
+
       .info {
         background-color: $grey-3;
         padding-bottom: $gutter-half;
         margin-bottom: $gutter;
-        h3, p {
+
+        h3,
+        p {
           padding: 0 $gutter-half;
         }
+
         h3 {
           font-weight: bold;
           margin-top: $gutter-half;
@@ -115,19 +118,6 @@
           display: block;
           color: $grey-1;
           margin-top: $gutter-one-sixth;
-        }
-      }
-    }
-
-    .person-detail {
-      @include core-19;
-      h3 {
-        font-weight: bold;
-      }
-      p {
-        margin-bottom: $gutter;
-        &.intro {
-          font-weight: bold;
         }
       }
     }

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -23,7 +23,7 @@
     .person-excerpt {
       .inner {
         .image-holder {
-            @include govuk-media-query($until: 'tablet') {
+            @include govuk-media-query($until: tablet) {
               margin-right: govuk-spacing(2);
             }
 
@@ -40,12 +40,6 @@
   }
 
   .foreign-secretaries {
-    .heading, ol {
-      @include media(tablet) {
-        float: left;
-        width: $one-quarter;
-      }
-    }
     ol {
       li {
         list-style: none;
@@ -53,17 +47,8 @@
           float: left;
           width: $one-third;
         }
-        .inner {
-          padding: $gutter-half;
-          h4 {
-            font-weight: bold;
           }
         }
-      }
-      @include media(tablet) {
-        width: 75%; // There's no variable for this in the toolkit yet, needs updating when the toolkit gets updated
-      }
-    }
     .heading {
       h3 {
         @include heading-36;
@@ -172,6 +157,25 @@
   }
 }
 
+// This class should be used on an element that wraps an image to prevent jank
+// (aka that thing where the page jumps around because the image has loaded and
+// now takes up space). For much more information (and a couple of other
+// techniques) take a look at https://css-tricks.com/aspect-ratio-boxes/.
+.aspect-ratio-3\:2 {
+  display: block;
+  height: 0;
+  overflow: hidden;
+  padding: 66% 0 0 0;
+  position: relative;
+
+  img {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+}
 
 .past-foreign-secretaries-menu li {
   border-bottom: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -168,3 +168,8 @@
 
   }
 }
+
+
+.past-foreign-secretaries-menu li {
+  border-bottom: 1px solid $govuk-border-colour;
+}

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -7,7 +7,7 @@
     margin-bottom: $gutter;
     .profiles {
       @include heading-36;
-      border-bottom: $gutter-one-sixth solid $black;
+      border-bottom: $gutter-one-sixth solid govuk-colour("black");
       margin: 0 $gutter-half $gutter-half;
     }
 
@@ -16,13 +16,17 @@
       font-weight: bold;
     }
     .term {
-      @include core-14;
-      color: $grey-1;
+      color: $govuk-secondary-text-colour;
+      display: block;
     }
 
     .person-excerpt {
       .inner {
         .image-holder {
+            @include govuk-media-query($until: 'tablet') {
+              margin-right: govuk-spacing(2);
+            }
+
           img {
             max-width: $full-width;
           }
@@ -79,9 +83,8 @@
 }
 
 
-
 .historic-people-show {
-  .historic-people-list, .person-info {
+  .person-info {
     @include media(tablet) {
       float: left;
       width: $one-quarter;

--- a/app/helpers/past_foreign_secretaries_helper.rb
+++ b/app/helpers/past_foreign_secretaries_helper.rb
@@ -1,7 +1,7 @@
 module PastForeignSecretariesHelper
   def past_foreign_secretary_nav(current_person)
     people = {
-      "edward-wood" => "Edward Frederick Lindley&nbsp;Wood",
+      "edward-wood" => "Edward Frederick Lindley Wood",
       "austen-chamberlain" => "Sir Austen Chamberlain",
       "george-curzon" => "George Nathaniel Curzon",
       "edward-grey" => "Sir Edward Grey",
@@ -14,8 +14,8 @@ module PastForeignSecretariesHelper
     }
     people
       .map { |slug, name|
-        content_tag(:li) do
-          link_to_if(slug == current_person, name.html_safe, past_foreign_secretary_path(id: slug))
+        content_tag(:li, class: "govuk-!-margin-0 govuk-body-s govuk-!-padding-top-2 govuk-!-padding-bottom-2") do
+          link_to_if(slug != current_person, name.html_safe, past_foreign_secretary_path(id: slug), class: "govuk-link  ")
         end
       }
       .join("")

--- a/app/views/past_foreign_secretaries/_information-box.html.erb
+++ b/app/views/past_foreign_secretaries/_information-box.html.erb
@@ -1,0 +1,17 @@
+<div class="person-profile">
+  <div class="inner">
+    <div class="info govuk-!-padding-0">
+      <%= image_tag image, alt: image_alt, loading: "lazy" %>
+      <dl class="govuk-!-padding-3">
+        <dt class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Lived</dt>
+          <dd class="govuk-body-s"><%= lived %></dd>
+        <dt class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Dates in office</dt>
+          <dd class="govuk-body-s"><%= dates_in_office %></dd>
+        <dt class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Political party</dt>
+          <dd class="govuk-body-s"><%= political_party %></dd>
+        <dt class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Interesting facts</dt>
+          <dd class="govuk-body-s govuk-!-margin-bottom-0"><%= interesting_facts.html_safe %></dd>
+      </dl>
+    </div>
+  </div>
+</div>

--- a/app/views/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/past_foreign_secretaries/_show_person.html.erb
@@ -1,24 +1,28 @@
-<header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', histories_path),
-                        heading: "Past Foreign Secretaries",
-                        big: true } %>
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: "History",
+        href: histories_path,
+      },
+      title: "Past Foreign Secretaries",
+    } %>
   </div>
 </header>
 
-<div class="block historic-people-list">
-  <div class="inner-block">
-    <a href="#contents" class="js-showhide contents-toggle">Show past Foreign Secretaries</a>
+<div class="govuk-grid-row">
+  <div class="historic-people-list govuk-grid-column-one-quarter govuk-!-padding-left-3 govuk-!-padding-right-3">
+    <a href="#contents" class="js-showhide contents-toggle govuk-!-margin-bottom-3">Show past Foreign Secretaries</a>
     <div id="contents">
-      <ol>
+      <ul class="govuk-list past-foreign-secretaries-menu govuk-!-margin-bottom-6">
         <%= past_foreign_secretary_nav(current_person) %>
-      </ol>
-      <p><a href="/government/history/past-foreign-secretaries">See all past Foreign Secretaries</a></p>
+      </ul>
+      <p class="govuk-body-s">
+        <a href="/government/history/past-foreign-secretaries" class="govuk-link">See all past Foreign Secretaries</a>
+      </p>
     </div>
   </div>
-</div>
-
-<div class="block person-info">
-  <%= yield %>
+  <div class="govuk-grid-column-three-quarters govuk-!-padding-0 person-info">
+    <%= yield %>
+  </div>
 </div>

--- a/app/views/past_foreign_secretaries/austen_chamberlain.html.erb
+++ b/app/views/past_foreign_secretaries/austen_chamberlain.html.erb
@@ -1,49 +1,46 @@
 <% page_title "History of Sir Austen Chamberlain" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'austen-chamberlain' } do %>
   <div class="name-title">
     <div class="inner">
-      <h2>Sir Austen Chamberlain <span>Foreign Secretary June 1924 to June 1929</span></h2>
+      <h2 class="govuk-heading-m">Sir Austen Chamberlain <span>Foreign Secretary June 1924 to June 1929</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain' %>
-        <h3>Lived</h3>
-        <p>1863 to 1937</p>
-        <h3>Dates in office</h3>
-        <p>June 1924 to June 1929</p>
-        <h3>Political party</h3>
-        <p>Conservative</p>
-        <h3>Interesting facts</h3>
-        <p>A Nobel Peace Prize winner who tried to prevent further war in Europe.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/austen-chamberlain.jpg",
+    image_alt: "Sir Austen Chamberlain",
+    lived: "1863 to 1937",
+    dates_in_office: "June 1924 to June 1929",
+    political_party: "Conservative",
+    interesting_facts: "A Nobel Peace Prize winner who tried to prevent further war in Europe.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">&ldquo;In appearance, costume, method of speech, he seemed almost a survival. His top hat, his eyeglass, his exquisite courtesy and his rotund oratory marked him out from his colleagues.&rdquo;</p>
-      <p>These were the words of one backbencher about Austen Chamberlain, a Conservative statesman and former Foreign Secretary, in his later years. His career was overshadowed firstly by the character of his father, Joseph Chamberlain, a pioneering Lord Mayor of Birmingham and prominent tariff reformer, and later by the &lsquo;peace in our time&rsquo; that his half-brother Neville, Prime Minister between 1937 and 1940, tried to ensure.</p>
-      <h3>The Locarno Pact</h3>
-      <p>Austen Chamberlain, Foreign Secretary in Stanley Baldwin’s Conservative government from 1924 &ndash; 1929, is best remembered as the author of the Locarno Pact of 1925. After the Treaty of Versailles in 1919, Europe was still very unsettled. France regarded Germany as a potential enemy. Germany felt wronged by the treaty &ndash; particularly the &lsquo;war guilt&rsquo; clause. In 1924 the League of Nations was promoting the Geneva Protocol, aimed at strengthening the League and penalising countries going to war, and the French wanted a treaty with the British as protection against Germany. As a Francophile, Chamberlain was in favour of this, but he realised that the government would not support any proposal that increased British commitments.</p>
-      <p>As an alternative to either the Geneva Protocol or an Anglo-French Treaty, Chamberlain put forward the German idea of a Pact of Mutual Guarantee. This meant that a number of neutral countries would intervene with military force if any one of Germany, France or Belgium violated their mutual frontiers. The process aimed to bring Germany back into the diplomatic fold, with a position as council member of the League of Nations. Austen regarded it as a guarantee of peace rather than a commitment.</p>
-      <p>Negotiations were held in the Italian resort of Locarno, on Lake Maggiore, led by Chamberlain. His natural courtesy helped him and he showed great attention to details.   For example, he requested that the table for the Locarno conference should place no country above any other. Most of the negotiating was done in small groups in hotels, &lsquo;tea party diplomacy&rsquo; as it was named, rather than in large groups.</p>
-      <p>As Chamberlain said at the time, Locarno was the beginning of a process. However, many people regarded it as the &lsquo;beginning of the great peace&rsquo;. The atmosphere of the conference was one of hope. Chamberlain, with his characteristic loyalty, remained favourably disposed towards the people present, including Mussolini, for the rest of his life. He emphasised strongly that the good will shown at the conference was evidence of the wish for peace. The treaty was later ratified in the Foreign Office&rsquo;s grandest reception rooms, still known today as the Locarno Suite.</p>
-      <h3>Chamberlain’s overconfidence</h3>
-      <p>Chamberlain had an uneasy relationship with the League of Nations. For example, he insisted on attending league meetings, although attendance was the responsibility of another Foreign Office Minister, Lord Robert Cecil. While his attendance encouraged other European countries to feel that Britain took the League seriously he often seemed condescending. He recognised that the British position was unpopular but was unaware that his own performance contributed to this.</p>
-      <p>Chamberlain was pleased with the generous praise following Locarno but began to see himself as the only person in government able to resolve international disputes with diplomacy.</p>
-      <p>This overconfidence later caused problems, such as when he agreed a disarmament treaty with France in 1928 and announced it in Parliament without agreeing the principle with the Cabinet. The agreement was highly preferential to the French as Austen had let his friend, the French Foreign Minister Aristide Briand, amend it as he wished. However, the treaty was disliked by the Americans and Germans who regarded it as a semi-military agreement.</p>
-      <p>In advocating Locarno, Chamberlain was not primarily concerned with German sensitivities, but with stability in western Europe. His relationship with the Germans was never good, despite his respect for Gustav Stresemann, the German Foreign Minister. This aversion had developed during a visit to Germany as far back as 1887, before he entered politics; he disliked the German character and was concerned that the Germans thought themselves superior. This meant that Austen Chamberlain was one of the first Britons to distrust Hitler.</p>
-      <p>Although Locarno was considered a success at the time, later criticism pointed out that it did not deliver peace. Poland and Czechoslovakia were concerned that the lack of a mutual assurance treaty for their borders amounted to an invitation to invade. Chamberlain had not supported the inclusion of Germany&rsquo;s eastern borders; it was, he said (adapting Bismarck&rsquo;s famous phrase), something for which &ldquo;no British government ever will or ever can risk the bones of a British Grenadier&rdquo;.</p>
-      <h3>The final years in office</h3>
-      <p>Chamberlain was in the Foreign Office for nearly 4 years after Locarno was signed, but had few other notable achievements. His time was taken up with issues outside Europe, in particular China and Egypt. It is not clear whether his interest in politics was ever so strongly engaged again.</p>
-      <p>During the post&ndash;Locarno years his health deteriorated. Diplomatic relations with the Americans, Egyptians, Chinese and Soviets degenerated, although this cannot be wholly attributed to Chamberlain. He left office in 1929 with the change of government, but always wanted to return to the Foreign Office.</p>
-      <p>Austen Chamberlain had a number of strengths, but some of these had unfortunate consequences. He behaved with integrity, but was taken by surprise when others failed to do so. He was intrinsically loyal, but would often back particularly unpopular people, or give too much leeway to people he liked, such as French Foreign Minister Briand. He fostered good relations with the French, who trusted him, but was dismissive of the Americans. His attention to detail included a desire for control that meant that he undermined others, such as his colleague Robert Cecil. In effect, he was very supportive and helpful to friends, but effectively blind to everything and everyone else.</p>    
+      <p class="govuk-body govuk-!-font-weight-bold">&ldquo;In appearance, costume, method of speech, he seemed almost a survival. His top hat, his eyeglass, his exquisite courtesy and his rotund oratory marked him out from his colleagues.&rdquo;</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body">These were the words of one backbencher about Austen Chamberlain, a Conservative statesman and former Foreign Secretary, in his later years. His career was overshadowed firstly by the character of his father, Joseph Chamberlain, a pioneering Lord Mayor of Birmingham and prominent tariff reformer, and later by the &lsquo;peace in our time&rsquo; that his half-brother Neville, Prime Minister between 1937 and 1940, tried to ensure.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The Locarno Pact</h3>
+      <p class="govuk-body">Austen Chamberlain, Foreign Secretary in Stanley Baldwin’s Conservative government from 1924 &ndash; 1929, is best remembered as the author of the Locarno Pact of 1925. After the Treaty of Versailles in 1919, Europe was still very unsettled. France regarded Germany as a potential enemy. Germany felt wronged by the treaty &ndash; particularly the &lsquo;war guilt&rsquo; clause. In 1924 the League of Nations was promoting the Geneva Protocol, aimed at strengthening the League and penalising countries going to war, and the French wanted a treaty with the British as protection against Germany. As a Francophile, Chamberlain was in favour of this, but he realised that the government would not support any proposal that increased British commitments.</p>
+      <p class="govuk-body">As an alternative to either the Geneva Protocol or an Anglo-French Treaty, Chamberlain put forward the German idea of a Pact of Mutual Guarantee. This meant that a number of neutral countries would intervene with military force if any one of Germany, France or Belgium violated their mutual frontiers. The process aimed to bring Germany back into the diplomatic fold, with a position as council member of the League of Nations. Austen regarded it as a guarantee of peace rather than a commitment.</p>
+      <p class="govuk-body">Negotiations were held in the Italian resort of Locarno, on Lake Maggiore, led by Chamberlain. His natural courtesy helped him and he showed great attention to details.   For example, he requested that the table for the Locarno conference should place no country above any other. Most of the negotiating was done in small groups in hotels, &lsquo;tea party diplomacy&rsquo; as it was named, rather than in large groups.</p>
+      <p class="govuk-body">As Chamberlain said at the time, Locarno was the beginning of a process. However, many people regarded it as the &lsquo;beginning of the great peace&rsquo;. The atmosphere of the conference was one of hope. Chamberlain, with his characteristic loyalty, remained favourably disposed towards the people present, including Mussolini, for the rest of his life. He emphasised strongly that the good will shown at the conference was evidence of the wish for peace. The treaty was later ratified in the Foreign Office&rsquo;s grandest reception rooms, still known today as the Locarno Suite.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Chamberlain’s overconfidence</h3>
+      <p class="govuk-body">Chamberlain had an uneasy relationship with the League of Nations. For example, he insisted on attending league meetings, although attendance was the responsibility of another Foreign Office Minister, Lord Robert Cecil. While his attendance encouraged other European countries to feel that Britain took the League seriously he often seemed condescending. He recognised that the British position was unpopular but was unaware that his own performance contributed to this.</p>
+      <p class="govuk-body">Chamberlain was pleased with the generous praise following Locarno but began to see himself as the only person in government able to resolve international disputes with diplomacy.</p>
+      <p class="govuk-body">This overconfidence later caused problems, such as when he agreed a disarmament treaty with France in 1928 and announced it in Parliament without agreeing the principle with the Cabinet. The agreement was highly preferential to the French as Austen had let his friend, the French Foreign Minister Aristide Briand, amend it as he wished. However, the treaty was disliked by the Americans and Germans who regarded it as a semi-military agreement.</p>
+      <p class="govuk-body">In advocating Locarno, Chamberlain was not primarily concerned with German sensitivities, but with stability in western Europe. His relationship with the Germans was never good, despite his respect for Gustav Stresemann, the German Foreign Minister. This aversion had developed during a visit to Germany as far back as 1887, before he entered politics; he disliked the German character and was concerned that the Germans thought themselves superior. This meant that Austen Chamberlain was one of the first Britons to distrust Hitler.</p>
+      <p class="govuk-body">Although Locarno was considered a success at the time, later criticism pointed out that it did not deliver peace. Poland and Czechoslovakia were concerned that the lack of a mutual assurance treaty for their borders amounted to an invitation to invade. Chamberlain had not supported the inclusion of Germany&rsquo;s eastern borders; it was, he said (adapting Bismarck&rsquo;s famous phrase), something for which &ldquo;no British government ever will or ever can risk the bones of a British Grenadier&rdquo;.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The final years in office</h3>
+      <p class="govuk-body">Chamberlain was in the Foreign Office for nearly 4 years after Locarno was signed, but had few other notable achievements. His time was taken up with issues outside Europe, in particular China and Egypt. It is not clear whether his interest in politics was ever so strongly engaged again.</p>
+      <p class="govuk-body">During the post&ndash;Locarno years his health deteriorated. Diplomatic relations with the Americans, Egyptians, Chinese and Soviets degenerated, although this cannot be wholly attributed to Chamberlain. He left office in 1929 with the change of government, but always wanted to return to the Foreign Office.</p>
+      <p class="govuk-body">Austen Chamberlain had a number of strengths, but some of these had unfortunate consequences. He behaved with integrity, but was taken by surprise when others failed to do so. He was intrinsically loyal, but would often back particularly unpopular people, or give too much leeway to people he liked, such as French Foreign Minister Briand. He fostered good relations with the French, who trusted him, but was dismissive of the Americans. His attention to detail included a desire for control that meant that he undermined others, such as his colleague Robert Cecil. In effect, he was very supportive and helpful to friends, but effectively blind to everything and everyone else.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Austen Chamberlain: Gentleman in politics by David Dutton (Ross Anderson Publications, 1985)</li>
         <li>Choose Your Weapons by Douglas Hurd (Orion Books, 2010)</li>
       </ul>

--- a/app/views/past_foreign_secretaries/charles_fox.html.erb
+++ b/app/views/past_foreign_secretaries/charles_fox.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of Charles James Fox" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'charles-fox' } do %>
   <div class="name-title">
@@ -7,37 +7,33 @@
       <h2>Charles James Fox <span>Foreign Secretary March to July 1782, April to December 1783 and February to September 1806</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox' %>
-        <h3>Lived</h3>
-        <p>1749 to 1806</p>
-        <h3>Dates in office</h3>
-        <p>March to July 1782, April to December 1783 and February to September 1806</p>
-        <h3>Political party</h3>
-        <p>Whig</p>
-        <h3>Interesting facts</h3>
-        <p>A brief but brilliant start to the line of Foreign Secretaries.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/charles-james-fox.jpg",
+    image_alt: "Charles James Fox",
+    lived: "1749 to 1806",
+    dates_in_office: "March to July 1782, April to December 1783 and February to September 1806",
+    political_party: "Whig",
+    interesting_facts: "A brief but brilliant start to the line of Foreign Secretaries.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Fox was a gambling addict, womaniser, debtor, and dandy who was forgiven his failings by many because of his defence of civil liberty and his overwhelming charisma. He was Britain's first Foreign Secretary. In fact, he was Secretary of State 3 times, in 1782, 1783 and 1806, but each time he used the position more successfully to fight for a constitutionally stronger Parliament than to achieve foreign policy aims.</p>
-      <p>In 1782, the Foreign Office was a new endeavour, and it was much smaller than it is today. When Fox took the post he had only 13 staff in London, one of whom was a &lsquo;necessary woman&rsquo;- the housekeeper. The total number of consuls and diplomats abroad was not much bigger. The Foreign Office was created because the Northern and Southern Departments that had dealt with home affairs, colonies, and international relations since the 1640s were no longer fit for purpose. George III created the Foreign Office to coordinate international diplomacy and the Home Office to run domestic policy and the British colonies. Fox saw other advantages than administrative necessity. He believed that George had too much power and hoped that the new Secretaries of State could force the king to accept American independence.</p>
-      <p>His hopes were dashed and the new division of powers contributed to Fox's resignation after only 4 months in the post. In April 1782, the cabinet agreed to grant the American colonies independence if they could guarantee France and Spain would not attack the new United States. When negotiations began in Paris, Fox sent Thomas Grenville to talk to the European powers and the Home Secretary, Lord Shelburne, sent Richard Oswald to meet with the Americans. Having 2 envoys with different instructions created complications that Shelburne exploited in an attempt to collapse Prime Minister Lord Rockingham's ministry so that he could lead a new government. When an agreement could not be reached Fox proposed to cabinet that independence should be granted immediately anyway. He was outvoted and decided to resign. In the 4 days between this meeting and his resignation on 4 July, Rockingham died leaving parliament in chaos and Shelburne poised to take power.</p>
-      <h3>After Prime Minister Rockingham’s death</h3>
-      <p>Fox returned to the Foreign Office a few months later as the joint head of an unexpected coalition. His Whig supporters and Lord North&rsquo;s Tories had nothing in common except a hatred of Shelburne but they formed a majority of over 100 so Fox believed that he would be safe from royal interference. He had underestimated George&rsquo;s hatred towards him. George believed Fox was &ldquo;as contemptible as he is odious&rdquo;. He blamed Fox for encouraging the Prince of Wales&rsquo; bad habits and hated Fox&rsquo;s lack of deference to his ministers. In 1783 the coalition introduced an India Bill to the House to stem corruption by replacing the East India Company with a board of commissioners. In November, it passed the House of Commons by 229 to 120 but when it came to the Lords, George bullied bishops and peers into rejecting it. He used this as an excuse to demand the seals of office from North and Fox.</p>
-      <p>When George finally found a prime minister - William Pitt the Younger - he was a 24 year old and without a party. When Fox was told he laughed uproariously and his friends declared it a &lsquo;mince pie administration&rsquo; because it could not last past Christmas. Again, Fox&rsquo;s complacency was misplaced, though no-one could have predicted that Pitt would not leave office for another 18 years.</p>
-      <h3>Fox's return to government</h3>
-      <p>Out of government, Fox found other ways to fill his time. He drank heavily and was a prodigious gambler with debts &lsquo;like Caesar&rsquo;s&rsquo;. Fox was bankrupted twice in the early 1780s and relied on friends and family to support him from then on. One vice he gave up was women. Fox&rsquo;s conquests included Georgiana, Duchess of Devonshire and the Prince of Wales&rsquo; former mistress, Mary &lsquo;Perdita&rsquo; Robinson, but from 1784 he lived with the actress, Elizabeth Armistead, and was loyal to her until his death.</p>
-      <p>By the time Fox returned to government in 1806, he was sick, and sick of politics. He had &lsquo;exulted&rsquo; in the French Revolution only to see France descend into terror and to watch Britain lead 7 years of revolutionary war. He had spent 18 years doggedly defending civil liberties from what he saw as the king's opportunistic attempts to seize more power, disguised as protection against home-grown revolutionaries. Pitt had died in office in January 1806 and Fox felt the absence of his great adversary &ldquo;as if there was something missing in the world - a chasm, a blank that cannot be supplied.&rdquo; He was also physically weakened by cirrhosis of the liver.</p>
-      <p>Despite his weariness, it was Fox who championed the abolition of the slave trade in the House of Commons. He proposed the bill that passed into law in 1807 as the Slave Trade Act. It was the greatest achievement of the &lsquo;Ministry of the Talents&rsquo; though Fox did not live to see it pass. As Foreign Secretary he wanted a lasting peace with France but, despite months of positive indicators from Talleyrand, Napoleon was more interested in establishing his new European order. When Fox died on 13 September 1806 he had not yet achieved either of his most important goals. Given his history, though, it is interesting to speculate how long he would have stayed in the post if he had lived.</p>
+      <p class="govuk-body govuk-!-font-weight-bold">Fox was a gambling addict, womaniser, debtor, and dandy who was forgiven his failings by many because of his defence of civil liberty and his overwhelming charisma. He was Britain's first Foreign Secretary. In fact, he was Secretary of State 3 times, in 1782, 1783 and 1806, but each time he used the position more successfully to fight for a constitutionally stronger Parliament than to achieve foreign policy aims.</p>
+
+      <p class="govuk-body">In 1782, the Foreign Office was a new endeavour, and it was much smaller than it is today. When Fox took the post he had only 13 staff in London, one of whom was a &lsquo;necessary woman&rsquo;- the housekeeper. The total number of consuls and diplomats abroad was not much bigger. The Foreign Office was created because the Northern and Southern Departments that had dealt with home affairs, colonies, and international relations since the 1640s were no longer fit for purpose. George III created the Foreign Office to coordinate international diplomacy and the Home Office to run domestic policy and the British colonies. Fox saw other advantages than administrative necessity. He believed that George had too much power and hoped that the new Secretaries of State could force the king to accept American independence.</p>
+      <p class="govuk-body">His hopes were dashed and the new division of powers contributed to Fox's resignation after only 4 months in the post. In April 1782, the cabinet agreed to grant the American colonies independence if they could guarantee France and Spain would not attack the new United States. When negotiations began in Paris, Fox sent Thomas Grenville to talk to the European powers and the Home Secretary, Lord Shelburne, sent Richard Oswald to meet with the Americans. Having 2 envoys with different instructions created complications that Shelburne exploited in an attempt to collapse Prime Minister Lord Rockingham's ministry so that he could lead a new government. When an agreement could not be reached Fox proposed to cabinet that independence should be granted immediately anyway. He was outvoted and decided to resign. In the 4 days between this meeting and his resignation on 4 July, Rockingham died leaving parliament in chaos and Shelburne poised to take power.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">After Prime Minister Rockingham’s death</h3>
+      <p class="govuk-body">Fox returned to the Foreign Office a few months later as the joint head of an unexpected coalition. His Whig supporters and Lord North&rsquo;s Tories had nothing in common except a hatred of Shelburne but they formed a majority of over 100 so Fox believed that he would be safe from royal interference. He had underestimated George&rsquo;s hatred towards him. George believed Fox was &ldquo;as contemptible as he is odious&rdquo;. He blamed Fox for encouraging the Prince of Wales&rsquo; bad habits and hated Fox&rsquo;s lack of deference to his ministers. In 1783 the coalition introduced an India Bill to the House to stem corruption by replacing the East India Company with a board of commissioners. In November, it passed the House of Commons by 229 to 120 but when it came to the Lords, George bullied bishops and peers into rejecting it. He used this as an excuse to demand the seals of office from North and Fox.</p>
+      <p class="govuk-body">When George finally found a prime minister - William Pitt the Younger - he was a 24 year old and without a party. When Fox was told he laughed uproariously and his friends declared it a &lsquo;mince pie administration&rsquo; because it could not last past Christmas. Again, Fox&rsquo;s complacency was misplaced, though no-one could have predicted that Pitt would not leave office for another 18 years.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Fox's return to government</h3>
+      <p class="govuk-body">Out of government, Fox found other ways to fill his time. He drank heavily and was a prodigious gambler with debts &lsquo;like Caesar&rsquo;s&rsquo;. Fox was bankrupted twice in the early 1780s and relied on friends and family to support him from then on. One vice he gave up was women. Fox&rsquo;s conquests included Georgiana, Duchess of Devonshire and the Prince of Wales&rsquo; former mistress, Mary &lsquo;Perdita&rsquo; Robinson, but from 1784 he lived with the actress, Elizabeth Armistead, and was loyal to her until his death.</p>
+      <p class="govuk-body">By the time Fox returned to government in 1806, he was sick, and sick of politics. He had &lsquo;exulted&rsquo; in the French Revolution only to see France descend into terror and to watch Britain lead 7 years of revolutionary war. He had spent 18 years doggedly defending civil liberties from what he saw as the king's opportunistic attempts to seize more power, disguised as protection against home-grown revolutionaries. Pitt had died in office in January 1806 and Fox felt the absence of his great adversary &ldquo;as if there was something missing in the world - a chasm, a blank that cannot be supplied.&rdquo; He was also physically weakened by cirrhosis of the liver.</p>
+      <p class="govuk-body">Despite his weariness, it was Fox who championed the abolition of the slave trade in the House of Commons. He proposed the bill that passed into law in 1807 as the Slave Trade Act. It was the greatest achievement of the &lsquo;Ministry of the Talents&rsquo; though Fox did not live to see it pass. As Foreign Secretary he wanted a lasting peace with France but, despite months of positive indicators from Talleyrand, Napoleon was more interested in establishing his new European order. When Fox died on 13 September 1806 he had not yet achieved either of his most important goals. Given his history, though, it is interesting to speculate how long he would have stayed in the post if he had lived.</p>
 
 
-      <h3>Further reading</h3>
-      <ul>
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>William Pitt the Younger by W Hague (London, 2005)</li>
         <li>Charles James Fox by L G Mitchell (Oxford, 1997)</li>
         <li>Entry for Charles James Fox in Oxford Dictionary of National Biography by L G Mitchell</li>

--- a/app/views/past_foreign_secretaries/edward_grey.html.erb
+++ b/app/views/past_foreign_secretaries/edward_grey.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of Sir Edward Grey" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'edward-grey' } do %>
   <div class="name-title">
@@ -7,46 +7,44 @@
       <h2>Sir Edward Grey, Viscount Grey of&nbsp;Fallodon <span>Foreign Secretary November 1905 to December 1916</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon' %>
-        <h3>Lived</h3>
-        <p>1862 to 1933</p>
-        <h3>Dates in office</h3>
-        <p>November 1905 to December 1916</p>
-        <h3>Political party</h3>
-        <p>Liberal</p>
-        <h3>Interesting facts</h3>
-        <p>Holds the longest continuous term of any Foreign Secretary.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/sir-edward-grey.jpg",
+    image_alt: "Sir Edward Grey, Viscount Grey of Fallodon",
+    lived: "1862 to 1933",
+    dates_in_office: "November 1905 to December 1916",
+    political_party: "Liberal",
+    interesting_facts: "Holds the longest continuous term of any Foreign Secretary.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Sir Edward Grey set out the main aspects of his foreign policy in a speech made in opposition in October 1905: friendship with the USA, the Anglo-Japanese alliance and the Anglo-French entente. The latter was tested as soon as he took office in December 1905, following the Liberal Party&rsquo;s landslide election victory, when Germany attempted to split the entente over the issue of Morocco. Grey gave strong support to France, and in January 1906 he authorised military conversations which resulted in plans being drawn up to send an expeditionary force to France in the event of war.</p>
-      <p>Grey did not inform the Cabinet of the talks, believing it to be unnecessary as he had given no commitment to the French. But he also knew there was a risk they would not agree and he did not want his authority questioned. Grey belonged to the group of &lsquo;Liberal Imperialists&rsquo; who had supported British action during the Boer War and had not long been reconciled to the rest of the Liberal Party.</p>
-      <h3>An unconventional Foreign Secretary</h3>
-      <p>Grey was not a conventional Foreign Secretary. He disliked travelling &ndash; his first official trip abroad was to France in 1914 &ndash; preferring instead to conduct relations through ambassadors in London. He also hated being in London, away from his north-country pursuits: bird watching, fly-fishing and hill-walking. The job imposed a heavy workload and there were 6 times more papers than usual received by the Foreign Office in the 20 years from 1895.</p>
-      <p>In August 1907 Grey concluded an entente with Russia, settling differences over Tibet, Afghanistan and Persia to improve the security of India. But the agreement was criticised by radicals who saw it as bolstering a reactionary empire.</p>
-      <h3>Maintaining the balance of power in Europe</h3>
-      <p>Grey would later be criticised for not converting the ententes with France and Russia into alliances and also for making the agreements in the first place. His aim was less about securing the Empire and more about maintaining the balance of power in Europe against an increasingly dominant Germany. But his balancing act was subtler than just supporting France against German hegemony. He also sought to prevent France and Russia from being drawn into the German orbit or allowing them to feel they could rely on British support to challenge Germany themselves.</p>
-      <p>Germany saw this balance of power as encirclement but its erratic foreign policy under Wilhelm II did little to help the country's cause. In July 1911 Germany provoked a second Moroccan crisis by sending the gunboat Panther to Agadir. During the crisis details of the 1906 staff talks surfaced, leading to angry exchanges within Cabinet.</p>
-      <p>The seemingly secretive nature of Grey&rsquo;s diplomacy drew criticism from the liberal press and resulted in a &lsquo;Grey must go!&rsquo; campaign. He came under strong pressure from radicals in the Commons and the Cabinet to take a stricter line with Russia over her interference in Persian affairs and to renew conversations with Berlin. Better relations with Germany would allow the government to prioritise spending on new social welfare over the navy.</p>
-      <p>Critics also claimed the Foreign Secretary was too influenced by his officials. Grey took office at a point when Foreign Office clerks had new freedom to advise ministers, and much of their advice was anti-German in tone. However, although Grey was always willing to listen to his officials, on policy direction he was always his own man.</p>
-      <h3>Attempts to reach a settlement with Germany</h3>
-      <p>In February 1912 the Secretary for War, Lord Haldane, was despatched to Berlin to reach a political and naval settlement with Germany. The mission failed. Each country had fundamentally different goals. Germany wanted to secure British neutrality in the event of a European war while Britain wanted an end to the naval race with Germany. Neither side was prepared to make concessions.</p>
-      <p>Instead a naval agreement with France saw Britain agree to safeguard the French north coast in return for France protecting the Mediterranean. This allowed the Royal Navy to concentrate in the North Sea to counter the growing German naval threat. This accommodation, like the renewal of the Japanese alliance in 1911, was intended to reduce costly defence expenditure. Grey and the Cabinet insisted on an exchange of notes, stressing that the agreement did not commit either government to action. But whether a moral, if not legal, obligation had been created would be tested later.</p>
-      <p>Grey recovered his authority and managed to achieve better relations with Germany over minor points. In August 1913 he came to an agreement with Berlin over the future of the Portuguese colonies and in June 1914 Britain finally agreed to join in the Baghdad railway scheme after years of stalled negotiations.</p>
-      <p>His prestige increased further during the Balkan crisis of December 1913. Grey called an ambassadors&rsquo; conference in London &ndash; the last act of the old Concert of Europe &ndash; and worked with Germany to restrain their respective partners to ensure peace. Grey tried to repeat his success following the assassination of Archduke Franz Ferdinand in 1914 but his call for a conference was rejected by Berlin.</p>
-      <h3>The final years in office</h3>
-      <p>During the July crisis of 1914 the crucial question was whether Britain would declare support for France in a war with Germany. Grey threatened to resign rather than see France abandoned but the Cabinet was split on the issue. Criticism that Grey did not align himself firmly and quickly enough with France and Russia to dissuade Germany from going to war credited him with too much decision-making power in Cabinet.</p>
-      <p>Grey warned the German ambassador that he should not believe Britain would stand aside if Germany and France went to war and he rejected a bid from the German Chancellor for British neutrality. But the issue that ultimately brought Britain into the War was one of age-old British national interest-Belgian neutrality.</p>
-      <p>Once the conflict began, Grey was of the view that wartime diplomacy should give way to military considerations. The influence of the Foreign Office declined, matched by a deterioration in Grey&rsquo;s health &ndash; he  was driven almost blind by stress and overwork. He was finally released from the rigours of office in December 1916 by which time he had become the longest continuously serving Foreign Secretary.</p> 
-   
+      <p class="govuk-body govuk-!-font-weight-bold">Sir Edward Grey set out the main aspects of his foreign policy in a speech made in opposition in October 1905: friendship with the USA, the Anglo-Japanese alliance and the Anglo-French entente. The latter was tested as soon as he took office in December 1905, following the Liberal Party&rsquo;s landslide election victory, when Germany attempted to split the entente over the issue of Morocco. Grey gave strong support to France, and in January 1906 he authorised military conversations which resulted in plans being drawn up to send an expeditionary force to France in the event of war.</p>
+      <p class="govuk-body">Grey did not inform the Cabinet of the talks, believing it to be unnecessary as he had given no commitment to the French. But he also knew there was a risk they would not agree and he did not want his authority questioned. Grey belonged to the group of &lsquo;Liberal Imperialists&rsquo; who had supported British action during the Boer War and had not long been reconciled to the rest of the Liberal Party.</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <h3 class="govuk-heading-s govuk-!-margin-0">An unconventional Foreign Secretary</h3>
+      <p class="govuk-body">Grey was not a conventional Foreign Secretary. He disliked travelling &ndash; his first official trip abroad was to France in 1914 &ndash; preferring instead to conduct relations through ambassadors in London. He also hated being in London, away from his north-country pursuits: bird watching, fly-fishing and hill-walking. The job imposed a heavy workload and there were 6 times more papers than usual received by the Foreign Office in the 20 years from 1895.</p>
+      <p class="govuk-body">In August 1907 Grey concluded an entente with Russia, settling differences over Tibet, Afghanistan and Persia to improve the security of India. But the agreement was criticised by radicals who saw it as bolstering a reactionary empire.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Maintaining the balance of power in Europe</h3>
+      <p class="govuk-body">Grey would later be criticised for not converting the ententes with France and Russia into alliances and also for making the agreements in the first place. His aim was less about securing the Empire and more about maintaining the balance of power in Europe against an increasingly dominant Germany. But his balancing act was subtler than just supporting France against German hegemony. He also sought to prevent France and Russia from being drawn into the German orbit or allowing them to feel they could rely on British support to challenge Germany themselves.</p>
+      <p class="govuk-body">Germany saw this balance of power as encirclement but its erratic foreign policy under Wilhelm II did little to help the country's cause. In July 1911 Germany provoked a second Moroccan crisis by sending the gunboat Panther to Agadir. During the crisis details of the 1906 staff talks surfaced, leading to angry exchanges within Cabinet.</p>
+      <p class="govuk-body">The seemingly secretive nature of Grey&rsquo;s diplomacy drew criticism from the liberal press and resulted in a &lsquo;Grey must go!&rsquo; campaign. He came under strong pressure from radicals in the Commons and the Cabinet to take a stricter line with Russia over her interference in Persian affairs and to renew conversations with Berlin. Better relations with Germany would allow the government to prioritise spending on new social welfare over the navy.</p>
+      <p class="govuk-body">Critics also claimed the Foreign Secretary was too influenced by his officials. Grey took office at a point when Foreign Office clerks had new freedom to advise ministers, and much of their advice was anti-German in tone. However, although Grey was always willing to listen to his officials, on policy direction he was always his own man.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Attempts to reach a settlement with Germany</h3>
+      <p class="govuk-body">In February 1912 the Secretary for War, Lord Haldane, was despatched to Berlin to reach a political and naval settlement with Germany. The mission failed. Each country had fundamentally different goals. Germany wanted to secure British neutrality in the event of a European war while Britain wanted an end to the naval race with Germany. Neither side was prepared to make concessions.</p>
+      <p class="govuk-body">Instead a naval agreement with France saw Britain agree to safeguard the French north coast in return for France protecting the Mediterranean. This allowed the Royal Navy to concentrate in the North Sea to counter the growing German naval threat. This accommodation, like the renewal of the Japanese alliance in 1911, was intended to reduce costly defence expenditure. Grey and the Cabinet insisted on an exchange of notes, stressing that the agreement did not commit either government to action. But whether a moral, if not legal, obligation had been created would be tested later.</p>
+      <p class="govuk-body">Grey recovered his authority and managed to achieve better relations with Germany over minor points. In August 1913 he came to an agreement with Berlin over the future of the Portuguese colonies and in June 1914 Britain finally agreed to join in the Baghdad railway scheme after years of stalled negotiations.</p>
+      <p class="govuk-body">His prestige increased further during the Balkan crisis of December 1913. Grey called an ambassadors&rsquo; conference in London &ndash; the last act of the old Concert of Europe &ndash; and worked with Germany to restrain their respective partners to ensure peace. Grey tried to repeat his success following the assassination of Archduke Franz Ferdinand in 1914 but his call for a conference was rejected by Berlin.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The final years in office</h3>
+      <p class="govuk-body">During the July crisis of 1914 the crucial question was whether Britain would declare support for France in a war with Germany. Grey threatened to resign rather than see France abandoned but the Cabinet was split on the issue. Criticism that Grey did not align himself firmly and quickly enough with France and Russia to dissuade Germany from going to war credited him with too much decision-making power in Cabinet.</p>
+      <p class="govuk-body">Grey warned the German ambassador that he should not believe Britain would stand aside if Germany and France went to war and he rejected a bid from the German Chancellor for British neutrality. But the issue that ultimately brought Britain into the War was one of age-old British national interest-Belgian neutrality.</p>
+      <p class="govuk-body">Once the conflict began, Grey was of the view that wartime diplomacy should give way to military considerations. The influence of the Foreign Office declined, matched by a deterioration in Grey&rsquo;s health &ndash; he  was driven almost blind by stress and overwork. He was finally released from the rigours of office in December 1916 by which time he had become the longest continuously serving Foreign Secretary.</p>
+
+
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)</li>
         <li>Sir Edward Grey by Keith Robbins (1971)</li>
         <li>The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)</li>

--- a/app/views/past_foreign_secretaries/edward_wood.html.erb
+++ b/app/views/past_foreign_secretaries/edward_wood.html.erb
@@ -1,47 +1,47 @@
 <% page_title "History of Edward Frederick Lindley Wood" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'edward-wood' } do %>
   <div class="name-title">
     <div class="inner">
-      <h2>Edward Frederick Lindley Wood, Viscount Halifax <span>Foreign Secretary February 1938 to December 1940</span></h2>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        Edward Frederick Lindley Wood, Viscount Halifax
+      </h2>
+      <p class="govuk-body">Foreign Secretary February 1938 to December 1940</p>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax' %>
-        <h3>Lived</h3>
-        <p>1881 to 1959</p>
-        <h3>Dates in office</h3>
-        <p>February 1938 to December 1940</p>
-        <h3>Political party</h3>
-        <p>Conservative</p>
-        <h3>Interesting facts</h3>
-        <p>Nick-named 'the Holy Fox' due to his passion for hunting and his Christian moral outlook</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/viscount-halifax.jpg",
+    image_alt: "Edward Frederick Lindley Wood, Viscount Halifax",
+    lived: "1881 to 1959",
+    dates_in_office: "February 1938 to December 1940",
+    political_party: "Conservative",
+    interesting_facts: "Nick-named 'the Holy Fox' due to his passion for hunting and his Christian moral outlook",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Lord Halifax took over at the Foreign Office following the resignation of Anthony Eden in February 1938. Eden&rsquo;s relations with Prime Minister Neville Chamberlain had reached breaking point over the latter&rsquo;s interference in foreign policy and differences over how best to deal with Germany and Italy.</p>
-      <p>The Prime Minister wrote privately that Halifax was a more congenial colleague: &ldquo;I thank  God for a steady unruffled Foreign Secretary who never causes me any worry&rdquo;. He hoped that Halifax would not become infected with the pessimism and suspicion of Hitler and Mussolini which, in Chamberlain&rsquo;s opinion, some senior Foreign Office officials displayed.</p>
-      <p>Halifax was nicknamed &lsquo;the Holy Fox&rsquo;, reflecting his passion for hunting and his Christian moral outlook. He was a man of great stature, who possessed a rational outlook, calm resolution and a conciliatory manner. His air of aristocratic reserve was accompanied by a shrewd political judgement.</p>
-      <h3>Negotiations with Hitler and Mussolini</h3>
-      <p>Halifax agreed with Chamberlain that it was not worth starting a war to defend the crumbling post&ndash;war Versailles settlement. Both men initially believed that they could find a satisfactory solution to the demands of Hitler and Mussolini through negotiation and concession. But their traditional &lsquo;gentlemanly&rsquo; approach to diplomacy was at odds with the new assertive Fascist leadership and the bullying brinksmanship they practiced.</p>
-      <p>Halifax realised earlier than Chamberlain, but later than others, that Britain would have to stand firm against Nazi demands for territorial aggrandisement. But it came too late to avoid him being cast in 1940 as one of the &lsquo;Guilty Men&rsquo; (in the publication of the same name), held responsible for the war by appeasing fascism.</p>
-      <p>Halifax was no stranger to foreign affairs having deputised for Eden and acted as spokesman in the Lords since 1935. During the crisis resulting from the Hoare-Laval Pact (which gave Italy territorial concessions at the expense of Abyssinia) Halifax had declared the government&rsquo;s moral standing was at stake and called for the Foreign Secretary to resign. In November 1937 he had accepted an invitation, as Master of the Middleton Hunt, from Reichsmarschall Hermann Goering to visit a hunting exhibition in Berlin and to shoot foxes with him in Pomerania. Chamberlain pushed for the visit to be used to make contact with the German leadership and sound-out their intentions.</p>
-      <p>Halifax visited Hitler at his mountain retreat at Berchtesgaden where he nearly mistook the German Chancellor for a footman. He recalled in his memoirs: &ldquo;As I looked out  of the car window, on eye level, I saw in the middle of this swept path a pair of black trousered legs, finishing up in silk socks and pumps. I assumed this was a footman who had come down to help me out of the car and up the steps, and was proceeding in leisurely fashion to get myself out of the car when I heard Von Neurath [the German foreign minister] or somebody throwing a hoarse whisper at my ear of &lsquo;Der F&uuml;hrer, der F&uuml;hrer&rsquo;; and it then dawned upon me that the legs were not the legs of a footman, but of Hitler&rdquo; (Halifax, Fulness of Days, London, 1957).</p>
-      <p>In a 3 hour conversation, Halifax did little to curb Hitler&rsquo;s ambitions towards Austria and Czechoslovakia with his vague talk of ‘possible alterations in the European order which might be destined to come about with the passage of time’.</p>
-      <h3>The Munich crisis</h3>
-      <p>At first Chamberlain continued to dominate foreign affairs and use personal diplomacy to circumvent the normal diplomatic channels. Even with a Foreign Secretary more to his liking, Chamberlain did not take Halifax with him to the Munich conference in September 1938 at which Czechoslovakia was carved up, and after which Chamberlain infamously declared he had secured &lsquo;peace for our time&rsquo;. And at a subsequent mission to Italy to woo Mussolini in January 1939, Halifax played only a secondary role.</p>
-      <p>However during the Munich crisis, conscious as he was of the political mood and public opinion, Halifax&rsquo;s attitude towards Germany hardened. He was consequently instrumental in modifying Chamberlain’s policies. In September 1938 he led the Cabinet in insisting on making fewer concessions to Germany over the Sudetenland. Following Hitler&rsquo;s complete annexation of Czechoslovakia, in March 1939, he pushed for Britain to offer a guarantee of security to Poland. Later that summer Halifax also made Chamberlain reassure France very publicly (if rather belatedly) of British military support should it too be invaded by Germany.</p>
-      <h3>The final years in office</h3>
-      <p>Chamberlain resigned as Prime Minister in May 1940 following the debacle of the Norwegian campaign. Halifax was seen as a leading candidate to replace him but he realised that Churchill would make a superior war leader and, pleading ill-health, withdrew from the race.</p>
-      <p>Halifax remained as Foreign Secretary and has been identified with various peacemaking initiatives in the summer of 1940. Churchill then decided he wanted Eden back as Foreign Secretary and in January 1941 Halifax was persuaded to take up the ambassadorship to Washington. There, after an initially hesitant start, he formed a strong working relationship with President Roosevelt and remained until May 1946.</p>
+      <p class="govuk-body govuk-!-font-weight-bold">Lord Halifax took over at the Foreign Office following the resignation of Anthony Eden in February 1938. Eden&rsquo;s relations with Prime Minister Neville Chamberlain had reached breaking point over the latter&rsquo;s interference in foreign policy and differences over how best to deal with Germany and Italy.</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body">The Prime Minister wrote privately that Halifax was a more congenial colleague: &ldquo;I thank  God for a steady unruffled Foreign Secretary who never causes me any worry&rdquo;. He hoped that Halifax would not become infected with the pessimism and suspicion of Hitler and Mussolini which, in Chamberlain&rsquo;s opinion, some senior Foreign Office officials displayed.</p>
+      <p class="govuk-body">Halifax was nicknamed &lsquo;the Holy Fox&rsquo;, reflecting his passion for hunting and his Christian moral outlook. He was a man of great stature, who possessed a rational outlook, calm resolution and a conciliatory manner. His air of aristocratic reserve was accompanied by a shrewd political judgement.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Negotiations with Hitler and Mussolini</h3>
+      <p class="govuk-body">Halifax agreed with Chamberlain that it was not worth starting a war to defend the crumbling post&ndash;war Versailles settlement. Both men initially believed that they could find a satisfactory solution to the demands of Hitler and Mussolini through negotiation and concession. But their traditional &lsquo;gentlemanly&rsquo; approach to diplomacy was at odds with the new assertive Fascist leadership and the bullying brinksmanship they practiced.</p>
+      <p class="govuk-body">Halifax realised earlier than Chamberlain, but later than others, that Britain would have to stand firm against Nazi demands for territorial aggrandisement. But it came too late to avoid him being cast in 1940 as one of the &lsquo;Guilty Men&rsquo; (in the publication of the same name), held responsible for the war by appeasing fascism.</p>
+      <p class="govuk-body">Halifax was no stranger to foreign affairs having deputised for Eden and acted as spokesman in the Lords since 1935. During the crisis resulting from the Hoare-Laval Pact (which gave Italy territorial concessions at the expense of Abyssinia) Halifax had declared the government&rsquo;s moral standing was at stake and called for the Foreign Secretary to resign. In November 1937 he had accepted an invitation, as Master of the Middleton Hunt, from Reichsmarschall Hermann Goering to visit a hunting exhibition in Berlin and to shoot foxes with him in Pomerania. Chamberlain pushed for the visit to be used to make contact with the German leadership and sound-out their intentions.</p>
+      <p class="govuk-body">Halifax visited Hitler at his mountain retreat at Berchtesgaden where he nearly mistook the German Chancellor for a footman. He recalled in his memoirs: &ldquo;As I looked out  of the car window, on eye level, I saw in the middle of this swept path a pair of black trousered legs, finishing up in silk socks and pumps. I assumed this was a footman who had come down to help me out of the car and up the steps, and was proceeding in leisurely fashion to get myself out of the car when I heard Von Neurath [the German foreign minister] or somebody throwing a hoarse whisper at my ear of &lsquo;Der F&uuml;hrer, der F&uuml;hrer&rsquo;; and it then dawned upon me that the legs were not the legs of a footman, but of Hitler&rdquo; (Halifax, Fulness of Days, London, 1957).</p>
+      <p class="govuk-body">In a 3 hour conversation, Halifax did little to curb Hitler&rsquo;s ambitions towards Austria and Czechoslovakia with his vague talk of ‘possible alterations in the European order which might be destined to come about with the passage of time’.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The Munich crisis</h3>
+      <p class="govuk-body">At first Chamberlain continued to dominate foreign affairs and use personal diplomacy to circumvent the normal diplomatic channels. Even with a Foreign Secretary more to his liking, Chamberlain did not take Halifax with him to the Munich conference in September 1938 at which Czechoslovakia was carved up, and after which Chamberlain infamously declared he had secured &lsquo;peace for our time&rsquo;. And at a subsequent mission to Italy to woo Mussolini in January 1939, Halifax played only a secondary role.</p>
+      <p class="govuk-body">However during the Munich crisis, conscious as he was of the political mood and public opinion, Halifax&rsquo;s attitude towards Germany hardened. He was consequently instrumental in modifying Chamberlain’s policies. In September 1938 he led the Cabinet in insisting on making fewer concessions to Germany over the Sudetenland. Following Hitler&rsquo;s complete annexation of Czechoslovakia, in March 1939, he pushed for Britain to offer a guarantee of security to Poland. Later that summer Halifax also made Chamberlain reassure France very publicly (if rather belatedly) of British military support should it too be invaded by Germany.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The final years in office</h3>
+      <p class="govuk-body">Chamberlain resigned as Prime Minister in May 1940 following the debacle of the Norwegian campaign. Halifax was seen as a leading candidate to replace him but he realised that Churchill would make a superior war leader and, pleading ill-health, withdrew from the race.</p>
+      <p class="govuk-body">Halifax remained as Foreign Secretary and has been identified with various peacemaking initiatives in the summer of 1940. Churchill then decided he wanted Eden back as Foreign Secretary and in January 1941 Halifax was persuaded to take up the ambassadorship to Washington. There, after an initially hesitant start, he formed a strong working relationship with President Roosevelt and remained until May 1946.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Halifax: The Life of Lord Halifax, by The Earl of Birkenhead (London, 1965)</li>
         <li>Chamberlain and the Lost Peace by John Charmley (London, 1989)</li>
         <li>The Holy Fox: A biography of Lord Halifax by Andrew Roberts (Bath, 1991)</li>

--- a/app/views/past_foreign_secretaries/george_curzon.html.erb
+++ b/app/views/past_foreign_secretaries/george_curzon.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of George Nathaniel Curzon" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'george-curzon' } do %>
   <div class="name-title">
@@ -7,41 +7,38 @@
       <h2>George Nathaniel Curzon <span>Foreign Secretary October 1919 to January 1924</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston' %>
-        <h3>Lived</h3>
-        <p>1859 to 1925</p>
-        <h3>Dates in office</h3>
-        <p>October 1919 to January 1924</p>
-        <h3>Political party</h3>
-        <p>Conservative</p>
-        <h3>Interesting facts</h3>
-        <p>A veteran of the &lsquo;Great Game&rsquo; (strategic rivalry and conflict between the British Empire and the Russian Empire for supremacy in Central Asia.)  Curzon was noted for his aristocratic disdain and vitriolic wit</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/george-nathaniel-curzon.jpg",
+    image_alt: "George Nathaniel Curzon, Marquess of Kedleston",
+    lived: "1859 to 1925",
+    dates_in_office: "October 1919 to January 1924",
+    political_party: "Conservative",
+    interesting_facts: "A veteran of the &lsquo;Great Game&rsquo; (strategic rivalry and conflict between the British Empire and the Russian Empire for supremacy in Central Asia.) Curzon was noted for his aristocratic disdain and vitriolic wit.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Curzon is best known for his illustrious career as Viceroy of India (1899 to 1905), and his expertise in Asian affairs was an important influence on his time as Foreign Secretary.</p>
-      <p>Curzon&rsquo;s departure from India in 1905 followed an acrimonious dispute with Lord Kitchener over the organisation of the Indian Army and cast him into the political wilderness for a decade. However, his appointment to Lloyd George&rsquo;s innovative 5-man War Cabinet in December 1916 signalled a return to political prominence. Heavily involved in foreign policy matters throughout the remainder of the war, he was the clear candidate to take charge of the Foreign Office when the incumbent Foreign Secretary, Arthur Balfour, departed with Lloyd George for the Paris Peace Conference in January 1919. In October, he took on the role permanently.</p>
-      <p>The Foreign Office had changed dramatically since Curzon&rsquo;s brief stint as Parliamentary Under&ndash;Secretary for Foreign Affairs between 1895 and 1898. Its autonomy had suffered under the energetic premiership of Lloyd George, while the war effort had increased the involvement of other government departments in foreign affairs. Within the Foreign Office, the reorganisation of departments by geographical area, ending the distinction between political and commercial matters, recognised the increasing close relationship between foreign affairs and other areas such as economic policy.</p>
-      <p>Beyond Whitehall, widespread disillusionment with pre-war diplomatic structures that, at worst, constituted a major cause of the conflict and at best a poor safeguard, then combined with the novel demands of reorganising Europe and beyond. Under the mantra of &lsquo;self-determination&rsquo;, a trend towards &lsquo;open&rsquo; or &lsquo;summit&rsquo; diplomacy that saw the creation of the League of Nations, and 23 international conferences between 1920 and 1922. Lloyd George, like many heads of government, played a major role in this new diplomacy, largely directing European affairs.</p>
-      <h3>Curzon's role at the Foreign Office </h3>
-      <p>To some extent, this suited Curzon. He was a veteran of the &lsquo;Great Game&rsquo; (strategic rivalry and conflict between the British Empire and the Russian Empire for supremacy in Central Asia) who had published accounts of his travels across the Middle East, Central Asia and the Far East while still a young MP in the 1880s and 1890s. His geopolitical outlook &ndash; and his reputation &ndash; was grounded in his knowledge of Asia and British concerns there. Lloyd George's preoccupation with stabilising Europe, which Curzon still saw primarily as a prerequisite for the security of India, gave Curzon latitude to pursue a more traditional imperial policy elsewhere.</p>
-      <p>He was unafraid to exploit the post-war diplomatic environment to this end. Curzon had urged an assertive British stance in the Persian Gulf since his time as Viceroy of India. Now, in nascent Arab nationalism within the political vacuum of the collapsed Ottoman Empire, he saw the potential to create a buffer zone of independent states in the Caucasus and the Middle East, protecting India from a Russian threat only exacerbated by the Bolshevik Revolution.</p>
-      <h3>Curzon's achievements while in office</h3>
-      <p>Curzon personally negotiated an Anglo-Persian Agreement in August 1919 (only to see it fail to be ratified by the Iranians in 1921); oversaw the division of the British Palestinian Mandate to create the Kingdom of Jordan and foresaw the difficulties initiated by the Balfour Declaration; and established an independent Egyptian constitutional monarchy in 1922. He recognised that the discovery of oil gave the Middle East a strategic significance of its own. During the war, he had chaired the Mesopotamian Administration Committee, overseeing British attempts to establish permanent influence after the invasion of Mesopotamia, with precisely this in mind.</p>
-      <h3>Tensions between Curzon and the Prime Minister</h3>
-      <p>Despite having a relatively free hand in Asian affairs, Lloyd George&rsquo;s incursions into foreign policy eventually became so irksome that Curzon repeatedly considered resignation. More personally, Lloyd George resented Curzon&rsquo;s aristocratic heritage, while Curzon&rsquo;s blunt and &lsquo;superior&rsquo; manner and increasingly defensive outlook from the Foreign Office did little to help matters.</p>
-      <p>Appropriately enough, the flashpoint occurred, literally, at the intersection of Europe and Asia. In August 1922, in what would become known as the &lsquo;Chanak Crisis&rsquo;, the Turks, under Mustafa Kemal, advanced against the Greeks occupying Smyrna. Lloyd George reacted belligerently with a threat of military action against the Turks that was at odds with a British public exhausted after the First World War. Curzon, in cooperation with the French, brokered a diplomatic deal to avert war, signed at Mudanya in October 1922. Peace was finally sealed with the Treaty of Lausanne in 1923, the negotiation of which was arguably Curzon&rsquo;s finest hour as Foreign Secretary. The Treaty set the borders of modern Turkey and secured the freedom of the Straits.</p>
-      <h3>The final years in office</h3>
-      <p>The relationship between Curzon and the Prime Minister was beyond repair, but by now others shared his frustration with Lloyd George. Conservative backbenchers voted to end the coalition, forcing Lloyd George to stand down. Andrew Bonar Law formed a new Conservative administration, retaining Curzon as Foreign Secretary, who operated much more independently. After Bonar Law&rsquo;s resignation in May 1923, Curzon was passed over for the job of Prime Minister in favour of Stanley Baldwin. Curzon remained as Foreign Secretary until January 1924, when the Conservative administration left office.</p>  
-   
+      <p class="govuk-body govuk-!-font-weight-bold">Curzon is best known for his illustrious career as Viceroy of India (1899 to 1905), and his expertise in Asian affairs was an important influence on his time as Foreign Secretary.</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body">Curzon&rsquo;s departure from India in 1905 followed an acrimonious dispute with Lord Kitchener over the organisation of the Indian Army and cast him into the political wilderness for a decade. However, his appointment to Lloyd George&rsquo;s innovative 5-man War Cabinet in December 1916 signalled a return to political prominence. Heavily involved in foreign policy matters throughout the remainder of the war, he was the clear candidate to take charge of the Foreign Office when the incumbent Foreign Secretary, Arthur Balfour, departed with Lloyd George for the Paris Peace Conference in January 1919. In October, he took on the role permanently.</p>
+      <p class="govuk-body">The Foreign Office had changed dramatically since Curzon&rsquo;s brief stint as Parliamentary Under&ndash;Secretary for Foreign Affairs between 1895 and 1898. Its autonomy had suffered under the energetic premiership of Lloyd George, while the war effort had increased the involvement of other government departments in foreign affairs. Within the Foreign Office, the reorganisation of departments by geographical area, ending the distinction between political and commercial matters, recognised the increasing close relationship between foreign affairs and other areas such as economic policy.</p>
+      <p class="govuk-body">Beyond Whitehall, widespread disillusionment with pre-war diplomatic structures that, at worst, constituted a major cause of the conflict and at best a poor safeguard, then combined with the novel demands of reorganising Europe and beyond. Under the mantra of &lsquo;self-determination&rsquo;, a trend towards &lsquo;open&rsquo; or &lsquo;summit&rsquo; diplomacy that saw the creation of the League of Nations, and 23 international conferences between 1920 and 1922. Lloyd George, like many heads of government, played a major role in this new diplomacy, largely directing European affairs.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Curzon's role at the Foreign Office </h3>
+      <p class="govuk-body">To some extent, this suited Curzon. He was a veteran of the &lsquo;Great Game&rsquo; (strategic rivalry and conflict between the British Empire and the Russian Empire for supremacy in Central Asia) who had published accounts of his travels across the Middle East, Central Asia and the Far East while still a young MP in the 1880s and 1890s. His geopolitical outlook &ndash; and his reputation &ndash; was grounded in his knowledge of Asia and British concerns there. Lloyd George's preoccupation with stabilising Europe, which Curzon still saw primarily as a prerequisite for the security of India, gave Curzon latitude to pursue a more traditional imperial policy elsewhere.</p>
+      <p class="govuk-body">He was unafraid to exploit the post-war diplomatic environment to this end. Curzon had urged an assertive British stance in the Persian Gulf since his time as Viceroy of India. Now, in nascent Arab nationalism within the political vacuum of the collapsed Ottoman Empire, he saw the potential to create a buffer zone of independent states in the Caucasus and the Middle East, protecting India from a Russian threat only exacerbated by the Bolshevik Revolution.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Curzon's achievements while in office</h3>
+      <p class="govuk-body">Curzon personally negotiated an Anglo-Persian Agreement in August 1919 (only to see it fail to be ratified by the Iranians in 1921); oversaw the division of the British Palestinian Mandate to create the Kingdom of Jordan and foresaw the difficulties initiated by the Balfour Declaration; and established an independent Egyptian constitutional monarchy in 1922. He recognised that the discovery of oil gave the Middle East a strategic significance of its own. During the war, he had chaired the Mesopotamian Administration Committee, overseeing British attempts to establish permanent influence after the invasion of Mesopotamia, with precisely this in mind.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Tensions between Curzon and the Prime Minister</h3>
+      <p class="govuk-body">Despite having a relatively free hand in Asian affairs, Lloyd George&rsquo;s incursions into foreign policy eventually became so irksome that Curzon repeatedly considered resignation. More personally, Lloyd George resented Curzon&rsquo;s aristocratic heritage, while Curzon&rsquo;s blunt and &lsquo;superior&rsquo; manner and increasingly defensive outlook from the Foreign Office did little to help matters.</p>
+      <p class="govuk-body">Appropriately enough, the flashpoint occurred, literally, at the intersection of Europe and Asia. In August 1922, in what would become known as the &lsquo;Chanak Crisis&rsquo;, the Turks, under Mustafa Kemal, advanced against the Greeks occupying Smyrna. Lloyd George reacted belligerently with a threat of military action against the Turks that was at odds with a British public exhausted after the First World War. Curzon, in cooperation with the French, brokered a diplomatic deal to avert war, signed at Mudanya in October 1922. Peace was finally sealed with the Treaty of Lausanne in 1923, the negotiation of which was arguably Curzon&rsquo;s finest hour as Foreign Secretary. The Treaty set the borders of modern Turkey and secured the freedom of the Straits.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The final years in office</h3>
+      <p class="govuk-body">The relationship between Curzon and the Prime Minister was beyond repair, but by now others shared his frustration with Lloyd George. Conservative backbenchers voted to end the coalition, forcing Lloyd George to stand down. Andrew Bonar Law formed a new Conservative administration, retaining Curzon as Foreign Secretary, who operated much more independently. After Bonar Law&rsquo;s resignation in May 1923, Curzon was passed over for the job of Prime Minister in favour of Stanley Baldwin. Curzon remained as Foreign Secretary until January 1924, when the Conservative administration left office.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Curzon and British Imperialism in the Middle East, 1916-19 by John Fisher, (London, 1999)</li>
         <li>Curzon by David Gilmour (London, 1994)</li>
         <li>Lord Curzon: The Last of the British Moguls by Nayana Goradia (Oxford, 1993)</li>

--- a/app/views/past_foreign_secretaries/george_gordon.html.erb
+++ b/app/views/past_foreign_secretaries/george_gordon.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of George Hamilton Gordon" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'george-gordon' } do %>
   <div class="name-title">
@@ -7,39 +7,35 @@
       <h2>George Hamilton Gordon, Earl of Aberdeen <span>Foreign Secretary May 1828 to November 1830 and September 1841 to July 1846</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen' %>
-        <h3>Lived</h3>
-        <p>1784 to 1860</p>
-        <h3>Dates in office</h3>
-        <p>May 1828 to November 1830 and September 1841 to July 1846</p>
-        <h3>Political party</h3>
-        <p>Conservative/ Peelite</p>
-        <h3>Interesting facts</h3>
-        <p>A quiet, serious Scot and a great favourite of Queen Victoria.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/lord-aberdeen.jpg",
+    image_alt: "George Hamilton Gordon, Earl of Aberdeen",
+    lived: "1784 to 1860",
+    dates_in_office: "May 1828 to November 1830 and September 1841 to July 1846",
+    political_party: "Conservative / Peelite",
+    interesting_facts: "A quiet, serious Scot and a great favourite of Queen Victoria.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Lord Aberdeen is a contradiction, in some ways he can be seen as a tragic figure of the Romantic period. He was a cousin of Byron, his wife and first 4 children predeceased him and he died unhappy at his inability to prevent the Crimean war. On the other hand he was a phlegmatic and unemotional Classicist.</p>
-      <p>He served 2 terms as Foreign Secretary, both times followed by Viscount Palmerston, with whom he is often contrasted. At 14, as an orphan, he exercised his right under Scottish law to select his guardians. One of these was William Pitt and it was under Pitt&rsquo;s influence that he entered politics.</p>
-      <h3>First term in office</h3>
-      <p>His first appointment as Foreign Secretary was under the Duke of Wellington. The issues he inherited made a significant portfolio for any Foreign Secretary &ndash; securing Greek independence, dealing with the latest war between Russia and Turkey, handling Anglo-French and Anglo-American relations, and tackling international slave trafficking. He faced many of these issues again in his second term.</p>
-      <p>Wellington regularly intervened in foreign policy affairs. While Aberdeen supported him publicly, he often privately disagreed and occasionally told Wellington so, such as about Russian intentions in Turkey. The most recent Russian-Turkish war (1828 to 1829) started before Aberdeen took office. It ended with the Treaty of Adrianople. Although the Turks signed it, with British encouragement, it was commonly considered unsatisfactory as it gave Russia access to the mouth of the Danube and commercial access to the Dardanelles at a time when there was concern about Russian expansionism.</p>
-      <h3>Second term in office</h3>
-      <p>Aberdeen was more successful in his second term in office. As Foreign Secretary he improved diplomatic relations with France, mainly due to his (initially) good personal relationship with the French Ambassador, Francois Guizot. Throughout his career, where Aberdeen held good relations with foreign diplomats, such as Guizot or Count Lieven of Russia, people questioned whether the relationship was too close and whether this affected his judgement. One domestic question that occasionally raised concerns was with Queen Victoria, who liked him, although he often diplomatically ignored her suggestions about foreign affairs.</p>
-      <p>A common criticism of Aberdeen by his contemporaries was that he was a pacifist, not a popular stance in the 19th century. This was not exactly accurate. Although he had acquired a strong dislike of war when he saw the carnage following the Battle of the Nations at Leipzig in 1813, later on in the role of Prime Minister he led the country into the Crimean War, albeit reluctantly. Ironically, it was this decision that ultimately caused him to resign the premiership, following questions from parliament into the conduct of the war.</p>
-      <p>Relations with the US in 1841 were strained. Both the Americans and the French resented Britain&rsquo;s stop and search policy at sea. Although this was intended to stop the transportation of slaves it was perceived as a means of ensuring that Britain continued to rule the waves. There were other issues of contention with America. Canadian rebels on the border with America had set fire to an American ship (the Caroline) and sent it over Niagara Falls. Another sensitive issue was where a group of slaves on a ship (the Creole) bound for Louisiana mutinied and killed the captain, near the British Bahamas. The Bahamian government were asked to hold the murderer, but they released the other slaves as Britain did not recognise slavery. All of these issues had to be treated sensitively because they were seen as matters of sovereignty.</p>
-      <p>Aberdeen was not a strong negotiator &ndash; he couldn't bluff. As Baron Brunow said about him: &ldquo;what he says is solid, true and carries the seal of integrity&rdquo;. So Aberdeen appointed Lord Ashburton, a better negotiator, and sent him to America. His negotiations lead to settlements on the border with Canada and an understanding with America about extradition.</p>
-      <h3>Legacy as Foreign Secretary</h3>
-      <p>Many of Aberdeen&rsquo;s achievements either as Foreign Secretary, or later as Prime Minister, were not valued in his lifetime. He faced significant opposition from Palmerston, and criticism from the Earl of Ellenborough (who wanted to be Foreign Secretary). His reputation was further damaged by Lane&ndash;Poole&rsquo;s biography of Stratford Canning, the influential Ambassador to Constantinople, over Greek independence in 1828. The government&rsquo;s position changed during the course of the independence negotiations, but Aberdeen did not clearly inform Canning until it was too late to change course.</p>
-      <p>The treaties negotiated during his terms as Foreign Secretary, were seen as flawed, especially those with America because they give away too much Canadian territory. His speeches were not memorable or highly regarded. In fact he was a particularly bad public speaker, often inaudible, even when he held strong opinions on the policy in question. What he achieved was an improvement in foreign relations with America and France (at least initially).</p>
-   
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body govuk-!-font-weight-bold">Lord Aberdeen is a contradiction, in some ways he can be seen as a tragic figure of the Romantic period. He was a cousin of Byron, his wife and first 4 children predeceased him and he died unhappy at his inability to prevent the Crimean war. On the other hand he was a phlegmatic and unemotional Classicist.</p>
+      <p class="govuk-link">He served 2 terms as Foreign Secretary, both times followed by Viscount Palmerston, with whom he is often contrasted. At 14, as an orphan, he exercised his right under Scottish law to select his guardians. One of these was William Pitt and it was under Pitt&rsquo;s influence that he entered politics.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">First term in office</h3>
+      <p class="govuk-link">His first appointment as Foreign Secretary was under the Duke of Wellington. The issues he inherited made a significant portfolio for any Foreign Secretary &ndash; securing Greek independence, dealing with the latest war between Russia and Turkey, handling Anglo-French and Anglo-American relations, and tackling international slave trafficking. He faced many of these issues again in his second term.</p>
+      <p class="govuk-link">Wellington regularly intervened in foreign policy affairs. While Aberdeen supported him publicly, he often privately disagreed and occasionally told Wellington so, such as about Russian intentions in Turkey. The most recent Russian-Turkish war (1828 to 1829) started before Aberdeen took office. It ended with the Treaty of Adrianople. Although the Turks signed it, with British encouragement, it was commonly considered unsatisfactory as it gave Russia access to the mouth of the Danube and commercial access to the Dardanelles at a time when there was concern about Russian expansionism.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Second term in office</h3>
+      <p class="govuk-link">Aberdeen was more successful in his second term in office. As Foreign Secretary he improved diplomatic relations with France, mainly due to his (initially) good personal relationship with the French Ambassador, Francois Guizot. Throughout his career, where Aberdeen held good relations with foreign diplomats, such as Guizot or Count Lieven of Russia, people questioned whether the relationship was too close and whether this affected his judgement. One domestic question that occasionally raised concerns was with Queen Victoria, who liked him, although he often diplomatically ignored her suggestions about foreign affairs.</p>
+      <p class="govuk-link">A common criticism of Aberdeen by his contemporaries was that he was a pacifist, not a popular stance in the 19th century. This was not exactly accurate. Although he had acquired a strong dislike of war when he saw the carnage following the Battle of the Nations at Leipzig in 1813, later on in the role of Prime Minister he led the country into the Crimean War, albeit reluctantly. Ironically, it was this decision that ultimately caused him to resign the premiership, following questions from parliament into the conduct of the war.</p>
+      <p class="govuk-link">Relations with the US in 1841 were strained. Both the Americans and the French resented Britain&rsquo;s stop and search policy at sea. Although this was intended to stop the transportation of slaves it was perceived as a means of ensuring that Britain continued to rule the waves. There were other issues of contention with America. Canadian rebels on the border with America had set fire to an American ship (the Caroline) and sent it over Niagara Falls. Another sensitive issue was where a group of slaves on a ship (the Creole) bound for Louisiana mutinied and killed the captain, near the British Bahamas. The Bahamian government were asked to hold the murderer, but they released the other slaves as Britain did not recognise slavery. All of these issues had to be treated sensitively because they were seen as matters of sovereignty.</p>
+      <p class="govuk-link">Aberdeen was not a strong negotiator &ndash; he couldn't bluff. As Baron Brunow said about him: &ldquo;what he says is solid, true and carries the seal of integrity&rdquo;. So Aberdeen appointed Lord Ashburton, a better negotiator, and sent him to America. His negotiations lead to settlements on the border with Canada and an understanding with America about extradition.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Legacy as Foreign Secretary</h3>
+      <p class="govuk-link">Many of Aberdeen&rsquo;s achievements either as Foreign Secretary, or later as Prime Minister, were not valued in his lifetime. He faced significant opposition from Palmerston, and criticism from the Earl of Ellenborough (who wanted to be Foreign Secretary). His reputation was further damaged by Lane&ndash;Poole&rsquo;s biography of Stratford Canning, the influential Ambassador to Constantinople, over Greek independence in 1828. The government&rsquo;s position changed during the course of the independence negotiations, but Aberdeen did not clearly inform Canning until it was too late to change course.</p>
+      <p class="govuk-link">The treaties negotiated during his terms as Foreign Secretary, were seen as flawed, especially those with America because they give away too much Canadian territory. His speeches were not memorable or highly regarded. In fact he was a particularly bad public speaker, often inaudible, even when he held strong opinions on the policy in question. What he achieved was an improvement in foreign relations with America and France (at least initially).</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Lord Aberdeen, a political biography by Muriel Chamberlain (Longman Group Limited, 1983)</li>
         <li>Choose Your Weapons by Douglas Hurd (Orion Books, 2010)</li>
       </ul>

--- a/app/views/past_foreign_secretaries/george_gower.html.erb
+++ b/app/views/past_foreign_secretaries/george_gower.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of George Leveson Gower" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'george-gower' } do %>
   <div class="name-title">
@@ -7,39 +7,36 @@
       <h2>George Leveson Gower, Earl Granville <span>Foreign Secretary December 1851 to February 1852, July 1870 to February 1874 and April 1880 to June 1885</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville' %>
-        <h3>Lived</h3>
-        <p>1815 to 1891</p>
-        <h3>Dates in office</h3>
-        <p>December 1851 to February 1852, July 1870 to February 1874 and April 1880 to June 1885</p>
-        <h3>Political party</h3>
-        <p>Whig</p>
-        <h3>Interesting facts</h3>
-        <p>The first of the 3 Whig Earls' (Granville, Clarendon, Rosebery) at the Foreign Office.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/earl-granville.jpg",
+    image_alt: "George Leveson Gower, Earl Granville",
+    lived: "1815 to 1891",
+    dates_in_office: "December 1851 to February 1852, July 1870 to February 1874 and April 1880 to June 1885",
+    political_party: "Whig",
+    interesting_facts: "The first of the three Whig Earls' (Granville, Clarendon, Rosebery) at the Foreign Office.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Granville had 3 stints as Foreign Secretary. The first term lasted a little under 3 months but it was enough time for Granville to draw up a memorandum on principles of foreign policy, at the request of Queen Victoria. In it he placed emphasis on the need for tact and discretion in matters abroad &ndash; in contrast to what he considered to be the overbearing approach of Palmerston &ndash; and the desirability of steering a middle course between meddling &lsquo;intervention&rsquo; in the affairs of other states and allowing British interests to go by default.</p>
-      <p>Granville was appointed Foreign Secretary for the second time in July 1870 after the death of Lord Clarendon. This was partly through his increasingly close friendship with Gladstone, and partly through a lack of more suitable candidates. Despite reassurances from his permanent under-secretary, Edmund Hammond, on his first day in the job that (apart from the growing tension between France and Prussia) he &lsquo;had never known so long a lull in foreign affairs&rsquo;, Granville&rsquo;s time in office turned out to be frequently trying.</p>
-      <h3>Franco-Prussian War</h3>
-      <p>He was confronted almost immediately with the outbreak of the Franco-Prussian War and, having fulfilled Britain's obligation to preserve neutrality for Belgium, Granville ensured Britain played no further part in the conflict. Russia took advantage of the international situation to repeal the conditions imposed at the end of the Crimean War to neutralise the Black Sea. At a London conference in January 1871 Granville could do little more than put a diplomatic gloss on this fait accompli. Russia continued to cause trouble in Central Asia. Granville negotiated for a neutral zone between the Russian frontier and Afghanistan but when Russia permanently occupied Khiva, within the zone, in 1873 Britain could take no effective action to prevent it.</p>
-      <p>Granville did succeed in re-establishing good relations with America which had been strained by the Civil War. He settled a dispute over the Alabama, a cruiser built in Britain for the Confederates, but only by agreeing to send the case to international arbitration and eventually paying &pound;300,000 in compensation.</p> 
-      <p>When the Liberals returned to power in 1880 Granville was instrumental in persuading Gladstone to return to No. 10, in spite of rumours of his own potential for the premiership. The friendship between the two was strong and Granville sometimes deputised for Gladstone.</p>
-      <h3>Granville's third term as Foreign Secretary</h3>
-      <p>As Granville took on the role of Foreign Secretary for the third and final time he inherited a war with Afghanistan, which he ended by agreeing with the Emir that Britain would direct Afghan foreign policy but not interfere in internal affairs.</p>
-      <p>In 1882 he acquiesced in the occupation of Egypt by the British army, a measure thought necessary to protect the route to India, through the Suez Canal, from increasing nationalist agitation. A treaty concluded with Portugal over the fate of the Congo in 1884 proved unpopular with other European nations and led to the Berlin West Africa Conference which sparked the European &lsquo;scramble for Africa&rsquo;.</p>
-      <p>This increased the workload of departments like the newly-created Consular and African department. In the 20 years in which Granville held the post the number of despatches entering the Foreign Office rose from 17,000 to 70,000 per year.</p>
-      <h3>The final years in office</h3>
-      <p>It was said that Granville's handwriting was unclear, his French perfect, his policy patchy. He was never quite allowed to be his own man &ndash; Gladstone always had his own view of how foreign policy should be run. But Granville also lacked an understanding of the changing European dynamic, following the Franco-Prussian War, and the new competitive spirit in international affairs, typified by the rush for colonies in Africa, which made his approach to foreign affairs lack vigour and drive.</p>
-      <p>Granville&rsquo;s career faded disappointingly in 1885 as the public laid the blame for both the loss of the Sudan and the death of the hugely popular General Gordon at his feet. When Gladstone&rsquo;s government returned briefly to power in 1886 he was only offered the Colonial Office.</p> 
-   
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body govuk-!-font-weight-bold">Granville had 3 stints as Foreign Secretary. The first term lasted a little under 3 months but it was enough time for Granville to draw up a memorandum on principles of foreign policy, at the request of Queen Victoria. In it he placed emphasis on the need for tact and discretion in matters abroad &ndash; in contrast to what he considered to be the overbearing approach of Palmerston &ndash; and the desirability of steering a middle course between meddling &lsquo;intervention&rsquo; in the affairs of other states and allowing British interests to go by default.</p>
+
+      <p class="govuk-body">Granville was appointed Foreign Secretary for the second time in July 1870 after the death of Lord Clarendon. This was partly through his increasingly close friendship with Gladstone, and partly through a lack of more suitable candidates. Despite reassurances from his permanent under-secretary, Edmund Hammond, on his first day in the job that (apart from the growing tension between France and Prussia) he &lsquo;had never known so long a lull in foreign affairs&rsquo;, Granville&rsquo;s time in office turned out to be frequently trying.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Franco-Prussian War</h3>
+      <p class="govuk-body">He was confronted almost immediately with the outbreak of the Franco-Prussian War and, having fulfilled Britain's obligation to preserve neutrality for Belgium, Granville ensured Britain played no further part in the conflict. Russia took advantage of the international situation to repeal the conditions imposed at the end of the Crimean War to neutralise the Black Sea. At a London conference in January 1871 Granville could do little more than put a diplomatic gloss on this fait accompli. Russia continued to cause trouble in Central Asia. Granville negotiated for a neutral zone between the Russian frontier and Afghanistan but when Russia permanently occupied Khiva, within the zone, in 1873 Britain could take no effective action to prevent it.</p>
+      <p class="govuk-body">Granville did succeed in re-establishing good relations with America which had been strained by the Civil War. He settled a dispute over the Alabama, a cruiser built in Britain for the Confederates, but only by agreeing to send the case to international arbitration and eventually paying &pound;300,000 in compensation.</p>
+      <p class="govuk-body">When the Liberals returned to power in 1880 Granville was instrumental in persuading Gladstone to return to No. 10, in spite of rumours of his own potential for the premiership. The friendship between the two was strong and Granville sometimes deputised for Gladstone.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Granville's third term as Foreign Secretary</h3>
+      <p class="govuk-body">As Granville took on the role of Foreign Secretary for the third and final time he inherited a war with Afghanistan, which he ended by agreeing with the Emir that Britain would direct Afghan foreign policy but not interfere in internal affairs.</p>
+      <p class="govuk-body">In 1882 he acquiesced in the occupation of Egypt by the British army, a measure thought necessary to protect the route to India, through the Suez Canal, from increasing nationalist agitation. A treaty concluded with Portugal over the fate of the Congo in 1884 proved unpopular with other European nations and led to the Berlin West Africa Conference which sparked the European &lsquo;scramble for Africa&rsquo;.</p>
+      <p class="govuk-body">This increased the workload of departments like the newly-created Consular and African department. In the 20 years in which Granville held the post the number of despatches entering the Foreign Office rose from 17,000 to 70,000 per year.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">The final years in office</h3>
+      <p class="govuk-body">It was said that Granville's handwriting was unclear, his French perfect, his policy patchy. He was never quite allowed to be his own man &ndash; Gladstone always had his own view of how foreign policy should be run. But Granville also lacked an understanding of the changing European dynamic, following the Franco-Prussian War, and the new competitive spirit in international affairs, typified by the rush for colonies in Africa, which made his approach to foreign affairs lack vigour and drive.</p>
+      <p class="govuk-body">Granville&rsquo;s career faded disappointingly in 1885 as the public laid the blame for both the loss of the Sudan and the death of the hugely popular General Gordon at his feet. When Gladstone&rsquo;s government returned briefly to power in 1886 he was only offered the Colonial Office.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>entry for Granville George Leveson Gower in Oxford Dictionary of National Biography  by ME Chamberlain (Oxford University Press, 2004–10)</li>
         <li>The Life of Granville George Leveson Gower, Second Earl Granville, 2 vols by Lord Edmund Fitzmaurice (Longmans, Green, &amp; Co., 1905)</li>
       </ul>

--- a/app/views/past_foreign_secretaries/henry_petty_fitzmaurice.html.erb
+++ b/app/views/past_foreign_secretaries/henry_petty_fitzmaurice.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of Henry Petty–Fitzmaurice" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'henry-petty-fitzmaurice' } do %>
   <div class="name-title">
@@ -7,43 +7,39 @@
       <h2>Henry Petty-Fitzmaurice, Marquess of Lansdowne <span>Foreign Secretary November 1900 to December 1905</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne' %>
-        <h3>Lived</h3>
-        <p>1845 to 1927</p>
-        <h3>Dates in office</h3>
-        <p>November 1905 to December 1916</p>
-        <h3>Political party</h3>
-        <p>Liberal Unionist</p>
-        <h3>Interesting facts</h3>
-        <p>He presided over a diplomatic revolution by concluding the Anglo-Japanese alliance and the Anglo-French Entente.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/lord-landsowne.jpg",
+    image_alt: "Henry Petty-Fitzmaurice, Marquess of Lansdowne",
+    lived: "1845 to 1927",
+    dates_in_office: "November 1905 to December 1916",
+    political_party: "Liberal Unionist",
+    interesting_facts: "He presided over a diplomatic revolution by concluding the Anglo-Japanese alliance and the Anglo-French Entente.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">In November 1900 Lord Salisbury relinquished his dual role as Prime Minister and Foreign Secretary and Lord Lansdowne took over at the Foreign Office. It was an uneasy time for Britain. The prevailing orthodoxy in foreign policy was to steer clear of entangling alliances with foreign powers. As colonial rivalries increased towards the end of the 19th century Britain was left isolated and exposed.</p>
-      <p>As War Secretary (1895 to 1900), during the campaign against the Boers, Lansdowne saw at first hand the military weakness of the empire, and a spell as viceroy of India (1888 to 1894) brought home to him the Russian threat to British interests in the East. Consequently Lansdowne sought a diplomatic realignment in favour of a series of accommodations and alliances aimed at shoring up Britain's imperial position.</p>
-      <p>This began in 1901 with the Hay-Pauncefote treaty which cultivated friendship with the United States by recognising their supremacy in Western waters. In the same year Lansdowne attempted to reach an understanding with Germany, and a draft agreement was prepared, but neither party could agree on final terms. It also met with disapproval from Lord Salisbury who, until he retired from public life in 1902, still exerted an influence over foreign affairs.</p>
-      <p>In January 1902 Lansdowne concluded that an alliance with Japan to improve imperial security against Russia and relieve pressure on the Royal Navy in the Far East was needed. The treaty committed each party to come to the other's aid if attacked by more than 1 country. Lansdowne was lucky the treaty did not drag Britain into the Russo-Japanese War which broke out in February 1904. Instead, Japan's surprising single-handed victories checked Russian ambition and meant Britain now had a powerful ally in the Far East.</p>
-      <h3>Achievements in office</h3>
-      <p>Lansdowne's main achievement came with the signing of the entente cordiale with France in April 1904. Edward VII's visit to Paris in May 1903, where the king won over an indifferent French public, helped produce an atmosphere conducive to negotiations. The agreement settled old colonial differences ranging from the Newfoundland fisheries to the independence of Siam (now Thailand). Britain agreed to support French ambitions in Morocco in return for French recognition of British predominance in Egypt.</p>
-      <p>Lansdowne's tact and patience made him an excellent negotiator and he was skilful in his handling of diplomats. His social standing allowed him to move easily in diplomatic circles and he inspired confidence amongst foreign representatives.</p>
-      <p>The entente was not intended to have a European dimension but the direction in which the settlement would pull Britain soon became clear. In March 1905 the Kaiser sailed into Tangiers and declared he would not accept any agreement over the future of Morocco made without his consent. The Moroccan Crisis, as it became known, threatened the basis for the entente and general European peace.</p>
-      <p>Lansdowne wanted to support France but also to contain the situation. He warned the German ambassador that if war broke out between France and Germany British public opinion might make it impossible for the government to stand aside. Fearful that France might try to reach a separate deal with Germany, Lansdowne told Cambon, the French ambassador, that both countries should keep each other fully informed and discuss in advance any contingencies they might face. Cambon took this as a desire to co-ordinate policy, even to move towards an alliance.</p>
-      <h3>Lansdowne's upbringing and personality</h3>
-      <p>The key to Lansdowne's handling of foreign affairs can be found in his upbringing. He came from one of the great Whig families and spent his life in public service, almost as a hereditary right. His patrician self-confidence meant he took a detached and unemotional approach to foreign policy. He was never obsessed by Russian strength, like many of his Tory colleagues, nor was he infected with the Germanophobia found in some of his Foreign Office staff. The jingoistic press exasperated him and he was constantly disappointed when anti-German outbursts, which he always viewed with distaste, kept Britain from taking part in the Berlin-Baghdad railway project.</p>
-      <p>Lansdowne was not dogmatic in his approach to policy but remained flexible and ready to adapt to circumstances. He brought a level-headedness to the increasingly fractious arena of European foreign politics and remained cool in a crisis. He steered clear of war during the &lsquo;Dogger Bank incident&rsquo; of 1904, when Russian warships sank British fishing boats in the North Sea and the country clamoured for redress.</p>
-      <p>As head of the Foreign Office Lansdowne showed a willingness to listen to and take advice from his senior officials. He approved reforms to modernise the Foreign Office machinery, which would eventually free clerks from the drudgery of administration and give them more scope to engage in the process of policy formulation. He also supported an inter-departmental committee to reorganise the Consular Service.</p>
-      <h3>Leaving office</h3>
-      <p>Lansdowne left office in December 1905 along with the Tory government. In August he had agreed a new treaty with Japan, which became operative against only one power and obliged Japan to defend India. Lansdowne had been successful in his aim of achieving greater security for Britain's imperial position.</p>
-      <p>However this success brought its own problems. Although intended as a colonial settlement the entente pulled Britain further into European affairs. Lansdowne&rsquo;s success in bringing Britain out of isolation was achieved at the unintended cost of increasing Germany&rsquo;s own sense of isolation within Europe. Germany now replaced Russia as Britain&rsquo;s main cause for concern in foreign affairs.</p>  
-   
+      <p class="govuk-body govuk-!-font-weight-bold">In November 1900 Lord Salisbury relinquished his dual role as Prime Minister and Foreign Secretary and Lord Lansdowne took over at the Foreign Office. It was an uneasy time for Britain. The prevailing orthodoxy in foreign policy was to steer clear of entangling alliances with foreign powers. As colonial rivalries increased towards the end of the 19th century Britain was left isolated and exposed.</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body">As War Secretary (1895 to 1900), during the campaign against the Boers, Lansdowne saw at first hand the military weakness of the empire, and a spell as viceroy of India (1888 to 1894) brought home to him the Russian threat to British interests in the East. Consequently Lansdowne sought a diplomatic realignment in favour of a series of accommodations and alliances aimed at shoring up Britain's imperial position.</p>
+      <p class="govuk-body">This began in 1901 with the Hay-Pauncefote treaty which cultivated friendship with the United States by recognising their supremacy in Western waters. In the same year Lansdowne attempted to reach an understanding with Germany, and a draft agreement was prepared, but neither party could agree on final terms. It also met with disapproval from Lord Salisbury who, until he retired from public life in 1902, still exerted an influence over foreign affairs.</p>
+      <p class="govuk-body">In January 1902 Lansdowne concluded that an alliance with Japan to improve imperial security against Russia and relieve pressure on the Royal Navy in the Far East was needed. The treaty committed each party to come to the other's aid if attacked by more than 1 country. Lansdowne was lucky the treaty did not drag Britain into the Russo-Japanese War which broke out in February 1904. Instead, Japan's surprising single-handed victories checked Russian ambition and meant Britain now had a powerful ally in the Far East.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Achievements in office</h3>
+      <p class="govuk-body">Lansdowne's main achievement came with the signing of the entente cordiale with France in April 1904. Edward VII's visit to Paris in May 1903, where the king won over an indifferent French public, helped produce an atmosphere conducive to negotiations. The agreement settled old colonial differences ranging from the Newfoundland fisheries to the independence of Siam (now Thailand). Britain agreed to support French ambitions in Morocco in return for French recognition of British predominance in Egypt.</p>
+      <p class="govuk-body">Lansdowne's tact and patience made him an excellent negotiator and he was skilful in his handling of diplomats. His social standing allowed him to move easily in diplomatic circles and he inspired confidence amongst foreign representatives.</p>
+      <p class="govuk-body">The entente was not intended to have a European dimension but the direction in which the settlement would pull Britain soon became clear. In March 1905 the Kaiser sailed into Tangiers and declared he would not accept any agreement over the future of Morocco made without his consent. The Moroccan Crisis, as it became known, threatened the basis for the entente and general European peace.</p>
+      <p class="govuk-body">Lansdowne wanted to support France but also to contain the situation. He warned the German ambassador that if war broke out between France and Germany British public opinion might make it impossible for the government to stand aside. Fearful that France might try to reach a separate deal with Germany, Lansdowne told Cambon, the French ambassador, that both countries should keep each other fully informed and discuss in advance any contingencies they might face. Cambon took this as a desire to co-ordinate policy, even to move towards an alliance.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Lansdowne's upbringing and personality</h3>
+      <p class="govuk-body">The key to Lansdowne's handling of foreign affairs can be found in his upbringing. He came from one of the great Whig families and spent his life in public service, almost as a hereditary right. His patrician self-confidence meant he took a detached and unemotional approach to foreign policy. He was never obsessed by Russian strength, like many of his Tory colleagues, nor was he infected with the Germanophobia found in some of his Foreign Office staff. The jingoistic press exasperated him and he was constantly disappointed when anti-German outbursts, which he always viewed with distaste, kept Britain from taking part in the Berlin-Baghdad railway project.</p>
+      <p class="govuk-body">Lansdowne was not dogmatic in his approach to policy but remained flexible and ready to adapt to circumstances. He brought a level-headedness to the increasingly fractious arena of European foreign politics and remained cool in a crisis. He steered clear of war during the &lsquo;Dogger Bank incident&rsquo; of 1904, when Russian warships sank British fishing boats in the North Sea and the country clamoured for redress.</p>
+      <p class="govuk-body">As head of the Foreign Office Lansdowne showed a willingness to listen to and take advice from his senior officials. He approved reforms to modernise the Foreign Office machinery, which would eventually free clerks from the drudgery of administration and give them more scope to engage in the process of policy formulation. He also supported an inter-departmental committee to reorganise the Consular Service.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Leaving office</h3>
+      <p class="govuk-body">Lansdowne left office in December 1905 along with the Tory government. In August he had agreed a new treaty with Japan, which became operative against only one power and obliged Japan to defend India. Lansdowne had been successful in his aim of achieving greater security for Britain's imperial position.</p>
+      <p class="govuk-body">However this success brought its own problems. Although intended as a colonial settlement the entente pulled Britain further into European affairs. Lansdowne&rsquo;s success in bringing Britain out of isolation was achieved at the unintended cost of increasing Germany&rsquo;s own sense of isolation within Europe. Germany now replaced Russia as Britain&rsquo;s main cause for concern in foreign affairs.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Lord Lansdowne: A Biography by Lord Newton (London, 1929)</li>
         <li>The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)</li>
         <li>The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)</li>

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -1,639 +1,779 @@
 <% page_title "Past Foreign Secretaries" %>
-<% page_class "historic-people-index" %>
+<% page_class "historic-people-index govuk-width-container" %>
 
-<header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', histories_path),
-                        heading: "Past Foreign Secretaries",
-                        big: true } %>
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: "History",
+        href: histories_path,
+      },
+      title: "Past Foreign Secretaries",
+    } %>
   </div>
 </header>
 
-<div class="block featured-profiles">
-  <div class="inner-block floated-children">
+<div class="govuk-grid-row featured-profiles">
+  <div class="govuk-grid-column-full govuk-!-padding-0">
     <h2 class="profiles">Selection of profiles</h2>
     <ol>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-wood" class="img"><%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/edward-wood" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount&nbsp;Halifax</a></h3>
-          <p class="term">1938 to 1940</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/edward-wood" class="govuk-link">
+              Edward Frederick Lindley Wood, Viscount Halifax
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-bottom-0 term">1938 to 1940</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="img"><%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h3>
-          <p class="term">1924 to 1929</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/austen-chamberlain">
+              Sir Austen Chamberlain
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1924 to 1929</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-curzon" class="img"><%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-curzon" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h3>
-          <p class="term">1919 to 1924</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-curzon">
+              George Nathaniel Curzon, Marquess of Kedleston
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1919 to 1924</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-grey" class="img"><%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/edward-grey" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of&nbsp;Fallodon</a></h3>
-          <p class="term">1905 to 1916</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/edward-grey">
+              Sir Edward Grey, Viscount Grey of Fallodon
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1905 to 1916</p>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h3>
-          <p class="term">1900 to 1905</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">
+              Henry Petty-Fitzmaurice, Marquess of Lansdowne
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1900 to 1905</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="img"><%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h3>
-          <p class="term">1878 to 1880, 1885 to 1886,<br />
-            1887 to 1892 and 1895 to 1900</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">
+              Robert Cecil, Marquess of Salisbury
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1878 to 1880, 1885 to 1886,<br> 1887 to 1892 and 1895 to 1900</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gower" class="img"><%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-gower" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h3>
-          <p class="term">1851 to 1852, 1870 to 1874<br />
-            and 1880 to 1885</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gower">
+              George Leveson Gower, Earl Granville
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1851 to 1852, 1870 to 1874<br> and 1880 to 1885</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gordon" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/george-gordon" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h3>
-          <p class="term">1828 to 1830 and 1841 to 1846</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gordon">
+              George Hamilton Gordon, Earl of Aberdeen
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1828 to 1830 and 1841 to 1846</p>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/charles-fox" class="img"><%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/charles-fox" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h3>
-          <p class="term">1782, 1783 and 1806</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/charles-fox">
+              Charles James Fox
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1782, 1783 and 1806</p>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/william-grenville" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville' %></a>
+          <div class="image-holder govuk-!-margin-bottom-1">
+            <a href="/government/history/past-foreign-secretaries/william-grenville" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
+              <%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville', loading: "lazy" %>
+            </a>
           </div>
-          <h3 class="name"><a href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord&nbsp;Grenville</a></h3>
-          <p class="term">1791 to 1801</p>
+          <p class="govuk-heading-s govuk-!-margin-bottom-1">
+            <a class="govuk-link" href="/government/history/past-foreign-secretaries/william-grenville">
+              William Wyndham Grenville, Lord Grenville
+            </a>
+          </p>
+          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1791 to 1801</p>
         </div>
       </li>
     </ol>
   </div>
 </div>
 
-<div class="block">
-  <div class="inner-block floated-children foreign-secretaries">
-    <section>
-      <div class="heading">
-        <h3>Foreign Secretaries <span>1782 to present</span></h3>
-      </div>
-      <ol>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/people/dominic-raab">Dominic Raab</a></h4>
-            <p class="term">2019 to present</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Jeremy Hunt</h4>
-            <p class="term">2018 to 2019</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Boris Johnson</h4>
-            <p class="term">2016 to 2018</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Philip Hammond</h4>
-            <p class="term">2014 to 2016</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">William Hague</h4>
-            <p class="term">2010 to 2014</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">David Miliband</h4>
-            <p class="term">2007 to 2010</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Margaret Beckett</h4>
-            <p class="term">2006 to 2007</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Jack Straw</h4>
-            <p class="term">2001 to 2006</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robin Cook</h4>
-            <p class="term">1997 to 2001</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Malcolm Rifkind</h4>
-            <p class="term">1995 to 1997</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Douglas Hurd, Lord Hurd of Westwell</h4>
-            <p class="term">1989 to 1995</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir John Major</h4>
-            <p class="term">1989</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Geoffrey Howe, Lord Howe of Aberavon</h4>
-            <p class="term">1983 to 1989</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Francis Pym, Lord Pym of Sandy</h4>
-            <p class="term">1982 to 1983</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Peter Carrington, Baron Carrington</h4>
-            <p class="term">1979 to 1982</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Dr David Owen, Lord Owen of the City of Plymouth</h4>
-            <p class="term">1977 to 1979</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Anthony Crosland</h4>
-            <p class="term">1976 to 1977</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Callaghan, Lord Callaghan of Cardiff</h4>
-            <p class="term">1974 to 1976</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
-            <p class="term">1970 to 1974</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
-            <p class="term">1968 to 1970</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Brown, Lord George-Brown of Jevington</h4>
-            <p class="term">1966 to 1968</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Michael Stewart, Lord Stewart of Fulham</h4>
-            <p class="term">1965 to 1966</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Patrick Gordon-Walker, Lord Gordon-Walker of Leyton</h4>
-            <p class="term">1964 to 1965</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Richard Austen Butler, Lord Butler of Saffron Walden</h4>
-            <p class="term">1963 to 1964</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Alec Douglas-Home, Lord Home of the Hirsel</h4>
-            <p class="term">1960 to 1963</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">John Selwyn Brooke Lloyd, Lord Selwyn-Lloyd</h4>
-            <p class="term">1955 to 1960</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Harold Macmillan, Earl of Stockton</h4>
-            <p class="term">1955</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1951 to 1955</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Herbert Morrison, Lord Morrison of Lambeth</h4>
-            <p class="term">1951</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Ernest Bevin</h4>
-            <p class="term">1945 to 1951</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1940 to 1945</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount Halifax</a></h4>
-            <p class="term">1938 to 1940</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir Anthony Eden, Earl of Avon</h4>
-            <p class="term">1935 to 1938</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Sir Samuel Hoare, Viscount Templewood</h4>
-            <p class="term">1935</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Sir John Simon, Viscount Simon</h4>
-            <p class="term">1931 to 1935</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Rufus Isaacs, Marquess of Reading</h4>
-            <p class="term">1931</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Arthur Henderson</h4>
-            <p class="term">1929 to 1931</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h4>
-            <p class="term">1924 to 1929</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Ramsay MacDonald</h4>
-            <p class="term">1924</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h4>
-            <p class="term">1919 to 1924</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Arthur James Balfour, Earl of Balfour</h4>
-            <p class="term">1916 to 1919</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of Fallodon</a></h4>
-            <p class="term">1905 to 1916</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a></h4>
-            <p class="term">1900 to 1905</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1895 to 1900</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">John Wodehouse, Earl of Kimberley</h4>
-            <p class="term">1894 to 1895</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
-            <p class="term">1892 to 1894</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1897 to 1892</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Stafford Northcote, Earl of Iddesleigh</h4>
-            <p class="term">1886 to 1887</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Archibald Primrose, Earl of Rosebery</h4>
-            <p class="term">1886</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1885 to 1886</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1880 to 1885</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h4>
-            <p class="term">1878 to 1880</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
-            <p class="term">1874 to 1878</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1870 to 1874</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1868 to 1870</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Lord Edward Stanley, Earl of Derby</h4>
-            <p class="term">1866 to 1868</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1865 to 1866</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Lord John Russell, Earl Russell</h4>
-            <p class="term">1859 to 1865</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Harris, Earl of Malmesbury</h4>
-            <p class="term">1858 to 1859</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Villiers, Earl of Clarendon</h4>
-            <p class="term">1853 to 1858</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Lord John Russell, Earl Russell</h4>
-            <p class="term">1852 to 1853</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">James Harris, Earl of Malmesbury</h4>
-            <p class="term">1852</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h4>
-            <p class="term">1851 to 1852</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1846 to 1851</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h4>
-            <p class="term">1841 to 1846</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1835 to 1841</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Arthur Wellesley, Duke of Wellington</h4>
-            <p class="term">1834 to 1835</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry John Temple, Viscount Palmerston</h4>
-            <p class="term">1830 to 1834</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h4>
-            <p class="term">1828 to 1830</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">John William Ward, Viscount Dudley and Ward</h4>
-            <p class="term">1827 to 1828</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Canning</h4>
-            <p class="term">1822 to 1827</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robert Stewart, Viscount Castlereagh</h4>
-            <p class="term">1812 to 1822</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Richard Wellesley, Marquess Wellesley</h4>
-            <p class="term">1809 to 1812</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry Bathurst, Earl Bathurst</h4>
-            <p class="term">1809</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Canning</h4>
-            <p class="term">1807 to 1809</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Charles Grey, Lord Howick</h4>
-            <p class="term">1806 to 1807</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1806</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Henry Phipps, Lord Mulgrave</h4>
-            <p class="term">1805 to 1806</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Dudley Ryder, Lord Harrowby</h4>
-            <p class="term">1804</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">Robert Banks Jenkinson, Lord Hawkesbury</h4>
-            <p class="term">1801 to 1804</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord&nbsp;Grenville</a></h4>
-            <p class="term">1791 to 1801</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Francis Godolphin Osborne, Marquess of Carmarthen</h4>
-            <p class="term">1783 to 1791</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name">George Nugent Temple Grenville, Earl Temple</h4>
-            <p class="term">1783</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1783</p>
-          </div>
-        </li>
-        <li class="clear-person">
-          <div class="inner">
-            <h4 class="name">Thomas Robinson, Lord Grantham</h4>
-            <p class="term">1782 to 1783</p>
-          </div>
-        </li>
-        <li>
-          <div class="inner">
-            <h4 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h4>
-            <p class="term">1782</p>
-          </div>
-        </li>
-      </ol>
-    </section>
-  </div>
-</div>
+<h3 class="govuk-heading-l govuk-!-margin-bottom-1">Foreign Secretaries</h3>
+<p class="govuk-body-s">1782 to present</p>
+
+<ol class="govuk-list govuk-grid-row featured-profiles">
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a href="/government/people/dominic-raab/" class="govuk-link">Dominic Raab</a>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2019 to present</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Jeremy Hunt
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2018 to 2019</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Boris Johnson
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2016 to 2018</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Philip Hammond
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2014 to 2016</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      William Hague
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2010 to 2014</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      David Miliband
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2007 to 2010</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Margaret Beckett
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2006 to 2007</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Jack Straw
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">2001 to 2006</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Robin Cook
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1997 to 2001</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Malcolm Rifkind
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1995 to 1997</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Douglas Hurd, Lord Hurd of Westwell
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1989 to 1995</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir John Major
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1989</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Geoffrey Howe, Lord Howe of Aberavon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1983 to 1989</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Francis Pym, Lord Pym of Sandy
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1982 to 1983</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Lord Peter Carrington, Baron Carrington
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1979 to 1982</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Dr David Owen, Lord Owen of the City of Plymouth
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1977 to 1979</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Anthony Crosland
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1976 to 1977</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      James Callaghan, Lord Callaghan of Cardiff
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1974 to 1976</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Alec Douglas-Home, Lord Home of the Hirsel
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1970 to 1974</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Michael Stewart, Lord Stewart of Fulham
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1968 to 1970</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Brown, Lord George-Brown of Jevington
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1966 to 1968</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Michael Stewart, Lord Stewart of Fulham
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1965 to 1966</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Patrick Gordon-Walker, Lord Gordon-Walker of Leyton
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1964 to 1965</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Richard Austen Butler, Lord Butler of Saffron Walden
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1963 to 1964</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Alec Douglas-Home, Lord Home of the Hirsel
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1960 to 1963</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      John Selwyn Brooke Lloyd, Lord Selwyn-Lloyd
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1955 to 1960</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Harold Macmillan, Earl of Stockton
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1955</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Anthony Eden, Earl of Avon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1951 to 1955</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Herbert Morrison, Lord Morrison of Lambeth
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1951</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Ernest Bevin
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1945 to 1951</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Anthony Eden, Earl of Avon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1940 to 1945</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount Halifax</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1938 to 1940</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Anthony Eden, Earl of Avon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1935 to 1938</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir Samuel Hoare, Viscount Templewood
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1935</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Sir John Simon, Viscount Simon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1931 to 1935</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Rufus Isaacs, Marquess of Reading
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1931</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Arthur Henderson
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1929 to 1931</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1924 to 1929</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      James Ramsay MacDonald
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1924</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of Kedleston</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1919 to 1924</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Arthur James Balfour, Earl of Balfour
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1916 to 1919</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of Fallodon</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1905 to 1916</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty-Fitzmaurice, Marquess of Lansdowne</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1900 to 1905</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1895 to 1900</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      John Wodehouse, Earl of Kimberley
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1894 to 1895</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Archibald Primrose, Earl of Rosebery
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1892 to 1894</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1897 to 1892</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Stafford Northcote, Earl of Iddesleigh
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1886 to 1887</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Archibald Primrose, Earl of Rosebery
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1886</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1885 to 1886</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1880 to 1885</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1878 to 1880</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Lord Edward Stanley, Earl of Derby
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1874 to 1878</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1870 to 1874</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Villiers, Earl of Clarendon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1868 to 1870</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Lord Edward Stanley, Earl of Derby
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1866 to 1868</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Villiers, Earl of Clarendon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1865 to 1866</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Lord John Russell, Earl Russell
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1859 to 1865</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      James Harris, Earl of Malmesbury
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1858 to 1859</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Villiers, Earl of Clarendon
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1853 to 1858</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Lord John Russell, Earl Russell
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1852 to 1853</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      James Harris, Earl of Malmesbury
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1852</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1851 to 1852</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Henry John Temple, Viscount Palmerston
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1846 to 1851</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1841 to 1846</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Henry John Temple, Viscount Palmerston
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1835 to 1841</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Arthur Wellesley, Duke of Wellington
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1834 to 1835</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Henry John Temple, Viscount Palmerston
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1830 to 1834</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1828 to 1830</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      John William Ward, Viscount Dudley and Ward
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1827 to 1828</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Canning
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1822 to 1827</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Robert Stewart, Viscount Castlereagh
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1812 to 1822</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Richard Wellesley, Marquess Wellesley
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1809 to 1812</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Henry Bathurst, Earl Bathurst
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1809</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Canning
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1807 to 1809</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Charles Grey, Lord Howick
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1806 to 1807</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1806</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Henry Phipps, Lord Mulgrave
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1805 to 1806</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Dudley Ryder, Lord Harrowby
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1804</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Robert Banks Jenkinson, Lord Hawkesbury
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1801 to 1804</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord Grenville</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1791 to 1801</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Francis Godolphin Osborne, Marquess of Carmarthen
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1783 to 1791</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      George Nugent Temple Grenville, Earl Temple
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1783</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1783</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter clear-person">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      Thomas Robinson, Lord Grantham
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1782 to 1783</span>
+    </p>
+  </li>
+  <li class="govuk-grid-column-one-quarter">
+    <p class="govuk-heading-s govuk-!-margin-bottom-4">
+      <a class="govuk-link" href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a>
+      <span class="govuk-visually-hidden"> &ndash; </span>
+      <span class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1782</span>
+    </p>
+  </li>
+</ol>

--- a/app/views/past_foreign_secretaries/robert_cecil.html.erb
+++ b/app/views/past_foreign_secretaries/robert_cecil.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of Robert Cecil" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'robert-cecil' } do %>
   <div class="name-title">
@@ -7,40 +7,35 @@
       <h2>Robert Cecil, Marquess of Salisbury <span>Foreign Secretary April 1878 to April 1880, June 1885 to February 1886, January 1887 to August 1892 and June 1895 to November 1900</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury' %>
-        <h3>Lived</h3>
-        <p>1830 to 1903</p>
-        <h3>Dates in office</h3>
-        <p>April 1878 to April 1880, June 1885 to February 1886, January 1887 to August 1892 and June 1895 to November 1900</p>
-        <h3>Political party</h3>
-        <p>Conservative</p>
-        <h3>Interesting facts</h3>
-        <p>A Secretary of State who successfully combined the offices of Prime Minister and Foreign Secretary.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/marquess-of-salisbury.jpg",
+    image_alt: "Robert Cecil, Marquess of Salisbury",
+    lived: "1830 to 1903",
+    dates_in_office: "April 1878 to April 1880, June 1885 to February 1886, January 1887 to August 1892 and June 1895 to November 1900",
+    political_party: "Conservative",
+    interesting_facts: "A Secretary of State who successfully combined the offices of Prime Minister and Foreign Secretary.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Lord Salisbury wrote in 1862 on his political hero, Lord Castlereagh, &lsquo;There is nothing dramatic in the success of a diplomatist.&rsquo; Rather, his successes are &lsquo;microscopic advantages&rsquo; derived from &lsquo;sleepless tact, immovable calmness, and a patience that no folly, no provocation, no blunders can shake&rsquo;. In 1900, at the end of over 13 years as Foreign Secretary from 1878, the 1862 biography seemed to serve as a self-portrait.</p>
-      <p>Salisbury had a diplomatic baptism of fire as Plenipotentiary at the Constantinople Conference (1876 to 1877) where the inaction shown by Foreign Secretary Derby, in the face of the Eastern Crisis, allowed Salisbury to witness the dangers of passivity in diplomacy. When Salisbury became Foreign Secretary in March 1878 his circular despatch of 1 April challenged the dominance Russia had achieved over Turkey through the Treaty of San Stefano (1877). Salisbury then negotiated 3 separate conventions with Austria, Russia and Turkey, endorsed at the Congress of Berlin in the summer, facilitating, in the words of Disraeli, &lsquo;peace with honour&rsquo;.</p>
-      <p>After 5 years out of office, Salisbury became Foreign Secretary and Prime Minister in the caretaker government of 1885. Salisbury much preferred the Foreign Office to Downing Street. It was as Foreign Secretary that he could pursue a sophisticated intellectual policy in relative peace and quiet. It was in solitude that Salisbury thrived, but his impeccable manners meant that he would always listen to ambassadors and foreign dignitaries, often jabbing himself with a paper knife under the table to remain awake.</p>
-      <h3>Salisbury's personality and style of working</h3>
-      <p>A deeply religious man who refused to subvert Christianity to political purposes, he became highly empirical in office and disliked all dogmas and doctrines declaring &lsquo;nothing can be certain until it happens&rsquo;. Refusing to delegate and finding discussion unhelpful, Salisbury could be exceptionally difficult to work for.</p>
-      <p>Salisbury&rsquo;s foreign policy has been labelled &lsquo;splendid isolation&rsquo; (in fact a phrase of Joseph Chamberlain's), but it was really anything but. In early 1888 he said, &ldquo;We are part of the community of Europe, and we must do our duty as such&rdquo;. Salisbury believed that Britain was a satisfied power, and as such, that her best interests (namely imperial trade) were served by peace. Considering that all of the Great Powers, save Austria, impinged upon the empire somewhere, Salisbury focused on European diplomacy as the key to imperial security. Indeed, in 1887 he was concerned that the other powers would collectively treat the empire as &lsquo;divisible booty&rsquo;.</p>
-      <p>However, his style was one of engagement without commitment. He struck agreements with Germany and France in 1890, Portugal in 1891 and the United States in 1895 which ensured that the &lsquo;scramble for Africa&rsquo; was, at least in British terms, rather orderly. Yet he never entered into a formal alliance with any power while he was Foreign Secretary. The closest he came were agreements with Austria and Italy to ensure the status quo in the Mediterranean in 1887, but these were ended in 1896 along with British interest in Constantinople, when Salisbury’s desire for the Royal Navy to intervene in the Armenian crisis was overruled by the Cabinet.</p>
-      <p>Despite not being a democrat, he maintained the (somewhat expedient) constitutional smokescreen that Britain could not commit to a formal alliance because he could not know &ldquo;what may be the humour of our people in circumstances which cannot be foreseen&rdquo;.</p>
-      <h3>Achievements in office</h3>
-      <p>Salisbury firmly believed peace was in the best interests of the empire, but he was no pacifist. However, he thought the first rule in negotiation was to select beforehand &ldquo;the one point which all others must subserve&rdquo;. For Salisbury, the passage to India was sacrosanct. Therefore, threats to the Suez Canal (rather than Constantinople) and the Cape would meet with force. Kitchener's securing of the Upper Nile in 1898 could easily have caused a war with France. Yet Salisbury, refusing to issue an ultimatum to a French government on the verge of collapse and allowing France to withdraw with some semblance of dignity, diffused the Fashoda Crisis in 1898.</p>
-      <p>Events in the Cape escalated more quickly in 1899, and Salisbury was taken unawares by the Boers desire for confrontation. His declining health and Chamberlain&rsquo;s secret German negotiations helped to weaken his grip on policy, yet he quickly replaced General Buller following Black Week with Roberts and Kitchener, and remained Prime Minister until June 1902 to see the war through.</p>
-      <p>Salisbury said that the method of foreign policy was more important than the substance. His patience, tact and clarity of thought were unquestionable. He conceived of the empire and diplomacy as a single unit. Thus, while he was attacked for apparent inaction at the Russian entrance into Port Arthur in 1898, this was because securing the Upper Nile was of greater importance to an empire which could not afford a confrontation with two powers at once.</p>
-      <p>Nevertheless, his tenure saw a huge expansion of imperial territory, including Nigeria, New Guinea, Rhodesia, Upper Burma, Zanzibar and the Transvaal. He fended off German and French endeavours in East and West Africa respectively in the face of the Franco-Russian Alliance without war, and having only to lean to the triple Alliance. His was a policy of engagement with room to manoeuvre. In 1864, Salisbury lamented Britain's position &ldquo;without a single ally and without a shred of influence&rdquo;. By 1900, Britain was still without an ally, singularly thanks to Salisbury, but without influence she was not.</p> 
-   
+      <p class="govuk-body govuk-!-font-weight-bold">Lord Salisbury wrote in 1862 on his political hero, Lord Castlereagh, &lsquo;There is nothing dramatic in the success of a diplomatist.&rsquo; Rather, his successes are &lsquo;microscopic advantages&rsquo; derived from &lsquo;sleepless tact, immovable calmness, and a patience that no folly, no provocation, no blunders can shake&rsquo;. In 1900, at the end of over 13 years as Foreign Secretary from 1878, the 1862 biography seemed to serve as a self-portrait.</p>
 
-      <h3>Further reading</h3>
-      <ul>
+      <p class="govuk-body">Salisbury had a diplomatic baptism of fire as Plenipotentiary at the Constantinople Conference (1876 to 1877) where the inaction shown by Foreign Secretary Derby, in the face of the Eastern Crisis, allowed Salisbury to witness the dangers of passivity in diplomacy. When Salisbury became Foreign Secretary in March 1878 his circular despatch of 1 April challenged the dominance Russia had achieved over Turkey through the Treaty of San Stefano (1877). Salisbury then negotiated 3 separate conventions with Austria, Russia and Turkey, endorsed at the Congress of Berlin in the summer, facilitating, in the words of Disraeli, &lsquo;peace with honour&rsquo;.</p>
+      <p class="govuk-body">After 5 years out of office, Salisbury became Foreign Secretary and Prime Minister in the caretaker government of 1885. Salisbury much preferred the Foreign Office to Downing Street. It was as Foreign Secretary that he could pursue a sophisticated intellectual policy in relative peace and quiet. It was in solitude that Salisbury thrived, but his impeccable manners meant that he would always listen to ambassadors and foreign dignitaries, often jabbing himself with a paper knife under the table to remain awake.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Salisbury's personality and style of working</h3>
+      <p class="govuk-body">A deeply religious man who refused to subvert Christianity to political purposes, he became highly empirical in office and disliked all dogmas and doctrines declaring &lsquo;nothing can be certain until it happens&rsquo;. Refusing to delegate and finding discussion unhelpful, Salisbury could be exceptionally difficult to work for.</p>
+      <p class="govuk-body">Salisbury&rsquo;s foreign policy has been labelled &lsquo;splendid isolation&rsquo; (in fact a phrase of Joseph Chamberlain's), but it was really anything but. In early 1888 he said, &ldquo;We are part of the community of Europe, and we must do our duty as such&rdquo;. Salisbury believed that Britain was a satisfied power, and as such, that her best interests (namely imperial trade) were served by peace. Considering that all of the Great Powers, save Austria, impinged upon the empire somewhere, Salisbury focused on European diplomacy as the key to imperial security. Indeed, in 1887 he was concerned that the other powers would collectively treat the empire as &lsquo;divisible booty&rsquo;.</p>
+      <p class="govuk-body">However, his style was one of engagement without commitment. He struck agreements with Germany and France in 1890, Portugal in 1891 and the United States in 1895 which ensured that the &lsquo;scramble for Africa&rsquo; was, at least in British terms, rather orderly. Yet he never entered into a formal alliance with any power while he was Foreign Secretary. The closest he came were agreements with Austria and Italy to ensure the status quo in the Mediterranean in 1887, but these were ended in 1896 along with British interest in Constantinople, when Salisbury’s desire for the Royal Navy to intervene in the Armenian crisis was overruled by the Cabinet.</p>
+      <p class="govuk-body">Despite not being a democrat, he maintained the (somewhat expedient) constitutional smokescreen that Britain could not commit to a formal alliance because he could not know &ldquo;what may be the humour of our people in circumstances which cannot be foreseen&rdquo;.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Achievements in office</h3>
+      <p class="govuk-body">Salisbury firmly believed peace was in the best interests of the empire, but he was no pacifist. However, he thought the first rule in negotiation was to select beforehand &ldquo;the one point which all others must subserve&rdquo;. For Salisbury, the passage to India was sacrosanct. Therefore, threats to the Suez Canal (rather than Constantinople) and the Cape would meet with force. Kitchener's securing of the Upper Nile in 1898 could easily have caused a war with France. Yet Salisbury, refusing to issue an ultimatum to a French government on the verge of collapse and allowing France to withdraw with some semblance of dignity, diffused the Fashoda Crisis in 1898.</p>
+      <p class="govuk-body">Events in the Cape escalated more quickly in 1899, and Salisbury was taken unawares by the Boers desire for confrontation. His declining health and Chamberlain&rsquo;s secret German negotiations helped to weaken his grip on policy, yet he quickly replaced General Buller following Black Week with Roberts and Kitchener, and remained Prime Minister until June 1902 to see the war through.</p>
+      <p class="govuk-body">Salisbury said that the method of foreign policy was more important than the substance. His patience, tact and clarity of thought were unquestionable. He conceived of the empire and diplomacy as a single unit. Thus, while he was attacked for apparent inaction at the Russian entrance into Port Arthur in 1898, this was because securing the Upper Nile was of greater importance to an empire which could not afford a confrontation with two powers at once.</p>
+      <p class="govuk-body">Nevertheless, his tenure saw a huge expansion of imperial territory, including Nigeria, New Guinea, Rhodesia, Upper Burma, Zanzibar and the Transvaal. He fended off German and French endeavours in East and West Africa respectively in the face of the Franco-Russian Alliance without war, and having only to lean to the triple Alliance. His was a policy of engagement with room to manoeuvre. In 1864, Salisbury lamented Britain's position &ldquo;without a single ally and without a shred of influence&rdquo;. By 1900, Britain was still without an ally, singularly thanks to Salisbury, but without influence she was not.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>Choose Your Weapons: The British Foreign Secretary, 200 Years of Argument Success and Failure by D Hurd (London, 2010)</li>
         <li>Salisbury 1830–1903: Portrait of a Statesman by AL Kennedy (London, 1953)</li>
         <li>‘The Principles and Methods of Lord Salisbury's Foreign Policy’ in the Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106, LM Penson ‘The Principles and Methods of Lord Salisbury’s Foreign Policy’ in Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106</li>

--- a/app/views/past_foreign_secretaries/william_grenville.html.erb
+++ b/app/views/past_foreign_secretaries/william_grenville.html.erb
@@ -1,5 +1,5 @@
 <% page_title "History of William Wyndham Grenville" %>
-<% page_class "historic-people-show" %>
+<% page_class "historic-people-show govuk-width-container" %>
 
 <%= render layout: 'show_person', locals: { current_person: 'william-grenville' } do %>
   <div class="name-title">
@@ -7,39 +7,33 @@
       <h2>William Wyndham Grenville, Lord Grenville <span>Foreign Secretary April 1791 to February 1801</span></h2>
     </div>
   </div>
-  <div class="person-profile">
-    <div class="inner">
-      <div class="info">
-        <%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville' %>
-        <h3>Lived</h3>
-        <p>1759 to 1834</p>
-        <h3>Dates in office</h3>
-        <p>April 1791 to February 1801</p>
-        <h3>Political party</h3>
-        <p>Conservative (until 1801)</p>
-        <h3>Interesting facts</h3>
-        <p>Spent almost a decade as Foreign Secretary during the struggle against Revolutionary France.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "information-box", {
+    image: "history/past-foreign-secretaries/lord-grenville.jpg",
+    image_alt: "William Wyndham Grenville, Lord Grenville",
+    lived: "1759 to 1834",
+    dates_in_office: "April 1791 to February 1801",
+    political_party: "Conservative (until 1801)",
+    interesting_facts: "Spent almost a decade as Foreign Secretary during the struggle against Revolutionary France.",
+  } %>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro">Lord Grenville spent almost a decade as Foreign Secretary during a turbulent period dominated by diplomacy and war against Revolutionary France. Grenville had a long political pedigree. His father, George Grenville, had been Prime Minister in 1763 to 1765 and he was the cousin of Pitt the Younger.</p>
-      <p>Before this period the roles of the Offices of State were not clearly delineated; indeed the Foreign Office was established only in 1782. Grenville&rsquo;s early years were taken up with establishing the office itself, which he did by increasing efficiency rather than size. By 1795 he had arranged for pay increases for all staff &ndash; including a &pound;6,000 salary for himself. The king commented, &ldquo;I find your new arrangement a great improvement &hellip; nothing can exceed the manner in which your business is done.&rdquo;</p>
-      <h3>The French wars </h3>
-      <p>Grenville&rsquo;s &lsquo;business&rsquo; throughout his time at the Foreign Office was characterised by caution, unsuccessful diplomacy and the interference of Pitt. His first year in office was inauspicious. The British government had been planning to supplement their fleet in the Black Sea as leverage against Russia&rsquo;s demand for the port of Ochakov. By the time it was equipped, however, it was too late and Britain had to concede.</p>
-      <p>The Prussians believed that the Triple Alliance of 1788 was rendered meaningless by the threat from Russia so they signed an accord with the Austrians and Britain was effectively forced out of European diplomacy until France declared war in 1793. Pitt&rsquo;s uncomplimentary assessment of the result was that it was done &ldquo;not very creditably, but better so than worse.&rdquo;</p>
-      <p>It was during the French wars that Grenville acquitted himself best although his achievements were modest in comparison to the energy expended. He proposed alliances first with Russia, then Spain and finally Sardinia. All these attempts at diplomacy foundered as the European powers prioritised the territorial gains they could make by war over peace. His only early success was with a country that was officially neutral: the United States. Grenville&rsquo;s good personal relationship with Chief Justice John Jay secured a treaty that ensured Britain was fighting only on the European front.</p>
-      <p>A true test of his position came in late 1794 when the Prussians withdrew from the war. Lord Malmesbury proposed a subsidy to encourage greater Prussian involvement but Grenville hated the idea so much that he offered Pitt his resignation if it went ahead. In the end he was saved by dithering in Cabinet. By the time the offer was sent, Prussia had signed the Peace of Basel with France. Grenville&rsquo;s distrust of the Prussians was vindicated and he withdrew his resignation.</p>
-      <h3>Grenville and Pitt</h3>
-      <p>This was the first in a series of diplomatic adventures that followed a similar pattern: Grenville would reject alliances he saw as detrimental to British interests, Pitt would persuade or overrule him, but eventually Grenville&rsquo;s pessimism would prove justified.</p>
-      <p>By 1795, attempts to establish a European axis had failed so completely that Pitt changed direction and sought peace with France. To Grenville this was a betrayal of Britain's counter-revolutionary allies and he lobbied for a tough negotiating stance. He insisted that France and its allies cede overseas territories to Britain in exchange for Britain allowing them to keep their territorial gains in Europe.</p>
-      <p>As a result, although the talks at Lille fell through in 1797, Grenville was in a stronger position in cabinet during his final phase as Foreign Secretary and was able to reinstate Britain&rsquo;s counter&ndash;revolutionary policy. It was as unsuccessful then as it had been before. When Grenville resigned with the rest of Pitt&rsquo;s government in 1801, Europe was in much the same position it had been in at the start of the war except that France had a new Consul - Napoleon Bonaparte.</p>
-      <p>In 1802 Grenville broke with Pitt, following the Treaty of Amiens with France, and formed his own opposition group. Grenville allied himself with Charles James Fox and briefly led the &lsquo;Ministry of all the Talents&rsquo; in 1806 to 1807 which secured the abolition of the slave trade.</p>
+      <p class="govuk-body govuk-!-font-weight-bold">Lord Grenville spent almost a decade as Foreign Secretary during a turbulent period dominated by diplomacy and war against Revolutionary France. Grenville had a long political pedigree. His father, George Grenville, had been Prime Minister in 1763 to 1765 and he was the cousin of Pitt the Younger.</p>
+      <p class="govuk-body">Before this period the roles of the Offices of State were not clearly delineated; indeed the Foreign Office was established only in 1782. Grenville&rsquo;s early years were taken up with establishing the office itself, which he did by increasing efficiency rather than size. By 1795 he had arranged for pay increases for all staff &ndash; including a &pound;6,000 salary for himself. The king commented, &ldquo;I find your new arrangement a great improvement &hellip; nothing can exceed the manner in which your business is done.&rdquo;</p>
 
-   
-      <h3>Further reading</h3>
-      <ul>
+      <h3 class="govuk-heading-s govuk-!-margin-0">The French wars </h3>
+      <p class="govuk-body">Grenville&rsquo;s &lsquo;business&rsquo; throughout his time at the Foreign Office was characterised by caution, unsuccessful diplomacy and the interference of Pitt. His first year in office was inauspicious. The British government had been planning to supplement their fleet in the Black Sea as leverage against Russia&rsquo;s demand for the port of Ochakov. By the time it was equipped, however, it was too late and Britain had to concede.</p>
+      <p class="govuk-body">The Prussians believed that the Triple Alliance of 1788 was rendered meaningless by the threat from Russia so they signed an accord with the Austrians and Britain was effectively forced out of European diplomacy until France declared war in 1793. Pitt&rsquo;s uncomplimentary assessment of the result was that it was done &ldquo;not very creditably, but better so than worse.&rdquo;</p>
+      <p class="govuk-body">It was during the French wars that Grenville acquitted himself best although his achievements were modest in comparison to the energy expended. He proposed alliances first with Russia, then Spain and finally Sardinia. All these attempts at diplomacy foundered as the European powers prioritised the territorial gains they could make by war over peace. His only early success was with a country that was officially neutral: the United States. Grenville&rsquo;s good personal relationship with Chief Justice John Jay secured a treaty that ensured Britain was fighting only on the European front.</p>
+      <p class="govuk-body">A true test of his position came in late 1794 when the Prussians withdrew from the war. Lord Malmesbury proposed a subsidy to encourage greater Prussian involvement but Grenville hated the idea so much that he offered Pitt his resignation if it went ahead. In the end he was saved by dithering in Cabinet. By the time the offer was sent, Prussia had signed the Peace of Basel with France. Grenville&rsquo;s distrust of the Prussians was vindicated and he withdrew his resignation.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Grenville and Pitt</h3>
+      <p class="govuk-body">This was the first in a series of diplomatic adventures that followed a similar pattern: Grenville would reject alliances he saw as detrimental to British interests, Pitt would persuade or overrule him, but eventually Grenville&rsquo;s pessimism would prove justified.</p>
+      <p class="govuk-body">By 1795, attempts to establish a European axis had failed so completely that Pitt changed direction and sought peace with France. To Grenville this was a betrayal of Britain's counter-revolutionary allies and he lobbied for a tough negotiating stance. He insisted that France and its allies cede overseas territories to Britain in exchange for Britain allowing them to keep their territorial gains in Europe.</p>
+      <p class="govuk-body">As a result, although the talks at Lille fell through in 1797, Grenville was in a stronger position in cabinet during his final phase as Foreign Secretary and was able to reinstate Britain&rsquo;s counter&ndash;revolutionary policy. It was as unsuccessful then as it had been before. When Grenville resigned with the rest of Pitt&rsquo;s government in 1801, Europe was in much the same position it had been in at the start of the war except that France had a new Consul - Napoleon Bonaparte.</p>
+      <p class="govuk-body">In 1802 Grenville broke with Pitt, following the Treaty of Amiens with France, and formed his own opposition group. Grenville allied himself with Charles James Fox and briefly led the &lsquo;Ministry of all the Talents&rsquo; in 1806 to 1807 which secured the abolition of the slave trade.</p>
+
+      <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>The Influence of Grenville on Pitt’s Foreign Policy: 1787–1798, by E Douglass Adams (Carnegie Institute of Washington, 1904)</li>
         <li>William Pitt the Younger by W Hague (Harper Perennial, 2005)</li>
         <li>Lord Grenville: 1758–1834 by P Jupp (OUP, 1985)</li>


### PR DESCRIPTION
 - Updating the links on the 'Past Foreign Secretaries' pages to the new focus states. 
 - Fixed the menu on the featured Foreign Secretaries pages to actually link to other pages.

Part of https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on

### Before:
Featured Foreign Secretaries page:
<img width="982" alt="Screenshot 2019-10-24 at 17 22 08" src="https://user-images.githubusercontent.com/1732331/67505270-d61e4480-f682-11e9-8951-074737b70ebe.png">

Featured past Foreign Secretaries:
<img width="264" alt="Screenshot 2019-10-24 at 17 23 41" src="https://user-images.githubusercontent.com/1732331/67505399-11207800-f683-11e9-9b1a-0f481f566e88.png">
<img width="256" alt="Screenshot 2019-10-24 at 17 23 02" src="https://user-images.githubusercontent.com/1732331/67505394-0ebe1e00-f683-11e9-807a-9758dfb45c35.png">

List of all Foreign Secretaries focus state:
<img width="312" alt="Screenshot 2019-10-24 at 17 23 18" src="https://user-images.githubusercontent.com/1732331/67505415-1c73a380-f683-11e9-8dc1-06ba357cd78e.png">


### After
Featured past Foreign Secretaries with new focus state; image no longer focusable:
<img width="385" alt="Screenshot 2019-10-24 at 17 13 35" src="https://user-images.githubusercontent.com/1732331/67504665-b8041480-f681-11e9-806c-0d76cf44358e.png">


List of all Foreign Secretaries links with new focus state:
<img width="427" alt="Screenshot 2019-10-24 at 17 13 57" src="https://user-images.githubusercontent.com/1732331/67504687-c2261300-f681-11e9-85b8-b36c11beb930.png">


Featured Foreign Secretaries page, with correct menu and new focus state:
<img width="971" alt="Screenshot 2019-10-24 at 17 18 56" src="https://user-images.githubusercontent.com/1732331/67505028-6445fb00-f682-11e9-8b32-5534f25fad13.png">
