### PR TITLE
Guard against deleting unpublished drafts in the EditionDeleter

### DIFF
--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -7,8 +7,17 @@ class EditionDeleter < EditionService
     "deleted"
   end
 
+  def can_transition?
+    edition.public_send("can_#{verb}?") &&
+      edition.unpublishing.nil?
+  end
+
   def failure_reason
-    "An edition that is #{edition.current_state} cannot be deleted" unless can_transition?
+    if !edition.unpublishing.nil?
+      "A draft edition cannot be deleted if it has been unpublished"
+    elsif !edition.public_send("can_#{verb}?")
+      "An edition that is #{edition.current_state} cannot be deleted"
+    end
   end
 
 private


### PR DESCRIPTION
This is the same constraint as the user interface. At least at the
moment, if you delete a edition which is in the draft state, because
it was unpublished, you end up a bit stuck, not being able to create a
new draft.

This doesn't fix that issue, but maybe this will help avoid documents
getting stuck like this in the future.