### PR TITLE
Bump friendly_id from 5.2.4 to 5.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "dalli", "~> 2.7"
 gem "deprecated_columns", "~> 0.1.1"
 gem "equivalent-xml", "~> 0.6.0", require: false
 gem "faraday"
-gem "friendly_id", "~> 5.2.4"
+gem "friendly_id", "~> 5.3.0"
 gem "fuzzy_match", "~> 2.1"
 gem "gds-sso", "~> 14.2"
 gem "globalize", "~> 5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
-    friendly_id (5.2.4)
+    friendly_id (5.3.0)
       activerecord (>= 4.0.0)
     fugit (1.3.3)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -576,7 +576,7 @@ DEPENDENCIES
   equivalent-xml (~> 0.6.0)
   factory_bot
   faraday
-  friendly_id (~> 5.2.4)
+  friendly_id (~> 5.3.0)
   fuzzy_match (~> 2.1)
   gds-api-adapters
   gds-sso (~> 14.2)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,8 @@
 # Abstract base class for Attachments.
 class Attachment < ApplicationRecord
+  extend FriendlyId
+  friendly_id :title, use: :scoped, scope: :attachable
+
   belongs_to :attachable, polymorphic: true
   has_one :attachment_source
 

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -1,4 +1,5 @@
 class ExternalAttachment < Attachment
+  extend FriendlyId
   include HasContentId
 
   validates :external_url, presence: true, uri: true, length: { maximum: 255 }

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -1,4 +1,5 @@
 class FileAttachment < Attachment
+  extend FriendlyId
   include HasContentId
 
   delegate :url,

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -1,6 +1,5 @@
 class HtmlAttachment < Attachment
   extend FriendlyId
-  friendly_id :title, use: :scoped, scope: :attachable
 
   include HasContentId
 


### PR DESCRIPTION
For: https://trello.com/c/rM6VLd6U/1301-audit-dependabot-for-whitehall

Added `extends FriendlyId` to `Attachment` and all classes that inherit from `Attachment` - as recommended [here](https://github.com/norman/friendly_id/blob/9cd4ce2b5d0425aa704872e1334b442cab03c29c/lib/friendly_id/base.rb#L21)...

> A note about single table inheritance (STI): you must extend FriendlyId in all classes that participate in STI, both your parent classes and their children.

Pull `friendly_id :title, use: :scoped, scope: :attachable` from `HtmlAttachment` up into the parent `Attachment` class.


