### PR TITLE
Do not check for document being locked if no changes are being made

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -19,7 +19,7 @@ class Admin::Export::DocumentController < Admin::Export::BaseController
 
   def lock
     document = Document.find(params[:id])
-    document.update!(locked: true)
+    document.update!(locked: true) unless document.locked?
   end
 
   def unlock

--- a/test/functional/admin/export/document_controller_test.rb
+++ b/test/functional/admin/export/document_controller_test.rb
@@ -212,8 +212,18 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "locks document" do
-    document = create(:document)
+  test "locks a document" do
+    document = create(:document, locked: false)
+    login_as :export_data_user
+
+    post :lock, params: { id: document.id }, format: "json"
+
+    assert document.reload.locked
+    assert_response :no_content
+  end
+
+  test "locks a locked document" do
+    document = create(:document, locked: true)
     login_as :export_data_user
 
     post :lock, params: { id: document.id }, format: "json"
@@ -228,8 +238,18 @@ class Admin::Export::DocumentControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "unlocks document" do
+  test "unlocks a document" do
     document = create(:document, locked: true)
+    login_as :export_data_user
+
+    post :unlock, params: { id: document.id }, format: "json"
+
+    assert_not document.reload.locked
+    assert_response :no_content
+  end
+
+  test "unlocks an unlocked document" do
+    document = create(:document, locked: false)
     login_as :export_data_user
 
     post :unlock, params: { id: document.id }, format: "json"


### PR DESCRIPTION
This has the effect of allowing us to lock a locked document without getting an error.  In these cases, we currently return a 500 error, but this change means an OK response will be returned instead.

Trello card: https://trello.com/c/9ULodMA9