### PR TITLE
Export alternative_path instead of alternative_url

### DIFF
--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -148,19 +148,23 @@ private
   def present_unpublishing(edition)
     return unless edition.unpublishing
 
+    unpublishing_data = {
+      unpublishing_reason: edition.unpublishing.unpublishing_reason.name,
+      alternative_path: edition.unpublishing.alternative_path,
+    }
+
     edition
       .unpublishing
       .as_json(
         only: %i[
           id
           explanation
-          alternative_url
           redirect
           created_at
           updated_at
         ],
       )
-      .merge(unpublishing_reason: edition.unpublishing.unpublishing_reason.name)
+      .merge(unpublishing_data)
   end
 
   def present_user(user)

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -400,7 +400,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     expected = {
       id: edition.unpublishing.id,
       explanation: edition.unpublishing.explanation,
-      alternative_url: nil,
+      alternative_path: nil,
       created_at: edition.unpublishing.created_at,
       updated_at: edition.unpublishing.updated_at,
       redirect: false,
@@ -418,7 +418,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
     expected = {
       id: edition.unpublishing.id,
       explanation: edition.unpublishing.explanation,
-      alternative_url: edition.unpublishing.alternative_url,
+      alternative_path: edition.unpublishing.alternative_path,
       created_at: edition.unpublishing.created_at,
       updated_at: edition.unpublishing.updated_at,
       redirect: true,


### PR DESCRIPTION
When checking an imported unpublishing alternative URL against the alternative
path present in Publishing API, we have found that Whitehall sends the path,
not the URL, to Publishing API. As such, the check was failing. This changes
the Document Export Presenter to send the unpublishing alternative path instead
so that these conflicts can be avoided.