### PR TITLE
Fix error message for command paper number validation

### DIFF
--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -85,7 +85,7 @@ private
     return if number.blank?
 
     unless command_paper_number_valid?(number)
-      attachment.errors[:command_paper_number] << "Command paper number invalid"
+      attachment.errors[:command_paper_number] << "invalid"
     end
   end
 end

--- a/test/unit/attachment_validator_test.rb
+++ b/test/unit/attachment_validator_test.rb
@@ -81,7 +81,7 @@ class AttachmentValidatorTest < ActiveSupport::TestCase
     test "should be invalid when the command paper number starts with '#{prefix}'" do
       attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
       @validator.validate(attachment)
-      assert attachment.errors[:command_paper_number].include?("Command paper number invalid")
+      assert attachment.errors[:command_paper_number].include?("invalid")
     end
   end
 


### PR DESCRIPTION
Currently it says:
  Command paper number Command paper number invalid

We just want it to say:
  Command paper number invalid

<img width="687" alt="Screenshot 2020-03-18 at 09 29 11" src="https://user-images.githubusercontent.com/5111927/76952283-c559be00-6904-11ea-99f5-54d413f76d2f.png">

Incorrect message was added in https://github.com/alphagov/whitehall/pull/5456.
Trello: https://trello.com/c/yG4gXFxI/1544-fix-buggy-command-paper-number-prefixes-in-whitehall