### PR TITLE
Revert "Allow mp4 uploads"

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -4,7 +4,7 @@ class AttachmentUploader < WhitehallUploader
 
   THUMBNAIL_GENERATION_TIMEOUT = 10.seconds
   FALLBACK_PDF_THUMBNAIL = File.expand_path("../assets/images/pub-cover.png", __dir__)
-  EXTENSION_WHITELIST = %w[chm csv diff doc docx dot dxf eps gif gml ics jpg kml mp4 odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt vcf wsdl xls xlsm xlsx xlt xml xsd xslt zip].freeze
+  EXTENSION_WHITELIST = %w[chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt vcf wsdl xls xlsm xlsx xlt xml xsd xslt zip].freeze
 
   before :cache, :validate_zipfile_contents!
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -12,7 +12,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test "should allow whitelisted file extensions" do
-    graphics = %w[dxf eps gif jpg png ps mp4]
+    graphics = %w[dxf eps gif jpg png ps]
     documents = %w[chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt vcf]
     document_support = %w[ris]
     spreadsheets = %w[csv ods xls xlsm xlsx]


### PR DESCRIPTION
Reverts alphagov/whitehall#5800

The user has an IT problem and is unable to upload the file due to a problem at their end. As we don't support MP4 files we should revert this