### PR TITLE
Remove organisations from preloaded DocumentCollectionGroups

### DIFF
--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -5,7 +5,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
   def index
     @groups = @collection.groups.includes(
       memberships: [
-        { document: { latest_edition: %i[organisations translations] } },
+        { document: { latest_edition: %i[translations] } },
         :non_whitehall_link,
       ],
     )

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -24,6 +24,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
 
   view_test "GET #index lets you move docs to another group" do
     @group.documents << create(:publication).document
+    @group.documents << create(:corporate_information_page).document
     @collection.groups << build(:document_collection_group)
     group_1, group_2 = @collection.groups
     get :index, params: { document_collection_id: @collection }


### PR DESCRIPTION
CorporateInformationPages don't have organisations as an association, so this throws an ActiveRecord error if one of the documents is a corp info page.

Examples: https://sentry.io/organizations/govuk/issues/1272469573

The fix is to not use `organisations` in the includes query, necessitating an additional query for organisations.

I tested on integration and it seems to work. The downside is that page load may be a little slower (though it wasn't noticeable on integration).

https://govuk.zendesk.com/agent/tickets/3834746

