### PR TITLE
Rescue bad request error and display a message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,8 @@ class ApplicationController < ActionController::Base
   layout "frontend"
   after_action :set_slimmer_template
 
+  rescue_from Notifications::Client::BadRequestError, with: :notify_bad_request
+
 private
 
   def set_audit_trail_whodunnit
@@ -86,5 +88,9 @@ private
     if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
+  end
+
+  def notify_bad_request(_exception)
+    render plain: "Error: One or more recipients not in GOV.UK Notify team (code: 400)", status: :bad_request
   end
 end


### PR DESCRIPTION
This is currently only a partial fix, as document exports are done from a worker and therefore can't feed back to the user (or at least not easily). One solution to that (and a nicer fix in general) would be if we could query the Notify API for a list of team members (or confirm that an address is in the team) before sending, rather than only upon sending. 

https://trello.com/c/l1qn22OR/2122-5-handle-not-in-team-notify-error-in-whitehall