### PR TITLE
Add base tag to html attachments view

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -8,6 +8,7 @@ class CsvPreviewController < ApplicationController
           @edition = visible_edition
           @attachment = attachment_data.visible_attachment_for(current_user)
           @csv_preview = CsvFileFromPublicHost.csv_preview_from(@csv_response)
+          @page_base_href = Plek.new.website_root
           render layout: "html_attachments"
         else
           fail

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -25,6 +25,7 @@
     <%= stylesheet_link_tag "frontend/print.css", media: "print", integrity: false %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
+    <%= tag :base, href: @page_base_href if @page_base_href %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>


### PR DESCRIPTION
This PR adds a `base` tag to the `html_attachments` view. This view is used by the `csv_preview` controller and links currently rendered in the footer on this page currently point to the wrong URL (assets rather than GOV.UK); as a result, they return 404s. The footer itself is obtained through Slimmer, using the `chromeless` view that's part of `Static` where most URLs in the footer are relative.

By adding a `base` tag, all relative URLs on the page will be prefixed with the `href` attribute specified, which is the GOV.UK website root. The `base` tag can only appear in the `head` of a page, which is the reason for adding it into the partial `frontend_base`.