### PR TITLE
Change role of the export:mappings job in schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,7 +8,7 @@ def integration_or_staging?
   ENV.fetch("GOVUK_WEBSITE_ROOT") =~ /integration|staging/
 end
 
-every :day, at: ["3am", "12:45pm"], roles: [:admin] do
+every :day, at: ["3am", "12:45pm"], roles: [:backend] do
   rake "export:mappings"
 end
 


### PR DESCRIPTION
This seems to be working, but I'm not quite sure why. Anyway, the job
jobs use :backend as the role, and that's what's being set in
govuk-app-deployment, so just change this to be consistent (and hope
nothing goes wrong!).