### PR TITLE
Don't allow managing editors to change historic content

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -52,7 +52,7 @@ module Whitehall::Authority::Rules
       elsif !can_see?
         false
       elsif action != :see && @subject.historic?
-        actor.gds_editor? || actor.gds_admin? || actor.managing_editor?
+        actor.gds_editor? || actor.gds_admin?
       elsif action == :unpublish && actor.managing_editor?
         true
       elsif action == :unwithdraw && actor.managing_editor?

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -45,10 +45,10 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_response :redirect
   end
 
-  view_test "lets managing editors edit historic documents" do
+  view_test "doesn't let managing editors edit historic documents" do
     login_as :managing_editor
     edit_historic_document
-    assert_response :success
+    assert_response :redirect
   end
 
   view_test "lets GDS editors edit historic documents" do

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -176,11 +176,11 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 
-  test "can modify historic editions" do
-    assert enforcer_for(managing_editor, historic_edition).can?(:modify)
+  test "cannot modify historic editions" do
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:modify)
   end
 
-  test "can publish historic editions" do
-    assert enforcer_for(managing_editor, historic_edition).can?(:publish)
+  test "cannot publish historic editions" do
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:publish)
   end
 end


### PR DESCRIPTION
We added this feature in https://github.com/alphagov/whitehall/pull/5194 but since we haven't activated history mode this year we want it reverted.