### PR TITLE
Revert hiding ministers during reshuffle

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -7,9 +7,7 @@
       title: "Ministers"
     } %>
 
-    <% unless @is_during_reshuffle %>
-      <p class="govuk-body-l">Read biographies and responsibilities of <a href="#cabinet-ministers" class="govuk-link">Cabinet ministers</a> and all <a href="#ministers-by-department" class="govuk-link">ministers by department</a>, as well as the <a href="#whips" class="govuk-link">whips</a> who help co-ordinate parliamentary business.</p>
-    <% end %>
+    <p class="govuk-body-l">Read biographies and responsibilities of <a href="#cabinet-ministers">Cabinet ministers</a> and all <a href="#ministers-by-department">ministers by department</a>, as well as the <a href="#whips">whips</a> who help co-ordinate parliamentary business.</p>
   </div>
 </header>
 
@@ -17,7 +15,7 @@
   <%= render "govuk_publishing_components/components/notice", {
     description_govspeak: bare_govspeak_to_html(@reshuffle_messaging),
   } %>
-<% else %>
+<% end %>
 
 <section class="cab_ministers govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -150,5 +148,3 @@
     <% end %>
   <% end %>
 </section>
-
-<% end %>

--- a/features/sitewide_settings.feature
+++ b/features/sitewide_settings.feature
@@ -9,7 +9,6 @@ Feature: Sitewide settings
     Given we are during a reshuffle
     When I visit the ministers page
     Then I should see a reshuffle warning message
-    And I should not see the ministers and cabinet
 
   Scenario: Minister counts should be visible outside of a minister reshuffle
     Given we are not during a reshuffle

--- a/features/step_definitions/sitewide_settings_steps.rb
+++ b/features/step_definitions/sitewide_settings_steps.rb
@@ -31,9 +31,3 @@ Then(/^I should (not )?see a reshuffle warning message$/) do |negate|
     assert_text "Test minister reshuffle message"
   end
 end
-
-Then(/^I should not see the ministers and cabinet$/) do
-  assert_no_selector "h2", text: "Cabinet ministers"
-  assert_no_selector "h2", text: "Also attends Cabinet"
-  assert_no_selector "h2", text: "Ministers by department"
-end


### PR DESCRIPTION
This reverts 45a1a21717c59cddad389a28e0bd94653a1fe2f0 and
46058c097faaa45eca6edafcef37fe07fef06b70 so the content team can test
the old method of incrementally seeing ministerial changes on the front
end.

[Trello](https://trello.com/c/YI4loGZK/1554-2-changes-to-ministers-page-ready-for-reshuffle)