### PR TITLE
Don't use history_path for the past foreign secretaries page

### DIFF
--- a/app/views/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/past_foreign_secretaries/_show_person.html.erb
@@ -3,7 +3,7 @@
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: histories_path,
+        href: "/government/history",
       },
       title: "Past Foreign Secretaries",
     } %>


### PR DESCRIPTION
As this magical Rails created function would have disappeared with the
change in 010033dfb19c15560c13da31d1bc73ce03a671b6.