### PR TITLE
Make blockquote example copy self explanatory

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -211,11 +211,11 @@
 
   <h3><a data-toggle="collapse" href="#govspeak-blockquotes" aria-expanded="false">Blockquotes</a></h3>
   <div class="collapse" id="govspeak-blockquotes">
-    <pre>As the Prime Minister said:
+    <pre>Introduction to the quote:
 
-  > Rule, Britannia, rule the waves.
+  > First paragraph of the quote.
   >
-  > Britons never shall be slaves.</pre>
+  > Second paragraph of the quote.</pre>
     <p>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
   </div>
 


### PR DESCRIPTION
This changes the previous terminology which, with it's reference to
slaves, was potentially divisive. Related to https://govuk.zendesk.com/agent/#/tickets/4198592

Before:
![Screenshot 2020-08-18 at 11 42 17](https://user-images.githubusercontent.com/282717/90504851-95c80f80-e149-11ea-9203-d8536b5270bc.png)

After:

![Screenshot 2020-08-18 at 12 14 54](https://user-images.githubusercontent.com/282717/90506597-74b4ee00-e14c-11ea-8e5f-97caffc892a1.png)

