### PR TITLE
[DO NOT MERGE] WIP Edit excluded nation form

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -237,6 +237,7 @@ private
       :political,
       :read_consultation_principles,
       :show_brexit_no_deal_content_notice,
+      :all_nation_applicability,
       brexit_no_deal_content_notice_links_attributes: %i[id title url],
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],

--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -10,11 +10,21 @@ module Edition::NationalApplicability
   end
 
   included do
+    validate :applicability_options
     has_many :nation_inapplicabilities, foreign_key: :edition_id, dependent: :destroy, autosave: true
     validates_associated :nation_inapplicabilities
     validates :nation_inapplicabilities, length: { maximum: Nation.all.count - 1, message: "can not exclude all nations" }
 
     add_trait Trait
+  end
+
+  def applicability_options
+    if !@all_nation_applicability && nation_inapplicabilities.size < 1
+      errors.add(:excluded_nations, "must either allow all nations or exclude at least one nation")
+    end
+    if @all_nation_applicability && nation_inapplicabilities.size > 0
+      errors.add(:excluded_nations, "cannot allow all nations and exclude nations")
+    end
   end
 
   def all_nation_applicability=(attributes)

--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -19,16 +19,12 @@ module Edition::NationalApplicability
   end
 
   def applicability_options
-    if !@all_nation_applicability && nation_inapplicabilities.size < 1
+    if !all_nation_applicability && nation_inapplicabilities.size < 1
       errors.add(:excluded_nations, "must either allow all nations or exclude at least one nation")
     end
-    if @all_nation_applicability && nation_inapplicabilities.size > 0
+    if all_nation_applicability && nation_inapplicabilities.size > 0
       errors.add(:excluded_nations, "cannot allow all nations and exclude nations")
     end
-  end
-
-  def all_nation_applicability=(attributes)
-    @all_nation_applicability ||= ActiveRecord::Type::Boolean.new.deserialize(attributes)
   end
 
   def nation_inapplicabilities_attributes=(attributes)

--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -17,6 +17,10 @@ module Edition::NationalApplicability
     add_trait Trait
   end
 
+  def all_nation_applicability=(attributes)
+    @all_nation_applicability ||= ActiveRecord::Type::Boolean.new.deserialize(attributes)
+  end
+
   def nation_inapplicabilities_attributes=(attributes)
     attributes.each_value do |params|
       existing = nation_inapplicabilities.detect { |ni| ni.nation_id == params[:nation_id].to_i }

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -12,10 +12,10 @@
     <%= form.fields_for :nation_inapplicabilities, inapplicability do |ni_fields| %>
       <%= content_tag_for(:div, ni_fields.object.nation, class: 'control-group') do %>
         <div class="control">
-          <%= ni_fields.check_box :excluded, label_text: nation.name, checked: ni_fields.object.excluded? %>
+          <%= ni_fields.check_box :excluded, label_text: "Does not apply to #{nation.name}", checked: ni_fields.object.excluded? %>
         </div>
         <div class="control">
-          <%= ni_fields.text_field :alternative_url %>
+          <%= ni_fields.text_field :alternative_url, label_text: "URL of corresponding content" %>
           <%= ni_fields.hidden_field :nation_id %>
         </div>
       <% end %>

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -1,6 +1,11 @@
 <fieldset class="excluded_nations <% if edition.errors[:nation_inapplicabilities].any? %>alert-danger form-errors field_with_errors<% end %>" >
   <legend>Excluded nations</legend>
 
+  <%= label_tag('edition[all_nation_applicability]') do %>
+    <%= check_box_tag('edition[all_nation_applicability]', "1", false)%>
+    Applies to all UK nations
+  <% end %>
+
   <% Nation.potentially_inapplicable.each do |nation| %>
     <% inapplicability = edition.nation_inapplicabilities.detect {|i| i.nation == nation } || edition.nation_inapplicabilities.build(nation: nation) %>
 

--- a/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
+++ b/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
@@ -1,0 +1,15 @@
+PUBLISHED_AND_PUBLISHABLE_STATES = %w[published draft archived submitted rejected scheduled].freeze
+EDITIONS_WITH_NATIONAL_APPLICABILITY = ['DetailedGuide', 'Publication', 'Consultation'].freeze
+
+
+edition_scope = Edition.where(type: EDITIONS_WITH_NATIONAL_APPLICABILITY).where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+
+edition_scope.find_each {|edition| update_all_nation_applicability(edition)}
+
+def update_all_nation_applicability(edition)
+  if edition.nation_inapplicabilities.any?
+    edition.update_column(:all_nation_applicability, false)
+  else
+    edition.update_column(:all_nation_applicability, true)
+  end
+end

