### PR TITLE
Fix government feed route type

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -21,6 +21,7 @@ namespace :publishing_api do
         title: "Government feed",
         description: "This route serves the feed of published content",
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+        type: "exact",
       },
       {
         base_path: "/courts-tribunals",


### PR DESCRIPTION
This should be an exact route. When requests are made for sub-resources of this route, it results in a 500 from the taxons controller in Collections.

Running this rake task updates the existing routes and fixes the problem. I thought that I might have to write a migration somewhere, but it seems not.

The `/courts-tribunals` route looks like it might also be ripe for an exact route now, because the individual pages are rendered by collections. I'm not feeling super-confident about it right now (without more investigation), and it doesn't seem to be causing any problems, so I'll ignore it for now.

Resolves https://sentry.io/organizations/govuk/issues/1425303152/?project=202213&query=is%3Aunresolved