### PR TITLE
Extract GOV.UK link validation logic to validator

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -48,7 +48,7 @@ class StatisticsAnnouncement < ApplicationRecord
   validates :publishing_state, inclusion: %w{published unpublished}
   validates :redirect_url, presence: { message: "must be provided when unpublishing an announcement" }, if: :unpublished?
   validates :redirect_url, uri: true, allow_blank: true
-  validates :redirect_url, gov_uk_url: true, allow_blank: true
+  validates :redirect_url, gov_uk_url_format: true, allow_blank: true
   validates :title, :summary, :organisations, :creator, :current_release_date, presence: true
   validates :cancellation_reason, presence: { message: "must be provided when cancelling an announcement" }, if: :cancelled?
   validates :publication_type_id,

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -7,7 +7,7 @@ class Unpublishing < ApplicationRecord
   validates :explanation, presence: { message: "must be provided when withdrawing", if: :withdrawn? }
   validates :alternative_url, presence: { message: "must be provided to redirect the document", if: :redirect? }
   validates :alternative_url, uri: true, allow_blank: true
-  validates :alternative_url, gov_uk_url: true, allow_blank: true
+  validates :alternative_url, gov_uk_url_format: true, allow_blank: true
   validate :redirect_not_circular
 
   after_initialize :ensure_presence_of_content_id

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,0 +1,14 @@
+#Accepts options[:message] and options[:allowed_protocols]
+class GovUkUrlFormatValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !%r(\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/).match?(value)
+      record.errors[attribute] << failure_message
+    end
+  end
+
+private
+
+  def failure_message
+    options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
+  end
+end


### PR DESCRIPTION
This refactor will allow us to use this custom validator wherever needed, potentially for the no-deal content notice links (https://github.com/alphagov/whitehall/pull/5249).

It extracts validation logic from `app/models/document_collection_non_whitehall_link/govuk_url.rb` into a custom validator, at `app/validators/gov_uk_url_validator.rb`.