### PR TITLE
Update change note form text

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -31,7 +31,7 @@
       function appendHintToFormLabel() {
         var $label = $($change_notes_section).find('label');
         var example_text = "For example, \"Edited chapter 6 - centres in Cardiff and Aberystwyth have closed.\""
-        var info_text = "The text will be published on the page and emailed to users signed up to alerts."
+        var info_text = "A change note will be published on the page and emailed to users signed up to alerts."
         $label.append('<p class="hint"; style="font-weight: normal">' + example_text + '<br>' + info_text + '</p>');
       }
 

--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -23,9 +23,17 @@
       var $radio_buttons             = $('input[type=radio]', $fieldset);
       var $minor_change_radio_button = $('#edition_minor_change_true', $fieldset);
       var $change_notes_section      = $('.js-change-notes-section', $fieldset);
+      var $change_notes_label        = $('.js-change-notes-section label');
 
       $radio_buttons.change(showOrHideChangeNotes);
+      appendHintToFormLabel();
       showOrHideChangeNotes();
+
+      function appendHintToFormLabel() {
+        var example_text = "For example, \"Edited chapter 6 - centres in Cardiff and Aberystwyth have closed.\""
+        var info_text = "The text will be published on the page and emailed to users signed up to alerts."
+        $change_notes_label.append(`<p class="hint"; style='font-weight: normal'>${example_text}<br>${info_text}<p>`);
+      }
 
       function showOrHideChangeNotes() {
         if ($minor_change_radio_button.prop('checked')){

--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -31,8 +31,7 @@
       function appendHintToFormLabel() {
         var $label = $($change_notes_section).find('label');
         var example_text = "For example, \"Edited chapter 6 - centres in Cardiff and Aberystwyth have closed.\""
-        var info_text = "A change note will be published on the page and emailed to users signed up to alerts."
-        $label.append('<p class="hint"; style="font-weight: normal">' + example_text + '<br>' + info_text + '</p>');
+        $label.append('<p class="hint"; style="font-weight: normal">' + example_text + '</p>');
       }
 
       function showOrHideChangeNotes() {

--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -23,16 +23,16 @@
       var $radio_buttons             = $('input[type=radio]', $fieldset);
       var $minor_change_radio_button = $('#edition_minor_change_true', $fieldset);
       var $change_notes_section      = $('.js-change-notes-section', $fieldset);
-      var $change_notes_label        = $('.js-change-notes-section label');
 
       $radio_buttons.change(showOrHideChangeNotes);
       appendHintToFormLabel();
       showOrHideChangeNotes();
 
       function appendHintToFormLabel() {
+        var $label = $($change_notes_section).find('label');
         var example_text = "For example, \"Edited chapter 6 - centres in Cardiff and Aberystwyth have closed.\""
         var info_text = "The text will be published on the page and emailed to users signed up to alerts."
-        $change_notes_label.append(`<p class="hint"; style='font-weight: normal'>${example_text}<br>${info_text}<p>`);
+        $label.append('<p class="hint"; style="font-weight: normal">' + example_text + '<br>' + info_text + '</p>');
       }
 
       function showOrHideChangeNotes() {

--- a/app/assets/stylesheets/admin/forms.scss
+++ b/app/assets/stylesheets/admin/forms.scss
@@ -196,6 +196,9 @@ fieldset.fatality-notice-casualties {
     padding-bottom: $gutter-two-thirds;
     p {
       margin: $gutter-one-third 0 0 0;
+      &.hint {
+        color: #626a6e;
+      }
     }
     label {
       font-size: 16px;

--- a/app/assets/stylesheets/admin/forms.scss
+++ b/app/assets/stylesheets/admin/forms.scss
@@ -197,6 +197,7 @@ fieldset.fatality-notice-casualties {
     p {
       margin: $gutter-one-third 0 0 0;
       &.hint {
+        margin-top: 0.2em;
         color: #626a6e;
       }
     }

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -4,18 +4,19 @@
   <div class="radio">
     <%= form.label :minor_change_true do %>
       <%= form.radio_button(:minor_change, true) %>
-      <strong>A typo, style change or similar</strong> (this won’t send an email to subscribed users)
+      <strong>Fixing a typo or broken link, a style change or similar</strong>
+      <p class="hint">Users signed up to email alerts won't be notified</p>
     <% end %>
   </div>
   <div class="radio">
     <%= form.label :minor_change_false do %>
       <%= form.radio_button(:minor_change, false) %>
-      <strong>A significant edit to the page, such as a change of address</strong> (your note will be visible on the page, and emailed to subscribers)
+      <strong>A significant edit that affects what users need to do or know</strong>
     <% end %>
   </div>
   <div class="js-change-notes-section">
     <div class="form-group">
-      <%= form.text_area(:change_note, rows: 4, placeholder: 'For example, "We have added potatoes to the banned import list" or "Attached new application form for 2018"', label_text:'Public change note', class: 'form-control') %>
+      <%= form.text_area(:change_note, rows: 4, label_text: "Enter a public change note", class: 'form-control') %>
     </div>
   </div>
   <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -16,7 +16,7 @@
   </div>
   <div class="js-change-notes-section">
     <div class="form-group">
-      <%= form.text_area(:change_note, rows: 4, label_text: "Enter a public change note", class: 'form-control') %>
+      <%= form.text_area(:change_note, rows: 4, label_text: "Public change note", class: 'form-control') %>
     </div>
   </div>
   <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -12,6 +12,7 @@
     <%= form.label :minor_change_false do %>
       <%= form.radio_button(:minor_change, false) %>
       <strong>A significant edit that affects what users need to do or know</strong>
+      <p class="hint">A change note will be published on the page and emailed to users signed up to alerts</p>
     <% end %>
   </div>
   <div class="js-change-notes-section">


### PR DESCRIPTION
This PR updates the text on change note radio buttons, and removes the placeholder text from the text box. 

It uses JS to append some text between a form label and text box, as there is not currently a straightforward way of implementing this using our custom FormBuilder.

Before:
<img width="620" alt="before" src="https://user-images.githubusercontent.com/13475227/81925554-9dbb6500-95d8-11ea-8ea1-c7c4445222c3.png">

After:
<img width="826" alt="Screenshot 2020-05-18 at 17 02 49" src="https://user-images.githubusercontent.com/13475227/82234520-6ecf2700-9929-11ea-8bf5-e51c0f3ffeb5.png">

[Trello](https://trello.com/c/XwabeJac/1966-2-changes-to-change-note-box-in-whitehall)
