### PR TITLE
Remove an unused find_asset call

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -60,8 +60,4 @@ private
   def file
     uploader.file
   end
-
-  def find_asset(asset)
-    Rails.application.assets.find_asset(asset)
-  end
 end


### PR DESCRIPTION
This would probably not work, and it also looks to be unused. The code
that did used this looks to have been removed back in 2017 in [1].

1: 6a18aac084846a6e4574bd136358b6fcc7f9ac91