### PR TITLE
Fix time of closed RSS feed entry

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -3,6 +3,7 @@ class TopicalEventsController < ClassificationsController
 
   CLOSED_FEEDS = {
     "coronavirus-covid-19-uk-government-response" => {
+      public_timestamp: Time.zone.iso8601("2020-06-05T17:00:00"),
       title: "coronavirus (COVID-19)",
       link: "/search/all.atom?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=most-viewed",
     },
@@ -56,7 +57,6 @@ private
   def closed_feed_document
     RummagerDocumentPresenter.new(
       closed_feed.stringify_keys.merge(
-        "public_timestamp" => Time.zone.now,
         "display_type" => "Replacement feed",
         "description" => "This #{closed_feed[:title]} RSS feed is being replaced with a new feed from Search - GOV.UK",
       ),


### PR DESCRIPTION
This shouldn't keep updating, as some feed readers assume that it's a new entry each time the feed is rendered with a new date.