### PR TITLE
Update focus state on people pages

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -142,8 +142,10 @@ $govuk-typography-use-rem: false;
 // When removing ensure all cases are captured - some rules in helpers/_headings.scss
 // are very specific, requiring the !important here
 #whitehall-wrapper {
-  a.govuk-link{
+  a.govuk-link,
+  a[class^="gem-c-"] {
     text-decoration: underline;
+
     &:focus {
       color: $govuk-focus-text-colour !important;
       text-decoration: none;

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -206,7 +206,7 @@ module OrganisationHelper
 
   def array_of_links_to_organisations(organisations)
     organisations.map do |organisation|
-      link_to organisation.name, organisation, class: "organisation-link"
+      link_to organisation.name, organisation, class: "organisation-link govuk-link"
     end
   end
 

--- a/app/presenters/role_presenter.rb
+++ b/app/presenters/role_presenter.rb
@@ -34,7 +34,7 @@ class RolePresenter < Whitehall::Decorators::Decorator
 
   def link
     if path
-      context.link_to name, path
+      context.link_to name, path, class: "govuk-link"
     else
       ERB::Util.html_escape name
     end

--- a/app/views/organisations/_organisations_name_list.html.erb
+++ b/app/views/organisations/_organisations_name_list.html.erb
@@ -1,6 +1,6 @@
 <%
   organisations ||= []
 %>
-<p class="js-hide-other-departments organisations-name-list">
+<p class="govuk-body-s">
   <%= array_of_links_to_organisations(organisations).to_sentence.html_safe %>
 </p>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -30,26 +30,26 @@
           <h2 id="document-contents-heading" <%= t_lang('document.contents') %>><%= t('document.contents') %></h2>
           <ul>
             <li <%= t_lang('people.biography') %> >
-              <%= link_to t('people.biography'), '#biography' %>
+              <%= link_to t('people.biography'), '#biography', class: "govuk-link" %>
             </li>
             <% if @person.currently_in_a_role? %>
               <li <%= t_lang('roles.heading', count: @person.current_role_appointments.count) %> >
-                <%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %>
+                <%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles", class: "govuk-link" %>
               </li>
             <% end %>
             <% if @person.previous_role_appointments.any? %>
               <li <%= t_lang('people.previous_roles') %>>
-                <%= link_to t('people.previous_roles'), "#previous-roles" %>
+                <%= link_to t('people.previous_roles'), "#previous-roles", class: "govuk-link" %>
               </li>
             <% end %>
             <% if @person.has_policy_responsibilities? %>
               <li <%= t_lang('policies.heading') %>>
-                <%= link_to t('policies.heading'), "#policy" %>
+                <%= link_to t('policies.heading'), "#policy", class: "govuk-link" %>
               </li>
             <% end %>
             <% if @person.announcements.any? %>
               <li <%= t_lang('announcements.heading') %>>
-                <%= link_to t('announcements.heading'), "#announcements" %>
+                <%= link_to t('announcements.heading'), "#announcements", class: "govuk-link" %>
               </li>
             <% end %>
           </ul>
@@ -72,7 +72,7 @@
             <div <%= t_lang_translated_locales(appointment.role) %> ><%= appointment.role.responsibilities %></div>
             <div class="read-more">
               <% if appointment.role.ministerial? %>
-                <%= link_to t('roles.read_more'), appointment.role %>
+            <p class="govuk-body-s"><%= link_to t("roles.read_more"), appointment.role, class: "govuk-link" %></p>
               <% end %>
               <% if appointment.role.worldwide? %>
                 <%= render partial: 'organisations/organisations_name_list', locals: { organisations: appointment.role.worldwide_organisations } %>
@@ -132,7 +132,7 @@
           <%= render "govuk_publishing_components/components/document_list", items: @person.announcements %>
 
           <div class="read-more" <%= t_lang('announcements.view_all') %>>
-            <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]) %>
+          <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]), class: "govuk-link" %>
           </div>
         </section>
       <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,24 +1,22 @@
 <% page_title @person.name %>
-<% page_class 'people-show biographical-page' %>
+<% page_class "people-show biographical-page govuk-width-container" %>
 
-<%= content_tag_for :div, @person, class: 'two-column-page' do %>
-  <header class="block headings-block">
-    <div class="inner-block floated-children">
-      <%= render partial: 'shared/heading',
-                locals: { type: @person.current_role_appointments.map { |a| a.role.name }.to_sentence,
-                          heading: @person.name,
-                          big: true, extra: true } %>
-      <div class="heading-extra">
-        <div class="inner-heading">
-          <%= render partial: 'shared/available_languages', locals: {object: @person } %>
-        </div>
-      </div>
+<%= content_tag_for :div, @person do %>
+  <header class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        context: @person.current_role_appointments.map { |a| a.role.name }.to_sentence,
+        title: @person.name,
+      } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render partial: 'shared/available_languages', locals: {object: @person } %>
     </div>
   </header>
 
