### PR TITLE
Republish worldwide organisation editions when reslugging

### DIFF
--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -20,7 +20,7 @@ module DataHygiene
       remove_from_search_index
       update_slug
       update_users if organisation.is_a? Organisation
-      update_editions if organisation.is_a? Organisation
+      update_editions if organisation.is_a?(Organisation) || organisation.is_a?(WorldOrganisation)
     end
 
   private


### PR DESCRIPTION
When worldwide organisations are re-slugged with the rake task `reslug:worldwide_organisation`, we want their editions to be updated, so we can filter on them using their new slug.