### PR TITLE
Correct spelling for Nederlands

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -334,7 +334,7 @@ nl:
   i18n:
     direction: ltr
   language_names:
-    nl: Nederlandse
+    nl: Nederlands
   latest_feed:
     no_updates:
     title:


### PR DESCRIPTION
Our translation for Dutch is incorrect