### PR TITLE
Remove order url and price from attachments

### DIFF
--- a/db/migrate/20200304165045_remove_order_url_and_price_in_pence_from_attachments.rb
+++ b/db/migrate/20200304165045_remove_order_url_and_price_in_pence_from_attachments.rb
@@ -1,0 +1,6 @@
+class RemoveOrderUrlAndPriceInPenceFromAttachments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :attachments, :order_url, :string
+    remove_column :attachments, :price_in_pence, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211132528) do
+ActiveRecord::Schema.define(version: 20200304165045) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -59,8 +59,6 @@ ActiveRecord::Schema.define(version: 20200211132528) do
     t.string "isbn"
     t.string "unique_reference"
     t.string "command_paper_number"
-    t.string "order_url"
-    t.integer "price_in_pence"
     t.integer "attachment_data_id"
     t.integer "ordering", null: false
     t.string "hoc_paper_number"


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5418 removed order url and price from the frontend. This removes them from the database.

Trello - https://trello.com/c/MZ6js01b/1441-simplify-order-a-copy-implementation-in-whitehall

This has had a [DO NOT MERGE FLAG] for about a month. This was to give us time to talk to publishers and make them aware of the changes that we've made. No one has raised any issues so this is now being merged and the data removed. 