### PR TITLE
Prevent making call to Asset Manager if missing file information

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -13,11 +13,21 @@ class AssetManager::AssetUpdater
     end
   end
 
+  class AssetFileDataEmpty < StandardError
+    def initialize(attachment_data_id, legacy_url_path)
+      super("Attempting to update '#{legacy_url_path}' for Attachment Data #{attachment_data_id} with blank file")
+    end
+  end
+
   def self.call(*args)
     new.call(*args)
   end
 
   def call(attachment_data, legacy_url_path, new_attributes = {})
+    if attachment_data.file.blank?
+      raise AssetFileDataEmpty.new(attachment_data.id, legacy_url_path)
+    end
+
     attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes["deleted"]
 

--- a/test/unit/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/services/asset_manager/asset_updater_test.rb
@@ -42,6 +42,21 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not update asset if blank file is provided" do
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns("id" => @asset_id, "draft" => true)
+    id = SecureRandom.random_number(1000)
+    attachment_data_without_file = FactoryBot.build(:attachment_data, id: id, file: nil)
+
+    err = assert_raises(AssetManager::AssetUpdater::AssetFileDataEmpty) do
+      @worker.call(attachment_data_without_file, @legacy_url_path, "draft" => false)
+    end
+    assert_match(
+      /Attempting to update '#{@legacy_url_path}' for Attachment Data #{id} with blank file/,
+      err.message,
+    )
+  end
+
   test "marks draft asset as published" do
     @worker.stubs(:find_asset_by).with(@legacy_url_path)
       .returns("id" => @asset_id, "draft" => true)


### PR DESCRIPTION
We're seeing [issues in Sentry][sentry-issue] as follows:

> URL: https://asset-manager.production.govuk-internal.digital/assets/5b115d34ed915d2cc681ab6f
> Response body:
> {"_response_info":{"status":["File can't be blank"]}}

An attempt was made in [#5581][log-attempt] to catch this error
and provide more detail to help make the error actionable.
Unfortunately, the error condition coded in that PR doesn't
ever appear to happen, so we're still seeing the more obtuse
Sentry logs.

It is evident that `new_attributes` ISN'T empty, but the file
is considered 'blank' when attempting to send to Asset Manager.
This commit has an explicit check that the `attachment_data.file`
property exists before trying to update the asset.

This is a short/medium term approach which will give us a slightly
more meaningful error message, and prevent us from making the
faulty Asset Manager call in the first place. In the long term
we will still need to figure out how some assets get into this
state and prevent that from happening.

Trello: https://trello.com/c/FDu35RHS/1977-investigate-whitehall-sending-blank-file-when-updating-assets

[log-attempt]: https://github.com/alphagov/whitehall/pull/5581
[sentry-issue]: https://sentry.io/organizations/govuk/issues/1650510012/?project=202259&query=blank&statsPeriod=14d