### PR TITLE
Run bundle update govspeak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     brakeman (4.7.1)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     capybara (2.18.0)
       addressable
@@ -135,7 +135,7 @@ GEM
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
-    faraday (0.17.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     friendly_id (5.2.4)
@@ -144,7 +144,7 @@ GEM
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     fuzzy_match (2.1.0)
-    gds-api-adapters (61.0.0)
+    gds-api-adapters (63.0.0)
       addressable
       link_header
       null_logger
@@ -166,7 +166,7 @@ GEM
       activemodel (>= 4.2, < 6.1)
       activerecord (>= 4.2, < 6.1)
       request_store (~> 1.0)
-    govspeak (6.5.1)
+    govspeak (6.5.2)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 16.16)
@@ -193,7 +193,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.13.1)
+    govuk_publishing_components (21.13.5)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -307,7 +307,7 @@ GEM
       connection_pool (~> 2.2)
     netrc (0.11.0)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -416,7 +416,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rinku (2.0.6)
-    rouge (3.13.0)
+    rouge (3.14.0)
     rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -511,7 +511,7 @@ GEM
     teaspoon-qunit (1.20.0)
       teaspoon (>= 1.0.0)
     test-queue (0.2.13)
-    thor (0.20.3)
+    thor (1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)


### PR DESCRIPTION
This will make "request an accessible version" links for attachments work again.