### PR TITLE
Use the phantomjs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"
   gem "rubocop-govuk", "~> 3"
+  gem "phantomjs"
   gem "teaspoon-qunit"
   gem "test-queue", "~> 0.2.13"
   # teaspoon has coffee assets that mean we need coffee script in order

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    phantomjs (2.1.1.0)
     plek (4.0.0)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
@@ -669,6 +670,7 @@ DEPENDENCIES
   parallel
   parallel_tests
   pdf-reader (~> 2.2)
+  phantomjs
   plek (~> 4.0)
   pry-byebug
   pry-rails


### PR DESCRIPTION
I think this should integrate with teaspoon which requires
phantomjs. This should remove the requirement of phantomjs being
available on the ci agent machines.