### PR TITLE
Add 'attachments' and 'featured_attachments' fields to content items

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -104,6 +104,30 @@ class Attachment < ApplicationRecord
     }
   end
 
+  def publishing_api_details
+    {
+      # fields in common across "file_attachment_asset",
+      # "html_attachment_asset", "external_attachment_asset"
+      attachment_type: readable_type.downcase,
+      id: publishing_api_attachment_id,
+      locale: locale,
+      title: title,
+      url: url,
+      # "publication_attachment_asset" fields
+      command_paper_number: command_paper_number,
+      hoc_paper_number: hoc_paper_number,
+      isbn: isbn,
+      parliamentary_session: nil,
+      unique_reference: unique_reference,
+      unnumbered_command_paper: unnumbered_command_paper?,
+      unnumbered_hoc_paper: unnumbered_hoc_paper?,
+    }.merge(publishing_api_details_for_format).compact
+  end
+
+  def publishing_api_details_for_format
+    {}
+  end
+
   def deep_clone
     dup
   end
@@ -122,6 +146,10 @@ class Attachment < ApplicationRecord
 
   def readable_type
     ""
+  end
+
+  def publishing_api_attachment_id
+    raise NotImplementedError, "Subclasses must implement the publishing_api_attachment_id method"
   end
 
   def url

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -46,6 +46,10 @@ class ExternalAttachment < Attachment
     "text/html"
   end
 
+  def publishing_api_attachment_id
+    content_id
+  end
+
   def url(_options = {})
     external_url
   end

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -36,7 +36,39 @@ class FileAttachment < Attachment
     false
   end
 
+  def publishing_api_details_for_format
+    {
+      accessible: accessible?,
+      alternative_format_contact_email: alternative_format_contact_email,
+      content_type: content_type,
+      file_size: file_size,
+      filename: filename,
+      number_of_pages: number_of_pages,
+      preview_url: preview_url,
+    }
+  end
+
+  def publishing_api_attachment_id
+    filename
+  end
+
 private
+
+  def alternative_format_contact_email
+    attachable.alternative_format_contact_email
+  rescue NoMethodError
+    nil
+  end
+
+  def preview_url
+    if csv? && attachable.is_a?(Edition)
+      Whitehall.url_maker.csv_preview_url(
+        id: attachment_data.id,
+        file: filename_without_extension,
+        extension: file_extension,
+      )
+    end
+  end
 
   def filename_is_unique
     if attachable && attachable.attachments.any? { |a| a.file? && a != self && a.filename.downcase == filename.try(:downcase) }

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -57,6 +57,10 @@ class HtmlAttachment < Attachment
     "HTML attachment"
   end
 
+  def publishing_api_attachment_id
+    slug
+  end
+
   def url(options = {})
     preview = options.delete(:preview)
     full_url = options.delete(:full_url)

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -79,6 +79,7 @@ module PublishingApi
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
         .merge(PayloadBuilder::TagDetails.for(consultation))
+        .merge(PayloadBuilder::Attachments.for(consultation))
     end
 
     def public_updated_at

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -79,7 +79,7 @@ module PublishingApi
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
         .merge(PayloadBuilder::TagDetails.for(consultation))
-        .merge(PayloadBuilder::Attachments.for(consultation))
+        .merge(PayloadBuilder::Attachments.for([consultation, consultation.outcome, consultation.public_feedback]))
     end
 
     def public_updated_at
@@ -185,6 +185,7 @@ module PublishingApi
         {
           final_outcome_detail: final_outcome_detail,
           final_outcome_documents: final_outcome_documents,
+          final_outcome_attachments: final_outcome_attachments,
         }.compact
       end
 
@@ -204,6 +205,10 @@ module PublishingApi
           outcome.attachments,
           outcome.alternative_format_contact_email,
         )
+      end
+
+      def final_outcome_attachments
+        (final_outcome_documents || []).map { |html| [{ content_type: "text/html", content: html }] }
       end
     end
 
@@ -246,6 +251,7 @@ module PublishingApi
         {
           public_feedback_detail: detail,
           public_feedback_documents: documents,
+          public_feedback_attachments: attachments,
           public_feedback_publication_date: publication_date,
         }.compact
       end
@@ -269,6 +275,10 @@ module PublishingApi
           public_feedback.alternative_format_contact_email,
           public_feedback.published_on,
         )
+      end
+
+      def attachments
+        (documents || []).map { |html| [{ content_type: "text/html", content: html }] }
       end
 
       def publication_date

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -124,7 +124,10 @@ module PublishingApi
       def call
         return {} if consultation.attachments.blank?
 
-        { documents: documents }
+        {
+          documents: documents,
+          featured_attachments: featured_attachments,
+        }
       end
 
     private
@@ -137,6 +140,10 @@ module PublishingApi
           consultation.attachments,
           consultation.alternative_format_contact_email,
         )
+      end
+
+      def featured_attachments
+        documents.map { |html| [{ content_type: "text/html", content: html }] }
       end
     end
 

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -77,6 +77,7 @@ module PublishingApi
         .merge(CorporateInformationGroups.for(corporate_information_page))
         .merge(Organisation.for(corporate_information_page))
         .merge(PayloadBuilder::TagDetails.for(corporate_information_page))
+        .merge(PayloadBuilder::Attachments.for(corporate_information_page))
     end
 
     def links_presenter

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -71,6 +71,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
       details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+      details_hash.merge!(PayloadBuilder::Attachments.for(item))
     end
 
     def body

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -80,6 +80,7 @@ module PublishingApi
         .merge(PayloadBuilder::FirstPublicAt.for(news_article))
         .merge(PayloadBuilder::PoliticalDetails.for(news_article))
         .merge(PayloadBuilder::TagDetails.for(news_article))
