### PR TITLE
Send attachment IDs in featured attachments list

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -143,7 +143,7 @@ module PublishingApi
       end
 
       def featured_attachments
-        []
+        consultation.attachments.map { |a| a.publishing_api_details[:id] }
       end
     end
 
@@ -208,7 +208,7 @@ module PublishingApi
       end
 
       def final_outcome_attachments
-        []
+        outcome.attachments.map { |a| a.publishing_api_details[:id] }
       end
     end
 
@@ -278,7 +278,7 @@ module PublishingApi
       end
 
       def attachments
-        []
+        public_feedback.attachments.map { |a| a.publishing_api_details[:id] }
       end
 
       def publication_date

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -102,7 +102,7 @@ module PublishingApi
     end
 
     def featured_attachments
-      []
+      attachments_for_current_locale.map { |a| a.publishing_api_details[:id] }
     end
 
     def attachments_for_current_locale

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -351,7 +351,8 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
 
       assert_details_attribute :public_feedback_documents, [attachments_double]
-      assert_details_attribute :public_feedback_attachments, []
+      assert_details_attribute :public_feedback_attachments,
+                               (consultation.public_feedback.attachments.map { |a| a.publishing_api_details[:id] })
     end
 
     test "public feedback publication date" do
@@ -418,7 +419,8 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :final_outcome_documents, [attachments_double]
-      assert_details_attribute :final_outcome_attachments, []
+      assert_details_attribute :final_outcome_attachments,
+                               (consultation.outcome.attachments.map { |a| a.publishing_api_details[:id] })
     end
 
     test "validity" do
@@ -462,7 +464,8 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :documents, [attachments_double]
-      assert_details_attribute :featured_attachments, []
+      assert_details_attribute :featured_attachments,
+                               (consultation.attachments.map { |a| a.publishing_api_details[:id] })
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -54,7 +54,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         attachments: [
           { attachment_type: "html", id: publication.attachments.first.slug, title: publication.attachments.first.title, url: publication.attachments.first.url, unnumbered_command_paper: false, unnumbered_hoc_paper: false },
         ],
-        featured_attachments: [],
+        featured_attachments: (publication.attachments.map { |a| a.publishing_api_details[:id] }),
       },
     }
 


### PR DESCRIPTION
Frontend apps will render these by looking up the ID in the
attachments list and chucking the metadata into a component.

This change looks a bit strange, because all the attachments IDs get
included, so a reasonable question is "what's the point? why not just
render 'attachments' as featured attachments if it's a publication or
consultation?"

This was addressed in the RFC but, in summary, there's no reason why a
format or document couldn't have both featured and non-featured
attachments, and there's no guarantee that the current situation will
remain the case.  So by adopting this approach, we don't need to
change things in the future.  You could say "YAGNI", but it's not like
it adds a lot of complication.

---

This is safe to deploy because [government-frontend isn't rendering this field at the moment](https://github.com/alphagov/government-frontend/pull/1676).

[Trello card](https://trello.com/c/TJfKNCSn/1430-do-featuredattachments-metadata-properly)