### PR TITLE
Fix focus state for World Organisation pages

### DIFF
--- a/app/assets/javascripts/application/hide-extra-rows.js
+++ b/app/assets/javascripts/application/hide-extra-rows.js
@@ -36,7 +36,7 @@
         });
 
         if($hiddenElements.contents().length > 0){
-          var openButton = $('<a class="show-other-content" href="#" title="Show additional content"><span class="plus">+&nbsp;</span>others</a>');
+          var openButton = $('<a class="show-other-content govuk-link" href="#" title="Show additional content"><span class="plus">+&nbsp;</span>others</a>');
 
           openButton.on('click', function(e) {
             e.preventDefault();

--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -92,10 +92,6 @@
         &:focus,
         &:active {
           text-decoration: none;
-
-          strong {
-            text-decoration: underline;
-          }
         }
       }
     }

--- a/app/assets/stylesheets/frontend/helpers/_social-media-accounts.scss
+++ b/app/assets/stylesheets/frontend/helpers/_social-media-accounts.scss
@@ -2,7 +2,6 @@
   li {
     list-style: none;
     clear: both;
-    overflow: hidden;
     margin: $gutter-one-third 0;
     @include core-16;
     padding: 0;

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -207,7 +207,7 @@ Please tell us:
     options[:locale] = locale
     options[:locale] = nil if locale.to_s == "en"
 
-    link_to native_language_name_for(locale), options, lang: locale
+    link_to native_language_name_for(locale), options, lang: locale, class: "govuk-link"
   end
 
   def part_of_metadata(document, policies = [], sector_tag_finder = SpecialistTagFinder::Null.new)

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -131,6 +131,7 @@ private
       .tap { |nokogiri_doc|
         # post-processors
         replace_internal_admin_links_in(nokogiri_doc, &block)
+        add_class_to_links(nokogiri_doc)
         add_class_to_last_blockquote_paragraph(nokogiri_doc)
 
         case options[:heading_numbering]
@@ -202,6 +203,12 @@ private
   def add_class_to_last_blockquote_paragraph(nokogiri_doc)
     nokogiri_doc.css("blockquote p:last-child").map do |el|
       el[:class] = "last-child"
+    end
+  end
+
+  def add_class_to_links(nokogiri_doc)
+    nokogiri_doc.css("a").map do |el|
+      el[:class] = "govuk-link"
     end
   end
 

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -67,7 +67,7 @@ class PersonPresenter < Whitehall::Decorators::Decorator
     name = ""
     name << "<span class='person-title'>The Rt Hon</span> " if privy_counsellor?
     name << "<strong>#{name_without_privy_counsellor_prefix}</strong>"
-    context.link_to name.html_safe, path, options
+    context.link_to name.html_safe, path, options.merge(class: "govuk-link")
   end
 
   def path

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -22,13 +22,13 @@
           <% if contact.email.present? %>
             <p class="email">
               <span class="type"><%= t('contact.email') %></span>
-              <%= mail_to contact.email, contact.email, class: 'email' %>
+              <%= mail_to contact.email, contact.email, class: "email govuk-link" %>
             </p>
           <% end %>
           <% if contact.contact_form_url.present? %>
             <p class="contact_form_url">
               <span class="type"><%= t('contact.contact_form') %></span>
-              <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url %>
+              <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
             </p>
           <% end %>
           <% contact.contact_numbers.each do |number| %>
@@ -41,7 +41,9 @@
       <% end %>
 
       <% if contact.comments.present? %>
-        <p class="comments"><%= auto_link(format_with_html_line_breaks(h(contact.comments))) %></p>
+        <p class="comments">
+          <%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %>
+        </p>
       <% end %>
 
       <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
@@ -49,7 +51,7 @@
           fallback = t_fallback('contact.access_and_opening_times')
           lang = fallback if fallback && fallback != I18n.locale
         %>
-        <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "url", lang: lang %>
+        <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "url govuk-link", lang: lang %>
       <% end %>
     </div>
   </div>

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -11,7 +11,7 @@
       <% unless hide_image %>
         <% if person.image %>
           <div class="image-holder">
-            <%= link_to person.image, person, class: "img" %>
+            <%= link_to person.image, person, class: "img", tabindex: '-1', aria: {hidden: true} %>
           </div>
         <% else %>
           <div class="blank-person">

--- a/app/views/shared/_social_media_accounts.html.erb
+++ b/app/views/shared/_social_media_accounts.html.erb
@@ -8,7 +8,7 @@
       <% socialable.social_media_accounts.each do |account| %>
         <%= content_tag_for(:li, account) do %>
           <%= link_to account.url,
-                      class: "social-media-link #{account.service_name.parameterize}" do %>
+                      class: "social-media-link #{account.service_name.parameterize} govuk-link" do %>
             <span class="connect"></span><%= account.display_name %>
           <% end %>
         <% end %>

--- a/app/views/worldwide_organisations/_corporate_information.html.erb
+++ b/app/views/worldwide_organisations/_corporate_information.html.erb
@@ -7,12 +7,12 @@
         <ul>
           <% organisation.corporate_information_pages.published.by_menu_heading(:our_information).each do |corporate_information_page| %>
             <% corporate_information_page.extend(UseSlugAsParam) %>
-            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page] %></li>
+            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page], class: "govuk-link" %></li>
           <% end %>
 
           <% organisation.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |corporate_information_page| %>
             <% corporate_information_page.extend(UseSlugAsParam) %>
-            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page]%></li>
+            <li <%= corporate_information_page.title_lang %> ><%= link_to corporate_information_page.title, [organisation, corporate_information_page], class: "govuk-link" %></li>
           <% end %>
         </ul>
       </nav>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -23,10 +23,10 @@
       <dl>
         <% if world_locations.any? %>
           <dt><%= t('worldwide_organisation.location') %>:</dt>
