### PR TITLE
Change how database queries are disabled in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,7 +119,10 @@ class ActiveSupport::TestCase
 
   def self.disable_database_queries
     setup do
-      ActiveRecord::Base.connection.expects(:select).never
+      ActiveRecord::Base
+        .connection
+        .stubs(:select)
+        .raises("Database queries are disabled")
     end
     teardown do
       ActiveRecord::Base.connection.unstub(:select)


### PR DESCRIPTION
Rather than using expectations, have select raise an exception, as
this makes tracking down where the query is coming from much easier,
as a backtrace will be shown.