### PR TITLE
Fix focus states on topical events page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_topical-events.scss
+++ b/app/assets/stylesheets/frontend/views/_topical-events.scss
@@ -53,6 +53,10 @@
         float: left;
         padding: 0 $gutter-half $gutter-half;
         min-height: 90px;
+
+        .organisation-logo:focus {
+          padding-bottom: govuk-spacing(1);
+        }
       }
 
       .non-govuk {

--- a/app/views/classifications/_classification_featuring.html.erb
+++ b/app/views/classifications/_classification_featuring.html.erb
@@ -1,10 +1,15 @@
 <%= content_tag_for(:article, classification_featuring, nil, class: "feature item-#{classification_featuring_counter}") do %>
+
+  <%
+    link_attributes ||= { class: 'govuk-link' }
+    link_attributes[:rel] = "external" if is_external?(classification_featuring.url)
+  %>
   <div class="content">
     <span class="image-holder">
-      <%= link_to classification_featuring.image_tag(:s465), classification_featuring.url, title: t("document.read", title: classification_featuring.title), class: 'img'%>
+      <%= link_to classification_featuring.image_tag(:s465), classification_featuring.url, title: t("document.read", title: classification_featuring.title), class: "img", aria: { hidden: true } %>
     </span>
     <div class="text">
-      <h2><%= link_to classification_featuring.title, classification_featuring.url, ({rel: 'external'} if is_external?(classification_featuring.url)) %></h2>
+      <h2><%= link_to classification_featuring.title, classification_featuring.url, link_attributes %></h2>
       <% unless classification_featuring.summary.blank? %>
         <p class="summary"><%= truncate(classification_featuring.summary, length: 160, separator: ' ') %></p>
       <% end %>

--- a/app/views/classifications/_classification_featuring.html.erb
+++ b/app/views/classifications/_classification_featuring.html.erb
@@ -6,7 +6,7 @@
   %>
   <div class="content">
     <span class="image-holder">
-      <%= link_to classification_featuring.image_tag(:s465), classification_featuring.url, title: t("document.read", title: classification_featuring.title), class: "img", aria: { hidden: true } %>
+      <%= link_to classification_featuring.image_tag(:s465), classification_featuring.url, title: t("document.read", title: classification_featuring.title), class: "img", aria: { hidden: true }, tabindex: "-1" %>
     </span>
     <div class="text">
       <h2><%= link_to classification_featuring.title, classification_featuring.url, link_attributes %></h2>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -39,7 +39,7 @@
           <%= govspeak_to_html @topical_event.description %>
           <% if @topical_event.about_page.present? %>
             <p class="read-more">
-              <%= link_to @topical_event.about_page.read_more_link_text, topical_event_about_pages_path(@topical_event) %>
+              <%= link_to @topical_event.about_page.read_more_link_text, topical_event_about_pages_path(@topical_event), class: "govuk-link" %>
             </p>
           <% end %>
           <% if @topical_event.social_media_accounts.any? %>
@@ -81,7 +81,7 @@
             <ol class="document-list">
               <% @detailed_guides.each do |detailed_guide| %>
                 <%= content_tag_for :li, detailed_guide, class: 'document-row' do %>
-                  <h2><%= link_to detailed_guide.title, public_document_path(detailed_guide) %></h2>
+                  <h2><%= link_to detailed_guide.title, public_document_path(detailed_guide), class: "govuk-link" %></h2>
                 <% end %>
               <% end %>
             </ol>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -104,7 +104,7 @@
               <% @topical_event.lead_organisations.each do |organisation| %>
                 <%= content_tag_for(:li, organisation, class: organisation_brand_colour_class(organisation)) do %>
                   <%= link_to organisation_path(organisation),
-                        class: logo_classes(organisation: organisation, stacked: true) do %>
+                        class: "#{logo_classes(organisation: organisation, stacked: true)} govuk-link" do %>
                     <span><%= organisation_logo_name(organisation) %></span>
                   <% end %>
                 <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -246,6 +246,36 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "49784789be767f198bf46b4533fc569d006cd147a753d401c97ef3e381a14cf3",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/classifications/_classification_featuring.html.erb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.image_tag(:s465), (Unresolved Model).new.url, :title => t(\"document.read\", :title => (Unresolved Model).new.title), :class => \"img\", :aria => ({ :hidden => true }), :tabindex => \"-1\")",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "topical_events/show",
+          "line": 58,
+          "file": "app/views/topical_events/show.html.erb",
+          "rendered": {
+            "name": "classifications/_classification_featuring",
+            "file": "app/views/classifications/_classification_featuring.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "classifications/_classification_featuring"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "Abstraction is unchanged. This warning was only caught when additional params for HTML were added to the link_to tag."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "4ab694e969b0cd5569812723ed4985088c9a4e2a8e241316bb97c26325cab992",
       "check_name": "CrossSiteScripting",
@@ -719,6 +749,6 @@
       "note": "This comes from a new model so we trust the data."
     }
   ],
-  "updated": "2020-03-13 15:24:32 +0000",
+  "updated": "2020-03-16 18:18:34 +0000",
   "brakeman_version": "4.8.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,36 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "063ee511c443d2e68ca12804d175ea6feaa8fccce2ba71bc5f0f022943ae9d9f",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/classifications/_classification_featuring.html.erb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.image_tag(:s465), (Unresolved Model).new.url, :title => t(\"document.read\", :title => (Unresolved Model).new.title), :class => \"img\", :aria => ({ :hidden => true }))",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "topical_events/show",
+          "line": 58,
+          "file": "app/views/topical_events/show.html.erb",
+          "rendered": {
+            "name": "classifications/_classification_featuring",
+            "file": "app/views/classifications/_classification_featuring.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "classifications/_classification_featuring"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "Abstraction is unchanged. This warning was only caught when additional params for HTML were added to the link_to tag."
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "0b14d4ff3460aca1ffc72f3408993c9a20264f454f291c3cbd92e1f9ff7239bc",
@@ -15,7 +45,7 @@
           "type": "controller",
           "class": "Admin::OrganisationsController",
           "method": "features",
-          "line": 57,
+          "line": 59,
           "file": "app/controllers/admin/organisations_controller.rb",
           "rendered": {
             "name": "admin/organisations/features",
@@ -147,7 +177,7 @@
           "type": "controller",
           "class": "Admin::EditionsController",
           "method": "show",
-          "line": 87,
+          "line": 82,
           "file": "app/controllers/admin/editions_controller.rb",
           "rendered": {
             "name": "admin/editions/show",
@@ -180,7 +210,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 26,
+      "line": 28,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).world_locations.map do\n link_to(l.name, l, :class => \"govuk-link\")\n end.to_sentence",
       "render_path": [
@@ -378,6 +408,36 @@
       "note": "We check that the params[:id] is valid before rendering the template."
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "7be1721c2118dede65d77aabdab49a1e048e7c7110f9a69821edb3306b657417",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/classifications/_classification_featuring.html.erb",
+      "line": 12,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.title, (Unresolved Model).new.url, :class => \"govuk-link\", :rel => \"external\")",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "topical_events/show",
+          "line": 58,
+          "file": "app/views/topical_events/show.html.erb",
+          "rendered": {
+            "name": "classifications/_classification_featuring",
+            "file": "app/views/classifications/_classification_featuring.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "classifications/_classification_featuring"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "Abstraction is unchanged. This warning was only caught when additional params for HTML were added to the link_to tag."
+    },
+    {
       "warning_type": "Remote Code Execution",
       "warning_code": 110,
       "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
@@ -408,7 +468,7 @@
           "type": "controller",
           "class": "Admin::WorldLocationsController",
           "method": "features",
-          "line": 29,
+          "line": 28,
           "file": "app/controllers/admin/world_locations_controller.rb",
           "rendered": {
             "name": "admin/world_locations/features",
@@ -451,7 +511,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 29,
+      "line": 31,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.has_key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).sponsoring_organisations.map do\n link_to(o.name, o, :class => \"sponsoring-organisation govuk-link\")\n end.to_sentence",
       "render_path": [
@@ -635,7 +695,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/classifications/_classification_featuring.html.erb",
-      "line": 4,
+      "line": 9,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Unresolved Model).new.image_tag(:s465), (Unresolved Model).new.url, :title => t(\"document.read\", :title => (Unresolved Model).new.title), :class => \"img\")",
       "render_path": [
@@ -659,6 +719,6 @@
       "note": "This comes from a new model so we trust the data."
     }
   ],
-  "updated": "2019-11-05 09:14:39 +0000",
-  "brakeman_version": "4.7.0"
+  "updated": "2020-03-13 15:24:32 +0000",
+  "brakeman_version": "4.8.0"
 }


### PR DESCRIPTION
Focus states on some parts of the Topical Event template were not using the correct focus state colours. This PR fixes the issue by applying the correct class to links.

This PR also adds one ignore rule to Brakeman, as one of the partials was triggering a false positive when the css class was added.

## Before
![Screenshot at Mar 13 2-34-15 pm](https://user-images.githubusercontent.com/424772/76630671-5234fe00-6538-11ea-9d2c-77edccf5240b.png)
![Screenshot at Mar 13 2-35-59 pm](https://user-images.githubusercontent.com/424772/76630680-56f9b200-6538-11ea-8e1a-eff68a88e05c.png)
![image](https://user-images.githubusercontent.com/1732331/76763589-51e07100-678b-11ea-9aa6-ff9ed6182893.png)

## After
![Screenshot at Mar 13 2-34-55 pm](https://user-images.githubusercontent.com/424772/76630705-60831a00-6538-11ea-97b0-acbf8f1bd75b.png)
![Screenshot at Mar 13 2-36-15 pm](https://user-images.githubusercontent.com/424772/76630715-6416a100-6538-11ea-9960-6fe0889ce932.png)
![Screenshot at Mar 17 12-44-17 pm](https://user-images.githubusercontent.com/424772/76857317-1b6b2a80-684d-11ea-9638-6d82b1a0d366.png)

