### PR TITLE
Render roles using collections

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: schema_name,
       )
       content.merge!(polymorphic_path)

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -21,7 +21,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       document_type: "ministerial_role",
       locale: "en",
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       public_updated_at: role.updated_at,
       routes: [
         {
@@ -68,7 +68,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       document_type: "board_member_role",
       locale: "en",
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       public_updated_at: role.updated_at,
       routes: [],
       redirects: [],


### PR DESCRIPTION
We've migrated roles so they are now rendered by Collections rather than Whitehall Frontend.