### PR TITLE
Add custom error when updating an asset without any attributes

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -7,6 +7,12 @@ class AssetManager::AssetUpdater
     end
   end
 
+  class AssetAttributesEmpty < StandardError
+    def initialize(attachment_data_id, legacy_url_path)
+      super("Attempting to update '#{legacy_url_path}' for Attachment Data #{attachment_data_id} with empty attachment attributes")
+    end
+  end
+
   def self.call(*args)
     new.call(*args)
   end
@@ -26,6 +32,9 @@ class AssetManager::AssetUpdater
     end
 
     keys = new_attributes.keys
+
+    raise AssetAttributesEmpty.new(attachment_data.id, legacy_url_path) if new_attributes.empty?
+
     unless attributes.slice(*keys) == new_attributes.slice(*keys)
       asset_manager.update_asset(attributes["id"], new_attributes)
     end

--- a/test/unit/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/services/asset_manager/asset_updater_test.rb
@@ -37,7 +37,9 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
       .returns("id" => @asset_url)
     Services.asset_manager.expects(:update_asset).never
 
-    @worker.call(@attachment_data, @legacy_url_path)
+    assert_raises(AssetManager::AssetUpdater::AssetAttributesEmpty) do
+      @worker.call(@attachment_data, @legacy_url_path)
+    end
   end
 
   test "marks draft asset as published" do


### PR DESCRIPTION
Whitehall's AssetManager::AssetUpdater is sending requests with apparently
empty `new_attributes` which is causing the AssetManager app to respond
with ['File must not be blank' errors.](https://sentry.io/organizations/govuk/issues/1244077370/?environment=production&project=202259&query=is%3Aunresolved&sort=freq&statsPeriod=24h) 

The intention is that empty attributes should not be sent to AssetManager,
so this commit adds an explicit error message to catch these before the request is made.

[Trello](https://trello.com/c/sId7JPg1/1949-5-investigate-asset-manager-not-uploading-files-sentry-errors)
