### PR TITLE
Request accessible format link correction

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -70,13 +70,14 @@
     <% unless attachment.accessible? %>
       <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
         <p><%= t('attachment.accessibility.intro') %>
-          <a class="toggler" href="#<%= help_block_toggle_id %>" data-controls="<%= help_block_toggle_id %>" data-expanded="false"><%= t('attachment.accessibility.request_a_different_format') %></a>
-        </p>
-        <p id="<%= help_block_toggle_id %>" class="js-hidden">
-          <%= t('attachment.accessibility.full_help_html',
-                email: alternative_format_order_link(attachment, alternative_format_contact_email),
-                title: attachment.title,
-                references: attachment_references(attachment)) %>
+          <%= render "govuk_publishing_components/components/details", {
+            title: t('attachment.accessibility.request_a_different_format')
+          } do %>
+            <%= t('attachment.accessibility.full_help_html',
+            email: alternative_format_order_link(attachment, alternative_format_contact_email),
+            title: attachment.title,
+            references: attachment_references(attachment)) %>
+          <% end %>
         </p>
       </div>
     <% end %>


### PR DESCRIPTION
## Why
The document list has a link that shows/hides a bit of text.
The link reads "Request an accessible format" and toggles an explanation of how to get in touch to ask for a different document format.
This is styled as a blue underlined link but has a role of button. People who use assistive tech may have trouble determining what this element does.

## What 
Change the "Request an accessible format" toggle to use a details component instead. The details component uses details/summary, which is more accessible.

I have released the branch to integration and republished [this page](https://www-origin.integration.publishing.service.gov.uk/government/publications/our-plan-to-rebuild-the-uk-governments-covid-19-recovery-strategy?ndwi=9229299292) for testing.

## Visual changes 
### Before
<img width="1656" alt="Screenshot 2020-09-16 at 14 50 42" src="https://user-images.githubusercontent.com/7116819/93346592-0dae5600-f82c-11ea-9399-0bee0dcc4bd5.png">

### After
<img width="1659" alt="Screenshot 2020-09-16 at 14 49 08" src="https://user-images.githubusercontent.com/7116819/93346588-0c7d2900-f82c-11ea-90cb-ec7fb4e17f1d.png">


https://trello.com/c/HeT8cXli