-          <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l) }.to_sentence.html_safe %></dd>
+          <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l, class: "govuk-link") }.to_sentence.html_safe %></dd>
         <% end %>
         <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-        <dd><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation") }.to_sentence.html_safe %></dd>
+        <dd><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
       </dl>
     </div>
   </div>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -1,6 +1,5 @@
 <% page_title @worldwide_organisation.name %>
 <% page_class "worldwide-organisations-show" %>
-
 <%= render partial: 'header', locals: { organisation: @worldwide_organisation, world_locations: @world_locations } %>
 
 <section class="block about-block" id="about-us">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -33,47 +33,6 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "1b28bbfd8fcc341513e1b805b05624e55defe0ef04198bc7f482b119dd2da7c4",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 29,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).sponsoring_organisations.map do\n link_to(o.name, o, :class => \"sponsoring-organisation\")\n end.to_sentence",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "CorporateInformationPagesController",
-          "method": "show",
-          "line": 9,
-          "file": "app/controllers/corporate_information_pages_controller.rb",
-          "rendered": {
-            "name": "corporate_information_pages/show_worldwide_organisation",
-            "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "corporate_information_pages/show_worldwide_organisation",
-          "line": 4,
-          "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb",
-          "rendered": {
-            "name": "worldwide_organisations/_header",
-            "file": "app/views/worldwide_organisations/_header.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "worldwide_organisations/_header"
-      },
-      "user_input": "Organisation.friendly.find(params[:organisation_id])",
-      "confidence": "Weak",
-      "note": "We don't link directly to any unescaped model attribute."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "1cc573a78d6cc4fbcde77a4b472fc7095eea27e1135442d379dd20e64f08085c",
       "check_name": "LinkToHref",
@@ -124,6 +83,36 @@
       "note": "The system binaries are constants, and the others are built in code, there is no user input."
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "2e8f4b07eb80d409f94338adaee161683ad19c71a77b71aab70ce5591e95cef1",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/contacts/_contact.html.erb",
+      "line": 31,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.contact_form_url.truncate(25), (Unresolved Model).new.contact_form_url, :class => \"govuk-link\")",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "organisations/show",
+          "line": 222,
+          "file": "app/views/organisations/show.html.erb",
+          "rendered": {
+            "name": "contacts/_contact",
+            "file": "app/views/contacts/_contact.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "contacts/_contact"
+      },
+      "user_input": "(Unresolved Model).new.contact_form_url",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "3bbe521f1296024aed2d6a49f3cb14ea53fdd0aaa221aac334d8fc89bd855e17",
@@ -158,7 +147,7 @@
           "type": "controller",
           "class": "Admin::EditionsController",
           "method": "show",
-          "line": 81,
+          "line": 87,
           "file": "app/controllers/admin/editions_controller.rb",
           "rendered": {
             "name": "admin/editions/show",
@@ -183,6 +172,47 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": "This comes from a new model so we trust the data."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "3ce1608afbd361b96667e68317e7c2c811a24f7313d7f87c1df5805670ac0813",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/worldwide_organisations/_header.html.erb",
+      "line": 26,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).world_locations.map do\n link_to(l.name, l, :class => \"govuk-link\")\n end.to_sentence",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "CorporateInformationPagesController",
+          "method": "show",
+          "line": 9,
+          "file": "app/controllers/corporate_information_pages_controller.rb",
+          "rendered": {
+            "name": "corporate_information_pages/show_worldwide_organisation",
+            "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "corporate_information_pages/show_worldwide_organisation",
+          "line": 4,
+          "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb",
+          "rendered": {
+            "name": "worldwide_organisations/_header",
+            "file": "app/views/worldwide_organisations/_header.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "worldwide_organisations/_header"
+      },
+      "user_input": "Organisation.friendly.find(params[:organisation_id])",
+      "confidence": "Weak",
+      "note": ""
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -417,13 +447,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "b9a59bd95d6f54e1a34b77c1f7dcceebfe0c44401a1060cf026bcb1f13263b5a",
+      "fingerprint": "bd844c633fbb1e3329169e5ca326d05505ef596d5ef24c9862c034d3cc000534",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 26,
+      "line": 29,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).world_locations.map do\n link_to(l.name, l)\n end.to_sentence",
+      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).sponsoring_organisations.map do\n link_to(o.name, o, :class => \"sponsoring-organisation govuk-link\")\n end.to_sentence",
       "render_path": [
         {
           "type": "controller",
@@ -453,7 +483,7 @@
       },
       "user_input": "Organisation.friendly.find(params[:organisation_id])",
       "confidence": "Weak",
-      "note": "We don't link directly to any unescaped model attribute."
+      "note": ""
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -474,36 +504,6 @@
       "user_input": "params[:id].underscore",
       "confidence": "Medium",
       "note": "We check that the params[:id] is valid before rendering the template."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "c08711cc21cb1dbf0709db0011a9a4a782bf6c1a6f7a0a1e1d4b000d20462ae2",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/contacts/_contact.html.erb",
-      "line": 31,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.contact_form_url.truncate(25), (Unresolved Model).new.contact_form_url)",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "organisations/show",
-          "line": 222,
-          "file": "app/views/organisations/show.html.erb",
-          "rendered": {
-            "name": "contacts/_contact",
-            "file": "app/views/contacts/_contact.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "contacts/_contact"
-      },
-      "user_input": "(Unresolved Model).new.contact_form_url",
-      "confidence": "Weak",
-      "note": "This comes from a new model so we trust the data."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -657,28 +657,8 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": "This comes from a new model so we trust the data."
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "eb4406ba30350c46d5613c9dc9bbd8c21c8565b95e19ca4975a4489c120835a0",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/email_signups_controller.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(EmailSignup.new(email_signup_params).signup_url)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "EmailSignupsController",
-        "method": "create"
-      },
-      "user_input": "EmailSignup.new(email_signup_params).signup_url",
-      "confidence": "High",
-      "note": "This comes from the Content Store and we trust data from there."
     }
   ],
