### PR TITLE
Reindex documents when reslugging world location

### DIFF
--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -78,6 +78,7 @@ namespace :reslug do
     world_location = WorldLocation.find_by!(slug: args.old_slug)
     Whitehall::SearchIndex.delete(world_location)
     world_location.update!(slug: args.new_slug)
+    world_location.editions.published.each(&:update_in_search_index)
   end
 
   def reslug_organisation(organisation_class, args)

--- a/test/unit/tasks/reslugging_test.rb
+++ b/test/unit/tasks/reslugging_test.rb
@@ -39,4 +39,11 @@ class ResluggingTest < ActiveSupport::TestCase
 
     assert_equal 2, Document.where(slug: "a-slug-that-is-not-unique").count
   end
+
+  test "it should reslug the world location" do
+    world_location = create(:world_location, slug: "old-name", news_page_content_id: SecureRandom.uuid)
+    Rake.application.invoke_task "reslug:world_location[old-name,new-name]"
+
+    assert_equal "new-name", world_location.reload.slug
+  end
 end


### PR DESCRIPTION
The rake task to reslug world locations needs to be able to reindex the documents. We need this so that documents are updated in Search API.

Trello: https://trello.com/c/9FttsSbr/1733-3-reslugging-a-world-location-doesnt-reindex-its-documents