### PR TITLE
Present governments to the Publishing API

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -1,4 +1,6 @@
 class Government < ApplicationRecord
+  include PublishesToPublishingApi
+
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :start_date, presence: true

--- a/app/presenters/publishing_api/government_presenter.rb
+++ b/app/presenters/publishing_api/government_presenter.rb
@@ -1,0 +1,57 @@
+module PublishingApi
+  class GovernmentPresenter
+    attr_accessor :item
+    attr_accessor :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      item.content_id
+    end
+
+    def content
+      BaseItemPresenter.new(
+        item,
+        title: item.name,
+        update_type: update_type,
+      ).base_attributes.merge(
+        base_path: base_path,
+        details: details,
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        schema_name: schema_name,
+      ).merge(
+        PayloadBuilder::Routes.for(base_path),
+      )
+    end
+
+    def links
+      {}
+    end
+
+  private
+
+    def schema_name
+      "government"
+    end
+
+    def base_path
+      "/government/#{item.slug}"
+    end
+
+    def details
+      {
+        started_on: item.start_date.rfc3339,
+        ended_on: item.end_date&.rfc3339,
+        # Use ended?, rather than current?, as this just checks if the
+        # Government has ended, which should be equivalent, and
+        # doesn't require looking up the details of other governments
+        current: !item.ended?,
+      }
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -14,6 +14,8 @@ module PublishingApiPresenters
       case model
       when ::Edition
         presenter_class_for_edition(model)
+      when Government
+        PublishingApi::GovernmentPresenter
       when AboutPage
         PublishingApi::TopicalEventAboutPagePresenter
       when PolicyGroup

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,7 @@ end
 if Government.where(name: "Test Government").present?
   puts "Skipping because Test Government already exists"
 else
+  Government.skip_callback(:commit, :after, :publish_to_publishing_api)
   Government.create(
     name: "Test Government",
     start_date: Time.new(2001, 1, 1),

--- a/test/factories/governments.rb
+++ b/test/factories/governments.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :government do
     sequence(:name) { |index| "Government #{index}" }
     start_date { "2010-05-06" }
+    content_id { SecureRandom.uuid }
   end
 
   factory :current_government, parent: :government do

--- a/test/unit/presenters/government_presenter_test.rb
+++ b/test/unit/presenters/government_presenter_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class GovernmentPresenterTest < PresenterTestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    @government = build(:government)
+    @presenter = PublishingApi::GovernmentPresenter.new(@government)
+  end
+
+  test "the presenter has the content_id" do
+    assert_equal @government.content_id, @presenter.content_id
+  end
+
+  test "the details has started_on" do
+    assert_equal(
+      @government.start_date.rfc3339,
+      @presenter.content.dig(:details, :started_on),
+    )
+  end
+
+  context "given a previous government" do
+    setup do
+      @government = build(:previous_government, slug: "foo")
+      @presenter = PublishingApi::GovernmentPresenter.new(@government)
+    end
+
+    test "the details has ended_on" do
+      assert_equal(
+        @government.end_date.rfc3339,
+        @presenter.content.dig(:details, :ended_on),
+      )
+    end
+
+    test "current is false" do
+      refute @presenter.content.dig(:details, :current)
+    end
+  end
+
+  context "given a current government" do
+    setup do
+      @government = build(:current_government)
+      @presenter = PublishingApi::GovernmentPresenter.new(@government)
+    end
+
+    test "the details has a null ended_on" do
+      assert_nil @presenter.content.dig(:details, :ended_on)
+    end
+
+    test "current is true" do
+      assert @presenter.content.dig(:details, :current)
+    end
+  end
+end


### PR DESCRIPTION
This is in preparation for linking content to these governments in the Publishing API, and then using this information in Government Frontend.