### PR TITLE
Add rake task to republish Brexit CTA documents

### DIFF
--- a/lib/tasks/republish_brexit_cta_documents.rake
+++ b/lib/tasks/republish_brexit_cta_documents.rake
@@ -1,0 +1,19 @@
+desc "Republish all documents containing $BrexitCTA in its body"
+task republish_brexit_cta_documents: :environment do
+  brexit_cta_document_ids = Edition.in_default_locale
+                                   .includes(:document)
+                                   .where("edition_translations.body LIKE ?", "%$BrexitCTA%")
+                                   .pluck(:document_id)
+                                   .uniq
+
+  puts "Republishing #{brexit_cta_document_ids.count} documents..."
+
+  brexit_cta_document_ids.each_with_index do |document_id, republished_document_count|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+      "bulk_republishing",
+      document_id,
+    )
+
+    puts "#{republished_document_count}/#{brexit_cta_document_ids.count} documents republished"
+  end
+end

--- a/test/unit/tasks/republish_brexit_cta_documents_test.rb
+++ b/test/unit/tasks/republish_brexit_cta_documents_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "rake"
+
+class RepublishBrexitCtaDocumentsTest < ActiveSupport::TestCase
+  setup do
+    # Without this condition the test runs the rake task twice locally
+    unless Rake::Task.task_defined?("republish_brexit_cta_documents")
+      Rake.application.rake_require "tasks/republish_brexit_cta_documents"
+    end
+    Rake::Task.define_task(:environment)
+    $stdout.stubs(:puts)
+  end
+
+  test "it should republish all documents with $BrexitCTA in the body" do
+    edition_one = create(:published_publication, body: "Some content\n\n$BrexitCTA")
+    edition_two = create(:published_publication, body: "$BrexitCTA\n\nSome content")
+    edition_three = create(:published_publication, body: "$CTA\n\nSome other CTA\n\n$CTA")
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue)
+                                           .with("bulk_republishing", edition_one.document_id)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue)
+                                           .with("bulk_republishing", edition_two.document_id)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue)
+                                           .with("bulk_republishing", edition_three.document_id)
+                                           .never
+
+    Rake.application.invoke_task "republish_brexit_cta_documents"
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/gVXSOuKl/268-create-rake-task-in-whitehall-to-republish-documents-containing-the-brexit-callout-element-in-govspeak

When the messaging in the Brexit CTA changes, we will need to republish
documents that contain `$BrexitCTA` markdown in order to re-present the
documents with the updated messaging to the Publishing API. This creates a rake
task to find all documents containing `$BrexitCTA` in the body and send them to
be republished.