### PR TITLE
Publish history pages as history pages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -2,7 +2,7 @@ class PublishStaticPages
   def publish
     index = Whitehall::SearchIndex.for(:government)
     pages.each do |page|
-      index.add(present_for_rummager(page)) unless page[:document_type] == "finder"
+      index.add(present_for_rummager(page)) unless %w[finder history].include? page[:document_type]
 
       payload = present_for_publishing_api(page)
       Services.publishing_api.put_content(payload[:content_id], payload[:content])
@@ -35,45 +35,51 @@ class PublishStaticPages
       {
         content_id: "db95a864-874f-4f50-a483-352a5bc7ba18",
         title: "History of the UK government",
-        document_type: "special_route",
+        document_type: "history",
+        schema_name: "history",
         description: "In this section you can read short biographies of notable people and explore the history of government buildings. You can also search our online records and read articles and blog posts by historians.",
-        indexable_content: TemplateContent.new("histories/index").indexable_content,
+        body: TemplateContent.new("histories/index").indexable_content,
         base_path: "/government/history",
       },
       {
         content_id: "14aa298f-03a8-4e76-96de-483efa3d001f",
         title: "History of 10 Downing Street",
-        document_type: "special_route",
+        document_type: "history",
+        schema_name: "history",
         description: "10 Downing Street, the locale of British prime ministers since 1735, vies with the White House as being the most important political building anywhere in the world in the modern era.",
-        indexable_content: TemplateContent.new("histories/10_downing_street").indexable_content,
+        body: TemplateContent.new("histories/10_downing_street").indexable_content,
         base_path: "/government/history/10-downing-street",
       },
       {
         content_id: "7be62825-1538-4ff5-aa29-cd09350349f2",
         title: "History of 1 Horse Guards Road",
-        document_type: "special_route",
-        indexable_content: TemplateContent.new("histories/1_horse_guards_road").indexable_content,
+        document_type: "history",
+        schema_name: "history",
+        body: TemplateContent.new("histories/1_horse_guards_road").indexable_content,
         base_path: "/government/history/1-horse-guards-road",
       },
       {
         content_id: "9bdb6017-48c9-4590-b795-3c19d5e59320",
         title: "History of 11 Downing Street",
-        document_type: "special_route",
-        indexable_content: TemplateContent.new("histories/11_downing_street").indexable_content,
+        document_type: "history",
+        schema_name: "history",
+        body: TemplateContent.new("histories/11_downing_street").indexable_content,
         base_path: "/government/history/11-downing-street",
       },
       {
         content_id: "bd216990-c550-4d28-ac05-649329298601",
         title: "History of King Charles Street (FCO)",
-        document_type: "special_route",
-        indexable_content: TemplateContent.new("histories/king_charles_street").indexable_content,
+        document_type: "history",
+        schema_name: "history",
+        body: TemplateContent.new("histories/king_charles_street").indexable_content,
         base_path: "/government/history/king-charles-street",
       },
       {
         content_id: "60808448-769d-4915-981c-f34eb5f1b7bc",
         title: "History of Lancaster House (FCO)",
-        document_type: "special_route",
-        indexable_content: TemplateContent.new("histories/lancaster_house").indexable_content,
+        document_type: "history",
+        schema_name: "history",
+        body: TemplateContent.new("histories/lancaster_house").indexable_content,
         base_path: "/government/history/lancaster-house",
       },
       {
@@ -143,11 +149,13 @@ class PublishStaticPages
     {
       content_id: page[:content_id],
       content: {
-        details: {},
+        details: {
+          body: page[:body],
+        }.compact,
         title: page[:title],
         description: page[:description],
         document_type: page[:document_type],
-        schema_name: "placeholder",
+        schema_name: (page[:schema_name] || "placeholder"),
         locale: "en",
         base_path: page[:base_path],
         publishing_app: "whitehall",


### PR DESCRIPTION
This is a stepping-stone to having the content in government-frontend:
get the document type in the publishing-api right, and also get the
content in the right search index.

This isn't strictly necessary, but it's nice to see that that part of
things all works before switching the publishing and rendering app
over.

---

[Trello card](https://trello.com/c/6IveqNKB/1982-3-render-10-downing-street-in-government-frontend)