### PR TITLE
Handle more edge cases for no deal notice link validations

### DIFF
--- a/app/models/brexit_no_deal_content_notice_link.rb
+++ b/app/models/brexit_no_deal_content_notice_link.rb
@@ -25,18 +25,28 @@ class BrexitNoDealContentNoticeLink < ApplicationRecord
 private
 
   def has_govuk_host?
-    URI.parse(url).host =~ /(publishing.service|www).gov.uk\Z/
+    govuk_url_regex.match?(host)
   end
 
   def has_no_host?
-    URI.parse(url).host.blank?
+    host.blank?
   end
 
   def link_title_is_not_a_url?
     errors.add(:title, "can't be a URL") if url_regex.match?(title)
   end
 
+  def govuk_url_regex
+    /(publishing.service|www).gov.uk\Z/
+  end
+
   def url_regex
     /https?:\/\/[\S]+/
+  end
+
+  def host
+    return URI.parse("https://#{url}").host if url.start_with?("www.")
+
+    URI.parse(url).host
   end
 end

--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -47,7 +47,11 @@ private
   end
 
   def govuk_url?
-    parsed_url.host =~ /(publishing.service|www).gov.uk\Z/
+    govuk_url_regex.match?(parsed_url.host)
+  end
+
+  def govuk_url_regex
+    /(publishing.service|www).gov.uk\Z/
   end
 
   def parsed_url

--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -2,9 +2,10 @@ class GovUkUrlValidator < ActiveModel::Validator
   def validate(record)
     return if record.url.blank?
 
-    validate_must_be_valid_govuk_host(record)
-    validate_must_reference_govuk_page(record)
-    validate_link_lookup(record)
+    url = parse_url(record.url)
+
+    validate_must_be_valid_govuk_host(url.host)
+    validate_must_reference_govuk_page(url.path)
   rescue URI::InvalidURIError
     record.errors.add(:url, "must be a valid GOV.UK URL")
   rescue GdsApi::HTTPNotFound
@@ -13,41 +14,71 @@ class GovUkUrlValidator < ActiveModel::Validator
     record.errors.add(:base, "Link lookup failed, please try again later")
   end
 
-private
-
-  def validate_must_be_valid_govuk_host(record)
-    if parse_url(record.url).host.present? && !valid_host?(record)
+  def validate_must_be_valid_govuk_host(host)
+    if host.present? && !valid_govuk_host?(host)
       raise URI::InvalidURIError
     end
   end
 
-  def validate_must_reference_govuk_page(record)
-    unless content_id(record)
-      raise GdsApi::HTTPNotFound.new(404)
+  def validate_must_reference_govuk_page(path)
+    if content_item_found?(path)
+      validate_link_lookup(content_id(path))
+    else
+      validate_must_reference_guide_subpage(path)
     end
   end
 
-  def validate_link_lookup(record)
-    Services.publishing_api.get_content(content_id(record)).to_h
+  def validate_must_reference_guide_subpage(path)
+    _separator, toplevel_path_segment, *_subpaths = path.split("/")
+    content_id = content_id("/#{toplevel_path_segment}")
+
+    if content_id.blank?
+      raise GdsApi::HTTPNotFound.new(404)
+    else
+      content_item = get_content_item(content_id)
+
+      if !guide?(content_item)
+        raise GdsApi::HTTPNotFound.new(404)
+      end
+    end
   end
 
-  def valid_host?(record)
-    parse_url(record.url).host =~ /(publishing.service|www).gov.uk\Z/
+private
+
+  def validate_link_lookup(content_id)
+    get_content_item(content_id)
   end
 
-  def content_id(record)
+  def guide?(content_item)
+    content_item["document_type"] == "guide"
+  end
+
+  def valid_govuk_host?(host)
+    govuk_url_regex.match?(host)
+  end
+
+  def content_item_found?(path)
+    content_id(path).present?
+  end
+
+  def content_id(path)
     Services.publishing_api.lookup_content_id(
-      base_path: base_path(record.url),
+      base_path: path,
       with_drafts: true,
     )
   end
 
-  def base_path(url)
-    _separator, path, *_subpaths = parse_url(url).path.split("/")
-    "/#{path}"
+  def get_content_item(content_id)
+    Services.publishing_api.get_content(content_id).to_h
+  end
+
+  def govuk_url_regex
+    /(publishing.service|www).gov.uk\Z/
   end
 
   def parse_url(url)
+    return URI.parse("https://#{url}") if url.start_with?("www.")
+
     URI.parse(url)
   end
 end

--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -37,9 +37,14 @@ private
 
   def content_id(record)
     Services.publishing_api.lookup_content_id(
-      base_path: parse_url(record.url).path,
+      base_path: base_path(record.url),
       with_drafts: true,
     )
+  end
+
+  def base_path(url)
+    _separator, path, *_subpaths = parse_url(url).path.split("/")
+    "/#{path}"
   end
 
   def parse_url(url)

--- a/test/unit/models/brexit_no_deal_content_notice_link_test.rb
+++ b/test/unit/models/brexit_no_deal_content_notice_link_test.rb
@@ -10,6 +10,20 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
                                  publishing_app: "content-publisher")
   end
 
+  test "external link starting with www is invalid" do
+    link = BrexitNoDealContentNoticeLink.new(title: "External Link", url: "www.example.com/foo")
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url is not valid. Make sure it starts with http(s)"
+  end
+
+  test "internal link starting with www is valid" do
+    link = BrexitNoDealContentNoticeLink.new(title: "Internal link", url: "www.gov.uk/test")
+
+    assert link.valid?
+  end
+
   test "should be invalid with a malformed url" do
     link = BrexitNoDealContentNoticeLink.new(title: "External Link", url: "htps://example.com/foo")
 
