### PR TITLE
Allow detailed_guides/topical_events association

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -19,6 +19,7 @@ class DetailedGuide < Edition
   include Edition::Organisations
   include Edition::TaggableOrganisations
   include Edition::RelatedDocuments
+  include Edition::TopicalEvents
 
   def self.format_name
     "detailed guidance"

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -20,7 +20,7 @@ class TopicalEvent < Classification
   has_many :announcements, through: :classification_memberships
   has_many :news_articles, through: :classification_memberships
   has_many :speeches, through: :classification_memberships
-
+  has_many :detailed_guides, through: :classification_memberships
   has_many :publications, through: :classification_memberships
   has_many :consultations, through: :classification_memberships
 

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -10,6 +10,8 @@
       <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
 
+      <%= render "topical_event_fields", form: form, edition: edition %>
+
       <% cache_if edition.related_detailed_guide_ids.empty?, taggable_detailed_guides_cache_digest do %>
         <%= form.label :related_detailed_guide_ids, 'Related guides' %>
         <%= form.select :related_detailed_guide_ids, options_for_select(taggable_detailed_guides_container, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related detailed guides…"} %>

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -74,6 +74,13 @@ class DetailedGuideTest < ActiveSupport::TestCase
     assert guide.has_additional_related_mainstream_content?
   end
 
+  test "can be associated with topical events" do
+    detailed_guide = create(:detailed_guide)
+    assert detailed_guide.can_be_associated_with_topical_events?
+    assert topical_event = detailed_guide.topical_events.create(name: "Test", description: "Test")
+    assert_equal [detailed_guide], topical_event.detailed_guides
+  end
+
   test "should be valid if all level-3 headings have a parent level-2 heading" do
     body = "## Parent1\n\n### Child1\n\n### Child2\n\n## Parent2\n\n### Child3"
     detailed_guide = build(:detailed_guide, body: body)


### PR DESCRIPTION
We need to be able to associate a `Detailed Guide` to a `Topical Event`
so that it is displayed on the `Topical Event` page. The code to show
this on the page is already in place in:
- `app/controllers/topical_events_controller.rb`
- `app/views/topical_events/show.html.erb`

Trello card: https://trello.com/c/9xNsGzmy/1773-investigate-allowing-detailed-guides-to-be-attached-to-topical-events-in-whitehall