### PR TITLE
Scope fixing command paper numbers to ones in use

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -58,8 +58,10 @@ namespace :data_hygiene do
     def call_attachment_attribute_updater(dry_run:)
       affected_attachments = []
       Attachment
+        .not_deleted
         .where.not(command_paper_number: nil)
         .where.not(command_paper_number: "")
+        .where.not(attachable_id: nil)
         .each do |attachment|
         old_attr = attachment.command_paper_number
         begin


### PR DESCRIPTION
https://trello.com/c/yG4gXFxI/1544-fix-buggy-command-paper-number-prefixes-in-whitehall

11:28:33 rake aborted!
11:28:33 ActiveRecord::RecordInvalid: Validation failed: Attachable can't be blank