### PR TITLE
Ensure editions have accurate UK Nation applicability

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -237,6 +237,7 @@ private
       :political,
       :read_consultation_principles,
       :show_brexit_no_deal_content_notice,
+      :all_nation_applicability,
       brexit_no_deal_content_notice_links_attributes: %i[id title url],
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -175,6 +175,11 @@ class Consultation < Publicationesque
     false
   end
 
+  def all_nation_applicability_selected?
+    newly_created = document.nil?
+    newly_created ? false : all_nation_applicability
+  end
+
 private
 
   def validate_closes_after_opens

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -124,6 +124,11 @@ class DetailedGuide < Edition
     related_mainstreams.create!(content_id: related_mainstream_content_ids[1], additional: true) if related_mainstream_content_ids[1]
   end
 
+  def all_nation_applicability_selected?
+    newly_created = document.nil?
+    newly_created ? false : all_nation_applicability
+  end
+
 private
 
   def date_for_government

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -567,6 +567,10 @@ EXISTS (
     latest_edition == self
   end
 
+  def all_nation_applicability_selected?
+    true
+  end
+
   def most_recent_change_note
     if minor_change?
       previous_major_version = Edition.unscoped.where("document_id=? and published_major_version=? and published_minor_version=0", document_id, published_major_version)

--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -20,10 +20,10 @@ module Edition::NationalApplicability
 
   def applicability_options
     if !all_nation_applicability && nation_inapplicabilities.none?(&:excluded?)
-      errors.add(:nation_inapplicabilities, "must either allow all nations or exclude at least one nation")
+      errors.add(:nation_inapplicabilities, "- you must select whether this content applies to all UK nations or which ones it excludes")
     end
     if all_nation_applicability && nation_inapplicabilities.any?(&:excluded?)
-      errors.add(:nation_inapplicabilities, "cannot allow all nations and exclude nations")
+      errors.add(:nation_inapplicabilities, "- you cannot select all UK nations and also exclude nations")
     end
   end
 

--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -10,11 +10,21 @@ module Edition::NationalApplicability
   end
 
   included do
+    validate :applicability_options
     has_many :nation_inapplicabilities, foreign_key: :edition_id, dependent: :destroy, autosave: true
     validates_associated :nation_inapplicabilities
     validates :nation_inapplicabilities, length: { maximum: Nation.all.count - 1, message: "can not exclude all nations" }
 
     add_trait Trait
+  end
+
+  def applicability_options
+    if !all_nation_applicability && nation_inapplicabilities.none?(&:excluded?)
+      errors.add(:nation_inapplicabilities, "must either allow all nations or exclude at least one nation")
+    end
+    if all_nation_applicability && nation_inapplicabilities.any?(&:excluded?)
+      errors.add(:nation_inapplicabilities, "cannot allow all nations and exclude nations")
+    end
   end
 
   def nation_inapplicabilities_attributes=(attributes)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -73,6 +73,11 @@ class Publication < Publicationesque
     true
   end
 
+  def all_nation_applicability_selected?
+    newly_created = document.nil?
+    newly_created ? false : all_nation_applicability
+  end
+
   def display_type
     publication_type.try(:singular_name)
   end

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -12,10 +12,10 @@
     <%= form.fields_for :nation_inapplicabilities, inapplicability do |ni_fields| %>
       <%= content_tag_for(:div, ni_fields.object.nation, class: 'control-group') do %>
         <div class="control">
-          <%= ni_fields.check_box :excluded, label_text: nation.name, checked: ni_fields.object.excluded? %>
+          <%= ni_fields.check_box :excluded, label_text: "Does not apply to #{nation.name}", checked: ni_fields.object.excluded? %>
         </div>
         <div class="control">
-          <%= ni_fields.text_field :alternative_url %>
+          <%= ni_fields.text_field :alternative_url, label_text: "URL of corresponding content" %>
           <%= ni_fields.hidden_field :nation_id %>
         </div>
       <% end %>

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -2,10 +2,9 @@
   <legend>Excluded nations</legend>
 
   <%= label_tag('edition[all_nation_applicability]') do %>
-    <%= check_box 'edition', 'all_nation_applicability', {checked: false}, '1', '0' %>
+    <%= check_box 'edition', 'all_nation_applicability', {checked: edition.all_nation_applicability_selected? }, '1', '0' %>
     Applies to all UK nations
   <% end %>
-
   <% Nation.potentially_inapplicable.each do |nation| %>
     <% inapplicability = edition.nation_inapplicabilities.detect {|i| i.nation == nation } || edition.nation_inapplicabilities.build(nation: nation) %>
 

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -1,6 +1,11 @@
 <fieldset class="excluded_nations <% if edition.errors[:nation_inapplicabilities].any? %>alert-danger form-errors field_with_errors<% end %>" >
   <legend>Excluded nations</legend>
 
+  <%= label_tag('edition[all_nation_applicability]') do %>
+    <%= check_box 'edition', 'all_nation_applicability', {checked: false}, '1', '0' %>
+    Applies to all UK nations
+  <% end %>
+
   <% Nation.potentially_inapplicable.each do |nation| %>
     <% inapplicability = edition.nation_inapplicabilities.detect {|i| i.nation == nation } || edition.nation_inapplicabilities.build(nation: nation) %>
 

--- a/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
+++ b/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
@@ -1,0 +1,12 @@
+PUBLISHED_AND_PUBLISHABLE_STATES = %w[published draft archived submitted rejected scheduled].freeze
+EDITIONS_WITH_NATIONAL_APPLICABILITY = ['DetailedGuide', 'Publication', 'Consultation'].freeze
+
+edition_scope = Edition.where(type: EDITIONS_WITH_NATIONAL_APPLICABILITY).where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+
+def update_all_nation_applicability(edition)
+  if edition.nation_inapplicabilities.any?
+    edition.update_column(:all_nation_applicability, false)
+  end
+end
+
+edition_scope.find_each {|edition| update_all_nation_applicability(edition)}

--- a/db/migrate/20200814153802_add_all_nation_applicability_to_edition.rb
+++ b/db/migrate/20200814153802_add_all_nation_applicability_to_edition.rb
@@ -1,0 +1,5 @@
+class AddAllNationApplicabilityToEdition < ActiveRecord::Migration[5.1]
+  def change
+    add_column :editions, :all_nation_applicability, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200304165045) do
+ActiveRecord::Schema.define(version: 20200814160434) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -424,6 +424,7 @@ ActiveRecord::Schema.define(version: 20200304165045) do
     t.string "logo_url"
     t.boolean "read_consultation_principles", default: false
     t.boolean "show_brexit_no_deal_content_notice", default: false
