### PR TITLE
Respect user defined organisation order when presenting links

### DIFF
--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -37,7 +37,19 @@ module PublishingApi
     end
 
     def organisation_ids
-      (item.try(:organisations) || []).map(&:content_id)
+      if item.try(:edition_organisations)
+        item
+          .try(:edition_organisations)
+          .sort_by { |organisation| [organisation.lead_ordering ? 0 : 1, organisation.lead_ordering] }
+          .map(&:organisation)
+          .map(&:content_id)
+      elsif item.try(:organisations)
+        item
+          .organisations
+          .map(&:content_id)
+      else
+        []
+      end
     end
 
     def primary_publishing_organisation_id

--- a/test/unit/presenters/publishing_api/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/links_presenter_test.rb
@@ -101,4 +101,23 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
       links,
     )
   end
+
+  test "respects the user-specified ordering of organisations and not their database order" do
+    second_lead_organisation = create(:organisation)
+    first_lead_organisation = create(:organisation)
+    supporting_organisation = create(:organisation)
+
+    edition = create(:document_collection, lead_organisations: [first_lead_organisation, second_lead_organisation], supporting_organisations: [supporting_organisation])
+
+    links = links_for(edition, [:organisations])
+
+    assert_equal(
+      {
+        organisations: [first_lead_organisation.content_id, second_lead_organisation.content_id, supporting_organisation.content_id],
+        primary_publishing_organisation: [first_lead_organisation.content_id],
+        original_primary_publishing_organisation: [first_lead_organisation.content_id],
+      },
+      links,
+    )
+  end
 end


### PR DESCRIPTION
Users can put lead organisations into a specified order, however these were not being presented to Publishing API in that order. Instead, they were presented ordered by the database's organisation ID.

This had the effect of organisations appearing in a seemingly random order on GOV.UK.  While [government-frontend has code to put "emphasised organisations" first](https://github.com/alphagov/government-frontend/blob/2a09d4dde8c2caf1399f3eb65d94261f85a35488/app/presenters/content_item/linkable.rb#L43-L48), it doesn't know which order to put organisations in if multiple are considered emphasised.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4200472