### PR TITLE
Guard against database failures in the HealthcheckController

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,5 +1,8 @@
 class HealthcheckController < ActionController::API
   def overdue
     render json: { overdue: Edition.due_for_publication.count }
+  rescue ActiveRecord::StatementInvalid => e
+    logger.error "HealthcheckController#overdue: #{e.message}"
+    render json: { overdue: nil }, status: 503
   end
 end


### PR DESCRIPTION
The overdue URL is accessed by the govuk_uptime_collector, and this
happens on Staging while the database is being synced from Production.

As the database is out of action when being restored, there are errors
getting to Sentry relating to the query here failing. Rather than
letting these errors get to Sentry, catch the exception and log the
message.