### PR TITLE
Re-work title of world page

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_index-list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_index-list.scss
@@ -40,30 +40,6 @@
 
   .js-filter-form {
     display: none;
-
-    label {
-      display: inline-block;
-    }
-    input {
-      display: inline-block;
-      margin: 7px $gutter-one-third 3px;
-      width: $half;
-      @include media(tablet) {
-        width: 30%;
-      }
-    }
-    div {
-      display: block;
-      input {
-        margin-left: 0;
-      }
-      @include media(tablet) {
-        display: inline;
-        input {
-          margin-left: $gutter-one-third;
-        }
-      }
-    }
   }
 
 }

--- a/app/assets/stylesheets/frontend/helpers/_page-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_page-header.scss
@@ -4,8 +4,6 @@
   background-position: 0 8px;
 
   h1 {
-    @include ig-core-48;
-    font-weight: bold;
     .label {
       display: block;
     }

--- a/app/assets/stylesheets/frontend/views/_world_locations.scss
+++ b/app/assets/stylesheets/frontend/views/_world_locations.scss
@@ -21,10 +21,6 @@
   }
 
   .world-locations {
-    h1 {
-      @include core-19;
-    }
-
     .world-location-type {
       @extend %contain-floats;
       margin-bottom: $gutter;
@@ -76,7 +72,9 @@
   }
 }
 
-
+.world-locations__heading {
+  @include core-19;
+}
 
 .world-locations-show {
   .block {

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -1,5 +1,7 @@
 <div class="page-header">
-  <h1><%= @edition.title %></h1>
+  <%= render "govuk_publishing_components/components/title", {
+    title: @edition.title
+  } %>
   <p class="lead"><%= @edition.summary %></p>
   <dl class="clearfix dl-horizontal">
     <dt>Type of document:</dt>

--- a/app/views/admin/editions/show_locked.html.erb
+++ b/app/views/admin/editions/show_locked.html.erb
@@ -13,7 +13,9 @@
 </div>
 <div class="row">
   <div class="page-header col-md-8">
-    <h1><%= @edition.title %></h1>
+    <%= render "govuk_publishing_components/components/title", {
+      title: @edition.title
+    } %>
     <p class="lead"><%= @edition.summary %></p>
     <dl class="clearfix dl-horizontal">
       <dt>Type of document:</dt>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -7,7 +7,9 @@
 
 <header class="page-header">
   <div class="logo">
-    <h1><%= organisation_logo(organisation, linked: link_to_organisation, size: logo_size) %></h1>
+    <%= render "govuk_publishing_components/components/title", {
+      title: organisation_logo(organisation, linked: link_to_organisation, size: logo_size)
+    } %>
 
     <% if organisation.type.sub_organisation? %>
       <p class="parent-organisations">

--- a/app/views/organisations/courts_index.html.erb
+++ b/app/views/organisations/courts_index.html.erb
@@ -5,7 +5,9 @@
   <div class="block-1">
     <div class="inner-block">
       <header class="page-header">
-        <h1 class="title">Courts and Tribunals</h1>
+        <%= render "govuk_publishing_components/components/title", {
+          title: "Courts and Tribunals"
+        } %>
       </header>
     </div>
   </div>

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -30,7 +30,7 @@
     <% @world_locations.each do |type, locations| %>
       <section id="<%= type.name.pluralize.parameterize %>" class="world-location-type js-filter-block">
         <header class="type-heading">
-          <h1><%= type.name.pluralize %></h1>
+          <h2 class="world-locations__heading"><%= type.name.pluralize %></h2>
           <p><span class="js-filter-count"><%= locations.length %></span> <span class="visuallyhidden">locations</span></p>
         </header>
         <div class="content">

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -3,14 +3,25 @@
 
 <div class="block">
   <div class="inner-block">
-    <header class="page-header js-filter-list">
-      <h1 class="title">Worldwide</h1>
-      <form class="js-filter-form">
-        <label for="help-and-services-in" class="label">
-          Help and services in <div><input name="help-and-services-in" id="help-and-services-in" placeholder="Example: France" class="govuk-input"></div>
-        </label>
-      </form>
-    </header>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <header class="js-filter-list">
+          <%= render "govuk_publishing_components/components/title", {
+            title: sanitize("Help and services around the&nbsp;world")
+          } %>
+
+          <form class="js-filter-form">
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Search by country or territory",
+              },
+              name: "help-and-services-in",
+              id: "help-and-services-in",
+            } %>
+          </form>  
+        </header>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -37,7 +37,7 @@
           <% if type === WorldLocationType::WorldLocation %>
             <% group_and_sort(locations).each do |letter, locations| %>
               <div class="js-filter-block">
-                <h2 class="letter"><%= letter %></h2>
+                <h3 class="letter"><%= letter %></h3>
                 <ol class="location-list">
                   <% locations.each do |location| %>
                     <%= render partial: 'world_location',

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -212,7 +212,7 @@ Then(/^there should be nothing featured on the home page of (?:world location|in
 end
 
 Then(/^I should see the following world locations grouped under "(.*?)" in order:$/) do |letter, ordered_locations|
-  within :xpath, ".//*#{xpath_class_selector('world-locations')}//*#{xpath_class_selector('js-filter-block')}[./h2[text()='#{letter}']]" do
+  within :xpath, ".//*#{xpath_class_selector('world-locations')}//*#{xpath_class_selector('js-filter-block')}[./h3[text()='#{letter}']]" do
     assert_equal ordered_locations.raw.map(&:first), all(".world_location").map(&:text)
   end
 end


### PR DESCRIPTION
## What
* Alters the markup of the title on the world page [the world page](https://www.gov.uk/world).
* Downgrades other headings on the page eg: h2 to h3, h1 to h2.
* Remove styling for `.js-filter-form`
* Replace other instances of h1 tags within a `.page-header` element across whitehall

## Why
This page currently has a confusing heading structure, there are several h1s and the first h1 doesn't explicitly describe what the page is ("worldwide"). This replaces the title with a much clearer "Help and services around the world" as well as moving the filter input out of the title for a bit more clarity.

Some additional housekeeing why's:

* Reworking the heading structure of the rest of the page means it makes more sense. There now aren't multiple h1s and headings within sections are suitably deemphasised.
* Removing the form class styles allows the input element to make use of default govuk styling as opposed to the bespoke styling that's currently in place
* Replacing h1s across whitehall is a small quality of life change to get rid of some unsightly CSS around h1s within `.page-header`

### Before
![Screenshot 2020-09-03 at 14 17 47](https://user-images.githubusercontent.com/64783893/92119908-4e4fad80-edf0-11ea-8a65-58355d012ec2.png)

### After
![Screenshot 2020-09-04 at 14 05 43](https://user-images.githubusercontent.com/64783893/92242774-38a5bb00-eeb8-11ea-9141-2b53625ccfa5.png)

**Card:** https://trello.com/c/ok9ltp3q/339-problematic-heading-structure