### PR TITLE
Revert "Change assets path and host"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ bundle exec rake
 - [How to publish a finder in whitehall](docs/finders.md)
 - [Internationalisation](docs/internationalisation_guide.md)
 - [JavaScript](docs/javascript.md)
+- [Local assets](docs/local_asset_setup_guide.md)
 - [Search setup guide](docs/search_setup_guide.md)
 - [Testing guide](docs/testing_guide.md)
 - [Timestamps](docs/timestamps.md)

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -94,7 +94,7 @@ module GovspeakHelper
   def fraction_image(numerator, denominator)
     denominator.downcase! if %w[X Y].include? denominator
     if numerator.present? && denominator.present? && asset_exists?("fractions/#{numerator}_#{denominator}.png")
-      asset_path("fractions/#{numerator}_#{denominator}.png", host: Whitehall.public_root)
+      asset_path("fractions/#{numerator}_#{denominator}.png", host: Whitehall.public_asset_host)
     end
   end
 

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -72,4 +72,10 @@ private
   def skip_organisation_validation?
     can_have_some_invalid_data? || person_override.present?
   end
+
+  def lead_image_url
+    ActionController::Base.helpers.image_url(
+      lead_image_path, host: Whitehall.public_asset_host
+    )
+  end
 end

--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -3,12 +3,20 @@ module LeadImagePresenterHelper
     !image_data.nil?
   end
 
-  def lead_image_url
-    image_data ? image_url : placeholder_image_url
+  def lead_image_path
+    if image_data
+      image_url
+    else
+      "placeholder.jpg"
+    end
   end
 
-  def high_resolution_lead_image_url
-    image_data ? image_data.file.url(:s960) : placeholder_image_url
+  def high_resolution_lead_image_path
+    if image_data
+      image_data.file.url(:s960)
+    else
+      "placeholder.jpg"
+    end
   end
 
   def lead_image_alt_text
@@ -27,13 +35,6 @@ module LeadImagePresenterHelper
   end
 
 private
-
-  def placeholder_image_url
-    ActionController::Base.helpers.image_url(
-      "placeholder.jpg",
-      host: Whitehall.public_root,
-    )
-  end
 
   def image_url
     content_type = file.content_type

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -71,7 +71,7 @@ module PublishingApi
 
     def image_details
       {
-        url: presented_case_study.lead_image_url,
+        url: presented_case_study.lead_image_path,
         alt_text: presented_case_study.lead_image_alt_text,
         caption: presented_case_study.lead_image_caption,
       }

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -126,10 +126,18 @@ module PublishingApi
       def call
         return {} unless news_article.has_lead_image?
 
