### PR TITLE
Send person description to the Publishing API

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,6 +74,10 @@ class Person < ApplicationRecord
     Govspeak::Document.new(biography_appropriate_for_role).to_text
   end
 
+  def biography_without_markup
+    Govspeak::Document.new(biography).to_text
+  end
+
   def biography_appropriate_for_role
     if currently_in_a_role?
       biography

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        description: nil,
+        description: item.biography_without_markup,
         details: details,
         document_type: "person",
         public_updated_at: item.updated_at,

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
     expected_hash = {
       base_path: public_path,
       title: "The Rt Hon Sir Winston Churchill PM",
-      description: nil,
+      description: "Sir Winston Churchill was a Prime Minister.",
       schema_name: "person",
       document_type: "person",
       locale: "en",


### PR DESCRIPTION
This will be used by the Search API to include a brief description about the content.

[Trello Card](https://trello.com/c/fyqUmZ9Q/1573-send-person-description-to-the-publishing-api)