### PR TITLE
Fix a replacement for an attachment

### DIFF
--- a/db/data_migration/20200106155553_fix_replacement_for_attachment_data787481.rb
+++ b/db/data_migration/20200106155553_fix_replacement_for_attachment_data787481.rb
@@ -1,0 +1,9 @@
+attachment_data_to_modify = AttachmentData.find(787481)
+
+# 845347 isn't the replacement, but use it to find it. This avoids the
+# situation where the replacement changes before this code runs
+replacement = AttachmentData.find(845347).replaced_by
+
+attachment_data_to_modify.replace_with!(replacement)
+
+AssetManager::AttachmentUpdater.call(attachment_data_to_modify, replacement_id: true)


### PR DESCRIPTION
This is for Zendesk ticket 3882452. The chain of replaced attachments
seems to have been broken, so the problematic attachment was left
replaced by a deleted attachment that was never published.

Therefore, manually update it's replacement to the latest version of
the attachment.