### PR TITLE
Redirect UKNCP page to new location

### DIFF
--- a/db/data_migration/20200108171705_redirect_ukncp_organisation_page.rb
+++ b/db/data_migration/20200108171705_redirect_ukncp_organisation_page.rb
@@ -1,0 +1,6 @@
+# Redirect UKNCP to new location
+
+content_id = "1bc90138-9b23-46ca-8a8f-57c6cc50c9b1"
+destination = "/government/organisations/uk-national-contact-point"
+
+PublishingApiRedirectWorker.new.perform(content_id, destination, "en")


### PR DESCRIPTION
This PR redirects the UKNCP page (https://www.gov.uk/government/groups/uk-national-contact-point-for-the-organisation-for-economic-co-operation-and-development-guidelines) to the new location (https://www.gov.uk/government/organisations/uk-national-contact-point), as part of Zendesk ticket 3885814.