### PR TITLE
Conditionally present publication attachment metadata

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -88,23 +88,30 @@ class Attachment < ApplicationRecord
   end
 
   def publishing_api_details
-    {
-      # fields in common across "file_attachment_asset",
-      # "html_attachment_asset", "external_attachment_asset"
+    # fields in common across "file_attachment_asset",
+    # "html_attachment_asset", "external_attachment_asset" schemas
+    attachment_fields = {
       attachment_type: readable_type.downcase,
       id: publishing_api_attachment_id || id.to_s,
       locale: locale,
       title: title,
       url: url,
-      # "publication_attachment_asset" fields
-      command_paper_number: command_paper_number,
-      hoc_paper_number: hoc_paper_number,
-      isbn: isbn,
-      parliamentary_session: nil,
-      unique_reference: unique_reference,
-      unnumbered_command_paper: unnumbered_command_paper?,
-      unnumbered_hoc_paper: unnumbered_hoc_paper?,
-    }.merge(publishing_api_details_for_format).compact
+    }
+
+    if attachable.allows_attachment_references?
+      # fields just for "publication_attachment_asset" schema
+      attachment_fields.merge!(
+        command_paper_number: command_paper_number,
+        hoc_paper_number: hoc_paper_number,
+        isbn: isbn,
+        parliamentary_session: nil,
+        unique_reference: unique_reference,
+        unnumbered_command_paper: unnumbered_command_paper?,
+        unnumbered_hoc_paper: unnumbered_hoc_paper?,
+      )
+    end
+
+    attachment_fields.merge(publishing_api_details_for_format).compact
   end
 
   def publishing_api_details_for_format

--- a/test/unit/models/attachment_test.rb
+++ b/test/unit/models/attachment_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class AttachemntTest < ActiveSupport::TestCase
+  test ".publishing_api_details has file_attachment_asset attributes" do
+    attachment = build(:file_attachment, attachable: build(:news_article))
+
+    output = attachment.publishing_api_details
+    assert_equal output.keys,
+                 %i[attachment_type id title url accessible alternative_format_contact_email filename]
+  end
+
+  test ".publishing_api_details includes publication attachment details for " \
+       "attachables that allow references" do
+    attachment = build(:file_attachment, attachable: build(:publication))
+
+    output = attachment.publishing_api_details
+    assert_not_empty output.keys & %i[unnumbered_command_paper unnumbered_hoc_paper]
+  end
+end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -411,4 +411,21 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_valid_against_schema presented_content, "corporate_information_page"
     end
   end
+
+  class CorporateInformationPageWithAttachments < TestCase
+    setup do
+      self.corporate_information_page = create(:corporate_information_page,
+                                               attachments: [create(:file_attachment)])
+    end
+
+    test "attachment" do
+      attachment = corporate_information_page.attachments.first
+      assert_equal presented_content.dig(:details, :attachments, 0, :id),
+                   attachment.publishing_api_attachment_id
+    end
+
+    test "validity" do
+      assert_valid_against_schema presented_content, "corporate_information_page"
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -232,4 +232,13 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     presented_item = present(detailed_guide)
     assert_equal "http://www.example.com/foo.jpg", presented_item.content[:details][:image][:url]
   end
+
+  test "DetailedGuide presents attachments" do
+    detailed_guide = create(:published_detailed_guide, :with_file_attachment)
+
+    presented_item = present(detailed_guide)
+    assert_valid_against_schema(presented_item.content, "detailed_guide")
+    assert_equal presented_item.content.dig(:details, :attachments, 0, :id),
+                 detailed_guide.attachments.first.publishing_api_attachment_id
+  end
 end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -380,4 +380,19 @@ module PublishingApi::NewsArticlePresenterTest
       assert_equal "major", presented_news_article.update_type
     end
   end
+
+  class NewsArticleWithAttachments < TestCase
+    setup do
+      self.news_article = create(:news_article, :with_file_attachment)
+    end
+
+    test "attachment" do
+      assert_equal presented_content.dig(:details, :attachments, 0, :id),
+                   news_article.attachments.first.publishing_api_attachment_id
+    end
+
+    test "validity" do
+      assert_valid_against_schema presented_content, "news_article"
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -186,6 +186,23 @@ class PublishingApi::StatisticalDataSetPresenterMinorUpdateTypeTest < ActiveSupp
   end
 end
 
+class PublishingApi::StatisticalDataSetPresenterAttachmentTest < ActiveSupport::TestCase
+  setup do
+    @statistical_data_set = create(:statistical_data_set, :with_file_attachment)
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
+  end
+
+  test "it presentes attachments" do
+    attachment = @statistical_data_set.attachments.first
+    assert_equal @presented_statistical_data_set.content.dig(:details, :attachments, 0, :id),
+                 attachment.publishing_api_attachment_id
+  end
+
+  test "its attachments are valid against the schema" do
+    assert_valid_against_schema @presented_statistical_data_set.content, "statistical_data_set"
+  end
+end
+
 class PublishingApi::StatisticalDataSetPresenterUpdateTypeArgumentTest < ActiveSupport::TestCase
   setup do
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -314,3 +314,21 @@ class PublishingApi::WorldLocationNewsArticlePlaceholderImageTest < ActiveSuppor
     assert_equal expected_placeholder_image, @presented_wlna.content[:details][:image]
   end
 end
+
+class PublishingApi::WorldLocationNewsArticlePresenterAttachmentTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+    @attachment = create(:file_attachment)
+    @wlna = create(:world_location_news_article, attachments: [@attachment])
+    @presented_wlna = PublishingApi::WorldLocationNewsArticlePresenter.new(@wlna)
+  end
+
+  test "it presentes attachments" do
+    assert_equal @presented_wlna.content.dig(:details, :attachments, 0, :id),
+                 @attachment.publishing_api_attachment_id
+  end
+
+  test "its attachments are valid against the schema" do
+    assert_valid_against_schema @presented_wlna.content, "world_location_news_article"
+  end
+end


### PR DESCRIPTION
The tests that are failing here will pass once https://github.com/alphagov/whitehall/pull/5432 is merged

Previously formats such as news were presenting metadata to the Publishing API that did not apply to their attachment type, notably command paper numbers and act paper numbers. This data can only be added on specific formats (Consultations, Publications and Statistical Data
Sets) and this can be determined by the `allows_attachment_references?` method on classes used as Attachable objects.

Making this change removes the somewhat misleading data we are showing for attachments on non-publication types such as: https://www.gov.uk/api/content/government/news/department-seeks-chair-of-the-british-pharmacopoeia-commission

Where we have:

```
{
  "attachment_type": "file",
  "id": "FINAL_Info_pack.pdf",
  "title": "information pack for applicants ",
  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/138213/FINAL_Info_pack.pdf",
  "unnumbered_command_paper": false,
  "unnumbered_hoc_paper": false,
  "accessible": false,
  "alternative_format_contact_email": "govuk-feedback@digital.cabinet-office.gov.uk",
  "content_type": "application/pdf",
  "file_size": 92549,
  "filename": "FINAL_Info_pack.pdf",
  "number_of_pages": 13
},
```
despite it not being possible that this a command paper or house of commons paper

This was rather painful to test as there weren't any unit tests for the existing changes and there were many different styles of tests in the various presenters. I've now included schema tests against presenters with attachments where applicable so that any further changes to schemas
can be caught by these.