### PR TITLE
Unpublish the document when removing a translation

### DIFF
--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -24,4 +24,8 @@ module PublishesToPublishingApi
       Whitehall::PublishingApi.publish_gone_async(content_id, nil, nil)
     end
   end
+
+  def publish_gone_translation_to_publishing_api(locale)
+    Whitehall::PublishingApi.publish_gone_async(content_id, nil, nil, locale)
+  end
 end

--- a/lib/translatable_model.rb
+++ b/lib/translatable_model.rb
@@ -20,6 +20,15 @@ module TranslatableModel
 
     if self.respond_to?(:content_id)
       Whitehall::PublishingApi.discard_translation_async(self, locale: locale)
+
+      # This is a bit of a hack to make sure that models _not_ using the
+      # edition workflow (i.e. people, roles, organisations) correctly remove
+      # translations from the Publishing API.
+      # The method publish_gone_translation_to_publishing_api is defined in the
+      # PublishesToPublishingApi module.
+      if self.respond_to?(:publish_gone_translation_to_publishing_api)
+        self.publish_gone_translation_to_publishing_api(locale)
+      end
     end
   end
 


### PR DESCRIPTION
Previously we were only discarding drafts of a translation which means that any published translations were not being unpublished.

This affects people and roles pages where if a translation is deleted, it still shows on the website.

[Trello Card](https://trello.com/c/sTfgfI2u/958-deleting-people-translations-should-unpublish-the-document) ・ [Zendesk Ticket](http://govuk.zendesk.com/hc/requests/3903967)