### PR TITLE
Add endpoints to lock and unlock a document

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -21,7 +21,10 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     document.update!(locked: true)
   end
 
-  def unlock; end
+  def unlock
+    document = Document.find(params[:id])
+    document.update!(locked: false)
+  end
 
   private
 

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -16,7 +16,10 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     )
   end
 
-  def lock; end
+  def lock
+    document = Document.find(params[:id])
+    document.update!(locked: true)
+  end
 
   private
 

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -1,4 +1,5 @@
 class Admin::Export::DocumentController < Admin::Export::BaseController
+  skip_before_action :verify_authenticity_token
   self.responder = Api::Responder
 
   def show

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -21,6 +21,8 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     document.update!(locked: true)
   end
 
+  def unlock; end
+
   private
 
   def paginated_document_ids

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -16,6 +16,8 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     )
   end
 
+  def lock; end
+
   private
 
   def paginated_document_ids

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,7 +189,11 @@ Whitehall::Application.routes.draw do
         root to: "dashboard#index", via: :get
 
         namespace "export" do
-          resources :document, only: %i[show index], defaults: { format: :json }
+          resources :document, only: %i[show index], defaults: { format: :json } do
+            member do
+              post :lock
+            end
+          end
         end
 
         get "find-in-admin-bookmarklet" => "find_in_admin_bookmarklet#index", as: :find_in_admin_bookmarklet_instructions_index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,7 @@ Whitehall::Application.routes.draw do
           resources :document, only: %i[show index], defaults: { format: :json } do
             member do
               post :lock
+              post :unlock
             end
           end
         end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -105,4 +105,14 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     post :unlock, params: { id: "1" }, format: "json"
     assert_response :forbidden
   end
+
+  test "unlocks document" do
+    document = create(:document, locked: true)
+    login_as :export_data_user
+
+    post :unlock, params: { id: document.id }, format: "json"
+
+    refute document.reload.locked
+    assert_response :no_content
+  end
 end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -83,4 +83,10 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
 
     assert_equal expected_response, json_response
   end
+
+  test "lock returns forbidden if user does not have export data permission" do
+    login_as :world_editor
+    post :lock, params: { id: "1" }, format: "json"
+    assert_response :forbidden
+  end
 end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -89,4 +89,14 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     post :lock, params: { id: "1" }, format: "json"
     assert_response :forbidden
   end
+
+  test "locks document" do
+    document = create(:document)
+    login_as :export_data_user
+
+    post :lock, params: { id: document.id }, format: "json"
+
+    assert document.reload.locked
+    assert_response :no_content
+  end
 end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -99,4 +99,10 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert document.reload.locked
     assert_response :no_content
   end
+
+  test "unlock returns forbidden if user does not have export data permission" do
+    login_as :world_editor
+    post :unlock, params: { id: "1" }, format: "json"
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/V17DA7ma
Follows on from: https://github.com/alphagov/whitehall/pull/4903

## What's changed?
Add two imports to the Document Export API to "lock" and "unlock" a document.

The lock and unlock requests are only allowed for authenticated users who have the export permission.

## Why?
A while ago we added the ability to lock a document in Whitehall to prevent a document from being edited in Whitehall during, and after, a migration. Should a migration fail we need the ability to unlock the document.

## Results from local testing

### Locking

```
curl -i -H "Content-Type: application/json" -H "Authorization: Bearer example" -X POST http://whitehall-admin.dev.gov.uk/government/admin/export/document/430652/lock

HTTP/1.1 204 No Content
Server: nginx/1.17.3
Date: Tue, 05 Nov 2019 16:09:53 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Cache-Control: no-cache
X-Request-Id: 97cd576e-45aa-4676-bbea-a66e625386bb
X-Runtime: 0.406012
Access-Control-Allow-Origin: *
```
```
Document.find(430652)
  Document Load (0.5ms)  SELECT  `documents`.* FROM `documents` WHERE `documents`.`id` = 430652 LIMIT 1
=> #<Document:0x000055bead9b26e0
 id: 430652,
 created_at: Sat, 02 Nov 2019 21:38:34 GMT +00:00,
 updated_at: Tue, 05 Nov 2019 16:09:53 GMT +00:00,
 slug: "18m-extension-to-opportunity-area-programme",
 document_type: "NewsArticle",
 content_id: "7104f52a-29c5-4597-ba96-eeceedff8a3e",
 locked: true>
```

### Unlocking
```
curl -i -H "Content-Type: application/json" -H "Authorization: Bearer example" -X POST http://whitehall-admin.dev.gov.uk/government/admin/export/document/430652/unlock

HTTP/1.1 204 No Content
Server: nginx/1.17.3
Date: Tue, 05 Nov 2019 16:11:58 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Cache-Control: no-cache
X-Request-Id: 7a59c026-42a8-4c38-ab42-2cfa1384bc24
X-Runtime: 0.310073
Access-Control-Allow-Origin: *

 Document.find(430652)
  Document Load (0.8ms)  SELECT  `documents`.* FROM `documents` WHERE `documents`.`id` = 430652 LIMIT 1
=> #<Document:0x000055beada01b00
 id: 430652,
 created_at: Sat, 02 Nov 2019 21:38:34 GMT +00:00,
 updated_at: Tue, 05 Nov 2019 16:11:58 GMT +00:00,
 slug: "18m-extension-to-opportunity-area-programme",
 document_type: "NewsArticle",
 content_id: "7104f52a-29c5-4597-ba96-eeceedff8a3e",
 locked: false>
```
