### PR TITLE
Retire BrexitCTA govspeak tag

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -116,7 +116,6 @@ module GovspeakHelper
     govspeak = render_embedded_fractions(govspeak)
     govspeak = set_classes_for_charts(govspeak)
     govspeak = set_classes_for_sortable_tables(govspeak)
-    govspeak = convert_brexit_cta(govspeak)
 
     markup_to_nokogiri_doc(govspeak, images)
       .tap { |nokogiri_doc|
@@ -262,12 +261,6 @@ private
         ""
       end
     end
-  end
-
-  def convert_brexit_cta(govspeak)
-    return govspeak if govspeak.blank?
-
-    govspeak.gsub(/\$BrexitCTA/, "")
   end
 
   def edition_body_with_attachments_and_alt_format_information(edition)

--- a/app/views/documents/_brexit_cta.text.erb
+++ b/app/views/documents/_brexit_cta.text.erb
@@ -1,8 +1,0 @@
-$CTA
-##The UK is leaving the EU
-
-This page tells you what you'll need to do from 1 January 2021. It'll be updated if anything changes.
-
-You can read about [the transition period](/transition).
-
-$CTA

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -476,10 +476,4 @@ class GovspeakHelperTest < ActionView::TestCase
     html = govspeak_with_attachments_to_html(body, attachments, "batman@wayne.technology")
     assert html.include? ">batman@wayne.technology</a>"
   end
-
-  test "does not render Brexit CTA govspeak" do
-    body = "$BrexitCTA\nSome other text"
-    output = govspeak_to_html(body)
-    assert_select_within_html output, ".govspeak", text: "Some other text"
-  end
 end


### PR DESCRIPTION
In the wake of the BrexitCTA govspeak tags from Whitehall drafts, we can look at removing legacy code around this.

https://trello.com/c/4tj1Ekcy/499-remove-brexit-cta-legacy-code