### PR TITLE
Ensure governments have content ids

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -14,7 +14,9 @@ class Admin::GovernmentsController < Admin::BaseController
   end
 
   def create
-    @government = Government.new(government_params)
+    @government = Government.new(
+      government_params.merge(content_id: SecureRandom.uuid),
+    )
 
     if @government.save
       redirect_to admin_governments_path, notice: "Created government information"

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -3,6 +3,7 @@ class Government < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
+  validates :content_id, presence: true, uniqueness: true
   validates :start_date, presence: true
 
   validate :not_overlapping?

--- a/db/migrate/20191122124408_change_government_content_id_to_be_non_null.rb
+++ b/db/migrate/20191122124408_change_government_content_id_to_be_non_null.rb
@@ -1,0 +1,6 @@
+class ChangeGovernmentContentIdToBeNonNull < ActiveRecord::Migration[5.1]
+  def change
+    change_column :governments, :content_id, :string, null: false
+    add_index :governments, :content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191122095033) do
+ActiveRecord::Schema.define(version: 20191122124408) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -534,7 +534,8 @@ ActiveRecord::Schema.define(version: 20191122095033) do
     t.date "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "content_id"
+    t.string "content_id", null: false
+    t.index ["content_id"], name: "index_governments_on_content_id", unique: true
     t.index ["end_date"], name: "index_governments_on_end_date"
     t.index ["name"], name: "index_governments_on_name", unique: true
     t.index ["slug"], name: "index_governments_on_slug", unique: true


### PR DESCRIPTION
The previous data migration generates content_id's for all governments, but these changes ensure that governments have content_id's going forward.