### PR TITLE
Use non whitehall link for migrated docs

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -36,6 +36,7 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
     end
 
     ContentPublisher::FeaturedDocumentMigrator.new(document).call
+    ContentPublisher::DocumentCollectionGroupMembershipMigrator.new(document).call
   end
 
   private

--- a/lib/content_publisher/document_collection_group_membership_migrator.rb
+++ b/lib/content_publisher/document_collection_group_membership_migrator.rb
@@ -9,6 +9,8 @@ module ContentPublisher
     def call
       edition = document.published_edition || document.latest_edition
 
+      return unless DocumentCollectionGroupMembership.exists?(document_id: document.id)
+
       non_whitehall_link = DocumentCollectionNonWhitehallLink.create!(
         content_id: document.content_id,
         title: edition.title,

--- a/lib/content_publisher/document_collection_group_membership_migrator.rb
+++ b/lib/content_publisher/document_collection_group_membership_migrator.rb
@@ -1,0 +1,27 @@
+module ContentPublisher
+  class DocumentCollectionGroupMembershipMigrator
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def call
+      edition = document.published_edition || document.latest_edition
+
+      non_whitehall_link = DocumentCollectionNonWhitehallLink.create!(
+        content_id: document.content_id,
+        title: edition.title,
+        base_path: Whitehall.url_maker.public_document_path(edition),
+        publishing_app: "content-publisher",
+      )
+
+      DocumentCollectionGroupMembership
+        .where(document_id: document.id)
+        .update_all(
+          document_id: nil,
+          non_whitehall_link_id: non_whitehall_link.id,
+        )
+    end
+  end
+end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -161,4 +161,19 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal "content_publisher_press_release", OffsiteLink.last.link_type
   end
+
+  test "calls DocumentCollectionGroupMembershipMigrator when document is marked as migrated" do
+    edition = create(:published_news_article)
+    create(:document_collection_group_membership, document: edition.document)
+    edition.document.update(slug: "some-document", locked: true)
+
+    login_as :export_data_user
+
+    assert_difference -> { DocumentCollectionNonWhitehallLink.count } do
+      post :migrated, params: { id: edition.document.id }, format: "json"
+    end
+
+    assert_response :success
+    assert_equal "content-publisher", DocumentCollectionNonWhitehallLink.last.publishing_app
+  end
 end

--- a/test/unit/content_publisher/document_collection_group_membership_migrator_test.rb
+++ b/test/unit/content_publisher/document_collection_group_membership_migrator_test.rb
@@ -32,5 +32,12 @@ module ContentPublisher
       assert_equal "/government/news/news-title", non_whitehall_link.base_path
       assert_equal "content-publisher", non_whitehall_link.publishing_app
     end
+
+    test "do not create non whitehall link if document is not in document collection" do
+      edition = create(:published_news_article)
+
+      ContentPublisher::DocumentCollectionGroupMembershipMigrator.new(edition.document).call
+      assert_equal 0, DocumentCollectionNonWhitehallLink.count
+    end
   end
 end

--- a/test/unit/content_publisher/document_collection_group_membership_migrator_test.rb
+++ b/test/unit/content_publisher/document_collection_group_membership_migrator_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "content_publisher/document_collection_group_membership_migrator"
+
+module ContentPublisher
+  class DocumentCollectionGroupMembershipMigratorTest < ActiveSupport::TestCase
+    test "update document collection group membership with non whitehall link" do
+      edition = create(:published_news_article)
+      document_collection_group_membership = create(:document_collection_group_membership, document: edition.document)
+
+      ContentPublisher::DocumentCollectionGroupMembershipMigrator.new(document_collection_group_membership.document).call
+      document_collection_group_membership.reload
+
+      non_whitehall_link = document_collection_group_membership.non_whitehall_link
+
+      assert_nil document_collection_group_membership.document_id
+      assert_equal edition.title, non_whitehall_link.title
+      assert_equal "/government/news/news-title", non_whitehall_link.base_path
+      assert_equal "content-publisher", non_whitehall_link.publishing_app
+    end
+
+    test "uses the latest edition if document is not published" do
+      edition = create(:news_article)
+      document_collection_group_membership = create(:document_collection_group_membership, document: edition.document)
+
+      ContentPublisher::DocumentCollectionGroupMembershipMigrator.new(document_collection_group_membership.document).call
+      document_collection_group_membership.reload
+
+      non_whitehall_link = document_collection_group_membership.non_whitehall_link
+
+      assert_nil document_collection_group_membership.document_id
+      assert_equal edition.title, non_whitehall_link.title
+      assert_equal "/government/news/news-title", non_whitehall_link.base_path
+      assert_equal "content-publisher", non_whitehall_link.publishing_app
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/9jaHpTwx

## What's changed and why?

When a document is marked as being migrated in Whitehall we need to change content that has pointers to the Whitehall local data and switch this to be something Whitehall agnostic.

One of the places we have to do this is document collections. If a document collection links to a document that has been migrated, change this link to be non-Whitehall link.

## Expected changes
### Before
![before-screenshot-whitehall-admin integration publishing service gov uk-2019 12 02-11-47-00](https://user-images.githubusercontent.com/5793815/69957173-fbac3280-14f9-11ea-9521-e37e246acaf8.png)

### After
![after-screenshot-whitehall-admin integration publishing service gov uk-2019 12 02-11-50-08](https://user-images.githubusercontent.com/5793815/69957176-ffd85000-14f9-11ea-9fc6-2d6bd6b01586.png)
