### PR TITLE
Sync enforce style for Naming/VariableNumber

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ inherit_mode:
   merge:
     - Exclude
 
-Naming/VariableNumber:
-  EnforcedStyle: snake_case
-
 # This has special infrastructure for one-time data
 # migration tasks, for which it's common to write to
 # STDOUT using 'puts'.

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -21,9 +21,9 @@ When(/^I draft a new consultation "([^"]*)"$/) do |title|
   click_button "Save"
 end
 
-Then(/^I can see links to the consultations "([^"]*)" and "([^"]*)"$/) do |title_1, title_2|
-  assert has_css?(".consultation a", text: title_1)
-  assert has_css?(".consultation a", text: title_2)
+Then(/^I can see links to the consultations "([^"]*)" and "([^"]*)"$/) do |title1, title2|
+  assert has_css?(".consultation a", text: title1)
+  assert has_css?(".consultation a", text: title2)
 end
 
 When(/^I add an outcome to the consultation$/) do

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -1,24 +1,24 @@
 Given(/^there is an organisation with some contacts on its home page$/) do
   @the_organisation = create_org_and_stub_content_store(:organisation, name: "Name of org with contacts")
-  contact_1 = create(:contact, contactable: @the_organisation, title: "Main office")
-  contact_2 = create(:contact, contactable: @the_organisation, title: "Summer office by the lake")
-  contact_3 = create(:contact, contactable: @the_organisation, title: "Emergency bunker office")
-  @the_organisation.add_contact_to_home_page!(contact_1)
-  @the_organisation.add_contact_to_home_page!(contact_2)
-  @the_organisation.add_contact_to_home_page!(contact_3)
-  @the_ordered_contacts = [contact_1, contact_2, contact_3]
+  contact1 = create(:contact, contactable: @the_organisation, title: "Main office")
+  contact2 = create(:contact, contactable: @the_organisation, title: "Summer office by the lake")
+  contact3 = create(:contact, contactable: @the_organisation, title: "Emergency bunker office")
+  @the_organisation.add_contact_to_home_page!(contact1)
+  @the_organisation.add_contact_to_home_page!(contact2)
+  @the_organisation.add_contact_to_home_page!(contact3)
+  @the_ordered_contacts = [contact1, contact2, contact3]
 end
 
 Given(/^there is a worldwide organisation with some offices on its home page$/) do
   @the_organisation = create(:worldwide_organisation)
   @the_main_office = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "HQ1.0")
-  office_1 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Main office")
-  office_2 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Summer office by the lake")
-  office_3 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Emergency bunker office")
-  @the_organisation.add_office_to_home_page!(office_1)
-  @the_organisation.add_office_to_home_page!(office_2)
-  @the_organisation.add_office_to_home_page!(office_3)
-  @the_ordered_offices = [office_1, office_2, office_3]
+  office1 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Main office")
+  office2 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Summer office by the lake")
+  office3 = create(:worldwide_office, worldwide_organisation: @the_organisation, title: "Emergency bunker office")
+  @the_organisation.add_office_to_home_page!(office1)
+  @the_organisation.add_office_to_home_page!(office2)
+  @the_organisation.add_office_to_home_page!(office3)
+  @the_ordered_offices = [office1, office2, office3]
 end
 
 When(/^I add a new contact to be featured on the home page of the organisation$/) do

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -67,7 +67,7 @@ When(/^I add the document "(.*?)" to the document collection$/) do |document_tit
   end
 end
 
-When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title_1, doc_title_2|
+When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title1, doc_title2|
   refute @document_collection.nil?, "No document collection to act on."
 
   visit admin_document_collection_path(@document_collection)
@@ -77,11 +77,11 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
   # Simulate drag-droping document.
   execute_script %{
     (function($) {
-      var doc_1_li = $('.document-list li:contains(#{doc_title_1})');
-      if(doc_1_li.length == 0) throw("Couldn't find li for document '#{doc_title_1}' in .document-list.");
+      var doc_1_li = $('.document-list li:contains(#{doc_title1})');
+      if(doc_1_li.length == 0) throw("Couldn't find li for document '#{doc_title1}' in .document-list.");
 
-      var doc_2_li = $('.document-list li:contains(#{doc_title_2})');
-      if(doc_2_li.length == 0) throw("Couldn't find li for document '#{doc_title_2}' in .document-list.");
+      var doc_2_li = $('.document-list li:contains(#{doc_title2})');
+      if(doc_2_li.length == 0) throw("Couldn't find li for document '#{doc_title2}' in .document-list.");
 
       doc_2_li.before(doc_1_li.remove());
 
@@ -152,9 +152,9 @@ Then(/^I can see in the admin that "(.*?)" does not appear$/) do |document_title
   refute_document_is_part_of_document_collection(document_title)
 end
 
-Then(/^I see that "(.*?)" is before "(.*?)" in the document collection$/) do |doc_title_1, doc_title_2|
-  assert_text doc_title_1
-  assert body.index(doc_title_1) < body.index(doc_title_2), "Expected #{doc_title_1} to be before #{doc_title_2}"
+Then(/^I see that "(.*?)" is before "(.*?)" in the document collection$/) do |doc_title1, doc_title2|
+  assert_text doc_title1
+  assert body.index(doc_title1) < body.index(doc_title2), "Expected #{doc_title1} to be before #{doc_title2}"
 end
 
 And(/^I search for "(.*?)" to add it to the document collection$/) do |document_title|

--- a/features/step_definitions/document_sources_steps.rb
+++ b/features/step_definitions/document_sources_steps.rb
@@ -3,10 +3,10 @@ Given(/^a draft publication "([^"]*)" with a legacy url "([^"]*)"$/) do |title, 
   publication.document.document_sources.create!(url: old_url)
 end
 
-Given(/^a draft publication "([^"]*)" with legacy urls "([^"]*)" and "([^"]*)"$/) do |title, old_url_1, old_url_2|
+Given(/^a draft publication "([^"]*)" with legacy urls "([^"]*)" and "([^"]*)"$/) do |title, old_url1, old_url2|
   publication = create(:draft_publication, title: title)
-  publication.document.document_sources.create!(url: old_url_1)
-  publication.document.document_sources.create!(url: old_url_2)
+  publication.document.document_sources.create!(url: old_url1)
+  publication.document.document_sources.create!(url: old_url2)
 end
 
 Then(/^I should see the legacy url "([^"]*)"$/) do |old_url|

--- a/features/step_definitions/historic_appointment_steps.rb
+++ b/features/step_definitions/historic_appointment_steps.rb
@@ -1,18 +1,18 @@
 Given(/^there are previous prime ministers$/) do
   pm_role = create(:role, name: "Prime Minister", slug: "prime-minister", supports_historical_accounts: true)
-  previous_pm_1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
-  previous_pm_2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
+  previous_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
+  previous_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
   _current_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)
-  _pm1_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm_1.person)
-  _pm2_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm_2.person)
+  _pm1_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm1.person)
+  _pm2_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm2.person)
   nineteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1801), ended_at: Date.civil(1804))
-  eighteenth_century_pm_1 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1704))
-  eighteenth_century_pm_2 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1704), ended_at: Date.civil(1708))
+  eighteenth_century_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1704))
+  eighteenth_century_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1704), ended_at: Date.civil(1708))
 
-  @modern_previous_pm_appointments = [previous_pm_2, previous_pm_1]
+  @modern_previous_pm_appointments = [previous_pm2, previous_pm1]
   @nineteenth_century_pm_appointments = [nineteenth_century_pm]
-  @eighteenth_century_pm_appointments = [eighteenth_century_pm_1, eighteenth_century_pm_2]
-  @most_recent_appointment = previous_pm_2
+  @eighteenth_century_pm_appointments = [eighteenth_century_pm1, eighteenth_century_pm2]
+  @most_recent_appointment = previous_pm2
 end
 
 When(/^I view the past prime ministers page$/) do

--- a/features/step_definitions/minister_steps.rb
+++ b/features/step_definitions/minister_steps.rb
@@ -85,43 +85,43 @@ Then(/^I should see that "([^"]*)" also attends cabinet$/) do |minister_name|
   end
 end
 
-Given(/^two cabinet ministers "([^"]*)" and "([^"]*)"$/) do |person_1, person_2|
-  create(:role_appointment, person: create(:person, forename: person_1), role: create(:ministerial_role, cabinet_member: true))
-  create(:role_appointment, person: create(:person, forename: person_2), role: create(:ministerial_role, cabinet_member: true))
+Given(/^two cabinet ministers "([^"]*)" and "([^"]*)"$/) do |person1, person2|
+  create(:role_appointment, person: create(:person, forename: person1), role: create(:ministerial_role, cabinet_member: true))
+  create(:role_appointment, person: create(:person, forename: person2), role: create(:ministerial_role, cabinet_member: true))
 end
 
-Given(/^two whips "([^"]*)" and "([^"]*)"$/) do |person_1, person_2|
+Given(/^two whips "([^"]*)" and "([^"]*)"$/) do |person1, person2|
   whip_organisation_id = Whitehall::WhipOrganisation::WhipsHouseOfCommons.id
   create(
     :role_appointment,
-    person: create(:person, forename: person_1),
+    person: create(:person, forename: person1),
     role: create(:ministerial_role, whip_organisation_id: whip_organisation_id, cabinet_member: false),
   )
   create(
     :role_appointment,
-    person: create(:person, forename: person_2),
+    person: create(:person, forename: person2),
     role: create(:ministerial_role, whip_organisation_id: whip_organisation_id, cabinet_member: false),
   )
 end
 
-When(/^I order the (?:cabinet ministers|whips) "([^"]*)", "([^"]*)"$/) do |role_1, role_2|
+When(/^I order the (?:cabinet ministers|whips) "([^"]*)", "([^"]*)"$/) do |role1, role2|
   visit admin_cabinet_ministers_path
-  [role_1, role_2].each_with_index do |role, index|
+  [role1, role2].each_with_index do |role, index|
     fill_in(role, with: index)
   end
   click_button "Save"
 end
 
-Then(/^I should see "([^"]*)", "([^"]*)" in that order on the ministers page$/) do |person_1, person_2|
+Then(/^I should see "([^"]*)", "([^"]*)" in that order on the ministers page$/) do |person1, person2|
   visit ministers_page
   actual = all(".person .current-appointee").map(&:text)
-  assert_equal [person_1, person_2], actual
+  assert_equal [person1, person2], actual
 end
 
-Then(/^I should see "([^"]*)", "([^"]*)" in that order on the whips section of the ministers page$/) do |person_1, person_2|
+Then(/^I should see "([^"]*)", "([^"]*)" in that order on the whips section of the ministers page$/) do |person1, person2|
   visit ministers_page
   actual = all(".whips .current-appointee").map(&:text)
-  assert_equal [person_1, person_2], actual
+  assert_equal [person1, person2], actual
 end
 
 Given(/^there are some ministers for the "([^"]*)"$/) do |organisation_name|

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -68,10 +68,10 @@ Given(/^a submitted corporate publication "([^"]*)" about the "([^"]*)"$/) do |p
   create(:submitted_corporate_publication, title: publication_title, organisations: [organisation])
 end
 
-Given(/^the organisation "([^"]*)" is associated with consultations "([^"]*)" and "([^"]*)"$/) do |name, consultation_1, consultation_2|
+Given(/^the organisation "([^"]*)" is associated with consultations "([^"]*)" and "([^"]*)"$/) do |name, consultation1, consultation2|
   organisation = create_org_and_stub_content_store(:organisation, name: name)
-  create(:published_consultation, title: consultation_1, organisations: [organisation])
-  create(:published_consultation, title: consultation_2, organisations: [organisation])
+  create(:published_consultation, title: consultation1, organisations: [organisation])
+  create(:published_consultation, title: consultation2, organisations: [organisation])
 end
 
 Given(/^a published publication "([^"]*)" with a PDF attachment and alternative format provider "([^"]*)"$/) do |title, organisation_name|
@@ -265,13 +265,13 @@ end
 
 Given(/^an organisation and some documents exist$/) do
   @organisation = create(:ministerial_department)
-  @organisation_2 = create(:ministerial_department)
-  @author_1 = create(:departmental_editor)
-  @author_2 = create(:departmental_editor)
+  @organisation2 = create(:ministerial_department)
+  @author1 = create(:departmental_editor)
+  @author2 = create(:departmental_editor)
   @documents = [
-    create(:published_news_article, title: "DOC1", organisations: [@organisation], creator: @author_1),
-    create(:published_news_article, title: "DOC2", organisations: [@organisation_2], creator: @author_1),
-    create(:published_consultation, title: "DOC3", organisations: [@organisation_2], creator: @author_2),
+    create(:published_news_article, title: "DOC1", organisations: [@organisation], creator: @author1),
+    create(:published_news_article, title: "DOC2", organisations: [@organisation2], creator: @author1),
+    create(:published_consultation, title: "DOC3", organisations: [@organisation2], creator: @author2),
   ]
 end
 
@@ -294,13 +294,13 @@ Then(/^I can filter instantaneously the list of documents by title, author, orga
     assert_no_selector record_css_selector(@documents[1])
     assert_no_selector record_css_selector(@documents[2])
   end
-  select @organisation_2.name, from: "organisation"
+  select @organisation2.name, from: "organisation"
   within "#search_results" do
     assert_no_selector record_css_selector(@documents[0])
     assert_selector record_css_selector(@documents[1])
     assert_selector record_css_selector(@documents[2])
   end
-  select @author_2.name, from: "author"
+  select @author2.name, from: "author"
   within "#search_results" do
     assert_no_selector record_css_selector(@documents[0])
     assert_no_selector record_css_selector(@documents[1])

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -49,8 +49,8 @@ Given(/^a (.*?) policy "([^"]*)" for the organisation "([^"]*)"$/) do |state, ti
   create("#{state}_policy", title: title, organisations: [org])
 end
 
-Given(/^a (.*?) policy "([^"]*)" for the organisations "([^"]*)" and "([^"]*)"$/) do |state, title, organisation_1, organisation_2|
-  organisation_1 = create(:organisation, name: organisation_1)
-  organisation_2 = create(:organisation, name: organisation_2)
-  create("#{state}_policy", title: title, organisations: [organisation_1, organisation_2])
+Given(/^a (.*?) policy "([^"]*)" for the organisations "([^"]*)" and "([^"]*)"$/) do |state, title, organisation1, organisation2|
+  organisation1 = create(:organisation, name: organisation1)
+  organisation2 = create(:organisation, name: organisation2)
+  create("#{state}_policy", title: title, organisations: [organisation1, organisation2])
 end

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -1,9 +1,9 @@
 Given(/^there are some take part pages for the get involved section$/) do
-  page_1 = create(:take_part_page, title: "Wearing a monocole", ordering: 2)
-  page_2 = create(:take_part_page, title: "Riding in a hansom cab", ordering: 3)
-  page_3 = create(:take_part_page, title: "Drinking in a gin palace", ordering: 1)
+  page1 = create(:take_part_page, title: "Wearing a monocole", ordering: 2)
+  page2 = create(:take_part_page, title: "Riding in a hansom cab", ordering: 3)
+  page3 = create(:take_part_page, title: "Drinking in a gin palace", ordering: 1)
 
-  @the_take_part_pages_in_order = [page_3, page_1, page_2]
+  @the_take_part_pages_in_order = [page3, page1, page2]
 end
 
 When(/^I create a new take part page called "([^"]*)"$/) do |title|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -91,17 +91,17 @@ Given(/^a worldwide organisation "([^"]*)" exists for the world location "([^"]*
 end
 
 When(/^I add an "([^"]*)" office for the home page with address, phone number, and some services$/) do |description|
-  service_1 = create(:worldwide_service, name: "Dance lessons")
-  _service_2 = create(:worldwide_service, name: "Courses in advanced sword fighting")
-  service_3 = create(:worldwide_service, name: "Beard grooming")
+  service1 = create(:worldwide_service, name: "Dance lessons")
+  _service2 = create(:worldwide_service, name: "Courses in advanced sword fighting")
+  service3 = create(:worldwide_service, name: "Beard grooming")
 
   visit admin_worldwide_organisation_worldwide_offices_path(WorldwideOrganisation.last)
   click_link "Add"
   fill_in_contact_details(title: description, feature_on_home_page: "yes")
   select WorldwideOfficeType.all.sample.name, from: "Office type"
 
-  check service_1.name
-  check service_3.name
+  check service1.name
+  check service3.name
 
   click_on "Save"
 end

--- a/features/support/admin_taxonomy_helper.rb
+++ b/features/support/admin_taxonomy_helper.rb
@@ -12,7 +12,7 @@ module AdminTaxonomyHelper
   end
 
   def stub_taxonomy_data
-    redis_cache_has_taxons [root_taxon, draft_taxon_1, draft_taxon_2]
+    redis_cache_has_taxons [root_taxon, draft_taxon1, draft_taxon2]
   end
 
   def stub_patch_links

--- a/features/support/publishing_api.rb
+++ b/features/support/publishing_api.rb
@@ -14,7 +14,7 @@ Before do
   GdsApi::PublishingApi.any_instance.stubs(:patch_links)
   GdsApi::PublishingApi.any_instance.stubs(:unpublish)
 
-  need_1 = {
+  need1 = {
     "content_id" => SecureRandom.uuid,
     "format" => "need",
     "title" => "Need #1",
@@ -22,7 +22,7 @@ Before do
     "links" => {},
   }
 
-  need_2 = {
+  need2 = {
     "content_id" => SecureRandom.uuid,
     "format" => "need",
     "title" => "Need #2",
@@ -31,7 +31,7 @@ Before do
   }
 
   stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/links})
-    .to_return(body: { links: { meets_user_needs: [need_1, need_2] } }.to_json)
+    .to_return(body: { links: { meets_user_needs: [need1, need2] } }.to_json)
 
   stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/expanded-links})
     .to_return(
@@ -39,8 +39,8 @@ Before do
         expanded_links: {
           meets_user_needs: [
             {
-              title: need_1["title"],
-              content_id: need_1["content_id"],
+              title: need1["title"],
+              content_id: need1["content_id"],
               details: {
                 role: "x",
                 goal: "y",
@@ -48,8 +48,8 @@ Before do
               },
             },
             {
-              title: need_2["title"],
-              content_id: need_2["content_id"],
+              title: need2["title"],
+              content_id: need2["content_id"],
               details: {
                 role: "c",
                 goal: "d",
@@ -61,7 +61,7 @@ Before do
       }.to_json,
     )
 
-  stub_publishing_api_has_linkables([need_1, need_2], document_type: "need")
+  stub_publishing_api_has_linkables([need1, need2], document_type: "need")
 end
 
 World(GdsApi::TestHelpers::PublishingApi)

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -12,73 +12,73 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
   end
 
   test "should reorder ministerial roles" do
-    role_2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation])
-    role_1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
+    role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation])
+    role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
 
     put :update,
         params: {
           roles: {
-            role_1.id.to_s => { ordering: 0 },
-            role_2.id.to_s => { ordering: 1 },
+            role1.id.to_s => { ordering: 0 },
+            role2.id.to_s => { ordering: 1 },
           },
         }
 
-    assert_equal MinisterialRole.cabinet.order(:seniority).to_a, [role_1, role_2]
+    assert_equal MinisterialRole.cabinet.order(:seniority).to_a, [role1, role2]
   end
 
   test "should reorder people who also attend cabinet" do
-    role_2 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation])
-    role_1 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation])
+    role2 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation])
+    role1 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation])
 
     put :update,
         params: {
           roles: {
-            role_1.id.to_s => { ordering: 0 },
-            role_2.id.to_s => { ordering: 1 },
+            role1.id.to_s => { ordering: 0 },
+            role2.id.to_s => { ordering: 1 },
           },
         }
 
-    assert_equal MinisterialRole.also_attends_cabinet.order(:seniority).to_a, [role_1, role_2]
+    assert_equal MinisterialRole.also_attends_cabinet.order(:seniority).to_a, [role1, role2]
   end
 
   test "should reorder whips as part of the same request" do
-    role_2 = create(:ministerial_role, name: "Whip 1", whip_organisation_id: 2, organisations: [organisation])
-    role_1 = create(:ministerial_role, name: "Whip 2", whip_organisation_id: 2, organisations: [organisation])
+    role2 = create(:ministerial_role, name: "Whip 1", whip_organisation_id: 2, organisations: [organisation])
+    role1 = create(:ministerial_role, name: "Whip 2", whip_organisation_id: 2, organisations: [organisation])
 
     put :update,
         params: {
           whips: {
-            role_1.id.to_s => { ordering: 0 },
-            role_2.id.to_s => { ordering: 1 },
+            role1.id.to_s => { ordering: 0 },
+            role2.id.to_s => { ordering: 1 },
           },
         }
 
-    assert_equal MinisterialRole.whip.order(:seniority).to_a, [role_2, role_1]
-    assert_equal MinisterialRole.whip.order(:whip_ordering).to_a, [role_1, role_2]
+    assert_equal MinisterialRole.whip.order(:seniority).to_a, [role2, role1]
+    assert_equal MinisterialRole.whip.order(:whip_ordering).to_a, [role1, role2]
   end
 
   test "should list ministerial organisations in ministerial order" do
-    org_1 = create(:ministerial_department, ministerial_ordering: 0)
-    org_2 = create(:ministerial_department, ministerial_ordering: 2)
-    org_3 = create(:ministerial_department, ministerial_ordering: 1)
+    org1 = create(:ministerial_department, ministerial_ordering: 0)
+    org2 = create(:ministerial_department, ministerial_ordering: 2)
+    org3 = create(:ministerial_department, ministerial_ordering: 1)
 
     get :show
 
-    assert_equal assigns(:organisations).to_a, [org_1, org_3, org_2]
+    assert_equal assigns(:organisations).to_a, [org1, org3, org2]
   end
 
   test "should reorder ministerial organisations" do
-    org_2 = create(:organisation)
-    org_1 = create(:organisation)
+    org2 = create(:organisation)
+    org1 = create(:organisation)
 
     put :update,
         params: {
           organisation: {
-            org_1.id.to_s => { ordering: 0 },
-            org_2.id.to_s => { ordering: 1 },
+            org1.id.to_s => { ordering: 0 },
+            org2.id.to_s => { ordering: 1 },
           },
         }
 
-    assert_equal Organisation.order(:ministerial_ordering), [org_1, org_2]
+    assert_equal Organisation.order(:ministerial_ordering), [org1, org2]
   end
 end

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -9,15 +9,15 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
   end
 
   test "GET :index assigns tagged_editions with a paginated collection of published editions related to the topical_event ordered by most recently created editions first" do
-    news_article_1 = create(:published_news_article, topical_events: [@topical_event])
-    news_article_2 = Timecop.travel(10.minutes) { create(:published_news_article, topical_events: [@topical_event]) }
+    news_article1 = create(:published_news_article, topical_events: [@topical_event])
+    news_article2 = Timecop.travel(10.minutes) { create(:published_news_article, topical_events: [@topical_event]) }
     _draft_article = create(:news_article, topical_events: [@topical_event])
     _unrelated_article = create(:news_article, :with_topical_events)
 
     get :index, params: { topical_event_id: @topical_event, page: 1 }
 
     tagged_editions = assigns(:tagged_editions)
-    assert_equal [news_article_2, news_article_1], tagged_editions
+    assert_equal [news_article2, news_article1], tagged_editions
     assert_equal 1, tagged_editions.current_page
     assert_equal 1, tagged_editions.total_pages
     assert_equal 25, tagged_editions.limit_value
@@ -77,20 +77,20 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
   end
 
   test "PUT :order saves the new order of featurings" do
-    feature_1 = create(:classification_featuring, classification: @topical_event)
-    feature_2 = create(:classification_featuring, classification: @topical_event)
-    feature_3 = create(:classification_featuring, classification: @topical_event)
+    feature1 = create(:classification_featuring, classification: @topical_event)
+    feature2 = create(:classification_featuring, classification: @topical_event)
+    feature3 = create(:classification_featuring, classification: @topical_event)
 
     put :order,
         params: { topical_event_id: @topical_event,
                   ordering: {
-                    feature_1.id.to_s => "1",
-                    feature_2.id.to_s => "2",
-                    feature_3.id.to_s => "0",
+                    feature1.id.to_s => "1",
+                    feature2.id.to_s => "2",
+                    feature3.id.to_s => "0",
                   } }
 
     assert_response :redirect
-    assert_equal [feature_3, feature_1, feature_2], @topical_event.reload.classification_featurings
+    assert_equal [feature3, feature1, feature2], @topical_event.reload.classification_featurings
   end
 
   view_test "GET :new renders only image fields if featuring an edition" do

--- a/test/functional/admin/contacts_controller_test.rb
+++ b/test/functional/admin/contacts_controller_test.rb
@@ -243,26 +243,26 @@ class Admin::ContactsControllerTest < ActionController::TestCase
 
   test "POST on :reorder_for_home_page takes id => ordering mappings and reorders the list based on this" do
     organisation = create(:organisation)
