### PR TITLE
Explicitly disable attachment validations

### DIFF
--- a/lib/data_hygiene/attachment_attribute_updater.rb
+++ b/lib/data_hygiene/attachment_attribute_updater.rb
@@ -15,7 +15,8 @@ module DataHygiene
 
       return valid_number if dry_run || old_number == valid_number
 
-      attachment.update(command_paper_number: valid_number)
+      attachment.assign_attributes(command_paper_number: valid_number)
+      attachment.save(validate: false)
       valid_number
     end
 


### PR DESCRIPTION
https://trello.com/c/yG4gXFxI/1544-fix-buggy-command-paper-number-prefixes-in-whitehall

Previously we softly ignored validations when updating attachments
(knowing our update is valid), but this can still cause an issue if
running the validations leads to a general error. This explicitly
stops validations from running.

rake aborted!
Module::DelegationError: Response#document delegated to consultation.document, but consultation is nil: #<ConsultationOutcome id: 12949, edition_id: 1035312