### PR TITLE
Ensure we build all edition dependencies on validation error

### DIFF
--- a/app/controllers/admin/case_studies_controller.rb
+++ b/app/controllers/admin/case_studies_controller.rb
@@ -1,8 +1,4 @@
 class Admin::CaseStudiesController < Admin::EditionsController
-  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
-
-  private
-
   def edition_class
     CaseStudy
   end

--- a/app/controllers/admin/detailed_guides_controller.rb
+++ b/app/controllers/admin/detailed_guides_controller.rb
@@ -1,8 +1,4 @@
 class Admin::DetailedGuidesController < Admin::EditionsController
-  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
-
-  private
-
   def edition_class
     DetailedGuide
   end

--- a/app/controllers/admin/document_collections_controller.rb
+++ b/app/controllers/admin/document_collections_controller.rb
@@ -1,8 +1,4 @@
 class Admin::DocumentCollectionsController < Admin::EditionsController
-  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
-
-  private
-
   def edition_class
     DocumentCollection
   end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -259,6 +259,7 @@ private
 
   def build_edition_dependencies
     build_blank_image
+    build_blank_brexit_no_deal_content_notice_links
   end
 
   def set_edition_defaults
@@ -294,6 +295,10 @@ private
       image = @edition.images.build
       image.build_image_data
     end
+  end
+
+  def build_blank_brexit_no_deal_content_notice_links
+    @edition.build_no_deal_notice_links if @edition.allows_brexit_no_deal_content_notice?
   end
 
   def default_filters
@@ -389,12 +394,6 @@ private
 
     if edition_params[:secondary_specialist_sector_tags] && edition_params[:primary_specialist_sector_tag]
       edition_params[:secondary_specialist_sector_tags] -= [edition_params[:primary_specialist_sector_tag]]
-    end
-  end
-
-  def build_blank_brexit_no_deal_content_notice_links
-    @edition.brexit_no_deal_content_notice_links_available_count.times do
-      @edition.brexit_no_deal_content_notice_links.build
     end
   end
 end

--- a/app/controllers/admin/publications_controller.rb
+++ b/app/controllers/admin/publications_controller.rb
@@ -1,6 +1,5 @@
 class Admin::PublicationsController < Admin::EditionsController
   before_action :pre_fill_edition_from_statistics_announcement, only: :new, if: :statistics_announcement
-  before_action :build_blank_brexit_no_deal_content_notice_links, only: %i[new edit]
 
 private
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,8 +1,6 @@
 # The base class for almost all editoral content.
 # @abstract Using STI should not create editions directly.
 class Edition < ApplicationRecord
-  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
-
   include Edition::Traits
 
   include Edition::NullImages
@@ -408,6 +406,10 @@ class Edition < ApplicationRecord
     false
   end
 
+  def allows_brexit_no_deal_content_notice?
+    false
+  end
+
   def can_be_grouped_in_collections?
     false
   end
@@ -679,10 +681,6 @@ class Edition < ApplicationRecord
 
   def locked?
     document.locked?
-  end
-
-  def brexit_no_deal_content_notice_links_available_count
-    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_no_deal_content_notice_links.count
   end
 
 private

--- a/app/models/edition/brexit_no_deal_content_notice_links.rb
+++ b/app/models/edition/brexit_no_deal_content_notice_links.rb
@@ -1,6 +1,8 @@
 module Edition::BrexitNoDealContentNoticeLinks
   extend ActiveSupport::Concern
 
+  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
+
   class Trait < Edition::Traits::Trait
     def process_associations_before_save(edition)
       @edition.brexit_no_deal_content_notice_links.each do |link|
@@ -15,5 +17,25 @@ module Edition::BrexitNoDealContentNoticeLinks
     accepts_nested_attributes_for :brexit_no_deal_content_notice_links, allow_destroy: true, reject_if: :all_blank
 
     add_trait Trait
+  end
+
+  def allows_brexit_no_deal_content_notice?
+    true
+  end
+
+  def build_no_deal_notice_links
+    brexit_no_deal_content_notice_links_available_count.times do
+      brexit_no_deal_content_notice_links.build
+    end
+  end
+
+  def brexit_no_deal_content_notice_links_available_count
+    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_no_deal_content_notice_links_count
+  end
+
+  def brexit_no_deal_content_notice_links_count
+    brexit_no_deal_content_notice_links.count do |link|
+      link.persisted? || link.new_record?
+    end
   end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -3,6 +3,22 @@ require "test_helper"
 class EditionTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
+  test "has three no deal content notice links" do
+    edition = build(
+      :draft_publication,
+      brexit_no_deal_content_notice_links: [
+        BrexitNoDealContentNoticeLink.new(title: "Title", url: "https://www.example.com"),
+        BrexitNoDealContentNoticeLink.new(title: "Invalid link", url: ""),
+      ],
+    )
+
+    edition.save
+
+    edition.build_no_deal_notice_links
+
+    assert_equal 3, edition.brexit_no_deal_content_notice_links_count
+  end
+
   test "returns downcased humanized class name as format name" do
     assert_equal "case study", CaseStudy.format_name
     assert_equal "publication", Publication.format_name


### PR DESCRIPTION
This fixes a bug where not all three pairs of fields would get built for no deal notice links when there has been a validation error.

This PR also reduces leakage of Brexit no deal notice logic into the app, by moving most of it into `Edition::BrexitNoDealContentNoticeLinks` module.

### Before

<img width="767" alt="Screenshot 2020-01-24 at 16 15 47" src="https://user-images.githubusercontent.com/3141541/73084656-437d8380-3ec5-11ea-97d6-efb8a12bf2bf.png">

### After

<img width="761" alt="Screenshot 2020-01-24 at 16 16 29" src="https://user-images.githubusercontent.com/3141541/73084661-47110a80-3ec5-11ea-8c70-e0ddd7e023aa.png">

