### PR TITLE
Correct first_published_at for NDA document

### DIFF
--- a/db/data_migration/20200330092543_correct_first_published_for_nda_document.rb
+++ b/db/data_migration/20200330092543_correct_first_published_for_nda_document.rb
@@ -1,0 +1,12 @@
+document = Document.find(305774)
+editions = document.editions.order(:created_at)
+correct_first_published_at = editions.first.first_published_at
+
+editions.each do |edition|
+  if edition.first_published_at != correct_first_published_at
+    edition.first_published_at = correct_first_published_at
+    edition.save(validate: false)
+  end
+end
+
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)


### PR DESCRIPTION
For https://trello.com/c/b7YPrzUz/1629-fix-incorrect-firstpublishedat-date-for-nda-document

While working on importing news content for the Nuclear Decommissioning
Authority in to Content Publisher we discovered a data inconsistency for the
`first_published_at` value for one of their documents. In the first edition
(id: 539202) the document was published on 3rd September 2015 and backdated to
23 August 2015. In a later edition (id: 560382), the document was backdated
once more to 6 November 2015. The impact of this is that when importing the
document in to Content Publisher, the integrity checker fails because the
proposed payload generated drops any change notes that exist prior to the
`first_published_at` date for the document. In this case, all change notes
prior to 6 November 2015 have been dropped, which doesn't match up with the
change history that exists in Publishing API. In this commit we change the
`first_published_at` date for all editions belonging to this document to the
earliest known backdate, 23 August 2015, as it shouldn't be possible to
backdate to a date later than when the document originally got published. There
is a validation in place on `first_published_at` which prevents it from being
updated on superseded editions, so unfortunately we have needed to skip this in
order to save the change.