### PR TITLE
Export dimensions of main image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'dalli', '~> 2.7'
 gem 'deprecated_columns', '~> 0.1.1'
 gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'faraday'
+gem 'fastimage'
 gem 'friendly_id', '~> 5.2.4'
 gem "fuzzy_match", "~> 2.1"
 gem 'gds-sso', '~> 14.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       activesupport (>= 4.2.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
+    fastimage (2.1.7)
     ffi (1.11.1)
     friendly_id (5.2.4)
       activerecord (>= 4.0.0)
@@ -578,6 +579,7 @@ DEPENDENCIES
   equivalent-xml (~> 0.6.0)
   factory_bot
   faraday
+  fastimage
   friendly_id (~> 5.2.4)
   fuzzy_match (~> 2.1)
   gds-api-adapters

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -110,6 +110,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
       image.as_json(methods: :url)
            .merge(image_dimensions(image))
            .merge(variants: image_variants(image))
+           .except("image_data_id", "edition_id")
     end
   end
 

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -120,6 +120,8 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   end
 
   def image_dimensions(image)
+    return {} if image.url.end_with?(".svg")
+
     width, height = FastImage.size(image.url)
     {
       width: width,

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -108,6 +108,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
     edition.images.map do |image|
       image.as_json(methods: :url)
+           .merge(image_dimensions(image))
            .merge(variants: image_variants(image))
     end
   end
@@ -116,6 +117,14 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
     image.image_data.file.versions.each_with_object({}) do |(variant, details), memo|
       memo[variant] = details.url if details.url
     end
+  end
+
+  def image_dimensions(image)
+    width, height = FastImage.size(image.url)
+    {
+      width: width,
+      height: height,
+    }
   end
 
   def present_organisations(edition)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -127,6 +127,16 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
                  result.dig(:editions, 0, :images, 0, :url)
   end
 
+  test "removes redundant fields from the images response hash" do
+    image = create(:image)
+    publication = create(:publication, images: [image])
+
+    result = DocumentExportPresenter.new(publication.document).as_json
+
+    assert_nil result.dig(:editions, 0, :images, 0, :image_data_id)
+    assert_nil result.dig(:editions, 0, :images, 0, :edition_id)
+  end
+
   test "appends the image dimensions to the images response hash" do
     image = create(:image)
     publication = create(:publication, images: [image])

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -157,13 +157,15 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
   end
 
-  test "ignores variants when they do not exist" do
+  test "doesn't attempt to return width/height information for SVGs" do
     svg_image_data = create(:image_data, file: File.open(File.join(Rails.root, "test", "fixtures", "images", "test-svg.svg")))
     publication = create(:publication, images: [create(:image, image_data: svg_image_data)])
     expected = {}
 
     result = DocumentExportPresenter.new(publication.document).as_json
     assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
+    assert_nil result.dig(:editions, 0, :images, 0, :width)
+    assert_nil result.dig(:editions, 0, :images, 0, :height)
   end
 
   test "appends expected attachment data to the file attachment response hash" do


### PR DESCRIPTION
This PR:

- exports `width` and `height` attributes of the main image, so that Content Publisher can know
  whether or not it conforms to the required 960x640 size.
- does not attempt to do this for SVGs
- removes redundant ID fields which have no use outside of Whitehall

I've decided not to implement `width`/`height` detection for image `variants` as we have no immediate need for this in Content Publisher. It can be calculated in Content Publisher later if needed, or even derived from the aspect ratio of the main image divided by the size of the variant (e.g. `960x640` => `s720 variant` => `720x480`). Deriving image dimensions is slow because of the network requests involved, and this way we can avoid making 6 out of 7 requests, making the export much faster than it would otherwise be.

Trello card: https://trello.com/c/VFSu0ClH/1179-export-exact-image-sizes-in-the-whitehall-export