### PR TITLE
Add transaction locking to the creation of new draft editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -485,11 +485,12 @@ EXISTS (
   # @!endgroup
 
   def create_draft(user)
-    unless published?
-      raise "Cannot create new edition based on edition in the #{state} state"
-    end
-
     ActiveRecord::Base.transaction do
+      lock!
+      unless published?
+        raise "Cannot create new edition based on edition in the #{state} state"
+      end
+
       ignorable_attribute_keys = %w[id
                                     type
                                     state


### PR DESCRIPTION
In extremely rare cases it was possible that a user could create two
draft editions simultaneously. This left us in a strange state wherein
we could have a draft edition older than the most recently published
edition, which among other smaller side effects would prevent users
from creating a new draft until the invalid draft was deleted.

This commit moves the transaction responsible for creating drafts
to the editions controller from the edition itself, and ensures that
the edition is locked such that we cannot have simultaneous creation of
drafts.

Trello: https://trello.com/c/swAFJohF/1973-5-investigate-why-sometimes-we-have-drafts-older-than-live-content