### PR TITLE
Allow linking to documents that will be published

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -100,6 +100,15 @@ class Document < ApplicationRecord
     )
   end
 
+  # this is to support linking to documents which haven't get been published,
+  # but will be published within 5 seconds
+  def published_very_soon?
+    Edition
+      .scheduled
+      .where("scheduled_publication <= ?", 5.seconds.from_now)
+      .exists?(document_id: id)
+  end
+
   def first_published_date
     published_edition.first_public_at if published?
   end

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -12,7 +12,7 @@ module Edition::Identifiable
   delegate :slug, :change_history, :content_id, to: :document
 
   def linkable?
-    document.published?
+    document.published? || document.published_very_soon?
   end
 
   def ensure_presence_of_document

--- a/test/unit/edition/identifiable_test.rb
+++ b/test/unit/edition/identifiable_test.rb
@@ -91,6 +91,14 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
     assert publication.linkable?
   end
 
+  test "should be linkable if scheduled to be published within 5 seconds" do
+    date = Date.new(2010, 1, 1, 9)
+    publication = create(:scheduled_publication, scheduled_publication: date)
+    Timecop.freeze(date - 5.seconds) do
+      assert publication.linkable?
+    end
+  end
+
   test "update slug if title changes on draft edition" do
     publication = create(:draft_publication, title: "This is my publication")
     publication.update!(title: "Another thing")


### PR DESCRIPTION
Whitehall currently supports a feature where publishers can add links to documents using the Whitehall URL, rather than the URL that it will be on GOV.UK.

This feature doesn't work if two new documents are scheduled to be published at the same time and they link to each other. It's a 50/50 chance that the link will work depending on which document gets published first.

To workaround this, we can allow linking to documents which aren't currently published, but will be published very shortly (in this case I've gone for 5 seconds at the "very short" timespan).

We could implement this in another way, with a more complex algorithm that makes sure that the jobs are ordered correctly, but that doesn't feel worth the effort. Note that this does introduce a potential problem where if the document due to be published fails for some reason, the link will still exist. However, at the moment we have the problem where the link appears as normal text, so either way there's an issue with the document.

[Trello Card](https://trello.com/c/wRNXsuTt/1818-5-fix-links-not-expanded-when-scheduled-publishing-multiple-linked-documents-in-whitehall)