### PR TITLE
Fix the auth/failure route

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,7 +4,11 @@ class Admin::BaseController < ApplicationController
 
   layout "admin"
   prepend_before_action :skip_slimmer
-  prepend_before_action :authenticate_user!
+  prepend_before_action :authenticate_user!, except: %i[auth_failure]
+
+  def auth_failure
+    render "authentications/failure", status: 403
+  end
 
   def limit_edition_access!
     enforce_permission!(:see, @edition)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,12 @@ Whitehall::Application.routes.draw do
   get "/world/:id(.:locale)", as: "world_location", to: "world_locations#show", constraints: { locale: VALID_LOCALES_REGEX }
   get "/world/:world_location_id/news(.:locale)", as: "world_location_news_index", to: "world_location_news#index", constraints: { locale: VALID_LOCALES_REGEX }
 
+  # Override the /auth/failure route in gds-sso, as Slimmer gets
+  # involved and causes the page to fail to render
+  #
+  # This can be removed once Slimmer is removed from Whitehall.
+  get '/auth/failure', to: 'admin/base#auth_failure', as: "auth_failure_fixed"
+
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
     external_redirect "/organisations/ministry-of-defence-police-and-guarding-agency",
       "http://webarchive.nationalarchives.gov.uk/20121212174735/http://www.mod.uk/DefenceInternet/AboutDefence/WhatWeDo/SecurityandIntelligence/MDPGA/"


### PR DESCRIPTION
Previously, Slimmer would try to handle the page, and crash for some
reason.

Instead, handle the route explictly through the Admin::BaseController,
which skips Slimmer.

This should avoid errors reaching Sentry for this issue, and provide a
better user experience as well.

![whitehall-auth-failure](https://user-images.githubusercontent.com/1130010/67863018-0d757100-fb1b-11e9-9f40-5e1394043e50.png)
