### PR TITLE
Add rake task to update sponsoring organisations

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -41,4 +41,15 @@ namespace :data_hygiene do
       speech.save!(validate: false)
     end
   end
+
+  desc "Update all Worldwide Organisations' sponsoring organisation from FCO to FCDO"
+  task update_sponsoring_organisation_from_fco_to_fcdo: :environment do
+    fco = Organisation.find_by(slug: "foreign-commonwealth-office")
+    fcdo = Organisation.find_by(slug: "foreign-commonwealth-development-office")
+
+    Sponsorship.where(organisation: fco).each do |sponsorship|
+      sponsorship.update!(organisation: fcdo)
+      puts "#{sponsorship.worldwide_organisation.name} updated from FCO to FCDO."
+    end
+  end
 end


### PR DESCRIPTION
This adds a rake task to update all Worldwide Organisations' sponsoring organisation from FCO to FCDO.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department.

Example run of this rake task in integration: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/172527/console

Trello card: https://trello.com/c/yBvz6SbU/2095-spike-updating-worldwide-organisation-sponsoring-organisations-automatically-to-a-new-org-replace-fco-with-fcdo