@@ -147,5 +161,14 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
     )
 
     assert_not link.valid?
+  end
+
+  test "a subpage is a valid link" do
+    link = BrexitNoDealContentNoticeLink.new(
+      title: "Internal Link",
+      url: "/test/subpage",
+    )
+
+    assert link.valid?
   end
 end

--- a/test/unit/models/brexit_no_deal_content_notice_link_test.rb
+++ b/test/unit/models/brexit_no_deal_content_notice_link_test.rb
@@ -10,6 +10,10 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
                                  publishing_app: "content-publisher")
   end
 
+  test "a link with both no title and URL is accepted (UI does not accomodate deletion of records)" do
+    assert BrexitNoDealContentNoticeLink.new(title: "", url: "").valid?
+  end
+
   test "external link starting with www is invalid" do
     link = BrexitNoDealContentNoticeLink.new(title: "External Link", url: "www.example.com/foo")
 
@@ -19,9 +23,7 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
   end
 
   test "internal link starting with www is valid" do
-    link = BrexitNoDealContentNoticeLink.new(title: "Internal link", url: "www.gov.uk/test")
-
-    assert link.valid?
+    assert BrexitNoDealContentNoticeLink.new(title: "Internal link", url: "www.gov.uk/test").valid?
   end
 
   test "should be invalid with a malformed url" do
@@ -33,21 +35,11 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
   end
 
   test "is invalid if the title is longer than 255 characters" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "a" * 256,
-      url: "https://www.gov.uk/test",
-    )
-
-    assert_not link.valid?
+    assert_not BrexitNoDealContentNoticeLink.new(title: "a" * 256, url: "https://www.gov.uk/test").valid?
   end
 
   test "an external link should be a valid URL" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "External Link",
-      url: "https://www.google.com",
-    )
-
-    assert link.valid?
+    assert BrexitNoDealContentNoticeLink.new(title: "External Link", url: "https://www.google.com").valid?
   end
 
   test "should be invalid when a GOV.UK URL points to content that is absent from Publishing API" do
@@ -64,12 +56,7 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
   end
 
   test "should be valid when a GOV.UK URL points to content that exists in Publishing API" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "GOV.UK Test",
-      url: "https://www.gov.uk/test",
-    )
-
-    assert link.valid?
+    assert BrexitNoDealContentNoticeLink.new(title: "GOV.UK Test", url: "https://www.gov.uk/test").valid?
   end
 
   test "should be invalid when Publishing API is down" do
@@ -86,30 +73,15 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
   end
 
   test "link is considered internal if the host is GOV.UK" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "GOV.UK Test",
-      url: "https://www.gov.uk/test",
-    )
-
-    assert link.is_internal?
+    assert BrexitNoDealContentNoticeLink.new(title: "GOV.UK Test", url: "https://www.gov.uk/test").is_internal?
   end
 
   test "link is considered internal if it consists only of a path" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "GOV.UK Test",
-      url: "/test",
-    )
-
-    assert link.is_internal?
+    assert BrexitNoDealContentNoticeLink.new(title: "GOV.UK Test", url: "/test").is_internal?
   end
 
   test "external link is not an internal one" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "External",
-      url: "https://www.example.com/2",
-    )
-
-    assert_not link.is_internal?
+    assert_not BrexitNoDealContentNoticeLink.new(title: "External", url: "https://www.example.com").is_internal?
   end
 
   test "link title is not a URL" do
@@ -146,29 +118,41 @@ class BrexitNoDealContentNoticeLinkTest < ActiveSupport::TestCase
   end
 
   test "path is a valid internal URL" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "Internal Link",
-      url: "/test",
-    )
-
-    assert link.valid?
+    assert BrexitNoDealContentNoticeLink.new(title: "Internal Link", url: "/test").valid?
   end
 
   test "non-existent path is invalid internal URL" do
-    link = BrexitNoDealContentNoticeLink.new(
-      title: "Internal Link",
-      url: "/foobar",
-    )
-
-    assert_not link.valid?
+    assert_not BrexitNoDealContentNoticeLink.new(title: "Internal Link", url: "/foobar").valid?
   end
 
-  test "a subpage is a valid link" do
+  test "a subpage from a mainstream guide is a valid link" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id: content_id,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "guide",
+                                 publishing_app: "content-publisher")
+
+    assert BrexitNoDealContentNoticeLink.new(title: "Internal Link", url: "/foo/subpage").valid?
+  end
+
+  test "a regular non-existent subpage fails validation" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id: content_id,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "publication",
+                                 publishing_app: "content-publisher")
+
     link = BrexitNoDealContentNoticeLink.new(
       title: "Internal Link",
-      url: "/test/subpage",
+      url: "/foo/subpage",
     )
 
-    assert link.valid?
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url must reference a GOV.UK page"
   end
 end


### PR DESCRIPTION
Handle these extra cases:

*  a link to a subpage (e.g. https://www.gov.uk/starting-to-import/moving-goods-from-eu-countries) is valid
* external link starting with `www` is invalid
* internal link starting with `www` is valid

---

https://trello.com/c/U066Cwpj/431-no-deal-content-notice-handle-more-edge-cases-for-no-deal-notice-link-validations