### PR TITLE
Strip whitespace from rendered person names

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -144,7 +144,7 @@ class Person < ApplicationRecord
 private
 
   def name_as_words(*elements)
-    elements.select(&:present?).join(" ")
+    elements.select(&:present?).map(&:strip).join(" ")
   end
 
   def image_changed?

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -41,6 +41,11 @@ class PersonTest < ActiveSupport::TestCase
     refute person.valid?
   end
 
+  test "should strip whitespace from names" do
+    person = build(:person, forename: " forename ", surname: " surname ")
+    assert_equal "forename surname", person.name
+  end
+
   test "should be invalid if image isn't 960x640px" do
     person = build(:person, image: File.open(Rails.root.join("test/fixtures/horrible-image.64x96.jpg")))
     refute person.valid?


### PR DESCRIPTION
Sometimes users enter whitespace into columns, by doing this we can be sure that when the name is presented to the Publishing API it will not have any unnecessary white space.