### PR TITLE
Add links to people in organisation content item

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -42,13 +42,13 @@ module PublishingApi
 
     def links
       {
+        ordered_child_organisations: child_organisation_links,
         ordered_contacts: contacts_links,
         ordered_foi_contacts: foi_contacts_links,
-        ordered_parent_organisations: parent_organisation_links,
-        ordered_child_organisations: child_organisation_links,
-        ordered_successor_organisations: successor_organisation_links,
         ordered_high_profile_groups: high_profile_groups_links,
+        ordered_parent_organisations: parent_organisation_links,
         ordered_roles: roles_links,
+        ordered_successor_organisations: successor_organisation_links,
         primary_publishing_organisation: [content_id],
       }
     end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -42,13 +42,19 @@ module PublishingApi
 
     def links
       {
+        ordered_board_members: people_content_items(role: "management"),
+        ordered_chief_professional_officers: people_content_items(role: "chief_professional_officer"),
         ordered_child_organisations: child_organisation_links,
         ordered_contacts: contacts_links,
         ordered_foi_contacts: foi_contacts_links,
         ordered_high_profile_groups: high_profile_groups_links,
+        ordered_military_personnel: people_content_items(role: "military"),
+        ordered_ministers: people_content_items(role: "ministerial"),
         ordered_parent_organisations: parent_organisation_links,
         ordered_roles: roles_links,
+        ordered_special_representatives: people_content_items(role: "special_representative"),
         ordered_successor_organisations: successor_organisation_links,
+        ordered_traffic_commissioners: people_content_items(role: "traffic_commissioner"),
         primary_publishing_organisation: [content_id],
       }
     end
@@ -414,6 +420,14 @@ module PublishingApi
 
           ary
         end
+    end
+
+    def people_content_items(role:)
+      item.send("#{role}_roles")
+        .order("organisation_roles.ordering")
+        .map(&:current_person)
+        .compact
+        .map(&:content_id)
     end
 
     def important_board_members

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -34,6 +34,9 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       summary: "This org is a thing!",
     )
     role = create(:role, organisations: [organisation])
+    minister = create(:person)
+    create(:ministerial_role_appointment, role: role, person: minister)
+
     public_path = Whitehall.url_maker.organisation_path(organisation)
     public_atom_path = "#{public_path}.atom"
 
@@ -72,7 +75,17 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         ordered_featured_links: [],
         ordered_featured_documents: [],
         ordered_promotional_features: [],
-        ordered_ministers: [],
+        ordered_ministers: [
+          {
+            name_prefix: nil,
+            name: minister.name,
+            role: role.name,
+            href: "/government/people/#{minister.slug}",
+            role_href: "/government/ministers/#{role.name}",
+            payment_type: nil,
+            attends_cabinet_type: nil,
+          },
+        ],
         ordered_board_members: [],
         ordered_military_personnel: [],
         ordered_traffic_commissioners: [],
@@ -98,10 +111,11 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     expected_links = {
       ordered_contacts: [],
       ordered_foi_contacts: [],
+      ordered_high_profile_groups: [],
       ordered_parent_organisations: [parent_organisation.content_id],
       ordered_child_organisations: [],
       ordered_successor_organisations: [],
-      ordered_high_profile_groups: [],
+      ordered_ministers: [minister.content_id],
       ordered_roles: [role.content_id],
       primary_publishing_organisation: [organisation.content_id],
     }


### PR DESCRIPTION
We want to start rendering this information from the links rather than the details so we can use dependency resolution to automatically represent these rather than having to do it in Whitehall.

Related to https://github.com/alphagov/govuk-content-schemas/pull/983.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)