### PR TITLE
Retire the coronavirus topical event RSS feed

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -1,6 +1,13 @@
 class TopicalEventsController < ClassificationsController
   enable_request_formats show: :atom
 
+  CLOSED_FEEDS = {
+    "coronavirus-covid-19-uk-government-response" => {
+      title: "coronavirus (COVID-19)",
+      link: "/search/all.atom?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=most-viewed",
+    }
+  }.freeze
+
   def show
     @topical_event = TopicalEvent.friendly.find(params[:id])
     @content_item = Whitehall.content_store.content_item(@topical_event.base_path)
@@ -20,7 +27,7 @@ class TopicalEventsController < ClassificationsController
         @recently_changed_documents = find_documents(count: 3)["results"]
       end
       format.atom do
-        @recently_changed_documents = find_documents(count: 10)["results"]
+        @recently_changed_documents = atom_documents
       end
     end
   end
@@ -34,5 +41,25 @@ private
 
   def announcement_document_types
     Whitehall::AnnouncementFilterOption.all.map(&:document_type).flatten
+  end
+
+  def atom_documents
+    return [closed_feed_document] if closed_feed
+
+    find_documents(count: 10)["results"]
+  end
+
+  def closed_feed
+    @closed_feed ||= CLOSED_FEEDS[params[:id]]
+  end
+
+  def closed_feed_document
+    RummagerDocumentPresenter.new(
+      closed_feed.stringify_keys.merge(
+        "public_timestamp" => Time.now,
+        "display_type" => "Replacement feed",
+        "description" => "This #{closed_feed[:title]} RSS feed is being replaced with a new feed from Search - GOV.UK",
+      )
+    )
   end
 end

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -5,7 +5,7 @@ class TopicalEventsController < ClassificationsController
     "coronavirus-covid-19-uk-government-response" => {
       title: "coronavirus (COVID-19)",
       link: "/search/all.atom?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=most-viewed",
-    }
+    },
   }.freeze
 
   def show
@@ -56,10 +56,10 @@ private
   def closed_feed_document
     RummagerDocumentPresenter.new(
       closed_feed.stringify_keys.merge(
-        "public_timestamp" => Time.now,
+        "public_timestamp" => Time.zone.now,
         "display_type" => "Replacement feed",
         "description" => "This #{closed_feed[:title]} RSS feed is being replaced with a new feed from Search - GOV.UK",
-      )
+      ),
     )
   end
 end

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -121,7 +121,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
 
     assert_select "feed > link[rel=?][type=?][href=?]", "self", "application/atom+xml", topical_event_url(topical_event, format: "atom"), 1
     assert_equal entries.size, 1
-    assert_equal entry.xpath('.//title').first.text, "Replacement feed: coronavirus (COVID-19)"
+    assert_equal entry.xpath(".//title").first.text, "Replacement feed: coronavirus (COVID-19)"
   end
 
   def create_topical_event_and_stub_in_content_store(*args)
@@ -139,7 +139,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
 
   def xml
     @xml ||= begin
-      xml = Nokogiri::XML(response.body) { |config| config.noblanks }
+      xml = Nokogiri::XML(response.body, &:noblanks)
       xml.remove_namespaces!
     end
   end


### PR DESCRIPTION
## What
Replaces the atom feed for the topical event *coronavirus-covid-19-uk-government-response* with a single entry pointing at a replacement service

## Why
https://www.gov.uk/government/topical-events/coronavirus-covid-19-uk-government-response.atom has a number of subscriptions. We need to retire this gracefully as it'll disappear when we delete the topical event.

We should generate a deprecation message to appear instead of any further entries, pointing people at https://www.gov.uk/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=most-viewed.