-    contact_1 = organisation.contacts.create!(title: "Head office", contact_type: ContactType::General)
-    contact_2 = organisation.contacts.create!(title: "Body office", contact_type: ContactType::General)
-    contact_3 = organisation.contacts.create!(title: "Spirit office", contact_type: ContactType::General)
-    organisation.add_contact_to_home_page!(contact_1)
-    organisation.add_contact_to_home_page!(contact_2)
-    organisation.add_contact_to_home_page!(contact_3)
+    contact1 = organisation.contacts.create!(title: "Head office", contact_type: ContactType::General)
+    contact2 = organisation.contacts.create!(title: "Body office", contact_type: ContactType::General)
+    contact3 = organisation.contacts.create!(title: "Spirit office", contact_type: ContactType::General)
+    organisation.add_contact_to_home_page!(contact1)
+    organisation.add_contact_to_home_page!(contact2)
+    organisation.add_contact_to_home_page!(contact3)
 
     post :reorder_for_home_page,
          params: {
            organisation_id: organisation,
            ordering: {
-             contact_1.id.to_s => "3",
-             contact_2.id.to_s => "1",
-             contact_3.id.to_s => "2",
+             contact1.id.to_s => "3",
+             contact2.id.to_s => "1",
+             contact3.id.to_s => "2",
            },
          }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %(Contacts on home page reordered successfully), flash[:notice]
-    assert_equal [contact_2, contact_3, contact_1], organisation.reload.home_page_contacts
+    assert_equal [contact2, contact3, contact1], organisation.reload.home_page_contacts
   end
 
   test "POST on :reorder_for_home_page doesn't break with unknown contact ids" do

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -26,11 +26,11 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     @group.documents << create(:publication).document
     @group.documents << create(:corporate_information_page).document
     @collection.groups << build(:document_collection_group)
-    group_1, group_2 = @collection.groups
+    group1, group2 = @collection.groups
     get :index, params: { document_collection_id: @collection }
     assert_select "section.group" do
-      assert_select "option[value='#{group_1.id}']", count: 0
-      assert_select "option[value='#{group_2.id}']", group_2.heading
+      assert_select "option[value='#{group1.id}']", count: 0
+      assert_select "option[value='#{group2.id}']", group2.heading
     end
   end
 
@@ -123,17 +123,17 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
            document_collection_id: @collection.id,
            groups: {
              0 => {
-               id: @group_1.id,
+               id: @group1.id,
                membership_ids: [
-                 @member_1_2.id,
-                 @member_1_1.id,
+                 @member_1b.id,
+                 @member_1a.id,
                ],
                order: 0,
              },
            },
          }
 
-    assert_equal [@member_1_2, @member_1_1], @group_1.reload.memberships
+    assert_equal [@member_1b, @member_1a], @group1.reload.memberships
   end
 
   test "POST #update_memberships saves the order of groups" do
@@ -143,18 +143,18 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
            document_collection_id: @collection.id,
            groups: {
              0 => {
-               id: @group_1.id,
+               id: @group1.id,
                membership_ids: [
-                 @member_1_1.id,
-                 @member_1_2.id,
+                 @member_1a.id,
+                 @member_1b.id,
                ],
                order: 1,
              },
              1 => {
-               id: @group_2.id,
+               id: @group2.id,
                membership_ids: [
-                 @member_2_1.id,
-                 @member_2_2.id,
+                 @member_2a.id,
+                 @member_2b.id,
                ],
                order: 0,
              },
@@ -162,7 +162,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
          }
 
     assert_response :success
-    assert_equal [@group_2.id, @group_1.id], @collection.reload.groups.pluck(:id)
+    assert_equal [@group2.id, @group1.id], @collection.reload.groups.pluck(:id)
   end
 
   test "POST #update_memberships should cope with duplicate members in group" do
@@ -172,17 +172,17 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
            document_collection_id: @collection.id,
            groups: {
              0 => {
-               id: @group_1.id,
+               id: @group1.id,
                membership_ids: [
-                 @member_1_1.id,
-                 @member_1_1.id,
+                 @member_1a.id,
+                 @member_1a.id,
                ],
                order: 0,
              },
            },
          }
 
-    assert_equal [@member_1_1], @group_1.reload.memberships
+    assert_equal [@member_1a], @group1.reload.memberships
   end
 
   test "POST #update_memberships should support moving memberships between groups" do
@@ -192,25 +192,25 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
            document_collection_id: @collection.id,
            groups: {
              0 => {
-               id: @group_1.id,
+               id: @group1.id,
                membership_ids: [
-                 @member_1_1.id,
+                 @member_1a.id,
                ],
                order: 0,
              },
              1 => {
-               id: @group_2.id,
+               id: @group2.id,
                membership_ids: [
-                 @member_1_2.id,
-                 @member_2_1.id,
-                 @member_2_2.id,
+                 @member_1b.id,
+                 @member_2a.id,
+                 @member_2b.id,
                ],
                order: 1,
              },
            },
          }
 
-    assert @group_2.reload.memberships.include?(@member_1_2)
+    assert @group2.reload.memberships.include?(@member_1b)
   end
 
   test "POST #update_memberships should handle empty groups" do
@@ -221,35 +221,35 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
            document_collection_id: @collection.id,
            groups: {
              0 => {
-               id: @group_1.id,
+               id: @group1.id,
                membership_ids: [
-                 @member_1_1.id,
-                 @member_1_2.id,
-                 @member_2_1.id,
-                 @member_2_2.id,
+                 @member_1a.id,
+                 @member_1b.id,
+                 @member_2a.id,
+                 @member_2b.id,
                ],
                order: 0,
              },
              1 => {
-               id: @group_2.id,
+               id: @group2.id,
                order: 1,
              },
            },
          }
 
     assert_response :success
-    assert_equal [@member_1_1, @member_1_2, @member_2_1, @member_2_2], @group_1.reload.memberships
-    assert_empty @group_2.reload.memberships
+    assert_equal [@member_1a, @member_1b, @member_2a, @member_2b], @group1.reload.memberships
+    assert_empty @group2.reload.memberships
   end
 
   def given_two_groups_with_memberships
-    @group_1 = build(:document_collection_group)
-    @group_2 = build(:document_collection_group)
-    @collection.update! groups: [@group_1, @group_2]
+    @group1 = build(:document_collection_group)
+    @group2 = build(:document_collection_group)
+    @collection.update! groups: [@group1, @group2]
 
-    @group_1.memberships << @member_1_1 = create(:document_collection_group_membership)
-    @group_1.memberships << @member_1_2 = create(:document_collection_group_membership)
-    @group_2.memberships << @member_2_1 = create(:document_collection_group_membership)
-    @group_2.memberships << @member_2_2 = create(:document_collection_group_membership)
+    @group1.memberships << @member_1a = create(:document_collection_group_membership)
+    @group1.memberships << @member_1b = create(:document_collection_group_membership)
+    @group2.memberships << @member_2a = create(:document_collection_group_membership)
+    @group2.memberships << @member_2b = create(:document_collection_group_membership)
   end
 end

--- a/test/functional/admin/feature_lists_controller_test.rb
+++ b/test/functional/admin/feature_lists_controller_test.rb
@@ -17,17 +17,17 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
   test "post reorder reorders the feature list" do
     world_location = create(:world_location)
     feature_list = create(:feature_list, featurable: world_location, locale: :fr)
-    feature_1 = create(:feature, feature_list: feature_list, ordering: 1)
-    feature_2 = create(:feature, feature_list: feature_list, ordering: 2)
+    feature1 = create(:feature, feature_list: feature_list, ordering: 1)
+    feature2 = create(:feature, feature_list: feature_list, ordering: 2)
 
     post :reorder,
          params: { id: feature_list,
                    ordering: {
-                     feature_2.id.to_s => "1",
-                     feature_1.id.to_s => "2",
+                     feature2.id.to_s => "1",
+                     feature1.id.to_s => "2",
                    } }
 
-    assert_equal [feature_2, feature_1], feature_list.reload.features
+    assert_equal [feature2, feature1], feature_list.reload.features
   end
 
   test "post reorder with no ordering does nothing" do

--- a/test/functional/admin/needs_controller_test.rb
+++ b/test/functional/admin/needs_controller_test.rb
@@ -9,14 +9,14 @@ class Admin::NeedsControllerTest < ActionController::TestCase
     @document = create(:edition, :with_document).document
     @url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
 
-    @need_1 = {
+    @need1 = {
       "content_id" => SecureRandom.uuid,
       "format" => "need",
       "title" => "Need #1",
       "base_path" => "/government/needs/need-1",
       "links" => {},
     }
-    @need_2 = {
+    @need2 = {
       "content_id" => SecureRandom.uuid,
       "format" => "need",
       "title" => "Need #2",
@@ -27,9 +27,9 @@ class Admin::NeedsControllerTest < ActionController::TestCase
     stub_request(
       :get,
       %r{\A#{Plek.find('publishing-api')}/v2/links},
-    ).to_return(body: { links: { meets_user_needs: [@need_1, @need_2] } }.to_json)
+    ).to_return(body: { links: { meets_user_needs: [@need1, @need2] } }.to_json)
 
-    stub_publishing_api_has_linkables([@need_1, @need_2], document_type: "need")
+    stub_publishing_api_has_linkables([@need1, @need2], document_type: "need")
   end
 
   test "associate user needs with a document" do

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -12,13 +12,13 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   end
 
   test "GET on :index assigns all organisations in alphabetical order" do
-    organisation_2 = create(:organisation, name: "org 2")
-    organisation_1 = create(:organisation, name: "org 1")
+    organisation2 = create(:organisation, name: "org 2")
+    organisation1 = create(:organisation, name: "org 1")
     get :index
 
     assert_response :success
     assert_template :index
-    assert_equal [organisation_1, organisation_2], assigns(:organisations)
+    assert_equal [organisation1, organisation2], assigns(:organisations)
   end
 
   test "GET on :new denied if not a gds admin" do
@@ -47,14 +47,14 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   test "POST on :create saves the organisation and its associations" do
     attributes = example_organisation_attributes
 
-    parent_org_1 = create(:organisation)
-    parent_org_2 = create(:organisation)
+    parent_org1 = create(:organisation)
+    parent_org2 = create(:organisation)
 
     post :create,
          params: {
            organisation: attributes
                            .merge(
-                             parent_organisation_ids: [parent_org_1.id, parent_org_2.id],
+                             parent_organisation_ids: [parent_org1.id, parent_org2.id],
                              organisation_type_key: :executive_agency,
                              govuk_status: "exempt",
                              featured_links_attributes: {
@@ -73,7 +73,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert organisation_top_task = organisation.featured_links.last
     assert_equal "http://www.gov.uk/mainstream/something", organisation_top_task.url
     assert_equal "Something on mainstream", organisation_top_task.title
-    assert_same_elements [parent_org_1, parent_org_2], organisation.parent_organisations
+    assert_same_elements [parent_org1, parent_org2], organisation.parent_organisations
     assert_equal OrganisationType.executive_agency, organisation.organisation_type
     assert_equal "exempt", organisation.govuk_status
   end
@@ -400,19 +400,19 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   end
 
   test "Non-admins can only edit their own organisations or children" do
-    organisation_1 = create(:organisation)
-    gds_editor = create(:gds_editor, organisation: organisation_1)
+    organisation1 = create(:organisation)
+    gds_editor = create(:gds_editor, organisation: organisation1)
     login_as(gds_editor)
 
-    get :edit, params: { id: organisation_1 }
+    get :edit, params: { id: organisation1 }
     assert_response :success
 
-    organisation_2 = create(:organisation)
-    get :edit, params: { id: organisation_2 }
+    organisation2 = create(:organisation)
+    get :edit, params: { id: organisation2 }
     assert_response 403
 
-    organisation_2.parent_organisations << organisation_1
-    get :edit, params: { id: organisation_2 }
+    organisation2.parent_organisations << organisation1
+    get :edit, params: { id: organisation2 }
     assert_response :success
   end
 

--- a/test/functional/admin/suggestions_controller_test.rb
+++ b/test/functional/admin/suggestions_controller_test.rb
@@ -11,20 +11,20 @@ class Admin::SuggestionsControllerTest < ActionController::TestCase
     organisation = create(:organisation, acronym: "org-name")
     worldwide_organisation = create(:worldwide_organisation, name: "world-name")
 
-    contact_1 = create(:contact, contactable: organisation)
-    contact_2 = create(:contact_with_country)
+    contact1 = create(:contact, contactable: organisation)
+    contact2 = create(:contact_with_country)
 
     create(
       :worldwide_office,
       worldwide_organisation: worldwide_organisation,
-      contact: contact_2,
+      contact: contact2,
     )
 
     get :index, format: :json
 
     assert_equal [
-      { id: contact_1.id, title: contact_1.title, summary: "org-name" },
-      { id: contact_2.id, title: contact_2.title, summary: "world-name" },
+      { id: contact1.id, title: contact1.title, summary: "org-name" },
+      { id: contact2.id, title: contact2.title, summary: "world-name" },
     ],
                  assigns(:contacts)
   end

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -8,13 +8,13 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   test "GET :index fetches all the take part pages in order" do
-    page_3 = create(:take_part_page, ordering: 3)
-    page_1 = create(:take_part_page, ordering: 1)
-    page_2 = create(:take_part_page, ordering: 2)
+    page3 = create(:take_part_page, ordering: 3)
+    page1 = create(:take_part_page, ordering: 1)
+    page2 = create(:take_part_page, ordering: 2)
 
     get :index
 
-    assert_equal [page_1, page_2, page_3], assigns(:take_part_pages)
+    assert_equal [page1, page2, page3], assigns(:take_part_pages)
     assert_response :success
     assert_template "index"
   end

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -90,8 +90,8 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   test "post create creates worldwide office with services" do
-    service_1 = create(:worldwide_service)
-    service_2 = create(:worldwide_service)
+    service1 = create(:worldwide_service)
+    service2 = create(:worldwide_service)
     worldwide_organisation = create(:worldwide_organisation)
 
     post :create,
@@ -102,13 +102,13 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
                title: "Main office",
                contact_type_id: ContactType::General.id,
              },
-             service_ids: [service_2.id, service_1.id],
+             service_ids: [service2.id, service1.id],
            },
            worldwide_organisation_id: worldwide_organisation.id,
          }
 
     assert_equal 1, worldwide_organisation.offices.count
-    assert_equal [service_1, service_2], worldwide_organisation.offices.first.services.sort_by(&:id)
+    assert_equal [service1, service2], worldwide_organisation.offices.first.services.sort_by(&:id)
   end
 
   test "post create creates associated phone numbers" do
@@ -220,20 +220,20 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   test "put update updates an offices services" do
-    service_2 = create(:worldwide_service)
-    service_3 = create(:worldwide_service)
+    service2 = create(:worldwide_service)
+    service3 = create(:worldwide_service)
     worldwide_organisation, office = create_worldwide_organisation_and_office
 
     put :update,
         params: {
           worldwide_office: {
-            service_ids: [service_3.id, service_2.id],
+            service_ids: [service3.id, service2.id],
           },
           id: office,
           worldwide_organisation_id: worldwide_organisation,
         }
 
-    assert_equal [service_2, service_3], office.reload.services.sort_by(&:id)
+    assert_equal [service2, service3], office.reload.services.sort_by(&:id)
   end
 
   test "put update updates associated phone numbers" do
@@ -314,38 +314,38 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   test "POST on :reorder_for_home_page takes id => ordering mappings and reorders the list based on this" do
-    worldwide_organisation, office_1 = create_worldwide_organisation_and_office
-    office_2 = worldwide_organisation.offices.create!(
+    worldwide_organisation, office1 = create_worldwide_organisation_and_office
+    office2 = worldwide_organisation.offices.create!(
       worldwide_office_type_id: WorldwideOfficeType::Other.id,
       contact_attributes: {
         title: "Body office",
         contact_type_id: ContactType::General.id,
       },
     )
-    office_3 = worldwide_organisation.offices.create!(
+    office3 = worldwide_organisation.offices.create!(
       worldwide_office_type_id: WorldwideOfficeType::Other.id,
       contact_attributes: {
         title: "Spirit office",
         contact_type_id: ContactType::General.id,
       },
     )
-    worldwide_organisation.add_office_to_home_page!(office_1)
-    worldwide_organisation.add_office_to_home_page!(office_2)
-    worldwide_organisation.add_office_to_home_page!(office_3)
+    worldwide_organisation.add_office_to_home_page!(office1)
+    worldwide_organisation.add_office_to_home_page!(office2)
+    worldwide_organisation.add_office_to_home_page!(office3)
 
     post :reorder_for_home_page,
          params: {
            worldwide_organisation_id: worldwide_organisation,
            ordering: {
-             office_1.id.to_s => "3",
-             office_2.id.to_s => "1",
-             office_3.id.to_s => "2",
+             office1.id.to_s => "3",
+             office2.id.to_s => "1",
+             office3.id.to_s => "2",
            },
          }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)
     assert_equal %(Offices on home page reordered successfully), flash[:notice]
-    assert_equal [office_2, office_3, office_1], worldwide_organisation.reload.home_page_offices
+    assert_equal [office2, office3, office1], worldwide_organisation.reload.home_page_offices
   end
 
   test "POST on :reorder_for_home_page doesn't break with unknown contact ids" do

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -116,11 +116,11 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
 
   test "unpublishing is specific to the organisation" do
     organisation = create(:organisation)
-    organisation_2 = create(:organisation, slug: "another_organisation")
+    organisation2 = create(:organisation, slug: "another_organisation")
     cip = create(:corporate_information_page, :unpublished, organisation: organisation)
     alternative_url = Whitehall.url_maker.root_url
     cip.unpublishing.update!(redirect: true, slug: cip.slug, alternative_url: alternative_url)
-    draft_cip = create(:corporate_information_page, organisation: organisation_2)
+    draft_cip = create(:corporate_information_page, organisation: organisation2)
 
     # Even though the Unpublishing has the same slug as the draft CIP, we should
     # only find it for the unpublished one.
@@ -129,7 +129,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     get :show, params: { organisation_id: organisation, id: cip.slug }
     assert_response :redirect
 
-    get :show, params: { organisation_id: organisation_2, id: cip.slug }
+    get :show, params: { organisation_id: organisation2, id: cip.slug }
     assert_response 404
   end
 end

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class CsvPreviewControllerTest < ActionController::TestCase
   attr_reader :attachment_data
   attr_reader :params
-  attr_reader :organisation_1
-  attr_reader :organisation_2
+  attr_reader :organisation1
+  attr_reader :organisation2
   attr_reader :edition
   attr_reader :attachment
   attr_reader :file
@@ -19,9 +19,9 @@ class CsvPreviewControllerTest < ActionController::TestCase
       extension: attachment_data.file_extension,
     }
 
-    @organisation_1 = create(:organisation)
-    @organisation_2 = create(:organisation)
-    @edition = create(:publication, organisations: [organisation_1, organisation_2])
+    @organisation1 = create(:organisation)
+    @organisation2 = create(:organisation)
+    @edition = create(:publication, organisations: [organisation1, organisation2])
     @attachment = build(:file_attachment)
 
     controller.stubs(:attachment_data).returns(attachment_data)
@@ -432,8 +432,8 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     get :show, params: params
 
-    assert_select "a[href=?]", organisation_path(organisation_1)
-    assert_select "a[href=?]", organisation_path(organisation_2)
+    assert_select "a[href=?]", organisation_path(organisation1)
+    assert_select "a[href=?]", organisation_path(organisation2)
   end
 
   view_test "renders CSV column headings" do

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -22,8 +22,8 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   end
 
   test "GET on :index loads the past appointments for the role and renders the index template" do
-    previous_pm_1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
-    previous_pm_2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
+    previous_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
+    previous_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
     _current_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)
     nineteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1801), ended_at: Date.civil(1804))
     eighteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1704))
@@ -35,7 +35,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     assert_template :index
     assert_equal pm_role, assigns(:role)
 
-    assert_equal_role_presenters [previous_pm_2, previous_pm_1], assigns(:recent_appointments)
+    assert_equal_role_presenters [previous_pm2, previous_pm1], assigns(:recent_appointments)
     assert_equal_role_presenters [nineteenth_century_pm], assigns(:nineteenth_century_appointments)
     assert_equal_role_presenters [eighteenth_century_pm], assigns(:eighteenth_century_appointments)
   end

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -108,13 +108,13 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "get involved collects all the take part pages in order" do
-    page_3 = create(:take_part_page, ordering: 3)
-    page_1 = create(:take_part_page, ordering: 1)
-    page_2 = create(:take_part_page, ordering: 2)
+    page3 = create(:take_part_page, ordering: 3)
+    page1 = create(:take_part_page, ordering: 1)
+    page2 = create(:take_part_page, ordering: 2)
 
     get :get_involved
 
-    assert_equal [page_1, page_2, page_3], assigns(:take_part_pages)
+    assert_equal [page1, page2, page3], assigns(:take_part_pages)
   end
 
 private

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -41,109 +41,109 @@ class MinisterialRolesControllerTest < ActionController::TestCase
   end
 
   test "shows ministers by organisation with the organisations in the cms-defined order" do
-    organisation_1 = create(:ministerial_department, ministerial_ordering: 1)
-    organisation_2 = create(:ministerial_department, ministerial_ordering: 0)
+    organisation1 = create(:ministerial_department, ministerial_ordering: 1)
+    organisation2 = create(:ministerial_department, ministerial_ordering: 0)
 
     create(
       :ministerial_role_appointment,
       person: create(:person),
-      role: create(:ministerial_role, cabinet_member: true, organisations: [organisation_1], seniority: 0),
+      role: create(:ministerial_role, cabinet_member: true, organisations: [organisation1], seniority: 0),
     )
 
     create(
       :ministerial_role_appointment,
       person: create(:person),
-      role: create(:ministerial_role, cabinet_member: true, organisations: [organisation_2], seniority: 0),
+      role: create(:ministerial_role, cabinet_member: true, organisations: [organisation2], seniority: 0),
     )
 
     get :index
 
-    assert_equal [organisation_2, organisation_1], assigns(:ministers_by_organisation).map(&:first)
+    assert_equal [organisation2, organisation1], assigns(:ministers_by_organisation).map(&:first)
   end
 
   test "shows ministers by organisation with the ministers in the cms-defined order" do
     organisation = create(:ministerial_department)
 
-    person_1 = create(:person, forename: "Nick", surname: "Clegg")
-    person_2 = create(:person, forename: "Jeremy", surname: "Hunt")
-    person_3 = create(:person, forename: "George", surname: "Foreman")
-    person_4 = create(:person, forename: "Brian", surname: "Smith")
+    person1 = create(:person, forename: "Nick", surname: "Clegg")
+    person2 = create(:person, forename: "Jeremy", surname: "Hunt")
+    person3 = create(:person, forename: "George", surname: "Foreman")
+    person4 = create(:person, forename: "Brian", surname: "Smith")
 
-    role_1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
-    role_2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation], seniority: 1)
-    role_3 = create(:board_member_role, name: "Chief Griller", organisations: [organisation], seniority: 3)
-    role_4 = create(:ministerial_role, name: "First Secretary of State", cabinet_member: true, organisations: [organisation], seniority: 2)
+    role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
+    role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation], seniority: 1)
+    role3 = create(:board_member_role, name: "Chief Griller", organisations: [organisation], seniority: 3)
+    role4 = create(:ministerial_role, name: "First Secretary of State", cabinet_member: true, organisations: [organisation], seniority: 2)
 
-    organisation.organisation_roles.find_by(role_id: role_2.id).update_column(:ordering, 3)
-    organisation.organisation_roles.find_by(role_id: role_1.id).update_column(:ordering, 2)
-    organisation.organisation_roles.find_by(role_id: role_4.id).update_column(:ordering, 1)
+    organisation.organisation_roles.find_by(role_id: role2.id).update_column(:ordering, 3)
+    organisation.organisation_roles.find_by(role_id: role1.id).update_column(:ordering, 2)
+    organisation.organisation_roles.find_by(role_id: role4.id).update_column(:ordering, 1)
 
-    create(:board_member_role_appointment, role: role_3, person: person_3)
-    create(:ministerial_role_appointment, role: role_1, person: person_1)
-    create(:ministerial_role_appointment, role: role_2, person: person_2)
-    create(:ministerial_role_appointment, role: role_4, person: person_4)
+    create(:board_member_role_appointment, role: role3, person: person3)
+    create(:ministerial_role_appointment, role: role1, person: person1)
+    create(:ministerial_role_appointment, role: role2, person: person2)
+    create(:ministerial_role_appointment, role: role4, person: person4)
 
     get :index
 
-    expected_results = [[organisation, RolesPresenter.new([role_4, role_1, role_2], @controller.view_context)]]
+    expected_results = [[organisation, RolesPresenter.new([role4, role1, role2], @controller.view_context)]]
     assert_equal expected_results, assigns(:ministers_by_organisation)
   end
 
   test "doesn't list closed organisations in the ministers by organisation list" do
-    organisation_1 = create(:ministerial_department)
-    person_1 = create(:person, forename: "Tony", surname: "Blair")
-    role_1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation_1], seniority: 0)
-    create(:ministerial_role_appointment, role: role_1, person: person_1)
+    organisation1 = create(:ministerial_department)
+    person1 = create(:person, forename: "Tony", surname: "Blair")
+    role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation1], seniority: 0)
+    create(:ministerial_role_appointment, role: role1, person: person1)
 
-    organisation_2 = create(:ministerial_department, :closed)
-    person_2 = create(:person, forename: "Frank", surname: "Underwood")
-    role_2 = create(:ministerial_role, name: "President", cabinet_member: true, organisations: [organisation_2], seniority: 0)
-    create(:ministerial_role_appointment, role: role_2, person: person_2)
+    organisation2 = create(:ministerial_department, :closed)
+    person2 = create(:person, forename: "Frank", surname: "Underwood")
+    role2 = create(:ministerial_role, name: "President", cabinet_member: true, organisations: [organisation2], seniority: 0)
+    create(:ministerial_role_appointment, role: role2, person: person2)
 
     get :index
 
