### PR TITLE
Add unpublishing details to document export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -38,6 +38,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       specialist_sectors: slice_association(edition, :specialist_sectors, %i[id topic_content_id primary]),
       topical_events: slice_association(edition, :topical_events, %i[id content_id]),
       translations: present_translations(edition),
+      unpublishing: present_unpublishing(edition),
       whitehall_admin_links: AdminLinkResolver.call(edition),
       world_locations: slice_association(edition, :world_locations, %i[id content_id]),
       worldwide_organisations: slice_association(edition, %i[worldwide_organisation worldwide_organisations], %i[id content_id]),
@@ -139,6 +140,21 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       base_path = Whitehall.url_maker.public_document_path(edition, locale: translation.locale)
       translation.as_json(except: :edition_id).merge(base_path: base_path)
     end
+  end
+
+  def present_unpublishing(edition)
+    edition
+      .unpublishing
+      .as_json(
+        only: %i[
+          id
+          explanation
+          alternative_url
+          redirect
+          created_at
+          updated_at
+        ],
+      )
   end
 
   def present_user(user)

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -143,18 +143,21 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   end
 
   def present_unpublishing(edition)
-    edition
-      .unpublishing
-      .as_json(
-        only: %i[
-          id
-          explanation
-          alternative_url
-          redirect
-          created_at
-          updated_at
-        ],
-      )
+    if edition.unpublishing
+      edition
+        .unpublishing
+        .as_json(
+          only: %i[
+            id
+            explanation
+            alternative_url
+            redirect
+            created_at
+            updated_at
+          ],
+        )
+        .merge(unpublishing_reason: edition.unpublishing.unpublishing_reason.name)
+    end
   end
 
   def present_user(user)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -393,6 +393,39 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal expected, result.dig(:editions, 0, :translations)
   end
 
+  test "includes unpublishing details for withdrawn documents" do
+    edition = create(:withdrawn_edition)
+    result = DocumentExportPresenter.new(edition.document).as_json
+
+    expected = {
+      id: edition.unpublishing.id,
+      explanation: edition.unpublishing.explanation,
+      alternative_url: nil,
+      created_at: edition.unpublishing.created_at,
+      updated_at: edition.unpublishing.updated_at,
+      redirect: false,
+    }
+
+    assert_equal expected, result.dig(:editions, 0, :unpublishing)
+  end
+
+  test "includes unpublishing details for unpublished documents" do
+    edition = create(:edition)
+    create(:published_in_error_redirect_unpublishing, edition: edition)
+    result = DocumentExportPresenter.new(edition.document).as_json
+
+    expected = {
+      id: edition.unpublishing.id,
+      explanation: edition.unpublishing.explanation,
+      alternative_url: edition.unpublishing.alternative_url,
+      created_at: edition.unpublishing.created_at,
+      updated_at: edition.unpublishing.updated_at,
+      redirect: true,
+    }
+
+    assert_equal expected, result.dig(:editions, 0, :unpublishing)
+  end
+
   test "includes world locations details" do
     edition = create(:news_article_world_news_story)
     world_location = edition.world_locations.last

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -404,6 +404,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
       created_at: edition.unpublishing.created_at,
       updated_at: edition.unpublishing.updated_at,
       redirect: false,
+      unpublishing_reason: edition.unpublishing.unpublishing_reason.name,
     }
 
     assert_equal expected, result.dig(:editions, 0, :unpublishing)
@@ -421,6 +422,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
       created_at: edition.unpublishing.created_at,
       updated_at: edition.unpublishing.updated_at,
       redirect: true,
+      unpublishing_reason: edition.unpublishing.unpublishing_reason.name,
     }
 
     assert_equal expected, result.dig(:editions, 0, :unpublishing)


### PR DESCRIPTION
Trello: https://trello.com/c/8U7JPIHT

## What's changed?
Adds unpublishing details to the export.

## Why?
So the that information it contains, for example the reason the document was unpublished, the user facing explanation, and where users may be being redirected to are not lost when the document is exported.

## Expected changes
![Screenshot 2019-11-06 at 12 21 30](https://user-images.githubusercontent.com/5793815/68297942-0fe24880-0090-11ea-8228-10c07ba029a0.png)
