### PR TITLE
Stop locked documents from appearing in CSV export

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -17,6 +17,10 @@ module Admin
       @options = options
     end
 
+    def options_for_export
+      @options.merge(include_locked_documents: false)
+    end
+
     def editions(locale = nil)
       @editions ||= {}
       return @editions[locale] if @editions[locale]

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -97,7 +97,7 @@
     <div class="col-md-5">
       <% if show_export && can?(:export, Edition) %>
         <div class="publishing-stats">
-          <%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}" %>
+          <%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options_for_export.to_param}" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/editions/confirm_export.html.erb
+++ b/app/views/admin/editions/confirm_export.html.erb
@@ -3,11 +3,11 @@
 <div class="row">
   <section class="col-md-8">
     <h1>Export as CSV</h1>
-    <p>Please confirm you want to export the documents list. The following will be emailed to <strong><%= current_user.email %></strong>:</p>
+    <p>Please confirm you want to export the documents list. Documents that have been moved to Content Publisher will not be exported. The following will be emailed to <strong><%= current_user.email %></strong>:</p>
     <ul>
       <li><%= @filter.page_title %></li>
     </ul>
-    <%= form_tag "#{export_admin_editions_path}?#{@filter.options.to_param}" %>
+    <%= form_tag "#{export_admin_editions_path}?#{@filter.options_for_export.to_param}" %>
       <%= submit_tag "Export as CSV", class: 'btn btn-primary' %>
 
       <%= link_to "Cancel and return to list", "#{admin_editions_path}?#{@filter.options.to_param}", class: 'btn btn-default' %>

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -17,7 +17,14 @@ private
   end
 
   def create_filter(filter_options, user)
-    Admin::EditionFilter.new(Edition, user, filter_options.symbolize_keys.merge(include_unpublishing: true))
+    Admin::EditionFilter.new(
+      Edition,
+      user,
+      filter_options.symbolize_keys.merge(
+        include_unpublishing: true,
+        include_locked_documents: false,
+      ),
+    )
   end
 
   def generate_csv(filter, csv_file)

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -345,4 +345,9 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2, include_locked_documents: true)
     assert_includes filter.editions, edition
   end
+
+  test "options for export should set 'include_locked_documents' to false" do
+    filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2, include_locked_documents: true)
+    assert_equal filter.options_for_export[:include_locked_documents], false
+  end
 end

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -7,7 +7,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   end
 
   test "instantiates an EditionFilter with passed options converted to symbols" do
-    Admin::EditionFilter.expects(:new).with(Edition, @user, state: "draft", include_unpublishing: true)
+    Admin::EditionFilter.expects(:new).with(Edition, @user, state: "draft", include_unpublishing: true, include_locked_documents: false)
     @worker.stubs(:generate_csv)
     @worker.stubs(:send_mail)
     @worker.perform({ "state" => "draft" }, @user.id)


### PR DESCRIPTION
Trello - https://trello.com/c/qgeWWHYa/1150-create-card-to-exclude-locked-doc-from-csv-export

As it stands when a user exports a CSV of documents from whitehall this includes
locked Documents that are either in the process of or has finished migrating to
content publisher. This should not be the case as once it has been migrated,
information that Whitehall has on the document may now be out of date. This PR
ensures that locked documents are no longer included in the CSV.

We've manually tested this in integration and it successfully changes the URL at
the bottom of the search results and stops Editions from appearing in the CSV report

Co-authored-by: Bruce Bolt <bruce.bolt@digital.cabinet-office.gov.uk>
