### PR TITLE
Add try to :show_brexit_no_deal_content_notice method call

### DIFF
--- a/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_no_deal_content.rb
@@ -41,7 +41,7 @@ module PublishingApi
       end
 
       def hide_no_deal_notice?
-        !item.show_brexit_no_deal_content_notice
+        !item.try(:show_brexit_no_deal_content_notice)
       end
     end
   end


### PR DESCRIPTION
Currently this method only exists on Edition, but is called during the HTML Attachment publishing workflow which is used by other models, such as ConsultationOutcome.