### PR TITLE
Render brexit-related cta as blank

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -267,9 +267,7 @@ private
   def convert_brexit_cta(govspeak)
     return govspeak if govspeak.blank?
 
-    govspeak.gsub(/\$BrexitCTA/) do
-      render(partial: "documents/brexit_cta", formats: :text)
-    end
+    govspeak.gsub(/\$BrexitCTA/, "")
   end
 
   def edition_body_with_attachments_and_alt_format_information(edition)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -477,17 +477,9 @@ class GovspeakHelperTest < ActionView::TestCase
     assert html.include? ">batman@wayne.technology</a>"
   end
 
-  test "converts Brexit CTA govspeak to HTML" do
+  test "does not render Brexit CTA govspeak" do
     body = "$BrexitCTA\nSome other text"
     output = govspeak_to_html(body)
-    paragraph_text = "This page tells you what you’ll need to do from 1 January 2021. It’ll be updated if anything changes."
-
-    assert_select_within_html output, "div.call-to-action"
-    assert_select_within_html output, "h2#the-uk-is-leaving-the-eu", "The UK is leaving the EU"
-    assert_select_within_html output, "p", paragraph_text
-    assert_select_within_html output,
-                              "a[href=?]",
-                              "/transition",
-                              text: "the transition period"
+    assert_select_within_html output, ".govspeak", text: "Some other text"
   end
 end


### PR DESCRIPTION
We won't render the `$BrexitCTA` on any page as it is on a number of pages it shouldn't be and therefore is currently giving incorrect guidance on those pages.

This is a short-term solution, the tech and content debt will be recorded [on the card](https://trello.com/c/kS5ZSeYV/424-spike-test-what-happens-if-we-make-the-brexit-cta-reusable-callout-blank) and addressed afterwards.

