### PR TITLE
Update the Brexit no-deal notice for transition

### DIFF
--- a/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
@@ -1,14 +1,15 @@
 <fieldset class="<% if edition.errors[:brexit_no_deal_content_notice_links].any? %>alert-danger form-errors field_with_errors<% end %>" >
 
   <legend class="add-bottom-margin">
-    Brexit no-deal content notice
+    Post-transition content notice
   </legend>
 
   <div class="checkbox add-bottom-margin">
-    <%= form.check_box :show_brexit_no_deal_content_notice, label_text: "Display the no-deal content notice on this page" %>
+    <%= form.check_box :show_brexit_no_deal_content_notice, label_text: "Display the post-transition call-out box on this page" %>
   </div>
 
-  <p>Add links to the current guidance, which will appear in the no-deal content notice.</p>
+  <p>Add links to current state guidance, which will appear in the call-out box.</p>
+  <p>Read the <a href="https://www.gov.uk/guidance/content-design/helping-users-prepare-for-change#preparing-users-for-changes-related-to-the-end-of-the-transition-period-with-the-eu" target="_blank" rel="noopener noreferrer">guidance on post-transition content</a> (opens in a new tab).</p>
   <p>Use full URLs for external websites, for example https://www.example.com.</p>
 
   <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>


### PR DESCRIPTION
This content is out of date and does not match the current intent of the notice box.

Guidance for publishers will be communicated on Basecamp.

https://trello.com/c/ULzLyIBv/366-update-language-used-for-brexit-no-deal-content-notice-in-whitehall-publisher