### PR TITLE
Remove order url and price

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -116,7 +116,7 @@ private
     params.fetch(:attachment, {}).permit(
       :title, :locale, :isbn, :unique_reference,
       :command_paper_number, :unnumbered_command_paper, :hoc_paper_number,
-      :unnumbered_hoc_paper, :parliamentary_session, :price, :accessible,
+      :unnumbered_hoc_paper, :parliamentary_session, :accessible,
       :external_url,
       govspeak_content_attributes: %i[id body manually_numbered_headings],
       attachment_data_attributes: %i[file to_replace_id file_cache]

--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -116,7 +116,7 @@ private
     params.fetch(:attachment, {}).permit(
       :title, :locale, :isbn, :unique_reference,
       :command_paper_number, :unnumbered_command_paper, :hoc_paper_number,
-      :unnumbered_hoc_paper, :parliamentary_session, :order_url, :price, :accessible,
+      :unnumbered_hoc_paper, :parliamentary_session, :price, :accessible,
       :external_url,
       govspeak_content_attributes: %i[id body manually_numbered_headings],
       attachment_data_attributes: %i[file to_replace_id file_cache]

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -53,7 +53,6 @@ private
       :unique_reference,
       :command_paper_number,
       :unnumbered_command_paper,
-      :order_url,
       :price,
       :hoc_paper_number,
       :unnumbered_hoc_paper,

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -53,7 +53,6 @@ private
       :unique_reference,
       :command_paper_number,
       :unnumbered_command_paper,
-      :price,
       :hoc_paper_number,
       :unnumbered_hoc_paper,
       :parliamentary_session,

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -243,7 +243,6 @@ module Admin::EditionsHelper
       isbn: "ISBN",
       unique_reference: "Unique reference",
       command_paper_number: "Command paper number",
-      order_url: "Order URL",
       price: "Price",
       hoc_paper_number: "House of Commons paper number",
       parliamentary_session: "Parliamentary session",

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -243,7 +243,6 @@ module Admin::EditionsHelper
       isbn: "ISBN",
       unique_reference: "Unique reference",
       command_paper_number: "Command paper number",
-      price: "Price",
       hoc_paper_number: "House of Commons paper number",
       parliamentary_session: "Parliamentary session",
     }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -23,9 +23,6 @@ class Attachment < ApplicationRecord
     allow_blank: true,
     message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}",
   }
-  validates :price, numericality: {
-    allow_blank: true, greater_than: 0
-  }
   validates :unique_reference, length: { maximum: 255 }, allow_blank: true
 
   scope :with_filename, ->(basename) {
@@ -55,19 +52,6 @@ class Attachment < ApplicationRecord
       ends = Date.new(year + 1).strftime("%y") # %y gives last two digits of year
       "#{starts}-#{ends}"
     end
-  end
-
-  def price
-    if @price
-      @price
-    elsif price_in_pence
-      price_in_pence / 100.0
-    end
-  end
-
-  def price=(price_in_pounds)
-    @price = price_in_pounds
-    store_price_in_pence
   end
 
   def is_command_paper?
@@ -165,14 +149,6 @@ class Attachment < ApplicationRecord
   end
 
 private
-
-  def store_price_in_pence
-    self.price_in_pence = if price && price.to_s.empty?
-                            nil
-                          elsif price
-                            price.to_f * 100
-                          end
-  end
 
   def set_ordering
     self.ordering = attachable.next_ordering

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -23,11 +23,6 @@ class Attachment < ApplicationRecord
     allow_blank: true,
     message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}",
   }
-  validates :order_url, uri: true, allow_blank: true
-  validates :order_url, presence: {
-    message: "must be entered as you've entered a price",
-    if: ->(publication) { publication.price.present? },
-  }
   validates :price, numericality: {
     allow_blank: true, greater_than: 0
   }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -54,6 +54,10 @@ class Attachment < ApplicationRecord
     end
   end
 
+  def is_official_document?
+    is_command_paper? || is_act_paper?
+  end
+
   def is_command_paper?
     command_paper_number.present? || unnumbered_command_paper?
   end

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -14,5 +14,4 @@
 <% if attachable.can_have_attached_house_of_commons_papers? %>
   <%= render 'admin/attachments/hoc_reference_fields', form: form %>
 <% end %>
-<%= form.text_field :order_url, label_text: 'Order URL' %>
 <%= form.text_field :price, label_text: "Price in £s" %>

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -14,4 +14,3 @@
 <% if attachable.can_have_attached_house_of_commons_papers? %>
   <%= render 'admin/attachments/hoc_reference_fields', form: form %>
 <% end %>
