### PR TITLE
Remove invisible clickable area & inconsistent focus state

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -78,14 +78,17 @@
   .text {
     float: left;
     width: $two-thirds;
+
     @include media(tablet) {
       float: none;
       width: $full-width;
     }
+
     .current-appointee {
       padding-top: 0;
+
       a {
-        display: block;
+        display: inline-block;
         overflow: hidden;
 
         &:hover,
@@ -102,6 +105,7 @@
 
       a {
         text-decoration: none;
+
         &:hover,
         &:focus,
         &:active {


### PR DESCRIPTION
Using display block made the link stretch to 100% of the parent element's width with no indication that it would trigger the link. It also made the focus state take up the complete width of the parent element, which isn't the behaviour of the other links on the page.

Changing to `display: inline-block` removes an invisible clickable area and produces a more consistent focus state.

Trello ticket: https://trello.com/c/kpqlLsmh/98-world-organisations-idlocale-eg-https-wwwgovuk-world-organisations-department-for-international-trade-francefr

Live example: https://www.gov.uk/world/organisations/department-for-international-trade-france

## Before
<img width="325" alt="Screenshot 2019-11-06 at 14 15 36" src="https://user-images.githubusercontent.com/1732331/68306904-4cb73b00-00a2-11ea-83bf-8a69785c41b1.png">

## After
<img width="299" alt="Screenshot 2019-11-06 at 14 15 46" src="https://user-images.githubusercontent.com/1732331/68306883-432dd300-00a2-11ea-8253-97af84b9ee07.png">