### PR TITLE
Use created_at of the unpublishing for unpublished_at date

### DIFF
--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -60,6 +60,8 @@ module ServiceListeners
           html_attachment.content_id,
           edition.unpublishing.explanation,
           edition.primary_locale,
+          false,
+          edition.unpublishing.created_at,
         )
       end
     end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -32,6 +32,7 @@ module ServiceListeners
           api.publish_withdrawal_async(
             edition.content_id,
             edition.unpublishing.explanation,
+            edition.unpublishing.created_at,
             translation.locale.to_s,
           )
         end

--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -43,6 +43,7 @@ class PublishingApiUnpublishingWorker
           unpublishing.explanation,
           locale,
           allow_draft,
+          unpublishing.created_at,
         )
       end
     end

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -1,13 +1,10 @@
 class PublishingApiWithdrawalWorker < PublishingApiWorker
-  def perform(content_id, explanation, locale, allow_draft = false)
+  # `explanation` and `unpublished_at` come from the unpublishing object. Rather than
+  # performing a database query here to look up the `unpublishing` linked to the most
+  # recent edition, we pass it in directly because the `unpublishing` isn't always
+  # saved in the database yet when this worker runs.
+  def perform(content_id, explanation, locale, allow_draft = false, unpublished_at = nil)
     check_if_locked_document(content_id: content_id)
-
-    unpublished_at = Edition
-      .joins(:document)
-      .where(documents: { content_id: content_id })
-      .where(state: "withdrawn")
-      .pluck(:updated_at)
-      .first
 
     Services.publishing_api.unpublish(
       content_id,
@@ -15,10 +12,29 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
       locale: locale,
       explanation: Whitehall::GovspeakRenderer.new.govspeak_to_html(explanation),
       allow_draft: allow_draft,
-      unpublished_at: unpublished_at,
+      unpublished_at: find_unpublished_at(content_id, unpublished_at),
     )
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
+  end
+
+private
+
+  def find_unpublished_at(content_id, given_unpublished_at)
+    if given_unpublished_at
+      # We call this job both directly and via Sidekiq. When called by Sidekiq, the date gets turned
+      # into a string (because jobs must be JSON serialisable) and `Services.publishing_api.unpublish`
+      # rejects it.
+      Time.zone.parse(given_unpublished_at.to_s)
+    else
+      # Temporary code to handle old workers that are still in the queue without an `unpublished_at`
+      Edition
+        .joins(:document)
+        .where(documents: { content_id: content_id })
+        .where(state: "withdrawn")
+        .pluck(:updated_at)
+        .first
+    end
   end
 end

--- a/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
+++ b/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
@@ -6307,6 +6307,7 @@ def unpublish(content_ids, draft)
           edition.unpublishing.explanation,
           locale,
           draft,
+          edition.unpublishing.created_at,
         )
       end
     else

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -135,8 +135,8 @@ module Whitehall
       PublishingApiVanishWorker.perform_async(document_content_id, locale)
     end
 
-    def self.publish_withdrawal_async(document_content_id, explanation, locale = I18n.default_locale.to_s)
-      PublishingApiWithdrawalWorker.perform_async(document_content_id, explanation, locale)
+    def self.publish_withdrawal_async(document_content_id, explanation, unpublished_at, locale = I18n.default_locale.to_s)
+      PublishingApiWithdrawalWorker.perform_async(document_content_id, explanation, locale, false, unpublished_at)
     end
 
     def self.unpublish_async(unpublishing)

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -6,7 +6,7 @@ class WithdrawingTest < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       edition = create(:published_case_study)
       edition.build_unpublishing(explanation: "Old information",
-        unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
+        unpublishing_reason_id: UnpublishingReason::Withdrawn.id).save
 
       request = stub_publishing_api_unpublish(
         edition.content_id,
@@ -14,7 +14,7 @@ class WithdrawingTest < ActiveSupport::TestCase
           type: "withdrawal",
           locale: "en",
           explanation: "<div class=\"govspeak\"><p>Old information</p>\n</div>",
-          unpublished_at: edition.updated_at.utc.iso8601,
+          unpublished_at: edition.unpublishing.created_at.utc.iso8601,
         },
       )
 

--- a/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
@@ -337,6 +337,8 @@ module ServiceListeners
             attachment.content_id,
             "content was withdrawn",
             "en",
+            false,
+            publication.unpublishing.created_at,
           )
           call(publication)
         end
@@ -426,6 +428,8 @@ module ServiceListeners
           attachment.content_id,
           "content was withdrawn",
           "en",
+          false,
+          publication.unpublishing.created_at,
         )
         call(publication)
       end

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -65,11 +65,11 @@ module ServiceListeners
         unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
 
       Whitehall::PublishingApi.expects(:publish_withdrawal_async)
-        .with(edition.document.content_id, edition.unpublishing.explanation, edition.primary_locale)
+        .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.created_at, edition.primary_locale)
 
       translations.each do |translation|
         Whitehall::PublishingApi.expects(:publish_withdrawal_async)
-          .with(edition.document.content_id, edition.unpublishing.explanation, translation.to_s)
+          .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.created_at, translation.to_s)
       end
 
       stub_html_attachment_pusher(edition, "withdraw")

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -79,6 +79,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
       unpublishing.explanation,
       :en,
       false,
+      unpublishing.created_at,
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -107,6 +108,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
       unpublishing.explanation,
       :en,
       true,
+      unpublishing.created_at,
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id, true)

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api_v2"
 class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
-  test "publishes a 'withdrawal' item for the supplied content id" do
+  test "publishes a 'withdrawal' item for the supplied 'content_id'" do
     publication = create(:withdrawn_publication)
 
     request = stub_publishing_api_unpublish(
@@ -19,6 +19,28 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
 
     PublishingApiWithdrawalWorker.new.perform(
       publication.document.content_id, "*why?*", "en"
+    )
+
+    assert_requested request
+  end
+
+  test "publishes a 'withdrawal' item for the supplied 'content_id' and 'unpublished_at'" do
+    publication = create(:withdrawn_publication)
+
+    unpublished_at = Time.zone.parse("2020-01-01 12:00")
+
+    request = stub_publishing_api_unpublish(
+      publication.document.content_id,
+      body: {
+        type: "withdrawal",
+        locale: "en",
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
+        unpublished_at: unpublished_at.utc.iso8601,
+      },
+    )
+
+    PublishingApiWithdrawalWorker.new.perform(
+      publication.document.content_id, "*why?*", "en", false, unpublished_at
     )
 
     assert_requested request


### PR DESCRIPTION
This changes how the `unpublished_at` date of a withdrawn document is found. Previously we were using the `updated_at` of the edition, which has the potential to change (most obviously through a bulk changing data migration). By using the `created_at` of the `unpublishing`, this date remains stable even if the editions change.

See individual commits for more details. Once this is merged, I will republish all the withdrawn documents where the `updated_at` doesn't match `unpublishing.created_at`.

[Trello Card](https://trello.com/c/wyvPYlI6/1837-5-investigate-why-some-withdrawn-documents-have-stray-drafts) ・ [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/3929420)