### PR TITLE
Fail validation if URL contains whitespace

### DIFF
--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -4,12 +4,16 @@ require "addressable/uri"
 # Accepts options[:message] and options[:allowed_protocols]
 class UriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if !(uri = Addressable::URI.parse(value))
+    return if value.nil?
+
+    uri = URI.parse(value)
+
+    if uri.blank?
       record.errors[attribute] << failure_message
-    elsif !allowed_protocols.include?(uri.scheme)
+    elsif allowed_protocols.exclude?(uri.scheme)
       record.errors[attribute] << "is not valid. Make sure it starts with http(s)"
     end
-  rescue Addressable::URI::InvalidURIError
+  rescue URI::Error
     record.errors[attribute] << failure_message
   end
 

--- a/test/unit/validators/uri_validator_test.rb
+++ b/test/unit/validators/uri_validator_test.rb
@@ -5,6 +5,11 @@ class UriValidatorTest < ActiveSupport::TestCase
     @validator = UriValidator.new(attributes: [:url])
   end
 
+  test "validates nil urls" do
+    feature_link = validate(PromotionalFeatureLink.new(url: nil))
+    assert feature_link.errors.empty?
+  end
+
   test "validates http urls" do
     feature_link = validate(PromotionalFeatureLink.new(url: "http://example.com"))
     assert feature_link.errors.empty?
@@ -22,8 +27,18 @@ class UriValidatorTest < ActiveSupport::TestCase
     feature_link = validate(PromotionalFeatureLink.new(url: "gopher://example.com"))
     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
 
-    feature_link = validate(PromotionalFeatureLink.new(url: "mailto://example.com"))
+    feature_link = validate(PromotionalFeatureLink.new(url: "mailto:name@example.com"))
     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
+  end
+
+  test "invalid urls get an error if they aren't https/http and are poorly formatted" do
+    feature_link = validate(PromotionalFeatureLink.new(url: "mailto://example.com"))
+    assert_equal ["is not valid."], feature_link.errors[:url]
+  end
+
+  test "invalid urls get an error if they include whitespace" do
+    feature_link = validate(PromotionalFeatureLink.new(url: "https://example.come/guidance/inspire-index-polygons-spatial-data blah blah"))
+    assert_equal ["is not valid."], feature_link.errors[:url]
   end
 
   test "invalid urls get an error, without http" do


### PR DESCRIPTION
A user managed to save a URL with whitespace which lead to
publishing-api rejecting the unpublishing request but whitehall saving
the consolidated URL leaving the edition is a funky state. This PR
prevents this from happening in the future.

This also switches over to using ruby's URI instead of Addressable. This
seems to of been added originally due to limitations in our URL
validation however from my testing using plain old ruby's URI is fine.
[Original PR](5b31351)

Now the class validating the URL matches what is present in
[publishing-api](https://github.com/alphagov/publishing-api/blob/93605514d7c32ddcb93bf793529de00b64cc1c39/app/validators/routes_and_redirects_validator.rb#L171) so we should no longer get a disparity in validating URL's between the
two apps.

This validation is used [here](https://github.com/alphagov/whitehall/blob/master/app/models/unpublishing.rb#L9) on the unpublishing model.

---

Zendesk:
https://govuk.zendesk.com/agent/tickets/4144535