### PR TITLE
Update news pages to use correct focus states

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_featured_news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_featured_news.scss
@@ -1,6 +1,9 @@
 .featured-news {
   article {
     clear: both;
+    .govuk-link {
+      line-height: 1.16;
+    }
 
     @include media(tablet) {
       float: left;

--- a/app/views/shared/_document_list_from_rummager.html.erb
+++ b/app/views/shared/_document_list_from_rummager.html.erb
@@ -22,6 +22,7 @@
       link_to(
         see_all_text,
         see_more_url,
+        class: "govuk-link",
         data: {
           track_category: 'navPolicyAreaLinkClicked',
           track_action: "#{heading}",

--- a/app/views/shared/_featured.html.erb
+++ b/app/views/shared/_featured.html.erb
@@ -18,7 +18,7 @@
       <% else %>
         <% feature_title = I18n.t("document.read", title: feature.title) %>
       <% end %>
-      <%= link_to image_tag(feature.image(image_size), {class: 'featured-image', alt: feature.alt_text}), feature.public_path, title: feature_title, class: 'img'%>
+      <%= link_to image_tag(feature.image(image_size), {class: 'featured-image', alt: feature.alt_text}), feature.public_path, class: 'img', tabindex: '-1', aria: {hidden:true} %>
     </span>
     <div class="text">
       <% if show_meta %>
@@ -34,7 +34,8 @@
           <% end %>
         </p>
       <% end %>
-      <h2><%= link_to feature.title, feature.public_path, ({rel: 'external'} if is_external?(feature.public_path)) %></h2>
+      <% rel = is_external?(feature.public_path) ? "external" : "internal" %>
+      <h2><%= link_to feature.title, feature.public_path, rel: "#{rel}", class: "govuk-link" %></h2>
       <% unless feature.summary.blank? %>
         <p class="summary"><%= truncate(feature.summary, length: 160, separator: ' ') %></p>
       <% end %>

--- a/app/views/shared/_featured_links.html.erb
+++ b/app/views/shared/_featured_links.html.erb
@@ -1,7 +1,8 @@
 <% if links %>
   <ul class="featured-links" <%= lang if local_assigns[:lang] %> >
     <% links.each do |link| %>
-      <li><%= link_to link.title, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
+      <% rel = is_external?(link.url) ? "external" : "internal" %>
+      <li><%= link_to link.title, link.url, rel: "#{rel}", class: "govuk-link" %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/shared/_list_description.html.erb
+++ b/app/views/shared/_list_description.html.erb
@@ -6,6 +6,7 @@
           link_to(
             edition.title,
             public_document_path(edition),
+            class: "govuk-link",
             data: {
               track_category: 'navPolicyAreaLinkClicked',
               track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",

--- a/app/views/shared/_list_description_for_rummager_list.html.erb
+++ b/app/views/shared/_list_description_for_rummager_list.html.erb
@@ -6,6 +6,7 @@
           link_to(
             edition.title,
             edition.link,
+            class: 'govuk-link',
             data: {
               track_category: 'navPolicyAreaLinkClicked',
               track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",

--- a/app/views/shared/_recently_updated.html.erb
+++ b/app/views/shared/_recently_updated.html.erb
@@ -16,7 +16,7 @@
     <%= render 'shared/feeds', atom_url: atom_url %>
     <% if local_assigns[:see_all_link] %>
       <p class="see-all" <%= t_lang('document.see_all') %> >
-        <%= link_to t('document.see_all'), see_all_link %>
+        <%= link_to t('document.see_all'), see_all_link, class: 'govuk-link' %>
       </p>
     <% end %>
   </div>

--- a/app/views/shared/_recently_updated_documents.html.erb
+++ b/app/views/shared/_recently_updated_documents.html.erb
@@ -1,7 +1,7 @@
 <ol class="document-list">
   <% recently_updated.each do |document| %>
     <%= content_tag_for :li, document, :recent, class: 'document-row' do %>
-      <h2><%= link_to document.title, public_document_path(document) %></h2>
+      <h2><%= link_to document.title, public_document_path(document), class: 'govuk-link' %></h2>
       <ul class="attributes">
         <li class="published-date">
           <%= published_or_updated(document) %>

--- a/app/views/shared/_recently_updated_documents_from_rummager.html.erb
+++ b/app/views/shared/_recently_updated_documents_from_rummager.html.erb
@@ -1,7 +1,7 @@
 <ol class="document-list">
   <% recently_updated.each do |document| %>
     <li class="recent_<%= document.display_type_key %> document-row" id="recent_<%= document.display_type_key %>_<%= document.content_id %>">
-      <h2><%= link_to document.title, document.link %></h2>
+      <h2><%= link_to document.title, document.link, class: 'govuk-link' %></h2>
       <ul class="attributes">
         <li class="published-date">
           <%= document.publication_date %>

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -73,7 +73,7 @@
             <div class="content">
               <%= render partial: "shared/list_description", locals: { editions: @non_statistics_publications } %>
               <p class="see-all">
-                <%= link_to t_see_all_our(:publication), publications_filter_path(@world_location) %>
+                <%= link_to t_see_all_our(:publication), publications_filter_path(@world_location), class: "govuk-link" %>
               </p>
             </div>
           </section>
@@ -84,7 +84,7 @@
             <div class="content">
               <%= render partial: "shared/list_description", locals: { editions: @statistics_publications } %>
               <p class="see-all">
-                <%= link_to t_see_all_our(:statistics), publications_filter_path(@world_location, publication_filter_option: 'statistics') %>
+                <%= link_to t_see_all_our(:statistics), publications_filter_path(@world_location, publication_filter_option: 'statistics'), class: "govuk-link" %>
               </p>
             </div>
           </section>


### PR DESCRIPTION
https://trello.com/c/xDndfg8h/101-publicationslocale-eg-https-wwwgovuk-government-publicationsfr

Sample urls:
http://whitehall-admin.dev.gov.uk/world/germany/news.de
http://whitehall-admin.dev.gov.uk/world/azerbaijan/news.az
http://whitehall-admin.dev.gov.uk/world/democratic-republic-of-the-congo/news.fr
http://whitehall-admin.dev.gov.uk/world/japan/news.ja

This PR adds the govuk-link class to various page sections to fix the focus state. It also removes this title which adds no value as it usually matches the alt text and contains the article title. 
<img width="844" alt="Screenshot 2019-11-13 at 11 26 02" src="https://user-images.githubusercontent.com/31649453/68851466-ea77bf00-06cd-11ea-86c0-fb71b91888d5.png">

### Before


![Screenshot 2019-11-14 at 10 52 55](https://user-images.githubusercontent.com/31649453/68851468-eb105580-06cd-11ea-89ea-f11130dfb06c.png)

---

![Screenshot 2019-11-14 at 10 53 09](https://user-images.githubusercontent.com/31649453/68851470-eb105580-06cd-11ea-9b0a-53360a2174ea.png)
---

![Screenshot 2019-11-14 at 10 53 35](https://user-images.githubusercontent.com/31649453/68851471-eb105580-06cd-11ea-8246-d14efc435afa.png)
---

![Screenshot 2019-11-14 at 10 55 50](https://user-images.githubusercontent.com/31649453/68851473-eb105580-06cd-11ea-8543-dccb69b3350e.png)

### After

![Screenshot 2019-11-14 at 11 06 33](https://user-images.githubusercontent.com/31649453/68852102-22333680-06cf-11ea-851a-422e6ad78535.png)

---

![Screenshot 2019-11-14 at 11 07 01](https://user-images.githubusercontent.com/31649453/68852103-22333680-06cf-11ea-9553-fff3377dc23c.png)

---

![Screenshot 2019-11-14 at 11 07 32](https://user-images.githubusercontent.com/31649453/68852104-22cbcd00-06cf-11ea-855c-98f2ee1c271a.png)

---

![Screenshot 2019-11-14 at 11 08 02](https://user-images.githubusercontent.com/31649453/68852105-22cbcd00-06cf-11ea-8a71-5373d516ddd8.png)
