### PR TITLE
Fix heading semantics

### DIFF
--- a/docs/timestamps.md
+++ b/docs/timestamps.md
@@ -1,6 +1,6 @@
-## Timestamps
+# Timestamps
 
-### `public_timestamp`
+## `public_timestamp`
 
 * point in time the edition became visible to the public on the website. Updated for major changes
 * used to sort documents in the atom feed
@@ -8,17 +8,17 @@
 * used when comparing edition published dates in scopes on Edition (e.g. `published_before(date)`)
 * set to `first_public_at` or `major_change_published_at` on every save
 
-### `first_published_at`
+## `first_published_at`
 
 * signifies when the document was 'first published', which may be before the public timestamp. E.g. transitioned content, etc.
 * Either user supplied on the form, or set during publishing to the `major_change_published_at` timestamp
 
-### `first_public_at`
+## `first_public_at`
 
 * `first_published_at` on Edition
 * `opening_at` on Consultation
 
-### `major_change_published_at`
+## `major_change_published_at`
 
 * date of the last major change. Major changes require change notes. This is decided by the user.
 


### PR DESCRIPTION
Noticed quirk on https://docs.publishing.service.gov.uk/apis.html
<img width="263" alt="Screenshot 2020-06-16 at 15 21 41" src="https://user-images.githubusercontent.com/5111927/84786834-274dc080-afe5-11ea-8b48-e3afb63a9794.png">

Markdown files should begin with a h1 (`#`).