### PR TITLE
Add a rake task for deleting old report links

### DIFF
--- a/lib/tasks/link_checker.rake
+++ b/lib/tasks/link_checker.rake
@@ -1,0 +1,6 @@
+namespace :link_checker do
+  task delete_old_report_links: :environment do
+    count = LinkCheckerApiReport::Link.deletable.delete_all
+    puts "Deleted #{count} old report links."
+  end
+end


### PR DESCRIPTION
This table has the potential to grow indefinitely, so we will configure this task to run periodically so it remains a good size. It also always us to delete the links using Jenkins so we have better visibility on the job.

This follows on from https://github.com/alphagov/whitehall/pull/5241.

[Trello Card](https://trello.com/c/akZkqlUE/1669-5-investigate-why-linkcheckerapireportlinks-table-in-the-whitehall-database-is-very-large)