### PR TITLE
Update link to subscribe to MHRA drug safety updates

### DIFF
--- a/app/models/email_signup_pages_finder.rb
+++ b/app/models/email_signup_pages_finder.rb
@@ -26,7 +26,7 @@ class EmailSignupPagesFinder
       ),
       OpenStruct.new(
         text: "Drug Safety Update",
-        description: "Subscribe to the <a href='/drug-safety-update/email-signup'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
+        description: "Subscribe to the <a href='https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
       ),
       OpenStruct.new(
         text: "News and publications from the MHRA",

--- a/features/step_definitions/email_signup_information_for_mhra_steps.rb
+++ b/features/step_definitions/email_signup_information_for_mhra_steps.rb
@@ -6,7 +6,7 @@ end
 
 Then(/^I should see email signup information for "(.*?)"$/) do |_organisation_name|
   assert(page.has_link?("MHRA's alerts and recalls for drugs and medical devices", href: "/drug-device-alerts/email-signup"))
-  assert(page.has_link?("Drug Safety Update", href: "/drug-safety-update/email-signup"))
+  assert(page.has_link?("Drug Safety Update", href: "https://public.govdelivery.com/accounts/UKMHRA/subscriber/new?topic_id=UKMHRA_0044"))
   assert(page.has_link?("MHRA's new publications, statistics, consultations and announcements",
                         href: "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fmedicines-and-healthcare-products-regulatory-agency.atom"))
 end


### PR DESCRIPTION
This PR updates the link to subscribe to MHRA drug safety updates, as requested.

Zendesk: 3869593