### PR TITLE
Don't run search:index:consultations overnight in Staging or Integration

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,16 +4,16 @@ env :PATH, "/usr/local/bin:/usr/bin:/bin"
 # We need Rake to use our own environment
 job_type :rake, "cd :path && govuk_setenv whitehall bundle exec rake :task --silent :output"
 
+def integration_or_staging?
+  ENV.fetch("GOVUK_WEBSITE_ROOT") =~ /integration|staging/
+end
+
 every :day, at: ["3am", "12:45pm"], roles: [:admin] do
   rake "export:mappings"
 end
 
 every :hour, roles: [:backend] do
   rake "search:index:consultations"
-end
-
-def integration_or_staging?
-  ENV.fetch("GOVUK_WEBSITE_ROOT") =~ /integration|staging/
 end
 
 def taxonomy_cron_rules

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,17 @@ every :day, at: ["3am", "12:45pm"], roles: [:admin] do
   rake "export:mappings"
 end
 
-every :hour, roles: [:backend] do
+def search_index_consultations_cron_rule
+  if integration_or_staging?
+    # Don't run near midnight, as this is when the data sync will
+    # likely happen, and the task will error
+    "0 2-22 * * *"
+  else
+    :hour
+  end
+end
+
+every search_index_consultations_cron_rule, roles: [:backend] do
   rake "search:index:consultations"
 end
 


### PR DESCRIPTION
As while the data syncs take place overnight, there's a chance it'll
error, adding to the noise in Signon.

