### PR TITLE
Reduce how long we keep link report links

### DIFF
--- a/app/models/link_checker_api_report/link.rb
+++ b/app/models/link_checker_api_report/link.rb
@@ -5,8 +5,8 @@ class LinkCheckerApiReport::Link < ApplicationRecord
   belongs_to :report, class_name: "LinkCheckerApiReport"
 
   scope :status_ok, -> { where(status: "ok") }
-  scope :created_six_months_ago, -> { where("created_at < ?", 6.months.ago) }
-  scope :deletable, -> { self.status_ok.merge(self.created_six_months_ago) }
+  scope :created_three_months_ago, -> { where("created_at < ?", 3.months.ago) }
+  scope :deletable, -> { self.status_ok.merge(self.created_three_months_ago) }
 
   def self.attributes_from_link_report(payload)
     {

--- a/test/unit/models/link_checker_api_report_link_test.rb
+++ b/test/unit/models/link_checker_api_report_link_test.rb
@@ -11,8 +11,8 @@ class LinkCheckerApiReportLinkTest < ActiveSupport::TestCase
     assert_equal LinkCheckerApiReport::Link.deletable.to_a, []
   end
 
-  test "with an ok link created over 6 months ago, mark as deletable" do
-    link = create(:link_checker_api_report_link, created_at: (6.months + 1.day).ago)
+  test "with an ok link created over 3 months ago, mark as deletable" do
+    link = create(:link_checker_api_report_link, created_at: (3.months + 1.day).ago)
     assert_equal LinkCheckerApiReport::Link.deletable.to_a, [link]
   end
 end


### PR DESCRIPTION
We originally decided to delete link checker report links after six months but the table is still quite large after this. It doesn't seem like we need to keep them for much longer so we're going to reduce the time to three months.

[Trello Card](https://trello.com/c/akZkqlUE/1669-5-investigate-why-linkcheckerapireportlinks-table-in-the-whitehall-database-is-very-large)