### PR TITLE
Update PublishingApiVanishWorker to not take strong args

### DIFF
--- a/app/workers/publishing_api_vanish_worker.rb
+++ b/app/workers/publishing_api_vanish_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiVanishWorker < PublishingApiWorker
-  def perform(content_id, locale, discard_drafts: false)
+  def perform(content_id, locale, discard_drafts = false)
     check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.unpublish(

--- a/db/data_migration/20200421181910_vanish_placeholder_working_groups_in_broken_state.rb
+++ b/db/data_migration/20200421181910_vanish_placeholder_working_groups_in_broken_state.rb
@@ -4,5 +4,5 @@ broken_group_content_ids = Services.publishing_api.lookup_content_ids(
 ).values
 
 broken_group_content_ids.each do |content_id|
-  PublishingApiVanishWorker.perform_async(content_id, "en", discard_drafts: true)
+  PublishingApiVanishWorker.perform_async(content_id, "en", true)
 end

--- a/test/unit/workers/publishing_api_vanish_worker_test.rb
+++ b/test/unit/workers/publishing_api_vanish_worker_test.rb
@@ -8,16 +8,15 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
     publication = create(:withdrawn_publication)
 
     request = stub_publishing_api_unpublish(
-      publication.document.content_id,
+      publication.content_id,
       body: {
         type: "vanish",
         locale: "en",
       },
     )
 
-    PublishingApiVanishWorker.new.perform(
-      publication.document.content_id, "en"
-    )
+    PublishingApiVanishWorker.perform_async(publication.content_id, "en")
+    PublishingApiVanishWorker.drain
 
     assert_requested request
   end
@@ -26,7 +25,7 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
     publication = create(:withdrawn_publication)
 
     request = stub_publishing_api_unpublish(
-      publication.document.content_id,
+      publication.content_id,
       body: {
         type: "vanish",
         locale: "en",
@@ -34,9 +33,8 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
       },
     )
 
-    PublishingApiVanishWorker.new.perform(
-      publication.document.content_id, "en", discard_drafts: true
-    )
+    PublishingApiVanishWorker.perform_async(publication.content_id, "en", true)
+    PublishingApiVanishWorker.drain
 
     assert_requested request
   end
@@ -45,7 +43,8 @@ class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
     document = create(:document, locked: true)
 
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
-      PublishingApiVanishWorker.new.perform(document.content_id, "en")
+      PublishingApiVanishWorker.perform_async(document.content_id, "en")
+      PublishingApiVanishWorker.drain
     end
   end
 end


### PR DESCRIPTION
This commit stop's using strong arguments when calling the vanish
worker. According to sidekiq you can't use key / value arguments when
calling perform_async but you apparently can when calling perform
synchronously (why... :facepalm:). This led to the tests not catching
the issue and only finding out when trying to run the associated data
migration. I've also updated the tests to reflect the actual use cases.

See the issue here -> https://github.com/mperham/sidekiq/issues/2372.

```
PublishingApiVanishWorker.perform_async('s', 's', discard_drafts: "S")
Sidekiq::RetrySet.new.select { |x| x }.last.item["error_message"]
-> "wrong number of arguments (given 3, expected 2)"
```

Trello:
https://trello.com/c/ygOqmhWw/1921-remove-legacy-placeholderworkinggroup-code-data-from-govuks-codebase