### PR TITLE
Use Plek#asset_root over Plek#public_asset_host

### DIFF
--- a/features/step_definitions/attachment_preview_steps.rb
+++ b/features/step_definitions/attachment_preview_steps.rb
@@ -11,7 +11,7 @@ end
 When(/^I preview the contents of the attachment$/) do
   fn = Rails.root.join("test/fixtures/sample.csv")
 
-  asset_host = URI.parse(Plek.new.public_asset_host).host
+  asset_host = URI.parse(Plek.new.asset_root).host
   stub_request(:get, "https://#{asset_host}/government/uploads/system/uploads/attachment_data/file/#{@attachment.attachment_data.id}/sample.csv")
     .with(headers: { "Range" => "bytes=0-300000" })
     .to_return(status: 206, body: File.read(fn))

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -6,7 +6,7 @@ class CsvFileFromPublicHost
   MAXIMUM_RANGE_BYTES = "300000".freeze
 
   def self.csv_response(path, env: ENV)
-    connection = Faraday.new(url: Plek.new.public_asset_host)
+    connection = Faraday.new(url: Plek.new.asset_root)
 
     if env.key?("BASIC_AUTH_CREDENTIALS")
       basic_auth_credentials = env["BASIC_AUTH_CREDENTIALS"].split(":")

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -34,7 +34,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def url
-      URI.join(Plek.new.public_asset_host, Addressable::URI.encode(@legacy_url_path)).to_s
+      URI.join(Plek.new.asset_root, Addressable::URI.encode(@legacy_url_path)).to_s
     end
 
     def filename

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ if [ -z "$SHOW_PRODUCTION_IMAGES" ]; then
   echo "$ SHOW_PRODUCTION_IMAGES=1 ./startup.sh"
 else
   echo "Showing production images"
-  export GOVUK_ASSET_HOST=https://assets.publishing.service.gov.uk
+  export GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk
 fi
 
 # Serve static from production

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -6,7 +6,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
   end
 
   def stub_csv_request(status: 206, body: "", path: "some-path")
-    stub_request(:get, "#{Plek.new.public_asset_host}/#{path}")
+    stub_request(:get, "#{Plek.new.asset_root}/#{path}")
       .with(headers: { "Range" => "bytes=0-300000" })
       .to_return(status: status, body: body)
   end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -254,7 +254,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "ways to respond" do
-      Plek.any_instance.stubs(:public_asset_host).returns("https://asset-host.com")
+      Plek.any_instance.stubs(:asset_root).returns("https://asset-host.com")
       expected_id = ConsultationResponseFormData.where(carrierwave_file: "two-pages.pdf").last.id
       expected_ways_to_respond = {
         attachment_url: "https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/#{expected_id}/two-pages.pdf",

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -113,8 +113,8 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     @file.delete
   end
 
-  test "constructs the url of the file using the public asset host and legacy url path" do
-    Plek.stubs(:new).returns(stub("plek", public_asset_host: "http://assets-host"))
+  test "constructs the url of the file using the assets root and legacy url path" do
+    Plek.stubs(:new).returns(stub("plek", asset_root: "http://assets-host"))
 
     expected_asset_url = URI.join("http://assets-host", @asset_url_path).to_s
 
@@ -137,7 +137,7 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     asset_path = "path/to/ässet.png"
     file = Whitehall::AssetManagerStorage::File.new(asset_path)
 
-    Plek.stubs(:new).returns(stub("plek", public_asset_host: "http://assets-host"))
+    Plek.stubs(:new).returns(stub("plek", asset_root: "http://assets-host"))
 
     assert_equal "http://assets-host/government/uploads/path/to/%C3%A4sset.png", file.url
   end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Whitehall no longer has a customised environment variable for
GOVUK_ASSET_ROOT so doesn't need to use the different, less common
GOVUK_ASSET_HOST one and corresponding method `#public_asset_host`.

I'm removing this with the hope that I can work towards removing the
GOVUK_ASSET_HOST env var since it's confusing similar to
GOVUK_ASSET_ROOT and the same value.