### PR TITLE
Add placeholder endpoint to mark a document as migrated

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -29,6 +29,7 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
 
   def migrated
     document = Document.find(params[:id])
+    head :bad_request unless document.locked?
   end
 
   private

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -27,6 +27,10 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     document.update!(locked: false)
   end
 
+  def migrated
+    document = Document.find(params[:id])
+  end
+
   private
 
   def paginated_document_ids

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,6 +193,7 @@ Whitehall::Application.routes.draw do
             member do
               post :lock
               post :unlock
+              post :migrated
             end
           end
         end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -116,12 +116,21 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
-  test "marks document as migrated" do
-    document = create(:document)
+  test "marks locked document as migrated" do
+    document = create(:document, locked: true)
     login_as :export_data_user
 
     post :migrated, params: { id: document.id }, format: "json"
 
     assert_response :no_content
+  end
+
+  test "does not mark unlocked document as migrated" do
+    document = create(:document, locked: false)
+    login_as :export_data_user
+
+    post :migrated, params: { id: document.id }, format: "json"
+
+    assert_response :bad_request
   end
 end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -115,4 +115,13 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     refute document.reload.locked
     assert_response :no_content
   end
+
+  test "marks document as migrated" do
+    document = create(:document)
+    login_as :export_data_user
+
+    post :migrated, params: { id: document.id }, format: "json"
+
+    assert_response :no_content
+  end
 end


### PR DESCRIPTION
Once a document has been migrated into Content Publisher, we will need to perform a number of post-migration processes in Whitehall.  This endpoint will be used to trigger such processes.

Trello card: https://trello.com/c/YIyJBmHN