### PR TITLE
Fix marshalling errors

### DIFF
--- a/app/services/search_rummager_service.rb
+++ b/app/services/search_rummager_service.rb
@@ -5,7 +5,10 @@ class SearchRummagerService
     Rails.cache.fetch(options, expires_in: 5.minutes) do
       search_response = Whitehall.search_client.search(options)
       search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
-      search_response
+      {
+        "results" => search_response["results"],
+        "total" => search_response["total"],
+      }
     end
   end
 

--- a/test/unit/services/search_rummager_service_test.rb
+++ b/test/unit/services/search_rummager_service_test.rb
@@ -10,6 +10,11 @@ class SearchRummagerServiceTest < ActiveSupport::TestCase
     @world_location = create(:world_location)
   end
 
+  test "returns a hash with two properties: 'results' and 'total" do
+    stub_any_search_to_return_no_results
+    assert_equal %w[results total], SearchRummagerService.new.fetch_related_documents(topical_params).keys
+  end
+
   test "returns empty results array if topical event has no documents" do
     stub_any_search_to_return_no_results
     assert_equal [], SearchRummagerService.new.fetch_related_documents(topical_params)["results"]


### PR DESCRIPTION
We were seeing errors in Logit as follows:

```
[4938944e-2f85-4a07-902f-585841876d22] Marshalling error for key 'count=1000/fields=["display_type", "title", "link", "public_timestamp", "format", "content_store_document_type", "description", "content_id", "organisations", "document_collections"]/filter_topical_events=coronavi:md5:a392a8c87eaf0fcfcbf88dcf77d910aa': no _dump_data is defined for class Thread::Mutex
```

The fields correspond to the `Rails.cache.fetch` call in
SearchRummagerService. Following the request ID, we can find other
logs that shed more light:

```
[4938944e-2f85-4a07-902f-585841876d22] You are trying to cache a Ruby object which cannot be serialized to memcached.
```

It appears what we are caching is an instance of 'GdsApi::Search'
(see rummager.rb: `Whitehall.search_client = GdsApi::Search.new`)
which evidently is not serializable.

Caching only a hash of what we need seems to do the trick to fix
it (have tested on integration and it stops the error from occurring).
In most places, 'results' is the only field used, but in the
'app/views/topical_events/show.html.erb' we can see that 'total'
is used too. I can't see any other fields used.

Trello: https://trello.com/c/ZZCFTp52/1974-5-investigate-whitehall-marshalling-errors