### PR TITLE
Add seniority to ministerial roles

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -58,7 +58,12 @@ module PublishingApi
         attends_cabinet_type: item.attends_cabinet_type&.name,
         role_payment_type: item.role_payment_type&.name,
         supports_historical_accounts: item.supports_historical_accounts,
-      }
+      }.merge(ministerial_role_details)
+    end
+
+    def ministerial_role_details
+      return {} unless item.is_a?(MinisterialRole)
+      { seniority: item.seniority }
     end
 
     def body

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -41,6 +41,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
         attends_cabinet_type: role.attends_cabinet_type,
         role_payment_type: role.role_payment_type,
         supports_historical_accounts: role.supports_historical_accounts,
+        seniority: 100,
       },
     }
     expected_links = {


### PR DESCRIPTION
Part of the work to migrate the rendering of /government/ministers
from whitehall to collections. Seniority will be used by collections
to sort the list of ministers so needed to be added to the content
item to collections had this information via link expansion.

More information here: https://trello.com/c/T6u4LjxS/2062-3-add-sorting-information-to-ministers-content-item

and here: https://trello.com/c/loAlkIp7/1715-8-migrate-government-ministers-to-collections

Relevant PR's:
https://github.com/alphagov/govuk-content-schemas/pull/999
https://github.com/alphagov/publishing-api/pull/1843