### PR TITLE
Allow managing editors to edit historial documents

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -19,7 +19,7 @@ class Admin::EditionsController < Admin::BaseController
   def forbid_editing_of_historic_content!
     unless can?(:modify, @edition)
       redirect_to [:admin, @edition],
-                  alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please <a href="https://support.publishing.service.gov.uk/content_change_request/new">contact GDS</a> if you need to change it.}
+                  alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it}
     end
   end
 

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -56,7 +56,7 @@ module Whitehall::Authority::Rules
       elsif action == :unwithdraw && actor.managing_editor?
         true
       elsif action == :modify && @subject.historic?
-        actor.gds_editor? || actor.gds_admin?
+        actor.gds_editor? || actor.gds_admin? || actor.managing_editor?
       elsif actor.gds_admin?
         gds_admin_can?(action)
       elsif actor.gds_editor?

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -29,31 +29,28 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_select ".political-status", count: 0
   end
 
-  view_test "doesn't let non-gds users edit historic documents" do
+  def edit_historic_document
     create(:previous_government, name: "old")
     create(:current_government, name: "new")
-
-    login_as :managing_editor
 
     published_edition = create(:published_news_article, first_published_at: 3.years.ago)
     new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
 
     get :edit, params: { id: new_draft }
+  end
 
     assert_response :redirect
   end
 
-  view_test "lets gds users edit historic documents" do
-    create(:previous_government, name: "old")
-    create(:current_government, name: "new")
+  view_test "doesn't let managing editors edit historic documents" do
+    login_as :managing_editor
+    edit_historic_document
+    assert_response :redirect
+  end
 
+  view_test "lets GDS editors edit historic documents" do
     login_as :gds_editor
-
-    published_edition = create(:published_news_article)
-    new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
-
-    get :edit, params: { id: new_draft }
-
+    edit_historic_document
     assert_response :success
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -39,13 +39,16 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     get :edit, params: { id: new_draft }
   end
 
+  view_test "doesn't let non-GDS users edit historic documents" do
+    login_as :departmental_editor
+    edit_historic_document
     assert_response :redirect
   end
 
-  view_test "doesn't let managing editors edit historic documents" do
+  view_test "lets managing editors edit historic documents" do
     login_as :managing_editor
     edit_historic_document
-    assert_response :redirect
+    assert_response :success
   end
 
   view_test "lets GDS editors edit historic documents" do

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -176,7 +176,7 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 
-  test "cannot modify historic editions" do
-    refute enforcer_for(managing_editor, historic_edition).can?(:modify)
+  test "can modify historic editions" do
+    assert enforcer_for(managing_editor, historic_edition).can?(:modify)
   end
 end


### PR DESCRIPTION
This builds on 03a9707 to allow managing editors to edit historical documents as well as GDS editors.

This has been requested by the Election Team. Previously, Content Support has received a lot of requests to change content that is locked down to GDS admins, and they would like to allow Managing Editors to do this themselves.

[Trello Card](https://trello.com/c/gTEzpUBs/1612-3-allow-managing-editors-to-create-new-editions-of-content-in-history-mode)