### PR TITLE
Only cache topic taxonomy overnight on production

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,6 +12,19 @@ every :hour, roles: [:backend] do
   rake "search:index:consultations"
 end
 
-every 10.minutes, roles: [:backend] do
+def integration_or_staging?
+  ENV.fetch("GOVUK_WEBSITE_ROOT") =~ /integration|staging/
+end
+
+def taxonomy_cron_rules
+  if integration_or_staging?
+    # at every 10th minute past the hour between 7am and 8pm
+    "*/10 7-20 * * *"
+  else
+    10.minutes
+  end
+end
+
+every taxonomy_cron_rules, roles: [:backend] do
   rake "taxonomy:rebuild_cache"
 end


### PR DESCRIPTION
This changes the topic taxonomy scheduled job to only run during the day (7am-8pm) in integration and staging. In production it will continue to run every 10 minutes.

This is to prevent Whitehall making unnecessary requests which fail while the data sync is happening.

[Trello Card](https://trello.com/c/7KM97eg2/1429-3-stop-whitehall-attempting-to-rebuild-the-topic-taxonomy-cache-overnight-on-staging-and-integration)