### PR TITLE
Create Brexit no-deal content notice

### DIFF
--- a/app/controllers/admin/case_studies_controller.rb
+++ b/app/controllers/admin/case_studies_controller.rb
@@ -1,4 +1,6 @@
 class Admin::CaseStudiesController < Admin::EditionsController
+  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
+
   private
 
   def edition_class

--- a/app/controllers/admin/detailed_guides_controller.rb
+++ b/app/controllers/admin/detailed_guides_controller.rb
@@ -1,4 +1,6 @@
 class Admin::DetailedGuidesController < Admin::EditionsController
+  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
+
   private
 
   def edition_class

--- a/app/controllers/admin/document_collections_controller.rb
+++ b/app/controllers/admin/document_collections_controller.rb
@@ -1,4 +1,6 @@
 class Admin::DocumentCollectionsController < Admin::EditionsController
+  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
+
   private
 
   def edition_class

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -10,7 +10,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :build_edition, only: %i[new create]
   before_action :detect_other_active_editors, only: [:edit]
   before_action :set_edition_defaults, only: :new
-  before_action :build_blank_image, only: %i[new edit]
+  before_action :build_edition_dependencies, only: %i[new edit]
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update submit destory revise]
   before_action :enforce_permissions!
   before_action :limit_edition_access!, only: %i[show edit update submit revise diff reject destroy]
@@ -193,6 +193,8 @@ private
       :corporate_information_page_type_id,
       :political,
       :read_consultation_principles,
+      :show_brexit_no_deal_content_notice,
+      brexit_no_deal_content_notice_links_attributes: %i[id title url],
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],
@@ -387,6 +389,12 @@ private
 
     if edition_params[:secondary_specialist_sector_tags] && edition_params[:primary_specialist_sector_tag]
       edition_params[:secondary_specialist_sector_tags] -= [edition_params[:primary_specialist_sector_tag]]
+    end
+  end
+
+  def build_blank_brexit_no_deal_content_notice_links
+    @edition.brexit_no_deal_content_notice_links_available_count.times do
+      @edition.brexit_no_deal_content_notice_links.build
     end
   end
 end

--- a/app/controllers/admin/publications_controller.rb
+++ b/app/controllers/admin/publications_controller.rb
@@ -1,5 +1,6 @@
 class Admin::PublicationsController < Admin::EditionsController
   before_action :pre_fill_edition_from_statistics_announcement, only: :new, if: :statistics_announcement
+  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
 
 private
 

--- a/app/models/brexit_no_deal_content_notice_link.rb
+++ b/app/models/brexit_no_deal_content_notice_link.rb
@@ -1,0 +1,42 @@
+class BrexitNoDealContentNoticeLink < ApplicationRecord
+  belongs_to :edition
+
+  validates :title,
+            length: { maximum: 255 },
+            presence: true, if: Proc.new { |link| link.url.present? }
+
+  validates :url,
+            presence: true, if: Proc.new { |link| link.title.present? }
+
+  validates :url, uri: true, if: :is_external?
+
+  validates_with GovUkUrlValidator, if: :is_internal?
+
+  validate :link_title_is_not_a_url?
+
+  def is_external?
+    !is_internal?
+  end
+
+  def is_internal?
+    has_govuk_host? || has_no_host?
+  end
+
+  private
+
+  def has_govuk_host?
+    URI.parse(url).host =~ /(publishing.service|www).gov.uk\Z/
+  end
+
+  def has_no_host?
+    URI.parse(url).host.blank?
+  end
+
+  def link_title_is_not_a_url?
+    errors.add(:title, "can't be a URL") if url_regex.match?(title)
+  end
+
+  def url_regex
+    /https?:\/\/[\S]+/
+  end
+end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -7,6 +7,7 @@ class CaseStudy < Edition
   include Edition::TaggableOrganisations
   include Edition::WorldLocations
   include Edition::WorldwideOrganisations
+  include Edition::BrexitNoDealContentNoticeLinks
 
   validates :first_published_at, presence: true, if: ->(e) { e.trying_to_convert_to_draft == true }
 

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,6 +1,7 @@
 class DetailedGuide < Edition
   include Edition::Images
   include Edition::NationalApplicability
+  include Edition::BrexitNoDealContentNoticeLinks
 
   # DID YOU MEAN: Policy Area?
   # "Policy area" is the newer name for "topic"

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -10,8 +10,8 @@ class DocumentCollection < Edition
   # You can help improve this code by renaming all usages of this field to use
   # the new terminology.
   include Edition::Topics
