### PR TITLE
Don't send Publishing API HTTP conflict errors to Sentry

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -20,6 +20,12 @@ class PublishingApiWorker < WorkerBase
     I18n.with_locale(locale) do
       begin
         send_item(presenter, locale, bulk_publishing)
+      rescue GdsApi::HTTPConflict => e
+        # The Publishing API sometimes returns: Cannot publish an
+        # already published edition. Ideally we'd avoid this error,
+        # but for now, just avoid recording it in Sentry, as it's
+        # not actionable.
+        logger.error "PublishingApiWorker: HTTPConflict: #{e.message}"
       rescue GdsApi::HTTPClientError => e
         handle_client_error(e)
       end


### PR DESCRIPTION
These are unactionable, as the Publishing API is saying that there's
nothing to Publish. This error relates to Whitehall using workers to
send content to the Publishing API, which is ideally something that
won't happen eventually.