### PR TITLE
Send draft item links to Publishing Api

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -142,6 +142,21 @@ namespace :publishing_api do
     puts "Finished queuing items for Publishing API"
   end
 
+  desc "Send draft item links to Publishing API."
+  task patch_draft_item_links: :environment do
+    editions = Edition.draft
+    count = editions.count
+    puts "# Sending #{count} draft editions to Publishing API"
+
+    editions.pluck(:id).each_with_index do |item_id, i|
+      PublishingApiLinksWorker.perform_async(item_id)
+
+      puts "Queuing #{i}-#{i + 99} of #{count} items" if (i % 100).zero?
+    end
+
+    puts "Finished queuing items for Publishing API"
+  end
+
   desc "Send publishable item links of a specific type to Publishing API (ie, 'CaseStudy')."
   task :publishing_api_patch_links_by_type, [:document_type] => :environment do |_, args|
     document_type = args[:document_type]


### PR DESCRIPTION
[Trello](https://trello.com/c/V1uLtsQV/1409-fix-mismatch-in-publishing-organisations-on-migration)

- links information is missing in the publishing-api for draft content.
- This is causing errors when importing data into Content Publisher as draft documents are missing `primary_publishing_organisation` within `links`.
- This task will patch the links information for draft documents. It looks like it was previously only run for published and withdrawn content.
- It seems like we may be encountering this issue for similar reasons to: https://github.com/alphagov/whitehall/pull/2792#issuecomment-255812139 - only in our case for draft rather than withdrawn content.