### PR TITLE
Fix url whitespace bug

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -153,7 +153,7 @@ private
   def parse_base_path_from_related_mainstream_url(url)
     return nil if url.nil? || url.empty?
 
-    parsed_url = URI.parse(url)
+    parsed_url = URI.parse(url.strip)
     url_is_invalid = !["gov.uk", "www.gov.uk"].include?(parsed_url.host)
     return nil if url_is_invalid
 

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -103,6 +103,17 @@ class DetailedGuideTest < ActiveSupport::TestCase
     assert_equal detailed_guide.additional_related_mainstream_base_path, "/additional-content"
   end
 
+  test "should return stripped base_path's for related mainstream content urls" do
+    detailed_guide = build(
+      :detailed_guide,
+      related_mainstream_content_url: "http://gov.uk/suffix-whitespace  ",
+      additional_related_mainstream_content_url: "  http://gov.uk/prefix-whitespace",
+    )
+
+    assert_equal detailed_guide.related_mainstream_base_path, "/suffix-whitespace"
+    assert_equal detailed_guide.additional_related_mainstream_base_path, "/prefix-whitespace"
+  end
+
   test "related_detailed_guide_ids works correctly" do
     some_detailed_guide = create(:published_detailed_guide)
     detailed_guide = create(


### PR DESCRIPTION
Previously if there was any whitespace in the URL for the related
content fields whitehall would crash throwing the standard 'Something
went wrong' message. This change strips all the whitespace from the URL
before parsing.

This problem became apparent when a zendesk came in which was related to
extra whitespace unknowingly added to the end of a URL.

Zendesk:
https://govuk.zendesk.com/agent/tickets/3831838