### PR TITLE
Standardise languages and IDs in Whitehall export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -61,13 +61,28 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   end
 
   def translate_ids_to_descriptive_values(edition)
+    replacements = []
+
     if edition[:news_article_type_id].present?
-      news_article_type = edition.news_article_type&.key
-      edition = edition.as_json
-      edition.delete("news_article_type_id")
-      edition["news_article_type"] = news_article_type
+      replacements << {
+        from: "news_article_type_id",
+        to: "news_article_type",
+        value: edition.news_article_type&.key,
+      }
     end
-    edition
+    if edition[:corporate_information_page_type_id].present?
+      replacements << {
+        from: "corporate_information_page_type_id",
+        to: "corporate_information_page_type",
+        value: edition.corporate_information_page_type&.key,
+      }
+    end
+
+    replacements.reduce(edition.as_json) do |memo, replacement|
+      memo.delete(replacement[:from])
+      memo[replacement[:to]] = replacement[:value]
+      memo
+    end
   end
 
   def provide_doctype_information(edition, output)

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -77,6 +77,13 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
         value: edition.corporate_information_page_type&.key,
       }
     end
+    if edition[:speech_type_id].present?
+      replacements << {
+        from: "speech_type_id",
+        to: "speech_type",
+        value: edition.speech_type&.key,
+      }
+    end
 
     replacements.reduce(edition.as_json) do |memo, replacement|
       memo.delete(replacement[:from])

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -41,6 +41,8 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
     if edition.withdrawn?
       output[:whitehall_admin_links].concat(resolve_whitehall_admin_links(edition.unpublishing.explanation))
     end
+
+    output[:edition] = translate_ids_to_descriptive_values(output[:edition])
     output
   end
 
@@ -56,6 +58,16 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
         json.merge!("govspeak_content" => attachment.govspeak_content.as_json) if attachment.respond_to?(:govspeak_content)
       end
     end
+  end
+
+  def translate_ids_to_descriptive_values(edition)
+    if edition[:news_article_type_id].present?
+      news_article_type = edition.news_article_type&.key
+      edition = edition.as_json
+      edition.delete("news_article_type_id")
+      edition["news_article_type"] = news_article_type
+    end
+    edition
   end
 
   def provide_doctype_information(edition, output)

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -84,6 +84,13 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
         value: edition.speech_type&.key,
       }
     end
+    if edition[:publication_type_id].present?
+      replacements << {
+        from: "publication_type_id",
+        to: "publication_type",
+        value: edition.publication_type&.key,
+      }
+    end
 
     replacements.reduce(edition.as_json) do |memo, replacement|
       memo.delete(replacement[:from])

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -61,40 +61,17 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   end
 
   def translate_ids_to_descriptive_values(edition)
-    replacements = []
-
-    if edition[:news_article_type_id].present?
-      replacements << {
-        from: "news_article_type_id",
-        to: "news_article_type",
-        value: edition.news_article_type&.key,
-      }
-    end
-    if edition[:corporate_information_page_type_id].present?
-      replacements << {
-        from: "corporate_information_page_type_id",
-        to: "corporate_information_page_type",
-        value: edition.corporate_information_page_type&.key,
-      }
-    end
-    if edition[:speech_type_id].present?
-      replacements << {
-        from: "speech_type_id",
-        to: "speech_type",
-        value: edition.speech_type&.key,
-      }
-    end
-    if edition[:publication_type_id].present?
-      replacements << {
-        from: "publication_type_id",
-        to: "publication_type",
-        value: edition.publication_type&.key,
-      }
-    end
-
-    replacements.reduce(edition.as_json) do |memo, replacement|
-      memo.delete(replacement[:from])
-      memo[replacement[:to]] = replacement[:value]
+    new_field_names = %w[
+      news_article_type
+      corporate_information_page_type
+      speech_type
+      publication_type
+    ]
+    new_field_names.reduce(edition.as_json) do |memo, new_field_name|
+      if edition["#{new_field_name}_id"].present?
+        memo.delete("#{new_field_name}_id")
+        memo[new_field_name] = edition.send(new_field_name)&.key
+      end
       memo
     end
   end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -114,6 +114,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
   test "converts ids to descriptive fields" do
     news = create(:news_article)
     corp_info = create(:corporate_information_page)