-  "updated": "2019-07-25 11:30:37 +0100",
-  "brakeman_version": "4.6.1"
+  "updated": "2019-11-05 09:14:39 +0000",
+  "brakeman_version": "4.7.0"
 }

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -139,7 +139,7 @@ class DocumentHelperTest < ActionView::TestCase
       locale: "it",
       id: "a-world-location",
     )
-    assert_dom_equal %(<a lang="de" href="/world/a-world-location.de">Deutsch</a>),
+    assert_dom_equal %(<a lang="de" class="govuk-link" href="/world/a-world-location.de">Deutsch</a>),
                      link_to_translation(:de)
   end
 
@@ -150,7 +150,7 @@ class DocumentHelperTest < ActionView::TestCase
       locale: "it",
       id: "a-world-location",
     )
-    assert_dom_equal %(<a lang="en" href="/world/a-world-location">English</a>),
+    assert_dom_equal %(<a lang="en"  class="govuk-link" href="/world/a-world-location">English</a>),
                      link_to_translation(:en)
   end
 


### PR DESCRIPTION
- Adds govuk-link class where needed
- Updates tests

Live example: https://www.gov.uk/world/organisations/british-consulate-general-hong-kong

### Before
![Screen Shot 2019-11-05 at 09 38 47](https://user-images.githubusercontent.com/31649453/68196291-48aaf080-ffb0-11e9-9b20-694627a44d09.png)
![Screen Shot 2019-11-05 at 09 39 01](https://user-images.githubusercontent.com/31649453/68196292-49438700-ffb0-11e9-945f-3c7d0e0ca844.png)
![Screen Shot 2019-11-05 at 09 39 09](https://user-images.githubusercontent.com/31649453/68196294-49438700-ffb0-11e9-98bc-dae9a5464f5c.png)

### After
![Screen Shot 2019-11-05 at 09 39 19](https://user-images.githubusercontent.com/31649453/68196320-552f4900-ffb0-11e9-8fda-9f5e073e9bd4.png)
![Screen Shot 2019-11-05 at 09 39 26](https://user-images.githubusercontent.com/31649453/68196321-552f4900-ffb0-11e9-9b12-84fd9bde8aaa.png)
![Screen Shot 2019-11-05 at 09 39 36](https://user-images.githubusercontent.com/31649453/68196322-552f4900-ffb0-11e9-89d2-f6cda81c1be1.png)

