### PR TITLE
Republish when alternative format email changes

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -215,6 +215,13 @@ class Organisation < ApplicationRecord
 
       documents.each { |d| Whitehall::PublishingApi.republish_document_async(d) }
     end
+
+    # If the alternative format contact rmail is changed, we need to republish
+    # all attachments belonging to the organisation
+    if saved_change_to_alternative_format_contact_email?
+      documents = Document.published.where(editions: { alternative_format_provider_id: self })
+      documents.find_each { |d| Whitehall::PublishingApi.republish_document_async(d) }
+    end
   end
 
   def update_organisations_index_page

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1083,4 +1083,18 @@ class OrganisationTest < ActiveSupport::TestCase
       default_news_image: create(:default_news_organisation_image_data),
     )
   end
+
+  test "#save triggers organisation with a changed alternative format provider to republish documents" do
+    organisation = create(:organisation)
+
+    edition_with_alternative_format_provider = create(:published_news_article, alternative_format_provider: organisation)
+    edition_without_alternative_format_provider = create(:published_news_article)
+
+    Whitehall::PublishingApi.expects(:republish_document_async)
+      .with(edition_with_alternative_format_provider.document)
+    Whitehall::PublishingApi.expects(:republish_document_async)
+      .with(edition_without_alternative_format_provider.document).never
+
+    organisation.update!(alternative_format_contact_email: "test@test.com")
+  end
 end


### PR DESCRIPTION
At the moment documents aren't republished with the alternative format contact email changes. This means that some documents are referring to out of date email addresses.

This PR changes the behaviour to automatically republish documents if the email address of the attached alternative format provider changes.

[Trello Card](https://trello.com/c/EfORALzP/2103-5-get-accessibility-request-email-updated-on-relevant-content-when-it-changes)