### PR TITLE
Republish organisations when roles are changed

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -50,12 +50,19 @@ class Role < ApplicationRecord
 
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
+  after_save :republish_organisation_to_publishing_api
 
   extend FriendlyId
   friendly_id
 
   include TranslatableModel
   translates :name, :responsibilities
+
+  def republish_organisation_to_publishing_api
+    organisations.each do |organisation|
+      Whitehall::PublishingApi.republish_async(organisation)
+    end
+  end
 
   def self.whip
     where(arel_table[:whip_organisation_id].not_eq(nil))

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -26,10 +26,18 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     content[:routes][0][:path] = new_base_path
     content_item.stubs(content: content)
 
+    organisation_content_item = PublishingApiPresenters.presenter_for(
+      @organisation,
+      update_type: "republish",
+    )
+
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
       stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: "en", update_type: nil),
+      stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
+      stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
+      stub_publishing_api_publish(organisation_content_item.content_id, locale: "en", update_type: nil),
     ]
 
     Sidekiq::Testing.inline! do


### PR DESCRIPTION
In the publishing API organisation presenter, we link to people,
instead of roles:

    def people_content_ids(role:)
      item.send("#{role}_roles")
        .order("organisation_roles.ordering")
        .map(&:current_person)
        .compact
        .map(&:content_id)
    end

This means that we can't rely on link expansion in the publishing-api
itself to handle the case where we link or unlink a role to an
organisation, because the "link expansion" for that case is happening
in whitehall.

This is a quick fix to make updating roles work again, but ideally
we'd change the presenter to link to roles, not to people.

---

Partially reverts https://github.com/alphagov/whitehall/pull/5575

See https://govuk.zendesk.com/agent/tickets/4145982