--- a/db/migrate/20200814153802_add_all_nation_applicability_to_edition.rb
+++ b/db/migrate/20200814153802_add_all_nation_applicability_to_edition.rb
@@ -1,0 +1,5 @@
+class AddAllNationApplicabilityToEdition < ActiveRecord::Migration[5.1]
+  def change
+    add_column :editions, :all_nation_applicability, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200304165045) do
+ActiveRecord::Schema.define(version: 20200814160434) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -424,6 +424,7 @@ ActiveRecord::Schema.define(version: 20200304165045) do
     t.string "logo_url"
     t.boolean "read_consultation_principles", default: false
     t.boolean "show_brexit_no_deal_content_notice", default: false
+    t.boolean "all_nation_applicability"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -1,9 +1,9 @@
 When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/) do |title, nations|
-  begin_drafting_publication(title)
+  begin_drafting_publication(title, all_nation_applicability: false)
   nations.raw.flatten.each do |nation_name|
     within record_css_selector(Nation.find_by_name!(nation_name)) do
       check nation_name
-      fill_in "Alternative url", with: "http://www.#{nation_name}.com/"
+      fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
     end
   end
   click_button "Save and continue"

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -122,6 +122,7 @@ end
 
 When(/^I save the draft statistics document$/) do
   fill_in "Body", with: "Statistics body text"
+  check "Applies to all UK nations"
   click_on "Save"
 end
 

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -7,7 +7,7 @@ Given(/^an unopened consultation exists$/) do
 end
 
 When(/^I draft a new consultation "([^"]*)"$/) do |title|
-  begin_drafting_document type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider)
+  begin_drafting_document type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider), all_nation_applicablity: false
   fill_in "Link URL", with: "http://participate.com"
   fill_in "Email", with: "participate@gov.uk"
   select_date 1.day.ago.to_s, from: "Opening Date"
@@ -15,7 +15,7 @@ When(/^I draft a new consultation "([^"]*)"$/) do |title|
 
   within record_css_selector(Nation.find_by_name!("Wales")) do
     check "Wales"
-    fill_in "Alternative url", with: "http://www.visitwales.co.uk/"
+    fill_in "URL of corresponding content", with: "http://www.visitwales.co.uk/"
   end
   check "Scotland"
   click_button "Save"

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -6,12 +6,12 @@ end
 
 When(/^I draft a new detailed guide "([^"]*)"$/) do |title|
   create(:government)
-  begin_drafting_document type: "detailed_guide", title: title, previously_published: false
+  begin_drafting_document type: "detailed_guide", title: title, previously_published: false, all_nation_applicability: true
   click_button "Save"
 end
 
 Given(/^I start drafting a new detailed guide$/) do
-  begin_drafting_document type: "detailed_guide", title: "Detailed Guide", previously_published: false
+  begin_drafting_document type: "detailed_guide", title: "Detailed Guide", previously_published: false, all_nation_applicability: true
 end
 
 Then(/^I should be able to select another image for the detailed guide$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -40,6 +40,10 @@ module DocumentHelper
       when true
         choose "has previously been published on another website."
       end
+
+      if options[:all_nation_applicability]
+        check "Applies to all UK nations"
+      end
     end
   end
 
@@ -59,7 +63,7 @@ module DocumentHelper
   end
 
   def begin_drafting_consultation(options)
-    begin_drafting_document(options.merge(type: "consultation"))
+    begin_drafting_document(options.merge(type: "consultation", all_nation_applicability: true))
     select_date 10.days.from_now.to_s, from: "Opening Date"
     select_date 40.days.from_now.to_s, from: "Closing Date"
   end
@@ -70,6 +74,7 @@ module DocumentHelper
       title: title,
       summary: "Some summary of the content",
       alternative_format_provider: create(:alternative_format_provider),
+      all_nation_applicability: options.key?(:all_nation_applicability) ? options[:all_nation_applicability] : true
     )
     fill_in_publication_fields(options.slice(:first_published, :publication_type))
   end

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -5,12 +5,17 @@ FactoryBot.define do
     opening_at { 1.day.ago }
     closing_at { 6.weeks.from_now }
     read_consultation_principles { true }
+    all_nation_applicability { true }
     transient do
       relevant_to_local_government { false }
     end
 
     trait(:with_html_attachment) do
       attachments { [FactoryBot.build(:html_attachment)] }
+    end
+
+    trait(:has_excluded_nations) do
+      all_nation_applicability { false }
     end
   end
 
@@ -53,4 +58,7 @@ FactoryBot.define do
   factory :consultation_with_public_feedback_html_attachment, parent: :closed_consultation do
     public_feedback { create(:consultation_public_feedback, :with_html_attachment) }
   end
+
+  factory :consultation_with_excluded_nations, parent: :consultation, traits: [:has_excluded_nations]
+  factory :published_consultation_with_excluded_nations, parent: :published_consultation, traits: [:has_excluded_nations]
 end

