### PR TITLE
Reschedule consultations in Rake task

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -60,6 +60,10 @@ class Consultation < Publicationesque
   # closes. We need to republish the consultation at these times to ensure
   # changes are reflected in any external systems.
   after_save do
+    schedule_republishing_workers
+  end
+
+  def schedule_republishing_workers
     if opening_at.try(:future?)
       PublishingApiDocumentRepublishingWorker
         .perform_at(opening_at, document.id)

--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -80,6 +80,11 @@ namespace :publishing do
         print "."
       end
       puts ""
+
+      # Consultations work slightly different to scheduled editions
+      puts "Queuing consultation jobs"
+      Consultation.open.or(Consultation.upcoming)
+        .find_each(&:schedule_republishing_workers)
     end
 
     desc "Finds editions that were meant to be published between 23:00 yesterday and 01:00 today - helps debug failed publications owing to British Summer Time"


### PR DESCRIPTION
We use this Rake task after a database restore to reschedule all editions, but it doesn't include consultations because they work slightly differently.

This came up after the migration to AWS as scheduled jobs related to consultations were lost.

We could do more here around consultations but it doesn't feel worth it as we're unlikely to be doing any large-scale migrations in the future.

[Trello Card](https://trello.com/c/d343C0m7/1817-5-consultations-arent-automatically-closing-on-govuk)