### PR TITLE
Work around an odd issue with atom feeds

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -26,10 +26,13 @@ module FeedHelper
     # spec.
     # The interpolation logic is straight out of:
     # http://api.rubyonrails.org/classes/ActionView/Helpers/AtomFeedHelper/AtomFeedBuilder.html#method-i-entry
-    id = record.try(:document) ? record.document.id : record.id
-    return id if record.is_a?(RummagerDocumentPresenter)
+    if record.is_a?(RummagerDocumentPresenter)
+      record.id
+    else
+      id = record.try(:document) ? record.document.id : record.id
 
-    "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
+      "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
+    end
   end
 
   def schema_date(builder)

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -29,7 +29,7 @@ module FeedHelper
     if record.is_a?(RummagerDocumentPresenter)
       record.id
     else
-      id = record.try(:document) ? record.document.id : record.id
+      id = record&.document&.id || record.id
 
       "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
     end


### PR DESCRIPTION
Somehow, with recent versions of the govuk_publishing_components,
`.try(:document)` is calling a function defined in the
_document_list.html.erb partial in the govuk_publishing_components...

I don't quite understand why, so switch the code around to avoid
calling try on objects that don't respond to .document. In the case of
english responses, the record will be a RummagerDocumentPresenter,
which doesn't respond to .document, so just return it's id. In the
case of non english responses, the record is a presented edition,
which does respond to .document.