### PR TITLE
Add current and person_appointment_order fields

### DIFF
--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -43,10 +43,13 @@ module PublishingApi
     end
 
     def details
-      {}.tap { |details|
+      {
+        current: item.current?,
+        person_appointment_order: item.id,
+      }.tap do |details|
         details[:started_on] = item.started_at.rfc3339 if item.started_at.present?
         details[:ended_on] = item.ended_at.rfc3339 if item.ended_at.present?
-      }
+      end
     end
 
     def locale

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -31,6 +31,8 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
       update_type: "major",
       details: {
         started_on: "2011-11-10T11:11:11+00:00",
+        current: true,
+        person_appointment_order: role_appointment.id,
       },
     }
     expected_links = {


### PR DESCRIPTION
These new fields have been added in https://github.com/alphagov/govuk-content schemas/pull/933 to support the new reverse links on role appointments.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)