### PR TITLE
Export image blank caption as nil

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -107,7 +107,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
 
     edition.images.map do |image|
       image["alt_text"].squish! if image["alt_text"]
-      image["caption"].strip! if image["caption"]
+      image["caption"] = image["caption"].presence&.strip if image["caption"]
       image.as_json(methods: :url)
            .merge(variants: image_variants(image))
     end

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -148,6 +148,15 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     assert_equal "Caption text", result.dig(:editions, 0, :images, 0, :caption)
   end
 
+  test "returns nil for empty image caption" do
+    image = create(:image, caption: "")
+    publication = create(:publication, images: [image])
+
+    result = DocumentExportPresenter.new(publication.document).as_json
+
+    assert_nil result.dig(:editions, 0, :images, 0, :caption)
+  end
+
   test "ignores variants when they do not exist" do
     svg_image_data = create(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
     publication = create(:publication, images: [create(:image, image_data: svg_image_data)])


### PR DESCRIPTION
When presenting a Whitehall image to Publishing API, we replace empty strings with a nil value: 
https://github.com/alphagov/whitehall/blob/9396ec5a69750bd41c106fa7517d8c3476988d31/app/presenters/lead_image_presenter_helper.rb#L26-L31

In the export API, we are including a blank string, so the Content Publisher integrity check fails as the caption is not the same.  Therefore the blank captions should be replaced with a nil value.

This affects six of NDA's news articles.

Trello card: https://trello.com/c/3AV7mZTG