### PR TITLE
Bulk organisation updater, update published editions as well when draft edition exists

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -90,7 +90,15 @@ module DataHygiene
         return
       end
 
-      PublishingApiDocumentRepublishingWorker.perform_async(document.id)
+      if !published_edition_updated
+        Whitehall::PublishingApi.save_draft(
+          pre_publication_edition,
+          "republish",
+          true, # bulk_publishing
+        )
+      else
+        PublishingApiDocumentRepublishingWorker.perform_async(document.id)
+      end
     end
 
     def update_edition(edition, new_lead_organisations, new_supporting_organisations)

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -97,7 +97,10 @@ module DataHygiene
           true, # bulk_publishing
         )
       else
-        PublishingApiDocumentRepublishingWorker.perform_async(document.id)
+        PublishingApiDocumentRepublishingWorker.perform_async(
+          document.id,
+          true, # bulk publishing
+        )
       end
     end
 


### PR DESCRIPTION
In cases where the latest edition for the document is a draft. I'm
guessing this is the desired behaviour, otherwise you'd have to wait
for the publishers to publish the draft, which could never be
published, or be discarded and then recreated without the organisation
change.

This Pull Request also includes a couple more changes.