### PR TITLE
Do not present "ministers" links to pub-api

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -42,7 +42,6 @@ module PublishingApi
       LinksPresenter
         .new(consultation)
         .extract(%i(organisations parent policy_areas topics government))
-        .merge(PayloadBuilder::People.for(consultation, :ministers))
         .merge(PayloadBuilder::People.for(consultation, :people))
         .merge(PayloadBuilder::Roles.for(consultation))
         .merge(PayloadBuilder::TopicalEvents.for(consultation))

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -42,7 +42,7 @@ module PublishingApi
       LinksPresenter
         .new(consultation)
         .extract(%i(organisations parent policy_areas topics government))
-        .merge(PayloadBuilder::People.for(consultation, :people))
+        .merge(PayloadBuilder::People.for(consultation))
         .merge(PayloadBuilder::Roles.for(consultation))
         .merge(PayloadBuilder::TopicalEvents.for(consultation))
     end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -45,7 +45,7 @@ module PublishingApi
       ).merge(
         field_of_operation: [item.operational_field.content_id],
       ).merge(
-        PayloadBuilder::People.for(item, :people),
+        PayloadBuilder::People.for(item),
       ).merge(
         PayloadBuilder::Roles.for(item),
       )

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -45,8 +45,6 @@ module PublishingApi
       ).merge(
         field_of_operation: [item.operational_field.content_id],
       ).merge(
-        PayloadBuilder::People.for(item, :ministers),
-      ).merge(
         PayloadBuilder::People.for(item, :people),
       ).merge(
         PayloadBuilder::Roles.for(item),

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -47,7 +47,7 @@ module PublishingApi
         .extract(link_keys)
         .merge(PayloadBuilder::TopicalEvents.for(news_article))
         .merge(PayloadBuilder::Roles.for(news_article))
-        .merge(PayloadBuilder::People.for(news_article, :people))
+        .merge(PayloadBuilder::People.for(news_article))
     end
 
     def document_type

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -45,7 +45,6 @@ module PublishingApi
       LinksPresenter
         .new(news_article)
         .extract(link_keys)
-        .merge(PayloadBuilder::People.for(news_article, :ministers))
         .merge(PayloadBuilder::TopicalEvents.for(news_article))
         .merge(PayloadBuilder::Roles.for(news_article))
         .merge(PayloadBuilder::People.for(news_article, :people))

--- a/app/presenters/publishing_api/payload_builder/people.rb
+++ b/app/presenters/publishing_api/payload_builder/people.rb
@@ -1,15 +1,14 @@
 module PublishingApi
   module PayloadBuilder
     class People
-      attr_reader :item, :key
+      attr_reader :item
 
-      def self.for(item, key)
-        self.new(item, key).call
+      def self.for(item)
+        self.new(item).call
       end
 
-      def initialize(item, key)
+      def initialize(item)
         @item = item
-        @key = key
       end
 
       def call
@@ -20,7 +19,7 @@ module PublishingApi
 
       def people
         {
-          key => role_appointments
+          people: role_appointments
             .map(&:person)
             .collect(&:content_id),
         }

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -51,7 +51,6 @@ module PublishingApi
       ).merge(
         PayloadBuilder::TopicalEvents.for(item),
       ).merge(
-        ministers: ministers,
         related_statistical_data_sets: related_statistical_data_sets,
       ).merge(
         PayloadBuilder::Roles.for(item),
@@ -112,10 +111,6 @@ module PublishingApi
       attachments.to_a.select do |attachment|
         locales_that_match.include?(attachment.locale.to_s)
       end
-    end
-
-    def ministers
-      item.role_appointments.collect { |a| a.person.content_id }
     end
 
     def related_statistical_data_sets

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -55,7 +55,7 @@ module PublishingApi
       ).merge(
         PayloadBuilder::Roles.for(item),
       ).merge(
-        PayloadBuilder::People.for(item, :people),
+        PayloadBuilder::People.for(item),
       )
     end
 

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -64,7 +64,7 @@ module PublishingApi
       links.merge!(links_for_speaker)
       links.merge!(links_for_topical_events)
       links.merge!(PayloadBuilder::Roles.for(item))
