### PR TITLE
Add h1 to stylesheets for worldwide organisation pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -1,4 +1,5 @@
 .govspeak {
+  h1:first-child,
   h2:first-child,
   h3:first-child,
   h4:first-child,
@@ -6,6 +7,7 @@
     margin-top: 0;
   }
 
+  h1,
   h2 {
     @include ig-core-27;
     font-weight: bold;


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5193/files#diff-bb26fcf8c43892d384807e5e8cae09b4L179
Stopped users from being able to use h1 tags within their text bodies. While this shouldn't be happening because it's not great from an accessibility front, there are too many pages that this effects for 2nd line to make changes to. We've created a card (below) that outlines the need to get content creators to remove h1 tags from text bodies. When that has been actioned these changes should be reverted.

Trello - https://trello.com/c/kzfGMNdH/800-look-into-replacing-h1s-with-h2s-on-worldwide-org-pages