### PR TITLE
Re-structure and reduce data output for document export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -24,6 +24,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,
       attachments: present_attachments(edition),
       authors: edition.authors.map { |u| present_user(u) },
+      contacts: slice_association(edition, :depended_upon_contacts, %i[id content_id]),
       edition_policies: slice_association(edition, :edition_policies, %i[id policy_content_id]),
       editorial_remarks: present_editorial_remarks(edition),
       fact_check_requests: present_fact_check_requests(edition),

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -17,7 +17,8 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   private
 
   def present_edition(edition)
-    except = DOCUMENT_SUB_TYPES.map { |type| "#{type}_id".to_sym }
+    document_subtype_ids = DOCUMENT_SUB_TYPES.map { |type| "#{type}_id" }
+    except = %w[title summary body] + document_subtype_ids
 
     edition.as_json(except: except).merge(
       alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -17,7 +17,9 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   private
 
   def present_edition(edition)
-    edition.as_json.merge(
+    except = DOCUMENT_SUB_TYPES.map { |type| "#{type}_id".to_sym }
+
+    edition.as_json(except: except).merge(
       alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,
       attachments: present_attachments(edition),
       authors: edition.authors.map { |u| present_user(u) },

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -138,7 +138,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
     end
 
     def call(edition)
-      links = admin_links(edition.body)
+      links = edition.translations.flat_map { |t| admin_links(t.body) }
 
       if edition.unpublishing&.explanation
         links.concat(admin_links(edition.unpublishing.explanation))

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -33,7 +33,6 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       government: edition.government&.as_json,
       revision_history: present_revision_history(edition),
       images: present_images(edition),
-      last_author: edition.last_author&.id,
       organisations: present_organisations(edition),
       role_appointments: slice_association(edition, %i[role_appointment role_appointments], %i[id content_id]),
       specialist_sectors: slice_association(edition, :specialist_sectors, %i[id topic_content_id primary]),

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -25,6 +25,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       attachments: present_attachments(edition),
       authors: edition.authors.map { |u| present_user(u) },
       edition_policies: slice_association(edition, :edition_policies, %i[id policy_content_id]),
+      editorial_remarks: present_editorial_remarks(edition),
       fact_check_requests: present_fact_check_requests(edition),
       government: edition.government&.as_json,
       revision_history: present_revision_history(edition),
@@ -65,6 +66,15 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
                          end
       attachment.as_json(include: :attachment_data, methods: %i[url type])
                 .merge(govspeak_content)
+    end
+  end
+
+  def present_editorial_remarks(edition)
+    return [] unless edition.try(:editorial_remarks)
+
+    edition.editorial_remarks.map do |remark|
+      remark.as_json(only: %i[id body created_at author_id])
+            .merge(author: present_user(remark.author))
     end
   end
 

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -9,72 +9,132 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   ].freeze
 
   def as_json
-    {
-      document: model,
-      editions: editions,
-    }
+    model.as_json
+         .merge(editions: model.editions.map { |e| present_edition(e) })
+         .deep_symbolize_keys
   end
 
   private
 
-  def editions
-    model.editions.map do |edition|
+  def present_edition(edition)
+    edition.as_json.merge(
+      alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,
+      attachments: present_attachments(edition),
+      authors: edition.authors.map { |u| present_user(u) },
+      edition_policies: slice_association(edition, :edition_policies, %i[id policy_content_id]),
+      fact_check_requests: present_fact_check_requests(edition),
+      government: edition.government&.as_json,
+      images: present_images(edition),
+      last_author: present_user(edition.last_author),
+      organisations: present_organisations(edition),
+      role_appointments: slice_association(edition, %i[role_appointment role_appointments], %i[id content_id]),
+      specialist_sectors: slice_association(edition, :specialist_sectors, %i[id topic_content_id primary]),
+      topical_events: slice_association(edition, :topical_events, %i[id content_id]),
+      translations: present_translations(edition),
+      whitehall_admin_links: AdminLinkResolver.call(edition),
+      world_locations: slice_association(edition, :world_locations, %i[id content_id]),
+      worldwide_organisations: slice_association(edition, %i[worldwide_organisation worldwide_organisations], %i[id content_id]),
+    ).merge(sub_document_type(edition))
+  end
+
+  def sub_document_type(edition)
+    DOCUMENT_SUB_TYPES.each_with_object({}) do |type, memo|
+      memo[type] = edition.try(type)&.key
+    end
+  end
+
+  def slice_association(edition, associations, fields)
+    association_data = Array(associations).flat_map { |a| edition.try(a) }.compact
+    return [] unless association_data
+
+    association_data.map { |item| item.as_json(only: fields) }
+  end
+
+  def present_attachments(edition)
+    return [] unless edition.respond_to?(:attachments)
+
+    edition.attachments.map do |attachment|
+      govspeak_content = if attachment.respond_to?(:govspeak_content)
+                           { govspeak_content: attachment.govspeak_content.as_json }
+                         else
+                           {}
+                         end
+      attachment.as_json(include: :attachment_data, methods: %i[url type])
+                .merge(govspeak_content)
+    end
+  end
+
+  def present_fact_check_requests(edition)
+    return [] unless edition.try(:fact_check_requests)
+
+    edition.fact_check_requests.map do |request|
+      request.as_json(except: "requestor_id")
+             .merge(requestor: present_user(request.requestor))
+    end
+  end
+
+  def present_images(edition)
+    return [] unless edition.try(:images)
+
+    edition.images.map { |image| image.as_json(methods: :url) }
+  end
+
+  def present_organisations(edition)
+    edition_organisations = edition.try(:edition_organisations) || edition.try(:edition_organisation)
+    return [] unless edition_organisations
+
+    Array(edition_organisations).map do |edition_organisation|
+      organisation = edition_organisation.organisation
       {
-        edition: edition,
-        government: edition.government,
-        whitehall_admin_links: resolve_whitehall_admin_links(edition),
-        associations: {
-          attachments: complete_attachments(edition),
-          images: complete_images(edition),
-        },
-      }.merge(provide_doctype_information(edition))
+        id: organisation.id,
+        content_id: organisation.content_id,
+        lead: edition_organisation.lead,
+        lead_ordering: edition_organisation.lead_ordering,
+      }
     end
   end
 
-  def complete_images(edition)
-    images = edition.try(:images)
-    return [] unless images
-
-    images.map do |image|
-      image.as_json(methods: :url)
+  def present_translations(edition)
+    edition.translations.map do |translation|
+      base_path = Whitehall.url_maker.public_document_path(edition, locale: translation.locale)
+      translation.as_json(except: :edition_id).merge(base_path: base_path)
     end
   end
 
-  def complete_attachments(edition)
-    attachments = edition.try(:attachments)
-    return [] unless attachments
+  def present_user(user)
+    return {} unless user
 
-    attachments.map do |attachment|
-      attachment.as_json(include: :attachment_data, methods: %i[url type]).tap do |json|
-        json.merge!("govspeak_content" => attachment.govspeak_content.as_json) if attachment.respond_to?(:govspeak_content)
+    { id: user.id, uid: user.uid }
+  end
+
+  class AdminLinkResolver
+    include GovspeakHelper
+
+    def self.call(*args)
+      new.call(*args)
+    end
+
+    def call(edition)
+      links = admin_links(edition.body)
+
+      if edition.unpublishing&.explanation
+        links.concat(admin_links(edition.unpublishing.explanation))
+      end
+
+      links
+    end
+
+  private
+
+    def admin_links(text)
+      whitehall_admin_links(text).map do |link|
+        edition = Whitehall::AdminLinkLookup.find_edition(link)
+        {
+          whitehall_admin_url: link,
+          public_url: edition ? Whitehall.url_maker.public_document_url(edition) : nil,
+          content_id: edition&.content_id,
+        }
       end
     end
-  end
-
-  def provide_doctype_information(edition)
-    DOCUMENT_SUB_TYPES.each_with_object({}) do |type, memo|
-      memo[type] = edition.public_send(type)&.key if edition.respond_to?(type)
-    end
-  end
-
-  def resolve_whitehall_admin_links(edition)
-    links = admin_links(edition.body)
-
-    if edition.withdrawn?
-      links.concat(admin_links(edition.unpublishing.explanation))
-    end
-
-    links
-  end
-
-  def admin_links(text)
-    whitehall_admin_links(text).map do |link|
-      { whitehall_admin_url: link, public_url: public_url_for_admin_link(link) }
-    end
-  end
-
-  def public_url_for_admin_link(url)
-    edition = Whitehall::AdminLinkLookup.find_edition(url)
-    Whitehall.url_maker.public_document_url(edition) if edition.present?
   end
 end

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -1,6 +1,13 @@
 class DocumentExportPresenter < Whitehall::Decorators::Decorator
   include GovspeakHelper
 
+  DOCUMENT_SUB_TYPES = %i[
+    news_article_type
+    publication_type
+    corporate_information_page_type
+    speech_type
+  ].freeze
+
   def as_json
     {
       document: model,
@@ -12,60 +19,56 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
   def editions
     model.editions.map do |edition|
-      edition_associations(edition)
+      {
+        edition: edition,
+        government: edition.government,
+        whitehall_admin_links: resolve_whitehall_admin_links(edition),
+        associations: {
+          attachments: complete_attachments(edition),
+          images: complete_images(edition),
+        },
+      }.merge(provide_doctype_information(edition))
     end
   end
 
-  def edition_associations(edition)
-    output = {
-               edition: edition,
-               associations: {},
-             }
+  def complete_images(edition)
+    images = edition.try(:images)
+    return [] unless images
 
-    associations = edition.class.reflect_on_all_associations.map(&:name)
-    associations.each do |association|
-      if association == :images
-        edition_images = edition.public_send(association)
-        output[:associations][association] = complete_images_hash(edition_images)
-      elsif association == :attachments
-        edition_attachments = edition.public_send(association)
-        output[:associations][association] = complete_attachments_hash(edition_attachments)
-      else
-        output[:associations][association] = edition.public_send(association)
-      end
-    end
-
-    provide_doctype_information(edition, output)
-    output[:government] = edition.government
-    output[:whitehall_admin_links] = resolve_whitehall_admin_links(edition.body)
-    if edition.withdrawn?
-      output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
-    end
-    output
-  end
-
-  def complete_images_hash(edition_images)
-    edition_images.map do |image|
+    images.map do |image|
       image.as_json(methods: :url)
     end
   end
 
-  def complete_attachments_hash(edition_attachments)
-    edition_attachments.map do |attachment|
+  def complete_attachments(edition)
+    attachments = edition.try(:attachments)
+    return [] unless attachments
+
+    attachments.map do |attachment|
       attachment.as_json(include: :attachment_data, methods: %i[url type]).tap do |json|
         json.merge!("govspeak_content" => attachment.govspeak_content.as_json) if attachment.respond_to?(:govspeak_content)
       end
     end
   end
 
-  def provide_doctype_information(edition, output)
-    %i[news_article_type publication_type corporate_information_page_type speech_type].each do |type|
-      output[type] = edition.public_send(type)&.key if edition.respond_to?(type)
+  def provide_doctype_information(edition)
+    DOCUMENT_SUB_TYPES.each_with_object({}) do |type, memo|
+      memo[type] = edition.public_send(type)&.key if edition.respond_to?(type)
     end
   end
 
-  def resolve_whitehall_admin_links(body)
-    whitehall_admin_links(body).map do |link|
+  def resolve_whitehall_admin_links(edition)
+    links = admin_links(edition.body)
+
+    if edition.withdrawn?
+      links.concat(admin_links(edition.unpublishing.explanation))
+    end
+
+    links
+  end
+
+  def admin_links(text)
+    whitehall_admin_links(text).map do |link|
       { whitehall_admin_url: link, public_url: public_url_for_admin_link(link) }
     end
   end

--- a/test/factories/specialist_sector.rb
+++ b/test/factories/specialist_sector.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :specialist_sector do
+    topic_content_id factory: :topic
   end
 end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -7,7 +7,7 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
 
     login_as :export_data_user
     get :show, params: { id: document.id }, format: "json"
-    assert_equal "some-document", json_response["document"]["slug"]
+    assert_equal "some-document", json_response["slug"]
   end
 
   test "shows forbidden if user does not have export data permission" do

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -11,6 +11,21 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal edition.id, result.dig(:editions, 0, :id)
   end
 
+  test "removes edition fields that are duplicated by the primary translation" do
+    news_result = DocumentExportPresenter.new(create(:news_article).document).as_json
+    edition = news_result[:editions].first
+    translation = edition[:translations].first
+
+    assert_equal "en", edition[:primary_locale]
+    assert_equal :en, translation[:locale]
+    assert_nil edition[:title]
+    assert_nil edition[:summary]
+    assert_nil edition[:body]
+    assert_equal "news-title", translation[:title]
+    assert_equal "news-summary", translation[:summary]
+    assert_equal "news-body", translation[:body]
+  end
+
   test "resolves internal Whitehall URLs in edition body with a public URL" do
     body = "Some text which contains an [internal link](/government/admin/news/2) to a public document"
     document = create(:document)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -159,6 +159,14 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
                  result.dig(:editions, 0, :authors, 0)
   end
 
+  test "includes contacts" do
+    contact = create(:contact)
+    edition = create(:edition, depended_upon_contacts: [contact])
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    assert_equal [{ id: contact.id, content_id: contact.content_id }], result.dig(:editions, 0, :contacts)
+  end
+
   test "includes edition policies" do
     edition = create(:news_article)
     EditionPolicy.create!(policy_content_id: SecureRandom.uuid, edition_id: edition.id)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -167,6 +167,19 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal edition_policy, result.dig(:editions, 0, :edition_policies, 0)
   end
 
+  test "includes editorial remarks" do
+    author = create(:user)
+    remark = create(:editorial_remark, body: "My remark", author: author)
+
+    result = DocumentExportPresenter.new(remark.edition.document).as_json
+    expected = { id: remark.id,
+                 body: "My remark",
+                 author_id: author.id,
+                 created_at: Time.zone.now,
+                 author: { id: author.id, uid: author.uid } }
+    assert_equal expected, result.dig(:editions, 0, :editorial_remarks, 0)
+  end
+
   test "returns fact check request details" do
     fact_check_request = create(:fact_check_request)
     requestor = fact_check_request.requestor

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -1,6 +1,16 @@
 require "test_helper"
 
 class DocumentExportPresenterTest < ActiveSupport::TestCase
+  test "includes basic document and edition information" do
+    document = create(:document)
+    edition = create(:edition, document: document)
+    result = DocumentExportPresenter.new(document).as_json
+
+    assert_equal document.content_id, result[:content_id]
+    assert_equal document.slug, result[:slug]
+    assert_equal edition.id, result.dig(:editions, 0, :id)
+  end
+
   test "resolves internal Whitehall URLs in edition body with a public URL" do
     body = "Some text which contains an [internal link](/government/admin/news/2) to a public document"
     document = create(:document)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -24,6 +24,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     expected_whitehall_admin_links = [{
       whitehall_admin_url: "/government/admin/news/2",
       public_url: "www.test.gov.uk/government/generic-editions/some-article",
+      content_id: linked_edition.content_id,
     }]
 
     result = DocumentExportPresenter.new(document).as_json
@@ -43,6 +44,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     expected_whitehall_admin_links = [{
       whitehall_admin_url: "/government/admin/news/2",
       public_url: "www.test.gov.uk/government/generic-editions/some-article",
+      content_id: linked_edition.content_id,
     }]
 
     result = DocumentExportPresenter.new(edition.document).as_json
@@ -54,40 +56,42 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     publication = create(:publication, images: [image])
 
     result = DocumentExportPresenter.new(publication.document).as_json
-    images = result[:editions].first[:associations][:images]
 
-    assert_equal image.image_data.file_url, images.first["url"]
+    assert_equal image.image_data.file_url,
+                 result.dig(:editions, 0, :images, 0, :url)
   end
 
   test "appends expected attachment data to the file attachment response hash" do
     publication_file = create(:publication, :with_command_paper)
 
     result = DocumentExportPresenter.new(publication_file.document).as_json
-    attachments = result[:editions].first[:associations][:attachments]
+    attachment = result.dig(:editions, 0, :attachments, 0)
 
-    assert_equal publication_file.attachments.first.url, attachments.first["url"]
-    assert_equal "FileAttachment", attachments.first["type"]
-    assert_equal publication_file.attachments.first.attachment_data.as_json, attachments.first["attachment_data"]
+    assert_equal publication_file.attachments.first.url, attachment[:url]
+    assert_equal "FileAttachment", attachment[:type]
+    assert_equal publication_file.attachments.first.attachment_data.as_json.symbolize_keys,
+                 attachment[:attachment_data]
   end
 
   test "exports expected data with the external attachment response hash" do
     publication_external = create(:publication, :with_external_attachment)
 
     result = DocumentExportPresenter.new(publication_external.document).as_json
-    attachments = result[:editions].first[:associations][:attachments]
+    attachment = result.dig(:editions, 0, :attachments, 0)
 
-    assert_equal publication_external.attachments.first.url, attachments.first["url"]
-    assert_equal "ExternalAttachment", attachments.first["type"]
+    assert_equal publication_external.attachments.first.url, attachment[:url]
+    assert_equal "ExternalAttachment", attachment[:type]
   end
 
   test "appends expected govspeak data to the html attachment response hash" do
     publication_html = create(:publication)
 
     result = DocumentExportPresenter.new(publication_html.document).as_json
-    attachments = result[:editions].first[:associations][:attachments]
+    attachment = result.dig(:editions, 0, :attachments, 0)
 
-    assert_equal "HtmlAttachment", attachments.first["type"]
-    assert_equal publication_html.attachments.first.govspeak_content.as_json, attachments.first["govspeak_content"]
+    assert_equal "HtmlAttachment", attachment[:type]
+    assert_equal publication_html.attachments.first.govspeak_content.as_json.symbolize_keys,
+                 attachment[:govspeak_content]
   end
 
   test "appends the editions document type key to the response" do
@@ -117,7 +121,195 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     current_government = create(:current_government)
     edition = create(:edition)
     result = DocumentExportPresenter.new(edition.document).as_json
-    assert_equal edition.government, result[:editions].first[:government]
-    assert_equal current_government, result[:editions].first[:government]
+    assert_equal current_government.slug, result.dig(:editions, 0, :government, :slug)
+  end
+
+  test "returns alternative_format_provider content_id" do
+    organisation = create(:organisation)
+    edition = create(:news_article, alternative_format_provider_id: organisation.id)
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    assert_equal organisation.content_id,
+                 result.dig(:editions, 0, :alternative_format_provider_content_id)
+  end
+
+  test "includes authors" do
+    edition = create(:edition)
+    author = edition.authors.first
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    assert_equal ({ id: author.id, uid: author.uid }),
+                 result.dig(:editions, 0, :authors, 0)
+  end
+
+  test "includes edition policies" do
+    edition = create(:news_article)
+    EditionPolicy.create!(policy_content_id: SecureRandom.uuid, edition_id: edition.id)
+    edition_policy = edition.edition_policies.first
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    edition_policy = { id: edition_policy.id, policy_content_id: edition_policy.policy_content_id }
+    assert_equal edition_policy, result.dig(:editions, 0, :edition_policies, 0)
+  end
+
+  test "returns fact check request details" do
+    fact_check_request = create(:fact_check_request)
+    requestor = fact_check_request.requestor
+    edition = fact_check_request.edition
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected_fact_check_request =
+      fact_check_request.as_json(except: "requestor_id")
+                        .merge(requestor: { id: requestor.id, uid: requestor.uid })
+    assert_equal expected_fact_check_request.deep_symbolize_keys,
+                 result.dig(:editions, 0, :fact_check_requests, 0)
+  end
+
+  test "includes last_author" do
+    edition = create(:edition)
+    user = create(:user)
+    edition.versions.last.update!(whodunnit: user.id)
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    last_author = { id: edition.last_author.id, uid: edition.last_author.uid }
+    assert_equal last_author, result.dig(:editions, 0, :last_author)
+  end
+
+  test "includes organisations details" do
+    organisation = create(:organisation)
+    edition = create(:news_article, lead_organisations: [organisation])
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: organisation.id,
+                 content_id: organisation.content_id,
+                 lead: true,
+                 lead_ordering: 1 }
+    assert_equal expected, result.dig(:editions, 0, :organisations, 0)
+  end
+
+  test "includes role appointment (singular) details" do
+    edition = create(:speech)
+    role_appointment = edition.role_appointment
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: role_appointment.id,
+                 content_id: role_appointment.content_id }
+    assert_equal expected, result.dig(:editions, 0, :role_appointments, 0)
+  end
+
+  test "returns role appointments (plural) details" do
+    role_appointment = create(:role_appointment)
+    edition = create(:news_article, role_appointments: [role_appointment])
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: role_appointment.id,
+                 content_id: role_appointment.content_id }
+    assert_equal expected, result.dig(:editions, 0, :role_appointments, 0)
+  end
+
+  test "includes specialist sector details" do
+    edition = create(:edition)
+    ss = create(:specialist_sector, edition: Edition.last)
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: ss.id, topic_content_id: ss.topic_content_id, primary: ss.primary }
+    assert_equal expected, result.dig(:editions, 0, :specialist_sectors, 0)
+  end
+
+  test "includes topical events details" do
+    edition = create(:news_article)
+    edition.topical_events.create!(name: "Super important event", description: "Not that important")
+    topical_event = edition.topical_events.last
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: topical_event.id, content_id: topical_event.content_id }
+    assert_equal expected, result.dig(:editions, 0, :topical_events, 0)
+  end
+
+  test "includes translations" do
+    edition = create(:news_article,
+                     title: "Hello",
+                     summary: "Are you well?",
+                     body: "I am well, thank you")
+
+    english_translation = edition.translations.first
+    french_translation = edition.translations
+                                .create!(locale: "fr",
+                                         title: "Bonjour",
+                                         summary: "Ça va",
+                                         body: "ça va bien merci")
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = [
+      { id: english_translation.id,
+        locale: :en,
+        title: "Hello",
+        summary: "Are you well?",
+        body: "I am well, thank you",
+        created_at: english_translation.created_at,
+        updated_at: english_translation.updated_at,
+        base_path: "/government/news/hello" },
+      { id: french_translation.id,
+        locale: :fr,
+        title: "Bonjour",
+        summary: "Ça va",
+        body: "ça va bien merci",
+        created_at: french_translation.created_at,
+        updated_at: french_translation.updated_at,
+        base_path: "/government/news/hello.fr" },
+    ]
+    assert_equal expected, result.dig(:editions, 0, :translations)
+  end
+
+  test "includes world locations details" do
+    edition = create(:news_article_world_news_story)
+    world_location = edition.world_locations.last
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: world_location.id, content_id: world_location.content_id }
+    assert_equal expected, result.dig(:editions, 0, :world_locations, 0)
+  end
+
+  test "includes worldwide organisation (singular) details" do
+    worldwide_organisation = create(:worldwide_organisation)
+    edition = create(:corporate_information_page,
+                     organisation: nil,
+                     worldwide_organisation: worldwide_organisation)
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: worldwide_organisation.id,
+                 content_id: worldwide_organisation.content_id }
+    assert_equal expected, result.dig(:editions, 0, :worldwide_organisations, 0)
+  end
+
+  test "includes worldwide organisations (plural) details" do
+    worldwide_organisation = create(:worldwide_organisation)
+    edition = create(:case_study,
+                     worldwide_organisations: [worldwide_organisation])
+
+    result = DocumentExportPresenter.new(edition.document).as_json
+    expected = { id: worldwide_organisation.id,
+                 content_id: worldwide_organisation.content_id }
+    assert_equal expected, result.dig(:editions, 0, :worldwide_organisations, 0)
+  end
+
+  test "appends the editions document sub type key to the response" do
+    news = create(:news_article_press_release)
+    news_result = DocumentExportPresenter.new(news.document).as_json
+    assert_equal "press_release", news_result.dig(:editions, 0, :news_article_type)
+
+    publication = create(:publication, :statistics)
+    publication_result = DocumentExportPresenter.new(publication.document).as_json
+    assert_equal "official_statistics",
+                 publication_result.dig(:editions, 0, :publication_type)
+
+    speech = create(:speech, speech_type: SpeechType::Transcript)
+    speech_result = DocumentExportPresenter.new(speech.document).as_json
+    assert_equal "transcript", speech_result.dig(:editions, 0, :speech_type)
+
+    corporate_information_page = create(:corporate_information_page)
+    cip_result = DocumentExportPresenter.new(corporate_information_page.document).as_json
+    assert_equal "corporate_information_page",
+                 cip_result.dig(:editions, 0, :corporate_information_page_type)
   end
 end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -43,7 +43,8 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     }]
 
     result = DocumentExportPresenter.new(document).as_json
