### PR TITLE
Update focus states on announcements pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_document_list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_list.scss
@@ -1,6 +1,10 @@
 .document-list {
   clear: both;
 
+  .govuk-link {
+    line-height: 1.16;
+  }
+
   .document-row {
     display: block;
     list-style: none;

--- a/app/assets/stylesheets/frontend/helpers/_filtered-index.scss
+++ b/app/assets/stylesheets/frontend/helpers/_filtered-index.scss
@@ -213,12 +213,8 @@
       }
     }
 
-    .feeds {
-      margin-bottom: $gutter;
-    }
-
     .no-results {
-      padding: $gutter 0 $gutter-half;
+      padding: 0 0 $gutter-half;
       border-bottom: 1px solid $border-colour;
       h2 {
         @include core-27;

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -5,6 +5,7 @@
         <h3>
           <a
             href="{{result.url}}"
+            class="govuk-link"
             data-category="nav{{category}}LinkClicked"
             data-action="{{index}}"
             data-label="{{result.url}}"
@@ -40,12 +41,12 @@
       <ul class="previous-next-navigation">
         {{#prev_page?}}
           <li class="previous">
-            <a href="{{prev_page_web_url}}" rel="prev">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
+            <a href="{{prev_page_web_url}}" rel="prev" class="govuk-link">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
           </li>
         {{/prev_page?}}
         {{#next_page?}}
           <li class="next">
-            <a href="{{next_page_web_url}}" rel="next">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
+            <a href="{{next_page_web_url}}" rel="next" class="govuk-link">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
           </li>
         {{/next_page?}}
       </ul>

--- a/app/views/historic_appointments/_role_appointments_list.html.erb
+++ b/app/views/historic_appointments/_role_appointments_list.html.erb
@@ -1,6 +1,6 @@
 <div class="block historic-people-list">
   <div class="inner-block">
-    <a href="#contents" class="js-showhide contents-toggle">Show past <%= @role.name.pluralize %></a>
+    <a href="#contents" class="js-showhide contents-toggle govuk-link">Show past <%= @role.name.pluralize %></a>
     <div id="contents">
       <h3>
         <span><%= previous_appointments_with_unique_people.size %></span>

--- a/app/views/shared/_feeds.html.erb
+++ b/app/views/shared/_feeds.html.erb
@@ -1,10 +1,14 @@
 <% unless atom_url.blank? %>
   <div class="feeds">
-    <span><%= t("feeds.get_updates_to_this_list") %></span>
-    <%= link_to t('feeds.email'), email_signup_path(atom_url), class: 'email-signup' %>&nbsp;<%= link_to t("feeds.feed"), atom_url, class: "feed js-feed" %>
-    <div class="feed-panel js-feed-panel">
-      <h3>Copy and paste this URL in to your feed reader</h3>
-      <input value="<%= atom_url %>">
-    </div>
+    <span class="govuk-body" <%= t_lang("feeds.get_updates_to_this_list") %>><%= t("feeds.get_updates_to_this_list") %></span>
+    <%= render "govuk_publishing_components/components/subscription-links", {
+      hide_heading: true,
+      email_signup_link: email_signup_path(atom_url),
+      email_signup_link_text: t('feeds.email'),
+      email_signup_link_text_locale: t_fallback('feeds.email'),
+      feed_link_box_value: atom_url,
+      feed_link_text: t("feeds.feed"),
+      feed_link_text_locale: t_fallback("feeds.feed"),
+    } %>
   </div>
 <% end %>

--- a/app/views/shared/_heading.html.erb
+++ b/app/views/shared/_heading.html.erb
@@ -7,6 +7,6 @@
 <div class="heading<%= "-big" if big %><%= "-with-extra" if extra %>">
   <div class="inner-heading">
     <% if type %><p class="type"><%= type %></p><% end %>
-    <h1><%= link_to_if url, heading, url %></h1>
+    <h1><%= link_to_if url, heading, url, class: "govuk-link" %></h1>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,7 +444,7 @@ en:
       title: There are no matching documents.
       description: Try making your search broader and try again.
       tna_heading: Older content
-      tna_link: Not all department publications from before May 2010 were migrated to GOV.UK. To find publications from before May 2010 try searching <a href="http://webarchive.nationalarchives.gov.uk/adv_search/">The National Archives</a>.
+      tna_link: Not all department publications from before May 2010 were migrated to GOV.UK. To find publications from before May 2010 try searching <a href="http://webarchive.nationalarchives.gov.uk/adv_search/" class="govuk-link">The National Archives</a>.
   attachment:
     headings:
       published: Published

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -209,7 +209,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index, params: { taxons: %w[taxon-1], departments: [organisation], locale: :fr }
 
     feed_url = publications_url(format: "atom", taxons: %w[taxon-1], departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
-    assert_select "a.feed[href=?]", feed_url
+    assert_select "input[name=\"feed-reader-box\"][value=?]", feed_url
   end
 
   view_test "#index should show relevant document collection information" do

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -39,7 +39,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
 
     get :show, params: { id: event }
 
-    assert_select "a.feed[href=?]", atom_feed_url_for(event)
+    assert_select "input[name=\"feed-reader-box\"][value=?]", atom_feed_url_for(event)
   end
 
   view_test "show has a link to email signup page" do
@@ -47,7 +47,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
 
     get :show, params: { id: event }
 
-    assert_select ".email-signup[href='https://www.test.gov.uk/email-signup?link=#{event.base_path}']"
+    assert_select "a.gem-c-subscription-links__link[href*=\"email-signup\"]"
   end
 
   view_test "#show displays extra org logos for first-world-war-centenary" do

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -196,7 +196,7 @@ class TopicsControllerTest < ActionController::TestCase
       assert_select_prefix_object news_article, "recent"
     end
 
-    assert_select ".email-signup[href='https://www.test.gov.uk/email-signup?link=#{topic.base_path}']"
+    assert_select ".gem-c-subscription-links__link[href='https://www.test.gov.uk/email-signup?link=#{topic.base_path}']"
     assert_select_autodiscovery_link atom_feed_url_for(topic)
   end
 

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -80,7 +80,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
       @rummager.expects(:search).twice.returns("results" => [])
       get :index, params: { world_location_id: @world_location }
 
-      assert_select "a.feed[href=?]", atom_feed_url_for(@world_location)
+      assert_select "input[name=\"feed-reader-box\"][value=?]", atom_feed_url_for(@world_location)
     end
   end
 

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -102,7 +102,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
       world_location_type: WorldLocationType::InternationalDelegation,
     )
     get :show, params: { id: world_location }
-    assert_select "a.feed[href=?]", atom_feed_url_for(world_location)
+    assert_select "input[name=\"feed-reader-box\"][value=?]", atom_feed_url_for(world_location)
   end
 
   view_test "show world location generates an atom feed with entries for latest activity" do

--- a/test/support/organisation_controller_test_helpers.rb
+++ b/test/support/organisation_controller_test_helpers.rb
@@ -101,7 +101,7 @@ module OrganisationControllerTestHelpers
         create(:feature, document: edition.document, feature_list: feature_list, ordering: 1)
         get :show, params: { id: organisation }
 
-        assert_select "a.feed[href=?]", atom_feed_url_for(organisation)
+        assert_select "input[name=\"feed-reader-box\"][value=?]", atom_feed_url_for(organisation)
       end
 
       view_test "#{org_type}:shows 3 most recently published editions associated with organisation when featuring a doc" do
@@ -118,8 +118,8 @@ module OrganisationControllerTestHelpers
 
         get :show, params: { id: organisation }
 
-        editions[0, 3].each do |edition|
-          assert_select_prefix_object edition, :recent
+        editions[0, 3].each do |e|
+          assert_select_prefix_object e, :recent
         end
         refute_select_prefix_object editions[3], :recent
       end
@@ -160,7 +160,7 @@ module OrganisationControllerTestHelpers
 
         get :show, params: { id: organisation }
 
-        assert_select ".email-signup[href='https://www.test.gov.uk/email-signup?link=#{organisation.base_path}']"
+        assert_select ".gem-c-subscription-links__link[href='https://www.test.gov.uk/email-signup?link=#{organisation.base_path}']"
       end
 
       view_test "#{org_type}:show has link to published corporate information pages" do


### PR DESCRIPTION
https://trello.com/c/pqebKmrS/100-announcementslocale-eg-https-wwwgovuk-government-announcementsfr

- add govuk-link class
- replace feed and email links with component
- update selectors in tests
- fix line height on links

### Before
![Screen Shot 2019-11-12 at 11 37 12](https://user-images.githubusercontent.com/31649453/68668862-0bf77000-0541-11ea-9c8e-06d0c1d341cd.png)
---
![Screen Shot 2019-11-12 at 11 37 04](https://user-images.githubusercontent.com/31649453/68668918-2df0f280-0541-11ea-8c5a-809441be6ad4.png)
---
![Screen Shot 2019-11-12 at 11 41 09](https://user-images.githubusercontent.com/31649453/68668989-5678ec80-0541-11ea-8fb0-4190cd476705.png)


### After

![Screen Shot 2019-11-12 at 11 36 11](https://user-images.githubusercontent.com/31649453/68669010-67296280-0541-11ea-92ed-184baee6844a.png)

---
![Screen Shot 2019-11-12 at 10 30 32](https://user-images.githubusercontent.com/31649453/68669009-67296280-0541-11ea-8757-bea37a41fa6f.png)

The intro text and the component are now on separate lines as otherwise the intro text moved when the feed box expanded.
---
![Screen Shot 2019-11-12 at 11 36 37](https://user-images.githubusercontent.com/31649453/68669111-aa83d100-0541-11ea-871d-19e963c8de51.png)

