### PR TITLE
Add data migration to redirect SAGE policy groups to org page

### DIFF
--- a/db/data_migration/20200716103130_redirect_sage_policy_groups_to_org_page.rb
+++ b/db/data_migration/20200716103130_redirect_sage_policy_groups_to_org_page.rb
@@ -1,0 +1,20 @@
+SLUGS = %w[
+  scientific-advisory-group-for-emergencies-sage
+  scientific-advisory-group-for-emergencies-sage-coronavirus-covid-19-response
+].freeze
+
+REDIRECT_PATH = "/government/organisations/scientific-advisory-group-for-emergencies".freeze
+
+SLUGS.each do |slug|
+  group = PolicyGroup.find_by(slug: slug)
+  unless group
+    puts "could not find #{slug}"
+    next
+  end
+
+  content_id = group.content_id
+  group.delete
+  PublishingApiRedirectWorker.new.perform(content_id, REDIRECT_PATH, "en")
+
+  puts "#{slug} -> #{REDIRECT_PATH}"
+end


### PR DESCRIPTION
A new org page for SAGE has been created, and content is being moved over from two existing policy groups.  When that's done, they want the group pages to redirect to the org page.

Migration based on https://github.com/alphagov/whitehall/blob/master/db/data_migration/20171102132014_remove_and_redirect_cts_group.rb

---

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4084253)