### PR TITLE
Tweak many tests to not involve Policy Areas/Topics where possible

### DIFF
--- a/test/factories/classification_memberships.rb
+++ b/test/factories/classification_memberships.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :classification_membership do
     publication
-    classification factory: :topic
+    classification factory: :topical_event
   end
 end

--- a/test/factories/classification_policy.rb
+++ b/test/factories/classification_policy.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :classification_policy do
-    association :classification, factory: :topic
+    association :classification, factory: :topical_event
   end
 end

--- a/test/factories/organisation_classification.rb
+++ b/test/factories/organisation_classification.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :organisation_classification do
     organisation { FactoryBot.build(:organisation) }
-    classification { FactoryBot.build(:topic) }
+    classification { FactoryBot.build(:topical_event) }
     lead { false }
   end
 end

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -4,17 +4,17 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   setup do
-    @topic = create(:topic)
+    @topical_event = create(:topical_event)
     login_as :writer
   end
 
-  test "GET :index assigns tagged_editions with a paginated collection of published editions related to the topic ordered by most recently created editions first" do
-    news_article_1 = create(:published_news_article, topics: [@topic])
-    news_article_2 = Timecop.travel(10.minutes) { create(:published_news_article, topics: [@topic]) }
-    _draft_article = create(:news_article, topics: [@topic])
-    _unrelated_article = create(:news_article, :with_topics)
+  test "GET :index assigns tagged_editions with a paginated collection of published editions related to the topical_event ordered by most recently created editions first" do
+    news_article_1 = create(:published_news_article, topical_events: [@topical_event])
+    news_article_2 = Timecop.travel(10.minutes) { create(:published_news_article, topical_events: [@topical_event]) }
+    _draft_article = create(:news_article, topical_events: [@topical_event])
+    _unrelated_article = create(:news_article, :with_topical_events)
 
-    get :index, params: { topic_id: @topic, page: 1 }
+    get :index, params: { topical_event_id: @topical_event, page: 1 }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article_2, news_article_1], tagged_editions
@@ -24,66 +24,65 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
   end
 
   test "GET :index assigns a filtered list to tagged_editions when given a title" do
-    create(:published_news_article, topics: [@topic])
-    news_article = create(:published_news_article, topics: [@topic], title: "Specific title")
-    _unrelated_article = create(:published_news_article, :with_topics, title: "Specific title")
+    create(:published_news_article, topical_events: [@topical_event])
+    news_article = create(:published_news_article, topical_events: [@topical_event], title: "Specific title")
+    _unrelated_article = create(:published_news_article, :with_topical_events, title: "Specific title")
 
-    get :index, params: { topic_id: @topic, title: "specific" }
+    get :index, params: { topical_event_id: @topical_event, title: "specific" }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
   end
 
   test "GET :index assigns a filtered list to tagged_editions when given an organisation" do
-    create(:published_news_article, topics: [@topic])
+    create(:published_news_article, topical_events: [@topical_event])
     org = create(:organisation)
-    news_article = create(:published_news_article, topics: [@topic])
+    news_article = create(:published_news_article, topical_events: [@topical_event])
     news_article.organisations << org
 
-    get :index, params: { topic_id: @topic, organisation: org.id }
+    get :index, params: { topical_event_id: @topical_event, organisation: org.id }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
   end
 
   test "GET :index assigns a filtered list to tagged_editions when given an author" do
-    create(:published_news_article, topics: [@topic])
-    news_article = create(:published_news_article, topics: [@topic])
+    create(:published_news_article, topical_events: [@topical_event])
+    news_article = create(:published_news_article, topical_events: [@topical_event])
     user = create(:user)
     create(:edition_author, edition: news_article, user: user)
 
-    get :index, params: { topic_id: @topic, author: user.id }
+    get :index, params: { topical_event_id: @topical_event, author: user.id }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
   end
 
   test "GET :index assigns a filtered list to tagged_editions when given a document type" do
