### PR TITLE
Change Print ISBN to ISBN

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -4,7 +4,7 @@
   <%= form.select :locale, options_for_locales(attachable.translated_locales), include_blank: 'All languages' %>
 <% end %>
 
-<%= form.text_field :isbn, label_text: "Print ISBN" %>
+<%= form.text_field :isbn, label_text: "ISBN" %>
 
 <%= form.text_field :unique_reference %>
 <div class="paper-number">

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -92,7 +92,7 @@ end
 When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)"$/) do |title, isbn|
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
-  fill_in "Print ISBN", with: isbn
+  fill_in "ISBN", with: isbn
   fill_in "Body", with: "Body"
   check "Manually numbered headings"
   click_on "Save"


### PR DESCRIPTION
When we removed web ISBN from Whitehall we were left with print ISBN. We should call this ISBN instead because there is only one ISBN regardless of whether the format is print or web and we might confuse people by calling it print ISBN.

Trello: https://trello.com/c/3kmhSdNO/1555-change-print-isbn-to-isbn-in-whitehall