### PR TITLE
Delete Document when deleting Edition, if it has no other Editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -94,6 +94,7 @@ class Edition < ApplicationRecord
   # @!group Callbacks
   before_save :set_public_timestamp
   before_save { check_if_locked_document(edition: self) }
+  after_destroy :delete_document_if_no_other_editions
   # @!endgroup
 
   class UnmodifiableValidator < ActiveModel::Validator
@@ -638,6 +639,12 @@ EXISTS (
                             else
                               major_change_published_at
                             end
+  end
+
+  def delete_document_if_no_other_editions
+    if document && document.editions.reject(id: id).count.zero?
+      document.destroy
+    end
   end
 
   def title_required?

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -518,6 +518,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_not EditorialRemark.find_by(id: relation.id)
   end
 
+  test "#destroy should also destroy the document if this is the first edition" do
+    document = create(:document)
+    edition = create(:draft_edition, document: document)
+    edition.destroy
+    assert_not Document.find_by(id: document.id)
+  end
+
+  test "#destroy should not destroy the document if it is associated with other editions" do
+    established_document = create(:document)
+    _first_edition = create(:published_edition, document: established_document)
+    second_edition = create(:draft_edition, document: established_document)
+    second_edition.destroy
+    assert Document.find(established_document.id)
+  end
+
   test ".in_chronological_order returns editions in ascending order of first_published_at" do
     jan = create(:edition, first_published_at: Date.parse("2011-01-01"))
     mar = create(:edition, first_published_at: Date.parse("2011-03-01"))


### PR DESCRIPTION
We have a bug in DocumentCollection whereby if you add a Document
to a DocumentCollectionGroup (thereby making a
DocumentCollectionGroupMembership), then put that Document in a
'deleted' state... it no longer appears in the group, but the
association is still there, and the publisher is unable to delete
that group. They see the following error message:

!["You can’t delete a group that has documents in it – remove the documents first, or move them into another group."](https://user-images.githubusercontent.com/5111927/82052188-21e21b00-96b3-11ea-9b40-bca1a51cab1f.png)


A Document can get into a deleted state by, for example, being a
newly created Document which has just one Edition, which is in a
draft state. The publisher is able to 'discard' that draft, which
puts the Edition in a 'deleted' state, and the Document no longer
has any non-deleted editions, so it is 'deleted'.

I say 'deleted' with air-quotes because it isn't actually deleted;
its record still exists if you do an explicit `Document.find(THE_ID)`.
The same applies to the Edition - it exists but has a state of
'deleted'. If you do a generic ActiveRecord search, it won't appear
in the results, as [by default we scope our queries to filter out
'deleted' editions](https://github.com/alphagov/whitehall/blob/9dcec7b76ed6617a293bf51fdca372b1abd085e1/app/models/edition/workflow.rb#L21).

Because the Document doesn't _actually_ get deleted, its
[`delete_all` callback](https://github.com/alphagov/whitehall/blob/41b611f3d8c092706b3a27f7063b6d014a0efb88/app/models/document.rb#L38) never gets fired, so its associated document collection group
memberships persist.

This commit adds an `after_destroy` callback to the Edition model,
to check if its associated Document has any other Editions associated
with it. If it doesn't, it can be safely deleted - which will
automatically trigger the cleaning up of any other associations.

Trello: https://trello.com/c/579DqsRD/1976-8-investigate-why-sometimes-document-collections-have-a-bad-state