### PR TITLE
Change transaction callbacks to after_commit

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -2,8 +2,7 @@ class CorporateInformationPage < Edition
   include ::Attachable
   include Searchable
 
-  after_save :republish_organisation_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api
+  after_commit :republish_organisation_to_publishing_api
   after_save :reindex_organisation_in_search_index, if: :about_page?
 
   has_one :edition_organisation, foreign_key: :edition_id, dependent: :destroy


### PR DESCRIPTION
On creating a new CorporateInformationPage, we need to republish the associated
Organisation to ensure that the new CIP is linked to.

The `after_save` callback causes the Organisation to be republished before the
database transaction has fully completed, and the CIP is still in `draft`, and
so the Organisation does not list it in it's list of published CIPs.

Changing this to `after_commit` ensures that the transaction has fully completed
before the Organisation is republished, and so the CIP will be `published`.

As `after_commit` also fires after a record is destroyed, we can remove the
`after_destroy` callback also.