### PR TITLE
Remove web_isbn and print_meta_data_contact_address

### DIFF
--- a/db/migrate/20200211132410_remove_web_isbn_from_attachments.rb
+++ b/db/migrate/20200211132410_remove_web_isbn_from_attachments.rb
@@ -1,0 +1,5 @@
+class RemoveWebIsbnFromAttachments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :attachments, :web_isbn, :string
+  end
+end

--- a/db/migrate/20200211132528_remove_print_meta_data_contact_address_from_attachments.rb
+++ b/db/migrate/20200211132528_remove_print_meta_data_contact_address_from_attachments.rb
@@ -1,0 +1,5 @@
+class RemovePrintMetaDataContactAddressFromAttachments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :attachments, :print_meta_data_contact_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200116125828) do
+ActiveRecord::Schema.define(version: 20200211132528) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -75,8 +75,6 @@ ActiveRecord::Schema.define(version: 20200116125828) do
     t.string "external_url"
     t.string "content_id"
     t.boolean "deleted", default: false, null: false
-    t.string "print_meta_data_contact_address"
-    t.string "web_isbn"
     t.index ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type"
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5333 removed web isbn and print meta data contact address from the app. This removes them from the database so that they're not hanging around as unusable and redundant fields

Trello - https://trello.com/c/w5dsqKuc/1381-remove-redundant-fields-for-whitehall-attachments-org-contact-and-web-isbn