### PR TITLE
Allow FCDO to tag to worldwide taxonomy

### DIFF
--- a/config/worldwide_tagging_organisations.yml
+++ b/config/worldwide_tagging_organisations.yml
@@ -6,3 +6,4 @@
 - "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
 - "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
 - "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union
+- "f9fcf3fe-2751-4dca-97ca-becaeceb4b26" # Foreign, Commonwealth & Development Office

--- a/test/integration/world_tagging_flow.rb
+++ b/test/integration/world_tagging_flow.rb
@@ -14,7 +14,7 @@ class WorldTaggingFlow < ActionDispatch::IntegrationTest
 
     context "given I want to tag to the WorldWide taxonomy" do
       let(:world_organisation) do
-        create(:organisation, content_id: "9adfc4ed-9f6c-4976-a6d8-18d34356367c")
+        create(:organisation, content_id: "f9fcf3fe-2751-4dca-97ca-becaeceb4b26")
       end
       let(:world_edition) do
         create(:publication, :guidance, organisations: [world_organisation])


### PR DESCRIPTION
This adds FCDO's `content_id` to the list of `content_id`s of organisations allowed to tag their documents to the worldwide taxonomy.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department.

Trello card: https://trello.com/c/Meb6kRZu/2099-1-allow-fcdo-to-tag-to-worldwide-taxonomy