### PR TITLE
Change organisation board member edit permissions

### DIFF
--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -111,7 +111,7 @@
     <%= render 'admin/shared/featured_link_fields', form: organisation_form %>
   <% end %>
 
-  <% if current_user.gds_editor? && @organisation.management_roles.any? %>
+  <% if can?(:manage_important_board_members, @organisation) && @organisation.management_roles.any? %>
     <fieldset>
       <div class="form-group">
         <%= organisation_form.label :important_board_members, 'Number of important members of the management team' %>

--- a/lib/whitehall/authority/rules/organisation_rules.rb
+++ b/lib/whitehall/authority/rules/organisation_rules.rb
@@ -7,13 +7,27 @@ module Whitehall::Authority::Rules
       when :edit
         actor.gds_admin? || actor_is_from_organisation_or_parent?(actor, subject)
       when :manage_featured_links
-        actor.gds_admin? || actor.gds_editor? || (actor.managing_editor? && actor_is_from_organisation_or_parent?(actor, subject))
+        actor.gds_admin? || actor.gds_editor? || managing_editor_for_org?(actor, subject)
+      when :manage_important_board_members
+        actor.gds_admin? || actor.gds_editor? || managing_editor_for_org?(actor, subject) || departmental_editor_for_org?(actor, subject)
       else
         false
       end
     end
 
   private
+
+    def managing_editor_for_org?(actor, subject)
+      actor.managing_editor? && actor_is_from_organisation_or_parent?(actor, subject)
+    end
+
+    def departmental_editor_for_org?(actor, subject)
+      actor.departmental_editor? && actor_is_from_organisation?(actor, subject)
+    end
+
+    def actor_is_from_organisation?(actor, organisation)
+      actor.organisation == organisation
+    end
 
     def actor_is_from_organisation_or_parent?(actor, organisation)
       actor.organisation == organisation || actor.organisation.try(:has_child_organisation?, organisation)

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -164,6 +164,18 @@ class DepartmentEditorTest < ActiveSupport::TestCase
     assert_not enforcer_for(user, other_org).can?(:manage_featured_links)
   end
 
+  test "can manage important board members for their organisation" do
+    user = department_editor
+
+    editors_org = user.organisation
+    other_org = build(:organisation)
+    child_org = create(:organisation, parent_organisations: [editors_org])
+
+    assert enforcer_for(user, editors_org).can?(:manage_important_board_members)
+    assert_not enforcer_for(user, child_org).can?(:manage_important_board_members)
+    assert_not enforcer_for(user, other_org).can?(:manage_important_board_members)
+  end
+
   test "can export editions" do
     assert enforcer_for(department_editor, Edition).can?(:export)
   end

--- a/test/unit/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/whitehall/authority/gds_editor_test.rb
@@ -177,6 +177,16 @@ class GDSEditorTest < ActiveSupport::TestCase
     assert enforcer_for(user, other_org).can?(:manage_featured_links)
   end
 
+  test "can manage important board members for any organisation" do
+    user = gds_editor
+
+    editors_org = user.organisation
+    other_org = build(:organisation)
+
+    assert enforcer_for(user, editors_org).can?(:manage_important_board_members)
+    assert enforcer_for(user, other_org).can?(:manage_important_board_members)
+  end
+
   test "can mark editions as political" do
     assert enforcer_for(gds_editor, normal_edition).can?(:mark_political)
   end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -174,6 +174,18 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert_not enforcer_for(user, other_org).can?(:manage_featured_links)
   end
 
+  test "can manage important board members for their organisation and child organisation" do
+    user = managing_editor
+
+    editors_org = user.organisation
+    child_org = create(:organisation, parent_organisations: [editors_org])
+    other_org = build(:organisation)
+
+    assert enforcer_for(user, editors_org).can?(:manage_important_board_members)
+    assert enforcer_for(user, child_org).can?(:manage_important_board_members)
+    assert_not enforcer_for(user, other_org).can?(:manage_important_board_members)
+  end
+
   test "can export editions" do
     assert enforcer_for(managing_editor, Edition).can?(:export)
   end


### PR DESCRIPTION
Currently only users with `GDS Editor` permissions are able to edit the number of important board members for an organisation. This is overly restrictive and preventing departments from making this change themselves.

This PR broadens access to allow 
* GDS Admins to edit board members for any organisation
* Managing Editors to edit board members for their organisation and any child organisations
* Departmental Editors to edit board members for their organisation

[trello](https://trello.com/c/2AbY6ieR/2060-2-signon-permissions-change-for-editing-organisation-pages)