-<%= form.text_field :price, label_text: "Price in £s" %>

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -56,6 +56,10 @@
         <%= attachment_attributes(attachment) %>
       <% end %>
     </p>
+    <% if attachment.is_official_document? %>
+      <%= link_to t('attachment.headings.order_a_copy'), "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents",
+            class: "order_url", title: t('attachment.headings.order_a_copy_full') %>
+    <% end %>
 
     <% if attachment.opendocument? %>
       <p class="opendocument-help">

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -56,15 +56,6 @@
         <%= attachment_attributes(attachment) %>
       <% end %>
     </p>
-    <% if attachment.order_url.present? %>
-      <p>
-        <%= link_to t('attachment.headings.order_a_copy'), attachment.order_url,
-            class: "order_url", title: t('attachment.headings.order_a_copy_full') %>
-        <% if attachment.price %>
-          (<span class="price"><%= number_to_currency(attachment.price, unit: "&pound;".html_safe) %></span>)
-        <% end %>
-      </p>
-    <% end %>
 
     <% if attachment.opendocument? %>
       <p class="opendocument-help">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -421,7 +421,6 @@ ar:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -436,7 +435,6 @@ ar:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -449,7 +447,6 @@ ar:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -421,7 +421,6 @@ ar:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -435,7 +434,6 @@ ar:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -447,7 +445,6 @@ ar:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -11,7 +11,6 @@ az:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ az:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ az:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -11,7 +11,6 @@ az:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ az:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ az:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -319,7 +319,6 @@ be:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ be:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ be:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -319,7 +319,6 @@ be:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ be:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ be:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -219,7 +219,6 @@ bg:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -233,7 +232,6 @@ bg:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -245,7 +243,6 @@ bg:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -219,7 +219,6 @@ bg:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -234,7 +233,6 @@ bg:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -247,7 +245,6 @@ bg:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -217,7 +217,6 @@ bn:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ bn:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ bn:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -217,7 +217,6 @@ bn:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ bn:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ bn:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -268,7 +268,6 @@ cs:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -283,7 +282,6 @@ cs:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -296,7 +294,6 @@ cs:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -268,7 +268,6 @@ cs:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -282,7 +281,6 @@ cs:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -294,7 +292,6 @@ cs:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -421,7 +421,6 @@ cy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -436,7 +435,6 @@ cy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -449,7 +447,6 @@ cy:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -421,7 +421,6 @@ cy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -435,7 +434,6 @@ cy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -447,7 +445,6 @@ cy:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -217,7 +217,6 @@ da:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ da:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ da:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -217,7 +217,6 @@ da:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ da:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ da:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -217,7 +217,6 @@ de:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ de:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ de:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -217,7 +217,6 @@ de:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ de:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ de:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -217,7 +217,6 @@ dr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ dr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ dr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -217,7 +217,6 @@ dr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ dr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ dr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -217,7 +217,6 @@ el:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ el:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ el:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -217,7 +217,6 @@ el:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ el:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ el:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,6 @@ en:
       command_paper_number: Attachment command paper number
       hoc_paper_number: House of Commons paper number
       isbn: Attachment ISBN
-      price: Attachment price
       title: Attachment title
       unique_reference: Attachment unique reference
       unnumbered_hoc_paper: Unnumbered House of Commons paper

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,6 @@ en:
       command_paper_number: Attachment command paper number
       hoc_paper_number: House of Commons paper number
       isbn: Attachment ISBN
-      order_url: Attachment order url
       price: Attachment price
       title: Attachment title
       unique_reference: Attachment unique reference

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -217,7 +217,6 @@ es-419:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ es-419:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ es-419:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -217,7 +217,6 @@ es-419:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ es-419:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ es-419:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -217,7 +217,6 @@ es:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ es:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ es:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -217,7 +217,6 @@ es:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ es:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ es:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -217,7 +217,6 @@ et:
         command_paper_number:
         hoc_paper_number: 'Parlamendi alamkoja dokumendi nr. '
         isbn: 'Manuse ISBN '
-        price: Manuse hind
         title: Manuse pealkiri
         unique_reference: Manuse unikaalne viide
         unnumbered_hoc_paper: Nummerdamata Parlamendi alamkoja dokument
@@ -231,7 +230,6 @@ et:
         command_paper_number:
         hoc_paper_number: Parlamendi alamkoja dokumendi nr.
         isbn: Manuse ISBN
