### PR TITLE
Revert world location signup

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -4,16 +4,27 @@ class EmailSignupsController < PublicFacingController
       redirect_to email_alert_frontend_signup
     elsif feed_url.match?(%r{/government/(publications|announcements|statistics)\.atom})
       redirect_to feed_url.sub(".atom", "")
+    elsif feed_url.match?(%r{/world/.*\.atom$})
+      @email_signup = WorldLocationEmailSignup.new(feed_url)
     else
       redirect_to "/"
+    end
+  end
+
+  def create
+    @email_signup = WorldLocationEmailSignup.new(feed_url)
+
+    if @email_signup.valid?
+      redirect_to @email_signup.signup_url
+    else
+      render action: "new"
     end
   end
 
 private
 
   def non_finder_url
-    feed_url.match?(%r{/government/(organisations|ministers|people|topical-events)/.*\.atom$}) ||
-      feed_url.match?(%r{/world/.*\.atom$})
+    feed_url.match?(%r{/government/(organisations|ministers|people|topical-events)/.*\.atom$})
   end
 
   def feed_url

--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -1,10 +1,16 @@
 module EmailSignupHelper
   def email_signup_path(atom_feed_url)
+    feed_uri = URI.parse(atom_feed_url)
+
     if EmailSignupPagesFinder.exists_for_atom_feed?(atom_feed_url)
       organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
+    elsif feed_uri.path.match(%r{^/world/(.*)\.atom$})
+      new_email_signups_path(email_signup: { feed: atom_feed_url })
     else
-      email_alert_frontend_signup_url(atom_feed_url)
+      email_alert_frontend_signup_url(feed_uri)
     end
+  rescue URI::InvalidURIError
+    "/"
   end
 
 private
@@ -17,8 +23,7 @@ private
     /\/([\w-]+).atom$/.match(atom_feed_url)[1]
   end
 
-  def email_alert_frontend_signup_url(feed_url)
-    base_path = URI.parse(feed_url).path.chomp(".atom")
-    "#{Plek.new.website_root}/email-signup?link=#{base_path}"
+  def email_alert_frontend_signup_url(feed_uri)
+    "#{Plek.new.website_root}/email-signup?link=#{feed_uri.path.chomp('.atom')}"
   end
 end

--- a/app/models/world_location_email_signup.rb
+++ b/app/models/world_location_email_signup.rb
@@ -1,0 +1,48 @@
+class WorldLocationEmailSignup
+  attr_reader :feed
+
+  def initialize(feed)
+    @feed = feed
+  end
+
+  def signup_url
+    subscriber_list = Services.email_alert_api.find_or_create_subscriber_list(criteria)
+    subscriber_list["subscriber_list"]["subscription_url"]
+  end
+
+  def name
+    world_location.name
+  end
+
+  def valid?
+    uri && world_location_slug && world_location.present?
+  end
+
+private
+
+  def criteria
+    {
+      "links" => {
+        "world_locations" => [
+          world_location.content_id,
+        ],
+      },
+    }.merge("title" => world_location.name)
+  end
+
+  def world_location
+    @world_location ||= WorldLocation.find_by(slug: uri.path.match(%r{^/world/(.*)\.atom$})[1])
+  end
+
+  def uri
+    @uri ||= begin
+               URI.parse(feed)
+             rescue URI::InvalidURIError
+               nil
+             end
+  end
+
+  def world_location_slug
+    uri.path.match(%r{^/world/(.*)\.atom$}).try(:[], 1)
+  end
+end

--- a/app/views/email_signups/_form.html.erb
+++ b/app/views/email_signups/_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_for email_signup, html: { class: "signup-form" } do |form| %>
+<%= form_for :email_signup, html: { class: "signup-form" }, url: { action: "create" } do |form| %>
   <%= form.hidden_field :feed %>
 