-    expected_results = [[organisation_1, RolesPresenter.new([role_1], @controller.view_context)]]
+    expected_results = [[organisation1, RolesPresenter.new([role1], @controller.view_context)]]
     assert_equal expected_results, assigns(:ministers_by_organisation)
   end
 
   test "shows ministers who also attend cabinet separately" do
     organisation = create(:ministerial_department)
-    person_1 = create(:person, forename: "Nick", surname: "Clegg")
-    person_2 = create(:person, forename: "Jeremy", surname: "Hunt")
-    person_3 = create(:person, forename: "Geroge", surname: "Foreman")
+    person1 = create(:person, forename: "Nick", surname: "Clegg")
+    person2 = create(:person, forename: "Jeremy", surname: "Hunt")
+    person3 = create(:person, forename: "Geroge", surname: "Foreman")
 
-    role_1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
-    role_2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation])
-    role_3 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", organisations: [organisation], whip_organisation_id: 1, attends_cabinet_type_id: 1)
+    role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
+    role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation])
+    role3 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", organisations: [organisation], whip_organisation_id: 1, attends_cabinet_type_id: 1)
 
-    create(:ministerial_role_appointment, role: role_1, person: person_1)
-    create(:ministerial_role_appointment, role: role_2, person: person_2)
-    create(:ministerial_role_appointment, role: role_3, person: person_3)
+    create(:ministerial_role_appointment, role: role1, person: person1)
+    create(:ministerial_role_appointment, role: role2, person: person2)
+    create(:ministerial_role_appointment, role: role3, person: person3)
 
     get :index
 
     actual_roles = assigns(:also_attends_cabinet).map { |_person, role| role.first.model }
 
-    assert_equal [role_3], actual_roles
+    assert_equal [role3], actual_roles
   end
 
   test "shows whips separately" do
     organisation = create(:ministerial_department)
-    person_1 = create(:person, forename: "Nick", surname: "Clegg")
-    person_2 = create(:person, forename: "Jeremy", surname: "Hunt")
-    person_3 = create(:person, forename: "Geroge", surname: "Foreman")
+    person1 = create(:person, forename: "Nick", surname: "Clegg")
+    person2 = create(:person, forename: "Jeremy", surname: "Hunt")
+    person3 = create(:person, forename: "Geroge", surname: "Foreman")
 
-    role_1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
-    role_2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation])
-    role_3 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", organisations: [organisation], whip_organisation_id: 1)
+    role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
+    role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: false, organisations: [organisation])
+    role3 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", organisations: [organisation], whip_organisation_id: 1)
 
-    create(:ministerial_role_appointment, role: role_1, person: person_1)
-    create(:ministerial_role_appointment, role: role_2, person: person_2)
-    create(:ministerial_role_appointment, role: role_3, person: person_3)
+    create(:ministerial_role_appointment, role: role1, person: person1)
+    create(:ministerial_role_appointment, role: role2, person: person2)
+    create(:ministerial_role_appointment, role: role3, person: person3)
 
     get :index
 
-    whips = [[Whitehall::WhipOrganisation.find_by_id(1), RolesPresenter.new([role_3], @controller.view_context)]]
+    whips = [[Whitehall::WhipOrganisation.find_by_id(1), RolesPresenter.new([role3], @controller.view_context)]]
 
     assert_equal whips, assigns(:whips_by_organisation)
   end
@@ -151,32 +151,32 @@ class MinisterialRolesControllerTest < ActionController::TestCase
   test "orders whips by organisation sort order" do
     organisation = create(:ministerial_department)
 
-    person_1 = create(:person)
-    person_2 = create(:person)
-    person_3 = create(:person)
-    person_4 = create(:person)
-    person_5 = create(:person)
+    person1 = create(:person)
+    person2 = create(:person)
+    person3 = create(:person)
+    person4 = create(:person)
+    person5 = create(:person)
 
-    role_1 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 1)
-    role_2 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 2)
-    role_3 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 3)
-    role_4 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 4)
-    role_5 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 5)
+    role1 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 1)
+    role2 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 2)
+    role3 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 3)
+    role4 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 4)
+    role5 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 5)
 
-    create(:ministerial_role_appointment, role: role_1, person: person_1)
-    create(:ministerial_role_appointment, role: role_2, person: person_2)
-    create(:ministerial_role_appointment, role: role_3, person: person_3)
-    create(:ministerial_role_appointment, role: role_4, person: person_4)
-    create(:ministerial_role_appointment, role: role_5, person: person_5)
+    create(:ministerial_role_appointment, role: role1, person: person1)
+    create(:ministerial_role_appointment, role: role2, person: person2)
+    create(:ministerial_role_appointment, role: role3, person: person3)
+    create(:ministerial_role_appointment, role: role4, person: person4)
+    create(:ministerial_role_appointment, role: role5, person: person5)
 
     get :index
 
     whips = [
-      [Whitehall::WhipOrganisation.find_by_id(1), RolesPresenter.new([role_1], @controller.view_context)],
-      [Whitehall::WhipOrganisation.find_by_id(3), RolesPresenter.new([role_3], @controller.view_context)],
-      [Whitehall::WhipOrganisation.find_by_id(4), RolesPresenter.new([role_4], @controller.view_context)],
-      [Whitehall::WhipOrganisation.find_by_id(2), RolesPresenter.new([role_2], @controller.view_context)],
-      [Whitehall::WhipOrganisation.find_by_id(5), RolesPresenter.new([role_5], @controller.view_context)],
+      [Whitehall::WhipOrganisation.find_by_id(1), RolesPresenter.new([role1], @controller.view_context)],
+      [Whitehall::WhipOrganisation.find_by_id(3), RolesPresenter.new([role3], @controller.view_context)],
+      [Whitehall::WhipOrganisation.find_by_id(4), RolesPresenter.new([role4], @controller.view_context)],
+      [Whitehall::WhipOrganisation.find_by_id(2), RolesPresenter.new([role2], @controller.view_context)],
+      [Whitehall::WhipOrganisation.find_by_id(5), RolesPresenter.new([role5], @controller.view_context)],
     ]
     assert_equal whips, assigns(:whips_by_organisation)
   end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -114,16 +114,16 @@ class PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "#index highlights selected world filter options" do
-    @world_location_1 = create(:world_location)
-    @world_location_2 = create(:world_location)
-    create(:published_publication, world_locations: [@world_location_1], translated_into: :fr)
-    create(:published_publication, world_locations: [@world_location_2], translated_into: :fr)
+    @world_location1 = create(:world_location)
+    @world_location2 = create(:world_location)
+    create(:published_publication, world_locations: [@world_location1], translated_into: :fr)
+    create(:published_publication, world_locations: [@world_location2], translated_into: :fr)
 
-    get :index, params: { world_locations: [@world_location_1, @world_location_2], locale: :fr }
+    get :index, params: { world_locations: [@world_location1, @world_location2], locale: :fr }
 
     assert_select "select#world_locations[name='world_locations[]']" do
-      assert_select "option[selected='selected']", text: @world_location_1.name
-      assert_select "option[selected='selected']", text: @world_location_2.name
+      assert_select "option[selected='selected']", text: @world_location1.name
+      assert_select "option[selected='selected']", text: @world_location2.name
     end
   end
 
@@ -242,10 +242,10 @@ private
   end
 
   def given_two_documents_in_two_organisations
-    @organisation_1 = create(:organisation, type: OrganisationType.ministerial_department)
-    @organisation_2 = create(:organisation, type: OrganisationType.ministerial_department)
-    create(:published_publication, organisations: [@organisation_1])
-    create(:published_consultation, organisations: [@organisation_2])
+    @organisation1 = create(:organisation, type: OrganisationType.ministerial_department)
+    @organisation2 = create(:organisation, type: OrganisationType.ministerial_department)
+    create(:published_publication, organisations: [@organisation1])
+    create(:published_consultation, organisations: [@organisation2])
   end
 
   view_test "index includes tracking details on all links" do

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -103,12 +103,12 @@ class StatisticsControllerTest < ActionController::TestCase
 
   view_test "#index requested as JSON includes data for statistics" do
     Sidekiq::Testing.inline! do
-      organisation_1 = create(:organisation, name: "org-name")
-      organisation_2 = create(:organisation, name: "other-org")
+      organisation1 = create(:organisation, name: "org-name")
+      organisation2 = create(:organisation, name: "other-org")
       statistics_publication = create(
         :published_statistics,
         title: "statistics-title",
-        organisations: [organisation_1, organisation_2],
+        organisations: [organisation1, organisation2],
         first_published_at: Date.parse("2011-03-14"),
         translated_into: :fr,
       )

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -221,15 +221,15 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     with_stubbed_rummager(@rummager) do
       @rummager.expects(:search).returns("results" => []).twice
 
-      publication_2 = create(:published_publication, world_locations: [@world_location], first_published_at: 2.days.ago)
-      publication_1 = create(:published_publication, world_locations: [@world_location], first_published_at: 1.day.ago)
+      publication2 = create(:published_publication, world_locations: [@world_location], first_published_at: 2.days.ago)
+      publication1 = create(:published_publication, world_locations: [@world_location], first_published_at: 1.day.ago)
       create(:published_publication, world_locations: [@world_location], first_published_at: 3.days.ago)
 
       create(:published_statistics, world_locations: [@world_location], first_published_at: 1.day.ago)
 
       get :index, params: { world_location_id: @world_location }
 
-      assert_equal [publication_1, publication_2], assigns[:non_statistics_publications].object
+      assert_equal [publication1, publication2], assigns[:non_statistics_publications].object
     end
   end
 
@@ -237,19 +237,19 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     with_stubbed_rummager(@rummager) do
       @rummager.expects(:search).returns("results" => []).twice
 
-      publication_2 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
-      publication_3 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
-      publication_1 = create(:published_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
+      publication2 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
+      publication3 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
+      publication1 = create(:published_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
 
       get :index, params: { world_location_id: @world_location }
 
       assert_select "#publications" do
-        assert_select_object publication_2 do
+        assert_select_object publication2 do
           assert_select ".publication-date time[datetime=?]", 2.days.ago.to_date.to_datetime.iso8601
           assert_select ".document-type", "Policy paper"
         end
-        assert_select_object publication_3
-        refute_select_object publication_1
+        assert_select_object publication3
+        refute_select_object publication1
         assert_select "a[href='#{publications_filter_path(@world_location)}']"
       end
     end
@@ -259,12 +259,12 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     with_stubbed_rummager(@rummager) do
       @rummager.expects(:search).returns("results" => []).twice
 
-      publication_2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago)
-      publication_1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago)
+      publication2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago)
+      publication1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago)
       create(:published_statistics, world_locations: [@world_location], first_published_at: 3.days.ago)
 
       get :index, params: { world_location_id: @world_location }
-      assert_equal [publication_1, publication_2], assigns[:statistics_publications].object
+      assert_equal [publication1, publication2], assigns[:statistics_publications].object
     end
   end
 
@@ -272,19 +272,19 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     with_stubbed_rummager(@rummager) do
       @rummager.expects(:search).returns("results" => []).twice
 
-      publication_2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
-      publication_3 = create(:published_statistics, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
-      publication_1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
+      publication2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
+      publication3 = create(:published_statistics, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
+      publication1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
 
       get :index, params: { world_location_id: @world_location }
 
       assert_select "#statistics-publications" do
-        assert_select_object publication_1 do
+        assert_select_object publication1 do
           assert_select ".publication-date time[datetime=?]", 1.day.ago.to_date.to_datetime.iso8601
           assert_select ".document-type", "National Statistics"
         end
-        assert_select_object publication_2
-        refute_select_object publication_3
+        assert_select_object publication2
+        refute_select_object publication3
         assert_select "a[href=?]", publications_filter_path(@world_location, publication_filter_option: "statistics")
       end
     end

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -260,11 +260,11 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    announcement_2 = create(:published_news_article, world_locations: [world_location], first_published_at: 2.days.ago)
-    _announcement_3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
-    announcement_1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
+    announcement2 = create(:published_news_article, world_locations: [world_location], first_published_at: 2.days.ago)
+    _announcement3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
+    announcement1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
     get :show, params: { id: world_location }
-    assert_equal [announcement_1, announcement_2], assigns[:announcements].object
+    assert_equal [announcement1, announcement2], assigns[:announcements].object
   end
 
   view_test "should display 2 announcements with details and a link to announcements filter if there are many announcements" do
@@ -272,17 +272,17 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    announcement_2 = create(:published_news_article, world_locations: [world_location], first_published_at: 2.days.ago)
-    announcement_3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
-    announcement_1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
+    announcement2 = create(:published_news_article, world_locations: [world_location], first_published_at: 2.days.ago)
+    announcement3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
+    announcement1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
     get :show, params: { id: world_location }
     assert_select "#announcements" do
-      assert_select_object announcement_1 do
+      assert_select_object announcement1 do
         assert_select ".publication-date time[datetime=?]", 1.day.ago.iso8601
         assert_select ".document-type", "Press release"
       end
-      assert_select_object announcement_2
-      refute_select_object announcement_3
+      assert_select_object announcement2
+      refute_select_object announcement3
       # There may be other args and we can't guarantee the order,
       # so just specify the bits we care about
       assert_select "a[href^='#{announcements_path}'][href*='world_locations%5B%5D=#{world_location.to_param}']"
@@ -294,12 +294,12 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    publication_2 = create(:published_publication, world_locations: [world_location], first_published_at: 2.days.ago)
-    _publication_3 = create(:published_publication, world_locations: [world_location], first_published_at: 3.days.ago)
-    publication_1 = create(:published_publication, world_locations: [world_location], first_published_at: 1.day.ago)
+    publication2 = create(:published_publication, world_locations: [world_location], first_published_at: 2.days.ago)
+    _publication3 = create(:published_publication, world_locations: [world_location], first_published_at: 3.days.ago)
+    publication1 = create(:published_publication, world_locations: [world_location], first_published_at: 1.day.ago)
     _statistics_publication = create(:published_statistics, world_locations: [world_location], first_published_at: 1.day.ago)
     get :show, params: { id: world_location }
-    assert_equal [publication_1, publication_2], assigns[:non_statistics_publications].object
+    assert_equal [publication1, publication2], assigns[:non_statistics_publications].object
   end
 
   view_test "should display 2 non-statistics publications with details and a link to publications filter if there are many publications" do
@@ -307,17 +307,17 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    publication_2 = create(:published_policy_paper, world_locations: [world_location], first_published_at: 2.days.ago.to_date)
-    publication_3 = create(:published_policy_paper, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
-    publication_1 = create(:published_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
+    publication2 = create(:published_policy_paper, world_locations: [world_location], first_published_at: 2.days.ago.to_date)
+    publication3 = create(:published_policy_paper, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
+    publication1 = create(:published_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
     get :show, params: { id: world_location }
     assert_select "#publications" do
-      assert_select_object publication_2 do
+      assert_select_object publication2 do
         assert_select ".publication-date time[datetime=?]", 2.days.ago.to_date.to_datetime.iso8601
         assert_select ".document-type", "Policy paper"
       end
-      assert_select_object publication_3
-      refute_select_object publication_1
+      assert_select_object publication3
+      refute_select_object publication1
       assert_select "a[href='#{publications_filter_path(world_location)}']"
     end
   end
@@ -327,11 +327,11 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    publication_2 = create(:published_statistics, world_locations: [world_location], first_published_at: 2.days.ago)
-    _publication_3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago)
-    publication_1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago)
+    publication2 = create(:published_statistics, world_locations: [world_location], first_published_at: 2.days.ago)
+    _publication3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago)
+    publication1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago)
     get :show, params: { id: world_location }
-    assert_equal [publication_1, publication_2], assigns[:statistics_publications].object
+    assert_equal [publication1, publication2], assigns[:statistics_publications].object
   end
 
   view_test "should display 2 statistics publications with details and a link to publications filter if there are many publications" do
@@ -339,17 +339,17 @@ class WorldLocationsControllerTest < ActionController::TestCase
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation,
     )
-    publication_2 = create(:published_statistics, world_locations: [world_location], first_published_at: 2.days.ago.to_date)
-    publication_3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
-    publication_1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
+    publication2 = create(:published_statistics, world_locations: [world_location], first_published_at: 2.days.ago.to_date)
+    publication3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
+    publication1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
     get :show, params: { id: world_location }
     assert_select "#statistics-publications" do
-      assert_select_object publication_1 do
+      assert_select_object publication1 do
         assert_select ".publication-date time[datetime=?]", 1.day.ago.to_date.to_datetime.iso8601
         assert_select ".document-type", "National Statistics"
       end
-      assert_select_object publication_2
-      refute_select_object publication_3
+      assert_select_object publication2
+      refute_select_object publication3
       assert_select "a[href=?]", publications_filter_path(world_location, publication_filter_option: "statistics")
     end
   end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -38,14 +38,14 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   view_test "shows links to associated world locations" do
-    location_1 = create(:world_location)
-    location_2 = create(:world_location)
-    organisation = create(:worldwide_organisation, world_locations: [location_1, location_2])
+    location1 = create(:world_location)
+    location2 = create(:world_location)
+    organisation = create(:worldwide_organisation, world_locations: [location1, location2])
 
     get :show, params: { id: organisation.id }
 
-    assert_select "a[href='#{world_location_path(location_1)}']"
-    assert_select "a[href='#{world_location_path(location_2)}']"
+    assert_select "a[href='#{world_location_path(location1)}']"
+    assert_select "a[href='#{world_location_path(location2)}']"
   end
 
   test "show redirects to the api worldwide organisation endpoint when json is requested" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -533,14 +533,14 @@ module AdminEditionControllerTestHelpers
       end
 
       test "creating an edition with multiple images should attach all files" do
-        image_file_0 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
-        image_file_1 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
+        image_file0 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
+        image_file1 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                   image_data_attributes: attributes_for(:image_data, file: image_file_0) },
+                   image_data_attributes: attributes_for(:image_data, file: image_file0) },
           "1" => { alt_text: "more-alt-text",
-                   image_data_attributes: attributes_for(:image_data, file: image_file_1) },
+                   image_data_attributes: attributes_for(:image_data, file: image_file1) },
         }
 
         post :create,
@@ -552,10 +552,10 @@ module AdminEditionControllerTestHelpers
 
         edition = edition_class.last!
         assert_equal 2, edition.images.length
-        image_1 = edition.images.first
-        assert_equal "some-alt-text", image_1.alt_text
-        image_2 = edition.images.last
-        assert_equal "more-alt-text", image_2.alt_text
+        image1 = edition.images.first
+        assert_equal "some-alt-text", image1.alt_text
+        image2 = edition.images.last
+        assert_equal "more-alt-text", image2.alt_text
       end
 
       view_test "creating an edition with an invalid image should show an error" do
@@ -673,13 +673,13 @@ module AdminEditionControllerTestHelpers
 
       test "updating an edition should attach multiple images" do
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
-        image_file_0 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
-        image_file_1 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
+        image_file0 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
+        image_file1 = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
         attributes = { images_attributes: {
           "0" => { alt_text: "some-alt-text",
-                   image_data_attributes: attributes_for(:image_data, file: image_file_0) },
+                   image_data_attributes: attributes_for(:image_data, file: image_file0) },
           "1" => { alt_text: "more-alt-text",
-                   image_data_attributes: attributes_for(:image_data, file: image_file_1) },
+                   image_data_attributes: attributes_for(:image_data, file: image_file1) },
         } }
 
         put :update, params: { id: edition, edition: attributes }
@@ -687,10 +687,10 @@ module AdminEditionControllerTestHelpers
         assert_response :redirect
 
         assert_equal 2, edition.images.length
-        image_1 = edition.images.first
-        assert_equal "some-alt-text", image_1.alt_text
-        image_2 = edition.images.last
-        assert_equal "more-alt-text", image_2.alt_text
+        image1 = edition.images.first
+        assert_equal "some-alt-text", image1.alt_text
+        image2 = edition.images.last
+        assert_equal "more-alt-text", image2.alt_text
       end
 
       view_test "updating an edition with invalid data should still allow image to be selected for upload" do
@@ -796,13 +796,13 @@ module AdminEditionControllerTestHelpers
         image = fixture_file_upload("minister-of-funk.960x640.jpg", "image/jpg")
 
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
-        image_1 = create(
+        image1 = create(
           :image,
           edition: edition,
           alt_text: "the first image",
           image_data_attributes: attributes_for(:image_data, file: image),
         )
-        image_2 = create(
+        image2 = create(
           :image,
           edition: edition,
           alt_text: "the second image",
@@ -811,8 +811,8 @@ module AdminEditionControllerTestHelpers
 
         attributes = {
           images_attributes: {
-            "0" => { id: image_1.id.to_s, _destroy: "1" },
-            "1" => { id: image_2.id.to_s, _destroy: "0" },
+            "0" => { id: image1.id.to_s, _destroy: "1" },
+            "1" => { id: image2.id.to_s, _destroy: "0" },
             "2" => { image_data_attributes: { file_cache: "" } },
           },
         }
@@ -820,7 +820,7 @@ module AdminEditionControllerTestHelpers
 
         refute_select ".errors"
         edition.reload
-        assert_equal [image_2], edition.images
+        assert_equal [image2], edition.images
       end
     end
 
@@ -985,43 +985,43 @@ module AdminEditionControllerTestHelpers
       end
 
       test "update should allow removal of an organisation" do
-        organisation_1 = create(:organisation)
-        organisation_2 = create(:organisation)
+        organisation1 = create(:organisation)
+        organisation2 = create(:organisation)
 
-        edition = create(edition_type, organisations: [organisation_1, organisation_2])
+        edition = create(edition_type, organisations: [organisation1, organisation2])
 
         put :update,
             params: {
               id: edition,
               edition: {
-                lead_organisation_ids: [organisation_2.id],
+                lead_organisation_ids: [organisation2.id],
               },
             }
 
         edition.reload
-        assert_equal [organisation_2], edition.lead_organisations
+        assert_equal [organisation2], edition.lead_organisations
       end
 
       test "update should allow swapping of an organisation from lead to supporting" do
-        organisation_1 = create(:organisation)
-        organisation_2 = create(:organisation)
-        organisation_3 = create(:organisation)
+        organisation1 = create(:organisation)
+        organisation2 = create(:organisation)
+        organisation3 = create(:organisation)
 
-        edition = create(edition_type, organisations: [organisation_1, organisation_2])
-        edition.organisations << organisation_3
+        edition = create(edition_type, organisations: [organisation1, organisation2])
+        edition.organisations << organisation3
 
         put :update,
             params: {
               id: edition,
               edition: {
-                lead_organisation_ids: [organisation_2.id, organisation_3.id],
-                supporting_organisation_ids: [organisation_1.id],
+                lead_organisation_ids: [organisation2.id, organisation3.id],
+                supporting_organisation_ids: [organisation1.id],
               },
             }
 
         edition.reload
-        assert_equal [organisation_2, organisation_3], edition.lead_organisations
-        assert_equal [organisation_1], edition.supporting_organisations
+        assert_equal [organisation2, organisation3], edition.lead_organisations
+        assert_equal [organisation1], edition.supporting_organisations
       end
     end
 

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -20,19 +20,19 @@ module AdminEditionWorldLocationsBehaviour
       end
 
       test "creating should create a new document with world locations" do
-        world_location_1 = create(:world_location)
-        world_location_2 = create(:world_location)
+        world_location1 = create(:world_location)
+        world_location2 = create(:world_location)
         attributes = controller_attributes_for(document_type)
 
         post :create,
              params: {
                edition: attributes.merge(
-                 world_location_ids: [world_location_1.id, world_location_2.id],
+                 world_location_ids: [world_location1.id, world_location2.id],
                ),
              }
 
         assert document = edition_class.last
-        assert_equal [world_location_1, world_location_2], document.world_locations
+        assert_equal [world_location1, world_location2], document.world_locations
       end
 
       view_test "edit displays document form with world locations field" do
@@ -51,18 +51,18 @@ module AdminEditionWorldLocationsBehaviour
       end
 
       test "updating should save modified document attributes with world locations" do
-        world_location_1 = create(:world_location)
-        world_location_2 = create(:world_location)
-        document = create(document_type, world_locations: [world_location_2])
+        world_location1 = create(:world_location)
+        world_location2 = create(:world_location)
+        document = create(document_type, world_locations: [world_location2])
 
         put :update,
             params: { id: document,
                       edition: {
-                        world_location_ids: [world_location_1.id],
+                        world_location_ids: [world_location1.id],
                       } }
 
         document = document.reload
-        assert_equal [world_location_1], document.world_locations
+        assert_equal [world_location1], document.world_locations
       end
 
       view_test "updating a stale document should render edit page with conflicting document and its world locations" do

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -47,19 +47,19 @@ module DocumentControllerTestHelpers
           :with_alternative_format_provider,
           body: "!@1\n\n!@2",
           attachments: [
-            attachment_1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf")),
-            attachment_2 = build(:file_attachment, file: fixture_file_upload("sample.rtf", "text/rtf")),
+            attachment1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf")),
+            attachment2 = build(:file_attachment, file: fixture_file_upload("sample.rtf", "text/rtf")),
           ],
         )
 
         get :show, params: { id: edition.document }
 
-        assert_select_object(attachment_1) do
-          assert_select ".title", text: attachment_1.title
+        assert_select_object(attachment1) do
+          assert_select ".title", text: attachment1.title
           assert_select "img[src$=?]", "thumbnail_greenpaper.pdf.png"
         end
-        assert_select_object(attachment_2) do
-          assert_select ".title", text: attachment_2.title
+        assert_select_object(attachment2) do
+          assert_select ".title", text: attachment2.title
           assert_select "img[src$=?]", "pub-cover.png", message: "should use default image for non-PDF attachments"
         end
       end
@@ -80,19 +80,19 @@ module DocumentControllerTestHelpers
           :with_alternative_format_provider,
           body: "!@1\n\n!@2",
           attachments: [
-            attachment_1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf"), accessible: true),
-            attachment_2 = build(:file_attachment, file: fixture_file_upload("sample.rtf", "text/rtf")),
+            attachment1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf"), accessible: true),
+            attachment2 = build(:file_attachment, file: fixture_file_upload("sample.rtf", "text/rtf")),
           ],
         )
 
         get :show, params: { id: edition.document }
 
-        assert_select_object(attachment_1) do
+        assert_select_object(attachment1) do
           refute_select ".accessibility-warning"
-          refute_select ".title a[aria-describedby='attachment-#{attachment_1.id}-accessibility-help']"
+          refute_select ".title a[aria-describedby='attachment-#{attachment1.id}-accessibility-help']"
         end
-        assert_select_object(attachment_2) do
-          assert_select ".title a[aria-describedby='attachment-#{attachment_2.id}-accessibility-help']"
+        assert_select_object(attachment2) do
+          assert_select ".title a[aria-describedby='attachment-#{attachment2.id}-accessibility-help']"
           assert_select ".accessibility-warning"
         end
       end
@@ -103,14 +103,14 @@ module DocumentControllerTestHelpers
           "published_#{document_type}",
           body: "!@1",
           attachments: [
-            attachment_1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf"), accessible: false),
+            attachment1 = build(:file_attachment, file: fixture_file_upload("greenpaper.pdf", "application/pdf"), accessible: false),
           ],
           alternative_format_provider: organisation,
         )
 
         get :show, params: { id: edition.document }
 
