### PR TITLE
Fix buggy command paper number prefixes - second attempt

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -43,7 +43,8 @@ class Admin::AttachmentsController < Admin::BaseController
     errors = {}
     params[:attachments].each do |id, attributes|
       attachment = attachable.attachments.find(id)
-      if attachment.update(attributes.permit(:title))
+      attachment.assign_attributes(attributes.permit(:title))
+      if attachment.save(context: :user_input)
         attachment_updater
       else
         errors[id] = attachment.errors.full_messages
@@ -187,7 +188,7 @@ private
   end
 
   def save_attachment
-    attachment.save.tap do |result|
+    attachment.save(context: :user_input).tap do |result|
       if result && attachment.is_a?(HtmlAttachment)
         Whitehall::PublishingApi.save_draft(attachment)
       end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,7 +14,7 @@ class Attachment < ApplicationRecord
 
   VALID_COMMAND_PAPER_NUMBER_PREFIXES = ["CP", "C.", "Cd.", "Cmd.", "Cmnd.", "Cm."].freeze
 
-  validates_with AttachmentValidator
+  validates_with AttachmentValidator, on: :user_input
   validates :attachable, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -18,11 +18,6 @@ class Attachment < ApplicationRecord
   validates :attachable, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true
-  validates :command_paper_number, format: {
-    with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.map { |prefix| Regexp.escape(prefix) }.join('|')}) \d+/,
-    allow_blank: true,
-    message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space",
-  }
   validates :unique_reference, length: { maximum: 255 }, allow_blank: true
 
   scope :with_filename, ->(basename) {

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -12,7 +12,7 @@ class Attachment < ApplicationRecord
   before_save :nilify_locale_if_blank
   before_save :prevent_saving_of_abstract_base_class
 
-  VALID_COMMAND_PAPER_NUMBER_PREFIXES = ["C.", "Cd.", "Cmd.", "Cmnd.", "Cm."].freeze
+  VALID_COMMAND_PAPER_NUMBER_PREFIXES = ["CP", "C.", "Cd.", "Cmd.", "Cmnd.", "Cm."].freeze
 
   validates_with AttachmentValidator
   validates :attachable, presence: true

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -19,9 +19,9 @@ class Attachment < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true
   validates :command_paper_number, format: {
-    with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.map { |prefix| Regexp.escape(prefix) }.join('|')}) ?\d+/,
+    with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.map { |prefix| Regexp.escape(prefix) }.join('|')}) \d+/,
     allow_blank: true,
-    message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}",
+    message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space",
   }
   validates :unique_reference, length: { maximum: 255 }, allow_blank: true
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -19,7 +19,7 @@ class Attachment < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true
   validates :command_paper_number, format: {
-    with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join('|')}) ?\d+/,
+    with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.map { |prefix| Regexp.escape(prefix) }.join('|')}) ?\d+/,
     allow_blank: true,
     message: "is invalid. The number must start with one of #{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}",
   }

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -58,14 +58,14 @@ class BulkUpload
     attachments.each { |attachment| attachment.attachable = edition }
 
     if valid?
-      attachments.all?(&:save)
+      attachments.all? { |a| a.save(context: :user_input) }
     else
       false
     end
   end
 
   def attachments_must_be_valid
-    unless attachments.all?(&:valid?)
+    unless attachments.all? { |a| a.valid?(context: :user_input) }
       errors[:base] << "Please enter missing fields for each attachment"
     end
   end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -7,6 +7,7 @@ class AttachmentValidator < ActiveModel::Validator
     check_if_hoc_paper_number_required(attachment)
     check_if_parliamentary_session_required(attachment)
     check_format_of_hoc_paper_number(attachment)
+    check_format_of_command_paper_number(attachment)
   end
 
 private
@@ -63,6 +64,22 @@ private
     number = attachment.hoc_paper_number
     if number.present? && (number !~ /^\d/)
       attachment.errors[:hoc_paper_number] << "must start with a number"
