### PR TITLE
Only show unique author IDs in document export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -25,7 +25,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
     edition.as_json(except: except).merge(
       alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,
       attachments: present_attachments(edition),
-      authors: edition.authors.pluck(:id),
+      authors: edition.authors.pluck(:id).uniq,
       contacts: slice_association(edition, :depended_upon_contacts, %i[id content_id]),
       edition_policies: slice_association(edition, :edition_policies, %i[id policy_content_id]),
       editorial_remarks: present_editorial_remarks(edition),


### PR DESCRIPTION
We are currently exporting the authors for each edition.  If a single user has edited an edition multiple times, they will unnecessarily appear multiple times in this list.

This change extracts only unique values, so removes the duplication.

Example:
<img width="335" alt="Screen Shot 2019-11-04 at 15 39 37" src="https://user-images.githubusercontent.com/6329861/68134175-a4766a80-ff19-11e9-9aad-ba7a2f03de59.png">