### PR TITLE
Update colours

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -1,6 +1,6 @@
 // BASE STYLESHEET COMPILER
 
-$govuk-use-legacy-palette: true;
+$govuk-use-legacy-palette: false;
 $govuk-typography-use-rem: false;
 
 @import "govuk_publishing_components/all_components";

--- a/app/assets/stylesheets/frontend/helpers/_filtered-index.scss
+++ b/app/assets/stylesheets/frontend/helpers/_filtered-index.scss
@@ -59,7 +59,6 @@
         }
 
         select {
-          @include ig-core-14;
           background: $white;
           line-height: 1.3;
           width: $full-width;

--- a/app/assets/stylesheets/frontend/views/_world_locations.scss
+++ b/app/assets/stylesheets/frontend/views/_world_locations.scss
@@ -61,12 +61,13 @@
 
           li {
             list-style: none;
+            border-bottom: 1px solid $border-colour;
 
             .location-link {
               @include core-19;
               padding: $gutter-one-sixth 0;
-              display: block;
-              border-bottom: 1px solid $border-colour;
+              display: inline-block;
+
             }
           }
         }

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -16,7 +16,7 @@ class EmbassyPresenter < SimpleDelegator
 
   def embassy_path
     if SPECIAL_CASES.key?(name)
-      link_to(SPECIAL_CASES[name][:building], SPECIAL_CASES[name][:base_path])
+      link_to(SPECIAL_CASES[name][:building], SPECIAL_CASES[name][:base_path], class: "govuk-link")
     elsif organisation
       link_to(
         organisation.name,

--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -66,7 +66,7 @@
         <% if filters.include? :locations %>
           <div class="filter">
             <%= label_tag "world_locations", t('document_filters.world_locations.label'), class: "title" %>
-            <%= select_tag "world_locations[]", locations_options(document_type, @filter.selected_locations), class: "single-row-select", id: "world_locations" %>
+            <%= select_tag "world_locations[]", locations_options(document_type, @filter.selected_locations), class: "govuk-select", id: "world_locations" %>
           </div>
         <% end %>
 

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -7,7 +7,7 @@
       <h1 class="title">Worldwide</h1>
       <form class="js-filter-form">
         <label for="help-and-services-in" class="label">
-          Help and services in <div><input name="help-and-services-in" id="help-and-services-in" placeholder="Example: France"></div>
+          Help and services in <div><input name="help-and-services-in" id="help-and-services-in" placeholder="Example: France" class="govuk-input"></div>
         </label>
       </form>
     </header>


### PR DESCRIPTION
https://trello.com/c/t9vZxNXX/124-switch-to-new-colours-in-whitehall

This PR mops up a few outstanding issues related to focus, and switches to the new colours. 

The branch is currently deployed to integration as it won't run locally, so worth looking there (although another deploy might be needed if anything else goes up meanwhile)

Some links on https://www.gov.uk/world/embassies weren't getting the right focus state as they were missing the link class, this was only visible with the colour change:
### Before
![Screenshot 2020-01-15 at 11 09 54](https://user-images.githubusercontent.com/31649453/72429256-7027f180-3787-11ea-93ae-b9aa46448d58.png)
### After
![Screenshot 2020-01-15 at 11 09 24](https://user-images.githubusercontent.com/31649453/72429255-7027f180-3787-11ea-88b5-bc904d586871.png)

World locations pages had a dropdown that was hard to read generally and didn't take the right focus state:
### Before
![Screenshot 2020-01-15 at 11 12 38](https://user-images.githubusercontent.com/31649453/72429461-e7f61c00-3787-11ea-83df-0bdcfaa609a1.png)

### After
![Screenshot 2020-01-15 at 11 12 13](https://user-images.githubusercontent.com/31649453/72429469-f04e5700-3787-11ea-9c20-0d5758e6e4c7.png)

World Locations list page had an input box that didn't take the correct focus state
https://www.gov.uk/world

### Before
![Screenshot 2020-01-15 at 11 15 36](https://user-images.githubusercontent.com/31649453/72429641-59ce6580-3788-11ea-88af-5d0e6abfa8f2.png)

### After

![Screenshot 2020-01-15 at 11 15 17](https://user-images.githubusercontent.com/31649453/72429655-6488fa80-3788-11ea-844a-69a94724d634.png)


