### PR TITLE
Restrict access to historic editions

### DIFF
--- a/app/concerns/historic_content_concern.rb
+++ b/app/concerns/historic_content_concern.rb
@@ -1,0 +1,12 @@
+module HistoricContentConcern
+  extend ActiveSupport::Concern
+
+  def forbid_editing_of_historic_content!
+    # We do this rather than relying on `enforce_permissions!` to be able
+    # to redirect with a nice message rather than just "permission denied".
+    if @edition.historic? && !can?(:modify, @edition)
+      redirect_to [:admin, @edition],
+                  alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.}
+    end
+  end
+end

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -1,8 +1,10 @@
 class Admin::EditionWorkflowController < Admin::BaseController
+  include HistoricContentConcern
   include PublicDocumentRoutesHelper
   include LockedDocumentConcern
 
   before_action :find_edition
+  before_action :forbid_editing_of_historic_content!
   before_action :enforce_permissions!
   before_action :limit_edition_access!
   before_action :lock_edition

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,4 +1,6 @@
 class Admin::EditionsController < Admin::BaseController
+  include HistoricContentConcern
+
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
@@ -9,19 +11,12 @@ class Admin::EditionsController < Admin::BaseController
   before_action :detect_other_active_editors, only: [:edit]
   before_action :set_edition_defaults, only: :new
   before_action :build_blank_image, only: %i[new edit]
+  before_action :forbid_editing_of_historic_content!, only: %i[create edit update submit destory revise]
   before_action :enforce_permissions!
   before_action :limit_edition_access!, only: %i[show edit update submit revise diff reject destroy]
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :deduplicate_specialist_sectors, only: %i[create update]
-  before_action :forbid_editing_of_historic_content!, only: %i[create edit update submit destory revise]
   before_action :forbid_editing_of_locked_documents, only: %i[edit update revise destroy]
-
-  def forbid_editing_of_historic_content!
-    unless can?(:modify, @edition)
-      redirect_to [:admin, @edition],
-                  alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it}
-    end
-  end
 
   def enforce_permissions!
     case action_name

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -51,12 +51,12 @@ module Whitehall::Authority::Rules
         true
       elsif !can_see?
         false
+      elsif action != :see && @subject.historic?
+        actor.gds_editor? || actor.gds_admin? || actor.managing_editor?
       elsif action == :unpublish && actor.managing_editor?
         true
       elsif action == :unwithdraw && actor.managing_editor?
         true
-      elsif action == :modify && @subject.historic?
-        actor.gds_editor? || actor.gds_admin? || actor.managing_editor?
       elsif actor.gds_admin?
         gds_admin_can?(action)
       elsif actor.gds_editor?

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -170,4 +170,8 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   test "cannot modify historic editions" do
     refute enforcer_for(department_editor, historic_edition).can?(:modify)
   end
+
+  test "cannot publish historic editions" do
+    refute enforcer_for(department_editor, historic_edition).can?(:publish)
+  end
 end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -179,4 +179,8 @@ class ManagingEditorTest < ActiveSupport::TestCase
   test "can modify historic editions" do
     assert enforcer_for(managing_editor, historic_edition).can?(:modify)
   end
+
+  test "can publish historic editions" do
+    assert enforcer_for(managing_editor, historic_edition).can?(:publish)
+  end
 end


### PR DESCRIPTION
Currently we limit creating a new edition of a historic document to managing and GDS editors. However, an edition that was drafted before the document became historic would not be included in this restriction meaning that it could be edited and published by any editor.

Departmental publishers shouldn't be able to interact in any way with content that is historic to preserve it as a record of the government of the time.

The reason why this wasn't working before is that we were only restricting access to these actions if the `action == :modify` which isn't a real action. Instead I've limited all actions except for `:see` and added the flash message redirect to the workflow controller so users understand why the operation failed.

[Trello Card](https://trello.com/c/u7T89leT/1617-fix-history-mode-permissions-for-publishing-and-withdrawing-unpublishing-redirecting)