### PR TITLE
Fix focus states on past prime ministers page

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -139,11 +139,13 @@ $govuk-typography-use-rem: false;
 // TODO: This 👇 `a.govuk-link:focus` overrides the global `a:link:focus` style
 // coming from static and the global styles set in `global/_links.scss`. This
 // can be removed when the style from static and Whitehall removed.
+// When removing ensure all cases are captured - some rules in helpers/_headings.scss
+// are very specific, requiring the !important here
 #whitehall-wrapper {
   a.govuk-link{
     text-decoration: underline;
     &:focus {
-      color: $govuk-focus-text-colour;
+      color: $govuk-focus-text-colour !important;
       text-decoration: none;
     }
   }

--- a/app/assets/stylesheets/frontend/helpers/_headings.scss
+++ b/app/assets/stylesheets/frontend/helpers/_headings.scss
@@ -22,6 +22,7 @@
       @include core-27;
       color: $secondary-text-colour;
       margin-bottom: $gutter-one-sixth;
+      text-decoration: none;
     }
   }
   .heading-with-extra {

--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -4,7 +4,7 @@
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', histories_path),
+              locals: { type: link_to('History', histories_path, class: "govuk-link"),
                         heading: "Past #{@role.name.pluralize}",
                         big: true } %>
   </div>
@@ -36,7 +36,7 @@
   </div>
   <div class="person-detail">
     <div class="inner">
-      <p class="intro"><%= @historical_account.summary %></p>
+      <p class="govuk-body-l"><%= @historical_account.summary %></p>
 
       <%= govspeak_to_html @historical_account.body %>
     </div>


### PR DESCRIPTION
Update focus states on links for the pages showing a past Prime Minister, eg
http://whitehall-admin.dev.gov.uk/government/history/past-prime-ministers/john-major

### Before
<img width="474" alt="Screen Shot 2019-11-06 at 13 34 16" src="https://user-images.githubusercontent.com/31649453/68303976-cea46580-009c-11ea-9aee-d0c8029202b1.png">

### After
<img width="472" alt="Screen Shot 2019-11-06 at 13 34 52" src="https://user-images.githubusercontent.com/31649453/68304007-d82dcd80-009c-11ea-8420-8942e953e206.png">

### Before
<img width="230" alt="Screen Shot 2019-11-06 at 13 34 32" src="https://user-images.githubusercontent.com/31649453/68304031-e11e9f00-009c-11ea-859f-fbf10d785df6.png">
### After
<img width="234" alt="Screen Shot 2019-11-06 at 13 35 23" src="https://user-images.githubusercontent.com/31649453/68304057-ebd93400-009c-11ea-87bc-6415f0077049.png">

### Before
<img width="209" alt="Screen Shot 2019-11-06 at 13 34 42" src="https://user-images.githubusercontent.com/31649453/68304078-f693c900-009c-11ea-898a-c28bd1169c08.png">
### After
<img width="220" alt="Screen Shot 2019-11-06 at 13 35 05" src="https://user-images.githubusercontent.com/31649453/68304094-ff849a80-009c-11ea-843e-2542d7b070a3.png">
