### PR TITLE
Remove image "placeholder" alt text

### DIFF
--- a/app/models/classification_featuring.rb
+++ b/app/models/classification_featuring.rb
@@ -6,7 +6,8 @@ class ClassificationFeaturing < ApplicationRecord
 
   accepts_nested_attributes_for :image, reject_if: :all_blank
 
-  validates :image, :alt_text, presence: true
+  validates :image, presence: true
+  validates :alt_text, presence: true, allow_blank: true
   validates :alt_text, length: { maximum: 255 }
 
   validates :classification, :ordering, presence: true

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -13,7 +13,8 @@ class Feature < ApplicationRecord
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
   validates :document, presence: true, unless: ->(feature) { feature.topical_event_id.present? || feature.offsite_link_id.present? }
   validates :started_at, presence: true
-  validates :image, :alt_text, presence: true, on: :create
+  validates :image, presence: true, on: :create
+  validates :alt_text, presence: true, allow_blank: true, on: :create
   validates :alt_text, length: { maximum: 255 }
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@ class Image < ApplicationRecord
   belongs_to :image_data
   belongs_to :edition
 
-  validates :alt_text, presence: true, length: { maximum: 255 }, unless: :skip_main_validation?
+  validates :alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, unless: :skip_main_validation?
   validates :image_data, presence: { message: "must be present" }
 
   after_destroy :destroy_image_data_if_required

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -15,7 +15,7 @@ class TakePartPage < ApplicationRecord
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
 
   validates :image, presence: true, on: :create
-  validates :image_alt_text, presence: true, length: { maximum: 255 }, on: :create
+  validates :image_alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, on: :create
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 
   include Searchable

--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -15,7 +15,7 @@ module LeadImagePresenterHelper
     if images.first
       images.first.alt_text.squish
     else
-      "placeholder"
+      ""
     end
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -338,9 +338,9 @@ class EditionTest < ActiveSupport::TestCase
     assert_not Edition.submitted.include?(edition)
   end
 
-  test "should be invalid if has image but no alt text" do
+  test "should be valid if it has image but no alt text" do
     article = build(:news_article, images: [build(:image, alt_text: nil)])
-    assert_not article.valid?
+    assert article.valid?
   end
 
   test "should still be valid if has no image and no alt text" do

--- a/test/unit/image_test.rb
+++ b/test/unit/image_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
 class ImageTest < ActiveSupport::TestCase
-  test "should be invalid without alt-text for accessibility" do
+  test "When alt_text is not passed, render with blank alt text for accessibility" do
     image = build(:image, alt_text: nil)
-    assert_not image.valid?
+    assert image.valid?
   end
 
   test "is invalid without any image data" do

--- a/test/unit/lead_image_presenter_helper_test.rb
+++ b/test/unit/lead_image_presenter_helper_test.rb
@@ -4,7 +4,7 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
   test "should use placeholder image if none had been uploaded" do
     presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
     assert_match %r{placeholder}, presenter.lead_image_url
-    assert_equal "placeholder", presenter.lead_image_alt_text
+    assert_equal "", presenter.lead_image_alt_text
   end
 
   test "should use first image with version :s300 if an image is present" do

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -106,7 +106,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       url: organisation_image.file.url(:s300),
-      alt_text: "placeholder",
+      alt_text: "",
       caption: nil,
     }
     presented_item = present(case_study)

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -69,8 +69,8 @@ class TakePartPageTest < ActiveSupport::TestCase
     assert_not build(:take_part_page, image: nil).valid?
   end
 
-  test "invalid without image alt text on create" do
-    assert_not build(:take_part_page, image_alt_text: nil).valid?
+  test "valid without image alt text on create" do
+    assert build(:take_part_page, image_alt_text: nil).valid?
   end
 
   test "limits image alt text to a maximum of 255 characters" do


### PR DESCRIPTION
### What
When the alt text field is left blank when uploading an image for a news article, the word 'placeholder' is used as alt text instead. This attempts to undo this, and leave image alt text blank instead.

### Why
Having "placeholder" as alt text is a problem for screen reader users as the word doesn't make sense in relation to the image.
It's better to leave alt text empty so screen readers can ignore it.

--------

We have deployed this branch to integration and have force-republished an article that used to have a "placeholder" as image alt text.
We can verify that the change worked by comparing the [production version](https://www.gov.uk/government/news/new-law-to-ensure-furloughed-employees-receive-full-redundancy-payments?trythis=tesewmdow) of the article with [the integration one](https://www-origin.integration.publishing.service.gov.uk/government/news/new-law-to-ensure-furloughed-employees-receive-full-redundancy-payments?trythis=tesewmdow).

### Image alt text is "placeholder" (PROD)
<img width="1237" alt="Screenshot 2020-07-31 at 15 28 15" src="https://user-images.githubusercontent.com/7116819/89044903-858af480-d342-11ea-8854-674f981303c5.png">


### Image alt text is blank (INTEGRATION)
<img width="1227" alt="Screenshot 2020-07-31 at 15 28 27" src="https://user-images.githubusercontent.com/7116819/89044907-86bc2180-d342-11ea-8514-ef9ed79d66a5.png">


----- 
https://trello.com/c/TfltwQMw