-    assert_equal expected_whitehall_admin_links, result[:editions][0][:whitehall_admin_links]
+    assert_equal expected_whitehall_admin_links,
+                 result.dig(:editions, 0, :whitehall_admin_links)
   end
 
   test "resolves internal Whitehall URLs in withdrawal explanation with a public URL" do
@@ -63,7 +64,8 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     }]
 
     result = DocumentExportPresenter.new(edition.document).as_json
-    assert_equal expected_whitehall_admin_links, result[:editions][-1][:whitehall_admin_links]
+    assert_equal expected_whitehall_admin_links,
+                 result.dig(:editions, 0, :whitehall_admin_links)
   end
 
   test "appends the image url to the images response hash" do

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -260,15 +260,6 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal expected, result.dig(:editions, 0, :revision_history)
   end
 
-  test "includes last_author" do
-    edition = create(:edition)
-    user = create(:user)
-    edition.versions.last.update!(whodunnit: user.id)
-
-    result = DocumentExportPresenter.new(edition.document).as_json
-    assert_equal edition.last_author.id, result.dig(:editions, 0, :last_author)
-  end
-
   test "includes organisations details" do
     organisation = create(:organisation)
     edition = create(:news_article, lead_organisations: [organisation])

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -312,4 +312,15 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal "corporate_information_page",
                  cip_result.dig(:editions, 0, :corporate_information_page_type)
   end
+
+  test "it removes document sub type ids" do
+    edition = create(:edition)
+    result = DocumentExportPresenter.new(edition.document).as_json
+
+    assert_equal edition.id, result.dig(:editions, 0, :id)
+    assert_nil result.dig(:edition, 0, :news_article_type_id)
+    assert_nil result.dig(:edition, 0, :publication_type_id)
+    assert_nil result.dig(:edition, 0, :speech_type_id)
+    assert_nil result.dig(:edition, 0, :corporate_information_page_type_id)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/at9jVJVu/1036-review-contents-of-document-export-and-remove-unnecessary-fields

This restructures the data of a document export from Whitehall so that it structured as a JSON dump of a document with editions inside that and edition relations inside the edition. This is instead of the previous system where we had document and editions distinct and then edition associations distinct too. A consequence of this is that Content Publisher will have to adapt its importing logic.

This reduces the amount of data output substantially be reducing most associations to just the bare ids. This is to only export data that we have control over and anticipate not to change. This has the benefit of reducing the amount of data exported massively too.

Btw @kevindew edited this empty PR description in-case writing this confuses future Peter