### PR TITLE
Fix inline attachment rendering

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -257,7 +257,7 @@ private
     end
     govspeak.gsub(/\[InlineAttachment:([0-9]+)\]/) do
       if (attachment = attachments[$1.to_i - 1])
-        render(partial: "documents/inline_attachment", formats: :html, locals: { attachment: attachment })
+        render(partial: "documents/inline_attachment", formats: :html, locals: { attachment: attachment }).chomp
       else
         ""
       end

--- a/app/views/documents/_inline_attachment.html.erb
+++ b/app/views/documents/_inline_attachment.html.erb
@@ -1,4 +1,1 @@
-<span id="attachment_<%= attachment.id %>" class="attachment-inline">
-  <%= link_to attachment.title, attachment.url %>
-  (<%= attachment_attributes(attachment) %>)
-</span>
+<span id="attachment_<%= attachment.id %>" class="attachment-inline"><%= link_to attachment.title, attachment.url %> (<%= attachment_attributes(attachment) %>)</span>

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -221,6 +221,7 @@ class GovspeakHelperTest < ActionView::TestCase
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h1"
     assert_select_within_html html, ".attachment-inline"
+    assert_includes strip_tags(html).gsub("\n", ""), " (PDF, )."
   end
 
   test "should ignore missing block attachments" do


### PR DESCRIPTION
## What
Removes trailing newlines from inline attachment view. There were two things causing the additional space:

- The closing span tag being on a newline
- The inline_attachment file having a newline at the end of the file (part of our standards)

## Why
- Inline attachments were rendering with an additional space after the inline attachment.
- Inline attachments in numbered lists displayed on a new line and showed a closing `</span>` tag on the page

## Before
<img width="372" alt="Screenshot 2020-01-07 at 15 30 11" src="https://user-images.githubusercontent.com/29889908/71906815-bc10e000-3162-11ea-86f7-e170ff5a84b3.png">

## After
<img width="368" alt="Screenshot 2020-01-07 at 15 29 57" src="https://user-images.githubusercontent.com/29889908/71906813-b915ef80-3162-11ea-8691-756931f381c0.png">

## Before
<img width="478" alt="Screenshot 2020-01-07 at 15 52 18" src="https://user-images.githubusercontent.com/29889908/71908342-b49f0600-3165-11ea-956f-469fee6f290d.png">

## After
<img width="475" alt="Screenshot 2020-01-07 at 15 45 57" src="https://user-images.githubusercontent.com/29889908/71907868-d77cea80-3164-11ea-8b4a-de6b2f0ea9c9.png">
