### PR TITLE
Reindex worldwide organisation

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -16,6 +16,9 @@ class WorldwideOrganisation < ApplicationRecord
   has_many :edition_worldwide_organisations, dependent: :destroy, inverse_of: :worldwide_organisation
   # This include is dependant on the above has_many
   include HasCorporateInformationPages
+
+  has_many :editions, through: :edition_worldwide_organisations
+
   has_one :access_and_opening_times, as: :accessible, dependent: :destroy
   belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
 

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -20,7 +20,7 @@ module DataHygiene
       remove_from_search_index
       update_slug
       update_users if organisation.is_a? Organisation
-      update_editions if organisation.is_a? Organisation
+      update_editions if organisation.is_a?(Organisation) || organisation.is_a?(WorldwideOrganisation)
     end
 
   private

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -96,5 +96,10 @@ module OrganisationResluggerTest
     def base_path
       "/world/organisations"
     end
+
+    test "calls update_editions" do
+      @reslugger.expects(:update_editions).once
+      @reslugger.run!
+    end
   end
 end


### PR DESCRIPTION
The rake task to reslug did not reindex the documents for WorldwideOrganisation, this was only being done for Organisation. We need this so that documents are updated in Search API. 

Trello: https://trello.com/c/XZHvzrT7/1734-3-reslugging-a-worldwide-organisation-doesnt-update-its-documents