### PR TITLE
Delete LinkCheckerApiReport's without links

### DIFF
--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -4,6 +4,17 @@ class LinkCheckerApiReport < ApplicationRecord
            -> { order(ordering: :asc) },
            class_name: "LinkCheckerApiReport::Link"
 
+  scope :no_links, -> {
+    where(
+      "
+NOT EXISTS (
+  SELECT 1
+  FROM link_checker_api_report_links
+  WHERE link_checker_api_report_id = link_checker_api_reports.id
+)",
+    )
+  }
+
   def self.create_noop_report(link_reportable)
     create(
       batch_id: nil,

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -40,5 +40,5 @@ every taxonomy_cron_rules, roles: [:backend] do
 end
 
 every :day, at: "4am", roles: [:backend] do
-  rake "link_checker:delete_old_report_links"
+  rake "link_checker:delete_old_data"
 end

--- a/lib/tasks/link_checker.rake
+++ b/lib/tasks/link_checker.rake
@@ -1,6 +1,8 @@
 namespace :link_checker do
-  task delete_old_report_links: :environment do
-    count = LinkCheckerApiReport::Link.deletable.delete_all
-    puts "Deleted #{count} old report links."
+  task delete_old_data: :environment do
+    link_count = LinkCheckerApiReport::Link.deletable.delete_all
+    puts "Deleted #{link_count} old report links."
+    report_count = LinkCheckerApiReport.no_links.delete_all
+    puts "Deleted #{report_count} old reports"
   end
 end


### PR DESCRIPTION
I don't think having reports without any associated links is useful,
so go ahead and delete these reports as well as deleting the related
links.

The intent here is to potentially help with the performance of the
Edition.only_broken_links method, by not having so much data to search
through.