### PR TITLE
Fix link for how to buy a print copy of official document

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -57,7 +57,7 @@
       <% end %>
     </p>
     <% if attachment.is_official_document? %>
-      <%= link_to t('attachment.headings.order_a_copy'), "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents",
+      <%= link_to t('attachment.headings.order_a_copy'), "#{Plek.new.website_root}/guidance/how-to-buy-printed-copies-of-official-documents",
             class: "order_url", title: t('attachment.headings.order_a_copy_full') %>
     <% end %>
 


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5418 introduced a new link but it was hardcoded to the production site. This uses plek to make it dependant on environment.