### PR TITLE
[DO NOT MERGE] Noindex withdrawn content for crawlers

### DIFF
--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -17,6 +17,9 @@
   )
 %>
 
+<%# This will be hoisted into <head> by Slimmer %>
+<% tag :meta, name: 'robots', content: 'noindex' if document.withdrawn? %>
+
 <%= render('documents/withdrawn_notice', document: document, type: document.format_name) if document.withdrawn? %>
 
 <div class="heading-extra">


### PR DESCRIPTION
** This has been paused until we sort out the proposition/comms **

We publish a sitemap with down-weighting for withdrawn content, however this does not seem to affect the ranking of external search results as much as we might hope.

By no-indexing here, we hope to surface current information more readily in places like google.

Should users wish to find withdrawn content, then it'll be findable via site search or navigation.

https://trello.com/c/YcXJ8OFD/258-noindex-withdrawn-content