-        assert_select_object(attachment_1) do
+        assert_select_object(attachment1) do
           assert_select ".accessibility-warning" do
             assert_select 'a[href^="mailto:alternative@example.com"]'
           end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -46,7 +46,7 @@ module TaxonomyHelper
   end
 
   def stub_taxonomy_with_all_taxons
-    redis_cache_has_taxons [root_taxon, draft_taxon_1, draft_taxon_2]
+    redis_cache_has_taxons [root_taxon, draft_taxon1, draft_taxon2]
   end
 
   def stub_taxonomy_with_world_taxons
@@ -197,7 +197,7 @@ private
     )
   end
 
-  def draft_taxon_1
+  def draft_taxon1
     FactoryBot.build(
       :taxon_hash,
       title: "About your organisation",
@@ -206,7 +206,7 @@ private
     )
   end
 
-  def draft_taxon_2
+  def draft_taxon2
     FactoryBot.build(
       :taxon_hash,
       title: "Parenting",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,8 +76,8 @@ class ActiveSupport::TestCase
     Edition::AuditTrail.acting_as(actor, &block)
   end
 
-  def assert_same_elements(array_1, array_2)
-    assert_equal array_1.to_set, array_2.to_set, "Different elements in #{array_1.inspect} and #{array_2}.inspect"
+  def assert_same_elements(array1, array2)
+    assert_equal array1.to_set, array2.to_set, "Different elements in #{array1.inspect} and #{array2}.inspect"
   end
 
   def assert_hash_includes(hash, should_exist)
@@ -157,8 +157,8 @@ class ActiveSupport::TestCase
     File.new(Rails.root.join("test/fixtures", filename))
   end
 
-  def assert_file_content_identical(file_1, file_2)
-    FileUtils.compare_file(file_1.path, file_2.path)
+  def assert_file_content_identical(file1, file2)
+    FileUtils.compare_file(file1.path, file2.path)
   end
 
   def publish(edition)

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -20,15 +20,15 @@ class AttachableTest < ActiveSupport::TestCase
       :publication,
       :with_file_attachment,
       attachments: [
-        attachment_1 = build(:file_attachment, ordering: 0),
-        attachment_2 = build(:file_attachment, ordering: 1, file: file_fixture("whitepaper.pdf")),
+        attachment1 = build(:file_attachment, ordering: 0),
+        attachment2 = build(:file_attachment, ordering: 1, file: file_fixture("whitepaper.pdf")),
       ],
     )
 
-    attachment_3 = FileAttachment.new(title: "Title", attachment_data: build(:attachment_data, file: file_fixture("sample.rtf")))
-    publication.attachments << attachment_3
+    attachment3 = FileAttachment.new(title: "Title", attachment_data: build(:attachment_data, file: file_fixture("sample.rtf")))
+    publication.attachments << attachment3
 
-    assert_equal [attachment_1, attachment_2, attachment_3], publication.attachments.reload
+    assert_equal [attachment1, attachment2, attachment3], publication.attachments.reload
   end
 
   test "creating a new attachable thing with multiple attachments sets the correct ordering" do
@@ -36,15 +36,15 @@ class AttachableTest < ActiveSupport::TestCase
       :publication,
       :with_file_attachment,
       attachments: [
-        attachment_1 = build(:file_attachment),
-        attachment_2 = build(:file_attachment, file: file_fixture("whitepaper.pdf")),
+        attachment1 = build(:file_attachment),
+        attachment2 = build(:file_attachment, file: file_fixture("whitepaper.pdf")),
       ],
     )
 
     publication.save!
-    assert_equal [attachment_1, attachment_2], publication.attachments
-    assert_equal 0, attachment_1.ordering
-    assert_equal 1, attachment_2.ordering
+    assert_equal [attachment1, attachment2], publication.attachments
+    assert_equal 0, attachment1.ordering
+    assert_equal 1, attachment2.ordering
   end
 
   test "should be invalid if an edition has an attachment but no alternative format provider" do
@@ -175,19 +175,19 @@ class AttachableTest < ActiveSupport::TestCase
   end
 
   test "has html_attachments association to fetch only HtmlAttachments" do
-    attachment_1 = build(:file_attachment, ordering: 0)
-    attachment_2 = build(:html_attachment, title: "Test HTML attachment", ordering: 1)
-    attachment_3 = build(:html_attachment, title: "Title", body: "Testing")
+    attachment1 = build(:file_attachment, ordering: 0)
+    attachment2 = build(:html_attachment, title: "Test HTML attachment", ordering: 1)
+    attachment3 = build(:html_attachment, title: "Title", body: "Testing")
 
     publication = create(
       :publication,
       :with_file_attachment,
-      attachments: [attachment_1, attachment_2],
+      attachments: [attachment1, attachment2],
     )
 
-    publication.attachments << attachment_3
+    publication.attachments << attachment3
 
-    assert_equal [attachment_2, attachment_3], publication.html_attachments.reload
+    assert_equal [attachment2, attachment3], publication.html_attachments.reload
   end
 
   test "attachment association excludes soft-deleted Attachments" do
@@ -195,24 +195,24 @@ class AttachableTest < ActiveSupport::TestCase
       :publication,
       :with_file_attachment,
       attachments: [
-        attachment_1 = build(:file_attachment),
+        attachment1 = build(:file_attachment),
         build(:html_attachment, title: "HTML attachment", deleted: true),
       ],
     )
 
-    assert_equal [attachment_1], publication.attachments.reload
+    assert_equal [attachment1], publication.attachments.reload
   end
 
   test "html_attachment association excludes soft-deleted HtmlAttachments" do
     publication = create(
       :publication,
       attachments: [
-        attachment_1 = build(:html_attachment, title: "Test HTML attachment"),
+        attachment1 = build(:html_attachment, title: "Test HTML attachment"),
         build(:html_attachment, title: "Another HTML attachment", deleted: true),
       ],
     )
 
-    assert_equal [attachment_1], publication.html_attachments.reload
+    assert_equal [attachment1], publication.html_attachments.reload
   end
 
   test "#has_command_paper? is true if an attachment is a command paper" do
@@ -256,17 +256,17 @@ class AttachableTest < ActiveSupport::TestCase
 
     assert_equal 2, draft.attachments.size
 
-    attachment_1 = draft.attachments[0]
-    assert attachment_1.persisted?
-    assert file_attachment.id != attachment_1.id
-    assert_equal file_attachment.attachment_data, attachment_1.attachment_data
-    assert_equal file_attachment.title, attachment_1.title
+    attachment1 = draft.attachments[0]
+    assert attachment1.persisted?
+    assert file_attachment.id != attachment1.id
+    assert_equal file_attachment.attachment_data, attachment1.attachment_data
+    assert_equal file_attachment.title, attachment1.title
 
-    attachment_2 = draft.attachments[1]
-    assert attachment_2.persisted?
-    assert html_attachment.id != attachment_2.id
-    assert_equal html_attachment.govspeak_content.body, attachment_2.govspeak_content.body
-    assert_equal html_attachment.title, attachment_2.title
+    attachment2 = draft.attachments[1]
+    assert attachment2.persisted?
+    assert html_attachment.id != attachment2.id
+    assert_equal html_attachment.govspeak_content.body, attachment2.govspeak_content.body
+    assert_equal html_attachment.title, attachment2.title
   end
 
   test "re-editioned editions persists invalid attachments" do
@@ -287,28 +287,28 @@ class AttachableTest < ActiveSupport::TestCase
   test "#delete_all_attachments soft-deletes any attachments that the edition has" do
     publication = create(:draft_publication)
 
-    publication.attachments << attachment_1 = build(:file_attachment)
-    publication.attachments << attachment_2 = build(:html_attachment)
+    publication.attachments << attachment1 = build(:file_attachment)
+    publication.attachments << attachment2 = build(:html_attachment)
 
     publication.delete_all_attachments
 
-    assert Attachment.find(attachment_1.id).deleted?
-    assert Attachment.find(attachment_2.id).deleted?
+    assert Attachment.find(attachment1.id).deleted?
+    assert Attachment.find(attachment2.id).deleted?
   end
 
   test "#deleted_html_attachments returns associated HTML attachments that have been deleted" do
     publication = create(
       :draft_publication,
       attachments: [
-        attachment_1 = build(:html_attachment, title: "First"),
-        attachment_2 = build(:html_attachment, title: "Second"),
+        attachment1 = build(:html_attachment, title: "First"),
+        attachment2 = build(:html_attachment, title: "Second"),
       ],
     )
 
-    attachment_1.destroy!
-    attachment_2.destroy!
+    attachment1.destroy!
+    attachment2.destroy!
 
-    assert_equal [attachment_1, attachment_2], publication.deleted_html_attachments
+    assert_equal [attachment1, attachment2], publication.deleted_html_attachments
   end
 
   test "#deleted_html_attachments doesn't return undeleted attachments" do

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -205,14 +205,14 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
   test "order attachments by attachable ID" do
     attachment_data = create(:attachment_data)
-    edition_1 = create(:edition)
-    edition_2 = create(:edition)
-    attachment_1 = build(:file_attachment, attachable: edition_2)
-    attachment_2 = build(:file_attachment, attachable: edition_1)
-    attachment_data.attachments << attachment_1
-    attachment_data.attachments << attachment_2
+    edition1 = create(:edition)
+    edition2 = create(:edition)
+    attachment1 = build(:file_attachment, attachable: edition2)
+    attachment2 = build(:file_attachment, attachable: edition1)
+    attachment_data.attachments << attachment1
+    attachment_data.attachments << attachment2
 
-    assert_equal [attachment_2, attachment_1], attachment_data.attachments.to_a
+    assert_equal [attachment2, attachment1], attachment_data.attachments.to_a
   end
 
   test "#access_limited? is falsey if there is no last attachable" do

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -34,44 +34,44 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
 
   test "should be invalid if it refers to the same document of another page" do
     organisation = create(:organisation)
-    corporate_information_page_1 = build(
+    corporate_information_page1 = build(
       :corporate_information_page,
       organisation: organisation,
       corporate_information_page_type: CorporateInformationPageType::AboutUs,
       state: "published",
       major_change_published_at: Time.zone.now,
     )
-    corporate_information_page_1.save!
+    corporate_information_page1.save!
 
-    corporate_information_page_2 = build(
+    corporate_information_page2 = build(
       :corporate_information_page,
       organisation: organisation,
       corporate_information_page_type: CorporateInformationPageType::AboutUs,
     )
-    assert_not corporate_information_page_2.valid?
+    assert_not corporate_information_page2.valid?
 
-    assert corporate_information_page_2.errors.full_messages.include?("Another 'About' page was already published for this organisation")
+    assert corporate_information_page2.errors.full_messages.include?("Another 'About' page was already published for this organisation")
   end
 
   test "should be valid if it is a new draft of the same document" do
     organisation = create(:organisation)
-    corporate_information_page_1 = build(
+    corporate_information_page1 = build(
       :corporate_information_page,
       organisation: organisation,
       corporate_information_page_type: CorporateInformationPageType::AboutUs,
       state: "published",
       major_change_published_at: Time.zone.now,
     )
-    corporate_information_page_1.save!
+    corporate_information_page1.save!
 
-    corporate_information_page_2 = build(
+    corporate_information_page2 = build(
       :corporate_information_page,
       organisation: organisation,
       corporate_information_page_type: CorporateInformationPageType::AboutUs,
-      document_id: corporate_information_page_1.document_id,
+      document_id: corporate_information_page1.document_id,
       state: "draft",
     )
-    assert corporate_information_page_2.valid?
+    assert corporate_information_page2.valid?
   end
 
   test "should return search index data suitable for Rummageable" do
@@ -88,10 +88,10 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
   end
 
   test "with_translations scope loads corporate information pages despite not have titles explicitly saved" do
-    cip_1 = create(:corporate_information_page, title: nil)
-    cip_2 = create(:corporate_information_page, title: "Should not be saved")
+    cip1 = create(:corporate_information_page, title: nil)
+    cip2 = create(:corporate_information_page, title: "Should not be saved")
 
-    assert_equal [cip_1, cip_2], CorporateInformationPage.with_translations
+    assert_equal [cip1, cip2], CorporateInformationPage.with_translations
   end
 
   test "should derive title from type" do
@@ -192,19 +192,19 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     transitioning_org = create(:organisation, govuk_status: "transitioning")
     live_org = create(:organisation, govuk_status: "live")
 
-    corporate_information_page_1 = create(:corporate_information_page, :published, organisation: joining_org)
-    corporate_information_page_2 = create(:corporate_information_page, :published, organisation: exempt_org)
-    corporate_information_page_3 = create(:corporate_information_page, :published, organisation: transitioning_org)
-    corporate_information_page_4 = create(:corporate_information_page, :published, organisation: live_org)
+    corporate_information_page1 = create(:corporate_information_page, :published, organisation: joining_org)
+    corporate_information_page2 = create(:corporate_information_page, :published, organisation: exempt_org)
+    corporate_information_page3 = create(:corporate_information_page, :published, organisation: transitioning_org)
+    corporate_information_page4 = create(:corporate_information_page, :published, organisation: live_org)
 
-    Whitehall::SearchIndex.expects(:add).with(corporate_information_page_1).never
-    Whitehall::SearchIndex.expects(:add).with(corporate_information_page_2).never
-    Whitehall::SearchIndex.expects(:add).with(corporate_information_page_3).never
-    Whitehall::SearchIndex.expects(:add).with(corporate_information_page_4).once
-    corporate_information_page_1.update_in_search_index
-    corporate_information_page_2.update_in_search_index
-    corporate_information_page_3.update_in_search_index
-    corporate_information_page_4.update_in_search_index
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page1).never
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page2).never
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page3).never
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page4).once
+    corporate_information_page1.update_in_search_index
+    corporate_information_page2.update_in_search_index
+    corporate_information_page3.update_in_search_index
+    corporate_information_page4.update_in_search_index
   end
 
   test "until we launch worldwide will not be indexed if the org it belongs to is a worldwide org" do

--- a/test/unit/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/unit/data_hygiene/bulk_organisation_updater_test.rb
@@ -62,12 +62,12 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
 
     document = create(:document, slug: "this-is-a-slug")
     edition = create(:publication, document: document)
-    organisation_1 = create(:organisation, slug: "supporting-organisation-1")
-    organisation_2 = create(:organisation, slug: "supporting-organisation-2")
+    organisation1 = create(:organisation, slug: "supporting-organisation-1")
+    organisation2 = create(:organisation, slug: "supporting-organisation-2")
 
     process(csv_file)
 
-    assert_equal edition.supporting_organisations, [organisation_1, organisation_2]
+    assert_equal edition.supporting_organisations, [organisation1, organisation2]
     assert_equal PublishingApiDocumentRepublishingWorker.jobs.size, 1
     assert_equal PublishingApiDocumentRepublishingWorker.jobs.first["args"].first, document.id
   end
@@ -79,14 +79,14 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
     CSV
 
     lead_organisation = create(:organisation, slug: "lead-organisation")
-    supporting_organisation_1 = create(:organisation, slug: "supporting-organisation-1")
-    supporting_organisation_2 = create(:organisation, slug: "supporting-organisation-2")
+    supporting_organisation1 = create(:organisation, slug: "supporting-organisation-1")
+    supporting_organisation2 = create(:organisation, slug: "supporting-organisation-2")
     document = create(:document, slug: "this-is-a-slug")
     create(
       :publication,
       document: document,
       lead_organisations: [lead_organisation],
-      supporting_organisations: [supporting_organisation_1, supporting_organisation_2],
+      supporting_organisations: [supporting_organisation1, supporting_organisation2],
     )
 
     process(csv_file)

--- a/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
+++ b/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
@@ -95,18 +95,18 @@ class DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncementsTest < Acti
   end
 
   test "#advanced_search with organisations returns results associated with the organisations" do
-    announcement_1 = create :statistics_announcement
-    _announcement_2 = create :statistics_announcement
+    announcement1 = create :statistics_announcement
+    _announcement2 = create :statistics_announcement
 
-    assert_equal [announcement_1.title], matched_titles(organisations: announcement_1.organisations_slugs)
+    assert_equal [announcement1.title], matched_titles(organisations: announcement1.organisations_slugs)
   end
 
   test "#advanced_search returns results ordered by current_release_date's release_date" do
-    announcement_1 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 2.days.from_now)
-    announcement_2 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 1.day.from_now)
-    announcement_3 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 3.days.from_now)
+    announcement1 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 2.days.from_now)
+    announcement2 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 1.day.from_now)
+    announcement3 = create :statistics_announcement, current_release_date: build(:statistics_announcement_date, release_date: 3.days.from_now)
 
-    assert_equal [announcement_2.title, announcement_1.title, announcement_3.title], matched_titles
+    assert_equal [announcement2.title, announcement1.title, announcement3.title], matched_titles
   end
 
   test "#advanced_search supports pagination" do

--- a/test/unit/edition/active_editors_test.rb
+++ b/test/unit/edition/active_editors_test.rb
@@ -22,13 +22,13 @@ class Edition::ActiveEditorsTest < ActiveSupport::TestCase
   end
 
   test "can check exclude a given editor from the list of recent edition openings" do
-    user_1 = create(:writer)
+    user1 = create(:writer)
     edition = create(:edition)
-    edition.open_for_editing_as(user_1)
+    edition.open_for_editing_as(user1)
     Timecop.travel(1.minute.from_now)
-    user_2 = create(:writer)
-    edition.open_for_editing_as(user_2)
-    assert_equal [user_1], edition.recent_edition_openings.except_editor(user_2).map(&:editor)
+    user2 = create(:writer)
+    edition.open_for_editing_as(user2)
+    assert_equal [user1], edition.recent_edition_openings.except_editor(user2).map(&:editor)
   end
 
   test "editors considered active for up to 2 hours" do

--- a/test/unit/edition/audit_trail_test.rb
+++ b/test/unit/edition/audit_trail_test.rb
@@ -4,7 +4,7 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
   def setup
     @previous_whodunnit = Edition::AuditTrail.whodunnit
     @user = create(:user)
-    @user_2 = create(:user)
+    @user2 = create(:user)
     Edition::AuditTrail.whodunnit = @user
   end
 
@@ -14,15 +14,15 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
   end
 
   test "#acting_as switches to the supplied user for the duration of the block, returning to the original user afterwards" do
-    Edition::AuditTrail.acting_as(@user_2) do
-      assert_equal @user_2, Edition::AuditTrail.whodunnit
+    Edition::AuditTrail.acting_as(@user2) do
+      assert_equal @user2, Edition::AuditTrail.whodunnit
     end
     assert_equal @user, Edition::AuditTrail.whodunnit
   end
 
   test "#acting_as will return to the previous whodunnit, even when an exception is thrown" do
     begin
-      Edition::AuditTrail.acting_as(@user_2) { raise "Boom!" }
+      Edition::AuditTrail.acting_as(@user2) { raise "Boom!" }
     rescue StandardError # rubocop:disable Lint/SuppressedException
     end
 
@@ -68,27 +68,27 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
 
   test "submitting for review records the person who submitted it" do
     edition = create(:draft_edition)
-    Edition::AuditTrail.whodunnit = @user_2
+    Edition::AuditTrail.whodunnit = @user2
     edition.submit!
-    assert_equal @user_2, edition.document_version_trail.last.actor
+    assert_equal @user2, edition.document_version_trail.last.actor
   end
 
   test "rejecting records a rejected action" do
     edition = create(:submitted_edition)
-    Edition::AuditTrail.whodunnit = @user_2
+    Edition::AuditTrail.whodunnit = @user2
     edition.reject!
     assert_equal "rejected", edition.document_version_trail.last.action
-    assert_equal @user_2, edition.document_version_trail.last.actor
+    assert_equal @user2, edition.document_version_trail.last.actor
   end
 
   test "publishing records a published action" do
     edition = create(:submitted_edition)
     edition.first_published_at = Time.zone.now
     edition.major_change_published_at = Time.zone.now
-    Edition::AuditTrail.whodunnit = @user_2
+    Edition::AuditTrail.whodunnit = @user2
     edition.publish!
     assert_equal "published", edition.document_version_trail.last.action
-    assert_equal @user_2, edition.document_version_trail.last.actor
+    assert_equal @user2, edition.document_version_trail.last.actor
   end
 
   test "creating a new draft of a published edition records an edition action" do
@@ -121,17 +121,17 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
   end
 
   test "latest_version_audit_entry_for returns most recent entry in a state" do
-    edition = create(:submitted_edition, creator: @user_2)
+    edition = create(:submitted_edition, creator: @user2)
     edition.body = "updated-body"
     edition.save!
     assert_equal @user, edition.latest_version_audit_entry_for("submitted").actor
   end
 
   test "most_recent_submission_audit_entry returns entry for submission action" do
-    edition = create(:submitted_edition, creator: @user_2)
+    edition = create(:submitted_edition, creator: @user2)
     edition.body = "updated-body"
     edition.save!
-    assert_equal @user_2, edition.most_recent_submission_audit_entry.actor
+    assert_equal @user2, edition.most_recent_submission_audit_entry.actor
   end
 
   test "publication_audit_entry returns entry when first edition was published" do

--- a/test/unit/edition/fact_checkable_test.rb
+++ b/test/unit/edition/fact_checkable_test.rb
@@ -9,15 +9,15 @@ class Edition::FactCheckableTest < ActiveSupport::TestCase
   end
 
   test "should list all completed fact check requests from all editions, newest first" do
-    time_0 = Time.zone.now
+    time0 = Time.zone.now
     user = create(:user)
     old_edition = create(:published_publication)
-    Timecop.freeze time_0
+    Timecop.freeze time0
     old_complete_fcr = create(:fact_check_request, edition: old_edition, comments: "Stuff")
-    Timecop.freeze time_0 + 1
+    Timecop.freeze time0 + 1
     _old_incomplete_fcr = create(:fact_check_request, edition: old_edition)
     new_edition = old_edition.create_draft(user)
-    Timecop.freeze time_0 + 2
+    Timecop.freeze time0 + 2
     new_complete_fcr = create(:fact_check_request, edition: new_edition, comments: "Stuff")
 
     expected = [new_complete_fcr, old_complete_fcr]

--- a/test/unit/edition/identifiable_test.rb
+++ b/test/unit/edition/identifiable_test.rb
@@ -21,10 +21,10 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
 
   test "should not allow the same slug to be used again for the same document type" do
     same_title = "same-title"
-    publication_1 = create(:publication, title: same_title)
-    publication_2 = create(:publication, title: same_title)
+    publication1 = create(:publication, title: same_title)
+    publication2 = create(:publication, title: same_title)
 
-    assert_not_equal publication_1.document.slug, publication_2.document.slug
+    assert_not_equal publication1.document.slug, publication2.document.slug
   end
 
   test "should allow the same slug to be used again for another document type" do

--- a/test/unit/edition/organisations_test.rb
+++ b/test/unit/edition/organisations_test.rb
@@ -9,10 +9,10 @@ class Edition::OrganisationsTest < ActiveSupport::TestCase
   end
 
   test "new edition of document will retain lead and supporting organisations and their orderings" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