+    t.boolean "all_nation_applicability"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -1,9 +1,9 @@
 When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/) do |title, nations|
-  begin_drafting_publication(title)
+  begin_drafting_publication(title, all_nation_applicability: false)
   nations.raw.flatten.each do |nation_name|
     within record_css_selector(Nation.find_by_name!(nation_name)) do
       check nation_name
-      fill_in "Alternative url", with: "http://www.#{nation_name}.com/"
+      fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
     end
   end
   click_button "Save and continue"

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -122,6 +122,7 @@ end
 
 When(/^I save the draft statistics document$/) do
   fill_in "Body", with: "Statistics body text"
+  check "Applies to all UK nations"
   click_on "Save"
 end
 

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -7,7 +7,7 @@ Given(/^an unopened consultation exists$/) do
 end
 
 When(/^I draft a new consultation "([^"]*)"$/) do |title|
-  begin_drafting_document type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider)
+  begin_drafting_document type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider), all_nation_applicablity: false
   fill_in "Link URL", with: "http://participate.com"
   fill_in "Email", with: "participate@gov.uk"
   select_date 1.day.ago.to_s, from: "Opening Date"
@@ -15,7 +15,7 @@ When(/^I draft a new consultation "([^"]*)"$/) do |title|
 
   within record_css_selector(Nation.find_by_name!("Wales")) do
     check "Wales"
-    fill_in "Alternative url", with: "http://www.visitwales.co.uk/"
+    fill_in "URL of corresponding content", with: "http://www.visitwales.co.uk/"
   end
   check "Scotland"
   click_button "Save"
@@ -53,6 +53,7 @@ When(/^I save and publish the amended consultation$/) do
   stub_publishing_api_links_with_taxons(consultation.content_id, %w[a-taxon-content-id])
   ensure_path edit_admin_consultation_path(consultation)
   fill_in_change_note_if_required
