### PR TITLE
Change config.logstasher.suppress_app_log to false

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,7 +125,7 @@ Whitehall::Application.configure do
   # Enable JSON-style logging
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new(Rails.root.join("log/#{Rails.env}.json.log"))
-  config.logstasher.suppress_app_log = true
+  config.logstasher.suppress_app_log = false
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
I'm not sure why this is true, it's also set to true in the
govuk_app_config gem, but this removes the "Started ..." log lines
that could potentially help separate out log lines related to
different requests.