### PR TITLE
Remove government from the political details presenter

### DIFF
--- a/app/presenters/publishing_api/payload_builder/political_details.rb
+++ b/app/presenters/publishing_api/payload_builder/political_details.rb
@@ -14,20 +14,6 @@ module PublishingApi
       def call
         {
           political: item.political?,
-          government: government,
-        }
-      end
-
-    private
-
-      def government
-        gov = item.government
-        return nil unless gov
-
-        {
-          title: gov.name,
-          slug: gov.slug,
-          current: gov.current?,
         }
       end
     end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -58,11 +58,6 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
           topics: [],
         },
         political: false,
-        government: {
-          title: government.name,
-          slug: government.slug,
-          current: government.current?,
-        },
         related_mainstream_content: [],
         emphasised_organisations: detailed_guide.lead_organisations.map(&:content_id),
         brexit_no_deal_notice: [],
@@ -76,6 +71,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       policy_areas: detailed_guide.topics.map(&:content_id),
       related_guides: [],
       related_mainstream_content: [],
+      government: [government.content_id],
     }
     presented_item = present(detailed_guide)
 
@@ -158,13 +154,8 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     presented_item = present(detailed_guide)
     details = presented_item.content[:details]
 
-    expected_government = {
-      title: government.name,
-      slug: government.slug,
-      current: government.current?,
-    }
     assert_equal details[:political], true
