### PR TITLE
Add Redis::CannotConnectError to excluded Sentry exceptions

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,3 +1,6 @@
 GovukError.configure do |config|
-  config.excluded_exceptions << "AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient"
+  config.excluded_exceptions += [
+    "AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient",
+    "Redis::CannotConnectError"
+  ]
 end


### PR DESCRIPTION
This PR adds `Redis::CannotConnectError` to the list of excluded Sentry exceptions. Currently, this exception is raised whenever connection is lost with Redis, which happens most often when Redis is restarted.

As part of the `/healthcheck` endpoint, we already call `GovukHealthcheck::SidekiqRedis` to determine the health of Redis. This raises a critical error if the call fails, which will then be flagged in Icinga: https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb.