### PR TITLE
Exclude unmodifiable speeches from migration

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -48,6 +48,8 @@ namespace :data_hygiene do
     end
 
     old_role_app.speeches.each do |speech|
+      next if speech.unmodifiable?
+
       speech.role_appointment = new_role_app
       speech.save!
     end


### PR DESCRIPTION
Superseded (and some other) editions cannot have their role appointment modified, exclude these from the migration to allow the others to be migrated.
