### PR TITLE
Export variants of image sizes and file attachments

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -95,7 +95,16 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   def present_images(edition)
     return [] unless edition.try(:images)
 
-    edition.images.map { |image| image.as_json(methods: :url) }
+    edition.images.map do |image|
+      image.as_json(methods: :url)
+           .merge(variants: image_variants(image))
+    end
+  end
+
+  def image_variants(image)
+    image.image_data.file.versions.each_with_object({}) do |(variant, details), memo|
+      memo[variant] = details.url
+    end
   end
 
   def present_organisations(edition)

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -68,6 +68,18 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
                          end
       attachment.as_json(include: :attachment_data, methods: %i[url type])
                 .merge(govspeak_content)
+                .merge(variants: attachment_variants(attachment))
+    end
+  end
+
+  def attachment_variants(attachment)
+    return {} unless attachment.try(:attachment_data)
+
+    attachment.attachment_data.file.versions.each_with_object({}) do |(variant, details), memo|
+      memo[variant] = {
+        content_type: details.content_type,
+        url: details.url,
+      }
     end
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -150,6 +150,23 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
                  attachment[:attachment_data]
   end
 
+  test "appends the attachment variants to the file attachment response hash" do
+    publication_file = create(:publication, :with_command_paper)
+    result = DocumentExportPresenter.new(publication_file.document).as_json
+    attachment = result.dig(:editions, 0, :attachments, 0)
+
+    attachment_url_parts = attachment[:url].split("/")
+    filename = attachment_url_parts.pop
+    attachment_dir_url = attachment_url_parts.join("/")
+    expected = {
+      thumbnail: {
+        content_type: "image/png",
+        url: "#{attachment_dir_url}/thumbnail_#{filename}.png",
+      },
+    }
+    assert_equal expected, attachment[:variants]
+  end
+
   test "exports expected data with the external attachment response hash" do
     publication_external = create(:publication, :with_external_attachment)
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -118,6 +118,26 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
                  result.dig(:editions, 0, :images, 0, :url)
   end
 
+  test "appends the image variants' urls to the images response hash" do
+    image = create(:image)
+    publication = create(:publication, images: [image])
+
+    image_url_parts = image.image_data.file_url.split("/")
+    filename = image_url_parts.pop
+    image_dir_url = image_url_parts.join("/")
+    expected = {
+      s960: "#{image_dir_url}/s960_#{filename}",
+      s712: "#{image_dir_url}/s712_#{filename}",
+      s630: "#{image_dir_url}/s630_#{filename}",
+      s465: "#{image_dir_url}/s465_#{filename}",
+      s300: "#{image_dir_url}/s300_#{filename}",
+      s216: "#{image_dir_url}/s216_#{filename}",
+    }
+
+    result = DocumentExportPresenter.new(publication.document).as_json
+    assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
+  end
+
   test "appends expected attachment data to the file attachment response hash" do
     publication_file = create(:publication, :with_command_paper)
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -145,6 +145,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     attachment = result.dig(:editions, 0, :attachments, 0)
 
     assert_equal publication_file.attachments.first.url, attachment[:url]
+    assert_match(/^file\-attachment\-title\-[0-9]+$/, attachment[:title])
     assert_equal "FileAttachment", attachment[:type]
     assert_equal publication_file.attachments.first.attachment_data.as_json.symbolize_keys,
                  attachment[:attachment_data]


### PR DESCRIPTION
When we import content from Whitehall, we need to ensure that we
transfer all the variants of image sizes and attachments too, in case they are
used by frontend applications. This is particularly true of image thumbnails.
There is no easy way to query these variants from outside of Whitehall, so this
work is best done as part of the export.

Trello card: https://trello.com/c/XOJ64DPo/1151-export-variants-of-images-and-attachments

![Screenshot of new data structure](https://user-images.githubusercontent.com/5111927/68030703-fe74f700-fcb1-11e9-9af5-645685d21725.png)
