### PR TITLE
Add new branch colour for FCDO

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -152,4 +152,9 @@ class OrganisationBrandColour
     title: "Department for International Trade",
     class_name: "department-for-international-trade",
   )
+  ForeignCommonwealthDevelopmentOffice = create!(
+    id: 30,
+    title: "Foreign & Commonwealth Development Office",
+    class_name: "foreign-commonwealth-development-office",
+  )
 end


### PR DESCRIPTION
This will include the department's brand colour as an option
under the `Brand colour` drop down option when editing or creating
an organisation page.

It pulls in the css with the department name as the class from
`govuk_frontend`, which has been added in https://github.com/alphagov/govuk-frontend/pull/1918/commits/04023943b366de707caa96b60ad9650568385680

However since there may be some time before `govuk_frontend` is released
again, we have added it to the govuk_publishing_components so we can get
these changes deployed - https://github.com/alphagov/govuk_publishing_components/pull/1648

Co-authored-by: Rebecca Pearce <rebecca.pearce@digital.cabinet-office.gov.uk>

Trello card: https://trello.com/c/s0NySL7Q/2098-add-new-brand-colour-for-fcdo