### PR TITLE
Prevent exporting image variants when they don't exist

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -115,7 +115,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
   def image_variants(image)
     image.image_data.file.versions.each_with_object({}) do |(variant, details), memo|
-      memo[variant] = details.url
+      memo[variant] = details.url if details.url
     end
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -138,6 +138,15 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
   end
 
+  test "ignores variants when they do not exist" do
+    svg_image_data = create(:image_data, file: File.open(File.join(Rails.root, "test", "fixtures", "images", "test-svg.svg")))
+    publication = create(:publication, images: [create(:image, image_data: svg_image_data)])
+    expected = {}
+
+    result = DocumentExportPresenter.new(publication.document).as_json
+    assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
+  end
+
   test "appends expected attachment data to the file attachment response hash" do
     publication_file = create(:publication, :with_command_paper)
 


### PR DESCRIPTION
SVGs would return 'variants: { s960: null, s712: null, ...etc }', as they are
SVGs and thus have no variants (SVGs scale automatically so no thumbs required).
Rather than relying on 'image.image_data.file.versions' to tell us which versions
of an image exist, we now make only populate the 'variants' hash if a URL exists.

Should have been done as part of https://github.com/alphagov/whitehall/pull/5100 - apologies.

Before:

![Screenshot 2019-11-05 at 10 38 24](https://user-images.githubusercontent.com/5111927/68202243-36827f80-ffbb-11e9-821f-ccac90acdcc9.png)

After:

![Screenshot 2019-11-05 at 10 55 57](https://user-images.githubusercontent.com/5111927/68202254-3aae9d00-ffbb-11e9-8ab6-0e220d2efe9b.png)

Trello: https://trello.com/c/XOJ64DPo/1151-export-variants-of-images-and-attachments