### PR TITLE
Send publishing-api attachment details to search

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -71,15 +71,8 @@ class Attachment < ApplicationRecord
     Locale.new(locale).rtl?
   end
 
-  # potentially overridden/extended in subclasses.
   def search_index
-    {
-      title: title,
-      isbn: isbn,
-      command_paper_number: command_paper_number,
-      unique_reference: unique_reference,
-      hoc_paper_number: hoc_paper_number,
-    }
+    publishing_api_details
   end
 
   def publishing_api_details

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -50,12 +50,6 @@ class ExternalAttachment < Attachment
     external_url
   end
 
-  def search_index
-    {
-      title: title,
-    }
-  end
-
   def readable_type
     "external"
   end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -75,18 +75,10 @@ class HtmlAttachment < Attachment
     Whitehall.url_maker.public_send(path_helper, attachable.slug, self, options)
   end
 
-  def extracted_text
-    Govspeak::Document.new(govspeak_content_body).to_text
-  end
-
   def should_generate_new_friendly_id?
     return false unless sluggable_locale?
 
     slug.nil? || attachable.nil? || !attachable.document.published?
-  end
-
-  def search_index
-    super.merge(content: extracted_text)
   end
 
   def deep_clone

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,4 +1,48 @@
 namespace :search do
+  desc "Re-index documents with HtmlAttachments.  This will be removed after running once."
+  task resend_documents_with_html_attachments: :environment do
+    editions = []
+
+    total = HtmlAttachment.count
+    count = 0
+    HtmlAttachment.find_each do |a|
+      count += 1
+      if (count % 1000).zero?
+        puts "#{a.id}: #{count} of #{total} (#{count.fdiv(total) * 100}%)"
+      end
+
+      # rubocop:disable Lint/SuppressedException
+      begin
+        next if a.attachable.document.latest_edition.nil?
+
+        editions << a.attachable.document.latest_edition
+      rescue StandardError
+        # just ignore any docs with invalid state
+      end
+      # rubocop:enable Lint/SuppressedException
+    end
+
+    unique = editions.uniq
+    total = unique.count
+
+    puts "all editions: #{editions.count}"
+    puts "unique editions: #{total}"
+
+    count = 0
+    unique.each do |ed|
+      count += 1
+      if (count % 1000).zero?
+        puts "#{ed.id}: #{count} of #{total} (#{count.fdiv(total) * 100}%)"
+      end
+
+      begin
+        ed.update_in_search_index
+      rescue StandardError
+        puts "couldn't update #{ed.id}"
+      end
+    end
+  end
+
   desc "Re-index one Document. Takes a `content_id` as argument."
   task :resend_document, [:content_id] => [:environment] do |_, args|
     Document.find_by(content_id: args[:content_id]).published_edition.update_in_search_index

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -118,19 +118,6 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal attachment.hoc_paper_number, edition.search_index["attachments"][index][:hoc_paper_number]
   end
 
-  test "should include html_attachment content into the #search_index" do
-    attachment = build(:html_attachment,
-                       title: "The title of the HTML attachment",
-                       unique_reference: "w123",
-                       body: "##Test HTML attachment")
-
-    edition = create(:publication, :with_html_attachment, attachments: [attachment])
-
-    assert_equal "The title of the HTML attachment", edition.search_index["attachments"][0][:title]
-    assert_equal "w123", edition.search_index["attachments"][0][:unique_reference]
-    assert_equal "Test HTML attachment", edition.search_index["attachments"][0][:content]
-  end
-
   test "#reorder_attachments should update the ordering of its attachments" do
     attachable = create(:consultation)
     a, b, c = 3.times.map { create(:file_attachment, attachable: attachable) }


### PR DESCRIPTION
The Whitehall side of https://github.com/alphagov/search-api/pull/2044

We'll need to reindex all documents with HTML attachments for the new parts to show up properly.

---

[Trello card](https://trello.com/c/fouzQRyD/1465-index-html-attachments-as-parts-of-their-parent-documents)