-    organisation_3 = create(:organisation)
-    news_article = create(:published_news_article, lead_organisations: [organisation_3, organisation_1], supporting_organisations: [organisation_2])
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
+    organisation3 = create(:organisation)
+    news_article = create(:published_news_article, lead_organisations: [organisation3, organisation1], supporting_organisations: [organisation2])
 
     new_edition = news_article.create_draft(create(:writer))
     new_edition.change_note = "change-note"
@@ -20,42 +20,42 @@ class Edition::OrganisationsTest < ActiveSupport::TestCase
 
     lead_edition_organisations = new_edition.lead_edition_organisations
     assert_equal 2, lead_edition_organisations.size
-    assert_equal organisation_3, lead_edition_organisations[0].organisation
-    assert_equal organisation_1, lead_edition_organisations[1].organisation
+    assert_equal organisation3, lead_edition_organisations[0].organisation
+    assert_equal organisation1, lead_edition_organisations[1].organisation
 
     supporting_edition_organisations = new_edition.supporting_edition_organisations
     assert_equal 1, supporting_edition_organisations.size
-    assert_equal organisation_2, supporting_edition_organisations[0].organisation
+    assert_equal organisation2, supporting_edition_organisations[0].organisation
   end
 
   test "reducing lead organisations from 2 to 1 (keeping the second) is ok" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1, organisation_2],
+      lead_organisations: [organisation1, organisation2],
       supporting_organisations: [],
     )
-    edition.lead_organisations = [organisation_2]
+    edition.lead_organisations = [organisation2]
     assert_nothing_raised do
       edition.save!
     end
   end
 
   test "#sorted_organisations returns organisations in alphabetical order" do
-    organisation_1 = create(:organisation, name: "Ministry of Jazz")
-    organisation_2 = create(:organisation, name: "Free Jazz Foundation")
-    organisation_3 = create(:organisation, name: "Jazz Bizniz")
-    edition = create(:published_news_article, lead_organisations: [organisation_3, organisation_1], supporting_organisations: [organisation_2])
+    organisation1 = create(:organisation, name: "Ministry of Jazz")
+    organisation2 = create(:organisation, name: "Free Jazz Foundation")
+    organisation3 = create(:organisation, name: "Jazz Bizniz")
+    edition = create(:published_news_article, lead_organisations: [organisation3, organisation1], supporting_organisations: [organisation2])
 
-    assert_equal [organisation_2, organisation_3, organisation_1], edition.sorted_organisations
+    assert_equal [organisation2, organisation3, organisation1], edition.sorted_organisations
   end
 
   test "#search_index should include organisations" do
-    organisation_1 = create(:organisation, name: "Ministry of Jazz")
-    organisation_2 = create(:organisation, name: "Free Jazz Foundation")
-    edition = create(:published_news_article, organisations: [organisation_1, organisation_2])
+    organisation1 = create(:organisation, name: "Ministry of Jazz")
+    organisation2 = create(:organisation, name: "Free Jazz Foundation")
+    edition = create(:published_news_article, organisations: [organisation1, organisation2])
 
     assert_equal %w[ministry-of-jazz free-jazz-foundation], edition.search_index["organisations"]
   end

--- a/test/unit/edition/validation_test.rb
+++ b/test/unit/edition/validation_test.rb
@@ -63,135 +63,135 @@ class Edition::ValidationTest < ActiveSupport::TestCase
   end
 
   test "should be invalid when it duplicates lead organisations on create" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = build(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1, organisation_1],
+      lead_organisations: [organisation1, organisation1],
     )
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates lead organisations on save" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
+      lead_organisations: [organisation1],
     )
-    edition.lead_organisations = [organisation_1, organisation_1]
+    edition.lead_organisations = [organisation1, organisation1]
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates organisations via lead and supporting on create" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = build(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
-      supporting_organisations: [organisation_1],
+      lead_organisations: [organisation1],
+      supporting_organisations: [organisation1],
     )
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates organisations via lead and supporting on save" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
+      lead_organisations: [organisation1],
     )
-    edition.lead_organisations = [organisation_1]
-    edition.supporting_organisations = [organisation_1]
+    edition.lead_organisations = [organisation1]
+    edition.supporting_organisations = [organisation1]
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates organisations via edition organisations directly on create" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = build(
       :publication,
       create_default_organisation: false,
-      edition_organisations: [build(:edition_organisation, organisation: organisation_1, lead: true),
-                              build(:edition_organisation, organisation: organisation_1, lead: false)],
+      edition_organisations: [build(:edition_organisation, organisation: organisation1, lead: true),
+                              build(:edition_organisation, organisation: organisation1, lead: false)],
     )
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates organisations via edition organisations directly on save" do
-    organisation_1 = create(:organisation)
+    organisation1 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      edition_organisations: [build(:edition_organisation, organisation: organisation_1, lead: true)],
+      edition_organisations: [build(:edition_organisation, organisation: organisation1, lead: true)],
     )
-    edition.edition_organisations.build(organisation: organisation_1, lead: false)
+    edition.edition_organisations.build(organisation: organisation1, lead: false)
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates support organisations on create" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = build(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
-      supporting_organisations: [organisation_2, organisation_2],
+      lead_organisations: [organisation1],
+      supporting_organisations: [organisation2, organisation2],
     )
     assert_not edition.valid?
   end
 
   test "should be invalid when it duplicates support organisations on save" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
-      supporting_organisations: [organisation_2],
+      lead_organisations: [organisation1],
+      supporting_organisations: [organisation2],
     )
-    edition.supporting_organisations = [organisation_2, organisation_2]
+    edition.supporting_organisations = [organisation2, organisation2]
     assert_not edition.valid?
   end
 
   test "should be valid when it swaps a lead and support organisation on save" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1],
-      supporting_organisations: [organisation_2],
+      lead_organisations: [organisation1],
+      supporting_organisations: [organisation2],
     )
-    edition.lead_organisations = [organisation_2]
-    edition.supporting_organisations = [organisation_1]
+    edition.lead_organisations = [organisation2]
+    edition.supporting_organisations = [organisation1]
     assert edition.valid?
   end
 
   test "should be valid when it removes one lead and replaces it with the other on save" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1, organisation_2],
+      lead_organisations: [organisation1, organisation2],
       supporting_organisations: [],
     )
-    edition.lead_organisations = [organisation_2]
+    edition.lead_organisations = [organisation2]
     assert edition.valid?
   end
 
   test "should be valid when it removes a lead to make it supporting, and swaps the other lead's position on save" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
     edition = create(
       :publication,
       create_default_organisation: false,
-      lead_organisations: [organisation_1, organisation_2],
+      lead_organisations: [organisation1, organisation2],
       supporting_organisations: [],
       organisations: [],
     )
-    edition.lead_organisations = [organisation_2]
-    edition.supporting_organisations = [organisation_1]
+    edition.lead_organisations = [organisation2]
+    edition.supporting_organisations = [organisation1]
     assert edition.valid?
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -109,17 +109,17 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.most_recent_change_note,
                "Expected nil, found #{edition.most_recent_change_note}"
 
-    version_2 = edition.create_draft(editor)
-    version_2.change_note = "My new version"
-    force_publish(version_2)
+    version2 = edition.create_draft(editor)
+    version2.change_note = "My new version"
+    force_publish(version2)
 
-    assert_equal "My new version", version_2.most_recent_change_note
+    assert_equal "My new version", version2.most_recent_change_note
 
-    version_3 = version_2.create_draft(editor)
-    version_3.minor_change = true
-    force_publish(version_3)
+    version3 = version2.create_draft(editor)
+    version3.minor_change = true
+    force_publish(version3)
 
-    assert_equal "My new version", version_3.most_recent_change_note
+    assert_equal "My new version", version3.most_recent_change_note
   end
 
   test "can find editions due for publication" do
@@ -158,15 +158,15 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should return a list of editions in an organisation" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
-    draft_edition = create(:draft_publication, organisations: [organisation_1])
-    published_edition = create(:published_publication, organisations: [organisation_1])
-    published_in_second_organisation = create(:published_publication, organisations: [organisation_2])
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
+    draft_edition = create(:draft_publication, organisations: [organisation1])
+    published_edition = create(:published_publication, organisations: [organisation1])
+    published_in_second_organisation = create(:published_publication, organisations: [organisation2])
 
-    assert_equal [draft_edition, published_edition], Publication.in_organisation(organisation_1)
-    assert_equal [published_edition], Publication.published.in_organisation(organisation_1)
-    assert_equal [published_in_second_organisation], Publication.in_organisation(organisation_2)
+    assert_equal [draft_edition, published_edition], Publication.in_organisation(organisation1)
+    assert_equal [published_edition], Publication.published.in_organisation(organisation1)
+    assert_equal [published_in_second_organisation], Publication.in_organisation(organisation2)
   end
 
   test "#first_published_version? is true if published and published_major_version is 1" do
@@ -198,18 +198,18 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "last_author returns user who last edited the edition" do
-    user_1 = create(:departmental_editor)
-    user_2 = create(:user)
+    user1 = create(:departmental_editor)
+    user2 = create(:user)
     edition = nil
-    acting_as(user_2) do
+    acting_as(user2) do
       edition = create(:draft_news_article)
     end
-    assert_equal user_2, edition.last_author, "creating"
+    assert_equal user2, edition.last_author, "creating"
 
-    acting_as(user_1) do
+    acting_as(user1) do
       force_publish(edition)
     end
-    assert_equal user_1, edition.reload.last_author, "publishing"
+    assert_equal user1, edition.reload.last_author, "publishing"
   end
 
   test ".authored_by includes editions created by the given user" do
@@ -539,12 +539,12 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test ".in_reverse_chronological_order works for editions that share the same document and timestamp" do
-    edition_1 = create(:superseded_edition)
-    document  = edition_1.document
-    edition_2 = create(:superseded_edition, document: document)
-    edition_3 = create(:superseded_edition, document: document)
+    edition1 = create(:superseded_edition)
+    document = edition1.document
+    edition2 = create(:superseded_edition, document: document)
+    edition3 = create(:superseded_edition, document: document)
 
-    assert_equal [edition_3, edition_2, edition_1].collect(&:id), Edition.in_reverse_chronological_order.collect(&:id)
+    assert_equal [edition3, edition2, edition1].collect(&:id), Edition.in_reverse_chronological_order.collect(&:id)
   end
 
   test ".published_before returns editions whose first_published_at is before the given date" do
@@ -725,32 +725,32 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "without_editions_of_type allows us to exclude certain subclasses from a result set" do
-    edition_1 = create(:case_study)
-    edition_2 = create(:fatality_notice)
+    edition1 = create(:case_study)
+    edition2 = create(:fatality_notice)
 
     no_case_studies = Edition.without_editions_of_type(CaseStudy)
-    assert no_case_studies.include?(edition_2)
-    assert_not no_case_studies.include?(edition_1)
+    assert no_case_studies.include?(edition2)
+    assert_not no_case_studies.include?(edition1)
   end
 
   test "without_editions_of_type takes multiple classes to exclude" do
-    edition_1 = create(:case_study)
-    edition_2 = create(:fatality_notice)
-    edition_3 = create(:detailed_guide)
+    edition1 = create(:case_study)
+    edition2 = create(:fatality_notice)
+    edition3 = create(:detailed_guide)
 
     no_fatalities_or_guides = Edition.without_editions_of_type(FatalityNotice, DetailedGuide)
-    assert no_fatalities_or_guides.include?(edition_1)
-    assert_not no_fatalities_or_guides.include?(edition_2)
-    assert_not no_fatalities_or_guides.include?(edition_3)
+    assert no_fatalities_or_guides.include?(edition1)
+    assert_not no_fatalities_or_guides.include?(edition2)
+    assert_not no_fatalities_or_guides.include?(edition3)
   end
 
   test "without_editions_of_type doesn't exclude subclasses of the supplied classes" do
-    edition_1 = create(:edition, type: "Announcement")
-    edition_2 = create(:fatality_notice)
+    edition1 = create(:edition, type: "Announcement")
+    edition2 = create(:fatality_notice)
 
     no_editions = Edition.without_editions_of_type(Announcement)
-    assert no_editions.include?(edition_2)
-    assert_not no_editions.include?(edition_1)
+    assert no_editions.include?(edition2)
+    assert_not no_editions.include?(edition1)
   end
 
   should_not_accept_footnotes_in :body

--- a/test/unit/feature_list_test.rb
+++ b/test/unit/feature_list_test.rb
@@ -32,42 +32,42 @@ class FeatureListTest < ActiveSupport::TestCase
     feature_list.features << create(:feature)
     feature_list.features << create(:feature)
 
-    feature_1, feature_2 = feature_list.features
+    feature1, feature2 = feature_list.features
 
     feature_list.reload
-    assert_equal [feature_1, feature_2], feature_list.features
+    assert_equal [feature1, feature2], feature_list.features
 
-    assert feature_list.reorder!([feature_2.id, feature_1.id])
+    assert feature_list.reorder!([feature2.id, feature1.id])
     assert_not feature_list.errors.any?
 
     feature_list.reload
-    assert_equal [feature_2, feature_1], feature_list.features
+    assert_equal [feature2, feature1], feature_list.features
   end
 
   test "validation errors when reordering features are propogated" do
