### PR TITLE
Fix the Specialist Sector factory

### DIFF
--- a/test/factories/specialist_sector.rb
+++ b/test/factories/specialist_sector.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :specialist_sector do
-    topic_content_id factory: :topic
+    topic_content_id { SecureRandom.uuid }
   end
 end


### PR DESCRIPTION
I believe topic_content_id in this context actually refers to the
content_id associated with this object, the specialist sector.

The naming is completely confused, which is probably how the topic
factory got dragged in here, where topic is also know as a policy
area.