### PR TITLE
Republish Organisation when an OrganisationRole is removed from a Role

### DIFF
--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -225,4 +225,15 @@ class RoleTest < ActiveSupport::TestCase
       assert_equal Time.zone.now, role_appointment.reload.updated_at
     end
   end
+
+  test "republishes an organisation when a role is linked or unlinked" do
+    stub_any_publishing_api_call
+    organisation = create(:organisation)
+    role = create(:role_without_organisations)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).twice
+
+    role.update(organisations: [organisation])
+    role.update(organisations: [])
+  end
 end


### PR DESCRIPTION
When an Organisation is unlinked from a Role, this PR ensures that the Organisation will be republished to the PublishingAPI. It uses an Association callback,`after_remove`, to identify when an OrganisatonRole has been removed from a Role, and republish the associated Organisation.

[trello](https://trello.com/c/Nqwy3H8W/2106-5-unlinking-a-role-from-an-organisation-in-whitehall-does-not-republish-the-organisation-page)