### PR TITLE
Add political status to organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -92,6 +92,7 @@ module PublishingApi
         organisation_featuring_priority: organisation_featuring_priority,
         organisation_govuk_status: organisation_govuk_status,
         organisation_type: organisation_type,
+        organisation_political: organisation_political,
         social_media_links: social_media_links,
       }
       details[:default_news_image] = default_news_image if default_news_image
@@ -116,6 +117,10 @@ module PublishingApi
 
     def html_summary
       Whitehall::GovspeakRenderer.new.govspeak_to_html(govspeak_summary)
+    end
+
+    def organisation_political
+      item.political
     end
 
     def text_summary

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -86,6 +86,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
           updated_at: nil,
         },
         organisation_type: "other",
+        organisation_political: false,
         social_media_links: [],
         default_news_image: {
           url: news_image.file.url(:s300),
@@ -285,5 +286,16 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     email = presented_item.content.dig(:details, :alternative_format_contact_email)
 
     assert_equal email, "foo@bar.com"
+  end
+
+  test "presents the organisation's political status" do
+    organisation = create(
+      :organisation,
+      political: true,
+    )
+    presented_item = present(organisation)
+    organisation_political = presented_item.content.dig(:details, :organisation_political)
+
+    assert organisation_political
   end
 end


### PR DESCRIPTION
We want to present organisations political status from Whitehall to Publishing
API so we can use this information in Content Publisher. It is currently
hardcoded in the YAML file and requires manual updates.

[Trello card](https://trello.com/c/zHm2B8VX/1242-present-organisation-political-status-from-whitehall-to-publishing-api)