### PR TITLE
Create rake task to link editions to a government

### DIFF
--- a/lib/tasks/link_governments.rake
+++ b/lib/tasks/link_governments.rake
@@ -1,0 +1,24 @@
+namespace :governments do
+  task relink: :environment do
+    STDOUT.sync = true
+    Edition.where.not(state: %w[deleted superseded]).find_each do |edition|
+      presenter = PublishingApiPresenters.presenter_for(edition)
+      begin
+        links = presenter.links
+
+        if links[:government].present?
+          print "."
+
+          Services.publishing_api.patch_links(
+            presenter.content_id,
+            links: links.slice(:government),
+            bulk_publishing: true,
+          )
+        end
+      rescue StandardError => e
+        puts "\nFAIL #{e.class} (#{e.message}) for document: #{presenter.content_id}"
+      end
+    end
+    puts
+  end
+end


### PR DESCRIPTION
Iterates over all published and drafted editions (superseded ones shouldn't be seen), then creates a presenter and uses that to patch the edition's links in the publishing API.

https://trello.com/c/7yyMiJwi/1574-link-all-relevant-whitehall-content-to-the-appropriate-governments-in-the-publishing-api