-
   include Edition::TopicalEvents
+  include Edition::BrexitNoDealContentNoticeLinks
 
   has_many :groups,
            -> { order("document_collection_groups.ordering") },

--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -5,6 +5,7 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
 
   validates_presence_of :url
   validates_presence_of :document_collection_group
+  validate :is_internal_url?
   validates_with GovUkUrlValidator
 
   def initialize(url:, document_collection_group:)
@@ -26,6 +27,15 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
     content_item["title"]
   end
 
+  def is_internal_url?
+    message = "must be a valid GOV.UK URL"
+    if !govuk_url?
+      errors.add(:url, message)
+    end
+  rescue URI::InvalidURIError
+    errors.add(:url, message)
+  end
+
   private
 
   def content_item
@@ -34,6 +44,10 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
 
   def content_id
     @content_id ||= Services.publishing_api.lookup_content_id(base_path: parsed_url.path, with_drafts: true)
+  end
+
+  def govuk_url?
+    parsed_url.host =~ /(publishing.service|www).gov.uk\Z/
   end
 
   def parsed_url

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,6 +1,8 @@
 # The base class for almost all editoral content.
 # @abstract Using STI should not create editions directly.
 class Edition < ApplicationRecord
+  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
+
   include Edition::Traits
 
   include Edition::NullImages
@@ -677,6 +679,10 @@ class Edition < ApplicationRecord
 
   def locked?
     document.locked?
+  end
+
+  def brexit_no_deal_content_notice_links_available_count
+    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_no_deal_content_notice_links.count
   end
 
 private

--- a/app/models/edition/brexit_no_deal_content_notice_links.rb
+++ b/app/models/edition/brexit_no_deal_content_notice_links.rb
@@ -1,0 +1,19 @@
+module Edition::BrexitNoDealContentNoticeLinks
+  extend ActiveSupport::Concern
+
+  class Trait < Edition::Traits::Trait
+    def process_associations_before_save(edition)
+      @edition.brexit_no_deal_content_notice_links.each do |link|
+        edition.brexit_no_deal_content_notice_links.build(link.attributes.except("id"))
+      end
+    end
+  end
+
+  included do
+    has_many :brexit_no_deal_content_notice_links, foreign_key: "edition_id", dependent: :destroy
+
+    accepts_nested_attributes_for :brexit_no_deal_content_notice_links, allow_destroy: true, reject_if: :all_blank
+
+    add_trait Trait
+  end
+end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -15,6 +15,7 @@ class Publication < Publicationesque
   include Edition::StatisticalDataSets
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
   include Edition::TopicalEvents
+  include Edition::BrexitNoDealContentNoticeLinks
 
   validates :first_published_at, presence: true, if: ->(e) { e.trying_to_convert_to_draft == true }
   validates :publication_type_id, presence: true

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -15,17 +15,19 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
-      content.merge!(
-        description: item.summary,
-        details: details,
-        document_type: document_type,
-        public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-        schema_name: "case_study",
+      BaseItemPresenter
+        .new(item, update_type: update_type)
+        .base_attributes
+        .merge(PayloadBuilder::PublicDocumentPath.for(item))
+        .merge(PayloadBuilder::AccessLimitation.for(item))
+        .merge(
+          description: item.summary,
+          details: details,
+          document_type: document_type,
+          public_updated_at: item.public_timestamp || item.updated_at,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          schema_name: "case_study",
       )
-      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content.merge!(PayloadBuilder::AccessLimitation.for(item))
     end
 
     def links
@@ -56,6 +58,7 @@ module PublishingApi
       }
       details_hash[:image] = image_details if image_available?
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
     end
 
     def first_public_at

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -18,6 +18,9 @@ module PublishingApi
       BaseItemPresenter
         .new(item, update_type: update_type)
         .base_attributes
+        .merge(PayloadBuilder::PublicDocumentPath.for(item))
+        .merge(PayloadBuilder::AccessLimitation.for(item))
+        .merge(PayloadBuilder::FirstPublishedAt.for(item))
         .merge(
           description: item.summary,
           details: details,
@@ -25,10 +28,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: item.rendering_app,
           schema_name: "detailed_guide",
-          )
-        .merge(PayloadBuilder::PublicDocumentPath.for(item))
-        .merge(PayloadBuilder::AccessLimitation.for(item))
-        .merge(PayloadBuilder::FirstPublishedAt.for(item))
+      )
     end
 
     def links
