### PR TITLE
Fight Rubocop over the bulk organisation updater

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -119,7 +119,7 @@ module DataHygiene
         edition.lead_organisations == new_lead_organisations &&
           edition.supporting_organisations == new_supporting_organisations
 
-      edition.update!(
+      edition.update( # rubocop:disable Rails/SaveBang
         lead_organisations: new_lead_organisations,
         supporting_organisations: new_supporting_organisations,
       )


### PR DESCRIPTION
This was changed in 7fb77d243229dd1d467ab159c49ca91e516a80c0 to be
update! rather than update, but this means that a single validation
issue with any of the editions that need updating will prevent the
script from completing, and I'm seeing this happen when testing in
Staging.

Ensuring that all Whitehall editions pass the Rails validations is not
what I'm trying to do here, so just go back to using update.