-  <div class="block-2 ">
-    <div class="inner-block">
-      <section class="contextual-info in-page-navigation ">
+  <div class="govuk-grid-row govuk-!-padding-bottom-9 govuk-!-margin-bottom-9">
+    <div class="govuk-grid-column-one-quarter">
+      <section class="contextual-info in-page-navigation govuk-!-margin-bottom-7 govuk-!-padding-bottom-7">
         <% if @person.currently_in_a_role? %>
           <div class="image">
             <figure class="img">
@@ -27,7 +25,12 @@
           </div>
         <% end %>
         <nav role="navigation" aria-labelledby="document-contents-heading">
-          <h2 id="document-contents-heading" <%= t_lang('document.contents') %>><%= t('document.contents') %></h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('document.contents'),
+            lang: t_locale('document.contents'),
+            heading_level: 2,
+            font_size: 19,
+          } %>
           <ul>
             <li <%= t_lang('people.biography') %> >
               <%= link_to t('people.biography'), '#biography', class: "govuk-link" %>
@@ -56,46 +59,63 @@
         </nav>
       </section>
     </div>
-  </div>
 
-  <div class="block-3">
-    <div class="inner-block">
-      <section class="biography" id="biography">
-        <h2 class="label gem-c-heading" <%= t_lang('people.biography') %>><%= t('people.biography') %></h2>
+    <div class="govuk-grid-column-two-thirds">
+      <section class="biography govuk-!-padding-bottom-9" id="biography">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('people.biography'),
+            lang: t_locale('people.biography'),
+            heading_level: 2,
+          } %>
         <%= @person.biography %>
       </section>
 
-      <div class="current-roles" id="current-roles">
+      <section class="current-roles" id="current-roles">
         <% @person.current_role_appointments.each do |appointment| %>
-          <%= content_tag_for :section, appointment, class: "role" do %>
-            <h2 class="gem-c-heading" id="<%= appointment.role.name.parameterize%>" <%= t_lang_translated_locales(appointment.role) %> ><%= appointment.role.name %></h2>
-            <div <%= t_lang_translated_locales(appointment.role) %> ><%= appointment.role.responsibilities %></div>
-            <div class="read-more">
-              <% if appointment.role.ministerial? %>
-            <p class="govuk-body-s"><%= link_to t("roles.read_more"), appointment.role, class: "govuk-link" %></p>
-              <% end %>
-              <% if appointment.role.worldwide? %>
-                <%= render partial: 'organisations/organisations_name_list', locals: { organisations: appointment.role.worldwide_organisations } %>
-              <% else %>
-                <%= render  partial: 'organisations/organisations_name_list', locals: { organisations: appointment.role.organisations } %>
-              <% end %>
+          <%= content_tag_for :section, appointment, class: "role govuk-!-padding-bottom-8" do %>
+
+            <%= render "govuk_publishing_components/components/heading", {
+              text: appointment.role.name,
+              lang: t_locale(appointment.role.name),
+              id: appointment.role.name.parameterize,
+              heading_level: 2,
+            } %>
+
+            <div <%= t_lang_translated_locales(appointment.role) %> >
+              <%= appointment.role.responsibilities %>
             </div>
+
+            <% if appointment.role.ministerial? %>
+              <p class="govuk-body-s"><%= link_to t("roles.read_more"), appointment.role, class: "govuk-link" %></p>
+            <% end %>
+            <% if appointment.role.worldwide? %>
+              <%= render partial: "organisations/organisations_name_list", locals: { organisations: appointment.role.worldwide_organisations } %>
+            <% else %>
+              <%= render  partial: "organisations/organisations_name_list", locals: { organisations: appointment.role.organisations } %>
+            <% end %>
+
           <% end %>
         <% end %>
-      </div>
+      </section>
 
       <% if @person.previous_role_appointments.any? %>
-        <section class="previous-roles" id="previous-roles">
-          <h2 class="gem-c-heading" <%= t_lang('people.previous_roles_in_government') %>>
-            <%= t('people.previous_roles_in_government') %>
-          </h2>
+        <section class="previous-roles govuk-!-padding-bottom-9" id="previous-roles">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('people.previous_roles_in_government'),
+            lang: t_locale('people.previous_roles_in_government'),
+            heading_level: 2,
+            margin_bottom: 0,
+          } %>
+
           <ol class="document-list">
             <% @person.previous_role_appointments.each do |appointment| %>
               <%= content_tag_for :li, appointment, class: "document-row" do %>
-                <h3 <%= t_lang_translated_locales(appointment.role) %>><%= appointment.role_link %></h3>
-                <ul class="attributes" <%= t_lang_translated_locales(appointment.role) %>>
-                  <li class="date"><%= appointment.date_range %></li>
-                </ul>
+                <h3 class="govuk-heading-s govuk-!-margin-0 govuk-!-padding-top-2" <%= t_lang_translated_locales(appointment.role) %>>
+                  <%= appointment.role_link %>
+                </h3>
+                <p class="date govuk-body-s govuk-!-margin-0" <%= t_lang_translated_locales(appointment.role) %>>
+                  <%= appointment.date_range %>
+                </p>
               <% end %>
             <% end %>
           </ol>