+    end
+  end
+
+  def check_format_of_command_paper_number(attachment)
+    number = attachment.command_paper_number
+    valid_prefixes = Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.map { |prefix| Regexp.escape(prefix) }
+    command_paper_number_regex = %r{
+      \A        # beginning of string
+      (#{valid_prefixes.join('|')}) # all allowed prefixes
+      \s        # single space
+      \d+       # number
+      (-[IV]+)? # optional Roman numeral suffix
+      \z        # end of string
+    }x
+    if number.present? && (number !~ command_paper_number_regex)
+      attachment.errors[:command_paper_number] << "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
     end
   end
 end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -85,7 +85,7 @@ private
     return if number.blank?
 
     unless command_paper_number_valid?(number)
-      attachment.errors[:command_paper_number] << "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
+      attachment.errors[:command_paper_number] << "invalid"
     end
   end
 end

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -10,6 +10,7 @@
 <div class="paper-number">
   <%= form.text_field :command_paper_number, class: 'input-md-3' %>
   <%= form.check_box :unnumbered_command_paper, label_text: 'Unnumbered' %>
+  <p class="help-block">The number must start with one of <%= Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') %>, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV</p>
 </div>
 <% if attachable.can_have_attached_house_of_commons_papers? %>
   <%= render 'admin/attachments/hoc_reference_fields', form: form %>

--- a/lib/data_hygiene/attachment_attribute_updater.rb
+++ b/lib/data_hygiene/attachment_attribute_updater.rb
@@ -1,0 +1,43 @@
+module DataHygiene
+  class AttachmentAttributeUpdater
+    def initialize(attachment, dry_run:)
+      @attachment = attachment
+      @dry_run = dry_run
+    end
+
+    def call
+      old_number = attachment.command_paper_number
+      valid_number = fix_command_paper_number(old_number)
+
+      unless AttachmentValidator.new.command_paper_number_valid?(valid_number)
+        raise DataHygiene::AttachmentAttributeNotFixable.new
+      end
+
+      return valid_number if dry_run || old_number == valid_number
+
+      attachment.update!(command_paper_number: valid_number)
+      valid_number
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :attachment, :dry_run
+
+    def fix_command_paper_number(original_number)
+      # for example, "CM.123-iv "
+      original_number.tr(". ", "") # remove periods and spaces: "CM123-iv"
+        .sub(/(\d+)/) { |number| ". #{number}" } # inject period & space before number: "CM. 123-iv"
+        .capitalize # "Cm. 123-iv"
+        .sub(/^Cp\./, "CP") # fix the special case "CP", which should be all caps and no period
+        .sub(/\d+-(.+)$/, &:upcase) # make suffix uppercase: "Cm. 123-IV"
+    end
+  end
+
+  class AttachmentAttributeNotFixable < StandardError; end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -111,7 +111,9 @@ namespace :data_hygiene do
     end
 
     task real: :environment do
-      call_attachment_attribute_updater(dry_run: false)
+      ActiveRecord::Base.transaction do
+        call_attachment_attribute_updater(dry_run: false)
+      end
     end
   end
 end

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -258,6 +258,19 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal html_attachment.title, attachment_2.title
   end
 
+  test "re-editioned editions persists invalid attachments" do
+    file_attachment = build(:file_attachment, command_paper_number: "invalid")
+    file_attachment.save(validate: false)
+    publication = create(:published_publication,
+                         :with_alternative_format_provider,
+                         attachments: [file_attachment])
+
+    draft = publication.create_draft(create(:writer))
+
+    assert_equal 1, draft.reload.attachments.size
+    assert draft.attachments[0].persisted?
+  end
+
   test "#delete_all_attachments soft-deletes any attachments that the edition has" do
     publication = create(:draft_publication)
 

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -47,14 +47,14 @@ class AttachmentTest < ActiveSupport::TestCase
     assert attachment.valid?
   end
 
-  ["C.", "Cd.", "Cmd.", "Cmnd.", "Cm."].each do |prefix|
+  ["C.", "Cd.", "Cmd.", "Cmnd.", "Cm.", "CP"].each do |prefix|
     test "should be valid when the Command paper number starts with '#{prefix}'" do
       attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
       assert attachment.valid?
     end
   end
 
-  ["NA", "C", "Cd ", "CM."].each do |prefix|
+  ["NA", "C", "Cd ", "CM.", "CP."].each do |prefix|
     test "should be invalid when the command paper number starts with '#{prefix}'" do
     attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
     assert_not attachment.valid?

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -54,8 +54,9 @@ class AttachmentTest < ActiveSupport::TestCase
     end
   end
 
-  test "should be invalid when the command paper number starts with an unrecognised prefix" do
-    attachment = build(:file_attachment, command_paper_number: "NA 1234")
+  ["NA", "C", "Cd ", "CM."].each do |prefix|
+    test "should be invalid when the command paper number starts with '#{prefix}'" do
+    attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
     assert_not attachment.valid?
     expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}"
     assert attachment.errors[:command_paper_number].include?(expected_message)

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -58,8 +58,22 @@ class AttachmentTest < ActiveSupport::TestCase
     test "should be invalid when the command paper number starts with '#{prefix}'" do
     attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
     assert_not attachment.valid?
