### PR TITLE
Add Brexit CTA

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -126,6 +126,7 @@ private
     govspeak = render_embedded_fractions(govspeak)
     govspeak = set_classes_for_charts(govspeak)
     govspeak = set_classes_for_sortable_tables(govspeak)
+    govspeak = convert_brexit_cta(govspeak)
 
     markup_to_nokogiri_doc(govspeak, images)
       .tap { |nokogiri_doc|
@@ -260,6 +261,14 @@ private
       else
         ""
       end
+    end
+  end
+
+  def convert_brexit_cta(govspeak)
+    return govspeak if govspeak.blank?
+
+    govspeak.gsub(/\$BrexitCTA/) do
+      render(partial: "documents/brexit_cta", formats: :text)
     end
   end
 

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -198,6 +198,11 @@
   $CTA</pre>
   </div>
 
+  <h3><a data-toggle="collapse" href="#brexit-cta" aria-expanded="false">Brexit call to action</a></h3>
+  <div class="collapse" id="brexit-cta">
+    <pre>$BrexitCTA</pre>
+  </div>
+
   <h3><a data-toggle="collapse" href="#govspeak-acronyms" aria-expanded="false">Abbreviations and acronyms</a></h3>
   <div class="collapse" id="govspeak-acronyms">
     <p>The first time you use an abbreviation or acroynm, write it out in full.</p>

--- a/app/views/documents/_brexit_cta.text.erb
+++ b/app/views/documents/_brexit_cta.text.erb
@@ -1,0 +1,8 @@
+$CTA
+##Stay up to date
+
+The UK is leaving the EU. This page tells you how to prepare for Brexit and will be updated if anything changes.
+
+[Sign up for email alerts](https://www.gov.uk/email-signup?topic=%2Fbrexit) to get the latest information.
+
+$CTA

--- a/test/support/html_assertions.rb
+++ b/test/support/html_assertions.rb
@@ -43,10 +43,6 @@ module HtmlAssertions
     assert EquivalentXml.equivalent?(expected, actual), "Expected\n#{actual}\n\nto equal\n\n#{expected}"
   end
 
-  def assert_has_link(expected_text, expected_href, html_fragment)
-    assert html_fragment.at_xpath(".//a[.='#{expected_text}'][@href='#{expected_href}']").present?, "Expected\n#{html_fragment} to include a link with text \"#{expected_text}\" and href \"#{expected_href}\"."
-  end
-
   def assert_has_meta_tag(name, content)
     assert_select %{meta[name="#{name}"][content="#{content}"]}
   end

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -475,4 +475,19 @@ class GovspeakHelperTest < ActionView::TestCase
     html = govspeak_with_attachments_to_html(body, attachments, "batman@wayne.technology")
     assert html.include? ">batman@wayne.technology</a>"
   end
+
+  test "converts Brexit CTA govspeak to HTML" do
+    body = "$BrexitCTA\nSome other text"
+    output = govspeak_to_html(body)
+    paragraph_text = "The UK is leaving the EU. This page tells you how to "\
+                       "prepare for Brexit and will be updated if anything changes."
+
+    assert_select_within_html output, "div.call-to-action"
+    assert_select_within_html output, "h2#stay-up-to-date", "Stay up to date"
+    assert_select_within_html output, "p", paragraph_text
+    assert_select_within_html output,
+                              "a[href=?]",
+                              "https://www.gov.uk/email-signup?topic=%2Fbrexit",
+                              text: "Sign up for email alerts"
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/RosX23YC/199-add-brexit-callout-element-to-whitehall

This adds support to convert `$BrexitCTA` 'markdown' to a CTA with static messaging.  The intention is that when the messaging needs to change, a developer with update the static messaging and republish content which contains the markdown (to be covered in a future PR).

**Body input**
<img width="775" alt="brexit-cta-body-input" src="https://user-images.githubusercontent.com/13434452/69741771-8b856180-1133-11ea-86c6-887e74947161.png">

**Brexit CTA body preview**
<img width="782" alt="brexit-cta-preview" src="https://user-images.githubusercontent.com/13434452/69741805-96d88d00-1133-11ea-91a8-40b84bfbb8b5.png">

_See https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/1016488/edit for comparison_

**Frontend representation**
<img width="840" alt="brexit-cta-frontend" src="https://user-images.githubusercontent.com/13434452/69741846-ac4db700-1133-11ea-8f80-06410b5f9dbe.png">

_See https://www.gov.uk/guidance/driving-in-the-eu-after-brexit for comparison_

**Govspeak help sidebar**
![2019-11-28-09-41-whitehall-admin dev gov uk](https://user-images.githubusercontent.com/13434452/69795173-91c31e80-11c3-11ea-93e2-564db7c02b5b.png)