+  apply_to_all_nations_if_required
   click_button "Save and continue"
   click_button "Save topic changes"
   publish force: true

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -6,12 +6,12 @@ end
 
 When(/^I draft a new detailed guide "([^"]*)"$/) do |title|
   create(:government)
-  begin_drafting_document type: "detailed_guide", title: title, previously_published: false
+  begin_drafting_document type: "detailed_guide", title: title, previously_published: false, all_nation_applicability: true
   click_button "Save"
 end
 
 Given(/^I start drafting a new detailed guide$/) do
-  begin_drafting_document type: "detailed_guide", title: "Detailed Guide", previously_published: false
+  begin_drafting_document type: "detailed_guide", title: "Detailed Guide", previously_published: false, all_nation_applicability: true
 end
 
 Then(/^I should be able to select another image for the detailed guide$/) do
@@ -24,6 +24,7 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   visit admin_edition_path(guide)
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
+  apply_to_all_nations_if_required
   click_button "Save and continue"
   click_button "Save topic changes"
   publish(force: true)

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -159,6 +159,7 @@ When("I force publish {edition}") do |edition|
   visit_edition_admin edition.title, :draft
   click_link "Edit draft"
   fill_in_change_note_if_required
+  apply_to_all_nations_if_required
   click_button "Save and continue"
   click_button "Save topic changes"
   publish(force: true)

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -76,6 +76,8 @@ When(/^I replace the data file of the attachment in a new draft of the publicati
 
   ensure_path edit_admin_publication_path(@new_edition)
   fill_in_change_note_if_required
+  apply_to_all_nations_if_required
+
   click_button "Save"
 end
 

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -49,6 +49,7 @@ end
 When(/^I draft a new publication "([^"]*)" relating it to topical event "([^"]*)"$/) do |publication_title, topical_event_name|
   begin_drafting_publication publication_title
   select topical_event_name, from: "Topical events"
+  check "Applies to all UK nations"
   click_button "Save and continue"
   click_button "Save topic changes"
   add_external_attachment

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -40,6 +40,10 @@ module DocumentHelper
       when true
         choose "has previously been published on another website."
       end
+
+      if options[:all_nation_applicability]
+        check "Applies to all UK nations"
+      end
     end
   end
 
@@ -59,7 +63,7 @@ module DocumentHelper
   end
 
   def begin_drafting_consultation(options)
-    begin_drafting_document(options.merge(type: "consultation"))
+    begin_drafting_document(options.merge(type: "consultation", all_nation_applicability: true))
     select_date 10.days.from_now.to_s, from: "Opening Date"
     select_date 40.days.from_now.to_s, from: "Closing Date"
   end
@@ -70,6 +74,7 @@ module DocumentHelper
       title: title,
       summary: "Some summary of the content",
       alternative_format_provider: create(:alternative_format_provider),
+      all_nation_applicability: options.key?(:all_nation_applicability) ? options[:all_nation_applicability] : true
     )
     fill_in_publication_fields(options.slice(:first_published, :publication_type))
   end
@@ -123,6 +128,12 @@ module DocumentHelper
   def fill_in_change_note_if_required
     if has_selector?("textarea[name='edition[change_note]']", wait: false)
       fill_in "edition_change_note", with: "changes"
+    end
+  end
+
+  def apply_to_all_nations_if_required
+    if has_selector?(".excluded_nations", wait: false)
+      check "Applies to all UK nations"
     end
   end
 

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -54,6 +54,7 @@ module SpecialistSectorHelper
   def assert_specialist_sectors_were_saved
     assert has_css?(".flash.notice")
     click_on "Edit draft"
+    check "Applies to all UK nations"
     click_on "Save and continue"
     click_on "Save and review legacy tagging"
     assert_equal "WELLS", find_field("Primary specialist sector").value

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -5,12 +5,17 @@ FactoryBot.define do
     opening_at { 1.day.ago }
     closing_at { 6.weeks.from_now }
     read_consultation_principles { true }
+    all_nation_applicability { true }
     transient do
       relevant_to_local_government { false }
     end
 
     trait(:with_html_attachment) do
       attachments { [FactoryBot.build(:html_attachment)] }
+    end
+
+    trait(:has_excluded_nations) do
+      all_nation_applicability { false }
     end
   end
 
