### PR TITLE
Do not overwrite CSS class for buttons

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -208,7 +208,7 @@ private
 
   def add_class_to_links(nokogiri_doc)
     nokogiri_doc.css("a").map do |el|
-      el[:class] = "govuk-link"
+      el[:class] = "govuk-link" unless el[:class] =~ /button/
     end
   end
 

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -38,6 +38,16 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, "a", text: "‘funny’"
   end
 
+  test "should add govuk-link class to links" do
+    html = govspeak_to_html("[Link text](https://www.gov.uk)")
+    assert_select_within_html html, "a.govuk-link", "Link text"
+  end
+
+  test "does not change css class on buttons" do
+    html = govspeak_to_html("{button}[Link text](https://www.gov.uk){/button}")
+    assert_select_within_html html, "a.button", "Link text"
+  end
+
   test "should not mark admin links as 'external'" do
     speech = create(:published_speech)
     url = admin_speech_url(speech, host: Whitehall.admin_host)


### PR DESCRIPTION
In 3714c054f0, a change was made that replaced replaced the class on all links to `govuk-link`.  Since buttons are styled links (with a `button` class), this meant that the buttons were being styled as links when being published.

This change retains the existing class(es) for buttons and adds tests to ensure this change will get caught in future.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3849949