### PR TITLE
Update location of embassy for Maldives

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -72,9 +72,9 @@ private
       base_path: "/government/world/organisations/british-consulate-general-hong-kong",
     },
     "Maldives" => {
-      building: "British High Commission Colombo",
-      location: "Sri Lanka",
-      base_path: "/government/world/organisations/british-high-commission-colombo",
+      building: "British Embassy Malé",
+      location: "Maldives",
+      base_path: "/government/world/organisations/british-embassy-maldives",
     },
     "Marshall Islands" => {
       building: "British High Commission Suva",


### PR DESCRIPTION
Previously British citizens in Maldives had to contact the British High Commission in Colombo (Sri Lanka), but there is now an embassy in Malé.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3844187