### PR TITLE
Update wordwide organisation view

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
@@ -1,20 +1,14 @@
 .worldwide-organisation-header {
-  margin: $gutter-half 0;
-  @include media(tablet) {
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include govuk-media-query($from: tablet) {
     padding-bottom: $gutter;
   }
 
   .logo {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       margin-top: $gutter-half;
-      float: left;
-      width: $two-thirds;
-      @include right-to-left {
-        float: right;
-      }
-    }
-    .gem-c-organisation-logo {
-      margin: 0 $gutter-half;
     }
   }
 
@@ -22,39 +16,29 @@
     float: left;
     width: $one-third;
   }
+
   .available-languages {
     ul {
       margin: 0 $gutter-half;
     }
   }
+
   .metadata {
     margin-top: $gutter-one-third;
 
-    @include media(tablet) {
-      float: right;
-      width: $one-third;
-      @include right-to-left {
-        float: left;
-      }
-    }
     dl {
-      @extend %contain-floats;
-      @include core-14;
-      margin: 0 $gutter-half;
+      @extend %govuk-body-s;
+      margin: 0;
 
-      dt {
-        float: left;
-        clear: both;
-        width: 7em;
-        @include right-to-left {
-          float: right;
-        }
+      @supports (display: grid) {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-gap: govuk-spacing(2);
       }
+
+      dt,
       dd {
-        float: left;
-        @include right-to-left {
-          float: right;
-        }
+        display: block;
       }
     }
   }

--- a/app/assets/stylesheets/frontend/views/_worldwide_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_worldwide_organisations.scss
@@ -176,7 +176,7 @@
   }
   .contact-us,
   .corporate-information {
-    h1 {
+    .keyline-header {
       @include heading-27;
       border-top: $gutter-one-sixth solid $black;
       border-bottom: 1px solid $border-colour;
@@ -190,12 +190,12 @@
     }
   }
   .corporate-information {
-    h1 {
+    .keyline-header {
       border-bottom: 0;
       margin: 0;
       @include media(tablet) {
         margin: 0;
       }
     }
-  }  
+  }
 }

--- a/app/views/worldwide_organisations/_corporate_information.html.erb
+++ b/app/views/worldwide_organisations/_corporate_information.html.erb
@@ -1,6 +1,6 @@
-<section class="corporate-information" id="corporate-info">
-  <div class="inner-block">
-    <h1 class="keyline-header"><%= t('worldwide_organisation.headings.corporate_information') %></h1>
+<section class="govuk-grid-row corporate-information" id="corporate-info">
+  <div class="govuk-grid-column-full">
+    <h2 class="keyline-header"><%= t('worldwide_organisation.headings.corporate_information') %></h2>
 
     <div class="corporate-information-block">
       <nav class="group sub_navigation" role="navigation">

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -3,31 +3,34 @@
   link_to_organisation ||= false
   object_for_translation ||= organisation
 %>
-<header class="block worldwide-organisation-header">
-  <div class="inner-block floated-children">
-    <div class="logo">
-      <%= render "govuk_publishing_components/components/organisation_logo", {
-        organisation: {
-          name: organisation_logo_name(organisation),
-          url: link_to_organisation ? worldwide_organisation_path(organisation) : nil,
-          crest: "single-identity",
-        }
-      } %>
+<header class="worldwide-organisation-header govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds logo">
+    <%= render "govuk_publishing_components/components/organisation_logo", {
+      organisation: {
+        name: organisation_logo_name(organisation),
+        url: link_to_organisation ? worldwide_organisation_path(organisation) : nil,
+        crest: "single-identity",
+      },
+      heading_level: 1,
+    } %>
+  </div>
+  <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render partial: 'shared/available_languages', locals: { object: object_for_translation } %>
+      </div>
     </div>
-
-    <div class="headings-block">
-      <%= render partial: 'shared/available_languages', locals: { object: object_for_translation } %>
-    </div>
-
-    <div class="metadata">
-      <dl>
-        <% if world_locations.any? %>
-          <dt><%= t('worldwide_organisation.location') %>:</dt>
-          <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l, class: "govuk-link") }.to_sentence.html_safe %></dd>
-        <% end %>
-        <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-        <dd><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
-      </dl>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full metadata">
+        <dl>
+          <% if world_locations.any? %>
+            <dt><%= t('worldwide_organisation.location') %>:</dt>
+            <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l, class: "govuk-link") }.to_sentence.html_safe %></dd>
+          <% end %>
+          <dt><%= t('worldwide_organisation.part_of') %>:</dt>
+          <dd><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
+        </dl>
+      </div>
     </div>
   </div>
 </header>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -1,52 +1,58 @@
 <% page_title @worldwide_organisation.name %>
