### PR TITLE
Delete unpublishings in ScheduledEditionPublisher

### DIFF
--- a/app/services/scheduled_edition_publisher.rb
+++ b/app/services/scheduled_edition_publisher.rb
@@ -25,5 +25,10 @@ private
     edition.publish
     edition.save(validate: false)
     supersede_previous_editions!
+    delete_unpublishing!
+  end
+
+  def delete_unpublishing!
+    edition.unpublishing.destroy if edition.unpublishing.present?
   end
 end


### PR DESCRIPTION
If a document is unpublished and then scheduled-published, whitehall
gets into a weird state where the document is reported as both
published and unpublished.  This is because it doesn't delete the
unpublishing record.

This commit copies the code to delete an unpublishing from the
EditionPublisher.  This makes the fire_transition! for scheduled
editions almost the same as the fire_transition! for non-scheduled
editions, but with one important difference: a scheduled edition isn't
validated.

This is intentional behaviour from the first implementation, 19fca44:

> Scheduled editions should bypass validation when being published to
> ensure that a change in the validation rules inbetween being
> scheduled and the scheduled publication date doesn't prevent the
> edition being published.

It would be nice to delete ScheduledEditionPublisher.fire_transition!,
but not really if we have to complicate EditionPublisher.fire_transition!
with selective validation logic.

---

[Trello card](https://trello.com/c/u5PfuWkb/1903-investigate-why-there-are-published-documents-showing-as-unpublished-in-whitehall-timebox-2-days)