-        price: Manuse hind
         title: Manuse pealkiri
         unique_reference: Manuse unikaalne viide
         unnumbered_hoc_paper: Nummerdamata Parlamendi alamkoja dokument
@@ -243,7 +241,6 @@ et:
       command_paper_number:
       hoc_paper_number: Parlamendi alamkoja dokumendi nr.
       isbn: Manuse ISBN
-      price: Manuse hind
       title: Manuse pealkiri
       unique_reference: Manuse unikaalne viide
       unnumbered_hoc_paper: Nummerdamata Parlamendi alamkoja dokument

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -217,7 +217,6 @@ et:
         command_paper_number:
         hoc_paper_number: 'Parlamendi alamkoja dokumendi nr. '
         isbn: 'Manuse ISBN '
-        order_url: Manuse tellimise link
         price: Manuse hind
         title: Manuse pealkiri
         unique_reference: Manuse unikaalne viide
@@ -232,7 +231,6 @@ et:
         command_paper_number:
         hoc_paper_number: Parlamendi alamkoja dokumendi nr.
         isbn: Manuse ISBN
-        order_url: Manuse tellimise link
         price: Manuse hind
         title: Manuse pealkiri
         unique_reference: Manuse unikaalne viide
@@ -245,7 +243,6 @@ et:
       command_paper_number:
       hoc_paper_number: Parlamendi alamkoja dokumendi nr.
       isbn: Manuse ISBN
