### PR TITLE
Remove some left over references to policies and policy areas

### DIFF
--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -6,7 +6,7 @@
   <%= standard_edition_form(edition) do |form| %>
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -44,7 +44,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <div class="js-external-url-set">
         <%= render 'appointment_fields', form: form, edition: edition %>
       </div>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -7,7 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
 
       <%= render "topical_event_fields", form: form, edition: edition %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -7,7 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="row">
   <h1><%= @edition.title %></h1>
   <p>
-    Policies, policy areas and specialist sectors will continue to be supported until the topic taxonomy replaces them.
+    Specialist sectors will continue to be supported until the topic taxonomy replaces them.
   </p>
 </div>
 

--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -7,7 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policy areas and specialist sectors later.</p>
+      <p>You'll be able to specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'appointment_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'operational_field_fields', locals: { form: form, edition: edition } %>

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -10,7 +10,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render 'appointment_fields', form: form, edition: edition %>
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'worldwide_organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -9,7 +9,7 @@
   <%= standard_edition_form(edition) do |form| %>
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -11,7 +11,7 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <p>You'll be able to select specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
     </fieldset>
   <% end %>


### PR DESCRIPTION
These have been replaced/merged in to the Topic Taxonomy, and the
tagging interfaces have been removed from Whitehall.