--- a/test/factories/detailed_guides.rb
+++ b/test/factories/detailed_guides.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :detailed_guide, class: DetailedGuide, parent: :edition, traits: %i[with_organisations] do
     sequence(:title) { |index| "detailed-guide-title-#{index}" }
     body { "detailed-guide-body" }
+    all_nation_applicability { true }
+  end
+
+  trait(:has_excluded_nations) do
+    all_nation_applicability { false }
   end
 
   factory :draft_detailed_guide, parent: :detailed_guide, traits: [:draft]
@@ -11,4 +16,5 @@ FactoryBot.define do
   factory :deleted_detailed_guide, parent: :detailed_guide, traits: [:deleted]
   factory :superseded_detailed_guide, parent: :detailed_guide, traits: [:superseded]
   factory :scheduled_detailed_guide, parent: :detailed_guide, traits: [:scheduled]
+  factory :published_detailed_guide_with_excluded_nations, parent: :detailed_guide, traits: %i[published has_excluded_nations]
 end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     summary { "publication-summary" }
     publication_type_id { PublicationType::PolicyPaper.id }
     attachments { FactoryBot.build_list :html_attachment, 1 }
+    all_nation_applicability { true }
+
+    trait(:has_excluded_nations) do
+      all_nation_applicability { false }
+    end
 
     trait(:corporate) do
       publication_type_id { PublicationType::CorporateReport.id }
@@ -78,6 +83,10 @@ FactoryBot.define do
           parent: :publication,
           traits: %i[draft consolidated_redirect]
   factory :withdrawn_publication, parent: :publication, traits: [:withdrawn]
