### PR TITLE
Use attachment ID as publishing-api ID

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -92,7 +92,7 @@ class Attachment < ApplicationRecord
     # "html_attachment_asset", "external_attachment_asset" schemas
     attachment_fields = {
       attachment_type: readable_type.downcase,
-      id: publishing_api_attachment_id || id.to_s,
+      id: id.to_s,
       locale: locale,
       title: title,
       url: url,
@@ -136,10 +136,6 @@ class Attachment < ApplicationRecord
 
   def readable_type
     ""
-  end
-
-  def publishing_api_attachment_id
-    raise NotImplementedError, "Subclasses must implement the publishing_api_attachment_id method"
   end
 
   def url

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -46,10 +46,6 @@ class ExternalAttachment < Attachment
     "text/html"
   end
 
-  def publishing_api_attachment_id
-    content_id
-  end
-
   def url(_options = {})
     external_url
   end

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -48,10 +48,6 @@ class FileAttachment < Attachment
     }
   end
 
-  def publishing_api_attachment_id
-    filename
-  end
-
 private
 
   def alternative_format_contact_email

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -57,10 +57,6 @@ class HtmlAttachment < Attachment
     "HTML attachment"
   end
 
-  def publishing_api_attachment_id
-    slug
-  end
-
   def url(options = {})
     preview = options.delete(:preview)
     full_url = options.delete(:full_url)

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -421,7 +421,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     test "attachment" do
       attachment = corporate_information_page.attachments.first
       assert_equal presented_content.dig(:details, :attachments, 0, :id),
-                   attachment.publishing_api_attachment_id
+                   attachment.id.to_s
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -239,6 +239,6 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     presented_item = present(detailed_guide)
     assert_valid_against_schema(presented_item.content, "detailed_guide")
     assert_equal presented_item.content.dig(:details, :attachments, 0, :id),
-                 detailed_guide.attachments.first.publishing_api_attachment_id
+                 detailed_guide.attachments.first.id.to_s
   end
 end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -388,7 +388,7 @@ module PublishingApi::NewsArticlePresenterTest
 
     test "attachment" do
       assert_equal presented_content.dig(:details, :attachments, 0, :id),
-                   news_article.attachments.first.publishing_api_attachment_id
+                   news_article.attachments.first.id.to_s
     end
 
     test "validity" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -46,9 +46,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         emphasised_organisations: publication.lead_organisations.map(&:content_id),
         political: false,
         brexit_no_deal_notice: [],
-        attachments: [
-          { attachment_type: "html", id: publication.attachments.first.slug, title: publication.attachments.first.title, url: publication.attachments.first.url, unnumbered_command_paper: false, unnumbered_hoc_paper: false },
-        ],
+        attachments: publication.attachments.map(&:publishing_api_details),
         featured_attachments: (publication.attachments.map { |a| a.publishing_api_details[:id] }),
       },
     }

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -195,7 +195,7 @@ class PublishingApi::StatisticalDataSetPresenterAttachmentTest < ActiveSupport::
   test "it presentes attachments" do
     attachment = @statistical_data_set.attachments.first
     assert_equal @presented_statistical_data_set.content.dig(:details, :attachments, 0, :id),
-                 attachment.publishing_api_attachment_id
+                 attachment.id.to_s
   end
 
   test "its attachments are valid against the schema" do

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -325,7 +325,7 @@ class PublishingApi::WorldLocationNewsArticlePresenterAttachmentTest < ActiveSup
 
   test "it presentes attachments" do
     assert_equal @presented_wlna.content.dig(:details, :attachments, 0, :id),
-                 @attachment.publishing_api_attachment_id
+                 @attachment.id.to_s
   end
 
   test "its attachments are valid against the schema" do


### PR DESCRIPTION
Using filename for file attachments isn't safe, as a document could
have two attachments with the same filename.  Using "{id}-{filename}"
would work but, in that case, why not just use the id directly?

There's no need to republish docs after this, as the old IDs are still
valid.