-<% page_class "worldwide-organisations-show" %>
-<%= render partial: 'header', locals: { organisation: @worldwide_organisation, world_locations: @world_locations } %>
+<% page_class "worldwide-organisations-show govuk-width-container" %>
 
-<section class="block about-block" id="about-us">
-  <div class="inner-block floated-children">
-    <div class="about-us">
-      <div class="content">
-        <p class="summary"><%= @worldwide_organisation.summary %></p>
-        <div class="description">
-          <% if @draft %>
-          <%= govspeak_edition_to_html @worldwide_organisation.draft_about_us %>
-          <% else %>
-          <%= govspeak_edition_to_html @worldwide_organisation.about_us %>
-          <% end %>
-        </div>
-      </div>
+<%= render partial: "header", locals: {
+  organisation: @worldwide_organisation,
+  world_locations: @world_locations
+} %>
+
+<section class="govuk-grid-row" id="about-us">
+  <div class="about-us govuk-grid-column-two-thirds worldwide-org-content">
+    <p class="govuk-body-l worldwide-org-summary"><%= @worldwide_organisation.summary %></p>
+    <div class="worldwide-org-description">
+      <% if @draft %>
+        <%= govspeak_edition_to_html @worldwide_organisation.draft_about_us %>
+      <% else %>
+        <%= govspeak_edition_to_html @worldwide_organisation.about_us %>
+      <% end %>
     </div>
-    <% if @worldwide_organisation.social_media_accounts.any? %>
-      <aside class="social-media-links">
-        <div class="content">
-          <h1><%= t('worldwide_organisation.headings.follow_us') %></h1>
-            <%= render 'shared/social_media_accounts', socialable: @worldwide_organisation, followus: true %>
-        </div>
-      </aside>
-    <% end %>
   </div>
+  <% if @worldwide_organisation.social_media_accounts.any? %>
+    <aside class="social-media-links govuk-grid-column-one-third">
+      <div class="content">
+        <h2><%= t("worldwide_organisation.headings.follow_us") %></h2>
+        <%= render "shared/social_media_accounts", socialable: @worldwide_organisation, followus: true %>
+      </div>
+    </aside>
+  <% end %>
 </section>
 
 <% if ([@primary_role]+@other_roles).compact.any?(&:has_appointment?) %>
-  <section class="block people" id="people">
-    <div class="inner-block floated-children">
-      <h1 class="keyline-header"><%= t('worldwide_organisation.headings.our_people' ) %></h1>
-      <%= render( partial: 'people/person',
-                  locals: {
-                    person: @primary_role.current_person,
-                    roles: [@primary_role],
-                    hlevel: 'h2',
-                    wrapping_element: :div }) if @primary_role %>
-      <ul class="people-list">
-        <% clear_person = 0 %>
-        <% @other_roles.each do |role| %>
-          <%= render( partial: 'people/person',
-                      locals: {
-                        person: role.current_person,
-                        roles: [role],
-                        hlevel: 'h2',
-                        hide_image: true,
-                        extra_class: ((clear_person += 1) % 3 == 1 ? 'clear-person' : '')}) %>
+  <section class="govuk-grid-row" id="people">
+    <div class="govuk-grid-column-full">
+      <h2 class="keyline-header"><%= t("worldwide_organisation.headings.our_people" ) %></h2>
+    </div>
+    <%= render( partial: "people/person",
+        locals: {
+          person: @primary_role.current_person,
+          roles: [@primary_role],
+          hlevel: "h3",
+          wrapping_element: :div,
+          extra_class: "govuk-grid-column-one-quarter",
+        }
+      ) if @primary_role %>
+    <div class="govuk-grid-column-three-quarters">
+      <ul class="govuk-list govuk-grid-row">
+        <% @other_roles.each.with_index do |role, i| %>
+          <%= render( partial: "people/person",
+            locals: {
+              person: role.current_person,
+              roles: [role],
+              hlevel: "h3",
+              hide_image: true,
+              extra_class: (i + 1) % 4 == 0 ? "govuk-grid-column-one-third clear-column" : "govuk-grid-column-one-third",
+            }
+          ) %>
         <% end %>
       </ul>
     </div>
@@ -54,18 +60,26 @@
 <% end %>
 
 <% if @main_office %>
