### PR TITLE
Add task to publish redirect routes

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -61,6 +61,40 @@ namespace :publishing_api do
     end
   end
 
+  desc "Publish redirect routes (eg /government/world)"
+  task publish_redirect_routes: :environment do
+    [
+      {
+        base_path: "/government/world",
+        destination: "/world",
+        content_id: "36620cf9-00b3-4d51-afab-e05e457061e3",
+        title: "Redirect to /world",
+      },
+    ].each do |route|
+      Services.publishing_api.put_content(
+        route[:content_id],
+        base_path: route[:base_path],
+        document_type: "redirect",
+        schema_name: "redirect",
+        title: route[:title],
+        description: "",
+        locale: "en",
+        details: {},
+        redirects: [
+          {
+            path: options[:base_path],
+            type: options.fetch(:type, "prefix"),
+            destination: options[:destination],
+          },
+        ],
+        publishing_app: "whitehall",
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: "major",
+      )
+      publishing_api.publish(route[:content_id])
+    end
+  end
+
   desc "Send published item links to Publishing API."
   task patch_published_item_links: :environment do
     editions = Edition.published


### PR DESCRIPTION
Spotted this while reviewing kibana for pages still rendered by whitehall-frontend, and thought it was straight-forward enough to just fix.

Once this has been run in production, we can remove this routing: https://github.com/alphagov/whitehall/blob/4fedaa4efa5267d45c989a1ff8b6011cc5c9ea40/config/routes.rb#L178-L183

---

[Trello card](https://trello.com/c/5HCKMQiw/1956-publish-a-route-redirecting-government-world-to-world)