### PR TITLE
Support creating drafts from some superseded editions

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -136,7 +136,31 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def revise
-    new_draft = @edition.create_draft(current_user)
+    if @edition.superseded? && @edition.latest_edition.id == @edition.id
+      # There are a number of documents in Whitehall for which the
+      # latest edition is also superseded, something of a
+      # contradiction.
+      #
+      # To allow for a way out in this circumstance, find the deleted
+      # edition that was probably the one that supersedes this
+      # superseded edition, and use that to create the draft.
+      probably_last_published_edition =
+        Edition
+          .unscoped # because we're looking for a deleted edition
+          .where(document_id: @edition.document_id)
+          .where("id > ?", @edition.id)
+          .where(state: :deleted)
+          .order(id: :asc)
+          .first
+
+      new_draft = probably_last_published_edition.create_draft(
+        current_user,
+        allow_creating_draft_from_deleted_edition: true,
+      )
+    else
+      new_draft = @edition.create_draft(current_user)
+    end
+
     if new_draft.persisted?
       redirect_to edit_admin_edition_path(new_draft)
     else

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -484,11 +484,15 @@ EXISTS (
 
   # @!endgroup
 
-  def create_draft(user)
+  def create_draft(user, allow_creating_draft_from_deleted_edition: false)
     ActiveRecord::Base.transaction do
       lock!
       unless published?
-        raise "Cannot create new edition based on edition in the #{state} state"
+        if allow_creating_draft_from_deleted_edition
+          raise "Edition not in the deleted state" unless deleted?
+        else
+          raise "Cannot create new edition based on edition in the #{state} state"
+        end
       end
 
       ignorable_attribute_keys = %w[id

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -487,12 +487,10 @@ EXISTS (
   def create_draft(user, allow_creating_draft_from_deleted_edition: false)
     ActiveRecord::Base.transaction do
       lock!
-      unless published?
-        if allow_creating_draft_from_deleted_edition
-          raise "Edition not in the deleted state" unless deleted?
-        else
-          raise "Cannot create new edition based on edition in the #{state} state"
-        end
+      if allow_creating_draft_from_deleted_edition && !deleted?
+        raise "Edition not in the deleted state"
+      elsif !published?
+        raise "Cannot create new edition based on edition in the #{state} state"
       end
 
       ignorable_attribute_keys = %w[id

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -487,8 +487,8 @@ EXISTS (
   def create_draft(user, allow_creating_draft_from_deleted_edition: false)
     ActiveRecord::Base.transaction do
       lock!
-      if allow_creating_draft_from_deleted_edition && !deleted?
-        raise "Edition not in the deleted state"
+      if allow_creating_draft_from_deleted_edition
+        raise "Edition not in the deleted state" unless deleted?
       elsif !published?
         raise "Cannot create new edition based on edition in the #{state} state"
       end

--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -1,8 +1,24 @@
 <% if edition.superseded? %>
-  <div class="alert alert-danger">
-    <p>This edition has been superseded.</p>
-    <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
-  </div>
+  <% if edition.latest_edition.id == edition.id %>
+    <div class="alert alert-info">
+      <p>
+        This edition has been superseded, you can still create a
+        new draft edition for this document.
+      </p>
+
+      <%= button_to(
+        "Create new edition to edit",
+        revise_admin_edition_path(edition),
+        title: "Create new edition to edit",
+        class: "btn btn-primary add-top-margin"
+      ) %>
+    </div>
+  <% else %>
+    <div class="alert alert-danger">
+      <p>This edition has been superseded.</p>
+      <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
+    </div>
+  <% end %>
 <% elsif edition.pre_publication? && edition.latest_published_edition %>
   <div class="alert alert-info">
     <p>This is a new draft of a document that has already been published.</p>

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -107,7 +107,17 @@ FactoryBot.define do
 
     trait(:deleted) { state { "deleted" } }
 
-    trait(:superseded) { state { "superseded" } }
+    trait(:superseded) do
+      state { "superseded" }
+    end
+
+    trait(:superseded_with_published) do
+      state { "superseded" }
+
+      after(:create) do |edition|
+        create(:published_edition, document: edition.document)
+      end
+    end
 
     trait(:featured) { featured { true } }
 

--- a/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
@@ -27,7 +27,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
   end
 
   view_test "should not be possible to revise an superseded edition" do
-    superseded_edition = create(:superseded_edition)
+    superseded_edition = create(:edition, :superseded_with_published)
     stub_publishing_api_expanded_links_with_taxons(superseded_edition.content_id, [])
 
     get :show, params: { id: superseded_edition }

--- a/test/unit/edition/creating_draft_test.rb
+++ b/test/unit/edition/creating_draft_test.rb
@@ -27,6 +27,15 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     assert_equal "Cannot create new edition based on edition in the superseded state", e.message
   end
 
+  test "should raise an exception when building a draft from a non-deleted edition and the allow_creating_draft_from_deleted_edition flag is passed" do
+    published_edition = create(:published_edition)
+    new_creator = create(:writer)
+    e = assert_raise(RuntimeError) do
+      published_edition.create_draft(new_creator, allow_creating_draft_from_deleted_edition: true)
+    end
+    assert_equal "Edition not in the deleted state", e.message
+  end
+
   test "should not copy create and update time when creating draft" do
     published_edition = create(:published_edition)
     Timecop.travel 1.minute.from_now


### PR DESCRIPTION
There are a number of documents in Whitehall where the latest edition
is in the superseded state, a bit of a contradiction. For the user,
this means there's nothing they can do any more with this document.

I believe a large proportion of these cases seem to be because the
published edition was made a draft when unpublished, and then somehow
deleted.

To try and help with this situation, this commit makes it possible to
create a new draft for documents in this state. The button appears on
the page for the latest edition, which is superseded. The draft
however is based on the oldest deleted edition which is newer than the
superseded edition, as this will probably have been published in the
past, and is most likely where the updated content is.

Of course, this is very uncertain, part of this is due to not being
able to really identify why these documents are in a suposedly
impossible state. It does however offer a better user experience.

Trello: https://trello.com/c/9u5j3uI0/1989-investigate-the-situation-regarding-documents-in-whitehall-where-the-latest-edition-is-somehow-also-superseded