### PR TITLE
Upgrade mocha to v1.10.0 & fix deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,6 @@ GEM
       nokogiri (~> 1.6)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
-    metaclass (0.0.4)
     method_source (0.9.2)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
@@ -295,8 +294,7 @@ GEM
     minitest-stub-const (0.6)
     mlanett-redis-lock (0.2.7)
       redis
-    mocha (1.9.0)
-      metaclass (~> 0.0.1)
+    mocha (1.10.0)
     msgpack (1.3.1)
     multi_json (1.14.1)
     multi_test (0.1.2)

--- a/features/support/mocha.rb
+++ b/features/support/mocha.rb
@@ -1,4 +1,4 @@
-require "mocha/api"
+require "mocha/minitest"
 
 World(Mocha::API)
 

--- a/features/support/rummageable_and_document_filter.rb
+++ b/features/support/rummageable_and_document_filter.rb
@@ -2,7 +2,7 @@
 # sure these Before / After happen before the ones I define below.  If
 # they go in their own it'll be support/**/*.rb load order defined and
 # who knows what that'll be.
-require 'mocha/setup'
+require 'mocha/api'
 World(Mocha::API)
 
 Before do

--- a/features/support/rummageable_and_document_filter.rb
+++ b/features/support/rummageable_and_document_filter.rb
@@ -2,7 +2,7 @@
 # sure these Before / After happen before the ones I define below.  If
 # they go in their own it'll be support/**/*.rb load order defined and
 # who knows what that'll be.
-require 'mocha/api'
+require 'mocha/minitest'
 World(Mocha::API)
 
 Before do

--- a/test/fast_test_helper.rb
+++ b/test/fast_test_helper.rb
@@ -16,6 +16,6 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 $LOAD_PATH.unshift File.expand_path(__dir__)
 
 require "minitest/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 
 require "logger"

--- a/test/support/model_stubbing_helpers.rb
+++ b/test/support/model_stubbing_helpers.rb
@@ -16,7 +16,7 @@ module ModelStubbingHelpers
 
   def stub_translatable_record(type, options = {})
     translations = []
-    Mocha::Configuration.allow(:stubbing_non_existent_method) do
+    Mocha::Configuration.override(stubbing_non_existent_method: :allow) do
       translations.stubs(
         loaded?: true,
         translated_locales: [:en],

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ end
 
 require "maxitest/autorun"
 require "rails/test_help"
-require "mocha/setup"
+require "mocha/minitest"
 require "slimmer/test"
 require "factories"
 require "webmock/minitest"
@@ -23,7 +23,9 @@ require "parallel_tests/test/runtime_logger"
 
 Dir[Rails.root.join("test/support/*.rb")].each { |f| require f }
 
-Mocha::Configuration.prevent(:stubbing_non_existent_method)
+Mocha.configure do |c|
+  c.stubbing_non_existent_method = :prevent
+end
 
 GovukContentSchemaTestHelpers.configure do |config|
   config.schema_type = "publisher_v2"

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -96,8 +96,8 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:new)
         .with(consultation)
         .returns(
-          mock("PublishingApi::LinksPresenter") {
-            expects(:extract)
+          mock("PublishingApi::LinksPresenter").tap { |m|
+            m.expects(:extract)
               .with(expected_link_keys)
               .returns(links_double)
           },

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -96,8 +96,8 @@ module PublishingApi::CorporateInformationPagePresenterTest
         .expects(:new)
         .with(corporate_information_page)
         .returns(
-          mock("PublishingApi::LinksPresenter") {
-            expects(:extract)
+          mock("PublishingApi::LinksPresenter").tap { |m|
+            m.expects(:extract)
               .with(expected_link_keys)
               .returns(links_double)
           },
@@ -153,8 +153,8 @@ module PublishingApi::CorporateInformationPagePresenterTest
         .stubs(:new)
         .with(corporate_information_page)
         .returns(
-          mock("PublishingApi::LinksPresenter") {
-            stubs(:extract)
+          mock("PublishingApi::LinksPresenter").tap { |m|
+            m.stubs(:extract)
               .with(expected_link_keys)
               .returns(links_double)
           },

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -102,8 +102,8 @@ module PublishingApi::NewsArticlePresenterTest
         .expects(:new)
         .with(news_article)
         .returns(
-          mock("PublishingApi::LinksPresenter") {
-            expects(:extract)
+          mock("PublishingApi::LinksPresenter").tap { |m|
+            m.expects(:extract)
               .with(expected_link_keys)
               .returns(links_double)
           },

--- a/test/unit/services/listeners/attachment_dependency_populator_test.rb
+++ b/test/unit/services/listeners/attachment_dependency_populator_test.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 require_relative "../../../../lib/govspeak/contacts_extractor"
 require_relative "../../../../app/services/service_listeners/attachment_dependency_populator"
 

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -27,7 +27,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
     title = "Everyone's editions"
     @worker.stubs(:create_filter).returns(stub(page_title: title))
     @worker.stubs(generate_csv: csv)
-    Notifications.expects(:document_list).with(csv, @user.email, title).returns(stub(:deliver_now))
+    Notifications.expects(:document_list).with(csv, @user.email, title).returns(stub(deliver_now: nil))
     @worker.perform({ "state" => "draft" }, @user.id)
   end
 end


### PR DESCRIPTION
I haven't been able to run *all* the tests locally, but I'm pretty sure I've caught most problems. Hopefully your CI server will be able to confirm.