### PR TITLE
Update reusable callout text

### DIFF
--- a/app/views/documents/_brexit_cta.text.erb
+++ b/app/views/documents/_brexit_cta.text.erb
@@ -1,8 +1,8 @@
 $CTA
-##Stay up to date
+##The UK is leaving the EU
 
-The UK is leaving the EU. This page tells you how to prepare for Brexit and will be updated if anything changes.
+This page tells you what you'll need to do from 1 January 2021. It'll be updated if anything changes.
 
-[Sign up for email alerts](https://www.gov.uk/email-signup?topic=%2Fbrexit) to get the latest information.
+You can read about [the transition period](/transition).
 
 $CTA

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -480,15 +480,14 @@ class GovspeakHelperTest < ActionView::TestCase
   test "converts Brexit CTA govspeak to HTML" do
     body = "$BrexitCTA\nSome other text"
     output = govspeak_to_html(body)
-    paragraph_text = "The UK is leaving the EU. This page tells you how to "\
-                       "prepare for Brexit and will be updated if anything changes."
+    paragraph_text = "This page tells you what you’ll need to do from 1 January 2021. It’ll be updated if anything changes."
 
     assert_select_within_html output, "div.call-to-action"
-    assert_select_within_html output, "h2#stay-up-to-date", "Stay up to date"
+    assert_select_within_html output, "h2#the-uk-is-leaving-the-eu", "The UK is leaving the EU"
     assert_select_within_html output, "p", paragraph_text
     assert_select_within_html output,
                               "a[href=?]",
-                              "https://www.gov.uk/email-signup?topic=%2Fbrexit",
-                              text: "Sign up for email alerts"
+                              "/transition",
+                              text: "the transition period"
   end
 end


### PR DESCRIPTION
## What
Update the reusable callout text so it matches the no-deal notice.

The callout will now look like this:
<img width="660" alt="Screenshot 2020-01-30 at 10 48 54" src="https://user-images.githubusercontent.com/29889908/73443242-3988d400-434e-11ea-8947-effab1a5bc7a.png">