-    feature_1 = create(:feature)
-    feature_list = create(:feature_list, locale: :en, features: [feature_1])
-    feature_1.document = nil
-    feature_1.save!(validate: false)
-    assert_not feature_list.reorder!([feature_1.id])
+    feature1 = create(:feature)
+    feature_list = create(:feature_list, locale: :en, features: [feature1])
+    feature1.document = nil
+    feature1.save!(validate: false)
+    assert_not feature_list.reorder!([feature1.id])
     assert_match %r{Can't reorder because '.*'}, feature_list.errors.full_messages.to_sentence
   end
 
   test "reordering fails if features which are not part of the feature list are referenced when re-ordering" do
-    feature_1 = create(:feature)
-    feature_2 = create(:feature)
-    feature_3 = create(:feature)
+    feature1 = create(:feature)
+    feature2 = create(:feature)
+    feature3 = create(:feature)
 
-    feature_list_1 = create(:feature_list, locale: :en, features: [feature_1, feature_2])
-    _feature_list_2 = create(:feature_list, locale: :fr, features: [feature_3])
+    feature_list1 = create(:feature_list, locale: :en, features: [feature1, feature2])
+    _feature_list2 = create(:feature_list, locale: :fr, features: [feature3])
 
-    assert_not_nil f3_original_ordering = feature_3.ordering
+    assert_not_nil f3_original_ordering = feature3.ordering
 
-    assert_not feature_list_1.reorder!([feature_2.id, feature_3.id, feature_1.id])
-    assert_match %r{Can't reorder because '.*'}, feature_list_1.errors[:base].to_sentence
+    assert_not feature_list1.reorder!([feature2.id, feature3.id, feature1.id])
+    assert_match %r{Can't reorder because '.*'}, feature_list1.errors[:base].to_sentence
 
-    assert_equal f3_original_ordering, feature_3.reload.ordering
-    assert_equal [feature_1, feature_2], feature_list_1.reload.features
+    assert_equal f3_original_ordering, feature3.reload.ordering
+    assert_equal [feature1, feature2], feature_list1.reload.features
   end
 
   test "#features should still return featured documents after republication" do

--- a/test/unit/govspeak/contacts_extractor_test.rb
+++ b/test/unit/govspeak/contacts_extractor_test.rb
@@ -2,25 +2,25 @@ require "test_helper"
 
 class ContactsExtractorTest < ActiveSupport::TestCase
   test "can collect all the embedded contacts into a list of Contacts in order" do
-    contact_1 = build(:contact)
-    contact_2 = build(:contact)
-    Contact.stubs(:find_by).with(id: "1").returns(contact_1)
-    Contact.stubs(:find_by).with(id: "2").returns(contact_2)
+    contact1 = build(:contact)
+    contact2 = build(:contact)
+    Contact.stubs(:find_by).with(id: "1").returns(contact1)
+    Contact.stubs(:find_by).with(id: "2").returns(contact2)
 
     input = "We have an office at [Contact:2] but deliveries go to [Contact:1]"
 
     embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
-    assert_equal [contact_2, contact_1], embedded_contacts
+    assert_equal [contact2, contact1], embedded_contacts
   end
 
   test "will remove duplicate contacts" do
-    contact_1 = build(:contact)
-    Contact.stubs(:find_by).with(id: "1").returns(contact_1)
+    contact1 = build(:contact)
+    Contact.stubs(:find_by).with(id: "1").returns(contact1)
 
     input = "Our office at [Contact:1] is brilliant, you should come for a cup of tea. Remeber the address is [Contact:1]"
 
     embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
-    assert_equal [contact_1], embedded_contacts
+    assert_equal [contact1], embedded_contacts
   end
 
   test "will silently remove contact references that do not resolve to a Contact" do

--- a/test/unit/helpers/admin/cabinet_ministers_helper_test.rb
+++ b/test/unit/helpers/admin/cabinet_ministers_helper_test.rb
@@ -2,15 +2,15 @@ require "test_helper"
 
 class Admin::CabinetMinistersHelperTest < ActionView::TestCase
   test "#organisation_ordering_fields returns input for org" do
-    org_1 = build(:organisation, id: 1, ministerial_ordering: 1, name: "first org")
-    org_2 = build(:organisation, id: 2, ministerial_ordering: 2, name: "second org")
+    org1 = build(:organisation, id: 1, ministerial_ordering: 1, name: "first org")
+    org2 = build(:organisation, id: 2, ministerial_ordering: 2, name: "second org")
 
-    html = organisation_ordering_fields([org_1, org_2])
+    html = organisation_ordering_fields([org1, org2])
 
-    assert_select_within_html(html, "div label[for='organisation_#{org_1.id}_ordering']", text: "first org")
-    assert_select_within_html(html, "div label[for='organisation_#{org_2.id}_ordering']", text: "second org")
+    assert_select_within_html(html, "div label[for='organisation_#{org1.id}_ordering']", text: "first org")
+    assert_select_within_html(html, "div label[for='organisation_#{org2.id}_ordering']", text: "second org")
 
-    assert_select_within_html(html, "div input[name='organisation[#{org_1.id}][ordering]']", value: "1")
-    assert_select_within_html(html, "div input[name='organisation[#{org_2.id}][ordering]']", value: "2")
+    assert_select_within_html(html, "div input[name='organisation[#{org1.id}][ordering]']", value: "1")
+    assert_select_within_html(html, "div input[name='organisation[#{org2.id}][ordering]']", value: "2")
   end
 end

--- a/test/unit/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/helpers/admin/taggable_content_helper_test.rb
@@ -136,14 +136,14 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
   end
 
   test "#taggable_statistical_data_sets_container returns an array of label/Document ID pairs for all statistical data sets" do
-    data_set_1 = create(:draft_statistical_data_set)
-    data_set_2 = create(:published_statistical_data_set)
-    data_set_3 = create(:submitted_statistical_data_set)
+    data_set1 = create(:draft_statistical_data_set)
+    data_set2 = create(:published_statistical_data_set)
+    data_set3 = create(:submitted_statistical_data_set)
 
     assert_equal [
-      [data_set_1.title, data_set_1.document_id],
-      [data_set_2.title, data_set_2.document_id],
-      [data_set_3.title, data_set_3.document_id],
+      [data_set1.title, data_set1.document_id],
+      [data_set2.title, data_set2.document_id],
+      [data_set3.title, data_set3.document_id],
     ],
                  taggable_statistical_data_sets_container
   end
@@ -176,40 +176,40 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
   end
 
   test "#taggable_document_collection_groups_container returns an array of label/ID pairs for document collection groups" do
-    group_1 = create(:document_collection_group, heading: "Group 1")
-    group_2 = create(:document_collection_group, heading: "Group 2")
-    group_3 = create(:document_collection_group, heading: "Group 3")
-    create(:document_collection, title: "Collection 1", groups: [group_1])
-    create(:document_collection, title: "Collection 2", groups: [group_2, group_3])
+    group1 = create(:document_collection_group, heading: "Group 1")
+    group2 = create(:document_collection_group, heading: "Group 2")
+    group3 = create(:document_collection_group, heading: "Group 3")
+    create(:document_collection, title: "Collection 1", groups: [group1])
+    create(:document_collection, title: "Collection 2", groups: [group2, group3])
 
     assert_equal [
-      ["Collection 1 (Group 1)", group_1.id],
-      ["Collection 2 (Group 2)", group_2.id],
-      ["Collection 2 (Group 3)", group_3.id],
+      ["Collection 1 (Group 1)", group1.id],
+      ["Collection 2 (Group 2)", group2.id],
+      ["Collection 2 (Group 3)", group3.id],
     ],
                  taggable_document_collection_groups_container
   end
 
   test "#taggable_worldwide_organisations_container returns an array of label/ID pairs for worldwide organisations" do
-    world_org_1 = create(:worldwide_organisation, name: "World Org 1")
-    world_org_2 = create(:worldwide_organisation, name: "World Org 2")
-    world_org_3 = create(:worldwide_organisation, name: "World Org 3")
+    world_org1 = create(:worldwide_organisation, name: "World Org 1")
+    world_org2 = create(:worldwide_organisation, name: "World Org 2")
+    world_org3 = create(:worldwide_organisation, name: "World Org 3")
 
     assert_equal [
-      ["World Org 1", world_org_1.id],
-      ["World Org 2", world_org_2.id],
-      ["World Org 3", world_org_3.id],
+      ["World Org 1", world_org1.id],
+      ["World Org 2", world_org2.id],
+      ["World Org 3", world_org3.id],
     ],
                  taggable_worldwide_organisations_container
   end
 
   test "#taggable_worldwide_organisations_container only returns worldwide organisations once even if they have more than one translation" do
-    world_org_1 = create(:worldwide_organisation, name: "World Org 1", translated_into: %i[fr es])
-    world_org_2 = create(:worldwide_organisation, name: "World Org 2")
+    world_org1 = create(:worldwide_organisation, name: "World Org 1", translated_into: %i[fr es])
+    world_org2 = create(:worldwide_organisation, name: "World Org 2")
 
     assert_equal [
-      ["World Org 1", world_org_1.id],
-      ["World Org 2", world_org_2.id],
+      ["World Org 1", world_org1.id],
+      ["World Org 2", world_org2.id],
     ],
                  taggable_worldwide_organisations_container
   end

--- a/test/unit/helpers/feed_helper_test.rb
+++ b/test/unit/helpers/feed_helper_test.rb
@@ -20,27 +20,27 @@ class FeedHelperTest < ActionView::TestCase
   end
 
   test "documents_as_feed_entries exposes each document as an entry and calls document_as_feed_entry on it" do
-    document_1 = Publication.new
-    document_1.stubs(:id).returns(12)
-    document_1.stubs(:first_public_at).returns(1.week.ago)
-    document_1.stubs(:public_timestamp).returns(3.days.ago)
-    document_2 = NewsArticle.new
-    document_2.stubs(:id).returns(14)
-    document_2.stubs(:first_public_at).returns(2.weeks.ago)
-    document_2.stubs(:public_timestamp).returns(13.days.ago)
+    document1 = Publication.new
+    document1.stubs(:id).returns(12)
+    document1.stubs(:first_public_at).returns(1.week.ago)
+    document1.stubs(:public_timestamp).returns(3.days.ago)
+    document2 = NewsArticle.new
+    document2.stubs(:id).returns(14)
+    document2.stubs(:first_public_at).returns(2.weeks.ago)
+    document2.stubs(:public_timestamp).returns(13.days.ago)
     builder = mock("builder")
     entries = sequence("entries")
     builder.stubs(:updated)
-    builder.expects(:entry).with(document_2, id: "tag:#{host},2005:NewsArticle/14", url: "/news_article_url", published: 2.weeks.ago, updated: 13.days.ago).yields(builder).in_sequence(entries)
-    builder.expects(:entry).with(document_1, id: "tag:#{host},2005:Publication/12", url: "/publication_url", published: 1.week.ago, updated: 3.days.ago).yields(builder).in_sequence(entries)
+    builder.expects(:entry).with(document2, id: "tag:#{host},2005:NewsArticle/14", url: "/news_article_url", published: 2.weeks.ago, updated: 13.days.ago).yields(builder).in_sequence(entries)
+    builder.expects(:entry).with(document1, id: "tag:#{host},2005:Publication/12", url: "/publication_url", published: 1.week.ago, updated: 3.days.ago).yields(builder).in_sequence(entries)
     feed_entry = sequence("feed_entry")
-    expects(:document_as_feed_entry).with(document_2, builder).in_sequence(feed_entry)
-    expects(:document_as_feed_entry).with(document_1, builder).in_sequence(feed_entry)
+    expects(:document_as_feed_entry).with(document2, builder).in_sequence(feed_entry)
+    expects(:document_as_feed_entry).with(document1, builder).in_sequence(feed_entry)
 
-    stubs(:public_document_url).with(document_2).returns "/news_article_url"
-    stubs(:public_document_url).with(document_1).returns "/publication_url"
+    stubs(:public_document_url).with(document2).returns "/news_article_url"
+    stubs(:public_document_url).with(document1).returns "/publication_url"
 
-    documents_as_feed_entries([document_2, document_1], builder)
+    documents_as_feed_entries([document2, document1], builder)
   end
 
   test "documents_as_feed_entries sets the updated of the builder to the supplied feed_updated_timestamp if no documents are present" do

--- a/test/unit/helpers/filter_helper_test.rb
+++ b/test/unit/helpers/filter_helper_test.rb
@@ -4,19 +4,19 @@ class FilterHelperTest < ActionView::TestCase
   include TaxonomyHelper
 
   test "#organisation_options_for_statistics_announcement_filter renders select options for all organisations with an associated release announcement in alphabetical order selecting passed in organisation" do
-    _org_1 = create(:organisation, name: "B org")
-    org_2 = create(:organisation, name: "C org")
-    org_3 = create(:organisation, name: "A org")
+    _org1 = create(:organisation, name: "B org")
+    org2 = create(:organisation, name: "C org")
+    org3 = create(:organisation, name: "A org")
 
-    create :statistics_announcement, organisation_ids: [org_2.id]
-    create :statistics_announcement, organisation_ids: [org_3.id]
+    create :statistics_announcement, organisation_ids: [org2.id]
+    create :statistics_announcement, organisation_ids: [org3.id]
 
-    rendered = Nokogiri::HTML::DocumentFragment.parse(organisation_options_for_statistics_announcement_filter(org_3.slug))
+    rendered = Nokogiri::HTML::DocumentFragment.parse(organisation_options_for_statistics_announcement_filter(org3.slug))
     options = rendered.css("option")
     option_values = options.map { |option| option[:value] }
 
-    assert_equal ["All departments", org_3.name, org_2.name], options.map(&:text)
-    assert_equal ["", org_3.slug, org_2.slug], option_values
+    assert_equal ["All departments", org3.name, org2.name], options.map(&:text)
+    assert_equal ["", org3.slug, org2.slug], option_values
     assert options[1][:selected]
   end
 

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -262,13 +262,13 @@ class GovspeakHelperTest < ActionView::TestCase
       :with_file_attachment,
       body: text,
       attachments: [
-        attachment_1 = build(:file_attachment, id: 1),
-        attachment_2 = build(:file_attachment, id: 2),
+        attachment1 = build(:file_attachment, id: 1),
+        attachment2 = build(:file_attachment, id: 2),
       ],
     )
     html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "#attachment_#{attachment_1.id}"
-    assert_select_within_html html, "#attachment_#{attachment_2.id}"
+    assert_select_within_html html, "#attachment_#{attachment1.id}"
+    assert_select_within_html html, "#attachment_#{attachment2.id}"
   end
 
   test "should convert multiple inline attachments" do
@@ -278,13 +278,13 @@ class GovspeakHelperTest < ActionView::TestCase
       :with_file_attachment,
       body: text,
       attachments: [
-        attachment_1 = build(:file_attachment, id: 1),
-        attachment_2 = build(:file_attachment, id: 2),
+        attachment1 = build(:file_attachment, id: 1),
+        attachment2 = build(:file_attachment, id: 2),
       ],
     )
     html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "#attachment_#{attachment_1.id}"
-    assert_select_within_html html, "#attachment_#{attachment_2.id}"
+    assert_select_within_html html, "#attachment_#{attachment1.id}"
+    assert_select_within_html html, "#attachment_#{attachment2.id}"
   end
 
   test "should not escape embedded attachment when attachment embed code only separated by one newline from a previous paragraph" do
@@ -324,17 +324,17 @@ class GovspeakHelperTest < ActionView::TestCase
 
   test "adds sub-numbers to h3 tags" do
     input = "## first\n\n### first point one\n\n### first point two\n\n## second\n\n### second point one"
-    expected_output_1 = '<h2 id="first"> <span class="number">1. </span>first</h2>'
-    expected_output_1_1 = '<h3 id="first-point-one"> <span class="number">1.1 </span>first point one</h3>'
-    expected_output_1_2 = '<h3 id="first-point-two"> <span class="number">1.2 </span>first point two</h3>'
-    expected_output_2 = '<h2 id="second"> <span class="number">2. </span>second</h2>'
-    expected_output_2_1 = '<h3 id="second-point-one"> <span class="number">2.1 </span>second point one</h3>'
+    expected_output1 = '<h2 id="first"> <span class="number">1. </span>first</h2>'
+    expected_output_1a = '<h3 id="first-point-one"> <span class="number">1.1 </span>first point one</h3>'
+    expected_output_1b = '<h3 id="first-point-two"> <span class="number">1.2 </span>first point two</h3>'
+    expected_output2 = '<h2 id="second"> <span class="number">2. </span>second</h2>'
+    expected_output_2a = '<h3 id="second-point-one"> <span class="number">2.1 </span>second point one</h3>'
     actual_output = govspeak_to_html(input, [], heading_numbering: :auto).gsub(/\s+/, " ")
-    assert_match %r{#{expected_output_1}}, actual_output
-    assert_match %r{#{expected_output_1_1}}, actual_output
-    assert_match %r{#{expected_output_1_2}}, actual_output
-    assert_match %r{#{expected_output_2}}, actual_output
-    assert_match %r{#{expected_output_2_1}}, actual_output
+    assert_match %r{#{expected_output1}}, actual_output
+    assert_match %r{#{expected_output_1a}}, actual_output
+    assert_match %r{#{expected_output_1b}}, actual_output
+    assert_match %r{#{expected_output2}}, actual_output
+    assert_match %r{#{expected_output_2a}}, actual_output
   end
 
   test "adds manual numbering to heading tags" do

--- a/test/unit/helpers/historic_appointments_helper_test.rb
+++ b/test/unit/helpers/historic_appointments_helper_test.rb
@@ -16,8 +16,8 @@ class HistoricAppointmentsHelperTest < ActionView::TestCase
   end
 
   test "#previous_dates_in_office returns comma separated year ranges when the person has been appointed to that role multiple times" do
-    role_appointment_1 = create(:role_appointment, started_at: Time.zone.parse("2001-01-01 00:00:00"), ended_at: Time.zone.parse("2005-01-01 00:00:00"))
-    _role_appointment_2 = create(:role_appointment, role: role_appointment_1.role, person: role_appointment_1.person, started_at: Time.zone.parse("2008-01-01 00:00:00"), ended_at: Time.zone.parse("2011-01-01 00:00:00"))
-    assert_equal "2008 to 2011, 2001 to 2005", previous_dates_in_office(role_appointment_1.role, role_appointment_1.person)
+    role_appointment1 = create(:role_appointment, started_at: Time.zone.parse("2001-01-01 00:00:00"), ended_at: Time.zone.parse("2005-01-01 00:00:00"))
+    _role_appointment2 = create(:role_appointment, role: role_appointment1.role, person: role_appointment1.person, started_at: Time.zone.parse("2008-01-01 00:00:00"), ended_at: Time.zone.parse("2011-01-01 00:00:00"))
+    assert_equal "2008 to 2011, 2001 to 2005", previous_dates_in_office(role_appointment1.role, role_appointment1.person)
   end
 end

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -106,18 +106,18 @@ class OrganisationHelperTest < ActionView::TestCase
   end
 
   test "#organisation_govuk_status_description describes an organisation that has been split" do
-    superseding_organisation_1 = create(:organisation, name: "Superseding organisation 1")
-    superseding_organisation_2 = create(:organisation, name: "Superseding organisation 2")
-    organisation = build(:organisation, name: "Beard Ministry", govuk_status: "closed", govuk_closed_status: "split", superseding_organisations: [superseding_organisation_1, superseding_organisation_2])
+    superseding_organisation1 = create(:organisation, name: "Superseding organisation 1")
+    superseding_organisation2 = create(:organisation, name: "Superseding organisation 2")
+    organisation = build(:organisation, name: "Beard Ministry", govuk_status: "closed", govuk_closed_status: "split", superseding_organisations: [superseding_organisation1, superseding_organisation2])
 
     assert_equal "Beard Ministry was replaced by <a href=\"/government/organisations/superseding-organisation-1\">Superseding organisation 1</a> and <a href=\"/government/organisations/superseding-organisation-2\">Superseding organisation 2</a>", organisation_govuk_status_description(organisation)
   end
 
   test "#organisation_govuk_status_description for an organisation that has been split includes the closed date if available" do
-    superseding_organisation_1 = create(:organisation, name: "Superseding organisation 1")
-    superseding_organisation_2 = create(:organisation, name: "Superseding organisation 2")
+    superseding_organisation1 = create(:organisation, name: "Superseding organisation 1")
+    superseding_organisation2 = create(:organisation, name: "Superseding organisation 2")
     closed_time = 1.day.ago
-    organisation = build(:organisation, name: "Beard Ministry", govuk_status: "closed", closed_at: closed_time, govuk_closed_status: "split", superseding_organisations: [superseding_organisation_1, superseding_organisation_2])
+    organisation = build(:organisation, name: "Beard Ministry", govuk_status: "closed", closed_at: closed_time, govuk_closed_status: "split", superseding_organisations: [superseding_organisation1, superseding_organisation2])
 
     assert_equal "Beard Ministry was replaced by <a href=\"/government/organisations/superseding-organisation-1\">Superseding organisation 1</a> and <a href=\"/government/organisations/superseding-organisation-2\">Superseding organisation 2</a> in November 2011",
                  organisation_govuk_status_description(organisation)
@@ -343,12 +343,12 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test "multiple parent organisations reflected as in copy" do
-    parent_1 = create(:organisation)
-    parent_2 = create(:organisation)
-    child = create(:organisation, parent_organisations: [parent_1, parent_2])
+    parent1 = create(:organisation)
+    parent2 = create(:organisation)
+    child = create(:organisation, parent_organisations: [parent1, parent2])
     result = organisation_display_name_and_parental_relationship(child)
-    assert_match parent_1.name, result
-    assert_match parent_2.name, result
+    assert_match parent1.name, result
+    assert_match parent2.name, result
   end
 
   test "single child organisation reflected as in copy" do
@@ -359,9 +359,9 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test "multiple child organisations reflected as in copy" do
-    child_1 = create(:organisation)
-    child_2 = create(:organisation)
-    parent = create(:ministerial_department, acronym: "PAN", name: "Parent Organisation Name", child_organisations: [child_1, child_2])
+    child1 = create(:organisation)
+    child2 = create(:organisation)
+    parent = create(:ministerial_department, acronym: "PAN", name: "Parent Organisation Name", child_organisations: [child1, child2])
     description = organisation_display_name_including_parental_and_child_relationships(parent)
     assert description.include? "2 agencies and public bodies"
   end

--- a/test/unit/historical_account_test.rb
+++ b/test/unit/historical_account_test.rb
@@ -66,11 +66,11 @@ class HistoricalAccountTest < ActiveSupport::TestCase
   end
 
   test "#role defaults to the first role when there are multiple" do
-    role_1 = create(:historic_role)
-    role_2 = create(:historic_role)
-    historical_account = create(:historical_account, roles: [role_1, role_2])
+    role1 = create(:historic_role)
+    role2 = create(:historic_role)
+    historical_account = create(:historical_account, roles: [role1, role2])
 
-    assert_equal role_1, historical_account.role
+    assert_equal role1, historical_account.role
   end
 
   should_not_accept_footnotes_in(:body)

--- a/test/unit/home_page_list_test.rb
+++ b/test/unit/home_page_list_test.rb
@@ -22,50 +22,50 @@ class HomePageListTest < ActiveSupport::TestCase
 
   test "is invalid if the owner already has a list with that name" do
     o = create(:organisation)
-    _list_1 = create(:home_page_list, owner: o, name: "contacts")
-    list_2 = build(:home_page_list, owner: o, name: "contacts")
-    assert_not list_2.valid?
+    _list1 = create(:home_page_list, owner: o, name: "contacts")
+    list2 = build(:home_page_list, owner: o, name: "contacts")
+    assert_not list2.valid?
   end
 
   test "adding a something to the list ensures it is added to the end of the list" do
     list = build(:home_page_list)
-    item_1 = build(:home_page_list_item, home_page_list: list, ordering: nil)
-    list.home_page_list_items << item_1
-    assert_not item_1.ordering.nil?
-    item_2 = build(:home_page_list_item, home_page_list: list, ordering: nil)
-    list.home_page_list_items << item_2
-    assert_not item_2.ordering.nil?
-    assert item_1.ordering < item_2.ordering
+    item1 = build(:home_page_list_item, home_page_list: list, ordering: nil)
+    list.home_page_list_items << item1
+    assert_not item1.ordering.nil?
+    item2 = build(:home_page_list_item, home_page_list: list, ordering: nil)
+    list.home_page_list_items << item2
+    assert_not item2.ordering.nil?
+    assert item1.ordering < item2.ordering
   end
 
   test "adding something that already has an ordering to the list doesn't change it" do
     list = build(:home_page_list)
-    item_1 = build(:home_page_list_item, home_page_list: list, ordering: 12)
-    list.home_page_list_items << item_1
-    assert_equal 12, item_1.ordering
+    item1 = build(:home_page_list_item, home_page_list: list, ordering: 12)
+    list.home_page_list_items << item1
+    assert_equal 12, item1.ordering
   end
 
   test "exposes all the items in the home_page_list_items in order" do
     o = create(:organisation)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    contact_3 = create(:contact)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    contact3 = create(:contact)
     list = create(:home_page_list, owner: o, name: "contacts")
-    list.home_page_list_items << build(:home_page_list_item, item: contact_2)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_3)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_1)
+    list.home_page_list_items << build(:home_page_list_item, item: contact2)
+    list.home_page_list_items << build(:home_page_list_item, item: contact3)
+    list.home_page_list_items << build(:home_page_list_item, item: contact1)
 
-    assert_equal [contact_2, contact_3, contact_1], list.items
+    assert_equal [contact2, contact3, contact1], list.items
   end
 
   test "#shown_on_home_page? tells us if a given thing is in the list or not" do
     list = create(:home_page_list)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_1)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    list.home_page_list_items << build(:home_page_list_item, item: contact1)
 
-    assert list.shown_on_home_page?(contact_1)
-    assert_not list.shown_on_home_page?(contact_2)
+    assert list.shown_on_home_page?(contact1)
+    assert_not list.shown_on_home_page?(contact2)
   end
 
   test "#add_item will put the supplied item onto the list" do
@@ -117,15 +117,15 @@ class HomePageListTest < ActiveSupport::TestCase
   end
 
   test ".get will return the list for the supplied owned_by: and called: params" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
 
-    create(:home_page_list, owner: organisation_1, name: "donkeys")
-    create(:home_page_list, owner: organisation_2, name: "cats")
+    create(:home_page_list, owner: organisation1, name: "donkeys")
+    create(:home_page_list, owner: organisation2, name: "cats")
 
-    list = create(:home_page_list, owner: organisation_1, name: "cats")
+    list = create(:home_page_list, owner: organisation1, name: "cats")
 
-    assert_equal list, HomePageList.get(owned_by: organisation_1, called: "cats")
+    assert_equal list, HomePageList.get(owned_by: organisation1, called: "cats")
   end
 
   test ".get will build a new list for the supplied owned_by: and called: params if one does not exist already" do
@@ -152,43 +152,43 @@ class HomePageListTest < ActiveSupport::TestCase
 
   test "#reorder_items! takes a list of items and reorders the existing list" do
     list = create(:home_page_list)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    contact_3 = create(:contact)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_1)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_2)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_3)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    contact3 = create(:contact)
+    list.home_page_list_items << build(:home_page_list_item, item: contact1)
+    list.home_page_list_items << build(:home_page_list_item, item: contact2)
+    list.home_page_list_items << build(:home_page_list_item, item: contact3)
 
-    list.reorder_items!([contact_2, contact_3, contact_1])
+    list.reorder_items!([contact2, contact3, contact1])
 
-    assert_equal [contact_2, contact_3, contact_1], list.reload.items
+    assert_equal [contact2, contact3, contact1], list.reload.items
   end
 
   test "#reorder_items! puts any existing items not mentioned in the new ordering at the end of the list" do
     list = create(:home_page_list)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    contact_3 = create(:contact)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_1)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_2)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_3)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    contact3 = create(:contact)
+    list.home_page_list_items << build(:home_page_list_item, item: contact1)
+    list.home_page_list_items << build(:home_page_list_item, item: contact2)
+    list.home_page_list_items << build(:home_page_list_item, item: contact3)
 
-    list.reorder_items!([contact_2, contact_3])
+    list.reorder_items!([contact2, contact3])
 
-    assert_equal [contact_2, contact_3, contact_1], list.reload.items
+    assert_equal [contact2, contact3, contact1], list.reload.items
   end
 
   test "#reorder_items! ignores any items not already in the list" do
     list = create(:home_page_list)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    contact_3 = create(:contact)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_1)
-    list.home_page_list_items << build(:home_page_list_item, item: contact_3)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    contact3 = create(:contact)
+    list.home_page_list_items << build(:home_page_list_item, item: contact1)
+    list.home_page_list_items << build(:home_page_list_item, item: contact3)
 
-    list.reorder_items!([contact_2, contact_3, contact_1])
+    list.reorder_items!([contact2, contact3, contact1])
 
-    assert_equal [contact_3, contact_1], list.reload.items
+    assert_equal [contact3, contact1], list.reload.items
   end
 
   test "#reorder_items! will persist the list" do
@@ -200,21 +200,21 @@ class HomePageListTest < ActiveSupport::TestCase
   end
 
   test ".remove_from_all_lists destroys all list items for the supplied content" do
-    list_1 = create(:home_page_list, name: "contacts")
-    list_2 = create(:home_page_list, name: "press_offices")
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
-    list_1.add_item(contact_1)
-    list_1.add_item(contact_2)
-    list_2.add_item(contact_1)
+    list1 = create(:home_page_list, name: "contacts")
+    list2 = create(:home_page_list, name: "press_offices")
+    contact1 = create(:contact)
+    contact2 = create(:contact)
+    list1.add_item(contact1)
+    list1.add_item(contact2)
+    list2.add_item(contact1)
 
-    HomePageList.remove_from_all_lists(contact_1)
+    HomePageList.remove_from_all_lists(contact1)
 
     # removes from all lists it's on
-    assert_not list_1.shown_on_home_page?(contact_1)
-    assert_not list_2.shown_on_home_page?(contact_1)
+    assert_not list1.shown_on_home_page?(contact1)
+    assert_not list2.shown_on_home_page?(contact1)
 
     # doesn't remove other items
-    assert list_1.shown_on_home_page?(contact_2)
+    assert list1.shown_on_home_page?(contact2)
   end
 end

--- a/test/unit/minister_sorter_test.rb
+++ b/test/unit/minister_sorter_test.rb
@@ -31,16 +31,16 @@ class MinisterSorterTest < ActiveSupport::TestCase
     c = person("c")
     d = person("d")
 
-    role_0 = role("r0", 0, true, [d])
-    role_1 = role("r1", 0, false, [c])
-    role_2 = role("r2", 0, true, [a, b])
+    role0 = role("r0", 0, true, [d])
+    role1 = role("r1", 0, false, [c])
+    role2 = role("r2", 0, true, [a, b])
 
-    roles = [role_0, role_1, role_2]
+    roles = [role0, role1, role2]
 
     expected = [
-      [a, [role_2]],
-      [b, [role_2]],
-      [d, [role_0]],
+      [a, [role2]],
+      [b, [role2]],
+      [d, [role0]],
     ]
 
     set = MinisterSorter.new(roles)
@@ -49,13 +49,13 @@ class MinisterSorterTest < ActiveSupport::TestCase
 
   def test_should_list_all_cabinet_ministers_roles_including_non_cabinet_roles_in_seniority_order
     roles = [
-      role_0 = role("r0", 2, false, [a = person("a")]),
-      role_1 = role("r1", 1, true, [a]),
-      role_2 = role("r2", 3, false, [a]),
+      role0 = role("r0", 2, false, [a = person("a")]),
+      role1 = role("r1", 1, true, [a]),
+      role2 = role("r2", 3, false, [a]),
     ]
 
     expected = [
-      [a, [role_1, role_0, role_2]],
+      [a, [role1, role0, role2]],
     ]
 
     set = MinisterSorter.new(roles)
@@ -67,15 +67,15 @@ class MinisterSorterTest < ActiveSupport::TestCase
     b = person("b")
     c = person("c")
 
-    role_0 = role("r0", 0, false, [c, b])
-    role_1 = role("r1", 0, true, [c])
-    role_2 = role("r2", 0, false, [a])
+    role0 = role("r0", 0, false, [c, b])
+    role1 = role("r1", 0, true, [c])
+    role2 = role("r2", 0, false, [a])
 
-    roles = [role_0, role_1, role_2]
+    roles = [role0, role1, role2]
 
     expected = [
-      [a, [role_2]],
-      [b, [role_0]],
+      [a, [role2]],
+      [b, [role0]],
     ]
 
     set = MinisterSorter.new(roles)

--- a/test/unit/ministerial_role_test.rb
+++ b/test/unit/ministerial_role_test.rb
@@ -28,9 +28,9 @@ class MinisterialRoleTest < ActiveSupport::TestCase
 
   test "should only ever get a news article once" do
     ministerial_role = create(:ministerial_role)
-    appointment_1 = create(:role_appointment, role: ministerial_role, started_at: 2.days.ago, ended_at: 1.day.ago)
-    appointment_2 = create(:role_appointment, role: ministerial_role)
-    editions = [create(:published_news_article, role_appointments: [appointment_1, appointment_2])]
+    appointment1 = create(:role_appointment, role: ministerial_role, started_at: 2.days.ago, ended_at: 1.day.ago)
+    appointment2 = create(:role_appointment, role: ministerial_role)
+    editions = [create(:published_news_article, role_appointments: [appointment1, appointment2])]
     assert_equal editions, ministerial_role.news_articles
   end
 

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -12,22 +12,22 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
         membership's ordering to the position of the membership id in the passed in array" do
     group = build(:document_collection_group)
 
-    membership_1 = create(:document_collection_group_membership)
-    membership_2 = create(:document_collection_group_membership)
-    membership_3 = create(:document_collection_group_membership)
+    membership1 = create(:document_collection_group_membership)
+    membership2 = create(:document_collection_group_membership)
+    membership3 = create(:document_collection_group_membership)
 
-    group.memberships << membership_1
-    group.memberships << membership_2
-    group.memberships << membership_3
+    group.memberships << membership1
+    group.memberships << membership2
+    group.memberships << membership3
 
-    group.set_membership_ids_in_order! [membership_3.id, membership_1.id]
+    group.set_membership_ids_in_order! [membership3.id, membership1.id]
 
-    assert group.memberships.include? membership_1
-    assert group.memberships.include? membership_3
-    assert_not group.memberships.include? membership_2
+    assert group.memberships.include? membership1
+    assert group.memberships.include? membership3
+    assert_not group.memberships.include? membership2
 
-    assert_equal 0, group.memberships.find(membership_3.id).ordering
-    assert_equal 1, group.memberships.find(membership_1.id).ordering
+    assert_equal 0, group.memberships.find(membership3.id).ordering
+    assert_equal 1, group.memberships.find(membership1.id).ordering
   end
 
   test "#dup should also clone document memberships" do

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -29,8 +29,8 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
   end
 
   test "organisations= parses slugs into real organisations" do
-    org_1, org_2 = 2.times.map { create(:organisation) }
-    assert_equal [org_1, org_2], build_class_instance(organisations: [org_1.slug, org_2.slug]).organisations
+    org1, org2 = 2.times.map { create(:organisation) }
+    assert_equal [org1, org2], build_class_instance(organisations: [org1.slug, org2.slug]).organisations
   end
 
   test "organisations= handles nil" do
@@ -43,13 +43,13 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
   end
 
   test "topics= parses content_ids into real topics" do
-    topic_1, topic_2 = 2.times.map { build(:taxon_hash) }
-    redis_cache_has_taxons([topic_1, topic_2])
+    topic1, topic2 = 2.times.map { build(:taxon_hash) }
+    redis_cache_has_taxons([topic1, topic2])
 
-    topics = build_class_instance(topics: [topic_1["content_id"], topic_2["content_id"]]).topics
+    topics = build_class_instance(topics: [topic1["content_id"], topic2["content_id"]]).topics
 
     assert_equal([true, true], (topics.map { |topic| topic.is_a?(Taxonomy::Taxon) }))
-    assert_equal topics.map(&:name), [topic_1["title"], topic_2["title"]]
+    assert_equal topics.map(&:name), [topic1["title"], topic2["title"]]
   end
 
   test "topic_ids returns topic ids" do

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -131,26 +131,26 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
   end
 
   test "supporting_bodies should exclude closed orgs, sub orgs, and courts and tribunals and be in alphabetical order" do
-    parent_org_1 = create(:organisation)
-    _parent_org_2 = create(:organisation)
-    child_org_1 = create(:organisation, parent_organisations: [parent_org_1], name: "b second")
-    _child_org_2 = create(:sub_organisation, parent_organisations: [parent_org_1])
-    child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
-    _child_org_4 = create(:closed_organisation, parent_organisations: [parent_org_1])
-    _child_org_5 = create(:court, parent_organisations: [parent_org_1])
-    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal)
+    parent_org1 = create(:organisation)
+    _parent_org2 = create(:organisation)
+    child_org1 = create(:organisation, parent_organisations: [parent_org1], name: "b second")
+    _child_org2 = create(:sub_organisation, parent_organisations: [parent_org1])
+    child_org3 = create(:organisation, parent_organisations: [parent_org1], name: "a first")
+    _child_org4 = create(:closed_organisation, parent_organisations: [parent_org1])
+    _child_org5 = create(:court, parent_organisations: [parent_org1])
+    child_org6 = create(:organisation, parent_organisations: [parent_org1], name: "c third", organisation_type_key: :tribunal)
 
