### PR TITLE
Remove migrated content from Whitehall search index

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -33,6 +33,7 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
 
     document.editions.each do |edition|
       Whitehall::InternalLinkUpdater.new(edition).call
+      Whitehall::SearchIndex.delete(edition)
     end
 
     ContentPublisher::FeaturedDocumentMigrator.new(document).call

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -126,6 +126,18 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
+  test "removes migrated document from search index" do
+    edition = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
+    edition.document.update(slug: "some-document", locked: true)
+    create(:edition_with_document)
+    login_as :export_data_user
+
+    post :migrated, params: { id: edition.document.id }, format: "json"
+
+    mock = MiniTest::Mock.new
+    mock.expect :call, nil, [Whitehall::SearchIndex.delete(edition)]
+  end
+
   test "does not mark unlocked document as migrated" do
     edition = create(:edition_with_document)
     login_as :export_data_user


### PR DESCRIPTION
## User story

**As a** publisher
**I want** my content to be removed from Whitehall search index when it is migrated
**So that** the content doesn't appear in search twice

## What
We are adding a step to the migrated endpoint to remove the content for this document from the government index.

## Why

When content has been migrated from Whitehall to Content Publisher we need it to no longer exist in the Search API index for Whitehall content.

[Trello](https://trello.com/c/nJARKkob/1231-remove-content-from-whitehall-search-index)