### PR TITLE
Fix feedback component layout

### DIFF
--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -32,7 +32,9 @@
       <div id="whitehall-wrapper">
         <%= yield %>
       </div>
-      <%= render 'govuk_publishing_components/components/feedback' %>
+      <div class="govuk-width-container">
+        <%= render 'govuk_publishing_components/components/feedback' %>
+      </div>
     </div>
     <%= javascript_include_tag "application", integrity: false %>
     <%= javascript_tag(yield :javascript_initialisers) %>


### PR DESCRIPTION
- component was recently modified to no longer limit its own size
- this means it now fills the available page width in whitehall pages, because it is outside of the normal page wrapper
- fix is to wrap it in a govuk-width-container

Problem is on pages like https://www.gov.uk/government/topical-events/a-plan-for-jobs-2020

Before:

<img width="990" alt="Screenshot 2020-07-08 at 13 49 51" src="https://user-images.githubusercontent.com/861310/86920666-02e78e80-c122-11ea-80d3-1b3db2f3cbba.png">

After:

<img width="990" alt="Screenshot 2020-07-08 at 13 49 43" src="https://user-images.githubusercontent.com/861310/86920674-0713ac00-c122-11ea-86a6-31b429bca3fb.png">
