### PR TITLE
Update to accomodate carrierwave 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "addressable", ">= 2.3.7"
 gem "babosa", "1.0.3"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views", "0.0.5"
-gem "carrierwave", "~> 2.0.2"
+gem "carrierwave", "~> 2.1.0"
 gem "carrierwave-i18n"
 gem "chronic"
 gem "dalli", "~> 2.7"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "addressable", ">= 2.3.7"
 gem "babosa", "1.0.3"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views", "0.0.5"
-gem "carrierwave", "~> 1.3.1"
+gem "carrierwave", "~> 2.0.2"
 gem "carrierwave-i18n"
 gem "chronic"
 gem "dalli", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    carrierwave (2.0.2)
+    carrierwave (2.1.0)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       addressable (~> 2.6)
@@ -581,7 +581,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap-kaminari-views (= 0.0.5)
-  carrierwave (~> 2.0.2)
+  carrierwave (~> 2.1.0)
   carrierwave-i18n
   chronic
   ci_reporter_minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,10 +77,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    carrierwave (1.3.1)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     carrierwave-i18n (0.2.0)
     childprocess (3.0.0)
     chronic (0.10.2)
@@ -235,6 +238,9 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     invalid_utf8_rejector (0.0.4)
     isbn_validation (1.2.2)
       activerecord (>= 3)
@@ -293,6 +299,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
+    mimemagic (0.3.4)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -446,6 +453,8 @@ GEM
     ruby-prof (1.2.0)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     rubyzip (2.2.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
@@ -572,7 +581,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap-kaminari-views (= 0.0.5)
-  carrierwave (~> 1.3.1)
+  carrierwave (~> 2.0.2)
   carrierwave-i18n
   chronic
   ci_reporter_minitest

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -10,6 +10,8 @@ class TakePartPage < ApplicationRecord
   extend FriendlyId
   friendly_id :title
 
+  include PublishesToPublishingApi
+
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
 
   validates :image, presence: true, on: :create
@@ -22,8 +24,6 @@ class TakePartPage < ApplicationRecord
              content: :body_without_markup,
              description: :summary,
              format: "take_part"
-
-  include PublishesToPublishingApi
 
   def search_link
     Whitehall.url_maker.take_part_page_path(self.slug)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,6 +6,7 @@ CarrierWave.configure do |config|
   config.storage Whitehall::AssetManagerStorage
   config.enable_processing = false if Rails.env.test?
   config.cache_dir = Rails.root.join "carrierwave-tmp"
+  config.cache_storage = :file
   config.validate_integrity = false
   config.validate_processing = false
 end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -83,7 +83,7 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset).with(logo_asset_id)
 
       Sidekiq::Testing.inline! do
-        organisation.remove_logo!
+        organisation.logo.remove!
       end
     end
   end
@@ -173,7 +173,7 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset).with(@asset_id).times(expected_number_of_versions)
 
       Sidekiq::Testing.inline! do
-        @person.remove_image!
+        @person.image.remove!
       end
     end
   end
@@ -261,7 +261,7 @@ class AssetManagerIntegrationTest
         .with(@consultation_response_form_asset_id)
 
       Sidekiq::Testing.inline! do
-        @consultation_response_form_data.remove_file!
+        @consultation_response_form_data.file.remove!
       end
     end
   end


### PR DESCRIPTION
- Updated carrierwave from 1.3.1 to 2.1.0
- As per this change
(carrierwaveuploader/carrierwave@629afec#diff-a2fae088fb0c57593e3c4c6bd69bc382R189),
carrierwave forced you to explicitly set what type of cache storage you
wanted, the default was file previsouly so it has been set to that.
- Convert carrierwave 'remove_#{field}!' to '#{field}.remove!'
- Add callback to store image after save on take part page

Trello:
https://trello.com/c/rM6VLd6U/1301-audit-dependabot-for-whitehall
https://trello.com/c/31CIOZdx/1358-carrierwave-gem-bum-to-202-in-whitehall