### PR TITLE
Deindex publications if the type has changed

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -105,6 +105,10 @@ class Publication < Publicationesque
     self.publication_type_id
   end
 
+  def has_changed_publication_type?
+    previous_edition && previous_edition.publication_type != publication_type
+  end
+
   def national_statistic?
     publication_type == PublicationType::NationalStatistics
   end

--- a/app/services/service_listeners/search_indexer.rb
+++ b/app/services/service_listeners/search_indexer.rb
@@ -2,6 +2,10 @@ module ServiceListeners
   SearchIndexer = Struct.new(:edition) do
     def index!
       if edition.can_index_in_search?
+        if edition.is_a?(Publication) && edition.has_changed_publication_type?
+          Whitehall::SearchIndex.delete(edition.previous_edition)
+        end
+
         Whitehall::SearchIndex.add(edition)
         reindex_collection_documents
       end

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -160,4 +160,21 @@ class PublicationTest < ActiveSupport::TestCase
     assert_equal "statistics-national-statistics", create(:published_national_statistics).search_index["detailed_format"]
     assert_equal "statistics", create(:published_statistics).search_index["detailed_format"]
   end
+
+  test "#has_changed_publication_type? false if no previous edition" do
+    publication = create(:publication)
+    assert_not publication.has_changed_publication_type?
+  end
+
+  test "#has_changed_publication_type? false if previous edition has the same type" do
+    published_publication = create(:published_policy_paper)
+    publication = create(:draft_policy_paper, document: published_publication.document)
+    assert_not publication.has_changed_publication_type?
+  end
+
+  test "#has_changed_publication_type? true if previous edition has a different type" do
+    published_publication = create(:published_national_statistics)
+    publication = create(:draft_policy_paper, document: published_publication.document)
+    assert publication.has_changed_publication_type?
+  end
 end

--- a/test/unit/services/service_listeners/search_indexer_test.rb
+++ b/test/unit/services/service_listeners/search_indexer_test.rb
@@ -32,6 +32,15 @@ class ServiceListeners::SearchIndexerTest < ActiveSupport::TestCase
     ServiceListeners::SearchIndexer.new(collection).index!
   end
 
+  test "#index! removes the edition first if the publication type has changed" do
+    published_publication = create(:published_policy_paper)
+    edition = create(:published_national_statistics, document: published_publication.document)
+
+    expect_removal_from_index(published_publication)
+    expect_indexing(edition)
+    ServiceListeners::SearchIndexer.new(edition).index!
+  end
+
   test "#remove! removes the edition from the search index" do
     edition = create(:published_news_article)
 


### PR DESCRIPTION
In some of these cases the `base_path` will have changed and if we don't first remove the previous edition, two entries will appear in the search index. This is because the search index uses the `base_path` as the unique index for each edition.

This branch is currently deployed to integration for testing.

[Trello Card](https://trello.com/c/r4tnFu0g/2038-investigate-search-results-showing-republished-document-twice-timebox-2-days)