-      order_url: Manuse tellimise link
       price: Manuse hind
       title: Manuse pealkiri
       unique_reference: Manuse unikaalne viide

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -11,7 +11,6 @@ fa:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ fa:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ fa:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -11,7 +11,6 @@ fa:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ fa:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ fa:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -217,7 +217,6 @@ fi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ fi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ fi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -217,7 +217,6 @@ fi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ fi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ fi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -217,7 +217,6 @@ fr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ fr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ fr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -217,7 +217,6 @@ fr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ fr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ fr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -319,7 +319,6 @@ gd:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ gd:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ gd:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -319,7 +319,6 @@ gd:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ gd:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ gd:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -217,7 +217,6 @@ he:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ he:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ he:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -217,7 +217,6 @@ he:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ he:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ he:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -217,7 +217,6 @@ hi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ hi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ hi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -217,7 +217,6 @@ hi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ hi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ hi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -319,7 +319,6 @@ hr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ hr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ hr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -319,7 +319,6 @@ hr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ hr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ hr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -217,7 +217,6 @@ hu:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ hu:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ hu:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -217,7 +217,6 @@ hu:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ hu:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ hu:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -217,7 +217,6 @@ hy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ hy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ hy:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -217,7 +217,6 @@ hy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ hy:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ hy:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -11,7 +11,6 @@ id:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ id:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ id:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -11,7 +11,6 @@ id:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ id:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ id:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -217,7 +217,6 @@ is:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ is:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ is:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -217,7 +217,6 @@ is:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ is:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ is:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -217,7 +217,6 @@ it:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ it:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ it:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -217,7 +217,6 @@ it:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ it:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ it:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,6 @@ ja:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ ja:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ ja:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,6 @@ ja:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ ja:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ ja:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -11,7 +11,6 @@ ka:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ ka:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ ka:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -11,7 +11,6 @@ ka:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ ka:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ ka:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -217,7 +217,6 @@ kk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ kk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ kk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -217,7 +217,6 @@ kk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ kk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ kk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -11,7 +11,6 @@ ko:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ ko:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ ko:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -11,7 +11,6 @@ ko:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ ko:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ ko:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -268,7 +268,6 @@ lt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -283,7 +282,6 @@ lt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -296,7 +294,6 @@ lt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -268,7 +268,6 @@ lt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -282,7 +281,6 @@ lt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -294,7 +292,6 @@ lt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -217,7 +217,6 @@ lv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ lv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ lv:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -217,7 +217,6 @@ lv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ lv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ lv:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -11,7 +11,6 @@ ms:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ ms:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ ms:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -11,7 +11,6 @@ ms:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ ms:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ ms:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -319,7 +319,6 @@ mt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ mt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ mt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -319,7 +319,6 @@ mt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ mt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ mt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -217,7 +217,6 @@ nl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ nl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ nl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -217,7 +217,6 @@ nl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ nl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ nl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -217,7 +217,6 @@
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -217,7 +217,6 @@
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -319,7 +319,6 @@ pl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ pl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ pl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -319,7 +319,6 @@ pl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ pl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ pl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -217,7 +217,6 @@ ps:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ ps:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ ps:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -217,7 +217,6 @@ ps:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ ps:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ ps:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -217,7 +217,6 @@ pt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ pt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ pt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -217,7 +217,6 @@ pt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ pt:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ pt:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -268,7 +268,6 @@ ro:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -282,7 +281,6 @@ ro:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -294,7 +292,6 @@ ro:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -268,7 +268,6 @@ ro:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -283,7 +282,6 @@ ro:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -296,7 +294,6 @@ ro:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -319,7 +319,6 @@ ru:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ ru:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ ru:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -319,7 +319,6 @@ ru:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ ru:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ ru:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -217,7 +217,6 @@ si:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ si:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ si:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -217,7 +217,6 @@ si:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ si:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ si:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -268,7 +268,6 @@ sk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -282,7 +281,6 @@ sk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -294,7 +292,6 @@ sk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -268,7 +268,6 @@ sk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -283,7 +282,6 @@ sk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -296,7 +294,6 @@ sk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -319,7 +319,6 @@ sl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ sl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ sl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -319,7 +319,6 @@ sl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ sl:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ sl:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -217,7 +217,6 @@ so:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ so:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ so:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -217,7 +217,6 @@ so:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ so:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ so:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -217,7 +217,6 @@ sq:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ sq:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ sq:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -217,7 +217,6 @@ sq:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ sq:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ sq:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -319,7 +319,6 @@ sr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ sr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ sr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -319,7 +319,6 @@ sr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ sr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ sr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -217,7 +217,6 @@ sv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ sv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ sv:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -217,7 +217,6 @@ sv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ sv:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ sv:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -217,7 +217,6 @@ sw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ sw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ sw:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -217,7 +217,6 @@ sw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ sw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ sw:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -217,7 +217,6 @@ ta:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ ta:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ ta:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -217,7 +217,6 @@ ta:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ ta:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ ta:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -11,7 +11,6 @@ th:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ th:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ th:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -11,7 +11,6 @@ th:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ th:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ th:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -217,7 +217,6 @@ tk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ tk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ tk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -217,7 +217,6 @@ tk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ tk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ tk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -11,7 +11,6 @@ tr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ tr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ tr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -11,7 +11,6 @@ tr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ tr:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ tr:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -319,7 +319,6 @@ uk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -334,7 +333,6 @@ uk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -347,7 +345,6 @@ uk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -319,7 +319,6 @@ uk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -333,7 +332,6 @@ uk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -345,7 +343,6 @@ uk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -217,7 +217,6 @@ ur:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ ur:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ ur:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -217,7 +217,6 @@ ur:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ ur:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ ur:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -217,7 +217,6 @@ uz:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -232,7 +231,6 @@ uz:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -245,7 +243,6 @@ uz:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -217,7 +217,6 @@ uz:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -231,7 +230,6 @@ uz:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -243,7 +241,6 @@ uz:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -11,7 +11,6 @@ vi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ vi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ vi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -11,7 +11,6 @@ vi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ vi:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ vi:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -11,7 +11,6 @@ zh-hk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ zh-hk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ zh-hk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -11,7 +11,6 @@ zh-hk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ zh-hk:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ zh-hk:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -11,7 +11,6 @@ zh-tw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ zh-tw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ zh-tw:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -11,7 +11,6 @@ zh-tw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ zh-tw:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ zh-tw:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -11,7 +11,6 @@ zh:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -25,7 +24,6 @@ zh:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        price:
         title:
         unique_reference:
         unnumbered_hoc_paper:
@@ -37,7 +35,6 @@ zh:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      price:
       title:
       unique_reference:
       unnumbered_hoc_paper:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -11,7 +11,6 @@ zh:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -26,7 +25,6 @@ zh:
         command_paper_number:
         hoc_paper_number:
         isbn:
-        order_url:
         price:
         title:
         unique_reference:
@@ -39,7 +37,6 @@ zh:
       command_paper_number:
       hoc_paper_number:
       isbn:
-      order_url:
       price:
       title:
       unique_reference:

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -61,43 +61,6 @@ class AttachmentTest < ActiveSupport::TestCase
     assert attachment.errors[:command_paper_number].include?(expected_message)
   end
 
