### PR TITLE
Only add/remove published corp info pages

### DIFF
--- a/app/models/organisation/organisation_search_index_concern.rb
+++ b/app/models/organisation/organisation_search_index_concern.rb
@@ -7,9 +7,9 @@ module Organisation::OrganisationSearchIndexConcern
 
   def update_search_index
     if going_live_on_govuk?
-      corporate_information_pages.each(&:update_in_search_index)
+      published_corporate_information_pages.each(&:update_in_search_index)
     elsif leaving_live_on_govuk?
-      corporate_information_pages.each(&:remove_from_search_index)
+      published_corporate_information_pages.each(&:remove_from_search_index)
     end
   end
 


### PR DESCRIPTION
This currently attempts to add/remove all corporate information pages that are associated with an organisation from search when the state of the organisation is changed.

One org has 14 published pages, but 1399 superseded ones which is way too much to process in the scope of one HTTP request:

```
irb(main):006:0> cip.group(:state).count
=> {"draft"=>4, "published"=>14, "superseded"=>1399}
```

Running https://www.gov.uk/api/search.json?filter_format=corporate_information_page&filter_organisations=department-for-international-development&fields=format,title&count=0
retrieves the result:

```
{
"results": [],
"total": 14,
"start": 0,
"aggregates": {},
"suggested_queries": [],
"suggested_autocomplete": [],
"es_cluster": "A",
"reranked": false
}
```

So it seems that doing _all_ of them is unnecessary.