### PR TITLE
Order presented editions by edition id

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -9,7 +9,7 @@ class DocumentExportPresenter < Whitehall::Decorators::Decorator
   ].freeze
 
   def as_json
-    presented_editions = model.editions.map { |e| present_edition(e) }
+    presented_editions = model.editions.order(:id).map { |e| present_edition(e) }
     presented_users = users.map { |u| present_user(u) }
     model.as_json
          .merge(editions: presented_editions, users: presented_users)


### PR DESCRIPTION
Make sure the editions that are returned by the export for a document
are always ordered in ascending order by edition id. This ordering is
important as we use it to create a sequential list of editions in
content-publisher ->
https://github.com/alphagov/content-publisher/blob/master/lib/whitehall_importer/import.rb#L31.