### PR TITLE
Update focus state for Past Prime Ministers page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_historic-appointments.scss
+++ b/app/assets/stylesheets/frontend/views/_historic-appointments.scss
@@ -53,6 +53,10 @@
         img {
           width: $full-width;
         }
+
+        .govuk-link {
+          line-height: 1.16;
+        }
       }
     }
   }

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,9 +1,9 @@
 <%= content_tag_for :li, role_appointment, class: 'person person-excerpt' do %>
   <div class="inner">
     <div class="image-holder">
-      <%= link_to_if role_appointment.has_historical_account?, role_appointment.person.image, historic_appointment_path(role.historic_param, role_appointment.person), class: 'img' %>
+      <%= link_to_if role_appointment.has_historical_account?, role_appointment.person.image, historic_appointment_path(role.historic_param, role_appointment.person), class: "img", aria: {hidden: true}, tabindex: "-1" %>
     </div>
-    <h3 class="name"><%= link_to_if role_appointment.has_historical_account?, role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person) %></h3>
+    <h3 class="name"><%= link_to_if role_appointment.has_historical_account?, role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person), class: "govuk-link" %></h3>
     <p class="term"><%= role_appointment.historical_account.try(:political_membership) %> <%= role_appointment.date_range %></p>
   </div>
 <% end %>

--- a/app/views/historic_appointments/_role_appointments_list.html.erb
+++ b/app/views/historic_appointments/_role_appointments_list.html.erb
@@ -4,13 +4,13 @@
     <div id="contents">
       <h3>
         <span><%= previous_appointments_with_unique_people.size %></span>
-        <%= link_to_unless_current "Past #{@role.name.pluralize}", historic_appointments_path(role.historic_param) %>
+        <%= link_to_unless_current "Past #{@role.name.pluralize}", historic_appointments_path(role.historic_param), class: "govuk-link" %>
       </h3>
       <ol>
         <% previous_appointments_with_unique_people.each do |role_appointment| %>
           <li>
             <% if role_appointment.has_historical_account? %>
-              <%= link_to_unless_current role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person) %>
+              <%= link_to_unless_current role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person), class: "govuk-link" %>
             <% else %>
               <%= role_appointment.person.name %>
             <% end %>

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -3,10 +3,13 @@
 
 <header class="block headings-block">
   <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', histories_path),
-                        heading: "Past #{@role.name.pluralize}",
-                        big: true } %>
+    <%= render "govuk_publishing_components/components/title", {
+        context: {
+          text: "History",
+          href: histories_path,
+        },
+        title: "Past #{@role.name.pluralize}"
+      } %>
   </div>
 </header>
 


### PR DESCRIPTION
Trello: https://trello.com/c/6H95jFL2

- Adds govuk-link class where needed
- Uses title component to inherit correct focus state
- Add tabindex to prevent images from getting focus (links are duplicated below in text)

Live page: https://www.gov.uk/government/history/past-prime-ministers

### Before

![Screen Shot 2019-11-04 at 14 29 59](https://user-images.githubusercontent.com/31649453/68128651-092cc780-ff10-11e9-84c3-fdd213a16480.png)
![Screen Shot 2019-11-04 at 14 30 24](https://user-images.githubusercontent.com/31649453/68128652-092cc780-ff10-11e9-8959-bc179617172d.png)
![Screen Shot 2019-11-04 at 14 30 33](https://user-images.githubusercontent.com/31649453/68128653-092cc780-ff10-11e9-883d-52180b1b7d1f.png)

### After
![Screen Shot 2019-11-04 at 14 31 44](https://user-images.githubusercontent.com/31649453/68128694-1e095b00-ff10-11e9-8629-a84044810f14.png)
![Screen Shot 2019-11-04 at 14 31 55](https://user-images.githubusercontent.com/31649453/68128695-1ea1f180-ff10-11e9-9d7f-6006f6b54ed0.png)

