### PR TITLE
Document-list export URLs should point to whitehall-admin service, not whitehall

### DIFF
--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -27,7 +27,7 @@ private
 
     filename = DocumentListExportPresenter.s3_filename(document_type_slug, export_id)
     S3FileHandler.save_file_to_s3(filename, csv)
-    Plek.find("whitehall", external: true) + "/export/#{document_type_slug}/#{export_id}"
+    Plek.find("whitehall-admin", external: true) + "/export/#{document_type_slug}/#{export_id}"
   end
 
   def create_filter(filter_options, user)

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -49,7 +49,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
     title = "Everyone's editions"
     @worker.stubs(:create_filter).returns(stub(page_title: title))
     @worker.stubs(generate_csv: csv)
-    Notifications.expects(:document_list).with(regexp_matches(%r{^https://whitehall\.test\.gov\.uk/export/documents/[a-f0-9-]{36}$}), @user.email, title).returns(stub(deliver_now: nil))
+    Notifications.expects(:document_list).with(regexp_matches(%r{^https://whitehall-admin\.test\.gov\.uk/export/documents/[a-f0-9-]{36}$}), @user.email, title).returns(stub(deliver_now: nil))
     @worker.perform({ "state" => "draft" }, @user.id)
   end
 end


### PR DESCRIPTION
https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used