-  <p>You're signing up to all alerts for <strong><%= email_signup.description %></strong></p>
+  <p>You're signing up to all alerts for <strong><%= email_signup.name %></strong></p>
 
   <div class="submit">
     <%= button_tag 'Create subscription' %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -596,6 +596,26 @@
       "note": "We check that the params[:id] is valid before rendering the template."
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "c210fdc84d925d7f9147ed11600537d94d73fa3cb3152d60a5bb1ead20a303e3",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/email_signups_controller.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(WorldLocationEmailSignup.new(feed_url).signup_url)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "EmailSignupsController",
+        "method": "create"
+      },
+      "user_input": "WorldLocationEmailSignup.new(feed_url).signup_url",
+      "confidence": "High",
+      "note": "Ignore this warning as the URL being generated comes directly from email-alert-api and so is trusted not to be user inputted data"
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "c4b40274a6e6d5a420ea1cf02c2a29e14817c60e5d3d4b870ce2e2a8b868754f",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Whitehall::Application.routes.draw do
     get "/history/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointment"
     resources :histories, path: "history", only: %i[index show]
 
-    resource :email_signups, path: "email-signup", only: %i[new]
+    resource :email_signups, path: "email-signup", only: %i[create new]
     get "/email-signup", to: redirect("/")
 
     get "/tour" => redirect("/tour", prefix: "")

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -33,11 +33,12 @@ class EmailSignupsControllerTest < ActionController::TestCase
     assert_redirected_to "http://test.host/email-signup?link=#{topical_event.base_path}"
   end
 
-  view_test "GET :new redirects to email-alert-frontend if signup is for a world location" do
+  view_test "GET :new renders a whitehall email signup page for a world location" do
     world_location = create(:world_location)
     get :new, params: { email_signup: { feed: atom_feed_url_for(world_location) } }
 
-    assert_redirected_to "http://test.host/email-signup?link=/world/#{world_location.slug}"
+    assert_select "h1", "Email alert subscription"
+    assert_select "p", "You're signing up to all alerts for #{world_location.name}"
   end
 
   view_test "GET :new redirects to publications controller if signup is for a publication finder" do
@@ -65,5 +66,28 @@ class EmailSignupsControllerTest < ActionController::TestCase
     get :new, params: { email_signup: { feed: "http://nonse-feed.atom" } }
 
     assert_redirected_to "http://test.host/"
+  end
+
+  view_test "POST :create with a valid email signup redirects to the signup URL" do
+    world_location = create(:world_location)
+    email_alert_api_has_subscriber_list(
+      "links" => { "world_locations" => [world_location.content_id] },
+      "subscription_url" => "http://email_alert_api_signup_url",
+    )
+
+    post :create, params: { email_signup: { feed: atom_feed_url_for(world_location) } }
+    assert_response :redirect
+    assert_redirected_to "http://email_alert_api_signup_url"
+  end
+
+  view_test "POST :create with a invalid email signup renders the new view" do
+    topical_event = create(:topical_event)
+    email_alert_api_has_subscriber_list(
+      "links" => { "topical_event" => [topical_event.content_id] },
+      "subscription_url" => "http://email_alert_api_signup_url",
+    )
+
+    post :create, params: { email_signup: { feed: atom_feed_url_for(topical_event) } }
+    assert_select "p", "Sorry, we could not find a valid email alerts feed for that."
   end
 end

--- a/test/unit/helpers/email_signup_helper_test.rb
+++ b/test/unit/helpers/email_signup_helper_test.rb
@@ -8,10 +8,24 @@ class EmailSignupHelperTest < ActionView::TestCase
     assert_equal expected, result
   end
 
+  test "#email_signup_path returns a whitehall signup url for a world_location" do
+    atom_feed_url = "https://www.gov.uk/world/uk-joint-delegation-to-nato.atom"
+    result = email_signup_path(atom_feed_url)
+    expected = "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fworld%2Fuk-joint-delegation-to-nato.atom"
+    assert_equal expected, result
+  end
+
   test "#email_signup_path returns a signup path for mhra" do
     atom_feed_url = "https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency.atom"
     result = email_signup_path(atom_feed_url)
     expected = "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup"
+    assert_equal expected, result
+  end
+
+  test "#email_signup_path returns website root if the feed is invalid" do
+    atom_feed_url = nil
+    result = email_signup_path(atom_feed_url)
+    expected = "/"
     assert_equal expected, result
   end
 end

