### PR TITLE
Replace internal links in documents that link to a migrated document

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -29,7 +29,11 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
 
   def migrated
     document = Document.find(params[:id])
-    head :bad_request unless document.locked?
+    return head :bad_request unless document.locked?
+
+    document.editions.each do |edition|
+      Whitehall::InternalLinkUpdater.new(edition).call
+    end
   end
 
   private

--- a/lib/whitehall/internal_link_updater.rb
+++ b/lib/whitehall/internal_link_updater.rb
@@ -1,0 +1,53 @@
+class Whitehall::InternalLinkUpdater
+  include GovspeakHelper
+
+  attr_reader :linked_to_edition
+
+  def initialize(linked_to_edition)
+    @linked_to_edition = linked_to_edition
+  end
+
+  def call
+    update_all_linking_editions(linked_to_edition)
+  end
+
+  private
+
+  def update_all_linking_editions(linked_to_edition)
+    linked_from_editions(linked_to_edition).each do |linked_from_edition|
+      update_all_translations(linked_from_edition)
+    end
+  end
+
+  def update_all_translations(linked_from_edition)
+    linked_from_edition.translations.each do |translation|
+      replace_translation_links(translation)
+    end
+  end
+
+  def replace_translation_links(translation)
+    whitehall_admin_links(translation.body).each do |whitehall_admin_link|
+      if whitehall_admin_link_edition(whitehall_admin_link).document_id == linked_to_edition.document_id
+        translation.body.sub!(whitehall_admin_link, edition_public_url(linked_to_edition))
+      end
+    end
+    translation.save(touch: false)
+  end
+
+  def linked_from_editions(edition)
+    EditionDependency.where(dependable_id: edition.id, dependable_type: "Edition").map(&:edition)
+  end
+
+  def whitehall_admin_links(body)
+    govspeak = build_govspeak_document(body)
+    Govspeak::LinkExtractor.new(govspeak).call
+  end
+
+  def whitehall_admin_link_edition(link)
+    Whitehall::AdminLinkLookup.find_edition(link)
+  end
+
+  def edition_public_url(edition)
+    Whitehall.url_maker.public_document_url(edition)
+  end
+end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -117,19 +117,20 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
   end
 
   test "marks locked document as migrated" do
-    document = create(:document, locked: true)
+    edition = create(:edition_with_document)
+    edition.document.update(locked: true)
     login_as :export_data_user
 
-    post :migrated, params: { id: document.id }, format: "json"
+    post :migrated, params: { id: edition.document.id }, format: "json"
 
     assert_response :no_content
   end
 
   test "does not mark unlocked document as migrated" do
-    document = create(:document, locked: false)
+    edition = create(:edition_with_document)
     login_as :export_data_user
 
-    post :migrated, params: { id: document.id }, format: "json"
+    post :migrated, params: { id: edition.document.id }, format: "json"
 
     assert_response :bad_request
   end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -134,4 +134,16 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
 
     assert_response :bad_request
   end
+
+  test "calls InternalLinkUpdater when document is marked as migrated" do
+    edition_linked_to = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
+    edition_linked_to.document.update(slug: "some-document", locked: true)
+    create(:edition_with_document)
+    login_as :export_data_user
+
+    post :migrated, params: { id: edition_linked_to.document.id }, format: "json"
+
+    mock = MiniTest::Mock.new
+    mock.expect :call, nil, [Whitehall::InternalLinkUpdater]
+  end
 end

--- a/test/unit/whitehall/internal_link_updater_test.rb
+++ b/test/unit/whitehall/internal_link_updater_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "whitehall/internal_link_updater"
+
+module Whitehall
+  class InternalLinkUpdaterTest < ActiveSupport::TestCase
+    test "relaces admin links in documents linking to the migrated document" do
+      edition_linked_to = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
+      edition_linked_to.document.update(slug: "some-document", locked: true)
+      edition_linked_from = create(:edition_with_document, body: "Text with a [link](/government/admin/news/#{edition_linked_to.id})")
+      ServiceListeners::EditionDependenciesPopulator.new(edition_linked_from).populate!
+
+      Whitehall::InternalLinkUpdater.new(edition_linked_to).call
+
+      expected_body = "Text with a [link](www.test.gov.uk/government/generic-editions/some-document)"
+      assert_equal edition_linked_from.reload.body, expected_body
+    end
+
+    test "does not replace admin links to other documents" do
+      edition_linked_to_1 = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
+      edition_linked_to_1.document.update(slug: "some-document-1", locked: true)
+      edition_linked_to_2 = create(:edition_with_document, body: "Some document not migrated to Content Publisher")
+      edition_linked_to_2.document.update(slug: "some-document-2")
+      edition_linked_from = create(:edition_with_document, body: "Text with a [link](/government/admin/news/#{edition_linked_to_1.id}) and another [link](/government/admin/news/#{edition_linked_to_2.id})")
+      ServiceListeners::EditionDependenciesPopulator.new(edition_linked_from).populate!
+
+      Whitehall::InternalLinkUpdater.new(edition_linked_to_1).call
+
+      expected_body = "Text with a [link](www.test.gov.uk/government/generic-editions/some-document-1) and another [link](/government/admin/news/#{edition_linked_to_2.id})"
+      assert_equal edition_linked_from.reload.body, expected_body
+    end
+  end
+end


### PR DESCRIPTION
Whitehall allows publishers to link to other Whitehall documents using an internal URL (rather than the public one).  On migration of a document out of Whitehall, links to this document will no resolve.  Therefore, we need to replace internal links to this document in other documents with the public URL.

E.g.

```
a [link](/government/admin/policies/101010)
```
in a document would be changed to (when edition 101010 is migrated):
```
a [link](https://www.gov.uk/news/test)
```

Trello card: https://trello.com/c/jSKNSjtA