### PR TITLE
Send broken_links_report via S3 instead of email attachment

### DIFF
--- a/app/controllers/broken_links_export_request_controller.rb
+++ b/app/controllers/broken_links_export_request_controller.rb
@@ -1,0 +1,16 @@
+class BrokenLinksExportRequestController < ApplicationController
+  def show
+    if user_signed_in?
+      filename = "broken-link-reports-#{params[:export_id]}.zip"
+
+      begin
+        file = S3FileHandler.get_file_from_s3(filename)
+        send_data(file, filename: filename)
+      rescue Fog::AWS::Storage::NotFound
+        head :not_found
+      end
+    else
+      head :unauthorized
+    end
+  end
+end

--- a/app/controllers/broken_links_export_request_controller.rb
+++ b/app/controllers/broken_links_export_request_controller.rb
@@ -3,10 +3,9 @@ class BrokenLinksExportRequestController < ApplicationController
     if user_signed_in?
       filename = "broken-link-reports-#{params[:export_id]}.zip"
 
-      begin
-        file = S3FileHandler.get_file_from_s3(filename)
+      if (file = S3FileHandler.get_file_from_s3(filename))
         send_data(file, filename: filename)
-      rescue Fog::AWS::Storage::NotFound
+      else
         head :not_found
       end
     else

--- a/app/controllers/document_list_export_request_controller.rb
+++ b/app/controllers/document_list_export_request_controller.rb
@@ -3,10 +3,9 @@ class DocumentListExportRequestController < ApplicationController
     if user_signed_in?
       filename = DocumentListExportPresenter.s3_filename(params[:document_type_slug], params[:export_id])
 
-      begin
-        file = S3FileHandler.get_file_from_s3(filename)
+      if (file = S3FileHandler.get_file_from_s3(filename))
         send_data(file, filename: filename)
-      rescue Fog::AWS::Storage::NotFound
+      else
         head :not_found
       end
     else

--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -65,7 +65,7 @@ class MailNotifications < ApplicationMailer
     @public_url = public_url
     view_mail template_id,
               to: recipient_address,
-              subject: "GOV.UK broken link reports"
+              subject: "Monthly Whitehall broken links report"
   end
 
   def document_list(public_url, recipient_address, filter_title)

--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -61,10 +61,8 @@ class MailNotifications < ApplicationMailer
               subject: subject
   end
 
-  def broken_link_reports(zip_path, recipient_address)
-    filename = File.basename(zip_path)
-    attachments[filename] = File.read(zip_path)
-
+  def broken_link_reports(public_url, recipient_address)
+    @public_url = public_url
     view_mail template_id,
               to: recipient_address,
               subject: "GOV.UK broken link reports"

--- a/app/views/mail_notifications/broken_link_reports.text.erb
+++ b/app/views/mail_notifications/broken_link_reports.text.erb
@@ -1,3 +1,5 @@
 Hi,
 
-Please find attached the latest set of bad link reports.
+You can download the latest set of bad link reports from the following address:
+
+<%= @public_url %>

--- a/app/views/mail_notifications/broken_link_reports.text.erb
+++ b/app/views/mail_notifications/broken_link_reports.text.erb
@@ -1,5 +1,17 @@
-Hi,
+Hello Whitehall publishers,
 
-You can download the latest set of bad link reports from the following address:
+Please help maintain your department’s content by fixing broken links.
+
+Download the attached zip file to find your department’s csv file. The csv shows:
+
+- what the broken link is
+- where you can find it
+
+If you need more help, you can [contact GDS content support](https://support.publishing.service.gov.uk/content_advice_request/new).
+
+Many thanks,
+
+Esther Woods
+Content Support - GOV.UK
 
 <%= @public_url %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,6 +429,7 @@ Whitehall::Application.routes.draw do
 
   get "/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview" => "csv_preview#show", as: :csv_preview
 
+  resources :broken_links_export_request, path: "/export/broken_link_reports", param: :export_id, only: [:show]
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]
 
   if Rails.env.development?

--- a/lib/s3_file_handler.rb
+++ b/lib/s3_file_handler.rb
@@ -4,9 +4,7 @@ class S3FileHandler
 
     file = directory.files.get(filename)
 
-    raise Fog::AWS::Storage::NotFound, "Object #{filename} does not exist." if file.nil?
-
-    file.body
+    file.body unless file.nil?
   end
 
   def self.save_file_to_s3(filename, csv)

