### PR TITLE
Send govspeak as text/govspeak

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -54,7 +54,7 @@ module PublishingApi
     def body
       [
         {
-          content_type: "text/html",
+          content_type: "text/govspeak",
           content: item.biography || "",
         },
       ]

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -68,7 +68,7 @@ module PublishingApi
     def body
       [
         {
-          content_type: "text/html",
+          content_type: "text/govspeak",
           content: item.responsibilities || "",
         },
       ]

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -57,7 +57,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
         },
         body: [
           {
-            content_type: "text/html",
+            content_type: "text/govspeak",
             content: "Sir Winston Churchill was a Prime Minister.",
           },
         ],

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -49,7 +49,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       details: {
         body: [
           {
-            content_type: "text/html",
+            content_type: "text/govspeak",
             content: "X and Y",
           },
         ],
@@ -93,7 +93,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       details: {
         body: [
           {
-            content_type: "text/html",
+            content_type: "text/govspeak",
             content: "Y and Z",
           },
         ],


### PR DESCRIPTION
This will allow the Publishing API to render it into HTML and present the HTML to the frontends rather than the raw govspeak.

This is an alternative to #5133.

[Trello Card](https://trello.com/c/evPuXJDW/1525-render-govspeak-in-person-and-roles-content-items)