-    expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space"
+    expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
     assert attachment.errors[:command_paper_number].include?(expected_message)
+  end
+
+  ["-I", "-IV", "-VIII"].each do |suffix|
+    test "should be valid when the command paper number ends with '#{suffix}'" do
+      attachment = build(:file_attachment, command_paper_number: "C. 1234#{suffix}")
+      assert attachment.valid?
+    end
+  end
+
+  ["-i", "-Iv", "VIII"].each do |suffix|
+    test "should be invalid when the command paper number ends with '#{suffix}'" do
+      attachment = build(:file_attachment, command_paper_number: "C. 1234#{suffix}")
+      assert_not attachment.valid?
+    end
   end
 
   test "should be invalid when the command paper number has no space after the prefix" do

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -47,40 +47,6 @@ class AttachmentTest < ActiveSupport::TestCase
     assert attachment.valid?
   end
 
-  ["C.", "Cd.", "Cmd.", "Cmnd.", "Cm.", "CP"].each do |prefix|
-    test "should be valid when the Command paper number starts with '#{prefix}'" do
-      attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
-      assert attachment.valid?
-    end
-  end
-
-  ["NA", "C", "Cd ", "CM.", "CP."].each do |prefix|
-    test "should be invalid when the command paper number starts with '#{prefix}'" do
-    attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
-    assert_not attachment.valid?
-    expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
-    assert attachment.errors[:command_paper_number].include?(expected_message)
-  end
-
-  ["-I", "-IV", "-VIII"].each do |suffix|
-    test "should be valid when the command paper number ends with '#{suffix}'" do
-      attachment = build(:file_attachment, command_paper_number: "C. 1234#{suffix}")
-      assert attachment.valid?
-    end
-  end
-
-  ["-i", "-Iv", "VIII"].each do |suffix|
-    test "should be invalid when the command paper number ends with '#{suffix}'" do
-      attachment = build(:file_attachment, command_paper_number: "C. 1234#{suffix}")
-      assert_not attachment.valid?
-    end
-  end
-
-  test "should be invalid when the command paper number has no space after the prefix" do
-    attachment = build(:file_attachment, command_paper_number: "C.1234")
-    assert_not attachment.valid?
-  end
-
   test "should be valid without a unique_reference" do
     attachment = build(:file_attachment, unique_reference: nil)
     assert attachment.valid?

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -58,8 +58,13 @@ class AttachmentTest < ActiveSupport::TestCase
     test "should be invalid when the command paper number starts with '#{prefix}'" do
     attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
     assert_not attachment.valid?
-    expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}"
+    expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space"
     assert attachment.errors[:command_paper_number].include?(expected_message)
+  end
+
+  test "should be invalid when the command paper number has no space after the prefix" do
+    attachment = build(:file_attachment, command_paper_number: "C.1234")
+    assert_not attachment.valid?
   end
 
   test "should be valid without a unique_reference" do

