### PR TITLE
Use a more accurate timestamp for withdrawals

### DIFF
--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -6,8 +6,9 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
       .joins(:document)
       .where(documents: { content_id: content_id })
       .where(state: "withdrawn")
-      .pluck(:updated_at)
       .first
+      .unpublishing
+      .created_at
 
     Services.publishing_api.unpublish(
       content_id,

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -13,7 +13,7 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
         type: "withdrawal",
         locale: "en",
         explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
-        unpublished_at: publication.updated_at.utc.iso8601,
+        unpublished_at: publication.unpublishing.created_at.utc.iso8601,
       },
     )
 


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3929420

As with all things involving timestamps, there's probably an edge
case to this. If this goes in, we should republish all withdrawn
documents to ensure their timestamp/message reflects the new rule.
Since we were relying on the 'updated_at' time previously, it does
look like we don't support requests for custom withdrawal times,
which is what I was concerned about when writing this...

Previously we used the 'updated_at' time of a withdrawn edition to
represent the time it was withdrawn. We have an issue where a bulk
update to a bunch of withdrawn editions advanced the timestamp to
the time the update was performed, instead of preserving the time.

This fixes the issue by using the 'created_at' time of the actual
unpublishing object associated with the original withdrawal, noting
that we do not replace this original withdrawal when changing the
unpublishing explanation (it's edited in-place).

irb(main):002:0> Edition.find(1021159).unpublishing
=> #<Unpublishing id: 45163, edition_id: 1021159, unpublishing_reason_id: 5, explanation: "EU rules continue...

irb(main):003:0> Edition.find(1021159).unpublishing
=> #<Unpublishing id: 45163, edition_id: 1021159, unpublishing_reason_id: 5, explanation: "Ben test"...