### PR TITLE
Invoke mailer in a loop

### DIFF
--- a/app/mailers/multi_notifications.rb
+++ b/app/mailers/multi_notifications.rb
@@ -1,0 +1,15 @@
+class MultiNotifications < ApplicationMailer
+  def self.consultation_deadline_upcoming(consultation, weeks_left:, mailer: Notifications)
+    addresses = consultation.authors.pluck(:email).uniq
+    addresses.map do |address|
+      mailer.consultation_deadline_upcoming(consultation, weeks_left: weeks_left, recipient_address: address)
+    end
+  end
+
+  def self.consultation_deadline_passed(consultation, mailer: Notifications)
+    addresses = consultation.authors.pluck(:email).uniq
+    addresses.map do |address|
+      mailer.consultation_deadline_passed(consultation, recipient_address: address)
+    end
+  end
+end

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -71,20 +71,20 @@ class Notifications < ApplicationMailer
     mail from: no_reply_email_address, to: recipient_address, subject: "#{filter_title} from GOV.UK"
   end
 
-  def consultation_deadline_upcoming(consultation, weeks_left:)
+  def consultation_deadline_upcoming(consultation, weeks_left:, recipient_address:)
     @title = consultation.title
     @weeks_left = weeks_left
 
     mail from: no_reply_email_address,
-         to: consultation.authors.uniq.map(&:email),
+         to: recipient_address,
          subject: "Consultation response due in #{pluralize(weeks_left, 'week')}"
   end
 
-  def consultation_deadline_passed(consultation)
+  def consultation_deadline_passed(consultation, recipient_address:)
     @title = consultation.title
 
     mail from: no_reply_email_address,
-         to: consultation.authors.uniq.map(&:email),
+         to: recipient_address,
          subject: "Consultation deadline breached"
   end
 

--- a/app/models/consultation_reminder.rb
+++ b/app/models/consultation_reminder.rb
@@ -14,14 +14,14 @@ class ConsultationReminder
     def send_deadline_reminder(weeks_left:)
       Consultation.awaiting_response.closed_at_or_within_24_hours_of((PUBLISH_DEADLINE - weeks_left).weeks.ago).each do |consultation|
         log(consultation)
-        Notifications.consultation_deadline_upcoming(consultation, weeks_left: weeks_left).deliver_now
+        MultiNotifications.consultation_deadline_upcoming(consultation, weeks_left: weeks_left).map(&:deliver_now)
       end
     end
 
     def send_deadline_passed_notification
       Consultation.awaiting_response.closed_at_or_within_24_hours_of(PUBLISH_DEADLINE.weeks.ago).each do |consultation|
         log(consultation)
-        Notifications.consultation_deadline_passed(consultation).deliver_now
+        MultiNotifications.consultation_deadline_passed(consultation).map(&:deliver_now)
       end
     end
 

--- a/test/functional/notifications_consultation_reminders_test.rb
+++ b/test/functional/notifications_consultation_reminders_test.rb
@@ -3,15 +3,19 @@ require "test_helper"
 class NotificationsConsultationRemindersTest < ActionMailer::TestCase
   setup do
     @consultation = build(:consultation)
+    author = build(:author)
+    @consultation.update(authors: [author, author])
   end
 
   test "reminder emails should contain the title text and weeks remaining" do
-    @email = Notifications.consultation_deadline_upcoming(@consultation, weeks_left: 2)
-    assert_includes @email.body.to_s, %(Publish the government response for "#{@consultation.title}" within 2 weeks)
+    @email = MultiNotifications.consultation_deadline_upcoming(@consultation, weeks_left: 2)
+    assert_includes @email.first.body.to_s, %(Publish the government response for "#{@consultation.title}" within 2 weeks)
+    assert_equal 1, @email.length
   end
 
   test "overdue notifications should contain the title text" do
-    @email = Notifications.consultation_deadline_passed(@consultation)
-    assert_includes @email.body.to_s, %(Publish the "#{@consultation.title}" response as soon as possible)
+    @email = MultiNotifications.consultation_deadline_passed(@consultation)
+    assert_includes @email.first.body.to_s, %(Publish the "#{@consultation.title}" response as soon as possible)
+    assert_equal 1, @email.length
   end
 end


### PR DESCRIPTION
Notify doesn't support sending to multiple recipients in a single API call, so we need to iterate over the list of recipients and invoke a separate instance of the mailer for each before we're able to migrate to that.

This is the technique we used in [short-url-manager](https://github.com/alphagov/short-url-manager/pull/451) and [publisher](https://github.com/alphagov/publisher/pull/1243).

https://trello.com/c/Q7xeFxCI/1993-8-whitehall-send-to-multiple-addresses-with-separate-mailer-instances-to-support-notify