-    assert_equal [child_org_3, child_org_1, child_org_6], parent_org_1.supporting_bodies
+    assert_equal [child_org3, child_org1, child_org6], parent_org1.supporting_bodies
   end
 
   test "supporting_bodies_grouped_by_type should return a 2D array with each 1st level member being a OrganisationType and a collection of organisations" do
     parent_org = create(:organisation)
-    child_org_1 = create(:organisation, parent_organisations: [parent_org], organisation_type_key: :executive_agency)
-    child_org_2 = create(:sub_organisation, parent_organisations: [parent_org], organisation_type_key: :advisory_ndpb)
+    child_org1 = create(:organisation, parent_organisations: [parent_org], organisation_type_key: :executive_agency)
+    child_org2 = create(:sub_organisation, parent_organisations: [parent_org], organisation_type_key: :advisory_ndpb)
 
     assert_equal [
-      [OrganisationType.executive_agency, [child_org_1]],
-      [OrganisationType.advisory_ndpb,    [child_org_2]],
+      [OrganisationType.executive_agency, [child_org1]],
+      [OrganisationType.advisory_ndpb,    [child_org2]],
     ],
                  parent_org.supporting_bodies_grouped_by_type
   end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -75,9 +75,9 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "should be invalid if govuk closed status is merged and it has more than one superseding organisation" do
-    organisation_1 = create(:organisation, name: "Superseding 1")
-    organisation_2 = create(:organisation, name: "Superseding 2")
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "merged", superseding_organisations: [organisation_1, organisation_2])
+    organisation1 = create(:organisation, name: "Superseding 1")
+    organisation2 = create(:organisation, name: "Superseding 2")
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "merged", superseding_organisations: [organisation1, organisation2])
     assert_not new_organisation.valid?
   end
 
@@ -87,9 +87,9 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "should be invalid if govuk closed status is replaced and it has more than one superseding organisation" do
-    organisation_1 = create(:organisation, name: "Superseding 1")
-    organisation_2 = create(:organisation, name: "Superseding 2")
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "replaced", superseding_organisations: [organisation_1, organisation_2])
+    organisation1 = create(:organisation, name: "Superseding 1")
+    organisation2 = create(:organisation, name: "Superseding 2")
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "replaced", superseding_organisations: [organisation1, organisation2])
     assert_not new_organisation.valid?
   end
 
@@ -99,15 +99,15 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "should be invalid if govuk closed status is name changed and it has more than one superseding organisation" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "changed_name", superseding_organisations: [organisation_1, organisation_2])
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "changed_name", superseding_organisations: [organisation1, organisation2])
     assert_not new_organisation.valid?
   end
 
   test "should be invalid if govuk closed status is split and it has less than two superseding organisations" do
-    organisation_1 = create(:organisation)
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "split", superseding_organisations: [organisation_1])
+    organisation1 = create(:organisation)
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "split", superseding_organisations: [organisation1])
     assert_not new_organisation.valid?
   end
 
@@ -117,15 +117,15 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "should be invalid if govuk closed status is devolved and it has more than one superseding organisation" do
-    organisation_1 = create(:organisation, name: "Superseding 1")
-    organisation_2 = create(:organisation, name: "Superseding 2")
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "devolved", superseding_organisations: [organisation_1, organisation_2])
+    organisation1 = create(:organisation, name: "Superseding 1")
+    organisation2 = create(:organisation, name: "Superseding 2")
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "devolved", superseding_organisations: [organisation1, organisation2])
     assert_not new_organisation.valid?
   end
 
   test "should be invalid if govuk closed status is devolved and its superseding organisation is not devolved" do
-    organisation_1 = create(:organisation)
-    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "devolved", superseding_organisations: [organisation_1])
+    organisation1 = create(:organisation)
+    new_organisation = build(:organisation, govuk_status: "closed", govuk_closed_status: "devolved", superseding_organisations: [organisation1])
     assert_not new_organisation.valid?
   end
 
@@ -182,23 +182,23 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "#child_organisations should return the parent's children organisations" do
-    parent_org_1 = create(:organisation)
-    parent_org_2 = create(:organisation)
-    child_org_1 = create(:organisation, parent_organisations: [parent_org_1])
-    child_org_2 = create(:organisation, parent_organisations: [parent_org_1])
-    _child_org_3 = create(:organisation, parent_organisations: [parent_org_2])
+    parent_org1 = create(:organisation)
+    parent_org2 = create(:organisation)
+    child_org1 = create(:organisation, parent_organisations: [parent_org1])
+    child_org2 = create(:organisation, parent_organisations: [parent_org1])
+    _child_org3 = create(:organisation, parent_organisations: [parent_org2])
 
-    assert_equal [child_org_1, child_org_2], parent_org_1.child_organisations
+    assert_equal [child_org1, child_org2], parent_org1.child_organisations
   end
 
   test "#parent_organisations should return the child's parent organisations" do
-    child_org_1 = create(:organisation)
-    child_org_2 = create(:organisation)
-    parent_org_1 = create(:organisation, child_organisations: [child_org_1])
-    parent_org_2 = create(:organisation, child_organisations: [child_org_1])
-    _parent_org_3 = create(:organisation, child_organisations: [child_org_2])
+    child_org1 = create(:organisation)
+    child_org2 = create(:organisation)
+    parent_org1 = create(:organisation, child_organisations: [child_org1])
+    parent_org2 = create(:organisation, child_organisations: [child_org1])
+    _parent_org3 = create(:organisation, child_organisations: [child_org2])
 
-    assert_equal [parent_org_1, parent_org_2], child_org_1.parent_organisations
+    assert_equal [parent_org1, parent_org2], child_org1.parent_organisations
   end
 
   test "can list all parent organisations" do
@@ -306,15 +306,15 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "featured links are returned in order of creation" do
     organisation = create(:organisation)
-    link_1 = create(:featured_link, linkable: organisation, title: "2 days ago", created_at: 2.days.ago)
-    link_2 = create(:featured_link, linkable: organisation, title: "12 days ago", created_at: 12.days.ago)
-    link_3 = create(:featured_link, linkable: organisation, title: "1 hour ago", created_at: 1.hour.ago)
-    link_4 = create(:featured_link, linkable: organisation, title: "2 hours ago", created_at: 2.hours.ago)
-    link_5 = create(:featured_link, linkable: organisation, title: "20 minutes ago", created_at: 20.minutes.ago)
-    link_6 = create(:featured_link, linkable: organisation, title: "2 years ago", created_at: 2.years.ago)
+    link1 = create(:featured_link, linkable: organisation, title: "2 days ago", created_at: 2.days.ago)
+    link2 = create(:featured_link, linkable: organisation, title: "12 days ago", created_at: 12.days.ago)
+    link3 = create(:featured_link, linkable: organisation, title: "1 hour ago", created_at: 1.hour.ago)
+    link4 = create(:featured_link, linkable: organisation, title: "2 hours ago", created_at: 2.hours.ago)
+    link5 = create(:featured_link, linkable: organisation, title: "20 minutes ago", created_at: 20.minutes.ago)
+    link6 = create(:featured_link, linkable: organisation, title: "2 years ago", created_at: 2.years.ago)
 
-    assert_equal [link_6, link_2, link_1, link_4, link_3, link_5], organisation.featured_links
-    assert_equal [link_6, link_2, link_1, link_4, link_3], organisation.featured_links.only_the_initial_set
+    assert_equal [link6, link2, link1, link4, link3, link5], organisation.featured_links
+    assert_equal [link6, link2, link1, link4, link3], organisation.featured_links.only_the_initial_set
   end
 
   test "should ignore blank featured link attributes" do
@@ -817,16 +817,16 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "can provide a list of all its FOI contacts" do
     organisation = create(:organisation)
-    contact_1 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
-    contact_2 = create(:contact, contact_type: ContactType::FOI)
-    contact_3 = create(:contact, contactable: organisation, contact_type: ContactType::Media)
-    contact_4 = create(:contact, contactable: organisation, contact_type: ContactType::General)
+    contact1 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
+    contact2 = create(:contact, contact_type: ContactType::FOI)
+    contact3 = create(:contact, contactable: organisation, contact_type: ContactType::Media)
+    contact4 = create(:contact, contactable: organisation, contact_type: ContactType::General)
 
     foi_contacts = organisation.foi_contacts
-    assert foi_contacts.include?(contact_1), "expected our foi contact to be in our list of foi contacts"
-    assert_not foi_contacts.include?(contact_2), "expected someone else's foi contact not to be in our list of foi contacts"
-    assert_not foi_contacts.include?(contact_3), "expected our media contact not to be in our list of foi contacts"
-    assert_not foi_contacts.include?(contact_4), "expected our general contact not to be in our list of foi contacts"
+    assert foi_contacts.include?(contact1), "expected our foi contact to be in our list of foi contacts"
+    assert_not foi_contacts.include?(contact2), "expected someone else's foi contact not to be in our list of foi contacts"
+    assert_not foi_contacts.include?(contact3), "expected our media contact not to be in our list of foi contacts"
+    assert_not foi_contacts.include?(contact4), "expected our general contact not to be in our list of foi contacts"
   end
 
   test "knows if a given contact is on its home page" do
@@ -841,11 +841,11 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "knows that its FOI contacts are on the home page, even if it's not explicitly in the list" do
     organisation = create(:organisation)
-    contact_1 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
-    contact_2 = create(:contact, contact_type: ContactType::FOI)
+    contact1 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
+    contact2 = create(:contact, contact_type: ContactType::FOI)
 
-    assert organisation.contact_shown_on_home_page?(contact_1), "expected FOI contact that belongs to org to be shown_on_home_page?, but it wasn't"
-    assert_not organisation.contact_shown_on_home_page?(contact_2), "expected FOI contact that doesn't belong to org to not be shown_on_home_page?, but it was"
+    assert organisation.contact_shown_on_home_page?(contact1), "expected FOI contact that belongs to org to be shown_on_home_page?, but it wasn't"
+    assert_not organisation.contact_shown_on_home_page?(contact2), "expected FOI contact that doesn't belong to org to not be shown_on_home_page?, but it was"
   end
 
   test "has a list of contacts that are on its home page" do
@@ -860,14 +860,14 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "the list of contacts that are on its home page excludes any FOI contacts" do
     organisation = create(:organisation)
-    contact_1 = create(:contact, contactable: organisation, contact_type: ContactType::General)
-    contact_2 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
-    contact_3 = create(:contact, contactable: organisation, contact_type: ContactType::Media)
-    organisation.add_contact_to_home_page!(contact_1)
-    organisation.add_contact_to_home_page!(contact_2)
-    organisation.add_contact_to_home_page!(contact_3)
+    contact1 = create(:contact, contactable: organisation, contact_type: ContactType::General)
+    contact2 = create(:contact, contactable: organisation, contact_type: ContactType::FOI)
+    contact3 = create(:contact, contactable: organisation, contact_type: ContactType::Media)
+    organisation.add_contact_to_home_page!(contact1)
+    organisation.add_contact_to_home_page!(contact2)
+    organisation.add_contact_to_home_page!(contact3)
 
-    assert_equal [contact_1, contact_3], organisation.home_page_contacts
+    assert_equal [contact1, contact3], organisation.home_page_contacts
   end
 
   test "can add a contact to the list of those that are on its home page" do
@@ -892,13 +892,13 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "can reorder the contacts on the list" do
     organisation = build(:organisation)
-    contact_1 = create(:contact)
-    contact_2 = create(:contact)
+    contact1 = create(:contact)
+    contact2 = create(:contact)
     h = build(:home_page_list)
     HomePageList.stubs(:get).returns(h)
-    h.expects(:reorder_items!).with([contact_1, contact_2]).returns :a_result
+    h.expects(:reorder_items!).with([contact1, contact2]).returns :a_result
 
-    assert_equal :a_result, organisation.reorder_contacts_on_home_page!([contact_1, contact_2])
+    assert_equal :a_result, organisation.reorder_contacts_on_home_page!([contact1, contact2])
   end
 
   test "maintains a home page list for storing contacts" do
@@ -915,15 +915,15 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "Organisation.with_published_editions returns organisations with published editions" do
-    organisation_1 = create(:organisation)
-    _organisation_2 = create(:organisation)
-    organisation_3 = create(:organisation)
-    _organisation_4 = create(:organisation)
+    organisation1 = create(:organisation)
+    _organisation2 = create(:organisation)
+    organisation3 = create(:organisation)
+    _organisation4 = create(:organisation)
 
-    create(:published_news_article, organisations: [organisation_1])
-    create(:published_publication, organisations: [organisation_3])
+    create(:published_news_article, organisations: [organisation1])
+    create(:published_publication, organisations: [organisation3])
 
-    assert_same_elements [organisation_1, organisation_3], Organisation.with_published_editions
+    assert_same_elements [organisation1, organisation3], Organisation.with_published_editions
   end
 
   test "#organisation_brand_colour fetches the brand colour" do

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -36,10 +36,10 @@ class OrganisationTypeTest < ActiveSupport::TestCase
   end
 
   test "get should return the same instance when called a second time with the same key" do
-    instance_1 = OrganisationType.get(:executive_agency)
-    instance_2 = OrganisationType.get(:executive_agency)
+    instance1 = OrganisationType.get(:executive_agency)
+    instance2 = OrganisationType.get(:executive_agency)
 
-    assert_equal instance_1, instance_2
+    assert_equal instance1, instance2
   end
 
   test "OrganisationType should have getters for each organisation type" do

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -55,10 +55,10 @@ class PersonTest < ActiveSupport::TestCase
 
   test "can access speeches associated via role_appointments" do
     person = create(:person)
-    speech_1 = create(:draft_speech, role_appointment: create(:role_appointment, person: person))
-    speech_2 = create(:draft_speech, role_appointment: create(:role_appointment, person: person))
+    speech1 = create(:draft_speech, role_appointment: create(:role_appointment, person: person))
+    speech2 = create(:draft_speech, role_appointment: create(:role_appointment, person: person))
 
-    assert_equal [speech_1, speech_2], person.speeches
+    assert_equal [speech1, speech2], person.speeches
   end
 
   test "can access news_articles associated with ministerial roles of a person" do

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -131,14 +131,14 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes main and other offices in offices with separate keys" do
-    office_1 = stub_record(
+    office1 = stub_record(
       :worldwide_office,
       contact: stub_translatable_record(:contact, title: "best-office", contact_numbers: []),
       services: [],
       worldwide_organisation: nil,
       access_and_opening_times: @access_times,
     )
-    office_2 = stub_record(
+    office2 = stub_record(
       :worldwide_office,
       contact: stub_translatable_record(:contact, title: "worst-office", contact_numbers: []),
       services: [],
@@ -146,8 +146,8 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
       access_and_opening_times: @access_times,
     )
 
-    @world_org.stubs(:main_office).returns(office_1)
-    @world_org.stubs(:other_offices).returns([office_2])
+    @world_org.stubs(:main_office).returns(office1)
+    @world_org.stubs(:other_offices).returns([office2])
     main_office_as_json = @presenter.as_json[:offices][:main]
     other_offices_as_json = @presenter.as_json[:offices][:other]
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -285,22 +285,22 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
   end
 
   test "includes history information" do
-    user_1 = create(:user)
-    Edition::AuditTrail.whodunnit = user_1
+    user1 = create(:user)
+    Edition::AuditTrail.whodunnit = user1
     edition = create(:edition)
 
-    user_2 = create(:user)
-    Edition::AuditTrail.whodunnit = user_2
+    user2 = create(:user)
+    Edition::AuditTrail.whodunnit = user2
     edition.update!(change_note: "changed")
 
     result = DocumentExportPresenter.new(edition.document).as_json
     expected = [
       { event: "create",
-        whodunnit: user_1.id,
+        whodunnit: user1.id,
         created_at: Time.zone.now,
         state: "draft" },
       { event: "update",
-        whodunnit: user_2.id,
+        whodunnit: user2.id,
         created_at: Time.zone.now,
         state: "draft" },
     ]

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -42,17 +42,17 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
   end
 
   test "#lead_organisations returns list of lead org names" do
-    org_1 = build(:organisation, name: "Org 1")
-    org_2 = build(:organisation, name: "Org 2")
+    org1 = build(:organisation, name: "Org 1")
+    org2 = build(:organisation, name: "Org 2")
     publication = build(:publication)
-    publication.stubs(:lead_organisations).returns([org_1, org_2])
+    publication.stubs(:lead_organisations).returns([org1, org2])
     pr = DocumentListExportPresenter.new(publication)
     assert_equal(["Org 1", "Org 2"], pr.lead_organisations)
   end
 
   test "#lead_organisations returns owning org for Corporate Info pages" do
-    org_1 = build(:organisation, name: "Org 1")
-    cip = build(:corporate_information_page, organisation: org_1)
+    org1 = build(:organisation, name: "Org 1")
+    cip = build(:corporate_information_page, organisation: org1)
     pr = DocumentListExportPresenter.new(cip)
     assert_equal("Org 1", pr.lead_organisations)
   end

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -127,17 +127,17 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test "links hash includes lead and supporting organisations in correct order" do
-    lead_org_1 = create(:organisation)
-    lead_org_2 = create(:organisation)
+    lead_org1 = create(:organisation)
+    lead_org2 = create(:organisation)
     supporting_org = create(:organisation)
     case_study = create(
       :published_case_study,
-      lead_organisations: [lead_org_1, lead_org_2],
+      lead_organisations: [lead_org1, lead_org2],
       supporting_organisations: [supporting_org],
     )
     presented_item = present(case_study)
     expected_links_hash = {
-      organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
+      organisations: [lead_org1.content_id, lead_org2.content_id, supporting_org.content_id],
       topics: [],
       parent: [],
       world_locations: [],

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -105,18 +105,18 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
   end
 
   test "links hash includes lead and supporting organisations in correct order" do
-    lead_org_1 = create(:organisation)
-    lead_org_2 = create(:organisation)
+    lead_org1 = create(:organisation)
+    lead_org2 = create(:organisation)
     supporting_org = create(:organisation)
     publication = create(
       :published_publication,
-      lead_organisations: [lead_org_1, lead_org_2],
+      lead_organisations: [lead_org1, lead_org2],
       supporting_organisations: [supporting_org],
     )
     presented_item = present(publication)
 
     expected_links_hash = {
-      organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
+      organisations: [lead_org1.content_id, lead_org2.content_id, supporting_org.content_id],
     }
 
     assert_valid_against_links_schema({ links: presented_item.links }, "publication")

--- a/test/unit/presenters/roles_presenter_test.rb
+++ b/test/unit/presenters/roles_presenter_test.rb
@@ -2,28 +2,28 @@ require "test_helper"
 
 class RolesPresenterTest < PresenterTestCase
   setup do
-    @person_1 = stub_translatable_record(:person)
-    @person_2 = stub_translatable_record(:person)
+    @person1 = stub_translatable_record(:person)
+    @person2 = stub_translatable_record(:person)
 
-    @role_1 = stub_translatable_record(:role_without_organisations)
-    @role_1.stubs(:current_person).returns(@person_1)
+    @role1 = stub_translatable_record(:role_without_organisations)
+    @role1.stubs(:current_person).returns(@person1)
 
-    @role_2 = stub_translatable_record(:role_without_organisations)
-    @role_2.stubs(:current_person).returns(@person_1)
+    @role2 = stub_translatable_record(:role_without_organisations)
+    @role2.stubs(:current_person).returns(@person1)
 
-    @role_3 = stub_translatable_record(:role_without_organisations)
-    @role_3.stubs(:current_person).returns(@person_2)
+    @role3 = stub_translatable_record(:role_without_organisations)
+    @role3.stubs(:current_person).returns(@person2)
 
     @empty_role = stub_translatable_record(:role_without_organisations)
     @empty_role.stubs(:current_person).returns(nil)
 
-    @presenter = RolesPresenter.new([@role_1, @role_2, @role_3, @empty_role], @view_context)
+    @presenter = RolesPresenter.new([@role1, @role2, @role3, @empty_role], @view_context)
   end
 
   test "it decorates a collection of roles" do
-    assert_equal [RolePresenter.new(@role_1),
-                  RolePresenter.new(@role_2),
-                  RolePresenter.new(@role_3),
+    assert_equal [RolePresenter.new(@role1),
+                  RolePresenter.new(@role2),
+                  RolePresenter.new(@role3),
                   RolePresenter.new(@empty_role)],
                  @presenter.decorated_collection
   end
@@ -34,28 +34,28 @@ class RolesPresenterTest < PresenterTestCase
   end
 
   test "it returns unique people" do
-    assert_equal [@person_1, @person_2], @presenter.unique_people
+    assert_equal [@person1, @person2], @presenter.unique_people
   end
 
   test "it returns roles with unique people" do
-    assert_equal [RolePresenter.new(@role_1), RolePresenter.new(@role_3)], @presenter.with_unique_people
+    assert_equal [RolePresenter.new(@role1), RolePresenter.new(@role3)], @presenter.with_unique_people
   end
 
   test "#with_unique_people doesn't clober #unique_people" do
     @presenter.with_unique_people
-    assert_equal [@person_1, @person_2], @presenter.unique_people
+    assert_equal [@person1, @person2], @presenter.unique_people
   end
 
   test "it returns the roles for a given person" do
-    assert_equal [RolePresenter.new(@role_1), RolePresenter.new(@role_2)], @presenter.roles_for(@role_1.current_person)
+    assert_equal [RolePresenter.new(@role1), RolePresenter.new(@role2)], @presenter.roles_for(@role1.current_person)
   end
 
   test "it can strip out roles that are not filled" do
     @presenter.remove_unfilled_roles!
 
-    assert_equal [RolePresenter.new(@role_1),
-                  RolePresenter.new(@role_2),
-                  RolePresenter.new(@role_3)],
+    assert_equal [RolePresenter.new(@role1),
+                  RolePresenter.new(@role2),
+                  RolePresenter.new(@role3)],
                  @presenter.decorated_collection
   end
 
@@ -63,9 +63,9 @@ class RolesPresenterTest < PresenterTestCase
     @presenter.decorated_collection
     @presenter.remove_unfilled_roles!
 
-    assert_equal [RolePresenter.new(@role_1),
-                  RolePresenter.new(@role_2),
-                  RolePresenter.new(@role_3)],
+    assert_equal [RolePresenter.new(@role1),
+                  RolePresenter.new(@role2),
+                  RolePresenter.new(@role3)],
                  @presenter.decorated_collection
   end
 end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -46,18 +46,18 @@ class RoleTest < ActiveSupport::TestCase
   end
 
   test "the ordering on organisation roles defaults to the end of the list" do
-    organisation_1 = create(:organisation)
-    organisation_2 = create(:organisation)
-    role_1 = create(:role, organisations: [organisation_1, organisation_2])
-    role_2 = create(:role, organisations: [organisation_2])
-    role_3 = create(:role, organisations: [organisation_1])
-    role_4 = create(:role, organisations: [organisation_1])
+    organisation1 = create(:organisation)
+    organisation2 = create(:organisation)
+    role1 = create(:role, organisations: [organisation1, organisation2])
+    role2 = create(:role, organisations: [organisation2])
+    role3 = create(:role, organisations: [organisation1])
+    role4 = create(:role, organisations: [organisation1])
 
-    assert_equal [role_1, role_3, role_4], organisation_1.roles
-    assert_equal [role_1, role_2], organisation_2.roles
+    assert_equal [role1, role3, role4], organisation1.roles
+    assert_equal [role1, role2], organisation2.roles
 
-    assert_equal [0, 1, 2], organisation_1.organisation_roles.pluck(:ordering)
-    assert_equal [0, 1], organisation_2.organisation_roles.pluck(:ordering)
+    assert_equal [0, 1, 2], organisation1.organisation_roles.pluck(:ordering)
+    assert_equal [0, 1], organisation2.organisation_roles.pluck(:ordering)
   end
 
   test "should be able to get the current person" do
@@ -177,15 +177,15 @@ class RoleTest < ActiveSupport::TestCase
   end
 
   test "should be able to scope roles by whips" do
-    role_1 = create(:role, whip_organisation_id: 1)
-    _role_2 = create(:role)
-    assert_equal [role_1], Role.whip
+    role1 = create(:role, whip_organisation_id: 1)
+    _role2 = create(:role)
+    assert_equal [role1], Role.whip
   end
 
   test "should be able to scope roles by cabinet attendance" do
-    role_1 = create(:role, attends_cabinet_type_id: 1)
-    _role_2 = create(:role)
-    assert_equal [role_1], Role.also_attends_cabinet
+    role1 = create(:role, attends_cabinet_type_id: 1)
+    _role2 = create(:role)
+    assert_equal [role1], Role.also_attends_cabinet
   end
 
   test "should be able to scope roles by whether they are occupied" do

--- a/test/unit/searchable_test.rb
+++ b/test/unit/searchable_test.rb
@@ -64,18 +64,18 @@ class SearchableTest < ActiveSupport::TestCase
   end
 
   test "#reindex_all will respect the scopes it is prefixed with" do
-    searchable_test_topic_1 = SearchableTestTopic.create!(name: "woo", state: "published")
-    searchable_test_topic_2 = SearchableTestTopic.create!(name: "moo", state: "published")
-    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic_1).never
-    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic_2)
+    searchable_test_topic1 = SearchableTestTopic.create!(name: "woo", state: "published")
+    searchable_test_topic2 = SearchableTestTopic.create!(name: "moo", state: "published")
+    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic1).never
+    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic2)
     SearchableTestTopic.where(name: "moo").reindex_all
   end
 
   test "#reindex_all will request indexing for each searchable instance" do
