### PR TITLE
Don't send blank links to publishing-api

### DIFF
--- a/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
@@ -20,11 +20,17 @@ module PublishingApi
       private
 
       def links
-        item.brexit_no_deal_content_notice_links.map do |link|
+        non_blank_links.map do |link|
           {
             title: link.title,
             href: href(link),
           }
+        end
+      end
+
+      def non_blank_links
+        item.brexit_no_deal_content_notice_links.reject do |link|
+          link.title.blank? && link.url.blank?
         end
       end
 

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
@@ -25,7 +25,7 @@ module PublishingApi
           ],
         }
 
-        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
       end
 
       test "builds Brexit no-deal content banner payload with no links" do
@@ -39,7 +39,7 @@ module PublishingApi
 
         expected_hash = {}
 
-        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
       end
 
       test "internal links expose only the URL path" do
@@ -64,7 +64,28 @@ module PublishingApi
           ],
         }
 
-        assert_equal BrexitNoDealContent.for(stubbed_item), expected_hash
+        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+      end
+
+      test "blank links are filtered out" do
+        stubbed_item = stub(
+          show_brexit_no_deal_content_notice: true,
+          brexit_no_deal_content_notice_links: [
+            BrexitNoDealContentNoticeLink.new(title: "", url: ""),
+            BrexitNoDealContentNoticeLink.new(title: "Link", url: "https://www.example.com"),
+          ],
+        )
+
+        expected_hash = {
+          brexit_no_deal_notice: [
+            {
+              title: "Link",
+              href: "https://www.example.com",
+            },
+          ],
+        }
+
+        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
       end
     end
   end


### PR DESCRIPTION
Fixes a bug where the front end would think no deal notice links were present, because the content item data showed this:

```
    "brexit_no_deal_notice": [
      {
        "title": "",
        "href": ""
      },
      {
        "title": "",
        "href": ""
      }
    ]
```

Steps to replicate bug:

* Create a document with the no deal notice. Add some links to show in the no deal notice. 
* Preview document - all looks good
* Edit draft to remove the no-deal links (but keep the checkbox ticked)
* Publish the document - the no deal notice displays with the "link intro" text.
* If you look in the content item, it still thinks the no deal links are there, but empty.

---

### Fix

Filter out blank links (i.e. where both `title` and `url` values are blank) when we send data to publishing-api.

---

https://trello.com/c/oq6uzkTP/430-no-deal-content-notice-dont-send-blank-links-to-publishing-api