### PR TITLE
Do not set placeholder image for news articles

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -1,4 +1,8 @@
 module LeadImagePresenterHelper
+  def has_lead_image?
+    !image_data.nil?
+  end
+
   def lead_image_path
     if image_data
       image_url

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -131,6 +131,8 @@ module PublishingApi
       end
 
       def call
+        return {} unless news_article.has_lead_image?
+
         image_url = ActionController::Base.helpers.image_url(
           news_article.lead_image_path, host: Whitehall.public_asset_host
         )

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -45,7 +45,7 @@ module PublishingApi
         body: govspeak_renderer.govspeak_edition_to_html(item),
         change_history: item.change_history.as_json,
       }.tap do |details_hash|
-        details_hash[:image] = image_details
+        details_hash.merge!(image_details)
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::TagDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
@@ -54,10 +54,14 @@ module PublishingApi
     end
 
     def image_details
+      return {} unless presented_world_location_news_article.has_lead_image?
+
       {
-        url: image_url,
-        alt_text: presented_world_location_news_article.lead_image_alt_text,
-        caption: presented_world_location_news_article.lead_image_caption,
+        image: {
+          url: image_url,
+          alt_text: presented_world_location_news_article.lead_image_alt_text,
+          caption: presented_world_location_news_article.lead_image_caption,
+        },
       }
     end
 

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -43,11 +43,6 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]
   end
 
-  test "search_index includes image_url" do
-    news_article = create(:news_article)
-    assert_equal "https://static.test.gov.uk/government/assets/placeholder.jpg", news_article.search_index["image_url"]
-  end
-
   test "search_format_types tags the news article as a news-article and announcement" do
     news_article = build(:news_article)
     assert news_article.search_format_types.include?("news-article")

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -232,6 +232,7 @@ module PublishingApi::NewsArticlePresenterTest
         .with(news_article)
         .returns(
           stub(
+            has_lead_image?: true,
             lead_image_path: "/foo",
             high_resolution_lead_image_path: "/foo-large",
             lead_image_alt_text: "Bar",

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -297,24 +297,6 @@ class PublishingApi::WorldLocationNewsArticleImageDetailsTest < ActiveSupport::T
   end
 end
 
-class PublishingApi::WorldLocationNewsArticlePlaceholderImageTest < ActiveSupport::TestCase
-  setup do
-    create(:current_government)
-    @wlna = create(:world_location_news_article)
-    @presented_wlna = PublishingApi::WorldLocationNewsArticlePresenter.new(@wlna)
-  end
-
-  test "includes a placeholder image when no image is presented" do
-    expected_placeholder_image = {
-      alt_text: "placeholder",
-      caption: nil,
-      url: Whitehall.public_asset_host + "/government/assets/placeholder.jpg",
-    }
-
-    assert_equal expected_placeholder_image, @presented_wlna.content[:details][:image]
-  end
-end
-
 class PublishingApi::WorldLocationNewsArticlePresenterAttachmentTest < ActiveSupport::TestCase
   setup do
     create(:current_government)


### PR DESCRIPTION
government-frontend has its own fallback images, so setting them here
prevents that one from being used.

See https://github.com/alphagov/government-frontend/blob/master/app/presenters/content_item/news_image.rb