### PR TITLE
Strip whitespace from image data on export

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -106,6 +106,8 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
     return [] unless edition.try(:images)
 
     edition.images.map do |image|
+      image["alt_text"].squish! if image["alt_text"]
+      image["caption"].strip! if image["caption"]
       image.as_json(methods: :url)
            .merge(variants: image_variants(image))
     end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -138,6 +138,16 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal expected, result.dig(:editions, 0, :images, 0, :variants)
   end
 
+  test "strips whitespace from image caption and alt_text" do
+    image = create(:image, alt_text: "Alternative text ", caption: "Caption text ")
+    publication = create(:publication, images: [image])
+
+    result = DocumentExportPresenter.new(publication.document).as_json
+
+    assert_equal "Alternative text", result.dig(:editions, 0, :images, 0, :alt_text)
+    assert_equal "Caption text", result.dig(:editions, 0, :images, 0, :caption)
+  end
+
   test "ignores variants when they do not exist" do
     svg_image_data = create(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
     publication = create(:publication, images: [create(:image, image_data: svg_image_data)])


### PR DESCRIPTION
A number of documents being imported to Content Publisher were failing the integrity check due to whitespace at the end of image alt_text or captions, which was not present in Publishing API.  This affects 24 of NDA's news articles.

Example:
- document export (with whitespace): https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/export/document/405390
- content item (without whitespace): https://www.integration.publishing.service.gov.uk/api/content/government/news/winfrith-land-transfer-secures-17-million-savings

Whitehall strips whitespace from the image caption before presenting to Publishing API [1] and squishes alt_text [2].  Content Publisher is doing neither, therefore any data imported to Content Publisher will fail the integrity check if whitespace is present.

Therefore updating the export code from Whitehall to match the processing that Whitehall would normally perform when presenting these data to Publishing API.

If we do not resolve this issue, alt_text and caption text will be shown to the user with excess (unintended) whitespace that is not present at the moment.

[1] https://github.com/alphagov/whitehall/blob/9396ec5a69750bd41c106fa7517d8c3476988d31/app/presenters/lead_image_presenter_helper.rb#L28
[2] https://github.com/alphagov/whitehall/blob/9396ec5a69750bd41c106fa7517d8c3476988d31/app/presenters/lead_image_presenter_helper.rb#L20

Trello card: https://trello.com/c/3AV7mZTG