### PR TITLE
Remove old appointment links from person and role

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -31,10 +31,7 @@ module PublishingApi
     end
 
     def links
-      {
-        ordered_current_appointments: [],
-        ordered_previous_appointments: [],
-      }
+      {}
     end
 
     def details

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -33,8 +33,6 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-        ordered_current_appointments: [],
-        ordered_previous_appointments: [],
       }
     end
 

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -30,7 +30,6 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
-      stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: "en", update_type: nil),
     ]
 

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -49,15 +49,11 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       },
       update_type: "major",
     }
-    expected_links = {
-      ordered_current_appointments: [],
-      ordered_previous_appointments: [],
-    }
 
     presented_item = present(person.reload)
 
     assert_equal expected_hash, presented_item.content
-    assert_hash_includes presented_item.links, expected_links
+    assert_equal presented_item.links, {}
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -45,8 +45,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ordered_current_appointments: [],
-      ordered_previous_appointments: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
All the people and roles have been republished from Whitehall now so the links no longer exist. Therefore we can stop sending them as an empty array.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)