-    searchable_test_topic_1 = SearchableTestTopic.create!(name: "woo", state: "draft")
-    searchable_test_topic_2 = SearchableTestTopic.create!(name: "woo", state: "published")
-    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic_1).never
-    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic_2)
+    searchable_test_topic1 = SearchableTestTopic.create!(name: "woo", state: "draft")
+    searchable_test_topic2 = SearchableTestTopic.create!(name: "woo", state: "published")
+    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic1).never
+    Whitehall::SearchIndex.expects(:add).with(searchable_test_topic2)
     SearchableTestTopic.reindex_all
   end
 

--- a/test/unit/services/edition_deleter_test.rb
+++ b/test/unit/services/edition_deleter_test.rb
@@ -55,12 +55,12 @@ class EditionDeleterTest < ActiveSupport::TestCase
 
   test "#perform! soft-deletes any attachments that the edition has" do
     publication = create(:draft_publication)
-    publication.attachments << attachment_1 = build(:file_attachment)
-    publication.attachments << attachment_2 = build(:html_attachment)
+    publication.attachments << attachment1 = build(:file_attachment)
+    publication.attachments << attachment2 = build(:html_attachment)
 
     assert EditionDeleter.new(publication).perform!
 
-    assert Attachment.find(attachment_1.id).deleted?
-    assert Attachment.find(attachment_2.id).deleted?
+    assert Attachment.find(attachment1.id).deleted?
+    assert Attachment.find(attachment2.id).deleted?
   end
 end

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -101,35 +101,35 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test "if ordering is not supplied, it is set to the next_ordering when saving" do
-    page_1 = create(:take_part_page, ordering: nil)
-    assert_equal 1, page_1.ordering
+    page1 = create(:take_part_page, ordering: nil)
+    assert_equal 1, page1.ordering
 
-    page_2 = create(:take_part_page, ordering: 20)
-    assert_equal 20, page_2.ordering
+    page2 = create(:take_part_page, ordering: 20)
+    assert_equal 20, page2.ordering
   end
 
   test ".reorder! updates the ordering of each page with an id in the supplied ordering, to match it's position in that ordering" do
-    page_1 = create(:take_part_page, ordering: 1)
-    page_2 = create(:take_part_page, ordering: 12)
-    page_3 = create(:take_part_page, ordering: 50)
+    page1 = create(:take_part_page, ordering: 1)
+    page2 = create(:take_part_page, ordering: 12)
+    page3 = create(:take_part_page, ordering: 50)
 
-    TakePartPage.reorder!([page_3.id, page_1.id, page_2.id])
+    TakePartPage.reorder!([page3.id, page1.id, page2.id])
 
-    assert_equal 2, page_1.reload.ordering
-    assert_equal 3, page_2.reload.ordering
-    assert_equal 1, page_3.reload.ordering
+    assert_equal 2, page1.reload.ordering
+    assert_equal 3, page2.reload.ordering
+    assert_equal 1, page3.reload.ordering
   end
 
   test ".reorder! places any pages not in the supplied ordering at the end of the list" do
-    page_1 = create(:take_part_page, ordering: 1)
-    page_2 = create(:take_part_page, ordering: 12)
-    page_3 = create(:take_part_page, ordering: 50)
+    page1 = create(:take_part_page, ordering: 1)
+    page2 = create(:take_part_page, ordering: 12)
+    page3 = create(:take_part_page, ordering: 50)
 
-    TakePartPage.reorder!([page_3.id])
+    TakePartPage.reorder!([page3.id])
 
-    assert_equal 2, page_1.reload.ordering
-    assert_equal 2, page_2.reload.ordering
-    assert_equal 1, page_3.reload.ordering
+    assert_equal 2, page1.reload.ordering
+    assert_equal 2, page2.reload.ordering
+    assert_equal 1, page3.reload.ordering
   end
 
   test "returns search index data suitable for Rummageable" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -147,10 +147,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "can be associated to world locations" do
-    location_1 = build(:world_location)
-    location_2 = build(:world_location)
-    user = build(:user, world_locations: [location_1, location_2])
-    assert_equal [location_1, location_2], user.world_locations
+    location1 = build(:world_location)
+    location2 = build(:world_location)
+    user = build(:user, world_locations: [location1, location2])
+    assert_equal [location1, location2], user.world_locations
   end
 
   test "#fuzzy_last_name returns second word" do

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -35,21 +35,21 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
   test "cannot do anything to an edition they are not allowed to see" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
     enforcer = enforcer_for(user, edition)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|
@@ -98,12 +98,12 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   end
 
   test "can force publish a limited access edition outside their org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_editor
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = limited_publication([organisation_2])
+    edition = limited_publication([organisation2])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/authority/department_writer_test.rb
+++ b/test/unit/whitehall/authority/department_writer_test.rb
@@ -35,21 +35,21 @@ class DepartmentWriterTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_writer
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
   test "cannot do anything to an edition they are not allowed to see" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_writer
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
     enforcer = enforcer_for(user, edition)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|
@@ -105,12 +105,12 @@ class DepartmentWriterTest < ActiveSupport::TestCase
   end
 
   test "can force publish a limited access edition outside their org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = department_writer
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = limited_publication([organisation_2])
+    edition = limited_publication([organisation2])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/authority/gds_editor_fatality_notice_test.rb
+++ b/test/unit/whitehall/authority/gds_editor_fatality_notice_test.rb
@@ -25,21 +25,21 @@ class GDSEditorFatalityNoticeTest < ActiveSupport::TestCase
   end
 
   test "cannot see a fatality notice that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = gds_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_fatality_notice([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_fatality_notice([organisation2])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
   test "cannot do anything to a fatality notice they are not allowed to see" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = gds_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_fatality_notice([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_fatality_notice([organisation2])
     enforcer = enforcer_for(user, edition)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|

--- a/test/unit/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/whitehall/authority/gds_editor_test.rb
@@ -38,21 +38,21 @@ class GDSEditorTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = gds_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
   test "cannot do anything to an edition they are not allowed to see" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = gds_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
     enforcer = enforcer_for(user, edition)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|
@@ -107,12 +107,12 @@ class GDSEditorTest < ActiveSupport::TestCase
   end
 
   test "can force publish a limited access edition outside their org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = gds_editor
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = limited_publication([organisation_2])
+    edition = limited_publication([organisation2])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -36,21 +36,21 @@ class ManagingEditorTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = managing_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
   test "cannot do anything to an edition they are not allowed to see" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = managing_editor
-    user.stubs(:organisation).returns(organisation_1)
-    edition = limited_publication([organisation_2])
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
     enforcer = enforcer_for(user, edition)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|
@@ -99,12 +99,12 @@ class ManagingEditorTest < ActiveSupport::TestCase
   end
 
   test "can force publish a limited access edition outside their org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = managing_editor
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = limited_publication([organisation_2])
+    edition = limited_publication([organisation2])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/authority/world_editor_test.rb
+++ b/test/unit/whitehall/authority/world_editor_test.rb
@@ -39,11 +39,11 @@ class WorldEditorTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition about their locaiton that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_editor(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land", "hat land"])
+    user.stubs(:organisation).returns(organisation1)
+    edition = with_locations(limited_publication([organisation2]), ["shirt land", "hat land"])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
@@ -139,23 +139,23 @@ class WorldEditorTest < ActiveSupport::TestCase
   end
 
   test "can force publish an edition about their location that is limited to another org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_editor(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land", "hat land"])
+    edition = with_locations(limited_publication([organisation2]), ["shirt land", "hat land"])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end
 
   test "can force publish a limited access edition outside their location and org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_editor(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land"])
+    edition = with_locations(limited_publication([organisation2]), ["shirt land"])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/authority/world_writer_test.rb
+++ b/test/unit/whitehall/authority/world_writer_test.rb
@@ -40,11 +40,11 @@ class WorldWriterTest < ActiveSupport::TestCase
   end
 
   test "cannot see an edition about their locaiton that is access limited if it is limited an organisation they don't belong to" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_writer(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land", "hat land"])
+    user.stubs(:organisation).returns(organisation1)
+    edition = with_locations(limited_publication([organisation2]), ["shirt land", "hat land"])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
@@ -140,23 +140,23 @@ class WorldWriterTest < ActiveSupport::TestCase
   end
 
   test "can force publish an edition about their location that is limited to another org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_writer(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land", "hat land"])
+    edition = with_locations(limited_publication([organisation2]), ["shirt land", "hat land"])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end
 
   test "can force publish a limited access edition outside their location and org if they can_force_publish_anything?" do
-    organisation_1 = "organisation_1"
-    organisation_2 = "organisation_2"
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
     user = world_writer(["hat land", "tie land"])
-    user.stubs(:organisation).returns(organisation_1)
+    user.stubs(:organisation).returns(organisation1)
     user.stubs(:can_force_publish_anything?).returns(true)
-    edition = with_locations(limited_publication([organisation_2]), ["shirt land"])
+    edition = with_locations(limited_publication([organisation2]), ["shirt land"])
 
     assert enforcer_for(user, edition).can?(:force_publish)
   end

--- a/test/unit/whitehall/document_filter/mysql_test.rb
+++ b/test/unit/whitehall/document_filter/mysql_test.rb
@@ -143,26 +143,26 @@ module Whitehall::DocumentFilter
       world_location = create(:world_location)
       other_world_location = create(:world_location)
 
-      item_1 = create(:published_publication, world_locations: [world_location])
-      item_2 = create(:published_statistical_data_set)
-      item_3 = create(:published_publication, world_locations: [other_world_location])
-      item_4 = create(:published_consultation)
+      item1 = create(:published_publication, world_locations: [world_location])
+      item2 = create(:published_statistical_data_set)
+      item3 = create(:published_publication, world_locations: [other_world_location])
+      item4 = create(:published_consultation)
 
       filter = Whitehall::DocumentFilter::Mysql.new(world_locations: [world_location.slug, other_world_location.slug])
       filter.publications_search
-      assert_same_elements [item_1, item_3], filter.documents
+      assert_same_elements [item1, item3], filter.documents
 
       filter = Whitehall::DocumentFilter::Mysql.new(world_locations: [world_location.slug])
       filter.publications_search
-      assert_same_elements [item_1], filter.documents
+      assert_same_elements [item1], filter.documents
 
       filter = Whitehall::DocumentFilter::Mysql.new(world_locations: [])
       filter.publications_search
-      assert_same_elements [item_1, item_2, item_3, item_4], filter.documents
+      assert_same_elements [item1, item2, item3, item4], filter.documents
 
       filter = Whitehall::DocumentFilter::Mysql.new(world_locations: "all")
       filter.publications_search
-      assert_same_elements [item_1, item_2, item_3, item_4], filter.documents
+      assert_same_elements [item1, item2, item3, item4], filter.documents
     end
 
     test "can filter consultations" do

--- a/test/unit/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/whitehall/govspeak_renderer_test.rb
@@ -24,13 +24,13 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
       :with_file_attachment,
       body: body,
       attachments: [
-        attachment_1 = build(:file_attachment, id: 1),
-        attachment_2 = build(:file_attachment, id: 2),
+        attachment1 = build(:file_attachment, id: 1),
+        attachment2 = build(:file_attachment, id: 2),
       ],
     )
     html = render_govspeak(edition)
-    assert_select_within_html html, "#attachment_#{attachment_1.id}"
-    assert_select_within_html html, "#attachment_#{attachment_2.id}"
+    assert_select_within_html html, "#attachment_#{attachment1.id}"
+    assert_select_within_html html, "#attachment_#{attachment2.id}"
   end
 
   test "converts block attachments and handles thumbnails for PDFs" do

--- a/test/unit/whitehall/internal_link_updater_test.rb
+++ b/test/unit/whitehall/internal_link_updater_test.rb
@@ -16,16 +16,16 @@ module Whitehall
     end
 
     test "does not replace admin links to other documents" do
-      edition_linked_to_1 = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
-      edition_linked_to_1.document.update!(slug: "some-document-1", locked: true)
-      edition_linked_to_2 = create(:edition_with_document, body: "Some document not migrated to Content Publisher")
-      edition_linked_to_2.document.update!(slug: "some-document-2")
-      edition_linked_from = create(:edition_with_document, body: "Text with a [link](/government/admin/news/#{edition_linked_to_1.id}) and another [link](/government/admin/news/#{edition_linked_to_2.id})")
+      edition_linked_to1 = create(:edition_with_document, body: "Some document being migrated to Content Publisher")
+      edition_linked_to1.document.update!(slug: "some-document-1", locked: true)
+      edition_linked_to2 = create(:edition_with_document, body: "Some document not migrated to Content Publisher")
+      edition_linked_to2.document.update!(slug: "some-document-2")
+      edition_linked_from = create(:edition_with_document, body: "Text with a [link](/government/admin/news/#{edition_linked_to1.id}) and another [link](/government/admin/news/#{edition_linked_to2.id})")
       ServiceListeners::EditionDependenciesPopulator.new(edition_linked_from).populate!
 
-      Whitehall::InternalLinkUpdater.new(edition_linked_to_1).call
+      Whitehall::InternalLinkUpdater.new(edition_linked_to1).call
 
-      expected_body = "Text with a [link](www.test.gov.uk/government/generic-editions/some-document-1) and another [link](/government/admin/news/#{edition_linked_to_2.id})"
+      expected_body = "Text with a [link](www.test.gov.uk/government/generic-editions/some-document-1) and another [link](/government/admin/news/#{edition_linked_to2.id})"
       assert_equal edition_linked_from.reload.body, expected_body
     end
   end

--- a/test/unit/whitehall/slugging_test.rb
+++ b/test/unit/whitehall/slugging_test.rb
@@ -7,15 +7,15 @@ class SluggingTest < ActiveSupport::TestCase
   end
 
   test "should resolve a conflict" do
-    _document_1 = create(:document, sluggable_string: "Slug conflict")
-    document_2 = create(:document, sluggable_string: "Slug conflict")
-    assert_equal "slug-conflict--2", document_2.slug
+    _document1 = create(:document, sluggable_string: "Slug conflict")
+    document2 = create(:document, sluggable_string: "Slug conflict")
+    assert_equal "slug-conflict--2", document2.slug
   end
 
   test "should handle document titles with numbers" do
-    _document_1 = create(:document, sluggable_string: "2010-2015 conflict")
-    document_2 = create(:document, sluggable_string: "2010-2015 conflict")
-    assert_equal "2010-2015-conflict--2", document_2.slug
+    _document1 = create(:document, sluggable_string: "2010-2015 conflict")
+    document2 = create(:document, sluggable_string: "2010-2015 conflict")
+    assert_equal "2010-2015-conflict--2", document2.slug
   end
 
   test "should strip punctuation properly" do

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -64,12 +64,12 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
   end
 
   test ".dequeue_all removes all scheduled publishing jobs" do
-    edition_1 = create(:scheduled_edition)
-    edition_2 = create(:scheduled_edition)
+    edition1 = create(:scheduled_edition)
+    edition2 = create(:scheduled_edition)
 
     with_real_sidekiq do
-      ScheduledPublishingWorker.queue(edition_1)
-      ScheduledPublishingWorker.queue(edition_2)
+      ScheduledPublishingWorker.queue(edition1)
+      ScheduledPublishingWorker.queue(edition2)
 
       assert_equal 2, Sidekiq::ScheduledSet.new.size
 

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -75,27 +75,27 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "ordered_by_name sorts by the I18n.default_locale translation for name" do
-    world_location_1 = create(:world_location, name: "Neverland")
-    world_location_2 = create(:world_location, name: "Middle Earth")
-    world_location_3 = create(:world_location, name: "Narnia")
+    world_location1 = create(:world_location, name: "Neverland")
+    world_location2 = create(:world_location, name: "Middle Earth")
+    world_location3 = create(:world_location, name: "Narnia")
 
     I18n.with_locale(I18n.default_locale) do
-      assert_equal [world_location_2, world_location_3, world_location_1], WorldLocation.ordered_by_name
+      assert_equal [world_location2, world_location3, world_location1], WorldLocation.ordered_by_name
     end
   end
 
   test "ordered_by_name uses the I18n.default_locale ordering even if the current locale is not I18n.default_locale" do
-    world_location_1 = create(:world_location, name: "Neverland")
-    world_location_2 = create(:world_location, name: "Middle Earth")
-    world_location_3 = create(:world_location, name: "Narnia")
+    world_location1 = create(:world_location, name: "Neverland")
+    world_location2 = create(:world_location, name: "Middle Earth")
+    world_location3 = create(:world_location, name: "Narnia")
 
     I18n.with_locale(:fr) do
-      world_location_1.name = "Pays imaginaire"
-      world_location_1.save!
-      world_location_2.name = "Terre du Milieu"
-      world_location_2.save!
+      world_location1.name = "Pays imaginaire"
+      world_location1.save!
+      world_location2.name = "Terre du Milieu"
+      world_location2.save!
 
-      assert_equal [world_location_2, world_location_3, world_location_1], WorldLocation.ordered_by_name
+      assert_equal [world_location2, world_location3, world_location1], WorldLocation.ordered_by_name
     end
   end
 
@@ -103,11 +103,11 @@ class WorldLocationTest < ActiveSupport::TestCase
     world_location_type = WorldLocationType::WorldLocation
     delegation_type = WorldLocationType::InternationalDelegation
 
-    location_1 = create(:world_location, world_location_type: world_location_type, name: "Narnia")
-    location_2 = create(:world_location, world_location_type: delegation_type, name: "Neverland")
-    location_3 = create(:world_location, world_location_type: world_location_type, name: "Middle Earth")
+    location1 = create(:world_location, world_location_type: world_location_type, name: "Narnia")
+    location2 = create(:world_location, world_location_type: delegation_type, name: "Neverland")
+    location3 = create(:world_location, world_location_type: world_location_type, name: "Middle Earth")
 
-    assert_equal [[world_location_type, [location_3, location_1]], [delegation_type, [location_2]]], WorldLocation.all_by_type
+    assert_equal [[world_location_type, [location3, location1]], [delegation_type, [location2]]], WorldLocation.all_by_type
   end
 
   test "#feature_list_for_locale should return the feature list for the given locale, or build one if not" do
@@ -156,15 +156,15 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   test "featured links are returned in order of creation" do
     world_location = create(:world_location)
-    link_1 = create(:featured_link, linkable: world_location, title: "2 days ago", created_at: 2.days.ago)
-    link_2 = create(:featured_link, linkable: world_location, title: "12 days ago", created_at: 12.days.ago)
-    link_3 = create(:featured_link, linkable: world_location, title: "1 hour ago", created_at: 1.hour.ago)
-    link_4 = create(:featured_link, linkable: world_location, title: "2 hours ago", created_at: 2.hours.ago)
-    link_5 = create(:featured_link, linkable: world_location, title: "20 minutes ago", created_at: 20.minutes.ago)
-    link_6 = create(:featured_link, linkable: world_location, title: "2 years ago", created_at: 2.years.ago)
+    link1 = create(:featured_link, linkable: world_location, title: "2 days ago", created_at: 2.days.ago)
+    link2 = create(:featured_link, linkable: world_location, title: "12 days ago", created_at: 12.days.ago)
+    link3 = create(:featured_link, linkable: world_location, title: "1 hour ago", created_at: 1.hour.ago)
+    link4 = create(:featured_link, linkable: world_location, title: "2 hours ago", created_at: 2.hours.ago)
+    link5 = create(:featured_link, linkable: world_location, title: "20 minutes ago", created_at: 20.minutes.ago)
+    link6 = create(:featured_link, linkable: world_location, title: "2 years ago", created_at: 2.years.ago)
 
-    assert_equal [link_6, link_2, link_1, link_4, link_3, link_5], world_location.featured_links
-    assert_equal [link_6, link_2, link_1, link_4, link_3], world_location.featured_links.only_the_initial_set
+    assert_equal [link6, link2, link1, link4, link3, link5], world_location.featured_links
+    assert_equal [link6, link2, link1, link4, link3], world_location.featured_links.only_the_initial_set
   end
 
   test "we can find those that are countries" do
@@ -285,13 +285,13 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "only one feature list per language per world location" do
-    world_location_1 = create(:world_location)
-    world_location_2 = create(:world_location)
-    FeatureList.create!(featurable: world_location_1, locale: :en)
-    FeatureList.create!(featurable: world_location_1, locale: :fr)
-    FeatureList.create!(featurable: world_location_2, locale: :en)
+    world_location1 = create(:world_location)
+    world_location2 = create(:world_location)
+    FeatureList.create!(featurable: world_location1, locale: :en)
+    FeatureList.create!(featurable: world_location1, locale: :fr)
+    FeatureList.create!(featurable: world_location2, locale: :en)
     assert_raise ActiveRecord::RecordInvalid do
-      FeatureList.create!(featurable: world_location_2, locale: :en)
+      FeatureList.create!(featurable: world_location2, locale: :en)
     end
   end
 

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -79,16 +79,16 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_nil worldwide_organisation.main_office
 
-    office_1 = create(:worldwide_office)
-    worldwide_organisation.offices << office_1
-    assert_equal office_1, worldwide_organisation.main_office
+    office1 = create(:worldwide_office)
+    worldwide_organisation.offices << office1
+    assert_equal office1, worldwide_organisation.main_office
 
-    office_2 = create(:worldwide_office)
-    worldwide_organisation.offices << office_2
-    assert_equal office_1, worldwide_organisation.main_office
+    office2 = create(:worldwide_office)
+    worldwide_organisation.offices << office2
+    assert_equal office1, worldwide_organisation.main_office
 
-    worldwide_organisation.main_office = office_2
-    assert_equal office_2, worldwide_organisation.main_office
+    worldwide_organisation.main_office = office2
+    assert_equal office2, worldwide_organisation.main_office
   end
 
   test "distinguishes between the main office and other offices" do
@@ -156,10 +156,10 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_equal [], worldwide_organisation.office_staff_roles
 
-    staff_role_1 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
-    staff_role_2 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
+    staff_role1 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
+    staff_role2 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
-    assert_equal [staff_role_1, staff_role_2], worldwide_organisation.office_staff_roles
+    assert_equal [staff_role1, staff_role2], worldwide_organisation.office_staff_roles
     assert_nil worldwide_organisation.primary_role
     assert_nil worldwide_organisation.secondary_role
   end
@@ -251,12 +251,12 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   test "knows that the main office is on the home page, even if it's not explicitly in the list" do
     world_organisation = create(:worldwide_organisation)
-    office_1 = create(:worldwide_office, worldwide_organisation: world_organisation)
-    office_2 = create(:worldwide_office, worldwide_organisation: world_organisation)
-    world_organisation.add_office_to_home_page!(office_1)
-    world_organisation.main_office = office_2
+    office1 = create(:worldwide_office, worldwide_organisation: world_organisation)
+    office2 = create(:worldwide_office, worldwide_organisation: world_organisation)
+    world_organisation.add_office_to_home_page!(office1)
+    world_organisation.main_office = office2
 
-    assert world_organisation.office_shown_on_home_page?(office_2)
+    assert world_organisation.office_shown_on_home_page?(office2)
   end
 
   test "has a list of offices that are on its home page" do
@@ -270,15 +270,15 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   test "the list of offices that are on its home page excludes the main office" do
     world_organisation = create(:worldwide_organisation)
-    office_1 = create(:worldwide_office, worldwide_organisation: world_organisation)
-    office_2 = create(:worldwide_office, worldwide_organisation: world_organisation)
-    office_3 = create(:worldwide_office, worldwide_organisation: world_organisation)
-    world_organisation.add_office_to_home_page!(office_1)
-    world_organisation.add_office_to_home_page!(office_2)
-    world_organisation.add_office_to_home_page!(office_3)
-    world_organisation.main_office = office_2
+    office1 = create(:worldwide_office, worldwide_organisation: world_organisation)
+    office2 = create(:worldwide_office, worldwide_organisation: world_organisation)
+    office3 = create(:worldwide_office, worldwide_organisation: world_organisation)
+    world_organisation.add_office_to_home_page!(office1)
+    world_organisation.add_office_to_home_page!(office2)
+    world_organisation.add_office_to_home_page!(office3)
+    world_organisation.main_office = office2
 
-    assert_equal [office_1, office_3], world_organisation.home_page_offices
+    assert_equal [office1, office3], world_organisation.home_page_offices
   end
 
   test "can add a office to the list of those that are on its home page" do
@@ -303,13 +303,13 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   test "can reorder the contacts on the list" do
     world_organisation = build(:worldwide_organisation)
-    office_1 = build(:worldwide_office)
-    office_2 = build(:worldwide_office)
+    office1 = build(:worldwide_office)
+    office2 = build(:worldwide_office)
     h = build(:home_page_list)
     HomePageList.stubs(:get).returns(h)
-    h.expects(:reorder_items!).with([office_1, office_2]).returns :a_result
+    h.expects(:reorder_items!).with([office1, office2]).returns :a_result
 
-    assert_equal :a_result, world_organisation.reorder_offices_on_home_page!([office_1, office_2])
+    assert_equal :a_result, world_organisation.reorder_offices_on_home_page!([office1, office2])
   end
 
   test "maintains a home page list for storing offices" do


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

There is no reason for this to be different to RuboCop GOV.UK.