### PR TITLE
Maldives is no longer a special case for embassies

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -71,11 +71,6 @@ private
       location: "Hong Kong",
       base_path: "/government/world/organisations/british-consulate-general-hong-kong",
     },
-    "Maldives" => {
-      building: "British Embassy Malé",
-      location: "Maldives",
-      base_path: "/government/world/organisations/british-embassy-maldives",
-    },
     "Marshall Islands" => {
       building: "British High Commission Suva",
       location: "Fiji",


### PR DESCRIPTION
Maldives can be removed from the special cases list of embassies, since there is now an embassy in Malé.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3844187