### PR TITLE
Data migration: remove BrexitCTA from withdrawn documents

### DIFF
--- a/db/data_migration/20200218104101_remove_brexit_cta_tag_from_withdrawn_docs.rb
+++ b/db/data_migration/20200218104101_remove_brexit_cta_tag_from_withdrawn_docs.rb
@@ -1,0 +1,11 @@
+withdrawn_brexit_cta_editions = Edition.in_default_locale
+  .includes(:document)
+  .where("edition_translations.body LIKE ?", "%$BrexitCTA%")
+  .withdrawn
+
+withdrawn_brexit_cta_editions.each do |edition|
+  edition.update(
+    minor_change: true,
+    body: edition.body.gsub(/\$BrexitCTA/, ""),
+  )
+end


### PR DESCRIPTION
Run this data migration before merging https://github.com/alphagov/whitehall/pull/5367.