### PR TITLE
Fix reordering contacts for organisation

### DIFF
--- a/app/controllers/admin/home_page_list_controller.rb
+++ b/app/controllers/admin/home_page_list_controller.rb
@@ -10,18 +10,21 @@ module Admin::HomePageListController
       define_method(:remove_from_home_page) do
         @show_on_home_page = "0"
         handle_show_on_home_page_param
+        publish_container_to_publishing_api
         redirect_to redirect_proc.call(home_page_list_container, home_page_list_item), notice: %{"#{home_page_list_item.title}" removed from home page successfully}
       end
 
       define_method(:add_to_home_page) do
         @show_on_home_page = "1"
         handle_show_on_home_page_param
+        publish_container_to_publishing_api
         redirect_to redirect_proc.call(home_page_list_container, home_page_list_item), notice: %{"#{home_page_list_item.title}" added to home page successfully}
       end
 
       define_method(:reorder_for_home_page) do
         reordered_items = extract_items_from_ordering_params(params[:ordering] || {})
         home_page_list_container.__send__(:"reorder_#{plural_name}_on_home_page!", reordered_items)
+        publish_container_to_publishing_api
         redirect_to redirect_proc.call(home_page_list_container, home_page_list_item), notice: %{#{plural_name.titleize} on home page reordered successfully}
       end
 
@@ -59,6 +62,10 @@ module Admin::HomePageListController
           map { |item, _| item }.
           # reject any blank contacts
           compact
+      end
+
+      define_method(:publish_container_to_publishing_api) do
+        home_page_list_container.try(:publish_to_publishing_api)
       end
     end
     self.before_action :extract_show_on_home_page_param, only: %i[create update]


### PR DESCRIPTION
Changes to reordering of contact for an organisation's home page
weren't being sent to Publishing API, this fixes that.

Zendesk ticket for more context:
https://govuk.zendesk.com/agent/tickets/3901270