### PR TITLE
Allow document export list to be filtered by subtype

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -73,7 +73,7 @@ private
 
   def document_type
     @document_type ||= Whitehall.edition_classes.find do |type|
-      type.name == params.require(:type).classify
+      type.name.underscore == params.require(:type)
     end
   end
 
@@ -81,7 +81,7 @@ private
     return unless document_type.respond_to?(:subtypes) && params[:subtypes]
 
     document_type.subtypes.select do |subtype|
-      Array(params[:subtypes]).include?(subtype.key.classify)
+      Array(params[:subtypes]).include?(subtype.key)
     end
   end
 end

--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -55,7 +55,7 @@ private
       .joins("INNER JOIN organisations o ON o.id = eo.organisation_id")
       .where(o: { content_id: params.require(:lead_organisation) })
       .where(eo: { lead: true })
-      .where(type: params.require(:type))
+      .by_type_or_subtypes(document_type, document_subtypes)
       .latest_edition
       .order(:document_id)
       .page(page_number)
@@ -69,5 +69,19 @@ private
 
   def items_per_page
     params.fetch(:page_count, 100)
+  end
+
+  def document_type
+    @document_type ||= Whitehall.edition_classes.find do |type|
+      type.name == params.require(:type).classify
+    end
+  end
+
+  def document_subtypes
+    return unless document_type.respond_to?(:subtypes) && params[:subtypes]
+
+    document_type.subtypes.select do |subtype|
+      Array(params[:subtypes]).include?(subtype.key.classify)
+    end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -172,6 +172,16 @@ class Edition < ApplicationRecord
     end
   end
 
+  def self.by_type_or_subtypes(type, subtypes)
+    if subtypes.nil?
+      by_type(type)
+    elsif subtypes.empty?
+      none
+    else
+      by_subtypes(type, subtypes.pluck(:id))
+    end
+  end
+
   # used by Admin::EditionFilter
   def self.by_type(type)
     where(type: type.to_s)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -182,22 +182,18 @@ class Edition < ApplicationRecord
     end
   end
 
-  # used by Admin::EditionFilter
   def self.by_type(type)
     where(type: type.to_s)
   end
 
-  # used by Admin::EditionFilter
   def self.by_subtype(type, subtype)
     type.by_subtype(subtype)
   end
 
-  # used by Admin::EditionFilter
   def self.by_subtypes(type, subtype_ids)
     type.by_subtypes(subtype_ids)
   end
 
-  # used by Admin::EditionFilter
   def self.in_world_location(world_location)
     joins(:world_locations).where("world_locations.id" => world_location)
   end
@@ -210,7 +206,6 @@ class Edition < ApplicationRecord
     where("editions.updated_at <= ?", date)
   end
 
-  # used by Admin::EditionFilter
   def self.only_broken_links
     joins("INNER JOIN link_checker_api_reports ON link_checker_api_reports.link_reportable_id = editions.id")
     .joins("INNER JOIN link_checker_api_report_links ON link_checker_api_report_links.link_checker_api_report_id = link_checker_api_reports.id")
@@ -218,7 +213,6 @@ class Edition < ApplicationRecord
     .distinct
   end
 
-  # used by Admin::EditionFilter
   def self.without_locked_documents
     joins(:document)
     .where.not("documents.locked = true")

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -45,13 +45,11 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
           "document_id" => news_story.document_id,
           "document_information" => {
             "locales" => %w[en],
-            "subtypes" => %w[news_story],
           },
         }, {
           "document_id" => press_release.document_id,
           "document_information" => {
             "locales" => %w[en],
-            "subtypes" => %w[press_release],
           },
         }],
         "page_number" => 1,
@@ -93,13 +91,11 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
           "document_id" => news_story.document_id,
           "document_information" => {
             "locales" => %w[en],
-            "subtypes" => %w[news_story],
           },
         }, {
           "document_id" => press_release.document_id,
           "document_information" => {
             "locales" => %w[en],
-            "subtypes" => %w[press_release],
           },
         }],
         "page_number" => 1,

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -37,7 +37,7 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: org.content_id,
-                          type: "NewsArticle" }, format: "json"
+                          type: "news_article" }, format: "json"
 
     expected_response =
       {
@@ -84,8 +84,8 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: org.content_id,
-                          type: "NewsArticle",
-                          subtypes: %w(PressRelease NewsStory) }, format: "json"
+                          type: "news_article",
+                          subtypes: %w(press_release news_story) }, format: "json"
 
     expected_response =
       {
@@ -121,8 +121,8 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: org.content_id,
-                          type: "NewsArticle",
-                          subtypes: %w(SomethingInvalid) }, format: "json"
+                          type: "news_article",
+                          subtypes: %w(something_invalid) }, format: "json"
 
     expected_response =
       {
@@ -158,7 +158,7 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: published_edition_org.content_id,
-                          type: "NewsArticle" }, format: "json"
+                          type: "news_article" }, format: "json"
 
     expected_response =
       {
@@ -186,7 +186,7 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: first_lead_org.content_id,
-                          type: "NewsArticle" }, format: "json"
+                          type: "news_article" }, format: "json"
 
     assert_equal edition.document.id, json_response["documents"].first["document_id"]
   end
@@ -205,7 +205,7 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     login_as :export_data_user
 
     get :index, params: { lead_organisation: second_lead_org.content_id,
-                          type: "NewsArticle" }, format: "json"
+                          type: "news_article" }, format: "json"
 
     assert_empty json_response["documents"]
   end

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -23,6 +23,16 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
       organisations: [org],
       news_article_type: NewsArticleType::NewsStory,
     )
+    press_release = create(
+      :news_article,
+      organisations: [org],
+      news_article_type: NewsArticleType::PressRelease,
+    )
+    create(
+      :publication,
+      organisations: [org],
+      publication_type: PublicationType::PolicyPaper,
+    )
 
     login_as :export_data_user
 
@@ -37,9 +47,15 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
             "locales" => %w[en],
             "subtypes" => %w[news_story],
           },
+        }, {
+          "document_id" => press_release.document_id,
+          "document_information" => {
+            "locales" => %w[en],
+            "subtypes" => %w[press_release],
+          },
         }],
         "page_number" => 1,
-        "page_count" => 1,
+        "page_count" => 2,
         "_response_info" => { "status" => "ok" },
     }
 

--- a/test/unit/whitehall/exporters/documents_info_exporter_test.rb
+++ b/test/unit/whitehall/exporters/documents_info_exporter_test.rb
@@ -2,35 +2,6 @@ require "test_helper"
 
 module Whitehall::Exporters
   class DocumentsInfoExporterTest < ActiveSupport::TestCase
-    test "returns all subtype information of a document" do
-      org = create(:organisation)
-      document = create(:document)
-      create(
-        :news_article,
-        :superseded,
-        organisations: [org],
-        document: document,
-        news_article_type: NewsArticleType::NewsStory,
-      )
-      create(
-        :news_article,
-        :published,
-        organisations: [org],
-        document: document,
-        news_article_type: NewsArticleType::PressRelease,
-      )
-
-      documents_info_exporter = DocumentsInfoExporter.new(
-        [document.id],
-      )
-
-      assert_equal(
-        %w[news_story press_release],
-        documents_info_exporter.call.first[:document_information][:subtypes],
-      )
-    end
-
-
     test "returns all the locales of a document" do
       org = create(:organisation)
       news_story = create(


### PR DESCRIPTION
We were only allowing the document export list to be filtered by document type, not subtype.  Since Content Publisher does not yet support some subtypes of news articles, we need to enable more refined filtering.

Trello card: https://trello.com/c/dmS7BYoG