### PR TITLE
[DNM cos reshuffle] Export contacts for all documents

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -26,7 +26,7 @@ private
       alternative_format_provider_content_id: edition.try(:alternative_format_provider)&.content_id,
       attachments: present_attachments(edition),
       authors: edition.authors.pluck(:id).uniq,
-      contacts: slice_association(edition, :depended_upon_contacts, %i[id content_id]),
+      contacts: present_contacts(edition),
       editorial_remarks: present_editorial_remarks(edition),
       fact_check_requests: present_fact_check_requests(edition),
       government: edition.government&.as_json,
@@ -48,6 +48,11 @@ private
     DOCUMENT_SUB_TYPES.each_with_object({}) do |type, memo|
       memo[type] = edition.try(type)&.key
     end
+  end
+
+  def present_contacts(edition)
+    contacts = Govspeak::ContactsExtractor.new(edition.body).contacts
+    contacts.map { |contact| contact.as_json(only: %i[id content_id]) }
   end
 
   def slice_association(edition, associations, fields)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -257,7 +257,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
   test "includes contacts" do
     contact = create(:contact)
-    edition = create(:edition, depended_upon_contacts: [contact])
+    edition = create(:edition, body: "[Contact:#{contact.id}]")
 
     result = DocumentExportPresenter.new(edition.document).as_json
     assert_equal [{ id: contact.id, content_id: contact.content_id }], result.dig(:editions, 0, :contacts)


### PR DESCRIPTION
Previously contacts were only exported for documents that had been
force_published, published or unwithdrawn. This was because we were
relying on an edition association - depended_upon_contacts which is only
populated when a document transitions to one of the states stated above.

Consequently draft editions never had any contacts information exported
and so when importing one in content-publisher an error was thrown
regarding missing contacts. The change in this commit now looks through
the body of text of the edition to pull out the relevant contacts.

Trello:
https://trello.com/c/OzdqkkW2/1455-fix-documents-that-failed-the-import-with-an-array-error