### PR TITLE
Stop sending role appointment links

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -32,8 +32,8 @@ module PublishingApi
 
     def links
       {
-        ordered_current_appointments: item.current_role_appointments.pluck(:content_id).compact,
-        ordered_previous_appointments: item.previous_role_appointments.pluck(:content_id).compact,
+        ordered_current_appointments: [],
+        ordered_previous_appointments: [],
       }
     end
 

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -33,8 +33,8 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-        ordered_current_appointments: item.current_role_appointments.pluck(:content_id).compact,
-        ordered_previous_appointments: item.previous_role_appointments.pluck(:content_id).compact,
+        ordered_current_appointments: [],
+        ordered_previous_appointments: [],
       }
     end
 

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -18,21 +18,6 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       image: fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg"),
       biography: "Sir Winston Churchill was a Prime Minister.",
     )
-    current_role = create(:role)
-    previous_role = create(:role)
-    current_role_appointment = create(
-      :role_appointment,
-      person: person,
-      role: current_role,
-      started_at: 1.hour.ago,
-    )
-    previous_role_appointment = create(
-      :role_appointment,
-      person: person,
-      role: previous_role,
-      started_at: 1.year.ago,
-      ended_at: 1.month.ago,
-    )
 
     public_path = Whitehall.url_maker.person_path(person)
 
@@ -65,8 +50,8 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       update_type: "major",
     }
     expected_links = {
-      ordered_current_appointments: [current_role_appointment.content_id],
-      ordered_previous_appointments: [previous_role_appointment.content_id],
+      ordered_current_appointments: [],
+      ordered_previous_appointments: [],
     }
 
     presented_item = present(person.reload)

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -12,21 +12,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       organisations: [organisation],
       responsibilities: "X and Y",
     )
-    current_person = create(:person)
-    previous_person = create(:person)
-    current_role_appointment = create(
-      :role_appointment,
-      person: current_person,
-      role: role,
-      started_at: 1.hour.ago,
-    )
-    previous_role_appointment = create(
-      :role_appointment,
-      person: previous_person,
-      role: role,
-      started_at: 1.year.ago,
-      ended_at: 1.month.ago,
-    )
 
     expected_hash = {
       base_path: "/government/ministers/#{role.slug}",
@@ -60,8 +45,8 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ordered_current_appointments: [current_role_appointment.content_id],
-      ordered_previous_appointments: [previous_role_appointment.content_id],
+      ordered_current_appointments: [],
+      ordered_previous_appointments: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
This changes the links we send to the Publishing API to make use of the new reverse links that have been added.

See https://github.com/alphagov/publishing-api/pull/1645 for more details.

The main benefit to doing this is to avoid having to maintain four sets of links for each role appointment (person -> appointment, appointment -> person, role -> appointment, appointment -> role) and instead we only have two links (appointment -> person, appointment -> role) and we can use the Publishing API to correctly present the reverse links back to the appointment on the person and the role.

This means we don't need to worry about the links ending up out of sync with each other which in practice would've meant that we had added some `after_save` hooks on role appointments which republish the person and role to the Publishing API.

[Trello Card](https://trello.com/c/roHfuPUV/1362-8-use-reverse-links-for-role-appointments)