--- a/test/unit/models/world_location_email_signup_test.rb
+++ b/test/unit/models/world_location_email_signup_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "gds_api/test_helpers/email_alert_api"
+
+class WorldLocationEmailSignupTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  setup do
+    @international_delegation = create(:international_delegation, name: "UK Joint Delegation to NATO")
+  end
+
+  test "#signup_url returns the subscription url from email-alert-api" do
+    email_signup = WorldLocationEmailSignup.new(feed_url)
+    response = { "subscription_url" => "http://example.com" }
+
+    email_alert_api_does_not_have_subscriber_list(
+      "links" => { "world_locations" => [@international_delegation.content_id] },
+      "title" => @international_delegation.name,
+    )
+    email_alert_api_creates_subscriber_list(response).with do |request|
+      assert_equal("UK Joint Delegation to NATO", JSON.parse(request.body)["title"])
+      assert_equal({ "world_locations" => [@international_delegation.content_id] }, JSON.parse(request.body)["links"])
+    end
+
+    assert_equal "http://example.com", email_signup.signup_url
+  end
+
+  test "#name returns the world locations name" do
+    email_signup = WorldLocationEmailSignup.new(feed_url)
+    assert_equal "UK Joint Delegation to NATO", email_signup.name
+  end
+
+  test "#valid? validates a world location feed url" do
+    email_signup = WorldLocationEmailSignup.new(feed_url)
+    assert email_signup.valid?
+  end
+
+  test "#valid? does not validate a feed url which is invalid" do
+    assert_not WorldLocationEmailSignup.new(nil).valid?
+  end
+
+  test "#valid? does not validate a feed url when the resource does not exist" do
+    assert_not WorldLocationEmailSignup.new(feed_url("/world/does-not-exist")).valid?
+  end
+
+  test "#valid? does not validate a feed url which isn't a world location feed" do
+    assert_not WorldLocationEmailSignup.new(feed_url("/government/publications/not-world.atom")).valid?
+  end
+
+  def feed_url(feed_path = "world/uk-joint-delegation-to-nato.atom")
+    "#{Whitehall.public_protocol}://#{Whitehall.public_host}/#{feed_path}"
+  end
+end


### PR DESCRIPTION
We want to revert some of the earlier work done to reduce the amount of email alert signup paths. 

This worked for most signup journeys (people, topical events etc) but actually broke for world locations. The change that lead to this bug came about when we moved the creation of the subscriber list from whitehall to email-alert-frontend as it turns out it's only possible to create a valid subscriber list for a world location from the information locally to whitehall for these world locations - world news, international delegations, world latest. The reason we can't signup users outside of whitehall is because the world locations previously listed don't really exist outside of whitehall, as in they don't have a content item in content-store and so all the data about them is only stored in whitehall (content-id, title etc).

### Whitehall email signup url
<img width="1132" alt="Screenshot 2020-03-16 at 11 28 56" src="https://user-images.githubusercontent.com/24479188/76754009-556afc80-6779-11ea-8565-e7f87af2e898.png">

### Whitehall email signup page
<img width="1171" alt="Screenshot 2020-03-16 at 11 29 07" src="https://user-images.githubusercontent.com/24479188/76754019-5865ed00-6779-11ea-871b-15d1ec3871bc.png">

### Emails being generated for world location Spain (aws staging)
<img width="748" alt="Screenshot 2020-03-16 at 12 57 14" src="https://user-images.githubusercontent.com/24479188/76760512-b13b8280-6785-11ea-9f85-b9999d9dda51.png">

Further details on the exact cause can be found within the incident document created for this bug - https://docs.google.com/document/d/1fL5mQjRX2ApoVd4rOIxrnwjhrC-w4pgNgNXaA93KeM8/edit#heading=h.p99426yo0rbv.

Reverting some of this PR:
https://github.com/alphagov/whitehall/pull/4996

Trello:
https://trello.com/c/lkD6aJ9v/1568-fix-world-locations-email-signup-bug