### PR TITLE
Removes default styles for list and paragraphs

### DIFF
--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -3,17 +3,6 @@
     clear: both;
   }
 
-  p, li{
-    @include ig-core-19;
-    a {
-      text-decoration: underline;
-    }
-  }
-
-  li {
-    margin-left: $gutter;
-  }
-
   .thirds-width-section,
   .halves-width-section {
     overflow: visible;
@@ -74,7 +63,6 @@
 
   .feature-value {
     display: block;
-    padding-bottom: 0;
 
     .feature-value__count {
       display: block;
@@ -93,6 +81,7 @@
   .feature-value__caption {
     color: inherit;
     display: inline-block;
+    margin: 0;
     padding: 0 0.2em;
     position: relative;
     top: -0.5em;


### PR DESCRIPTION
GOV.UK Frontend was clashing with the `p` and `li` rules nested under a long list of Whitehall selectors - and losing. Removing the styles will mean that `govuk-body` and other GOV.UK Frontend classes are not overridden. This removes the inconsistent rendering of spacing and text sizes.

## Before:
![image](https://user-images.githubusercontent.com/1732331/68302541-28eff700-009a-11ea-9282-d8b455ff77a4.png)

## After
![image](https://user-images.githubusercontent.com/1732331/68302787-913ed880-009a-11ea-9a94-66f2e2ebd298.png)

## Before:
![image](https://user-images.githubusercontent.com/1732331/68302621-4d4bd380-009a-11ea-997a-f11acdb7dd56.png)

## After
![image](https://user-images.githubusercontent.com/1732331/68302814-a0be2180-009a-11ea-994a-9179e26da7b5.png)

## Before:
![image](https://user-images.githubusercontent.com/1732331/68302703-72404680-009a-11ea-8755-13066877bbf8.png)

## After
![image](https://user-images.githubusercontent.com/1732331/68303008-eda1f800-009a-11ea-8f23-e61fd9bbdceb.png)
