### PR TITLE
Don't create s3 objects as public

### DIFF
--- a/lib/s3_file_handler.rb
+++ b/lib/s3_file_handler.rb
@@ -15,7 +15,6 @@ class S3FileHandler
     directory.files.create( # rubocop:disable Rails/SaveBang
       key: filename,
       body: csv,
-      public: true,
     )
   end
 


### PR DESCRIPTION
This causes a permission denied error. Fixes a bug introduced in #5709.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used