### PR TITLE
Lock the document in the Publishing API document republishing worker

### DIFF
--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -10,6 +10,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       id: 1,
       pre_publication_edition: draft_edition = build(:edition, id: 2),
       locked?: false,
+      lock!: true,
     )
 
     Document.stubs(:find).returns(document)
@@ -42,6 +43,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       id: 1,
       pre_publication_edition: build(:edition),
       locked?: false,
+      lock!: true,
     )
 
     Document.stubs(:find).returns(document)
@@ -97,6 +99,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
+      lock!: true,
     )
 
     Document.stubs(:find).returns(document)
@@ -125,6 +128,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
+      lock!: true,
     )
 
     Document.stubs(:find).returns(document)


### PR DESCRIPTION
This should help prevent this job running twice, at the same time, for
the same document.

I've been investigating how updating a organisation contact in
Whitehall caused a draft HTML publication to be published before it
should have been. Because of some unaddressed technical debt, when a
change to a contact is made, Whitehall republishes the dependent
content via this worker [1]. If you make several changes to a contact
in quick succession, the document republishing worker will be run
multiple times. Assuming the jobs execute in parallel, it's possible
that the requests to the Publishing API are ordered such that the
draft for the document, or related HTML publications end up being
published incorrectly. Serialising the jobs through a database level
lock should prevent this.

1: This is to update the text for the contact in the details of the
document. The debt here is that organisation contacts should be
content items in the Publishing API, and content should link to
them. Once this is done, calling the document republishing worker when
changing contacts will be unnecessary.