### PR TITLE
Fix vertical alignment on past PMs page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_historic-appointments.scss
+++ b/app/assets/stylesheets/frontend/views/_historic-appointments.scss
@@ -1,3 +1,15 @@
+.historic-appointments:not(.historical-past-chancellors) .featured-profiles .year-block {
+  @include media(mobile) {
+    h2.profiles {
+      margin: 0 0 $gutter-one-sixth;
+    }
+
+    .inner {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}
 .historic-appointments {
   .historic-people-list {
     @include media(tablet) {
@@ -6,7 +18,7 @@
     }
     h3 {
       @include core-19;
-      margin-bottom: $gutter;
+      margin: $gutter 0;
 
       span {
         @include core-80;

--- a/app/assets/stylesheets/frontend/views/_historic-appointments.scss
+++ b/app/assets/stylesheets/frontend/views/_historic-appointments.scss
@@ -1,7 +1,7 @@
 .historic-appointments:not(.historical-past-chancellors) .featured-profiles .year-block {
-  @include media(mobile) {
+  @include govuk-media-query($until: tablet) {
     h2.profiles {
-      margin: 0 0 $gutter-one-sixth;
+      margin: 0 0 govuk-spacing(1) 0;
     }
 
     .inner {
@@ -17,8 +17,8 @@
       width: $one-quarter;
     }
     h3 {
-      @include core-19;
-      margin: $gutter 0;
+      @include govuk-font(19);
+      margin: govuk-spacing(6) 0;
 
       span {
         @include core-80;

--- a/app/views/historic_appointments/_role_appointments_list.html.erb
+++ b/app/views/historic_appointments/_role_appointments_list.html.erb
@@ -1,5 +1,6 @@
 <div class="block historic-people-list">
-  <div class="inner-block">
+  <%# TODO: remove the govuk-!-padding-0 when re-implement this template with components/grid layout %>
+  <div class="inner-block govuk-!-padding-0">
     <a href="#contents" class="js-showhide contents-toggle govuk-link">Show past <%= @role.name.pluralize %></a>
     <div id="contents">
       <h3>

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -1,8 +1,8 @@
 <% page_title "Past #{@role.name.pluralize}" %>
-<% page_class "historic-appointments historic-appointments-index" %>
+<% page_class "historic-appointments historic-appointments-index govuk-width-container" %>
 
-<header class="block headings-block">
-  <div class="inner-block floated-children">
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {
         context: {
           text: "History",


### PR DESCRIPTION
## What
The alignment of the heading on https://www.gov.uk/government/history/past-prime-ministers is broken (bleeding into the gutter).

https://trello.com/c/hwc5fDgR

## Before

### Desktop

![image](https://user-images.githubusercontent.com/424772/75704016-7c70fb00-5cb0-11ea-944e-9deb6e2b2ae0.png)

### Mobile

![image (1)](https://user-images.githubusercontent.com/424772/75704013-7bd86480-5cb0-11ea-9f95-67c8f822f2c5.png)

## After

### Desktop

![whitehall-admin dev gov uk_government_history_past-prime-ministers (1)](https://user-images.githubusercontent.com/424772/75704151-bd690f80-5cb0-11ea-8cf9-7a9c358292ba.png)

### Mobile

![whitehall-admin dev gov uk_government_history_past-prime-ministers](https://user-images.githubusercontent.com/424772/75704153-be01a600-5cb0-11ea-9240-0a8699066dd7.png)


