### PR TITLE
Add ministers index page to the content item

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-      }
+      }.merge(item.ministerial? ? { ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f] } : {})
     end
 
   private

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -45,6 +45,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
+      ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
If the role is ministerial we want to present the ministers index page.

The content id of the ministers index page is found from https://github.com/alphagov/whitehall/blob/master/lib/publish_static_pages.rb#L102-L109, which is '324e4708-2285-40a0-b3aa-cb13af14ec5f'.

Trello: https://trello.com/c/i1ffrXiZ/1913-5-link-ministers-to-the-government-ministers-content-item