@@ -103,10 +123,12 @@
       <% end %>
 
       <% if @person.has_policy_responsibilities? %>
-        <section id="policy">
-          <h2 class="gem-c-heading" <%= t_lang('policies.heading') %>>
-            <%= t('policies.heading') %>
-          </h2>
+        <section id="policy" class="govuk-!-padding-bottom-9">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('policies.heading'),
+            lang: t_locale('policies.heading'),
+            heading_level: 2,
+          } %>
           <%= render 'policies/document_list', policies: @person.published_policies %>
         </section>
       <% end %>
@@ -116,23 +138,26 @@
       <% if @person.announcements.any? %>
         <section class="announcements" id="announcements" <%= t_lang('announcements.heading') %>>
           <%= render 'govuk_publishing_components/components/heading', {
-            text: t('announcements.heading')
+            text: t('announcements.heading'),
+            margin_bottom: 5,
           } %>
 
-          <%= render "govuk_publishing_components/components/subscription-links", {
-            hide_heading: true,
-            email_signup_link: email_signup_path(atom_feed_url_for(@person)),
-            email_signup_link_text: t('feeds.get_email_alerts'),
-            email_signup_link_text_locale: t_locale('feeds.get_email_alerts'),
-            feed_link: atom_feed_url_for(@person),
-            feed_link_text: t('feeds.subscribe_to_feed'),
-            feed_link_text_locale: t_locale('feeds.subscribe_to_feed')
-          } %>
+          <div class="govuk-!-padding-bottom-5">
+            <%= render "govuk_publishing_components/components/subscription-links", {
+              hide_heading: true,
+              email_signup_link: email_signup_path(atom_feed_url_for(@person)),
+              email_signup_link_text: t('feeds.get_email_alerts'),
+              email_signup_link_text_locale: t_locale('feeds.get_email_alerts'),
+              feed_link: atom_feed_url_for(@person),
+              feed_link_text: t('feeds.subscribe_to_feed'),
+              feed_link_text_locale: t_locale('feeds.subscribe_to_feed')
+            } %>
+          </div>
 
           <%= render "govuk_publishing_components/components/document_list", items: @person.announcements %>
 
           <div class="read-more" <%= t_lang('announcements.view_all') %>>
-          <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]), class: "govuk-link" %>
+            <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]), class: "govuk-link" %>
           </div>
         </section>
       <% end %>


### PR DESCRIPTION
Update the focus state on the people pages to use the v3 updated focus state, plus other fixes.

Trello card: https://trello.com/c/ELpMOkWW/105-people-idlocale

## Before
![Screenshot 2019-11-11 at 15 28 35](https://user-images.githubusercontent.com/1732331/68599349-57a20f00-0498-11ea-8373-1758c1179731.png)
![Screenshot 2019-11-11 at 15 28 30](https://user-images.githubusercontent.com/1732331/68599351-57a20f00-0498-11ea-87e3-6a7f099bbb42.png)
![Screenshot 2019-11-11 at 15 28 20](https://user-images.githubusercontent.com/1732331/68599353-57a20f00-0498-11ea-98c8-7f99f6031bb3.png)
![Screenshot 2019-11-11 at 15 27 33](https://user-images.githubusercontent.com/1732331/68599354-583aa580-0498-11ea-9900-bfd5e5afc5a4.png)
![Screenshot 2019-11-11 at 15 27 22](https://user-images.githubusercontent.com/1732331/68599355-583aa580-0498-11ea-9593-e9d8fecc3874.png)

## After

![Screenshot 2019-11-11 at 15 29 34](https://user-images.githubusercontent.com/1732331/68599414-6dafcf80-0498-11ea-9b33-0f981186d12c.png)
![Screenshot 2019-11-11 at 15 29 47](https://user-images.githubusercontent.com/1732331/68599433-743e4700-0498-11ea-88b2-2b643134490f.png)
![Screenshot 2019-11-11 at 15 30 22](https://user-images.githubusercontent.com/1732331/68599442-786a6480-0498-11ea-9564-a6c0e1d1bfae.png)
![Screenshot 2019-11-11 at 15 30 42](https://user-images.githubusercontent.com/1732331/68599456-7ef8dc00-0498-11ea-872a-ae857fbd7661.png)
![Screenshot 2019-11-11 at 15 31 05](https://user-images.githubusercontent.com/1732331/68599463-8324f980-0498-11ea-975b-fb583bd4eb29.png)


Examples:
 - http://whitehall-admin.dev.gov.uk/government/people/nick-clegg
 - http://whitehall-admin.dev.gov.uk/government/people/alex-mitham
 - http://whitehall-admin.dev.gov.uk/government/people/dominic-raab
 - or any page that is listed on https://www.gov.uk/government/people