### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run govuk-lint-ruby"
-task lint: :environment do |_task, _args|
-  system "rubocop --parallel app lib test"
-end


### PR DESCRIPTION
- Now we run RuboCop directly with `rubocop-govuk`, we don't need the
  `lint` task as a wrapper around it.
- Typing `bundle exec rubocop` is fewer keypresses than `bundle exec
  rake lint`, with none of the options and directories it operates on
  invisible to us.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.