### PR TITLE
Remove transitive asset replacement logic

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -77,9 +77,6 @@ class AttachmentData < ApplicationRecord
     raise ActiveRecord::RecordInvalid, self if self.errors.any?
 
     self.update_column(:replaced_by_id, replacement.id)
-    AttachmentData.where(replaced_by_id: self.id).find_each do |ad|
-      ad.replace_with!(replacement)
-    end
   end
 
   def uploaded_to_asset_manager!

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -203,16 +203,6 @@ class AttachmentDataTest < ActiveSupport::TestCase
     end
   end
 
-  test "replace_with! will walk the chain and set our replacees to be replaced_by our replacer" do
-    to_be_replaced = create(:attachment_data)
-    replaced = create(:attachment_data, replaced_by: to_be_replaced)
-    replacer = create(:attachment_data)
-
-    to_be_replaced.replace_with!(replacer)
-    assert_equal replacer, to_be_replaced.replaced_by
-    assert_equal replacer, replaced.reload.replaced_by
-  end
-
   test "order attachments by attachable ID" do
     attachment_data = create(:attachment_data)
     edition_1 = create(:edition)


### PR DESCRIPTION
This is handled in Asset Manager, and has been for a while.  This code
as it is causes problems with redirect chains.  Say you have two live
assets:

    Asset 1 -> Asset 2

(where `->` means "is replaced by")

Visiting Asset 1 redirects you to Asset 2, good stuff.

Then you add a third, draft, asset, as a replacement for Asset 2.
This transitive closure logic kicks in, and we end up with:

    Asset 1 -> Asset 3
    Asset 2 -> Asset 3

As Asset 3 is a draft, neither Asset 1 nor Asset 2 redirect to it.
But the redirect from Asset 1 to Asset 2 is now broken!

Asset Manager handles this properly, so stop trying to be clever and
just let it do its thing.

---

[Trello card](https://trello.com/c/dsIeWe0W/1904-5-plan-how-to-address-issues-with-asset-manager-drafts)