### PR TITLE
Fix missing parameter in change note remover

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -17,7 +17,7 @@ namespace :data_hygiene do
 
     desc "Remove a change note from a document and represent to the content store (for reals)."
     task :real, %i[content_id locale query] => :environment do |_, args|
-      edition = DataHygiene::ChangeNoteRemover.call(args[:content_id], args[:locale], args[:query])
+      edition = DataHygiene::ChangeNoteRemover.call(args[:content_id], args[:locale], args[:query], dry_run: false)
       puts "Updated change history: #{edition.document.change_history.inspect}"
     end
   end


### PR DESCRIPTION
This was changed in 91865fb33c68271a692e2c7e111923d2dfb8119d and we're now getting this error:

```
15:38:44 ArgumentError: missing keyword: dry_run
15:38:44 /data/vhost/whitehall-admin/releases/20200526112402/lib/data_hygiene/change_note_remover.rb:3:in `initialize'
15:38:44 /data/vhost/whitehall-admin/releases/20200526112402/lib/data_hygiene/change_note_remover.rb:21:in `new'
15:38:44 /data/vhost/whitehall-admin/releases/20200526112402/lib/data_hygiene/change_note_remover.rb:21:in `call'
```