-    create(:published_statistical_data_set, topics: [@topic])
-    news_article = create(:published_news_article, topics: [@topic])
+    news_article = create(:published_news_article, topical_events: [@topical_event])
 
-    get :index, params: { topic_id: @topic, type: news_article.display_type_key }
+    get :index, params: { topical_event_id: @topical_event, type: news_article.display_type_key }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
   end
 
   view_test "GET :index contains a message when no results matching search criteria were found" do
-    create(:published_news_article, topics: [@topic])
+    create(:published_news_article, topical_events: [@topical_event])
 
-    get :index, params: { topic_id: create(:topic) }
+    get :index, params: { topical_event_id: create(:topical_event) }
 
     assert_equal 0, assigns(:tagged_editions).count
     assert_match "No documents found", response.body
   end
 
   test "PUT :order saves the new order of featurings" do
-    feature_1 = create(:classification_featuring, classification: @topic)
-    feature_2 = create(:classification_featuring, classification: @topic)
-    feature_3 = create(:classification_featuring, classification: @topic)
+    feature_1 = create(:classification_featuring, classification: @topical_event)
+    feature_2 = create(:classification_featuring, classification: @topical_event)
+    feature_3 = create(:classification_featuring, classification: @topical_event)
 
     put :order,
-        params: { topic_id: @topic,
+        params: { topical_event_id: @topical_event,
                   ordering: {
                     feature_1.id.to_s => "1",
                     feature_2.id.to_s => "2",
@@ -91,12 +90,12 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
                   } }
 
     assert_response :redirect
-    assert_equal [feature_3, feature_1, feature_2], @topic.reload.classification_featurings
+    assert_equal [feature_3, feature_1, feature_2], @topical_event.reload.classification_featurings
   end
 
   view_test "GET :new renders only image fields if featuring an edition" do
     edition = create :edition
-    get :new, params: { topic_id: @topic.id, edition_id: edition.id }
+    get :new, params: { topical_event_id: @topical_event.id, edition_id: edition.id }
 
     assert_select "#classification_featuring_image_attributes_file"
     assert_select "#classification_featuring_alt_text"
@@ -104,7 +103,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
 
   view_test "GET :new renders all fields if not featuring an edition" do
     offsite_link = create :offsite_link
-    get :new, params: { topic_id: @topic.id, offsite_link_id: offsite_link.id }
+    get :new, params: { topical_event_id: @topical_event.id, offsite_link_id: offsite_link.id }
 
     assert_select "#classification_featuring_image_attributes_file"
     assert_select "#classification_featuring_alt_text"

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -235,12 +235,11 @@ class AnnouncementsControllerTest < ActionController::TestCase
   end
 
   view_test "index atom feed autodiscovery link includes any present filters" do
-    topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, params: { topics: [topic], departments: [organisation], locale: "fr" }
+    get :index, params: { departments: [organisation], locale: "fr" }
 
-    assert_select_autodiscovery_link announcements_url(format: "atom", topics: [topic], departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
+    assert_select_autodiscovery_link announcements_url(format: "atom", departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
   end
 
   view_test "index generates an atom feed for the current filter" do
@@ -262,10 +261,9 @@ class AnnouncementsControllerTest < ActionController::TestCase
   end
 
   view_test "index requested as JSON redirects to news and comms finder" do
-    topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, params: { to_date: "2012-01-01", topics: [topic.slug], departments: [organisation.slug] }, format: :json
+    get :index, params: { to_date: "2012-01-01", departments: [organisation.slug] }, format: :json
     assert_response :redirect
   end
 

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -80,12 +80,12 @@ class RoutingLocaleTest < ActionDispatch::IntegrationTest
   end
 
   test "#show for a non-localised resource" do
-    topic = create(:topic)
-    assert_equal "/government/topics/#{topic.slug}", topic_path(topic)
+    topical_event = create(:topical_event)
+    assert_equal "/government/topical-events/#{topical_event.slug}", topical_event_path(topical_event)
   end
 
   test "#show for a non-localised resource with a format" do
-    topic = create(:topic)
-    assert_equal "/government/topics/#{topic.slug}.json", topic_path(topic, format: "json")
+    topical_event = create(:topical_event)
+    assert_equal "/government/topical-events/#{topical_event.slug}.json", topical_event_path(topical_event, format: "json")
   end
 end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -196,10 +196,10 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "can filter by classifications" do
-    topic       = create(:topic)
-    tagged_news = create(:published_news_article, topics: [topic])
-    _not_tagged = create(:published_news_article)
-    filter      = Admin::EditionFilter.new(Edition, @current_user, classification: topic.to_param)
+    topical_event = create(:topical_event)
+    tagged_news   = create(:published_news_article, topical_events: [topical_event])
+    _not_tagged   = create(:published_news_article)
+    filter        = Admin::EditionFilter.new(Edition, @current_user, classification: topical_event.to_param)
 
     assert_equal [tagged_news], filter.editions
   end

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -4,52 +4,52 @@ class ClassificationTest < ActiveSupport::TestCase
   should_protect_against_xss_and_content_attacks_on :name, :description
 
   test "should default to the 'current' state" do
-    topic = Classification.new
-    assert topic.current?
+    topical_event = Classification.new
+    assert topical_event.current?
   end
 
   test "should be invalid without a name" do
-    topic = build(:classification, name: nil)
-    assert_not topic.valid?
+    topical_event = build(:classification, name: nil)
+    assert_not topical_event.valid?
   end
 
   test "should be current when created" do
-    topic = build(:classification)
-    assert_equal "current", topic.state
+    topical_event = build(:classification)
+    assert_equal "current", topical_event.state
   end
 
   test "should be invalid with an unsupported state" do
-    topic = build(:classification, state: "foobar")
-    assert_not topic.valid?
+    topical_event = build(:classification, state: "foobar")
+    assert_not topical_event.valid?
   end
 
   test "should be invalid without a unique name" do
-    existing_topic = create(:classification)
-    new_topic = build(:classification, name: existing_topic.name)
-    assert_not new_topic.valid?
+    existing_topical_event = create(:classification)
+    new_topical_event = build(:classification, name: existing_topical_event.name)
+    assert_not new_topical_event.valid?
   end
 
   test "should be invalid without a description" do
-    topic = build(:classification, description: nil)
-    assert_not topic.valid?
+    topical_event = build(:classification, description: nil)
+    assert_not topical_event.valid?
   end
 
   test "#latest should return specified number of associated publised editions except world location news articles in reverse chronological order" do
-    topic = create(:topic)
-    other_topic = create(:topic)
+    topical_event = create(:topical_event)
+    other_topical_event = create(:topical_event)
     expected_order = [
-      create(:published_publication, topics: [topic], first_published_at: 1.day.ago),
-      create(:published_news_article, topics: [topic], first_published_at: 1.week.ago),
-      create(:published_publication, topics: [topic], first_published_at: 2.weeks.ago),
-      create(:published_speech, topics: [topic], first_published_at: 3.weeks.ago),
-      create(:published_publication, topics: [topic], first_published_at: 4.weeks.ago),
+      create(:published_publication, topical_events: [topical_event], first_published_at: 1.day.ago),
+      create(:published_news_article, topical_events: [topical_event], first_published_at: 1.week.ago),
+      create(:published_publication, topical_events: [topical_event], first_published_at: 2.weeks.ago),
+      create(:published_speech, topical_events: [topical_event], first_published_at: 3.weeks.ago),
+      create(:published_publication, topical_events: [topical_event], first_published_at: 4.weeks.ago),
     ]
-    create(:draft_speech, topics: [topic], first_published_at: 2.days.ago)
-    create(:published_speech, topics: [other_topic], first_published_at: 2.days.ago)
-    create(:published_world_location_news_article, topics: [topic], first_published_at: 2.days.ago)
+    create(:draft_speech, topical_events: [topical_event], first_published_at: 2.days.ago)
+    create(:published_speech, topical_events: [other_topical_event], first_published_at: 2.days.ago)
+    create(:published_world_location_news_article, topical_events: [topical_event], first_published_at: 2.days.ago)
 
-    assert_equal expected_order, topic.latest(10)
-    assert_equal expected_order[0..1], topic.latest(2)
+    assert_equal expected_order, topical_event.latest(10)
+    assert_equal expected_order[0..1], topical_event.latest(2)
   end
 
   test "an unfeatured news article is not featured" do
@@ -82,13 +82,13 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#featured_editions returns featured editions by ordering" do
-    topic = create(:topic)
-    _alpha = topic.feature(edition_id: create(:edition, title: "Alpha").id, ordering: 1, alt_text: "A thing", image: create(:classification_featuring_image_data))
-    beta = topic.feature(edition_id: create(:published_news_article, title: "Beta").id, ordering: 2, alt_text: "A thing", image: create(:classification_featuring_image_data))
-    gamma = topic.feature(edition_id: create(:published_news_article, title: "Gamma").id, ordering: 3, alt_text: "A thing", image: create(:classification_featuring_image_data))
-    delta = topic.feature(edition_id: create(:published_news_article, title: "Delta").id, ordering: 0, alt_text: "A thing", image: create(:classification_featuring_image_data))
+    topical_event = create(:topical_event)
+    _alpha = topical_event.feature(edition_id: create(:edition, title: "Alpha").id, ordering: 1, alt_text: "A thing", image: create(:classification_featuring_image_data))
+    beta = topical_event.feature(edition_id: create(:published_news_article, title: "Beta").id, ordering: 2, alt_text: "A thing", image: create(:classification_featuring_image_data))
+    gamma = topical_event.feature(edition_id: create(:published_news_article, title: "Gamma").id, ordering: 3, alt_text: "A thing", image: create(:classification_featuring_image_data))
+    delta = topical_event.feature(edition_id: create(:published_news_article, title: "Delta").id, ordering: 0, alt_text: "A thing", image: create(:classification_featuring_image_data))
 
-    assert_equal [delta.edition, beta.edition, gamma.edition], topic.featured_editions
+    assert_equal [delta.edition, beta.edition, gamma.edition], topical_event.featured_editions
   end
 
   test "#featured_editions includes the newly published version of a featured edition, but not the original" do
@@ -106,14 +106,14 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#importance_ordered_organisations" do
-    topic = create(:topic)
+    topical_event = create(:topical_event)
     supporting_org = create(:organisation)
-    supporting_org.organisation_classifications.create(classification_id: topic.id, lead: false)
+    supporting_org.organisation_classifications.create(classification_id: topical_event.id, lead: false)
     second_lead_org = create(:organisation)
-    second_lead_org.organisation_classifications.create(classification_id: topic.id, lead: true, lead_ordering: 2)
+    second_lead_org.organisation_classifications.create(classification_id: topical_event.id, lead: true, lead_ordering: 2)
     first_lead_org = create(:organisation)
-    first_lead_org.organisation_classifications.create(classification_id: topic.id, lead: true, lead_ordering: 1)
-    assert_equal topic.importance_ordered_organisations, [first_lead_org, second_lead_org, supporting_org]
+    first_lead_org.organisation_classifications.create(classification_id: topical_event.id, lead: true, lead_ordering: 1)
+    assert_equal topical_event.importance_ordered_organisations, [first_lead_org, second_lead_org, supporting_org]
   end
 
   should_not_accept_footnotes_in :description

--- a/test/unit/edition/creating_draft_test.rb
+++ b/test/unit/edition/creating_draft_test.rb
@@ -72,16 +72,14 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     assert_equal published_edition.first_published_at, draft_edition.first_published_at
   end
 
-  test "should build a draft copy with references to topics, organisations & world locations" do
-    topic = create(:topic)
+  test "should build a draft copy with references to organisations & world locations" do
     organisation = create(:organisation)
     country = create(:world_location)
 
-    published_publication = create(:published_publication, topics: [topic], organisations: [organisation], world_locations: [country])
+    published_publication = create(:published_publication, organisations: [organisation], world_locations: [country])
 
     draft_publication = published_publication.create_draft(create(:writer))
 
-    assert_equal [topic], draft_publication.topics
     assert_equal [organisation], draft_publication.organisations
     assert_equal [country], draft_publication.world_locations
   end

--- a/test/unit/helpers/classification_routes_helper_test.rb
+++ b/test/unit/helpers/classification_routes_helper_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ClassificationRoutesHelperTest < ActionView::TestCase
-  %i[topic topical_event].each do |type|
+  %i[topical_event].each do |type|
     test "given a #{type} creates a #{type} path" do
       classification = create(type)
       assert_equal send("#{type}_path", classification), classification_path(classification)

--- a/test/unit/helpers/document_filter_helper_test.rb
+++ b/test/unit/helpers/document_filter_helper_test.rb
@@ -67,17 +67,17 @@ class DocumentFilterHelperTest < ActionView::TestCase
   end
 
   test "filter_results_selections gets objects ready for mustache" do
-    topic = build(:topic, slug: "my-slug")
-    stubs(:params).returns(controller: "announcements", action: "index", "topics" => %w[my-slug three])
+    organisation = build(:organisation, slug: "my-slug")
+    stubs(:params).returns(controller: "announcements", action: "index", "organisations" => %w[my-slug three])
 
-    assert_equal [{ name: topic.name, value: topic.slug, url: announcements_path(topics: %w[three]), joining: "" }], filter_results_selections([topic], "topics")
+    assert_equal [{ name: organisation.name, value: organisation.slug, url: announcements_path(organisations: %w[three]), joining: "" }], filter_results_selections([organisation], "organisations")
   end
 
   test "filter_results_selections handles when params aren't in the expected format" do
-    topic = build(:topic, slug: "my-slug")
-    stubs(:params).returns(controller: "announcements", action: "index", "topics" => "my-slug")
+    organisation = build(:organisation, slug: "my-slug")
+    stubs(:params).returns(controller: "announcements", action: "index", "organisations" => "my-slug")
 
-    assert_equal [{ name: topic.name, value: topic.slug, url: announcements_path, joining: "" }], filter_results_selections([topic], "topics")
+    assert_equal [{ name: organisation.name, value: organisation.slug, url: announcements_path(organisations: organisation.slug), joining: "" }], filter_results_selections([organisation], "organisation")
   end
 
   test "filter_results_keywords gets objects ready for mustache" do

--- a/test/unit/helpers/filter_routes_helper_test.rb
+++ b/test/unit/helpers/filter_routes_helper_test.rb
@@ -17,11 +17,10 @@ class FilterRoutesHelperTest < ActionView::TestCase
       assert_equal send("#{filter}_path", world_locations: [world_location.slug]), send("#{filter}_filter_path", world_location)
     end
 
-    test "uses the organisation and topic and world_location to generate the route to #{filter} filter" do
+    test "uses the organisation and world_location to generate the route to #{filter} filter" do
       organisation = create(:organisation)
-      topic = create(:topic)
       world_location = create(:world_location)
-      assert_equal send("#{filter}_path", departments: [organisation.slug], topics: [topic.slug], world_locations: [world_location.slug]), send("#{filter}_filter_path", organisation, topic, world_location)
+      assert_equal send("#{filter}_path", departments: [organisation.slug], world_locations: [world_location.slug]), send("#{filter}_filter_path", organisation, world_location)
     end
 
     test "uses optional hash to route to #{filter} filter" do

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -110,19 +110,14 @@ class TopicalEventFilterTest < ActiveSupport::TestCase
   include SearchRummagerHelper
 
   test "#documents should return a list of documents for the topical event" do
-    filter = LatestDocumentsFilter::TopicalEventFilter.new(topic)
+    topical_event = create(:topical_event)
+    filter = LatestDocumentsFilter::TopicalEventFilter.new(topical_event)
 
     search_rummager_service_stub(
-      filter_topical_events: topic.slug,
+      filter_topical_events: topical_event.slug,
       reject_any_content_store_document_type: "news_article",
     )
 
     assert_equal attributes(processed_rummager_documents), attributes(filter.documents)
-  end
-
-private
-
-  def topic
-    @topic ||= create(:topic)
   end
 end

--- a/test/unit/whitehall/admin_link_lookup_test.rb
+++ b/test/unit/whitehall/admin_link_lookup_test.rb
@@ -50,9 +50,9 @@ module Whitehall
     end
 
     test "does not find editions for pages which are not editions" do
-      topic = create(:topic)
+      topical_event = create(:topical_event)
 
-      assert_nil(AdminLinkLookup.find_edition("/government/admin/topics/#{topic.id}"))
+      assert_nil(AdminLinkLookup.find_edition("/government/admin/topical_event/#{topical_event.id}"))
     end
 
     test "does find editions for non-admin URLs" do

--- a/test/unit/whitehall/not_quite_as_fake_search_test.rb
+++ b/test/unit/whitehall/not_quite_as_fake_search_test.rb
@@ -54,17 +54,17 @@ module Whitehall
 
       test "advanced search can select documents with a field matching a list of values" do
         @index.add_batch(build_documents("Foo", "Bar"))
-        assert_search_returns_documents %w[Bar], policy_areas: %w[Bar-topic1]
+        assert_search_returns_documents %w[Bar], topical_events: %w[Bar-topical_event1]
       end
 
       test "advanced search can select documents with a field matching any item from a list of values" do
         @index.add_batch(build_documents("Foo", "Bar", "FooBar"))
-        assert_search_returns_documents %w[Foo Bar], policy_areas: %w[Foo-topic2 Bar-topic1]
+        assert_search_returns_documents %w[Foo Bar], topical_events: %w[Foo-topical_event2 Bar-topical_event1]
       end
 
       test "advanced search can select documents with a field matching a single value" do
         @index.add_batch(build_documents("Foo", "Bar"))
-        assert_search_returns_documents %w[Bar], policy_areas: "Bar-topic1"
+        assert_search_returns_documents %w[Bar], topical_events: "Bar-topical_event1"
       end
 
       test "advanced search for a field which is not present in a document does not return the document" do
@@ -176,7 +176,7 @@ module Whitehall
             "title" => title,
             "description" => "#{title}-description",
             "indexable_content" => "#{title}-indexable_content",
-            "policy_areas" => ["#{title}-topic1", "#{title}-topic2"],
+            "topical_events" => ["#{title}-topical_event1", "#{title}-topical_event2"],
             "has_official_document" => false,
             "public_timestamp" => Time.zone.parse("2011-01-01 00:00:00"),
           }

--- a/test/unit/whitehall/url_maker_test.rb
+++ b/test/unit/whitehall/url_maker_test.rb
@@ -27,9 +27,9 @@ module Whitehall
 
     test "the default format can be overridden for a non-localised resource" do
       maker = Whitehall::UrlMaker.new(host: "gov.uk", format: "atom")
-      topic = create(:topic)
+      topical_event = create(:topical_event)
 
-      assert_equal "http://gov.uk/government/topics/#{topic.slug}.atom", maker.url_for(topic)
+      assert_equal "http://gov.uk/government/topical-events/#{topical_event.slug}.atom", maker.url_for(topical_event)
     end
   end
 end

--- a/test/unit/workers/search_index_add_worker_test.rb
+++ b/test/unit/workers/search_index_add_worker_test.rb
@@ -11,7 +11,7 @@ class SearchIndexAddWorkerTest < ActiveSupport::TestCase
 
   test "#perform logs a warning if the instance does not exist" do
     Sidekiq.logger.expects(:warn).once
-    SearchIndexAddWorker.new.perform("Topic", 1)
+    SearchIndexAddWorker.new.perform("Publication", 1)
   end
 
   test "#perform indexes searchable instances" do


### PR DESCRIPTION
This is a step towards removing the Policy Area/Topic functionality
from Whitehall, as it's effectively been replaced by the similar, and
similarly named Topic Taxonomy.