### PR TITLE
Make the images part of the edit edition form more readable

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition_form.scss
+++ b/app/assets/stylesheets/admin/views/_edition_form.scss
@@ -26,4 +26,9 @@
       display: none;
     }
   }
+
+  fieldset.images .fields-container {
+    padding-top: 15px;
+    border-top: 1px solid #EEE;
+  }
 }

--- a/app/views/admin/editions/_image_fields.html.erb
+++ b/app/views/admin/editions/_image_fields.html.erb
@@ -14,17 +14,13 @@
       </div>
     <% else %>
       <% i += 1 %>
-      <div class="image">
+      <div class="row image">
         <%= images_fields.hidden_field :id %>
-        <div class="image-container">
-          <%= image_tag(images_fields.object.url) %>
-        </div>
-        <div class="fields-container">
+        <div class="col-md-6 fields-container">
           <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
           <%= images_fields.text_area :caption, rows: 2 %>
           <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
           <%= images_fields.check_box :_destroy, *checkbox_args  %>
-        </div>
           <% if edition.image_disallowed_in_body_text?(i) %>
             <p>This image is shown automatically, and is not available for use inline in the body.</p>
           <% else %>
@@ -32,6 +28,12 @@
               <input type="text" readonly="readonly" value="!!<%= i %>" />
             </p>
           <% end %>
+        </div>
+        <div class="col-md-6">
+          <a href="<%= images_fields.object.url %>">
+            <%= image_tag(images_fields.object.url, class: "img-responsive") %>
+          </a>
+        </div>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
I'm not sure what's gone wrong here, there are some classes like
image-container that are in the HTML, but there's no corresponding
CSS. The CSS for image-container seems to have been removed 8 years
ago back in 2012 [1].

1: cb59ac01728238cee9d2a938d45b9a635d96efe4

These changes don't try and make things better, just less worse. Each
image will take up less vertical space on the page, and it should be
visually clearer which image the form elements relate to.

I was looking at this because I wanted to see if something could be
done here to clear up confusion about how the special images for
speeches are handled, but that's hard to do with the interface in such
a state...

## Before

![whitehall-edit-edition-images-before](https://user-images.githubusercontent.com/1130010/86475475-a6a8f700-bd3c-11ea-9656-c83464cda7c8.jpg)

## After

![whitehall-edit-edition-images-after](https://user-images.githubusercontent.com/1130010/86475464-a1e44300-bd3c-11ea-8000-7211e67f21df.jpg)