### PR TITLE
Change cached image used to resize images

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -15,16 +15,16 @@ class ImageUploader < WhitehallUploader
   version :s712, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [712, 480]
   end
-  version :s630, from_version: :s712, if: :bitmap? do
+  version :s630, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [630, 420]
   end
-  version :s465, from_version: :s630, if: :bitmap? do
+  version :s465, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [465, 310]
   end
-  version :s300, from_version: :s465, if: :bitmap? do
+  version :s300, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [300, 195]
   end
-  version :s216, from_version: :s300, if: :bitmap? do
+  version :s216, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [216, 140]
   end
 


### PR DESCRIPTION
We received a [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/3923306) about a loss of quality in thumbnail images for a Person. While the uploaded image looks to be processed correctly in Whitehall, the thumbnail representation showed a significant degradation in quality. 

After investigation we found an [issue raised on the Carrierwave gem](https://github.com/carrierwaveuploader/carrierwave/issues/2436) which suggested that repeatedly recreating versions of an image is causing degradation in image quality for the resulting variants. 

In our Image Uploader we use the `:from_version` option to get different image variants, which uses a cached version of the file instead of the original version, presumably since according to the [README for Carrierwave](https://github.com/carrierwaveuploader/carrierwave#create-versions-from-existing-versions) it "potentially results in faster processing". Our existing approach to using the `:from_version` option is to use the cached file for the variant that is the next size up from the variant being created. This repeated resizing of images that have already been processed seems to be the cause of the image quality degradation; switching all variants to use the cached file for the largest variant seems to fix the issue.

**Before**
![jc-prod](https://user-images.githubusercontent.com/13434452/75150789-0fcc8e00-56fd-11ea-87f8-416e2b7303ca.jpg)

**After**
![jc-int](https://user-images.githubusercontent.com/13434452/75150723-eb70b180-56fc-11ea-83bb-7c6e73c5f5b1.jpg)

