### PR TITLE
Removes lead orgs for latest edition code

### DIFF
--- a/lib/whitehall/exporters/documents_info_exporter.rb
+++ b/lib/whitehall/exporters/documents_info_exporter.rb
@@ -12,7 +12,6 @@ class Whitehall::Exporters::DocumentsInfoExporter
         document_information: {
           locales: locales_hash[doc_id],
           subtypes: subtypes_hash[doc_id],
-          lead_organisations: lead_orgs_for_latest_edition_hash[doc_id],
         },
       }
     end
@@ -37,18 +36,6 @@ class Whitehall::Exporters::DocumentsInfoExporter
       corporate_types = corporate.to_s.split(",").map { |id| CorporateInformationPageType.find_by_id(id.to_i)&.key }
       memo[document_id] = [news_article_types, speech_types, publications_types, corporate_types].flatten
     end
-  end
-
-  def lead_orgs_for_latest_edition_hash
-    @lead_orgs_for_latest_edition_hash ||= Edition
-      .joins("INNER JOIN edition_organisations eo ON eo.edition_id = editions.id")
-      .joins("INNER JOIN organisations o ON o.id = eo.organisation_id")
-      .latest_edition
-      .where(document_id: document_ids)
-      .where(eo: { lead: true })
-      .group(:document_id)
-      .pluck(:document_id, "GROUP_CONCAT(DISTINCT(o.content_id))")
-      .each_with_object({}) { |(k, v), memo| memo[k] = v.split(",") }
   end
 
   def subtypes_query

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -36,7 +36,6 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
           "document_information" => {
             "locales" => %w[en],
             "subtypes" => %w[news_story],
-            "lead_organisations" => [org.content_id],
           },
         }],
         "page_number" => 1,

--- a/test/unit/whitehall/exporters/documents_info_exporter_test.rb
+++ b/test/unit/whitehall/exporters/documents_info_exporter_test.rb
@@ -50,36 +50,5 @@ module Whitehall::Exporters
         documents_info_exporter.call.first[:document_information][:locales],
       )
     end
-
-    test "returns the lead organisations of the latest edition of a document" do
-      published_edition_org = create(:organisation)
-      published_edition_org_2 = create(:organisation)
-      superseded_edition_org = create(:organisation)
-      document = create(:document)
-      create(
-        :news_article,
-        :superseded,
-        document: document,
-        organisations: [superseded_edition_org],
-        news_article_type: NewsArticleType::NewsStory,
-      )
-
-      create(
-        :news_article,
-        :published,
-        document: document,
-        organisations: [published_edition_org, published_edition_org_2],
-        news_article_type: NewsArticleType::NewsStory,
-      )
-
-      documents_info_exporter = DocumentsInfoExporter.new(
-        [document.id],
-      )
-
-      assert_same_elements(
-        [published_edition_org.content_id, published_edition_org_2.content_id],
-        documents_info_exporter.call.first[:document_information][:lead_organisations],
-      )
-    end
   end
 end


### PR DESCRIPTION
These organisation content-ids are not used by content-publisher's
import script and are superfluous. We already have logic making sure
that the documents are returned only when the 'primary org' (lowest
numerical lead_ordering) is matched against the passed in organisation
so including these lead orgs in the document info stage is pointless.