@@ -53,4 +58,7 @@ FactoryBot.define do
   factory :consultation_with_public_feedback_html_attachment, parent: :closed_consultation do
     public_feedback { create(:consultation_public_feedback, :with_html_attachment) }
   end
+
+  factory :consultation_with_excluded_nations, parent: :consultation, traits: [:has_excluded_nations]
+  factory :published_consultation_with_excluded_nations, parent: :published_consultation, traits: [:has_excluded_nations]
 end

--- a/test/factories/detailed_guides.rb
+++ b/test/factories/detailed_guides.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :detailed_guide, class: DetailedGuide, parent: :edition, traits: %i[with_organisations] do
     sequence(:title) { |index| "detailed-guide-title-#{index}" }
     body { "detailed-guide-body" }
+    all_nation_applicability { true }
+  end
+
+  trait(:has_excluded_nations) do
+    all_nation_applicability { false }
   end
 
   factory :draft_detailed_guide, parent: :detailed_guide, traits: [:draft]
@@ -11,4 +16,5 @@ FactoryBot.define do
   factory :deleted_detailed_guide, parent: :detailed_guide, traits: [:deleted]
   factory :superseded_detailed_guide, parent: :detailed_guide, traits: [:superseded]
   factory :scheduled_detailed_guide, parent: :detailed_guide, traits: [:scheduled]
+  factory :published_detailed_guide_with_excluded_nations, parent: :detailed_guide, traits: %i[published has_excluded_nations]
 end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     summary { "publication-summary" }
     publication_type_id { PublicationType::PolicyPaper.id }
     attachments { FactoryBot.build_list :html_attachment, 1 }
+    all_nation_applicability { true }
+
+    trait(:has_excluded_nations) do
+      all_nation_applicability { false }
+    end
 
     trait(:corporate) do
       publication_type_id { PublicationType::CorporateReport.id }
@@ -78,6 +83,10 @@ FactoryBot.define do
           parent: :publication,
           traits: %i[draft consolidated_redirect]
   factory :withdrawn_publication, parent: :publication, traits: [:withdrawn]
+
+  factory :published_publication_with_excluded_nations, parent: :published_publication, traits: [:has_excluded_nations]
+  factory :draft_publication_with_excluded_nations, parent: :draft_publication, traits: [:has_excluded_nations]
+
 
   factory :draft_corporate_publication, parent: :publication, traits: %i[draft corporate]
   factory :submitted_corporate_publication, parent: :publication, traits: %i[submitted corporate]

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -88,7 +88,7 @@ module TestsForNationalApplicability
 
       assert_nil Edition.last
 
-      assert_page_has_error("Excluded nations must either allow all nations or exclude at least one nation")
+      assert_page_has_error("Excluded nations - you must select whether this content applies to all UK nations or which ones it excludes")
     end
 
     view_test "creating with all_nation_applicability and an excluded nation should fail validation" do
@@ -101,7 +101,7 @@ module TestsForNationalApplicability
         )
       }
 
-      assert_page_has_error("Excluded nations cannot allow all nations and exclude nations")
+      assert_page_has_error("Excluded nations - you cannot select all UK nations and also exclude nations")
     end
 
     view_test "creating with invalid edition data should not lose the nation inapplicability fields or values" do

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -12,43 +12,19 @@ module TestsForNationalApplicability
 
     test "create should create a new edition with nation inapplicabilities" do
       create(:government)
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
 
