### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -17,12 +17,12 @@
       stylesheet_base = local_assigns[:stylesheet] || "base"
       stylesheet_base += "-rtl" if right_to_left?
     -%>
-    <!--[if gt IE 9]><!--><%= stylesheet_link_tag "frontend/#{stylesheet_base}.css", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
+    <!--[if gt IE 9]><!--><%= stylesheet_link_tag "frontend/#{stylesheet_base}.css", integrity: false %><!--<![endif]-->
     <!--[if IE 6]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie6.css" %><script>var ieVersion = 6;</script><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie7.css" %><script>var ieVersion = 7;</script><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie8.css" %><script>var ieVersion = 8;</script><![endif]-->
     <!--[if IE 9]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie9.css" %><script>var ieVersion = 9;</script><![endif]-->
-    <%= stylesheet_link_tag "frontend/print.css", media: "print", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "frontend/print.css", media: "print", integrity: false %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
   </head>
@@ -34,7 +34,7 @@
       </div>
       <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
-    <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
+    <%= javascript_include_tag "application", integrity: false %>
     <%= javascript_tag(yield :javascript_initialisers) %>
   </body>
 </html>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :head do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "admin.css", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "admin.css", integrity: false %><!--<![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "admin-ie7.css" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "admin-ie8.css" %><script>var ieVersion = 8;</script><![endif]-->
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)