### PR TITLE
Stop fonts from loading twice

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -1,7 +1,7 @@
 // BASE STYLESHEET COMPILER
 
+$govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
-$govuk-typography-use-rem: false;
 
 @import "govuk_publishing_components/all_components";
 


### PR DESCRIPTION
## What

Both old and new versions of Transport were being loaded on pages rendered in Whitehall. Setting the `$govuk-compatibility-govuktemplate` flag to true switched off the new version of the font.

Much thanks to @Nooshu and @36degrees for flagging this and coming up with a solution.

## Why

Loading a font that isn't being used is pointless.

## Visual differences

None