-  <section class="block contact-us" id="contact-us">
-    <div class="inner-block floated-children">
-      <h1 class="keyline-header"><%= t('worldwide_organisation.headings.contact_us' ) %></h1>
-      <%= render partial: 'contacts/contact', locals: {contact: @main_office, is_main: true, lang: t_lang_translated_locales(@main_office.contact) } %>
-
-      <% @home_page_offices.each do |home_page_office| %>
-        <%= render partial: 'contacts/contact', locals: { contact: home_page_office, lang:  t_lang_translated_locales(home_page_office.contact) } %>
-      <% end %>
-    </div>
+  <section class="govuk-grid-row contact-us" id="contact-us">
+    <h2 class="keyline-header">
+      <%= t("worldwide_organisation.headings.contact_us" ) %>
+    </h2>
+    <%= render partial: "contacts/contact", locals: {
+      contact: @main_office,
+      is_main: true,
+      lang: t_lang_translated_locales(@main_office.contact)
+    } %>
+    <% @home_page_offices.each do |home_page_office| %>
+      <%= render partial: "contacts/contact", locals: {
+        contact: home_page_office,
+        lang: t_lang_translated_locales(home_page_office.contact)
+      } %>
+    <% end %>
   </section>
 <% end %>
 
 <% if @worldwide_organisation.corporate_information_pages.any? %>
-  <%= render partial: 'corporate_information', locals: { organisation: @worldwide_organisation } %>
+  <%= render partial: "corporate_information", locals: {
+    organisation: @worldwide_organisation
+  } %>
 <% end %>

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -16,7 +16,7 @@ When(/^I visit the world organisation that is translated$/) do
 end
 
 Then(/^I should see the translation of that world organisation$/) do
-  assert page.has_css?(".summary", text: "fr-summary"), "expected to see the french summary, but didn't"
+  assert page.has_css?(".worldwide-org-summary", text: "fr-summary"), "expected to see the french summary, but didn't"
 end
 
 Given(/^I have drafted a translatable document "([^"]*)"$/) do |title|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -262,9 +262,9 @@ Then(/^when viewing the worldwide organisation "([^"]*)" with the locale "([^"]*
 
   visit worldwide_organisation_path(worldwide_organisation, locale: locale)
 
-  assert page.has_css?('.summary', text: translation["summary"]), "Summary wasn't present"
-  assert page.has_css?('.description', text: translation["description"]), "Description wasn't present"
-  assert page.has_css?('.content', text: translation["services"]), "Services wasn't present"
+  assert page.has_css?('.worldwide-org-summary', text: translation["summary"]), "Summary wasn't present"
+  assert page.has_css?('.worldwide-org-description', text: translation["description"]), "Description wasn't present"
+  assert page.has_css?('.worldwide-org-content', text: translation["services"]), "Services wasn't present"
 end
 
 Given(/^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/) do |name, native_locale_name|

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -70,25 +70,25 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
     create(:about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: "pre-edit body")
     get :show, params: { id: worldwide_organisation }
-    assert_select ".description", text: "pre-edit body"
+    assert_select ".worldwide-org-description", text: "pre-edit body"
 
     draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: "post-edit body")
 
     get :show, params: { id: worldwide_organisation }
-    assert_select ".description", text: "pre-edit body"
+    assert_select ".worldwide-org-description", text: "pre-edit body"
 
     get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
-    assert_select ".description", text: "post-edit body"
+    assert_select ".worldwide-org-description", text: "post-edit body"
   end
 
   view_test "not showing a preview of draft content when requested and a user is not logged in" do
     worldwide_organisation = create(:worldwide_organisation)
     create(:about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: "pre-edit body")
     get :show, params: { id: worldwide_organisation }
-    assert_select ".description", text: "pre-edit body"
+    assert_select ".worldwide-org-description", text: "pre-edit body"
 
     draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: "post-edit body")
     get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
-    assert_select ".description", text: "pre-edit body"
+    assert_select ".worldwide-org-description", text: "pre-edit body"
   end
 end


### PR DESCRIPTION
## Why

The wordwide org view had a bug - the list of people were displayed at full width, rather than being in quarter-width columns

## What

To remedy this, the entire page needed to be updated to use the grid from GOV.UK Frontend. 

Plus some other fixes:

 - the organisation logo is now wrapped in a `h1`; previously this was a `div`
 - heading levels changed to give page some hierarchy to make it easier for assistive tech to understand the page
 - rogue single quotes swapped for double

## Where

Examples to check:

- http://whitehall-admin.dev.gov.uk/world/organisations/uk-mission-to-asean
- http://whitehall-admin.dev.gov.uk/world/organisations/uk-representation-in-the-commonwealth
- http://whitehall-admin.dev.gov.uk/world/organisations/uk-permanent-delegation-to-the-oecd
- http://whitehall-admin.dev.gov.uk/world/organisations/united-kingdom-mission-to-the-united-nations
- http://whitehall-admin.dev.gov.uk/world/organisations/uk-mission-to-un-in-new-york
- http://whitehall-admin.dev.gov.uk/world/organisations/uk-representation-to-the-eu

## Before
![image](https://user-images.githubusercontent.com/1732331/70081133-dace0500-15ff-11ea-9340-46e5e2297446.png)

## After

(Images broken because this is on a local dev environment.)

![image](https://user-images.githubusercontent.com/1732331/70081177-f46f4c80-15ff-11ea-8243-bac016a475ef.png)
