### PR TITLE
Update to remove .button class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       activemodel (>= 4.2, < 6.1)
       activerecord (>= 4.2, < 6.1)
       request_store (~> 1.0)
-    govspeak (6.5.2)
+    govspeak (6.5.3)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 16.16)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -45,7 +45,7 @@ class GovspeakHelperTest < ActionView::TestCase
 
   test "does not change css class on buttons" do
     html = govspeak_to_html("{button}[Link text](https://www.gov.uk){/button}")
-    assert_select_within_html html, "a.button", "Link text"
+    assert_select_within_html html, "a.govuk-button", "Link text"
   end
 
   test "should not mark admin links as 'external'" do


### PR DESCRIPTION
This PR is part of the work to remove govuk_frontend_toolkit from static, specifically to remove the `.button` class. Work has previously been done in `govspeak` to change it to use the `govuk_publishing_components` gem to render buttons (removing the reliance on the `.button` class there) and a new version of the components gem produced to account for this change in the govspeak component.

This PR updates whitehall to have both of these changes. It also fixes a test that expected the old class. While whitehall does make use of the `.button` class, it appears to be relying on its own styles for this, not the styles from static.

Trello card: https://trello.com/c/d8D7JTJE/203-remove-design-patterns-buttons-from-static