--- a/lib/tasks/broken_link_reporting.rake
+++ b/lib/tasks/broken_link_reporting.rake
@@ -27,8 +27,12 @@ task :generate_broken_link_reports, %i[reports_dir email_address organisation_sl
       puts "Reports generated. Zipping..."
       system "zip #{report_zip_path} #{reports_dir}/*_links_report.csv --junk-paths"
 
-      puts "Reports zipped. Emailing to #{email_address}"
-      MailNotifications.broken_link_reports(report_zip_path, email_address).deliver_now
+      puts "Reports zipped. Uploading..."
+      S3FileHandler.save_file_to_s3(report_zip_name, report_zip_path)
+      public_url = Plek.find("whitehall-admin", external: true) + "/export/broken_link_reports/#{Time.zone.today.strftime}"
+
+      puts "Reports uploaded. Emailing to #{email_address}"
+      MailNotifications.broken_link_reports(public_url, email_address).deliver_now
       puts "Email sent."
     else
       puts "There are no broken link reports so hopefully this means there " \

--- a/test/functional/broken_links_export_request_controller_test.rb
+++ b/test/functional/broken_links_export_request_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+class BrokenLinksExportRequestControllerTest < ActionController::TestCase
+  setup do
+    setup_fog_mock
+  end
+
+  teardown do
+    Fog::Mock.reset
+  end
+
+  test "responds successfully if there is a valid file" do
+    login_as :gds_editor
+
+    export_id = Time.zone.today.strftime
+    filename = "broken-link-reports-#{export_id}.zip"
+
+    @directory.files.create(key: filename, body: "hello world") # rubocop:disable Rails/SaveBang
+
+    get :show, params: { export_id: export_id }
+    assert_equal 200, response.status
+    assert_equal "hello world", response.body
+  end
+
+  test "returns an error if there is no request" do
+    login_as :gds_editor
+
+    get :show, params: { export_id: "1970-01-01" }
+    assert_equal 404, response.status
+  end
+
+  test "returns an error if not logged in" do
+    export_id = Time.zone.today.strftime
+    filename = "broken-link-reports-#{export_id}.zip"
+
+    @directory.files.create(key: filename, body: "hello world") # rubocop:disable Rails/SaveBang
+
+    get :show, params: { export_id: export_id }
+    assert_equal 401, response.status
+  end
+end

--- a/test/functional/notifications_fact_check_request_response_test.rb
+++ b/test/functional/notifications_fact_check_request_response_test.rb
@@ -120,8 +120,8 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
     mail = MailNotifications.broken_link_reports(public_url, receiver)
 
     assert_equal ["test@gov.co.uk"], mail.to
-    assert_equal "GOV.UK broken link reports", mail.subject
-    assert_match %r{bad link reports}, mail.body.to_s
+    assert_equal "Monthly Whitehall broken links report", mail.subject
+    assert_match %r{fixing broken links}, mail.body.to_s
     assert_match public_url, mail.body.to_s
   end
 

--- a/test/functional/notifications_fact_check_request_response_test.rb
+++ b/test/functional/notifications_fact_check_request_response_test.rb
@@ -115,15 +115,14 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
   end
 
   test "#broken_link_reports mail includes the supplied file as an attachment" do
-    file_path = file_fixture("sample_attachment.zip").path
-    receiver  = "test@gov.co.uk"
-    mail      = MailNotifications.broken_link_reports(file_path, receiver)
+    public_url = Plek.find("whitehall-admin", external: true) + "/export/broken_link_reports/#{Time.zone.today.strftime}"
+    receiver = "test@gov.co.uk"
+    mail = MailNotifications.broken_link_reports(public_url, receiver)
 
     assert_equal ["test@gov.co.uk"], mail.to
     assert_equal "GOV.UK broken link reports", mail.subject
-    assert attachment = mail.attachments.first
-    assert_equal "sample_attachment.zip", attachment.filename
-    assert_match %r{bad link reports}, mail.parts.first.body.to_s
+    assert_match %r{bad link reports}, mail.body.to_s
+    assert_match public_url, mail.body.to_s
   end
 
   test "#document_list includes a link in the body" do

--- a/test/lib/s3_file_handler_test.rb
+++ b/test/lib/s3_file_handler_test.rb
@@ -22,4 +22,9 @@ class S3FileHandlerTest < ActiveSupport::TestCase
     file = S3FileHandler.get_file_from_s3("test_file_name.txt")
     assert_equal "hello, world\n", file
   end
+
+  test "downloading a nonexistent file returns nil" do
+    file = S3FileHandler.get_file_from_s3("not_a_real_file.txt")
+    assert_nil file
+  end
 end


### PR DESCRIPTION
https://trello.com/c/BIes5aYv/2080-2-fix-brokenlinksreport-in-whitehall