### PR TITLE
Make attachment thumbnails use public GOV.UK hostname

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -133,17 +133,18 @@ module DocumentHelper
   end
 
   def attachment_thumbnail(attachment)
-    if attachment.pdf?
-      image_tag(attachment.file.thumbnail.url, alt: "")
-    elsif attachment.html?
-      image_tag("pub-cover-html.png", alt: "")
-    elsif %w[doc docx odt].include? attachment.file_extension
-      image_tag("pub-cover-doc.png", alt: "")
-    elsif %w[xls xlsx ods csv].include? attachment.file_extension.downcase
-      image_tag("pub-cover-spreadsheet.png", alt: "")
-    else
-      image_tag("pub-cover.png", alt: "")
-    end
+    image_url = if attachment.pdf?
+                  attachment.file.thumbnail.url
+                elsif attachment.html?
+                  image_url("pub-cover-html.png", host: Whitehall.public_root)
+                elsif %w[doc docx odt].include? attachment.file_extension
+                  image_url("pub-cover-doc.png", host: Whitehall.public_root)
+                elsif %w[xls xlsx ods csv].include? attachment.file_extension.downcase
+                  image_url("pub-cover-spreadsheet.png", host: Whitehall.public_root)
+                else
+                  image_url("pub-cover.png", host: Whitehall.public_root)
+                end
+    image_tag(image_url, alt: "")
   end
 
   def alternative_format_order_link(attachment, alternative_format_contact_email)

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -61,24 +61,24 @@ class DocumentHelperTest < ActionView::TestCase
     assert_nil humanized_content_type(nil)
   end
 
-  test "should return DOC specific thumbnail for DOC files" do
+  test "#attachment_thumbnail returns document thumbnails with public URLs for .doc files" do
     attachment = create(:file_attachment, file: fixture_file_upload("sample.docx", "application/msword"))
-    assert_match %r{pub-cover-doc\.png}, attachment_thumbnail(attachment)
+    assert_match %r{#{Whitehall.public_root}/images/pub-cover-doc\.png}, attachment_thumbnail(attachment)
   end
 
-  test "should return spreadsheet specific thumbnail for spreadsheet files" do
+  test "#attachment_thumbnail returns spreadsheet thumbnails with public URLs for spreadsheet files" do
     attachment = create(:file_attachment, file: fixture_file_upload("sample-from-excel.csv", "text/csv"))
-    assert_match %r{pub-cover-spreadsheet\.png}, attachment_thumbnail(attachment)
+    assert_match %r{#{Whitehall.public_root}/images/pub-cover-spreadsheet\.png}, attachment_thumbnail(attachment)
   end
 
-  test "should return spreadsheet specific thumbnail for spreadsheet files with any case file extension" do
-    attachment = create(:file_attachment, file: fixture_file_upload("sample_case.CSV", "text/csv"))
-    assert_match(/pub-cover-spreadsheet\.png/, attachment_thumbnail(attachment))
-  end
-
-  test "should return HTML specific thumbnail for HTML attachments" do
+  test "#attachment_thumbnail returns HTML thumbnails with public URLs for HTML attachments" do
     publication = create(:published_publication, :with_html_attachment)
-    assert_match %r{pub-cover-html\.png}, attachment_thumbnail(publication.attachments.first)
+    assert_match %r{#{Whitehall.public_root}/images/pub-cover-html\.png}, attachment_thumbnail(publication.attachments.first)
+  end
+
+  test "#attachment_thumbnail returns generic thumbnails with public URLs for other files" do
+    attachment = create(:file_attachment, file: fixture_file_upload("sample_attachment.zip", "application/zip"))
+    assert_match %r{#{Whitehall.public_root}/images/pub-cover\.png}, attachment_thumbnail(attachment)
   end
 
   test "should return PDF Document for humanized content type" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -40,7 +40,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
           browse_pages: [],
           topics: [],
         },
-        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/assets/whitehall/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
+        documents: ["<section class=\"attachment embedded\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"https://www.test.gov.uk/assets/whitehall/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
         first_public_at: publication.first_public_at,
         change_history: [
           { public_timestamp: publication.public_timestamp, note: "change-note" }.as_json,


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Attachment thumbnails are inconsistent with the other means that assets
can be embedded in content items. Unlike placeholder images and
fractions these images are not embedded with a hostname. The change here
makes this approach consistent with the other two.

As far as I can tell these URLs should have been set an absolute URL
with the asset host around the time https://github.com/alphagov/whitehall/pull/2481
was introduced. In theory these should have stopped working when
Whitehall started using the assets hostname for serving assets, however
the /government content item prefix route provided a loop hole that kept
them working.

I considered whether to either make the other URLs used to embed assets
relative so that all of these use less data and are a bit more flexible,
however this approach conflicts with some JSON schema semantics. The
placeholder image is used with a URI schema validation [1] and as per
JSON Schema a URI should be absolute with a scheme [2]. Thus the
consistent approach was setting these all as full URIs.

It's worth noting (as I have in many related commits) that we really
shouldn't be embedding Whitehall assets in content items as this a
rather fragile abstraction and a strange coupling of an applications
internal structure with public content.

[1]: https://github.com/alphagov/govuk-content-schemas/blob/91ef588841f6073b3cc0d362f562ed298a4c0a15/dist/formats/speech/publisher_v2/schema.json#L338
[2]: https://json-schema.org/draft-06/json-schema-release-notes.html#formats-uri-vs-uri-reference