### PR TITLE
Expand the unpublishing hack in the HTML attachments worker

### DIFF
--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -64,7 +64,7 @@ class PublishingApiHtmlAttachmentsWorker
     current_html_attachments.each do |html_attachment|
       PublishingApiWithdrawalWorker.new.perform(
         html_attachment.content_id,
-        edition.unpublishing.explanation,
+        unpublishing.explanation,
         edition.primary_locale,
       )
     end
@@ -95,7 +95,7 @@ private
   end
 
   def unpublish_if_required
-    if edition.unpublishing
+    if unpublishing
       if edition.withdrawn?
         withdraw
       else


### PR DESCRIPTION
The updating of edition.unpublishing is apparently broken, and this
worker works around that by also attempting to access the unpublishing
by id.

Do this in a couple of more cases, so the behaviour is hopefully
broken less often.