+    speech = create(:speech)
 
     news_result = DocumentExportPresenter.new(news.document).as_json
     edition = news_result[:editions].first[:edition]
@@ -124,5 +125,10 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     edition = corp_result[:editions].first[:edition]
     assert_nil edition["corporate_information_page_type_id"]
     assert_equal "corporate_information_page", edition["corporate_information_page_type"]
+
+    speech_result = DocumentExportPresenter.new(speech.document).as_json
+    edition = speech_result[:editions].first[:edition]
+    assert_nil edition["speech_type_id"]
+    assert_equal "transcript", edition["speech_type"]
   end
 end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -113,10 +113,16 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
   test "converts ids to descriptive fields" do
     news = create(:news_article)
+    corp_info = create(:corporate_information_page)
+
     news_result = DocumentExportPresenter.new(news.document).as_json
     edition = news_result[:editions].first[:edition]
-
     assert_nil edition["news_article_type_id"]
     assert_equal "press_release", edition["news_article_type"]
+
+    corp_result = DocumentExportPresenter.new(corp_info.document).as_json
+    edition = corp_result[:editions].first[:edition]
+    assert_nil edition["corporate_information_page_type_id"]
+    assert_equal "corporate_information_page", edition["corporate_information_page_type"]
   end
 end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -110,4 +110,13 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal edition.government, result[:editions].first[:government]
     assert_equal current_government, result[:editions].first[:government]
   end
+
+  test "converts ids to descriptive fields" do
+    news = create(:news_article)
+    news_result = DocumentExportPresenter.new(news.document).as_json
+    edition = news_result[:editions].first[:edition]
+
+    assert_nil edition["news_article_type_id"]
+    assert_equal "press_release", edition["news_article_type"]
+  end
 end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -115,6 +115,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     news = create(:news_article)
     corp_info = create(:corporate_information_page)
     speech = create(:speech)
+    publication = create(:publication)
 
     news_result = DocumentExportPresenter.new(news.document).as_json
     edition = news_result[:editions].first[:edition]
@@ -130,5 +131,10 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     edition = speech_result[:editions].first[:edition]
     assert_nil edition["speech_type_id"]
     assert_equal "transcript", edition["speech_type"]
+
+    publication_result = DocumentExportPresenter.new(publication.document).as_json
+    edition = publication_result[:editions].first[:edition]
+    assert_nil edition["publication_type_id"]
+    assert_equal "policy_paper", edition["publication_type"]
   end
 end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -137,4 +137,19 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_nil edition["publication_type_id"]
     assert_equal "policy_paper", edition["publication_type"]
   end
+
+  test "removes edition fields that are duplicated by the primary translation" do
+    news_result = DocumentExportPresenter.new(create(:news_article).document).as_json
+    edition = news_result[:editions].first[:edition]
+    translation = news_result[:editions].first[:associations][:translations].first
+
+    assert_equal "en", edition["primary_locale"]
+    assert_equal "en", translation["locale"]
+    assert_nil edition["title"]
+    assert_nil edition["summary"]
+    assert_nil edition["body"]
+    assert_equal "news-title", translation["title"]
+    assert_equal "news-summary", translation["summary"]
+    assert_equal "news-body", translation["body"]
+  end
 end


### PR DESCRIPTION
This PR improves the output when exporting content from Whitehall (e.g. http://whitehall-admin.dev.gov.uk/government/admin/export/document/376644) by:

- Removing duplicated fields on the edition root and the primary translation. (Fields are retained on the translation and removed from the edition root. We can therefore treat all languages the same)
- Converting various IDs into more useful 'type' values (e.g. `publication_type_id => 1` becomes `publication_type => "policy_paper"`)

Trello: https://trello.com/c/at9jVJVu/1036-review-contents-of-document-export-and-remove-unnecessary-fields