### PR TITLE
Add a scope for filtering on link report links

### DIFF
--- a/app/models/link_checker_api_report/link.rb
+++ b/app/models/link_checker_api_report/link.rb
@@ -4,6 +4,10 @@ class LinkCheckerApiReport::Link < ApplicationRecord
 
   belongs_to :report, class_name: "LinkCheckerApiReport"
 
+  scope :status_ok, -> { where(status: "ok") }
+  scope :created_six_months_ago, -> { where("created_at < ?", 6.months.ago) }
+  scope :deletable, -> { self.status_ok.merge(self.created_six_months_ago) }
+
   def self.attributes_from_link_report(payload)
     {
       uri: payload.fetch("uri"),

--- a/test/factories/link_checker_api_report_link.rb
+++ b/test/factories/link_checker_api_report_link.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     uri { "http://www.example.com" }
     status { "ok" }
     ordering { 0 }
+
+    trait :broken do
+      status { "broken" }
+    end
   end
 end

--- a/test/unit/models/link_checker_api_report_link_test.rb
+++ b/test/unit/models/link_checker_api_report_link_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class LinkCheckerApiReportLinkTest < ActiveSupport::TestCase
+  test "with a broken link, don't mark as deletable" do
+    create(:link_checker_api_report_link, :broken)
+    assert_equal LinkCheckerApiReport::Link.deletable.to_a, []
+  end
+
+  test "with an ok link, don't mark as deletable" do
+    create(:link_checker_api_report_link)
+    assert_equal LinkCheckerApiReport::Link.deletable.to_a, []
+  end
+
+  test "with an ok link created over 6 months ago, mark as deletable" do
+    link = create(:link_checker_api_report_link, created_at: (6.months + 1.day).ago)
+    assert_equal LinkCheckerApiReport::Link.deletable.to_a, [link]
+  end
+end


### PR DESCRIPTION
This allows us to filter on link report links which can be deleted. The link table has exceeded 10 GB and is the biggest Whitehall table so we need to find a way of reducing the size. We've decided that links with a status of `ok` which were created over 6 months ago can be deleted.

Once this is deployed I will manually delete these links by doing `Link.deletable.delete_all` and then after that set up some sort of automated process to do this regularly.

[Trello Card](https://trello.com/c/akZkqlUE/1669-5-investigate-why-linkcheckerapireportlinks-table-in-the-whitehall-database-is-very-large)