### PR TITLE
Data migration to remove BrexitCTA govspeak from documents

### DIFF
--- a/db/data_migration/20200205164643_remove_brexit_cta_govspeak_tag.rb
+++ b/db/data_migration/20200205164643_remove_brexit_cta_govspeak_tag.rb
@@ -1,0 +1,20 @@
+gds_user = User.find_by!(name: "GDS Inside Government Team")
+
+brexit_cta_editions = Edition.in_default_locale
+  .includes(:document)
+  .where("edition_translations.body LIKE ?", "%$BrexitCTA%")
+  .uniq
+
+brexit_cta_editions.each do |edition|
+  draft = edition.create_draft(gds_user)
+
+  draft.update(
+    minor_change: true,
+    body: draft.body.gsub(/\$BrexitCTA/, ""),
+  )
+
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+    "bulk_republishing",
+    edition.document_id,
+  )
+end

--- a/db/data_migration/20200205164643_remove_brexit_cta_govspeak_tag.rb
+++ b/db/data_migration/20200205164643_remove_brexit_cta_govspeak_tag.rb
@@ -1,20 +1,11 @@
-gds_user = User.find_by!(name: "GDS Inside Government Team")
-
-brexit_cta_editions = Edition.in_default_locale
+brexit_cta_editions_drafts = Edition.in_default_locale
   .includes(:document)
   .where("edition_translations.body LIKE ?", "%$BrexitCTA%")
-  .uniq
+  .draft
 
-brexit_cta_editions.each do |edition|
-  draft = edition.create_draft(gds_user)
-
+brexit_cta_editions_drafts.each do |draft|
   draft.update(
     minor_change: true,
     body: draft.body.gsub(/\$BrexitCTA/, ""),
-  )
-
-  PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
-    "bulk_republishing",
-    edition.document_id,
   )
 end


### PR DESCRIPTION
https://trello.com/c/nQiF07Vy/446-brexit-cta-reusable-callout-plan-how-to-and-then-remove-the-brexit-cta-govspeak-across-whitehall