### PR TITLE
Allow mp4 uploads

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -4,7 +4,7 @@ class AttachmentUploader < WhitehallUploader
 
   THUMBNAIL_GENERATION_TIMEOUT = 10.seconds
   FALLBACK_PDF_THUMBNAIL = File.expand_path("../assets/images/pub-cover.png", __dir__)
-  EXTENSION_WHITELIST = %w[chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt vcf wsdl xls xlsm xlsx xlt xml xsd xslt zip].freeze
+  EXTENSION_WHITELIST = %w[chm csv diff doc docx dot dxf eps gif gml ics jpg kml mp4 odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt vcf wsdl xls xlsm xlsx xlt xml xsd xslt zip].freeze
 
   before :cache, :validate_zipfile_contents!
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -12,7 +12,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test "should allow whitelisted file extensions" do
-    graphics = %w[dxf eps gif jpg png ps]
+    graphics = %w[dxf eps gif jpg png ps mp4]
     documents = %w[chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt vcf]
     document_support = %w[ris]
     spreadsheets = %w[csv ods xls xlsm xlsx]


### PR DESCRIPTION
Allow mp4 uploads via whitehall
This is meant to be a temporary deploy in response to this ticket: https://govuk.zendesk.com/agent/tickets/4182931
Other approaches to uploading mp4 files are possible but are likely to have problems - this is by far the simplest and most reliable