-    assert_equal details[:government], expected_government
+    assert_equal presented_item.links[:government][0], government.content_id
   end
 
   test "DetailedGuide presents related_guides correctly" do

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -359,7 +359,7 @@ class PublishingApi::DocumentCollectionPresenterCurrentGovernmentTest < ActiveSu
   setup do
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
-    create(
+    @current_government = create(
       :current_government,
       name: "The Current Government",
       slug: "the-current-government",
@@ -371,12 +371,8 @@ class PublishingApi::DocumentCollectionPresenterCurrentGovernmentTest < ActiveSu
 
   test "presents a current government" do
     assert_equal(
-      {
-        "title": "The Current Government",
-        "slug": "the-current-government",
-        "current": true,
-      },
-      @presented_document_collection.content[:details][:government],
+      @current_government.content_id,
+      @presented_document_collection.links.dig(:government, 0),
     )
   end
 end
@@ -386,7 +382,7 @@ class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveS
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
     create(:current_government)
-    previous_government = create(
+    @previous_government = create(
       :previous_government,
       name: "A Previous Government",
       slug: "a-previous-government",
@@ -394,19 +390,15 @@ class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveS
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
       create(
         :document_collection,
-        first_published_at: previous_government.start_date + 1.day,
+        first_published_at: @previous_government.start_date + 1.day,
       ),
     )
   end
 
   test "presents a previous government" do
     assert_equal(
-      {
-        "title": "A Previous Government",
-        "slug": "a-previous-government",
-        "current": false,
-      },
-      @presented_document_collection.content[:details][:government],
+      @previous_government.content_id,
+      @presented_document_collection.links.dig(:government, 0),
     )
   end
 end

--- a/test/unit/presenters/publishing_api/payload_builder/political_details_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/political_details_test.rb
@@ -4,18 +4,11 @@ module PublishingApi
   module PayloadBuilder
     class PoliticalDetailsTest < ActiveSupport::TestCase
       test "returns political details for the item" do
-        government = create(:government, name: "Foo")
         stubbed_item = stub(
           political?: true,
-          government: government,
         )
         expected_hash = {
           political: true,
-          government: {
-            title: "Foo",
-            slug: government.slug,
-            current: true,
-          },
         }
 
         assert_equal PoliticalDetails.for(stubbed_item), expected_hash

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -6,7 +6,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
   end
 
   test "publication presentation includes the correct values" do
-    government = create(:government)
+    create(:government)
     statistical_data_set = create(:published_statistical_data_set)
     publication = create(:published_publication,
                          title: "Publication title",
@@ -45,11 +45,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         ],
         emphasised_organisations: publication.lead_organisations.map(&:content_id),
         political: false,
-        government: {
-          title: government.name,
-          slug: government.slug,
-          current: government.current?,
-        },
         brexit_no_deal_notice: [],
         attachments: [
           { attachment_type: "html", id: publication.attachments.first.slug, title: publication.attachments.first.title, url: publication.attachments.first.url, unnumbered_command_paper: false, unnumbered_hoc_paper: false },

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -9,7 +9,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
     end
 
     setup do
-      create(:government, name: "The Government", slug: "the-government")
+      @current_government = create(:government, name: "The Government", slug: "the-government")
     end
 
     let(:minister) { create(:ministerial_role) }
@@ -70,10 +70,6 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_match(iso8601_regex,     details[:delivered_on])
         assert_equal("Transcript of the speech, exactly as it was delivered", details[:speech_type_explanation])
 
-        assert_equal("The Government",  details[:government][:title])
-        assert_equal("the-government",  details[:government][:slug])
-        assert_equal(true,              details[:government][:current])
-
         assert_equal("Tony",             details[:image][:alt_text])
         assert_match(/960x640_gif.gif$/, details[:image][:url])
       end
@@ -108,6 +104,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_includes(presented.links.keys, :people)
         assert_includes(presented.links.keys, :roles)
         assert_includes(presented.links.keys, :world_locations)
+        assert_includes(presented.links.keys, :government)
 
         assert_includes(presented.links[:organisations], speech.organisations.first.content_id)
         assert_includes(presented.links[:speaker], person.content_id)
@@ -115,6 +112,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_includes(presented.links[:roles], speech.role_appointment.role.content_id)
         assert_includes(presented.links[:people], person.content_id)
         assert_includes(presented.links[:world_locations], world_location.content_id)
+        assert_includes(presented.links[:government], @current_government.content_id)
       end
 
       context "no role appointment (no speaker)" do

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -203,7 +203,7 @@ class PublishingApi::StatisticalDataSetPresenterCurrentGovernmentTest < ActiveSu
   setup do
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
-    create(
+    @current_government = create(
       :current_government,
       name: "The Current Government",
       slug: "the-current-government",
@@ -215,12 +215,8 @@ class PublishingApi::StatisticalDataSetPresenterCurrentGovernmentTest < ActiveSu
 
   test "presents a current government" do
     assert_equal(
-      {
-        "title": "The Current Government",
-        "slug": "the-current-government",
-        "current": true,
-      },
-      @presented_statistical_data_set.content[:details][:government],
+      @current_government.content_id,
+      @presented_statistical_data_set.links.dig(:government, 0),
     )
   end
 end
@@ -230,7 +226,7 @@ class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveS
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
     create(:current_government)
-    previous_government = create(
+    @previous_government = create(
       :previous_government,
       name: "A Previous Government",
       slug: "a-previous-government",
@@ -238,19 +234,15 @@ class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveS
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
       create(
         :statistical_data_set,
-        first_published_at: previous_government.start_date + 1.day,
+        first_published_at: @previous_government.start_date + 1.day,
       ),
     )
   end
 
   test "presents a previous government" do
     assert_equal(
-      {
-        "title": "A Previous Government",
-        "slug": "a-previous-government",
-        "current": false,
-      },
-      @presented_statistical_data_set.content[:details][:government],
+      @previous_government.content_id,
+      @presented_statistical_data_set.links.dig(:government, 0),
     )
   end
 end

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -195,7 +195,7 @@ class PublishingApi::WorldLocationNewsArticlePresenterCurrentGovernmentTest < Ac
   setup do
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
-    create(
+    @current_government = create(
       :current_government,
       name: "The Current Government",
       slug: "the-current-government",
@@ -207,12 +207,8 @@ class PublishingApi::WorldLocationNewsArticlePresenterCurrentGovernmentTest < Ac
 
   test "presents a current government" do
     assert_equal(
-      {
-        "title": "The Current Government",
-        "slug": "the-current-government",
-        "current": true,
-      },
-      @presented_world_location_news_article.content[:details][:government],
+      @current_government.content_id,
+      @presented_world_location_news_article.links.dig(:government, 0),
     )
   end
 end
@@ -222,7 +218,7 @@ class PublishingApi::WorldLocationNewsArticlePresenterPreviousGovernmentTest < A
     # Goverments are not explicitly associated with an Edition.
     # The Government is determined based on date of publication.
     create(:current_government)
-    previous_government = create(
+    @previous_government = create(
       :previous_government,
       name: "A Previous Government",
       slug: "a-previous-government",
@@ -230,19 +226,15 @@ class PublishingApi::WorldLocationNewsArticlePresenterPreviousGovernmentTest < A
     @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
       create(
         :world_location_news_article,
-        first_published_at: previous_government.start_date + 1.day,
+        first_published_at: @previous_government.start_date + 1.day,
       ),
     )
   end
 
   test "presents a previous government" do
     assert_equal(
-      {
-        "title": "A Previous Government",
-        "slug": "a-previous-government",
-        "current": false,
-      },
-      @presented_world_location_news_article.content[:details][:government],
+      @previous_government.content_id,
+      @presented_world_location_news_article.links.dig(:government, 0),
     )
   end
 end


### PR DESCRIPTION
The association between content and a government is now handled
through links in the Publishing API. This makes it easier to handle
transitions between governments, as the Publishing API will take care
of updating content where the details of the government has
changed (it's no longer current for example).

To avoid having the problem of updating the details of a document when
the government changes for new content in the future, stop sending
information about the government in the details for the content.