### PR TITLE
Add govuk-link to organisations for Courts and Tribunals page

### DIFF
--- a/app/views/organisations/_index_item_plain.html.erb
+++ b/app/views/organisations/_index_item_plain.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag_for :li, organisation, class: 'js-filter-item department index-item-plain',
               "data-filter-terms" => filter_terms(organisation) do %>
   <%= link_to organisation.name, organisation_path(organisation),
-    id: organisation.slug, class: 'department-link' %>
+    id: organisation.slug, class: 'department-link govuk-link' %>
   <%= govuk_status_meta_data_for(organisation) %>
   <%= render partial: 'works_with', locals: { organisation: organisation } %>
 <% end %>


### PR DESCRIPTION
- Adds govuk-link class

Live link: https://www.gov.uk/courts-tribunals
Part of https://trello.com/c/KJo6tZXo/58-5-update-whitehall-to-govukpublishingcomponents-v21x-with-compatibility-mode-on

### Before

![Screen Shot 2019-11-04 at 14 53 50](https://user-images.githubusercontent.com/31649453/68130459-4a72a680-ff13-11e9-9e7b-c1fb862ddfad.png)

### After
![Screen Shot 2019-11-04 at 14 55 04](https://user-images.githubusercontent.com/31649453/68130462-4d6d9700-ff13-11e9-89f2-4ae3ef8fdb77.png)