--- a/test/unit/attachment_validator_test.rb
+++ b/test/unit/attachment_validator_test.rb
@@ -81,8 +81,7 @@ class AttachmentValidatorTest < ActiveSupport::TestCase
     test "should be invalid when the command paper number starts with '#{prefix}'" do
       attachment = build(:file_attachment, command_paper_number: "#{prefix} 1234")
       @validator.validate(attachment)
-      expected_message = "is invalid. The number must start with one of #{Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ')}, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
-      assert attachment.errors[:command_paper_number].include?(expected_message)
+      assert attachment.errors[:command_paper_number].include?("invalid")
     end
   end
 

--- a/test/unit/data_hygiene/attachment_attribute_updater_test.rb
+++ b/test/unit/data_hygiene/attachment_attribute_updater_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class AttachmentAttributeUpdaterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe DataHygiene::AttachmentAttributeUpdater do
+    let(:attachment) { build(:file_attachment, attachment_data: build(:attachment_data), command_paper_number: original_command_paper_number) }
+
+    def call_attachment_attribute_updater
+      DataHygiene::AttachmentAttributeUpdater.call(attachment, dry_run: dry_run)
+    end
+
+    context "during a dry run" do
+      let(:dry_run) { true }
+      let(:original_command_paper_number) { "CM123" }
+      let(:new_paper_number) { "Cm. 123" }
+
+      it "doesn't update the command paper number" do
+        call_attachment_attribute_updater
+        assert_equal(attachment.command_paper_number, original_command_paper_number)
+      end
+
+      it "does return what the command paper number should be" do
+        new_number = call_attachment_attribute_updater
+        assert_equal(new_number, new_paper_number)
+      end
+    end
+
+    context "during a real run" do
+      let(:dry_run) { false }
+      let(:original_command_paper_number) { "CM123" }
+      let(:new_paper_number) { "Cm. 123" }
+
+      it "does update the command paper number" do
+        call_attachment_attribute_updater
+        assert_equal(attachment.command_paper_number, new_paper_number)
+      end
+
+      context "given a command paper number beginning with CP" do
+        let(:original_command_paper_number) { "cp . 123" }
+
+        it "omits the period and retains the uppercasing" do
+          call_attachment_attribute_updater
+          assert_equal(attachment.command_paper_number, "CP 123")
+        end
+      end
+
+      context "given a command paper number with a suffix" do
+        let(:original_command_paper_number) { "cM 123- iV" }
+
+        it "uppercases the suffix" do
+          call_attachment_attribute_updater
+          assert_equal(attachment.command_paper_number, "Cm. 123-IV")
+        end
+      end
+
+      context "given a command paper number it cannot fix" do
+        let(:original_command_paper_number) { "Cmd 123-1" }
+
+        it "raises an exception" do
+          assert_raises DataHygiene::AttachmentAttributeNotFixable do
+            call_attachment_attribute_updater
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is identical to #5456, but also incorporates the small fix added in #5467 (in the "Move command paper number rules into hint text" commit). Unfortunately I had to revert these (quite badly) in #5468, as it had introduced a bug. Documents with any attachment that have a command paper number we now class as 'invalid' would lose their attachment(s) when creating a new edition of that document. (I'm not sure if they would lose _all_ attachments or just the ones with the invalid command paper numbers).

TODO: add a fix for the bug described above. Otherwise, this PR:

- fixes the command paper number regex, which previously allowed `.`, which allows any character in a regex. It is now escaped (`\.`), therefore only a period is allowed at that point in the regex
- tightens up the spacing and capitalisation validation, as many variations exist in the wild
- adds support for the new `CP` prefix, which differs from the others as it should not have a `.` period after it
- adds validation for suffixes (only capitalised Roman numerals are allowed)
- updates the validation message accordingly
- adds some hint text to the form, covering the more stringent validation checks
- adds a rake task to run which fixes up the existing command paper numbers and provides detailed logs.

Trello: https://trello.com/c/yG4gXFxI/1544-fix-buggy-command-paper-number-prefixes-in-whitehall