@@ -70,6 +70,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
     end
 
     def body

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -14,19 +14,21 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
-      content.merge!(
-        description: item.summary,
-        details: details,
-        document_type: document_type,
-        public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
-        schema_name: "document_collection",
-        links: edition_links,
-      )
-      content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
+      BaseItemPresenter
+        .new(item, update_type: update_type)
+        .base_attributes
+        .merge(PayloadBuilder::AccessLimitation.for(item))
+        .merge(PayloadBuilder::PublicDocumentPath.for(item))
+        .merge(PayloadBuilder::FirstPublishedAt.for(item))
+        .merge(
+          description: item.summary,
+          details: details,
+          document_type: document_type,
+          public_updated_at: item.public_timestamp || item.updated_at,
+          rendering_app: item.rendering_app,
+          schema_name: "document_collection",
+          links: edition_links,
+        )
     end
 
     def links
@@ -62,6 +64,7 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+        details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
       end
     end
 

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -14,23 +14,20 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(
-        item,
-        locale: locale,
-        update_type: update_type,
-      ).base_attributes
-
-      content.merge!(
-        base_path: base_path,
-        description: nil,
-        details: details,
-        document_type: schema_name,
-        public_updated_at: item.updated_at,
-        rendering_app: item.rendering_app,
-        schema_name: schema_name,
-        links: edition_links,
+      BaseItemPresenter
+        .new(item, locale: locale, update_type: update_type)
+        .base_attributes
+        .merge(PayloadBuilder::Routes.for(base_path))
+        .merge(
+          base_path: base_path,
+          description: nil,
+          details: details,
+          document_type: schema_name,
+          public_updated_at: item.updated_at,
+          rendering_app: item.rendering_app,
+          schema_name: schema_name,
+          links: edition_links,
       )
-      content.merge!(PayloadBuilder::Routes.for(base_path))
     end
 
     def links
@@ -60,11 +57,12 @@ module PublishingApi
     end
 
     def details
-      {
+      details_hash = {
         body: body,
         public_timestamp: public_timestamp,
         first_published_version: first_published_version?,
       }
+      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(parent))
     end
 
     def body

--- a/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
@@ -1,0 +1,42 @@
+module PublishingApi
+  module PayloadBuilder
+    class BrexitNoDealContent
+      attr_reader :item
+
+      def self.for(item)
+        new(item).call
+      end
+
+      def initialize(item)
+        @item = item
+      end
+
+      def call
+        return {} if hide_no_deal_notice?
+
+        { brexit_no_deal_notice: links }
+      end
+
+      private
+
+      def links
+        item.brexit_no_deal_content_notice_links.map do |link|
+          {
+            title: link.title,
+            href: href(link),
+          }
+        end
+      end
+
+      def href(link)
+        return URI.parse(link.url).path if link.is_internal?
+
+        link.url
+      end
+
+      def hide_no_deal_notice?
+        !item.show_brexit_no_deal_content_notice
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -83,6 +83,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
     end
 
     def body

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -15,18 +15,20 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
-      content.merge!(
-        description: item.summary,
-        details: details,
-        document_type: document_type,
-        public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-        schema_name: "speech",
+      BaseItemPresenter
+        .new(item, update_type: update_type)
+        .base_attributes
+        .merge(PayloadBuilder::PublicDocumentPath.for(item))
+        .merge(PayloadBuilder::AccessLimitation.for(item))
+        .merge(PayloadBuilder::FirstPublishedAt.for(item))
+        .merge(
+          description: item.summary,
+          details: details,
+          document_type: document_type,
+          public_updated_at: item.public_timestamp || item.updated_at,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          schema_name: "speech",
       )
-      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
     def details

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -14,18 +14,20 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
-      content.merge!(
-        description: item.summary,
-        details: details,
-        document_type: document_type,
-        public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
-        schema_name: "statistical_data_set",
+      BaseItemPresenter
+        .new(item, update_type: update_type)
+        .base_attributes
+        .merge(PayloadBuilder::AccessLimitation.for(item))
+        .merge(PayloadBuilder::PublicDocumentPath.for(item))
+        .merge(PayloadBuilder::FirstPublishedAt.for(item))
+        .merge(
+          description: item.summary,
+          details: details,
+          document_type: document_type,
+          public_updated_at: item.public_timestamp || item.updated_at,
+          rendering_app: item.rendering_app,
+          schema_name: "statistical_data_set",
       )
-      content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
     def links

--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -2,7 +2,7 @@ class GovUkUrlValidator < ActiveModel::Validator
   def validate(record)
     return if record.url.blank?
 
-    validate_must_be_valid_govuk_url(record)
+    validate_must_be_valid_govuk_host(record)
     validate_must_reference_govuk_page(record)
     validate_link_lookup(record)
   rescue URI::InvalidURIError
@@ -15,8 +15,8 @@ class GovUkUrlValidator < ActiveModel::Validator
 
 private
 
-  def validate_must_be_valid_govuk_url(record)
-    unless parse_url(record.url).host =~ /(publishing.service|www).gov.uk\Z/
+  def validate_must_be_valid_govuk_host(record)
+    if parse_url(record.url).host.present? && !valid_host?(record)
       raise URI::InvalidURIError
     end
   end
@@ -29,6 +29,10 @@ private
 
   def validate_link_lookup(record)
     Services.publishing_api.get_content(content_id(record)).to_h
+  end
+
+  def valid_host?(record)
+    parse_url(record.url).host =~ /(publishing.service|www).gov.uk\Z/
   end
 
   def content_id(record)

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -11,5 +11,7 @@
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>
+
+    <%= render("brexit_no_deal_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -28,5 +28,6 @@
     </fieldset>
 
     <%= render partial: 'nation_fields', locals: { form: form, edition: edition } %>
+    <%= render "brexit_no_deal_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -11,5 +11,7 @@
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>
+
+    <%= render("brexit_no_deal_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
@@ -1,0 +1,19 @@
+<fieldset class="<% if edition.errors[:brexit_no_deal_content_notice_links].any? %>alert-danger form-errors field_with_errors<% end %>" >
+
+  <legend class="add-bottom-margin">
+    Brexit no-deal content notice
+  </legend>
+
+  <div class="checkbox add-bottom-margin">
+    <%= form.check_box :show_brexit_no_deal_content_notice, label_text: "Display the no-deal content notice on this page" %>
+  </div>
+
+  <p>Add links to the current guidance, which will appear in the no-deal content notice.</p>
+
+  <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
+    <div class="well">
+      <%= links_fields.text_field :title, label_text: 'Link text' %>
+      <%= links_fields.text_field :url,  label_text: 'URL' %>
+    </div>
+  <% end %>
+</fieldset>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -23,5 +23,7 @@
       <%= render 'organisation_fields', form: form, edition: edition %>
       <%= render 'nation_fields', form: form, edition: edition %>
     </fieldset>
+
+    <%= render "brexit_no_deal_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/db/migrate/20200114162301_add_show_brexit_no_deal_content_notice_to_editions.rb
+++ b/db/migrate/20200114162301_add_show_brexit_no_deal_content_notice_to_editions.rb
@@ -1,0 +1,5 @@
+class AddShowBrexitNoDealContentNoticeToEditions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :editions, :show_brexit_no_deal_content_notice, :boolean, default: false
+  end
+end

--- a/db/migrate/20200116125828_create_brexit_no_deal_content_notice_links.rb
+++ b/db/migrate/20200116125828_create_brexit_no_deal_content_notice_links.rb
@@ -1,0 +1,11 @@
+class CreateBrexitNoDealContentNoticeLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :brexit_no_deal_content_notice_links do |t|
+      t.string :title
+      t.string :url
+      t.integer :edition_id, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191122124408) do
+ActiveRecord::Schema.define(version: 20200116125828) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -81,6 +81,14 @@ ActiveRecord::Schema.define(version: 20191122124408) do
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"
     t.index ["ordering"], name: "index_attachments_on_ordering"
+  end
+
+  create_table "brexit_no_deal_content_notice_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title"
+    t.string "url"
+    t.integer "edition_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "classification_featuring_image_data", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -419,6 +427,7 @@ ActiveRecord::Schema.define(version: 20191122124408) do
     t.boolean "political", default: false
     t.string "logo_url"
     t.boolean "read_consultation_principles", default: false
+    t.boolean "show_brexit_no_deal_content_notice", default: false
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/lib/tasks/feature_flag.rake
+++ b/lib/tasks/feature_flag.rake
@@ -1,6 +1,41 @@
 namespace :feature_flag do
-  desc "sets a feature flag"
-  task :set, %i[key value] => :environment do |_t, args|
-    FeatureFlag.set(args[:key], args[:value])
+  desc "Creates a feature flag"
+  task :create, %i[key] => :environment do |_t, args|
+    raise "Please specify a feature flag key." if args[:key].blank?
+
+    FeatureFlag.create(key: args[:key])
+
+    puts "Succesfully created feature flag with key: #{args[:key]}."
+  end
+
+  desc "Deletes a feature flag"
+  task :delete, %i[key] => :environment do |_t, args|
+    raise "Please specify a feature flag key" if args[:key].blank?
+
+    flag = FeatureFlag.find_by(key: args[:key])
+
+    raise "Could not find feature flag with key: #{args[:key]}." if flag.nil?
+
+    flag.delete
+
+    puts "Succesfully deleted feature flag with key: #{args[:key]}."
+  end
+
+  desc "Enables feature flag"
+  task :enable, %i[key] => :environment do |_t, args|
+    raise "Please specify a feature flag key" if args[:key].blank?
+
+    FeatureFlag.set(args[:key], true)
+
+    puts "Succesfully enabled feature flag with key: #{args[:key]}."
+  end
+
+  desc "Disables feature flag"
+  task :disable, %i[key] => :environment do |_t, args|
+    raise "Please specify a feature flag key" if args[:key].blank?
+
+    FeatureFlag.set(args[:key], false)
+
+    puts "Succesfully disabled feature flag with key: #{args[:key]}."
   end
 end

--- a/test/unit/models/brexit_no_deal_content_notice_link_test.rb
+++ b/test/unit/models/brexit_no_deal_content_notice_link_test.rb
@@ -1,0 +1,151 @@
+require "test_helper"
+
+class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
+  setup do
+    @content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/test" => @content_id)
+    stub_publishing_api_has_item(content_id: @content_id,
+                                 title: "Test",
+                                 base_path: "/test",
+                                 publishing_app: "content-publisher")
+  end
+
+  test "should be invalid with a malformed url" do
+    link = BrexitNoDealContentNoticeLink.new(title: "External Link", url: "htps://example.com/foo")
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url is not valid. Make sure it starts with http(s)"
+  end
+
+  test "is invalid if the title is longer than 255 characters" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "a" * 256,
+      url: "https://www.gov.uk/test",
+    )
+
+    assert_not link.valid?
+  end
+
+  test "an external link should be a valid URL" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "External Link",
+      url: "https://www.google.com",
+    )
+
+    assert link.valid?
+  end
+
+  test "should be invalid when a GOV.UK URL points to content that is absent from Publishing API" do
+    stub_any_publishing_api_call_to_return_not_found
+
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "Not an existing GOV.UK page",
+      url: "https://www.gov.uk/path-to-no-document",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url must reference a GOV.UK page"
+  end
+
+  test "should be valid when a GOV.UK URL points to content that exists in Publishing API" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "GOV.UK Test",
+      url: "https://www.gov.uk/test",
+    )
+
+    assert link.valid?
+  end
+
+  test "should be invalid when Publishing API is down" do
+    stub_publishing_api_isnt_available
+
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "GOV.UK Test",
+      url: "https://www.gov.uk/test",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Link lookup failed, please try again later"
+  end
+
+  test "link is considered internal if the host is GOV.UK" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "GOV.UK Test",
+      url: "https://www.gov.uk/test",
+    )
+
+    assert link.is_internal?
+  end
+
+  test "link is considered internal if it consists only of a path" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "GOV.UK Test",
+      url: "/test",
+    )
+
+    assert link.is_internal?
+  end
+
+  test "external link is not an internal one" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "External",
+      url: "https://www.example.com/2",
+    )
+
+    assert_not link.is_internal?
+  end
+
+  test "link title is not a URL" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "https://www.example.com/2",
+      url: "https://www.example.com/2",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Title can't be a URL"
+  end
+
+  test "title must be present if URL is specified" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "",
+      url: "https://www.example.com/2",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Title can't be blank"
+  end
+
+  test "URL must be present if title is specified" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "Link title",
+      url: "",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url can't be blank"
+  end
+
+  test "path is a valid internal URL" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "Internal Link",
+      url: "/test",
+    )
+
+    assert link.valid?
+  end
+
+  test "non-existent path is invalid internal URL" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "Internal Link",
+      url: "/foobar",
+    )
+
+    assert_not link.valid?
+  end
+end

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -11,6 +11,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       title: "Case study title",
       summary: "The summary",
       body: "Some content",
