### PR TITLE
Add ministers index presenter

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -1,0 +1,47 @@
+module PublishingApi
+  class MinistersIndexPresenter
+    attr_accessor :update_type
+
+    def initialize(update_type: nil)
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      "324e4708-2285-40a0-b3aa-cb13af14ec5f"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: "ministers_index",
+        update_type: update_type,
+      ).base_attributes
+
+      content.merge!(
+        base_path: base_path,
+        details: details,
+        document_type: "ministers_index",
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "ministers_index",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+  private
+
+    def details
+      setting = SitewideSetting.find_by(key: :minister_reshuffle_mode)
+
+      return {} unless setting.on
+
+      { reshuffle: { message: setting.govspeak } }
+    end
+
+    def base_path
+      return "/government/ministers" if I18n.locale == :en
+
+      "/government/ministers.#{I18n.locale}"
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
+  def presented_item
+    PublishingApi::MinistersIndexPresenter.new
+  end
+
+  test "presenter is valid against ministers index schema" do
+    I18n.with_locale(:en) do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+
+      assert_valid_against_schema(presented_item.content, "ministers_index")
+    end
+  end
+
+  test "presents ministers index page ready for the publishing-api in english" do
+    I18n.with_locale(:en) do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
+
+      expected_hash = {
+        title: "ministers_index",
+        locale: "en",
+        publishing_app: "whitehall",
+        redirects: [],
+        update_type: "major",
+        base_path: "/government/ministers",
+        details: {},
+        document_type: "ministers_index",
+        rendering_app: "whitehall-frontend",
+        schema_name: "ministers_index",
+        routes: [
+          {
+            path: "/government/ministers",
+            type: "exact",
+          },
+        ],
+      }
+
+      assert_equal expected_hash, presented_item.content
+    end
+  end
+
+  test "presents ministers index page ready for the publishing-api with correct reshuffle message" do
+    I18n.with_locale(:en) do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+
+      expected_details = {
+        reshuffle: {
+          message: "example text",
+        },
+      }
+
+      assert_equal expected_details, presented_item.content[:details]
+    end
+  end
+
+  test "presents ministers index page ready for the publishing-api in welsh" do
+    I18n.with_locale(:cy) do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
+
+      expected_hash = {
+        title: "ministers_index",
+        locale: "cy",
+        publishing_app: "whitehall",
+        redirects: [],
+        update_type: "major",
+        base_path: "/government/ministers.cy",
+        details: {},
+        document_type: "ministers_index",
+        rendering_app: "whitehall-frontend",
+        schema_name: "ministers_index",
+        routes: [
+          {
+            path: "/government/ministers.cy",
+            type: "exact",
+          },
+        ],
+      }
+
+      assert_equal expected_hash, presented_item.content
+    end
+  end
+end


### PR DESCRIPTION
### Create a new presenter for the ministers index page.

This is part of the work to migrate rendering of the ministers index page from Whitehall to collections. The first 
step in this was to present a content item to the publishing-api that could be later rendered by collections.

I've added necessary tests to check that the content item contains what it should do, and that it abides by the schema
set out in govuk-content-schemas (https://github.com/alphagov/govuk-content-schemas/commit/66ebaf0e2d0454719c6f3a96f1b5ae22317a50a4#L9-L10)

https://trello.com/c/I92GWawi/2027-5-write-ministers-index-presenter