### PR TITLE
Vanish funky groups from govuk

### DIFF
--- a/app/workers/publishing_api_vanish_worker.rb
+++ b/app/workers/publishing_api_vanish_worker.rb
@@ -1,11 +1,12 @@
 class PublishingApiVanishWorker < PublishingApiWorker
-  def perform(content_id, locale)
+  def perform(content_id, locale, discard_drafts: false)
     check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.unpublish(
       content_id,
       type: "vanish",
       locale: locale,
+      discard_drafts: discard_drafts,
     )
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as we can't unpublish something that doesn't exist

--- a/db/data_migration/20200421181910_vanish_placeholder_working_groups_in_broken_state.rb
+++ b/db/data_migration/20200421181910_vanish_placeholder_working_groups_in_broken_state.rb
@@ -1,0 +1,8 @@
+broken_group_content_ids = Services.publishing_api.lookup_content_ids(
+  base_paths: ["/government/groups/funding-external-technical-advisory-group",
+               "/government/groups/military-stabilisation-support-group"],
+).values
+
+broken_group_content_ids.each do |content_id|
+  PublishingApiVanishWorker.perform_async(content_id, "en", discard_drafts: true)
+end

--- a/test/unit/workers/publishing_api_vanish_worker_test.rb
+++ b/test/unit/workers/publishing_api_vanish_worker_test.rb
@@ -22,6 +22,25 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
     assert_requested request
   end
 
+  test "publishes a 'vanish' item for the supplied content id including the discard drafts flag" do
+    publication = create(:withdrawn_publication)
+
+    request = stub_publishing_api_unpublish(
+      publication.document.content_id,
+      body: {
+        type: "vanish",
+        locale: "en",
+        discard_drafts: true,
+      },
+    )
+
+    PublishingApiVanishWorker.new.perform(
+      publication.document.content_id, "en", discard_drafts: true
+    )
+
+    assert_requested request
+  end
+
   test "an error if document is locked" do
     document = create(:document, locked: true)
 


### PR DESCRIPTION
We want to vanish two broken placeholder_working_group editions from pub-api and from relevant services downstream. This is due to data being inconsistent or missing for these groups causing them to be flagged as live in pub-api and content-store but missing routes and not present in the original publishing application (whitehall).

Trello:
https://trello.com/c/ygOqmhWw/1921-remove-legacy-placeholderworkinggroup-code-data-from-govuks-codebase