### PR TITLE
Revert "Exclude unmodifiable speeches from migration"

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -48,8 +48,6 @@ namespace :data_hygiene do
     end
 
     old_role_app.speeches.each do |speech|
-      next if speech.unmodifiable?
-
       speech.role_appointment = new_role_app
       speech.save(validate: false)
     end


### PR DESCRIPTION
Unmodifiable speeches still need to be modified! Leaving them alone means the old role can't be removed, which is the whole point. The correct fix is to bypass the validations, which was done in https://github.com/alphagov/whitehall/pull/5425.

Reverts alphagov/whitehall#5421