### PR TITLE
Gitignore new assets path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /.sass-cache/
 /public/system/
 /public/uploads/
-/public/government/
+/public/assets/
 /config/whitehall_secrets.yml
 /coverage
 /test/reports


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Now that assets are wrote in the more conventional assets directory this
should be ignored from git so it doesn't get caught up in a developers
local files.