### PR TITLE
Remove duplicate development config assignment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,9 +17,6 @@ Whitehall::Application.configure do
   config.action_controller.perform_caching = false
   config.action_controller.action_on_unpermitted_parameters = :raise
 
-  # Show full error reports.
-  config.consider_all_requests_local = true
-
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true


### PR DESCRIPTION
`consider_all_requests_local` is already set to true three lines above
this (on line 16). Having it set twice could trip people up if they're
trying to change the value locally to debug an issue with logging and
only spot one use (this just happened to me).