### PR TITLE
Fix find_asset bug

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -93,7 +93,7 @@ module GovspeakHelper
 
   def fraction_image(numerator, denominator)
     denominator.downcase! if %w{X Y}.include? denominator
-    if numerator.present? && denominator.present? && Rails.application.assets.find_asset("fractions/#{numerator}_#{denominator}.png")
+    if numerator.present? && denominator.present? && asset_exists?("fractions/#{numerator}_#{denominator}.png")
       asset_path("fractions/#{numerator}_#{denominator}.png", host: Whitehall.public_asset_host)
     end
   end
@@ -136,6 +136,10 @@ module GovspeakHelper
   end
 
 private
+
+  def asset_exists?(path)
+    Rails.application.assets_manifest.files.values.map { |v| v["logical_path"] }.include?(path)
+  end
 
   def remove_extra_quotes_from_blockquotes(govspeak)
     Whitehall::ExtraQuoteRemover.new.remove(govspeak)


### PR DESCRIPTION
Rails.application.assets resolves to nil which causes a no method error
when find_asset is run. I'm unsure what exactly changed to cause
Rails.application.assets to be set to nil, apparently this was a common
issue when upgrading to sprockets-rails version 3. It also could be
related to a recent bump of the carrier-wave gem
(https://github.com/alphagov/whitehall/pull/5253) but it's not obvious
what would cause this to happen.

This commits implements a workaround for find_asset which seems to work
as expected.