### PR TITLE
Previous Chancellors List: Add Sajid Javid

### DIFF
--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -15,6 +15,10 @@
       <h2 class="profiles">20th &amp; 21st centuries</h2>
       <ol>
         <li class="person person-excerpt"><div class="inner">
+          <h3 class="name">Sajid Javid</h3>
+          <p class="term">2019 to 2020</p>
+        </div></li>
+        <li class="person person-excerpt"><div class="inner">
           <h3 class="name">Philip Hammond</h3>
           <p class="term">2016 to 2019</p>
         </div></li>


### PR DESCRIPTION
Sajid Javid has resigned, so add him to this page: https://www.gov.uk/government/history/past-chancellors

<img width="1096" alt="Screenshot 2020-02-13 at 19 49 49" src="https://user-images.githubusercontent.com/43215253/74472612-1efc4200-4e9a-11ea-8c6d-99e21cfeb248.png">
