### PR TITLE
Update features when document migrated away from Whitehall

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -34,6 +34,8 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     document.editions.each do |edition|
       Whitehall::InternalLinkUpdater.new(edition).call
     end
+
+    ContentPublisher::FeaturedDocumentMigrator.new(document).call
   end
 
   private

--- a/lib/content_publisher/featured_document_migrator.rb
+++ b/lib/content_publisher/featured_document_migrator.rb
@@ -1,0 +1,31 @@
+module ContentPublisher
+  class FeaturedDocumentMigrator
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def call
+      edition = document.published_edition.present? ? document.published_edition : document.latest_edition
+
+      public_url = Whitehall.url_maker.public_document_url(edition)
+      public_updated_at = (edition.public_timestamp || edition.updated_at)
+
+      Feature.includes(:feature_list).where(document_id: document.id).each do |feature|
+        offsite_link = OffsiteLink.create!(title: edition.title,
+                                          summary: edition.summary,
+                                          link_type: "content_publisher_#{link_type(edition)}",
+                                          url: public_url,
+                                          date: public_updated_at,
+                                          parent_type: feature.feature_list.featurable_type,
+                                          parent_id: feature.feature_list.featurable_id)
+        feature.update!(document_id: nil, offsite_link_id: offsite_link.id)
+      end
+    end
+
+    def link_type(edition)
+      edition.news_article_type.key
+    end
+  end
+end

--- a/test/unit/content_publisher/featured_document_migrator_test.rb
+++ b/test/unit/content_publisher/featured_document_migrator_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "content_publisher/featured_document_migrator"
+
+module ContentPublisher
+  class FeaturedDocumentMigratorTest < ActiveSupport::TestCase
+    test "updates feature with offsite url" do
+      edition = create(:published_news_article)
+      feature = create(:feature, document: edition.document, feature_list: feature_list)
+      edition.document.update(locked: true)
+
+      ContentPublisher::FeaturedDocumentMigrator.new(edition.document).call
+      feature.reload
+
+      assert_nil feature.document_id
+      assert_equal "https://www.test.gov.uk/government/news/news-title", feature.offsite_link.url
+      assert_equal edition.public_timestamp, feature.offsite_link.date
+    end
+
+    test "uses the latest edition if document is not published" do
+      edition = create(:news_article)
+      feature = create(:feature, document: edition.document, feature_list: feature_list)
+      edition.document.update(locked: true)
+
+      ContentPublisher::FeaturedDocumentMigrator.new(edition.document).call
+      feature.reload
+
+      assert_nil feature.document_id
+      assert_equal "https://www.test.gov.uk/government/news/news-title", feature.offsite_link.url
+      assert_equal edition.updated_at, feature.offsite_link.date
+    end
+
+    test "sets the correct link type for press_release" do
+      edition = create(:published_news_article)
+      feature = create(:feature, document: edition.document, feature_list: feature_list)
+      edition.document.update(locked: true)
+
+      ContentPublisher::FeaturedDocumentMigrator.new(edition.document).call
+      feature.reload
+
+      assert_nil feature.document_id
+      assert_equal "content_publisher_press_release", feature.offsite_link.link_type
+    end
+
+    test "sets the correct link type for news_story" do
+      edition = create(:published_news_story)
+      feature = create(:feature, document: edition.document, feature_list: feature_list)
+      edition.document.update(locked: true)
+
+      ContentPublisher::FeaturedDocumentMigrator.new(edition.document).call
+      feature.reload
+
+      assert_nil feature.document_id
+      assert_equal "content_publisher_news_story", feature.offsite_link.link_type
+    end
+
+    def feature_list
+      create(:feature_list, locale: "en")
+    end
+  end
+end


### PR DESCRIPTION
When a document is marked as being migrated away from Whitehall, we need to update all featured document links to point to the public GOV.UK URL rather than referencing a document in Whitehall.

Trello card: https://trello.com/c/Fyt9he0f

## Featured document before migration
![before-screenshot-whitehall-admin integration publishing service gov uk-2019 11 29-11-14-26](https://user-images.githubusercontent.com/5793815/69865649-a83ba980-1299-11ea-9f04-01a70d0820d2.png)

## Feature document after migration
![after-screenshot-whitehall-admin integration publishing service gov uk-2019 11 29-11-21-56](https://user-images.githubusercontent.com/5793815/69865917-87c01f00-129a-11ea-85a3-b370cd4db269.png)

```
#<OffsiteLink:0x00007f8d308937e8
 id: 2902,
 title: "Kylo Ren, monster and murderer?",
 summary:
  "The life and times of Kylo Ren the new Supreme Leader of the First Order",
 url:
  "https://www.integration.publishing.service.gov.uk/government/news/kylo-ren-monster-and-murderer",
 link_type: "content_publisher_news_story",
 parent_id: 1056,
 parent_type: "Organisation",
 date: Fri, 29 Nov 2019 11:21:30 GMT +00:00,
 created_at: Fri, 29 Nov 2019 11:21:30 GMT +00:00,
 updated_at: Fri, 29 Nov 2019 11:21:30 GMT +00:00>
```