### PR TITLE
Simplify deleting document collection groups

### DIFF
--- a/app/views/admin/document_collection_groups/delete.html.erb
+++ b/app/views/admin/document_collection_groups/delete.html.erb
@@ -5,21 +5,16 @@
   <section class="col-md-8">
     <h1>Delete group</h1>
 
-    <% if (@collection.groups.size == 1) || @group.documents.present? %>
+    <% if @collection.groups.size == 1 %>
       <div class="alert alert-danger">
-        <% if @collection.groups.size == 1 %>
-          <p>
-            Every document collection needs at least one group, so you can’t
-            delete the last one.
-          </p>
-          <p>
-            If you were planning on replacing it you can return to the
-            collection page, click the edit link, and rename it instead.
-          </p>
-        <% else %>
-          You can’t delete a group that has documents in it &ndash;
-          remove the documents first, or move them into another group.
-        <% end %>
+        <p>
+          Every document collection needs at least one group, so you can’t
+          delete the last one.
+        </p>
+        <p>
+          If you were planning on replacing it you can return to the
+          collection page, click the edit link, and rename it instead.
+        </p>
       </div>
 
       <p>

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -97,21 +97,13 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_select ".errors li", text: /Heading/
   end
 
-  view_test "GET #delete explains you can't delete groups that have members" do
-    @group.documents = [create(:publication).document]
-    @collection.groups << build(:document_collection_group)
-    get :delete, params: { document_collection_id: @collection, id: @group }
-    assert_select "div.alert", /can’t delete a group.*documents/
-    assert_select 'input[type="submit"]', count: 0
-  end
-
   view_test "GET #delete explains you can't delete the last group" do
     get :delete, params: { document_collection_id: @collection, id: @group }
     assert_select "div.alert", /can’t\s+delete the last/
     assert_select 'input[type="submit"]', count: 0
   end
 
-  view_test "GET #delete allows you to delete an empty group" do
+  view_test "GET #delete allows you to delete a group" do
     @collection.groups << build(:document_collection_group)
     get :delete, params: { document_collection_id: @collection, id: @group }
     assert_select 'input[type="submit"][value="Delete"]'


### PR DESCRIPTION
Rather than having the user delete the group items if there are any,
just handle that as part of deleting the group.

This also resolves an issue where a document associated with the group
with just one edition, which happens to be deleted, would prevent the
group from being deleted, as it's not visible to the user to remove
from the group.