### PR TITLE
Set all_nation_applicability for withdrawn editions

### DIFF
--- a/db/migrate/20200904104601_add_all_nation_applicability_to_withdrawn_editions.rb
+++ b/db/migrate/20200904104601_add_all_nation_applicability_to_withdrawn_editions.rb
@@ -1,0 +1,11 @@
+class AddAllNationApplicabilityToWithdrawnEditions < ActiveRecord::Migration[5.1]
+  def up
+    Edition.where(type: %w[DetailedGuide Publication Consultation], state: "withdrawn").each do |edition|
+      if edition.nation_inapplicabilities.any?
+        edition.update_column(:all_nation_applicability, false)
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200814160434) do
+ActiveRecord::Schema.define(version: 20200904104601) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"


### PR DESCRIPTION
In 93acb17 (#5766), a migration was added which updates the `all_nations_applicability` field for editions which have any nation applicability specified.

However, this migration did not make the change for withdrawn publications, which had the value set as `true` even if applicable nations are specified.  This led to a validation error when publishers attempt to unwithdraw the edition.

Therefore adding another migration to update this value for withdrawn editions.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4222394