### PR TITLE
Include hostname in CSV preview link

### DIFF
--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -22,7 +22,7 @@
 
     <%- end -%>
     <div class="return">
-      <p><%= link_to "See more information about #{with_this_determiner(@edition.display_type.downcase)}", public_document_path(@edition) %></p>
+      <p><%= link_to "See more information about #{with_this_determiner(@edition.display_type.downcase)}", public_document_url(@edition) %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The CSV preview page can be accessed on gov.uk, but also on assets.publishing.service.gov.uk. In the latter case, these links don't work because they are on gov.uk and not assets.publishing.service.gov.uk.