-  test "should be valid if the price is nil" do
-    attachment = build(:file_attachment, price: nil)
-    assert attachment.valid?
-  end
-
-  test "should be valid if the price is blank" do
-    attachment = build(:file_attachment, price: "")
-    assert attachment.valid?
-  end
-
-  test "should not save a nil price as a zero price_in_pence" do
-    attachment = create(:file_attachment, price: nil)
-    attachment.reload
-    assert_nil attachment.price_in_pence
-  end
-
-  test "should not save a blank price as a zero price_in_pence" do
-    attachment = create(:file_attachment, price: "")
-    attachment.reload
-    assert_nil attachment.price_in_pence
-  end
-
-  test "should prefer the memoized price over price_in_pence" do
-    attachment = build(:file_attachment, price: "1.23", price_in_pence: 345)
-    assert_equal "1.23", attachment.price
-  end
-
-  test "should convert price_in_pence to price in pounds when a new price hasn't been set" do
-    attachment = build(:file_attachment, price_in_pence: 345)
-    assert_equal 3.45, attachment.price
-  end
-
-  test "should return nil if neither price nor price_in_pence are set" do
-    attachment = build(:file_attachment, price: nil, price_in_pence: nil)
-    assert_nil attachment.price
-  end
-
   test "should be valid without a unique_reference" do
     attachment = build(:file_attachment, unique_reference: nil)
     assert attachment.valid?

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -61,31 +61,6 @@ class AttachmentTest < ActiveSupport::TestCase
     assert attachment.errors[:command_paper_number].include?(expected_message)
   end
 
-  test "should be invalid with malformed order url" do
-    attachment = build(:file_attachment, order_url: "invalid-url")
-    assert_not attachment.valid?
-  end
-
-  test "should be valid with order url with HTTP protocol" do
-    attachment = build(:file_attachment, order_url: "http://example.com")
-    assert attachment.valid?
-  end
-
-  test "should be valid with order url with HTTPS protocol" do
-    attachment = build(:file_attachment, order_url: "https://example.com")
-    assert attachment.valid?
-  end
-
-  test "should be valid without order url" do
-    attachment = build(:file_attachment, order_url: nil)
-    assert attachment.valid?
-  end
-
-  test "should be valid with blank order url" do
-    attachment = build(:file_attachment, order_url: nil)
-    assert attachment.valid?
-  end
-
   test "should be valid if the price is nil" do
     attachment = build(:file_attachment, price: nil)
     assert attachment.valid?
@@ -94,50 +69,6 @@ class AttachmentTest < ActiveSupport::TestCase
   test "should be valid if the price is blank" do
     attachment = build(:file_attachment, price: "")
     assert attachment.valid?
-  end
-
-  test "should be valid if the price appears to be in whole pounds" do
-    attachment = build(:file_attachment, price: "9", order_url: "http://example.com")
-    assert attachment.valid?
-  end
-
-  test "should be valid if the price is in pounds and pence" do
-    attachment = build(:file_attachment, price: "1.23", order_url: "http://example.com")
-    assert attachment.valid?
-  end
-
-  test "should be invalid if the price is non numeric" do
-    attachment = build(:file_attachment, price: "free", order_url: "http://example.com")
-    assert_not attachment.valid?
-  end
-
-  test "should be invalid if the price is zero" do
-    attachment = build(:file_attachment, price: "0", order_url: "http://example.com")
-    assert_not attachment.valid?
-  end
-
-  test "should be invalid if the price is less than zero" do
-    attachment = build(:file_attachment, price: "-1.23", order_url: "http://example.com")
-    assert_not attachment.valid?
-  end
-
-  test "should be invalid if a price is entered without an order url" do
-    attachment = build(:file_attachment, price: "1.23")
-    assert_not attachment.valid?
-  end
-
-  test "should save the price as price_in_pence" do
-    attachment = create(:file_attachment, price: "1.23", order_url: "http://example.com")
-    attachment.reload
-    assert_equal 123, attachment.price_in_pence
-  end
-
-  test "should save the price as nil if an existing price_in_pence is being reset to blank" do
-    attachment = create(:file_attachment, price_in_pence: 999, order_url: "http://example.com")
-    attachment.price = ""
-    attachment.save!
-    attachment.reload
-    assert_nil attachment.price_in_pence
   end
 
   test "should not save a nil price as a zero price_in_pence" do


### PR DESCRIPTION
Trello - https://trello.com/c/MZ6js01b/1441-simplify-order-a-copy-implementation-in-whitehall

Removal of Price and Order URL from attachments

The order URL should be the same and the prices are often out of date. This PR removes the option for inputting a price or order URL and shows a link on official documents that lets users know how to purchase them. 

There will be a further PR to remove the fields and data from the database