-      post :create, params: { edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/")) }
+      post :create, params: { edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.example.com/scotland")) }
 
       assert edition = Edition.last
       assert scotland_inapplicability = edition.nation_inapplicabilities.for_nation(Nation.scotland).first
-      assert_equal "http://www.scotland.com/", scotland_inapplicability.alternative_url
+      assert_equal "http://www.example.com/scotland", scotland_inapplicability.alternative_url
     end
 
     test "create should create a new edition with all_nation_applicability including all nations" do
       create(:government)
-      attributes = attributes_for_edition
 
-      expected_national_applicability = {
-        england: {
-          label: "England",
-          applicable: true,
-        },
-        northern_ireland: {
-          label: "Northern Ireland",
-          applicable: true,
-        },
-        scotland: {
-          label: "Scotland",
-          applicable: true,
-        },
-        wales: {
-          label: "Wales",
-          applicable: true,
-        },
-      }
-
-      post :create, params: {
-        edition: attributes.merge(
-          all_nation_applicability: "1"
-        )
-      }
+      post :create, params: { edition: attributes_for_edition }
 
       assert edition = Edition.last
       assert_equal edition.national_applicability, expected_national_applicability
@@ -56,32 +32,8 @@ module TestsForNationalApplicability
 
     test "create should create a new edition with all_nation_applicability overriding individual options" do
       create(:government)
-      attributes = attributes_for_edition
 
-      expected_national_applicability = {
-        england: {
-          label: "England",
-          applicable: true,
-        },
-        northern_ireland: {
-          label: "Northern Ireland",
-          applicable: true,
-        },
-        scotland: {
-          label: "Scotland",
-          applicable: true,
-        },
-        wales: {
-          label: "Wales",
-          applicable: true,
-        },
-      }
-
-      post :create, params: {
-        edition: attributes.merge(
-          all_nation_applicability: "1"
-        )
-      }
+      post :create, params: { edition: attributes_for_edition }
 
       assert edition = Edition.last
       assert_equal edition.national_applicability, expected_national_applicability
@@ -91,56 +43,85 @@ module TestsForNationalApplicability
       scotland_nation_inapplicability = create(
         :nation_inapplicability,
         nation: Nation.scotland,
-        alternative_url: "http://scotland.com",
+        alternative_url: "http://www.example.com/scotland",
       )
       detailed_guide = create(
-        :published_detailed_guide,
+        :published_detailed_guide_with_excluded_nations,
         nation_inapplicabilities: [
           scotland_nation_inapplicability,
         ],
       )
 
-      expected_national_applicability = {
-        england: {
-          label: "England",
-          applicable: true,
-        },
-        northern_ireland: {
-          label: "Northern Ireland",
-          applicable: true,
-        },
+      national_applicability_excluding_scotland = expected_national_applicability.merge(
         scotland: {
           label: "Scotland",
           applicable: false,
-          alternative_url: "http://scotland.com",
+          alternative_url: "http://www.example.com/scotland",
         },
-        wales: {
-          label: "Wales",
-          applicable: true,
-        },
+      )
+
+      assert_equal detailed_guide.national_applicability, national_applicability_excluding_scotland
+    end
+
+    view_test "creating with all nations excluded should fail validation" do
+      create(:government)
+      attributes = attributes_for_edition(all_nation_applicability: "0")
+
+      all_nations = nation_inapplicabilities_attributes_for({
+        Nation.england => "http://www.example.com/england.",
+        Nation.scotland => "http://www.example.com/scotland",
+        Nation.wales => "http://www.example.com/wales",
+        Nation.northern_ireland => "http://www.example.com/ni"
+        })
+
+      post :create, params: { edition: attributes.merge(all_nations) }
+
+      assert_nil Edition.last
+
+      assert_page_has_error("Excluded nations can not exclude all nations")
+    end
+
+    view_test "creating with no applicability options should fail validation" do
+      create(:government)
+
+      post :create, params: { edition: attributes_for_edition(all_nation_applicability: "0")}
+
+      assert_nil Edition.last
+
+      assert_page_has_error("Excluded nations must either allow all nations or exclude at least one nation")
+    end
+
+    view_test "creating with all_nation_applicability and an excluded nation should fail validation" do
+      create(:government)
+
+      post :create, params: {
+        edition: attributes_for_edition.merge(
+          nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.example.com/scotland"),
+          all_nation_applicability: "1"
+        )
       }
 
-      assert_equal detailed_guide.national_applicability, expected_national_applicability
+      assert_page_has_error("Excluded nations cannot allow all nations and exclude nations")
     end
 
     view_test "creating with invalid edition data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
       post :create,
            params: {
              edition: attributes.merge(
                title: "",
-             ).merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/")),
+             ).merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.example.com/scotland")),
            }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: true, alternative_url: "http://www.scotland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: true, alternative_url: "http://www.example.com/scotland")
       assert_nation_inapplicability_fields_set_as(index: 2, checked: false)
       assert_nation_inapplicability_fields_set_as(index: 3, checked: false)
     end
 
     view_test "creating with invalid nation inapplicability data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
+      attributes = attributes_for_edition(all_nation_applicability: "0")
       post :create,
            params: {
              edition: attributes.merge(
@@ -157,7 +138,8 @@ module TestsForNationalApplicability
 
     view_test "edit displays edition form with nation inapplicability fields and values" do
       edition = create_edition(all_nation_applicability: "1")
-      edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")
+      edition.update_column(:all_nation_applicability, false)
+      edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.example.com/ni")
 
       get :edit, params: { id: edition }
 
@@ -166,51 +148,52 @@ module TestsForNationalApplicability
         assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
         assert_nation_inapplicability_fields_set_as(index: 1, checked: false)
         assert_nation_inapplicability_fields_set_as(index: 2, checked: false)
-        assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.discovernorthernireland.com/")
+        assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.example.com/ni")
       end
     end
 
     test "updating should save modified edition with nation inapplicabilities" do
-      create(:government)
-      attributes = ({all_nation_applicability: "1"}).merge(attributes_for_edition)
-      edition = create_edition(attributes)
-
-      assert_equal 0, edition.inapplicable_nations.size
-
-      northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")
+      edition = create_edition(all_nation_applicability: "1")
+      edition.update_column(:all_nation_applicability, false)
+      northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.example.com/ni")
+      edition.save
 
       assert_equal [Nation.northern_ireland], edition.inapplicable_nations
-      assert_equal "http://www.discovernorthernireland.com/", edition.nation_inapplicabilities.for_nation(Nation.northern_ireland).first.alternative_url
+      assert_equal "http://www.example.com/ni", edition.nation_inapplicabilities.for_nation(Nation.northern_ireland).first.alternative_url
 
-      put :update, params: { id: edition, edition: nation_inapplicabilities_attributes_for({ Nation.scotland => "http://www.visitscotland.com/" }, northern_ireland_inapplicability) }
+      put :update, params: { id: edition, edition: nation_inapplicabilities_attributes_for({ Nation.scotland => "http://www.example.com/scotland" }, northern_ireland_inapplicability) }
 
       edition.reload
       assert_equal [Nation.scotland], edition.inapplicable_nations
-      assert_equal "http://www.visitscotland.com/", edition.nation_inapplicabilities.for_nation(Nation.scotland).first.alternative_url
+      assert_equal "http://www.example.com/scotland", edition.nation_inapplicabilities.for_nation(Nation.scotland).first.alternative_url
     end
 
     view_test "updating with invalid edition data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
-      edition = create_edition(attributes)
-      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
-      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.wales.com/")
+      edition = create_edition(all_nation_applicability: "1")
+      edition.update_column(:all_nation_applicability, false)
+      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.example.com/scotland")
+      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.example.com/wales")
+      edition.save
 
-      attributes = nation_inapplicabilities_attributes_for({ Nation.northern_ireland => "http://www.northernireland.com/" }, scotland_inapplicability, wales_inapplicability).merge(title: "")
+      attributes = nation_inapplicabilities_attributes_for({ Nation.northern_ireland => "http://www.example.com/ni" }, scotland_inapplicability, wales_inapplicability).merge(title: "")
 
       put :update, params: { id: edition, edition: attributes }
 
+      assert_page_has_error("Title can't be blank")
+
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
-      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.northernireland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.example.com/scotland")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.example.com/wales")
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.example.com/ni")
     end
 
     view_test "updating with invalid nation inapplicability data should not lose the nation inapplicability fields or values" do
-      attributes = attributes_for_edition
-      edition = create_edition(attributes)
-      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
-      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.wales.com/")
+      edition = create_edition(all_nation_applicability: "1")
+      edition.update_column(:all_nation_applicability, false)
+      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.example.com/scotland")
+      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.example.com/wales")
+      edition.save
 
       put :update,
           params: { id: edition,
@@ -222,31 +205,54 @@ module TestsForNationalApplicability
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.example.com/scotland")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.example.com/wales")
       assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "invalid-url")
     end
 
     view_test "updating a stale edition should not lose the nation inapplicability fields or values" do
-      edition = create_edition
-      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
-      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.wales.com/")
+      edition = create_edition(all_nation_applicability: "1")
+      edition.update_column(:all_nation_applicability, false)
+      scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.example.com/scotland")
+      wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.example.com/wales")
+
       lock_version = edition.lock_version
       edition.update!(title: "new title", change_note: "foo")
 
-      attributes = nation_inapplicabilities_attributes_for({ Nation.northern_ireland => "http://www.northernireland.com/" }, scotland_inapplicability, wales_inapplicability).merge(lock_version: lock_version)
+      stale_attributes = nation_inapplicabilities_attributes_for({ Nation.northern_ireland => "http://www.example.com/ni" }, scotland_inapplicability, wales_inapplicability).merge(lock_version: lock_version)
 
-      put :update, params: { id: edition, edition: attributes }
+      put :update, params: { id: edition, edition: stale_attributes }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
-      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.northernireland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.example.com/scotland")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.example.com/wales")
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.example.com/ni")
     end
   end
 
 private
+
+  def expected_national_applicability
+    {
+      england: {
+        label: "England",
+        applicable: true,
+      },
+      northern_ireland: {
+        label: "Northern Ireland",
+        applicable: true,
+      },
+      scotland: {
+        label: "Scotland",
+        applicable: true,
+      },
+      wales: {
+        label: "Wales",
+        applicable: true,
+      },
+    }
+  end
 
   def attributes_for_edition(attributes = {})
     controller_attributes_for(edition_class.name.underscore, attributes)
@@ -269,7 +275,7 @@ private
 
   def nation_inapplicabilities_attributes_for(nations_vs_urls, *existing_applicabilities)
     result = {}
-    [Nation.scotland, Nation.wales, Nation.northern_ireland].each.with_index do |nation, index|
+    [Nation.england, Nation.scotland, Nation.wales, Nation.northern_ireland].each.with_index do |nation, index|
       h = result[index.to_s] = {
         excluded: (nations_vs_urls.key?(nation) ? "1" : "0"),
         nation_id: nation,
@@ -283,6 +289,11 @@ private
       end
     end
     { nation_inapplicabilities_attributes: result }
+  end
+
+
+  def assert_page_has_error(error)
+    assert_select(".errors", text: error)
   end
 
   def assert_nation_inapplicability_fields_set_as(attributes)

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -66,7 +66,7 @@ class ConsultationTest < ActiveSupport::TestCase
 
   test "should build a draft copy of the existing consultation with inapplicable nations" do
     published_consultation = create(
-      :published_consultation,
+      :published_consultation_with_excluded_nations,
       nation_inapplicabilities: [
         create(:nation_inapplicability, nation_id: Nation.wales.id, alternative_url: "http://wales.gov.uk"),
         create(:nation_inapplicability, nation_id: Nation.scotland.id, alternative_url: "http://scot.gov.uk"),

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -486,4 +486,16 @@ class ConsultationTest < ActiveSupport::TestCase
   test "consultations cannot be previously published" do
     assert_not build(:consultation).previously_published
   end
+
+  test "#all_nation_applicability_selected? false if first draft and unsaved" do
+    unsaved_publication = build(:consultation)
+    assert_not unsaved_publication.all_nation_applicability_selected?
+  end
+
+  test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do
+    published_publication = create(:consultation)
+    assert published_publication.all_nation_applicability_selected?
+    published_with_excluded = create(:published_consultation_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    assert_not published_with_excluded.all_nation_applicability_selected?
+  end
 end

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -263,4 +263,16 @@ class DetailedGuideTest < ActiveSupport::TestCase
   test "is rendered by government-frontend" do
     assert DetailedGuide.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
+
+  test "#all_nation_applicability_selected? false if first draft and unsaved" do
+    unsaved_publication = build(:detailed_guide)
+    assert_not unsaved_publication.all_nation_applicability_selected?
+  end
+
+  test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do
+    published_publication = create(:detailed_guide)
+    assert published_publication.all_nation_applicability_selected?
+    published_with_excluded = create(:published_detailed_guide_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    assert_not published_with_excluded.all_nation_applicability_selected?
+  end
 end

--- a/test/unit/edition/nation_inapplicability_test.rb
+++ b/test/unit/edition/nation_inapplicability_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Edition::NationInapplicabilityTest < ActiveSupport::TestCase
   setup do
     @nation_inapplicability = create(:nation_inapplicability, nation_id: 2)
-    @edition = create(:draft_publication, nation_inapplicabilities: [@nation_inapplicability])
+    @edition = create(:draft_publication_with_excluded_nations, nation_inapplicabilities: [@nation_inapplicability])
   end
 
   test "#destroy should also remove the relationship" do
@@ -38,7 +38,7 @@ class Edition::NationInapplicabilityTest < ActiveSupport::TestCase
   test "mass-assignment of nation inapplicabilities removes existing exclusions" do
     @edition.nation_inapplicabilities_attributes = nation_inapplicability_attributes_for(excluded: "0", nation_id: "2", id: @nation_inapplicability.to_param, alternative_url: "http://scotland.org")
 
-    assert @edition.save
+    assert @edition.save(validate: false)
     assert_equal 0, @edition.nation_inapplicabilities.size
   end
 

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -28,25 +28,25 @@ class DocumentHelperTest < ActionView::TestCase
   end
 
   test "should generate list of links to inapplicable nations with alternative URL" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
     html = list_of_links_to_inapplicable_nations(publication.nation_inapplicabilities)
     assert_select_within_html html, "a[href='http://scotland.com']", text: "Scotland"
   end
 
   test "should generate list of inapplicable nations without alternative URL" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.wales, alternative_url: nil)])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.wales, alternative_url: nil)])
     assert_equal "Wales", list_of_links_to_inapplicable_nations(publication.nation_inapplicabilities)
   end
 
   test "#see_alternative_urls_for_inapplicable_nations lists names and links if any alternative urls exist" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
     html = see_alternative_urls_for_inapplicable_nations(publication)
     assert_select_within_html html, "a[href='http://scotland.com']", text: "Scotland"
     assert html.starts_with?(" (see publication for ")
   end
 
   test "#see_alternative_urls_for_inapplicable_nations skips nations without alternative urls" do
