### PR TITLE
Fix mappings export task

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -13,7 +13,7 @@ namespace :export do
 
     exporter = Whitehall::Exporters::Mappings.new
 
-    filename = "public/government/mappings.csv"
+    filename = "public/assets/mappings.csv"
     temporary_filename = filename + ".new"
     CSV.open(Rails.root.join(temporary_filename), "wb") do |csv_out|
       exporter.export(csv_out)


### PR DESCRIPTION
Since https://github.com/alphagov/whitehall/pull/5701 was merged,
we've seen Sentry errors as follows:

```
Errno::ENOENT
No such file or directory @ rb_sysopen - /data/vhost/whitehall-admin/releases/20200619095927/public/government/mappings.csv.new
```

https://sentry.io/organizations/govuk/issues/1732210772/events/176631e7d06e4bad911b4c42d7451cdd/?environment=production&project=202259&query=is%3Aunresolved&statsPeriod=24h

The mappings.csv file is still being generated, but it is now
available under /var/apps/whitehall/public/assets, rather than
/var/apps/whitehall/public/government.