### PR TITLE
Add rake task to send political content to search index

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -104,6 +104,13 @@ namespace :search do
     end
   end
 
+  desc "Update search index for all political content"
+  task political: :environment do
+    Edition
+      .where(political: true, state: "published")
+      .find_each { |edition| edition&.update_in_search_index }
+  end
+
   desc "removes and re-indexes all searchable whitehall content"
   task reset: ["search:reset:detailed", "search:reset:government"]
 


### PR DESCRIPTION
If the government changes, we currently republish all political content
so that the banner stating that the content was published under a
previous government is displayed appropriately.

According to alphagov/search-api@ee2f8d8,  we also need to send 
these editions to search so they can be re-indexed.