### PR TITLE
Explain bug and link to support form

### DIFF
--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -1,7 +1,12 @@
 <% if edition.superseded? %>
   <div class="alert alert-danger">
-    <p>This edition has been superseded.</p>
-    <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
+    <% if edition.id == edition.latest_edition.id %>
+      <p>This edition has been marked as superseded, but the edition that supersedes it has been deleted.</p>
+      <p>Fill out the <a href="https://www.gov.uk/support/internal">GDS support form (Zendesk)</a> if you need to create a new edition.</p>
+    <% else %>
+      <p>This edition has been superseded.</p>
+      <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
+    <% end %>
   </div>
 <% elsif edition.pre_publication? && edition.latest_published_edition %>
   <div class="alert alert-info">


### PR DESCRIPTION
Sometimes a document can get into a state whereby its latest
edition is deleted, and the most recent non-deleted edition
is marked as 'superseded'. The result is a 'Go to most
recent edition' button that just refreshes the same page
again and again.

A 'proper fix' needs careful consideration. When an edition
is deleted, should the previous edition itself be changed
from 'superseded', or should it be cloned to retain history
(i.e. a timeline of ['superseded', 'deleted', 'draft'])?
Do we have any way of knowing what the previous edition
state was prior to being 'superseded' (e.g. 'draft' /
'published'), and therefore what it should now be set to?

In the absence of a permanent fix, a pragmatic stop-gap
would be to explain the situation to users and link to a
support form so that they can ask for help if needed. The
extra context should enable us to help them more quickly
too.

This PR arises out of https://trello.com/c/9u5j3uI0/1989-investigate-the-situation-regarding-documents-in-whitehall-where-the-latest-edition-is-somehow-also-superseded
An example of a document in this state is https://whitehall-admin.staging.publishing.service.gov.uk/government/admin/statistical-data-sets/75305

Before:

<img width="1185" alt="Screenshot 2020-05-14 at 16 11 44" src="https://user-images.githubusercontent.com/5111927/81952890-eab23200-95fe-11ea-8d1e-3f9040242074.png">

After:

<img width="1175" alt="Screenshot 2020-05-14 at 16 11 50" src="https://user-images.githubusercontent.com/5111927/81952907-ef76e600-95fe-11ea-99bf-cddbc1b531fb.png">