-    publication = create(:publication, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com"), create(:nation_inapplicability, nation: Nation.wales, alternative_url: "")])
+    publication = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com"), create(:nation_inapplicability, nation: Nation.wales, alternative_url: "")])
     html = see_alternative_urls_for_inapplicable_nations(publication)
     assert_no_match %r{Wales}, html
   end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -543,7 +543,7 @@ module PublishingApi::ConsultationPresenterTest
       )
 
       self.consultation = create(
-        :consultation,
+        :consultation_with_excluded_nations,
         nation_inapplicabilities: [scotland_nation_inapplicability],
       )
     end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -186,7 +186,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     )
     create(:government)
     detailed_guide = create(
-      :published_detailed_guide,
+      :published_detailed_guide_with_excluded_nations,
       nation_inapplicabilities: [
         scotland_nation_inapplicability,
       ],

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -177,4 +177,16 @@ class PublicationTest < ActiveSupport::TestCase
     publication = create(:draft_policy_paper, document: published_publication.document)
     assert publication.has_changed_publication_type?
   end
+
+  test "#all_nation_applicability_selected? false if first draft and unsaved" do
+    unsaved_publication = build(:publication)
+    assert_not unsaved_publication.all_nation_applicability_selected?
+  end
+
+  test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do
+    published_publication = create(:publication)
+    assert published_publication.all_nation_applicability_selected?
+    published_with_excluded = create(:published_publication_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
+    assert_not published_with_excluded.all_nation_applicability_selected?
+  end
 end


### PR DESCRIPTION
When creating or updating an edition of a `Publication`, `Consultation` or `DetailedGuide`, the user has the option to exclude one or more UK Nation if the document is not applicable. This feature is not well used or understood, leading to some editions being created without relevant excluded nations being applied.

This PR adds a new checkbox to the form, to explicitly state that the edition should apply to all UK nations. 

Validations have been added to ensure that
- either the new checkbox is selected or at least one nation is excluded
- only one of these selections is allowed

As the validation means the newly added `all_nation_applicability` parameter is mandatory for creating or updating, we have added a column to the DB schema. A data migration will check all relevant existing edition types and, if they have excluded nations present, set this `all_nation_applicability` to `false`. 

See individual commit messages for further details.

[Passing Publishing-E2E tests](https://github.com/alphagov/publishing-e2e-tests/pull/394)

[trello](https://trello.com/c/GBdunyhP/2082-3-change-excluded-nation-fieldset-in-whitehall)