### PR TITLE
Export content_id from documents_info

### DIFF
--- a/lib/whitehall/exporters/documents_info_exporter.rb
+++ b/lib/whitehall/exporters/documents_info_exporter.rb
@@ -7,10 +7,12 @@ class Whitehall::Exporters::DocumentsInfoExporter
 
   def call
     document_ids.map do |doc_id|
+      document = Document.find(doc_id)
       {
         document_id: doc_id,
         document_information: {
           locales: locales_hash[doc_id],
+          content_id: document.content_id
         },
       }
     end


### PR DESCRIPTION
- This will enable us to populate the document_imports#content_id field in content-publisher
- This in turn will allow us to link to view the imported document in Whitehall, from the content-publisher migration UI
- Makes it easier to find the relationship between a content-publisher document_import and the original Whitehall document