-      links.merge!(PayloadBuilder::People.for(item, :people))
+      links.merge!(PayloadBuilder::People.for(item))
     end
 
     def document_type

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -629,16 +629,6 @@ module PublishingApi::ConsultationPresenterTest
       )
     end
 
-    test "ministers" do
-      expected_content_ids = consultation
-        .role_appointments
-        .map(&:person)
-        .map(&:content_id)
-
-      assert expected_content_ids.present?
-      assert_equal expected_content_ids, presented_links[:ministers]
-    end
-
     test "people" do
       expected_content_ids = consultation
         .role_appointments

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -68,7 +68,6 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents edition links" do
     expected_links = {
       field_of_operation: [@fatality_notice.operational_field.content_id],
-      ministers: [],
       organisations: [],
       people: [],
       policy_areas: [],
@@ -194,13 +193,6 @@ class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::
     assert_equal(
       [@fatality_notice.operational_field.content_id],
       @presented_links[:field_of_operation],
-    )
-  end
-
-  test "it presents the role_appointments person content_ids as links, ministers" do
-    assert_equal(
-      @fatality_notice.role_appointments.map(&:person).collect(&:content_id),
-      @presented_links[:ministers],
     )
   end
 

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -262,15 +262,6 @@ module PublishingApi::NewsArticlePresenterTest
       )
     end
 
-    test "ministers" do
-      expected_content_ids = news_article
-        .role_appointments
-        .map(&:person)
-        .map(&:content_id)
-
-      assert_equal presented_links[:ministers], expected_content_ids
-    end
-
     test "roles" do
       expected_content_ids = news_article
         .role_appointments

--- a/test/unit/presenters/publishing_api/payload_builder/people_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/people_test.rb
@@ -8,7 +8,7 @@ module PublishingApi
 
         expected_hash = { people: [] }
 
-        assert_equal expected_hash, People.for(edition_with_no_roles_or_people, :people)
+        assert_equal expected_hash, People.for(edition_with_no_roles_or_people)
       end
 
       test "returns empty array of people if role_appointment is nil" do
@@ -16,7 +16,7 @@ module PublishingApi
 
         expected_hash = { people: [] }
 
-        assert_equal expected_hash, People.for(stubbed_edition, :people)
+        assert_equal expected_hash, People.for(stubbed_edition)
       end
 
       test "returns single person when role_appointment is present but edition_role_appointments is not" do
@@ -26,7 +26,7 @@ module PublishingApi
         stubbed_edition = stub(role_appointment: role_appointment)
         expected_hash = { people: [person.content_id] }
 
-        assert_equal expected_hash, People.for(stubbed_edition, :people)
+        assert_equal expected_hash, People.for(stubbed_edition)
       end
 
       test "returns an empty array of people if role_appointments are nil" do
@@ -34,7 +34,7 @@ module PublishingApi
 
         expected_hash = { people: [] }
 
-        assert_equal expected_hash, People.for(stubbed_edition, :people)
+        assert_equal expected_hash, People.for(stubbed_edition)
       end
 
       test "returns an array of content_ids from people in edition_role_appointments" do
@@ -50,7 +50,7 @@ module PublishingApi
           end,
         }
 
-        assert_equal expected_hash, People.for(stubbed_edition, :people)
+        assert_equal expected_hash, People.for(stubbed_edition)
       end
     end
   end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -51,8 +51,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       },
     }
 
-    minister = create(:ministerial_role_appointment)
-    publication.role_appointments << minister
     topical_event = create(:topical_event)
     publication.classification_memberships.create(classification_id: topical_event.id)
     expected_links = {
@@ -62,7 +60,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       original_primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       organisations: publication.lead_organisations.map(&:content_id),
-      ministers: [minister.person.content_id],
       related_statistical_data_sets: [statistical_data_set.content_id],
       world_locations: [],
       topical_events: [topical_event.content_id],


### PR DESCRIPTION
This link type was [deprecated in 2018](https://github.com/alphagov/govuk-content-schemas/commit/100723ddca309a65d80d03493bf61ba7e91d5366), and doesn't seem to be used any
more.

---

[Trello card](https://trello.com/c/i1ffrXiZ/1913-5-link-ministers-to-the-government-ministers-content-item)