### PR TITLE
Add task to republish all editions with at least one official attachment

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -188,6 +188,21 @@ namespace :publishing_api do
     puts "Finished queuing items for Publishing API"
   end
 
+  desc "Republish all documents with official attachments"
+  task republish_documents_with_official_attachments: :environment do
+    attachment_scope = Attachment.where("unnumbered_command_paper = true OR command_paper_number != '' OR unnumbered_hoc_paper = true OR hoc_paper_number != ''")
+    edition_ids = attachment_scope.where(attachable_type: "Edition").distinct.pluck(:attachable_id)
+    response_ids = attachment_scope.where(attachable_type: "Response").distinct.pluck(:attachable_id)
+    edition_ids += Response.where(id: response_ids).pluck(:edition_id)
+    document_ids = Document.joins(:editions).where("editions.id": edition_ids).pluck(:document_id).uniq
+
+    puts "# Sending #{document_ids.count} documents to Publishing API"
+
+    document_ids.each do |doc_id|
+      PublishingApiDocumentRepublishingWorker.perform_async(doc_id)
+    end
+  end
+
   desc "Republish a document to the Publishing API"
   task :republish_document, [:slug] => :environment do |_, args|
     document = Document.find_by!(slug: args[:slug])


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5418 removed order url and price from attachments. In order to see these changes the editions that they're attachments of need to be republished. This is a rake task to republish all of those editions. It will only need to be run once on each environment and then swiftly deleted.