+        image_url = ActionController::Base.helpers.image_url(
+          news_article.lead_image_path, host: Whitehall.public_asset_host
+        )
+
+        high_resolution_url = ActionController::Base.helpers.image_url(
+          news_article.high_resolution_lead_image_path, host: Whitehall.public_asset_host
+        )
+
         {
           image: {
-            high_resolution_url: news_article.high_resolution_lead_image_url,
-            url: news_article.lead_image_url,
+            high_resolution_url: high_resolution_url,
+            url: image_url,
             caption: image_caption,
             alt_text: image_alt_text,
           },

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -157,7 +157,9 @@ module PublishingApi
       return unless item.custom_logo_selected?
 
       {
-        url: item.logo.url,
+        url: ActionController::Base.helpers.image_url(
+          item.logo.url, host: Whitehall.public_asset_host
+        ),
         alt_text: item.name,
       }
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,12 +55,5 @@ module Whitehall
     end
 
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
-
-    # Path within public/ where assets are compiled to
-    config.assets.prefix = "/assets/whitehall"
-
-    # allow overriding the asset host with an enironment variable, useful for
-    # when router is proxying to this app but asset proxying isn't set up.
-    config.asset_host = ENV["ASSET_HOST"]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,9 @@ Whitehall::Application.configure do
 
   config.assets.cache_store = :null_store
   config.sass.cache = false
+  config.slimmer.asset_host = ENV["STATIC_DEV"] || Plek.find("static")
+
+  if ENV["SHOW_PRODUCTION_IMAGES"]
+    config.asset_host = "https://assets.publishing.service.gov.uk"
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,12 @@ Whitehall::Application.configure do
   # Specifies the header that your server uses for sending files
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for nginx
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  config.action_controller.asset_host = Whitehall.asset_root
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
@@ -59,6 +65,19 @@ Whitehall::Application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :dalli_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server
+  # Make sure we always use the public_asest_host for uploads as these are
+  # currently served by the whitehall backend machines so any asset urls need
+  # to use the public asset host because our CORS settings disallow the admin
+  # asset host from serve assets to the public pages
+  config.action_controller.asset_host = proc do |_source, request|
+    if request && request.path =~ %r{system/uploads}
+      Whitehall.public_asset_host
+    else
+      Whitehall.asset_root
+    end
+  end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,8 @@ Whitehall::Application.configure do
   # Don't use digests in assets during tests
   config.assets.digest = false
 
+  config.slimmer.asset_host = "http://tests-should-not-depend-on-external-host.com"
+
   # These environment variables are required for Plek. Conditionally setting
   # them here means we don't have to explicitly set them just to run tests.
   ENV["GOVUK_APP_DOMAIN"] ||= "test.gov.uk"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -37,3 +37,5 @@ Rails.application.config.assets.precompile += %w[
   frontend/print.css
   admin.js
 ]
+
+Rails.application.config.assets.prefix = Whitehall.router_prefix + Rails.application.config.assets.prefix

--- a/docs/local_asset_setup_guide.md
+++ b/docs/local_asset_setup_guide.md
@@ -1,0 +1,17 @@
+# Assets
+
+Ideally, you will have a copy of
+[`static`](https://github.com/alphagov/static) running locally (at http://static.dev.gov.uk by default) 
+and that will be used to serve shared assets. This is how things will work by default if you
+are running the GOV.UK development VM with `foreman` or `bowler`.
+
+If you are running Whitehall with `bundle exec rails server` and don't want to
+run a local copy of `static`, you can tell the app to use assets served
+directly from the Integration environment by setting `STATIC_DEV`:
+
+```
+STATIC_DEV=https://assets-origin.integration.publishing.service.gov.uk/ bundle exec rails server
+```
+
+If you are only working on the Whitehall admin interface, you don't need the
+assets available.

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -108,6 +108,14 @@ module Whitehall
     "/government"
   end
 
+  def self.asset_root
+    @asset_root ||= Plek.new.asset_root
+  end
+
+  def self.public_asset_host
+    @public_asset_host ||= Plek.new.public_asset_host
+  end
+
   def self.admin_host
     @admin_host ||= URI(admin_root).host
   end

--- a/startup.sh
+++ b/startup.sh
@@ -8,11 +8,10 @@ if [ -z "$SHOW_PRODUCTION_IMAGES" ]; then
   echo "$ SHOW_PRODUCTION_IMAGES=1 ./startup.sh"
 else
   echo "Showing production images"
-  export GOVUK_ASSET_HOST=https://assets.publishing.service.gov.uk
 fi
-
-# Serve static from production
-export PLEK_SERVICE_STATIC_URI=https://assets.publishing.service.gov.uk
+# Serve static shared assets from integration so static doesn't need to be running
+: ${STATIC_DEV:="https://assets-origin.integration.publishing.service.gov.uk"}
+export STATIC_DEV
 echo
 bundle install
 bundle exec rails s -p 3020

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -24,6 +24,9 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       attachable.attachments << attachment
       stub_whitehall_asset(filename, id: asset_id)
       attachable.save!
+
+      asset_host = URI.parse(Plek.new.public_asset_host).host
+      host! asset_host
     end
 
     context "given a published document with file attachment" do

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -24,6 +24,9 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
       stub_publishing_api_has_linkables([], document_type: "topic")
       setup_publishing_api_for(edition)
       stub_whitehall_asset(filename, id: asset_id)
+
+      asset_host = URI.parse(Plek.new.public_asset_host).host
+      host! asset_host
     end
 
     context "given a draft document with a file attachment" do

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -10,6 +10,17 @@ class RoutingTest < ActionDispatch::IntegrationTest
     assert_redirected_to "#{Whitehall.router_prefix}/topics"
   end
 
+  test "assets are served under the #{Whitehall.router_prefix} prefix" do
+    stub_content_store_has_item("/courts-tribunals", {})
+    stub_taxonomy_with_all_taxons
+    rummager = stub
+
+    with_stubbed_rummager(rummager) do
+      get organisations_path
+      assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
+    end
+  end
+
   test "visiting #{Whitehall.router_prefix} when not in frontend redirects to /" do
     get Whitehall.router_prefix
     assert_redirected_to "/"

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -302,6 +302,13 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end
 
+  test "does not prefix embedded attachment urls with asset host so that access to them can be authenticated when previewing draft documents" do
+    Whitehall.stubs(:public_asset_host).returns("https://some.cdn.com")
+    edition = build(:published_publication, :with_file_attachment, body: "!@1")
+    html = govspeak_edition_to_html(edition)
+    assert_select_within_html html, ".govspeak .attachment.embedded a[href^='/'][href$='greenpaper.pdf']"
+  end
+
   test "should remove extra quotes from blockquote text" do
     remover = stub("remover")
     remover.expects(:remove).returns("remover return value")
@@ -439,7 +446,7 @@ class GovspeakHelperTest < ActionView::TestCase
 
   test "fraction image paths include the public asset host and configured asset prefix" do
     prefix = Rails.application.config.assets.prefix
-    path   = "#{Whitehall.public_root}#{prefix}/fractions/1_2.png"
+    path   = "#{Whitehall.public_asset_host}#{prefix}/fractions/1_2.png"
     html   = govspeak_to_html("I'm [Fraction:1/2] a person")
 
     assert_select_within_html(html, "img[src='#{path}']")

--- a/test/unit/lead_image_presenter_helper_test.rb
+++ b/test/unit/lead_image_presenter_helper_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class LeadImagePresenterHelperTest < ActiveSupport::TestCase
   test "should use placeholder image if none had been uploaded" do
     presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
-    assert_match %r{placeholder}, presenter.lead_image_url
+    assert_match %r{placeholder}, presenter.lead_image_path
     assert_equal "placeholder", presenter.lead_image_alt_text
   end
 
@@ -15,7 +15,7 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
     image = stub("Image", alt_text: "alt_text", image_data: image_data)
     uploader.expects(:url).with(:s300).returns("url")
     presenter.stubs(images: [image])
-    assert_equal "url", presenter.lead_image_url
+    assert_equal "url", presenter.lead_image_path
     assert_equal "alt_text", presenter.lead_image_alt_text
   end
 
@@ -27,7 +27,7 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
     image = stub("Image", alt_text: "alt_text", image_data: image_data)
     uploader.expects(:url).with.returns("url")
     presenter.stubs(images: [image])
-    assert_equal "url", presenter.lead_image_url
+    assert_equal "url", presenter.lead_image_path
     assert_equal "alt_text", presenter.lead_image_alt_text
   end
 end

--- a/test/unit/presenters/news_article_presenter_test.rb
+++ b/test/unit/presenters/news_article_presenter_test.rb
@@ -7,11 +7,11 @@ class NewsArticlePresenterTest < ActionView::TestCase
     @presenter = NewsArticlePresenter.new(@news_article, @view_context)
   end
 
-  test "lead_image_url returns the placeholder" do
-    assert_match "placeholder", @presenter.lead_image_url
+  test "lead_image_path returns the default image" do
+    assert_match "placeholder", @presenter.lead_image_path
   end
 
-  test "lead_image_url returns the department default image" do
+  test "lead_image_path returns the department default image" do
     image = create(:default_news_organisation_image_data)
     organisation = create(
       :organisation,
@@ -19,6 +19,6 @@ class NewsArticlePresenterTest < ActionView::TestCase
     )
     news_article = create(:news_article, organisations: [organisation])
     presenter = NewsArticlePresenter.new(news_article, @view_context)
-    assert_match organisation.default_news_image.file.url(:s300), presenter.lead_image_url
+    assert_match organisation.default_news_image.file.url(:s300), presenter.lead_image_path
   end
 end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -232,8 +232,8 @@ module PublishingApi::NewsArticlePresenterTest
         .returns(
           stub(
             has_lead_image?: true,
-            lead_image_url: "/foo",
-            high_resolution_lead_image_url: "/foo-large",
+            lead_image_path: "/foo",
+            high_resolution_lead_image_path: "/foo-large",
             lead_image_alt_text: "Bar",
             lead_image_caption: "Baz",
           ),
@@ -243,8 +243,8 @@ module PublishingApi::NewsArticlePresenterTest
       expected_image_alt_text = "Bar"
 
       expected_image = {
-        high_resolution_url: "/foo-large",
-        url: "/foo",
+        high_resolution_url: Whitehall.public_asset_host + "/foo-large",
+        url: Whitehall.public_asset_host + "/foo",
         caption: expected_image_caption,
         alt_text: expected_image_alt_text,
       }

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -40,7 +40,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
           browse_pages: [],
           topics: [],
         },
-        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/assets/whitehall/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
+        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
         first_public_at: publication.first_public_at,
         change_history: [
           { public_timestamp: publication.public_timestamp, note: "change-note" }.as_json,

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -139,7 +139,7 @@ class SpeechTest < ActiveSupport::TestCase
 
   test "search_index includes default image_url if it has no image" do
     speech = create(:published_speech)
-    assert_equal "https://www.test.gov.uk/assets/whitehall/placeholder.jpg", speech.search_index["image_url"]
+    assert_equal "https://static.test.gov.uk/government/assets/placeholder.jpg", speech.search_index["image_url"]
   end
 
   test "search_index includes default image_url if it has one" do


### PR DESCRIPTION
Reverts alphagov/whitehall#5685

I've hit a problem where assets aren't served for CSV preview (these are hosted off the assets hostname so relative asset paths fail). Reverting this to give me some time to have a ponder the best way to fix that.