### PR TITLE
Revert "Revert hiding ministers during reshuffle"

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -7,7 +7,9 @@
       title: "Ministers"
     } %>
 
-    <p class="govuk-body-l">Read biographies and responsibilities of <a href="#cabinet-ministers">Cabinet ministers</a> and all <a href="#ministers-by-department">ministers by department</a>, as well as the <a href="#whips">whips</a> who help co-ordinate parliamentary business.</p>
+    <% unless @is_during_reshuffle %>
+      <p class="govuk-body-l">Read biographies and responsibilities of <a href="#cabinet-ministers" class="govuk-link">Cabinet ministers</a> and all <a href="#ministers-by-department" class="govuk-link">ministers by department</a>, as well as the <a href="#whips" class="govuk-link">whips</a> who help co-ordinate parliamentary business.</p>
+    <% end %>
   </div>
 </header>
 
@@ -15,7 +17,7 @@
   <%= render "govuk_publishing_components/components/notice", {
     description_govspeak: bare_govspeak_to_html(@reshuffle_messaging),
   } %>
-<% end %>
+<% else %>
 
 <section class="cab_ministers govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -148,3 +150,5 @@
     <% end %>
   <% end %>
 </section>
+
+<% end %>

--- a/features/sitewide_settings.feature
+++ b/features/sitewide_settings.feature
@@ -9,6 +9,7 @@ Feature: Sitewide settings
     Given we are during a reshuffle
     When I visit the ministers page
     Then I should see a reshuffle warning message
+    And I should not see the ministers and cabinet
 
   Scenario: Minister counts should be visible outside of a minister reshuffle
     Given we are not during a reshuffle

--- a/features/step_definitions/sitewide_settings_steps.rb
+++ b/features/step_definitions/sitewide_settings_steps.rb
@@ -31,3 +31,9 @@ Then(/^I should (not )?see a reshuffle warning message$/) do |negate|
     assert_text "Test minister reshuffle message"
   end
 end
+
+Then(/^I should not see the ministers and cabinet$/) do
+  assert_no_selector "h2", text: "Cabinet ministers"
+  assert_no_selector "h2", text: "Also attends Cabinet"
+  assert_no_selector "h2", text: "Ministers by department"
+end


### PR DESCRIPTION
Reverts alphagov/whitehall#5169

This means the logic goes back to not showing any ministers while reshuffle mode is on.

[Trello Card](https://trello.com/c/YjVJt7jF/1887-1-revert-reshuffle-mode-banner-logic)