### PR TITLE
Remove the Org contact and web isbn from document

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -114,10 +114,10 @@ private
 
   def attachment_params
     params.fetch(:attachment, {}).permit(
-      :title, :locale, :isbn, :web_isbn, :unique_reference,
+      :title, :locale, :isbn, :unique_reference,
       :command_paper_number, :unnumbered_command_paper, :hoc_paper_number,
       :unnumbered_hoc_paper, :parliamentary_session, :order_url, :price, :accessible,
-      :external_url, :print_meta_data_contact_address,
+      :external_url,
       govspeak_content_attributes: %i[id body manually_numbered_headings],
       attachment_data_attributes: %i[file to_replace_id file_cache]
     ).merge(attachable: attachable)

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -50,8 +50,6 @@ private
       :title,
       :locale,
       :isbn,
-      :web_isbn,
-      :print_meta_data_contact_address,
       :unique_reference,
       :command_paper_number,
       :unnumbered_command_paper,

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -5,10 +5,6 @@
 <% end %>
 
 <%= form.text_field :isbn, label_text: "Print ISBN" %>
-<% if attachment.is_a?(HtmlAttachment) %>
-  <%= form.text_field :web_isbn, label_text: "Web ISBN" %>
-  <%= form.text_area :print_meta_data_contact_address, rows: 5, label_text: "Organisation's Contact Details", placeholder: "This can contain the address, email, or telephone number" %>
-<% end %>
 
 <%= form.text_field :unique_reference %>
 <div class="paper-number">

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -57,6 +57,6 @@ Feature: Managing attachments on editions
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
-    And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783" and the web isbn "978-1-78246-569-0" and the contact address "Address 1"
+    And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783"
     And I publish the draft edition for publication "Standard Beard Lengths"
-    Then the html attachment "Beard Length Graphs 2012" includes the contact address "Address 1" and the isbn "9781474127783" and the web isbn "978-1-78246-569-0"
+    Then the html attachment "Beard Length Graphs 2012" includes the isbn "9781474127783"

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -89,12 +89,10 @@ Then(/^I can see the preview link to the attachment "(.*?)"$/) do |attachment_ti
   assert has_link?("a", href: /draft-origin/, text: attachment_title)
 end
 
-When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)" and the contact address "(.*?)"$/) do |title, isbn, web_isbn, contact_address|
+When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)"$/) do |title, isbn|
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
   fill_in "Print ISBN", with: isbn
-  fill_in "Web ISBN", with: web_isbn
-  fill_in "Organisation's Contact Details", with: contact_address
   fill_in "Body", with: "Body"
   check "Manually numbered headings"
   click_on "Save"
@@ -105,13 +103,11 @@ When(/^I publish the draft edition for publication "(.*?)"$/) do |publication_ti
   publication.update!(state: "published", major_change_published_at: Time.zone.today)
 end
 
-Then(/^the html attachment "(.*?)" includes the contact address "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)"$/) do |attachment_title, contact_address, isbn, web_isbn|
+Then(/^the html attachment "(.*?)" includes the isbn "(.*?)"$/) do |attachment_title, isbn|
   html_attachment = HtmlAttachment.find_by title: attachment_title
 
   assert_equal attachment_title, html_attachment.title
-  assert_equal contact_address, html_attachment.print_meta_data_contact_address
   assert_equal isbn, html_attachment.isbn
-  assert_equal web_isbn, html_attachment.web_isbn
 end
 
 Then(/^I see a validation error for uploading attachments$/) do


### PR DESCRIPTION
Trello - https://trello.com/c/w5dsqKuc/1381-remove-redundant-fields-for-whitehall-attachments-org-contact-and-web-isbn

These fields are rendundant and should be removed. They are no longer being sent to the publishing api from whitehall. Once this is released I'll raise a separate PR to remove the columns from the database.

These fields are also being removed from government frontend and govuk content schemas
government frontend - https://github.com/alphagov/government-frontend/pull/1649
content schemas - https://github.com/alphagov/govuk-content-schemas/pull/958