### PR TITLE
Renders govspeak in person and role content items

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -52,12 +52,7 @@ module PublishingApi
     end
 
     def body
-      [
-        {
-          content_type: "text/html",
-          content: item.biography || "",
-        },
-      ]
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.biography || "")
     end
   end
 end

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -66,12 +66,7 @@ module PublishingApi
     end
 
     def body
-      [
-        {
-          content_type: "text/html",
-          content: item.responsibilities || "",
-        },
-      ]
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.responsibilities || "")
     end
   end
 end

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -55,12 +55,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
           url: person.image_url(:s465),
           alt_text: "The Rt Hon Sir Winston Churchill PM",
         },
-        body: [
-          {
-            content_type: "text/html",
-            content: "Sir Winston Churchill was a Prime Minister.",
-          },
-        ],
+        body: "<div class=\"govspeak\"><p>Sir Winston Churchill was a Prime Minister.</p>\n</div>",
       },
       update_type: "major",
     }

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -47,12 +47,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       redirects: [],
       update_type: "major",
       details: {
-        body: [
-          {
-            content_type: "text/html",
-            content: "X and Y",
-          },
-        ],
+        body: "<div class=\"govspeak\"><p>X and Y</p>\n</div>",
         attends_cabinet_type: role.attends_cabinet_type,
         role_payment_type: role.role_payment_type,
         supports_historical_accounts: role.supports_historical_accounts,
@@ -91,12 +86,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       redirects: [],
       update_type: "major",
       details: {
-        body: [
-          {
-            content_type: "text/html",
-            content: "Y and Z",
-          },
-        ],
+        body: "<div class=\"govspeak\"><p>Y and Z</p>\n</div>",
         attends_cabinet_type: role.attends_cabinet_type,
         role_payment_type: role.role_payment_type,
         supports_historical_accounts: role.supports_historical_accounts,


### PR DESCRIPTION
This makes it simpler to write a frontend application since it doesn't need to be concerned with converting the govspeak into HTML.

It also matches the behaviour [we already have with organisations](https://github.com/alphagov/whitehall/blob/fbe29188fee761bbc18ab601afec6a60f3b43f7d/app/presenters/publishing_api/organisation_presenter.rb#L117-L119) and other document types.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/930.

[Trello Card](https://trello.com/c/evPuXJDW/1525-render-govspeak-in-person-and-roles-content-items)