+
+  factory :published_publication_with_excluded_nations, parent: :published_publication, traits: [:has_excluded_nations]
+  factory :draft_publication_with_excluded_nations, parent: :draft_publication, traits: [:has_excluded_nations]
+
 
   factory :draft_corporate_publication, parent: :publication, traits: %i[draft corporate]
   factory :submitted_corporate_publication, parent: :publication, traits: %i[submitted corporate]

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -12,7 +12,7 @@ module TestsForNationalApplicability
 
     test "create should create a new edition with nation inapplicabilities" do
       create(:government)
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
 
       post :create, params: { edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/")) }
 
@@ -23,8 +23,6 @@ module TestsForNationalApplicability
 
     test "create should create a new edition with all_nation_applicability including all nations" do
       create(:government)
-      attributes = attributes_for_edition
-
       expected_national_applicability = {
         england: {
           label: "England",
@@ -44,11 +42,7 @@ module TestsForNationalApplicability
         },
       }
 
-      post :create, params: {
-        edition: attributes.merge(
-          all_nation_applicability: "1"
-        )
-      }
+      post :create, params: { edition: attributes_for_edition }
 
       assert edition = Edition.last
       assert_equal edition.national_applicability, expected_national_applicability
@@ -56,8 +50,6 @@ module TestsForNationalApplicability
 
     test "create should create a new edition with all_nation_applicability overriding individual options" do
       create(:government)
-      attributes = attributes_for_edition
-
       expected_national_applicability = {
         england: {
           label: "England",
@@ -77,11 +69,7 @@ module TestsForNationalApplicability
         },
       }
 
-      post :create, params: {
-        edition: attributes.merge(
-          all_nation_applicability: "1"
-        )
-      }
+      post :create, params: { edition: attributes_for_edition }
 
       assert edition = Edition.last
       assert_equal edition.national_applicability, expected_national_applicability
@@ -94,7 +82,7 @@ module TestsForNationalApplicability
         alternative_url: "http://scotland.com",
       )
       detailed_guide = create(
-        :published_detailed_guide,
+        :published_detailed_guide_with_excluded_nations,
         nation_inapplicabilities: [
           scotland_nation_inapplicability,
         ],
@@ -125,7 +113,7 @@ module TestsForNationalApplicability
 
     view_test "creating with all nations excluded should fail validation" do
       create(:government)
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
 
       all_nations = nation_inapplicabilities_attributes_for({
         Nation.england => "http://www.england.com/",
@@ -144,7 +132,7 @@ module TestsForNationalApplicability
     view_test "creating with no applicability options should fail validation" do
       create(:government)
 
-      post :create, params: { edition: attributes_for_edition}
+      post :create, params: { edition: attributes_for_edition(all_nation_applicability: "0")}
 
       assert_nil Edition.last
 
@@ -165,7 +153,7 @@ module TestsForNationalApplicability
     end
 
     view_test "creating with invalid edition data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
       post :create,
            params: {
              edition: attributes.merge(
@@ -181,7 +169,7 @@ module TestsForNationalApplicability
     end
 
     view_test "creating with invalid nation inapplicability data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
       post :create,
            params: {
              edition: attributes.merge(
@@ -212,7 +200,7 @@ module TestsForNationalApplicability
     end
 
     test "updating should save modified edition with nation inapplicabilities" do
-      edition = build_edition(attributes_for_edition)
+      edition = build_edition(all_nation_applicability: "0")
       northern_ireland_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")
       edition.save
 
@@ -227,7 +215,7 @@ module TestsForNationalApplicability
     end
 
     view_test "updating with invalid edition data should not lose the nation inapplicability fields or values" do
-      edition = build_edition(attributes_for_edition)
+      edition = build_edition(all_nation_applicability: "0")
       scotland_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
       wales_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.wales, alternative_url: "http://www.wales.com/")
       edition.save
@@ -246,7 +234,7 @@ module TestsForNationalApplicability
     end
 
     view_test "updating with invalid nation inapplicability data should not lose the nation inapplicability fields or values" do
-      edition = build_edition(attributes_for_edition)
+      edition = build_edition(all_nation_applicability: "0")
       scotland_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
       wales_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.wales, alternative_url: "http://www.wales.com/")
       edition.save
@@ -267,7 +255,7 @@ module TestsForNationalApplicability
     end
 
     view_test "updating a stale edition should not lose the nation inapplicability fields or values" do
-      edition = build_edition(attributes_for_edition)
+      edition = build_edition(all_nation_applicability: "0")
       scotland_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
       wales_inapplicability = edition.nation_inapplicabilities.build(nation: Nation.wales, alternative_url: "http://www.wales.com/")
       edition.save

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -66,7 +66,7 @@ class ConsultationTest < ActiveSupport::TestCase
 
   test "should build a draft copy of the existing consultation with inapplicable nations" do
     published_consultation = create(
-      :published_consultation,
+      :published_consultation_with_excluded_nations,
       nation_inapplicabilities: [
         create(:nation_inapplicability, nation_id: Nation.wales.id, alternative_url: "http://wales.gov.uk"),
         create(:nation_inapplicability, nation_id: Nation.scotland.id, alternative_url: "http://scot.gov.uk"),

--- a/test/unit/edition/nation_inapplicability_test.rb
+++ b/test/unit/edition/nation_inapplicability_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Edition::NationInapplicabilityTest < ActiveSupport::TestCase
   setup do
     @nation_inapplicability = create(:nation_inapplicability, nation_id: 2)
-    @edition = create(:draft_publication, nation_inapplicabilities: [@nation_inapplicability])
+    @edition = create(:draft_publication_with_excluded_nations, nation_inapplicabilities: [@nation_inapplicability])
   end
 
   test "#destroy should also remove the relationship" do

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -28,25 +28,25 @@ class DocumentHelperTest < ActionView::TestCase
   end
 
   test "should generate list of links to inapplicable nations with alternative URL" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
     html = list_of_links_to_inapplicable_nations(publication.nation_inapplicabilities)
     assert_select_within_html html, "a[href='http://scotland.com']", text: "Scotland"
   end
 
   test "should generate list of inapplicable nations without alternative URL" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.wales, alternative_url: nil)])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.wales, alternative_url: nil)])
     assert_equal "Wales", list_of_links_to_inapplicable_nations(publication.nation_inapplicabilities)
   end
 
   test "#see_alternative_urls_for_inapplicable_nations lists names and links if any alternative urls exist" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
     html = see_alternative_urls_for_inapplicable_nations(publication)
     assert_select_within_html html, "a[href='http://scotland.com']", text: "Scotland"
     assert html.starts_with?(" (see publication for ")
   end
 
   test "#see_alternative_urls_for_inapplicable_nations skips nations without alternative urls" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com"), create(:nation_inapplicability, nation: Nation.wales, alternative_url: "")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com"), create(:nation_inapplicability, nation: Nation.wales, alternative_url: "")])
     html = see_alternative_urls_for_inapplicable_nations(publication)
     assert_no_match %r{Wales}, html
   end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -543,7 +543,7 @@ module PublishingApi::ConsultationPresenterTest
       )
 
       self.consultation = create(
-        :consultation,
+        :consultation_with_excluded_nations,
         nation_inapplicabilities: [scotland_nation_inapplicability],
       )
     end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -186,7 +186,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     )
     create(:government)
     detailed_guide = create(
-      :published_detailed_guide,
+      :published_detailed_guide_with_excluded_nations,
       nation_inapplicabilities: [
         scotland_nation_inapplicability,
       ],


### PR DESCRIPTION
This WIP PR adds an additional checkbox, `all_nation_applicability`, to the Excluded Nations fieldset in `/admin/publications/new`.

It adds validation to ensure that either this new checkbox or one of the existing Excluded Nations checkboxes is selected, and also that they are not both selected.

If `all_nation_applicability` is selected any previous `nation_inapplicabilities` will be discarded, similarly to submitting the form with all Excluded Nations empty.