### PR TITLE
Present internal taxon name to publishers

### DIFF
--- a/lib/taxonomy/taxon.rb
+++ b/lib/taxonomy/taxon.rb
@@ -18,7 +18,7 @@ module Taxonomy
 
     def self.from_taxon_hash(taxon_hash)
       taxon = Taxon.new(
-        title: taxon_hash["title"],
+        title: taxon_hash.dig("details", "internal_name") || taxon_hash["title"],
         base_path: taxon_hash["base_path"],
         content_id: taxon_hash["content_id"],
         phase: taxon_hash["phase"],


### PR DESCRIPTION
This will help give more context to areas of the taxonomy that are mixed, such as the new coronavirus branch.  This has areas that collide with others (such as education or business topics), so additional information in the publishing tool is useful.