### PR TITLE
Bulk change organisation

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -1,0 +1,70 @@
+module DataHygiene
+  class BulkOrganisationUpdater
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def call
+      CSV.foreach(filename, **CSV_OPTIONS) do |row|
+        process_row(row)
+      end
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+  private
+
+    attr_reader :filename
+
+    CSV_OPTIONS = {
+      headers: true,
+    }.freeze
+
+    def process_row(row)
+      document = find_document(row)
+      new_lead_organisations = find_new_lead_organisations(row)
+      new_supporting_organisations = find_new_supporting_organisations(row)
+
+      update_document(document, new_lead_organisations, new_supporting_organisations)
+    end
+
+    def find_document(row)
+      Document.find_by!(slug: row.fetch("Slug"))
+    end
+
+    def find_organisations(row, column)
+      column_data = row.fetch(column)
+      return [] unless column_data
+
+      column_data
+        .split(",")
+        .map { |slug| Organisation.find_by!(slug: slug.strip) }
+    end
+
+    def find_new_lead_organisations(row)
+      find_organisations(row, "New lead organisations")
+    end
+
+    def find_new_supporting_organisations(row)
+      find_organisations(row, "New supporting organisations")
+    end
+
+    def update_document(document, new_lead_organisations, new_supporting_organisations)
+      edition = document.latest_edition
+
+      return if edition.lead_organisations == new_lead_organisations \
+        && edition.supporting_organisations == new_supporting_organisations
+
+      puts "#{document.slug}: #{new_lead_organisations.map(&:slug).join(', ')} (#{new_supporting_organisations.map(&:slug).join(', ')})"
+
+      edition.update(
+        lead_organisations: new_lead_organisations,
+        supporting_organisations: new_supporting_organisations,
+      )
+
+      PublishingApiDocumentRepublishingWorker.perform_async(document.id)
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -32,4 +32,9 @@ namespace :data_hygiene do
       call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: false)
     end
   end
+
+  desc "Bulk update the organisations associated with documents."
+  task :bulk_update_organisation, %i(csv_filename) => :environment do |_, args|
+    DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
+  end
 end

--- a/test/unit/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/unit/data_hygiene/bulk_organisation_updater_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
+  def process(csv_file)
+    file = Tempfile.new("bulk_update_organisation")
+    file.write(csv_file)
+    file.close
+
+    begin
+      Sidekiq::Testing.fake! do
+        DataHygiene::BulkOrganisationUpdater.call(file.path)
+      end
+    ensure
+      file.unlink
+    end
+  end
+
+  test "it fails with invalid CSV data" do
+    csv_file = <<~CSV
+      document slug,new lead organisation,supporting organisations
+      this-is-a-slug,new-organisation,new-supporting-organisation
+    CSV
+
+    assert_raises KeyError do
+      process(csv_file)
+    end
+  end
+
+  test "it fails if document doesn't exist" do
+    csv_file = <<~CSV
+      Slug,New lead organisations,New supporting organisations
+      this-is-a-slug,new-organisation,new-supporting-organisation
+    CSV
+
+    assert_raises ActiveRecord::RecordNotFound do
+      process(csv_file)
+    end
+  end
+
+  test "it changes the lead organisations" do
+    csv_file = <<~CSV
+      Slug,New lead organisations,New supporting organisations
+      this-is-a-slug,lead-organisation,
+    CSV
+
+    document = create(:document, slug: "this-is-a-slug")
+    edition = create(:publication, document: document)
+    organisation = create(:organisation, slug: "lead-organisation")
+
+    process(csv_file)
+
+    assert_equal edition.lead_organisations, [organisation]
+    assert_equal PublishingApiDocumentRepublishingWorker.jobs.size, 1
+    assert_equal PublishingApiDocumentRepublishingWorker.jobs.first["args"].first, document.id
+  end
+
+  test "it changes the supporting organisations" do
+    csv_file = <<~CSV
+      Slug,New lead organisations,New supporting organisations
+      this-is-a-slug,,"supporting-organisation-1,supporting-organisation-2"
+    CSV
+
+    document = create(:document, slug: "this-is-a-slug")
+    edition = create(:publication, document: document)
+    organisation_1 = create(:organisation, slug: "supporting-organisation-1")
+    organisation_2 = create(:organisation, slug: "supporting-organisation-2")
+
+    process(csv_file)
+
+    assert_equal edition.supporting_organisations, [organisation_1, organisation_2]
+    assert_equal PublishingApiDocumentRepublishingWorker.jobs.size, 1
+    assert_equal PublishingApiDocumentRepublishingWorker.jobs.first["args"].first, document.id
+  end
+
+  test "it doesn't change a document which has already changed" do
+    csv_file = <<~CSV
+      Slug,New lead organisations,New supporting organisations
+      this-is-a-slug,lead-organisation,"supporting-organisation-1,supporting-organisation-2"
+    CSV
+
+    lead_organisation = create(:organisation, slug: "lead-organisation")
+    supporting_organisation_1 = create(:organisation, slug: "supporting-organisation-1")
+    supporting_organisation_2 = create(:organisation, slug: "supporting-organisation-2")
+    document = create(:document, slug: "this-is-a-slug")
+    create(
+      :publication,
+      document: document,
+      lead_organisations: [lead_organisation],
+      supporting_organisations: [supporting_organisation_1, supporting_organisation_2],
+    )
+
+    process(csv_file)
+
+    assert_equal PublishingApiDocumentRepublishingWorker.jobs.size, 0
+  end
+end


### PR DESCRIPTION
This class takes a path to a CSV file and performs a bulk update of the lead and supporting organisations associated with documents. This is useful during machinery of government changes.

The CSV file must contain at least the following columns:
- 'Slug'
- 'New lead organisations'
- 'New supporting organisations'

Multiple organisations may be split by a comma.

[Trello Card](https://trello.com/c/tDJ5oeIu/1702-add-rake-tasks-to-handle-machinery-of-government-changes)