### PR TITLE
Brakeman bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (4.7.1)
+    brakeman (4.8.0)
     builder (3.2.4)
     byebug (11.1.1)
     capybara (3.31.0)

--- a/app/controllers/admin/classification_featurings_controller.rb
+++ b/app/controllers/admin/classification_featurings_controller.rb
@@ -3,10 +3,12 @@ class Admin::ClassificationFeaturingsController < Admin::BaseController
   before_action :load_featuring, only: %i[edit destroy]
 
   def index
-    filter_params = params.permit!.to_h.slice(:page, :type, :author, :organisation, :title).
-      merge(state: "published", classification: @classification.to_param)
-    @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
+    filter_params = params.slice(:page, :type, :author, :organisation, :title)
+                          .permit!
+                          .to_h
+                          .merge(state: "published", classification: @classification.to_param)
 
+    @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @tagged_editions = editions_to_show
 
     @classification_featurings = @classification.classification_featurings
@@ -87,7 +89,7 @@ private
   end
 
   def filter_values_set?
-    !params.permit!.to_h.slice(:type, :author, :organisation, :title).empty?
+    params.slice(:page, :type, :author, :organisation, :title).permit!.to_h.any?
   end
 
   def classification_featuring_params

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -310,7 +310,9 @@ private
   end
 
   def params_filters
-    params.permit!.to_h.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
+          .permit!
+          .to_h
   end
 
   def params_filters_with_default_state

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -44,8 +44,10 @@ class Admin::OrganisationsController < Admin::BaseController
 
     filtering_organisation = params[:organisation] || @organisation.id
 
-    filter_params = params.permit!.to_h.slice(:page, :type, :author, :title).
-      merge(state: "published", organisation: filtering_organisation)
+    filter_params = params.slice(:page, :type, :author, :title)
+                          .permit!
+                          .to_h
+                          .merge(state: "published", organisation: filtering_organisation)
 
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @featurable_topical_events = TopicalEvent.active

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -77,9 +77,10 @@ private
   end
 
   def filter_params
-    params.permit!.to_h
-      .slice(:title, :page, :per_page, :organisation_id, :dates, :unlinked_only)
-      .reverse_merge(filter_defaults)
+    params.slice(:title, :page, :per_page, :organisation_id, :dates, :unlinked_only)
+          .permit!
+          .to_h
+          .reverse_merge(filter_defaults)
   end
 
   def filter_defaults

--- a/app/controllers/admin/world_locations_controller.rb
+++ b/app/controllers/admin/world_locations_controller.rb
@@ -16,9 +16,8 @@ class Admin::WorldLocationsController < Admin::BaseController
   def features
     @feature_list = @world_location.load_or_create_feature_list(params[:locale])
 
-    filter_params = default_filter_params
-      .merge(params.permit!.to_h.slice(:page, :type, :world_location, :title).symbolize_keys)
-      .merge(state: "published")
+    filter_params = default_filter_params.merge(optional_filter_params).merge(state: "published")
+
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @featurable_topical_events = TopicalEvent.active
     @featurable_offsite_links = @world_location.offsite_links
@@ -36,6 +35,10 @@ private
     {
       world_location: @world_location.id,
     }
+  end
+
+  def optional_filter_params
+    params.slice(:page, :type, :world_location, :title).permit!.to_h.symbolize_keys
   end
 
   def load_world_location

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -1,6 +1,9 @@
 class ConsultationsController < DocumentsController
   def index
-    filter_params = params.permit!.except(:controller, :action, :format, :_, :host)
-    redirect_to publications_path(filter_params.merge(publication_filter_option: "consultations").to_h)
+    filter_params = Whitehall::DocumentFilter::CleanedParams.new(
+      params.except(:controller, :action, :format, :_, :host),
+    ).to_h
+
+    redirect_to publications_path(filter_params.merge(publication_filter_option: "consultations"))
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -99,8 +99,11 @@ private
   def redirect_statistics_filtering
     if !request.xhr? && (params[:publication_filter_option] == "statistics")
       redirect_to statistics_path(
-        params.permit!.except(:publication_filter_option, :controller, :action, :host).to_h,
-      ), status: :moved_permanently
+        Whitehall::DocumentFilter::CleanedParams.new(
+          params.except(:publication_filter_option, :controller, :action, :host),
+        ),
+        status: :moved_permanently,
+      )
     end
   end
 

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -19,7 +19,11 @@ module Admin::AuditTrailHelper
   end
 
   def paginated_audit_trail_url(page)
-    url_for(params.permit!.except(:host, :controller, :action).merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page)))
+    url_for(
+      params.to_unsafe_hash
+            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page))
+            .symbolize_keys,
+    )
   end
 
   def render_editorial_remarks_in_sidebar(remarks, edition)

--- a/app/helpers/filter_routes_helper.rb
+++ b/app/helpers/filter_routes_helper.rb
@@ -16,7 +16,9 @@ module FilterRoutesHelper
   end
 
   def filter_atom_feed_url
-    Whitehall::FeedUrlBuilder.new({ document_type: params.permit!.to_h[:controller].to_s }.merge(params.permit!.to_h)).url
+    Whitehall::FeedUrlBuilder.new(
+      params.to_unsafe_hash.merge(document_type: params[:controller].to_s).symbolize_keys,
+    ).url
   end
 
   def filter_json_url(args = {})

--- a/lib/attachment_data_reporter.rb
+++ b/lib/attachment_data_reporter.rb
@@ -57,11 +57,11 @@ class AttachmentDataReporter
       JOIN organisations o ON eo.organisation_id = o.id
       JOIN organisation_translations ot ON o.id = ot.organisation_id
       WHERE e.state = 'published'
-      AND a.created_at BETWEEN '#{start_date.strftime('%Y-%m-%d %H:%M:%S')}' AND '#{end_date.strftime('%Y-%m-%d %H:%M:%S')}'
+      AND a.created_at BETWEEN ? AND ?
       ORDER BY a.created_at DESC
     SQL
 
-    results = ActiveRecord::Base.connection.execute(sql)
+    results = ActiveRecord::Base.connection.execute(sql, start_date.strftime("%Y-%m-%d %H:%M:%S"), end_date.strftime("%Y-%m-%d %H:%M:%S"))
 
     CSV.open(csv_file_path("upload-report"), "wb") do |csv|
       csv << ["Attached date", "Document title", "Attachment title", "Organisation", "Mime type", "Filename"]

--- a/lib/whitehall/feed_url_builder.rb
+++ b/lib/whitehall/feed_url_builder.rb
@@ -23,7 +23,7 @@ module Whitehall
       params.except(:document_type).reject { |key, value|
         values = Array(value)
         values.empty? || values.all?(&:blank?) || values.include?("all") || DocumentFilter::Options.new.invalid_filter_key?(key)
-      }.merge(format: :atom)
+      }.merge(format: :atom).symbolize_keys
     end
   end
 end


### PR DESCRIPTION
Code to bump brakeman to the most recent version was previously [here](https://github.com/alphagov/whitehall/pull/5289), but as the gem has now been [removed from the Gemfile](https://github.com/alphagov/whitehall/pull/5350) of whitehall the dependabot PR is no longer relevant.

This PR updates gem dependencies for govuk_test where brakeman now resides so by default bumping brakeman to the most recent version.

Trello:
https://trello.com/c/UAOaEOG6/1469-bump-brakeman-to-v472