### PR TITLE
Handle missing documents when bulk updating organisations

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -24,6 +24,9 @@ module DataHygiene
 
     def process_row(row)
       document = find_document(row)
+
+      return unless document
+
       new_lead_organisations = find_new_lead_organisations(row)
       new_supporting_organisations = find_new_supporting_organisations(row)
 
@@ -31,7 +34,14 @@ module DataHygiene
     end
 
     def find_document(row)
-      Document.find_by!(slug: row.fetch("Slug"))
+      slug = row.fetch("Slug")
+      document = Document.find_by(slug: slug)
+
+      if document.nil?
+        puts "#{slug}: could not find document"
+      end
+
+      document
     end
 
     def find_organisations(row, column)

--- a/test/unit/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/unit/data_hygiene/bulk_organisation_updater_test.rb
@@ -26,17 +26,6 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
     end
   end
 
-  test "it fails if document doesn't exist" do
-    csv_file = <<~CSV
-      Slug,New lead organisations,New supporting organisations
-      this-is-a-slug,new-organisation,new-supporting-organisation
-    CSV
-
-    assert_raises ActiveRecord::RecordNotFound do
-      process(csv_file)
-    end
-  end
-
   test "it changes the lead organisations" do
     csv_file = <<~CSV
       Slug,New lead organisations,New supporting organisations


### PR DESCRIPTION
Just so the script continues, but tells the user which document
couldn't be found.