+        .merge(PayloadBuilder::Attachments.for(news_article))
     end
 
     def emphasised_organisations

--- a/app/presenters/publishing_api/payload_builder/attachments.rb
+++ b/app/presenters/publishing_api/payload_builder/attachments.rb
@@ -1,0 +1,21 @@
+module PublishingApi
+  module PayloadBuilder
+    class Attachments
+      attr_reader :item
+
+      def self.for(item)
+        new(item).call
+      end
+
+      def initialize(item)
+        @item = item
+      end
+
+      def call
+        {
+          attachments: item.attachments.map(&:publishing_api_details),
+        }
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/payload_builder/attachments.rb
+++ b/app/presenters/publishing_api/payload_builder/attachments.rb
@@ -1,20 +1,29 @@
 module PublishingApi
   module PayloadBuilder
     class Attachments
-      attr_reader :item
+      attr_reader :items
 
-      def self.for(item)
-        new(item).call
+      def self.for(items)
+        items = [items] unless items.is_a? Array
+        new(items).call
       end
 
-      def initialize(item)
-        @item = item
+      def initialize(items)
+        @items = items
       end
 
       def call
-        {
-          attachments: item.attachments.map(&:publishing_api_details),
-        }
+        { attachments: attachments }
+      end
+
+      def attachments
+        items.flat_map do |item|
+          if item
+            item.attachments.map(&:publishing_api_details)
+          else
+            []
+          end
+        end
       end
     end
   end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -84,6 +84,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
       details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+      details_hash.merge!(PayloadBuilder::Attachments.for(item))
     end
 
     def body

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -77,6 +77,7 @@ module PublishingApi
         body: body,
         change_history: item.change_history.as_json,
         documents: documents,
+        featured_attachments: featured_attachments,
         emphasised_organisations: item.lead_organisations.map(&:content_id),
       }
       details_hash = maybe_add_national_applicability(details_hash)
@@ -98,6 +99,10 @@ module PublishingApi
         attachments_for_current_locale,
         alternative_format_email,
       )
+    end
+
+    def featured_attachments
+      documents.map { |html| [{ content_type: "text/html", content: html }] }
     end
 
     def attachments_for_current_locale

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -52,6 +52,7 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+        details_hash.merge!(PayloadBuilder::Attachments.for(item))
       end
     end
 

--- a/app/presenters/publishing_api/working_group_presenter.rb
+++ b/app/presenters/publishing_api/working_group_presenter.rb
@@ -48,7 +48,7 @@ module PublishingApi
       {
         email: item.email,
         body: body,
-      }
+      }.merge(PayloadBuilder::Attachments.for(item))
     end
 
     def body

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -49,6 +49,7 @@ module PublishingApi
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::TagDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+        details_hash.merge!(PayloadBuilder::Attachments.for(item))
       end
     end
 

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -449,15 +449,17 @@ module PublishingApi::ConsultationPresenterTest
           consultation.attachments,
           consultation.alternative_format_contact_email,
         )
-        .returns(attachments_double)
+        .returns([attachments_double])
+        .at_least_once
 
-      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
-      assert_details_attribute :documents, attachments_double
+      assert_details_attribute :documents, [attachments_double]
+      assert_details_attribute :featured_attachments, [[{ content_type: "text/html", content: attachments_double }]]
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -341,16 +341,17 @@ module PublishingApi::ConsultationPresenterTest
           consultation.public_feedback.alternative_format_contact_email,
           consultation.public_feedback.published_on,
         )
-        .returns(attachments_double)
+        .returns([attachments_double])
+        .at_least_once
 
-      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
       PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
 
-      assert_details_attribute :public_feedback_documents,
-                               attachments_double
+      assert_details_attribute :public_feedback_documents, [attachments_double]
+      assert_details_attribute :public_feedback_attachments, [[{ content_type: "text/html", content: attachments_double }]]
     end
 
     test "public feedback publication date" do
@@ -407,15 +408,17 @@ module PublishingApi::ConsultationPresenterTest
           consultation.outcome.attachments,
           consultation.outcome.alternative_format_contact_email,
         )
-        .returns(attachments_double)
+        .returns([attachments_double])
+        .at_least_once
 
-      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
       PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
-      assert_details_attribute :final_outcome_documents, attachments_double
+      assert_details_attribute :final_outcome_documents, [attachments_double]
+      assert_details_attribute :final_outcome_attachments, [[{ content_type: "text/html", content: attachments_double }]]
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -66,6 +66,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         related_mainstream_content: [],
         emphasised_organisations: detailed_guide.lead_organisations.map(&:content_id),
         brexit_no_deal_notice: [],
+        attachments: [],
       },
     }
     expected_links = {

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -54,6 +54,9 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         attachments: [
           { attachment_type: "html", id: publication.attachments.first.slug, title: publication.attachments.first.title, url: publication.attachments.first.url, unnumbered_command_paper: false, unnumbered_hoc_paper: false },
         ],
+        featured_attachments: [
+          [{ content_type: "text/html", content: "<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"#{publication.attachments.first.url}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"#{publication.attachments.first.url}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>" }],
+        ],
       },
     }
 

--- a/test/unit/presenters/publishing_api/working_group_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/working_group_presenter_test.rb
@@ -31,6 +31,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
       details: {
         email: "group-1@example.com",
         body: "<div class=\"govspeak\"><p>This is some <em>Govspeak</em> in the description field</p>\n</div>", # This is deliberately the 'wrong' way around
+        attachments: [],
       },
     }
 


### PR DESCRIPTION
We shouldn't merge this until the deploy freeze is over.

---

[Trello card](https://trello.com/c/ZTfLGWYT/1387-get-whitehall-sending-attachments-featuredattachments-data-to-publishing-api)