+      show_brexit_no_deal_content_notice: true,
     )
     public_path = Whitehall.url_maker.public_document_path(case_study)
     expected_content = {
@@ -40,6 +41,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
           topics: [],
         },
         emphasised_organisations: case_study.lead_organisations.map(&:content_id),
+        brexit_no_deal_notice: [],
       },
     }
     expected_links = {

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -30,6 +30,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       title: "Some detailed guide",
       summary: "Some summary",
       body: "Some content",
+      show_brexit_no_deal_content_notice: true,
     )
     EditionPolicy.create(edition_id: detailed_guide.id, policy_content_id: "dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8")
 
@@ -64,6 +65,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         },
         related_mainstream_content: [],
         emphasised_organisations: detailed_guide.lead_organisations.map(&:content_id),
+        brexit_no_deal_notice: [],
       },
     }
     expected_links = {

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -8,6 +8,7 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
       :document_collection,
       title: "Document Collection title",
       summary: "Document Collection summary",
+      show_brexit_no_deal_content_notice: true,
     )
 
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
@@ -56,6 +57,10 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
 
   test "it presents the global process wide locale as the locale of the document_collection" do
     assert_equal "de", @presented_content[:locale]
+  end
+
+  test "it presents no deal content notice" do
+    assert_equal [], @presented_content[:details][:brexit_no_deal_notice]
   end
 end
 

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+module PublishingApi
+  module PayloadBuilder
+    class BrexitNoDealContentTest < ActiveSupport::TestCase
+      test "builds Brexit no-deal content banner payload with links" do
+        stubbed_item = stub(
+          show_brexit_no_deal_content_notice: true,
+          brexit_no_deal_content_notice_links: [
+            BrexitNoDealContentNoticeLink.new(title: "Link 1", url: "https://www.example.com/1"),
+            BrexitNoDealContentNoticeLink.new(title: "Link 2", url: "https://www.example.com/2"),
+          ],
+        )
+
+        expected_hash = {
+          brexit_no_deal_notice: [
+            {
+              title: "Link 1",
+              href: "https://www.example.com/1",
+            },
+            {
+              title: "Link 2",
+              href: "https://www.example.com/2",
+            },
+          ],
+        }
+
+        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+      end
+
+      test "builds Brexit no-deal content banner payload with no links" do
+        stubbed_item = stub(
+          show_brexit_no_deal_content_notice: false,
+          brexit_no_deal_content_notice_links: [
+            BrexitNoDealContentNoticeLink.new(title: "Link 1", url: "https://www.example.com/1"),
+            BrexitNoDealContentNoticeLink.new(title: "Link 2", url: "https://www.example.com/2"),
+          ],
+        )
+
+        expected_hash = {}
+
+        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+      end
+
+      test "internal links expose only the URL path" do
+        stubbed_item = stub(
+          show_brexit_no_deal_content_notice: true,
+          brexit_no_deal_content_notice_links: [
+            BrexitNoDealContentNoticeLink.new(title: "Internal", url: "https://www.gov.uk/1"),
+            BrexitNoDealContentNoticeLink.new(title: "External", url: "https://www.example.com/2"),
+          ],
+        )
+
+        expected_hash = {
+          brexit_no_deal_notice: [
+            {
+              title: "Internal",
+              href: "/1",
+            },
+            {
+              title: "External",
+              href: "https://www.example.com/2",
+            },
+          ],
+        }
+
+        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+      end
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -12,6 +12,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
                          title: "Publication title",
                          summary: "The summary",
                          body: "Some content",
+                         show_brexit_no_deal_content_notice: true,
                          statistical_data_sets: [statistical_data_set])
 
     public_path = Whitehall.url_maker.public_document_path(publication)
@@ -49,6 +50,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
           slug: government.slug,
           current: government.current?,
         },
+        brexit_no_deal_notice: [],
       },
     }
 


### PR DESCRIPTION
Change GOV.UK content schemas to support the new no-deal Brexit box on all formats managed by Whitehall publisher.

https://trello.com/c/1a6qiEnB/372-back-end-develop-brexit-no-deal-content-notice