### PR TITLE
Flesh out no deal notice URL hint text

### DIFF
--- a/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
@@ -9,6 +9,7 @@
   </div>
 
   <p>Add links to the current guidance, which will appear in the no-deal content notice.</p>
+  <p>Use full URLs for external websites, for example https://www.example.com.</p>
 
   <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
     <div class="well">


### PR DESCRIPTION
Adds some hint text to Brexit no deal content notice links fields.

<img width="782" alt="Screenshot 2020-01-30 at 17 02 55" src="https://user-images.githubusercontent.com/3141541/73472153-7d95cc00-4382-11ea-8ca1-cd047cb9e772.png">

Can't really have a custom error message, because the validators are used in other places, so we should keep them as vanilla as possible.

https://trello.com/c/fPYlaey8/436-use-full-urls-for-external-websites-for-example-https-wwwexamplecom