### PR TITLE
Automatically delete old link checker report links

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -38,3 +38,7 @@ end
 every taxonomy_cron_rules, roles: [:backend] do
   rake "taxonomy:rebuild_cache"
 end
+
+every :day, at: "4am", roles: [:backend] do
+  rake "link_checker:delete_old_report_links"
+end


### PR DESCRIPTION
This will prevent the database from growing continously.

[Trello Card](https://trello.com/c/akZkqlUE/1669-5-investigate-why-linkcheckerapireportlinks-table-in-the-whitehall-database-is-very-large)