### PR TITLE
Add role responsibilities to description

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -168,6 +168,10 @@ class Role < ApplicationRecord
     HISTORIC_ROLE_PARAM_MAPPINGS.invert[slug]
   end
 
+  def responsibilities_without_markup
+    Govspeak::Document.new(responsibilities).to_text
+  end
+
 private
 
   def prevent_destruction_unless_destroyable

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        description: nil,
+        description: item.responsibilities_without_markup,
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -16,7 +16,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     expected_hash = {
       base_path: "/government/ministers/#{role.slug}",
       title: role.name,
-      description: nil,
+      description: "X and Y",
       schema_name: "role",
       document_type: "ministerial_role",
       locale: "en",
@@ -63,7 +63,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     expected_hash = {
       base_path: nil,
       title: role.name,
-      description: nil,
+      description: "Y and Z",
       schema_name: "role",
       document_type: "board_member_role",
       locale: "en",


### PR DESCRIPTION
This will allow it to be shown in search results rather than currently where you don't see anything about the role and instead see just the title.

This may also be useful as we can include that information in meta tags on the page for other search engines.

This copies what we did for people where we included the biography without HTML markup. https://github.com/alphagov/whitehall/pull/5182

[Trello Card](https://trello.com/c/uLfR4OT8/1644-3-use-govuk-search-index-for-people-and-roles)