### PR TITLE
Do not send featured attachments to the publishing-api

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -143,7 +143,7 @@ module PublishingApi
       end
 
       def featured_attachments
-        documents.map { |html| [{ content_type: "text/html", content: html }] }
+        []
       end
     end
 
@@ -208,7 +208,7 @@ module PublishingApi
       end
 
       def final_outcome_attachments
-        (final_outcome_documents || []).map { |html| [{ content_type: "text/html", content: html }] }
+        []
       end
     end
 
@@ -278,7 +278,7 @@ module PublishingApi
       end
 
       def attachments
-        (documents || []).map { |html| [{ content_type: "text/html", content: html }] }
+        []
       end
 
       def publication_date

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -102,7 +102,7 @@ module PublishingApi
     end
 
     def featured_attachments
-      documents.map { |html| [{ content_type: "text/html", content: html }] }
+      []
     end
 
     def attachments_for_current_locale

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -351,7 +351,7 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
 
       assert_details_attribute :public_feedback_documents, [attachments_double]
-      assert_details_attribute :public_feedback_attachments, [[{ content_type: "text/html", content: attachments_double }]]
+      assert_details_attribute :public_feedback_attachments, []
     end
 
     test "public feedback publication date" do
@@ -418,7 +418,7 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :final_outcome_documents, [attachments_double]
-      assert_details_attribute :final_outcome_attachments, [[{ content_type: "text/html", content: attachments_double }]]
+      assert_details_attribute :final_outcome_attachments, []
     end
 
     test "validity" do
@@ -462,7 +462,7 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :documents, [attachments_double]
-      assert_details_attribute :featured_attachments, [[{ content_type: "text/html", content: attachments_double }]]
+      assert_details_attribute :featured_attachments, []
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -54,9 +54,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         attachments: [
           { attachment_type: "html", id: publication.attachments.first.slug, title: publication.attachments.first.title, url: publication.attachments.first.url, unnumbered_command_paper: false, unnumbered_hoc_paper: false },
         ],
-        featured_attachments: [
-          [{ content_type: "text/html", content: "<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"#{publication.attachments.first.url}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"#{publication.attachments.first.url}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>" }],
-        ],
+        featured_attachments: [],
       },
     }
 


### PR DESCRIPTION
We're changing this field to a list of attachment references
instead.