### PR TITLE
Disable validations when fixing command paper numbers

### DIFF
--- a/lib/data_hygiene/attachment_attribute_updater.rb
+++ b/lib/data_hygiene/attachment_attribute_updater.rb
@@ -15,7 +15,7 @@ module DataHygiene
 
       return valid_number if dry_run || old_number == valid_number
 
-      attachment.update!(command_paper_number: valid_number)
+      attachment.update(command_paper_number: valid_number)
       valid_number
     end
 


### PR DESCRIPTION
https://trello.com/c/yG4gXFxI/1544-fix-buggy-command-paper-number-prefixes-in-whitehall

We have already checked the new paper number is valid, 
so there's no reason to be concerned about (other) validations.

rake aborted!
ActiveRecord::RecordInvalid: Validation failed: This publication already has a file called "post-legislative-assessment-of-the-foi-act.pdf"