### PR TITLE
Make case study images optional

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -14,6 +14,7 @@
       this.toggleWorldNewsStoryVisibility();
       this.resetWorldNewsStoryFields();
       this.toggleFirstPublishedDate();
+      this.showImageUploaderIfCustomImage();
 
       GOVUK.formChangeProtection.init($('#edit_edition'), 'You have unsaved changes that will be lost if you leave this page.');
     },
@@ -265,6 +266,22 @@
         $(this).parent().hide().next().removeClass('if-js-hide');
         e.preventDefault();
       });
+    },
+
+    showImageUploaderIfCustomImage: function showImageUploaderIfCustomImage() {
+      var $imageUploader = $('.image_section .js-show-image-uploader');
+      var $customImageRadioButton = $('#edition_image_display_option_custom_image');
+      var $radioButtons = $('.image_section input[type=radio]');
+
+      function showOrHideImageUploader() {
+        if ($customImageRadioButton.prop('checked')){
+          $imageUploader.show();
+        } else {
+          $imageUploader.hide();
+        }
+      }
+      $radioButtons.on('change', showOrHideImageUploader);
+      showOrHideImageUploader();
     }
   }
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -238,6 +238,7 @@ private
       :read_consultation_principles,
       :show_brexit_no_deal_content_notice,
       :all_nation_applicability,
+      :image_display_option,
       brexit_no_deal_content_notice_links_attributes: %i[id title url],
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -54,7 +54,11 @@ module PublishingApi
         first_public_at: first_public_at,
         format_display_type: item.display_type_key,
       }
-      details_hash[:image] = image_details if image_available?
+      details_hash[:image] = if image_available? && image_required?
+                               image_details
+                             else
+                               { url: "", caption: nil, alt_text: "" }
+                             end
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
     end
@@ -79,6 +83,10 @@ module PublishingApi
 
     def image_available?
       item.images.any? || emphasised_organisation_default_image_available?
+    end
+
+    def image_required?
+      item.image_display_option != "no_image"
     end
 
     def emphasised_organisation_default_image_available?

--- a/app/views/admin/editions/_image_fields.html.erb
+++ b/app/views/admin/editions/_image_fields.html.erb
@@ -1,40 +1,64 @@
-<%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
-  <legend class="add-bottom-margin">Images</legend>
-  <% i = 0 %>
-  <%= form.fields_for :images do |images_fields| %>
-    <% if images_fields.object.new_record? %>
-      <div class="file_upload well">
-        <h3 class="remove-top-margin">New image</h3>
-        <p>Images must be 960px wide and 640px tall.</p>
-        <%= images_fields.fields_for :image_data do |image_data_fields| %>
-          <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
-        <% end %>
-        <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
-        <%= images_fields.text_area :caption, rows: 2 %>
-      </div>
-    <% else %>
-      <% i += 1 %>
-      <div class="row image">
-        <%= images_fields.hidden_field :id %>
-        <div class="col-md-6 fields-container">
-          <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
-          <%= images_fields.text_area :caption, rows: 2 %>
-          <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
-          <%= images_fields.check_box :_destroy, *checkbox_args  %>
-          <% if edition.image_disallowed_in_body_text?(i) %>
-            <p>This image is shown automatically, and is not available for use inline in the body.</p>
-          <% else %>
-            <p>Markdown to use:
-              <input type="text" readonly="readonly" value="!!<%= i %>" />
-            </p>
-          <% end %>
-        </div>
-        <div class="col-md-6">
-          <a href="<%= images_fields.object.url %>">
-            <%= image_tag(images_fields.object.url, class: "img-responsive") %>
-          </a>
-        </div>
-      </div>
+<fieldset class="image_section">
+  <div class="radio">
+    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
+      <%= form.radio_button(:image_display_option, "no_image") %>
+      <strong>Don't use an image</strong>
+      <p class="hint">No image will be shown on page</p>
     <% end %>
-  <% end %>
-<% end %>
+  </div>
+  <div class="radio">
+    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
+      <%= form.radio_button(:image_display_option, "organisation_image") %>
+      <strong>Use the default organisation image</strong>
+      <p class="hint">The image set in the organisation page will be shown</p>
+    <% end %>
+  </div>
+  <div class="radio">
+    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
+      <%= form.radio_button(:image_display_option, "custom_image") %>
+      <strong>Use a custom image</strong>
+      <p class="hint">Upload a custom image</p>
+    <% end %>
+  </div>
+  <div class="js-show-image-uploader show-image-uploader">
+    <%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
+      <% i = 0 %>
+        <%= form.fields_for :images do |images_fields| %>
+          <% if images_fields.object.new_record? %>
+            <div class="file_upload well">
+              <h3 class="remove-top-margin">New image</h3>
+              <p>Images must be 960px wide and 640px tall.</p>
+              <%= images_fields.fields_for :image_data do |image_data_fields| %>
+                <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
+              <% end %>
+              <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+              <%= images_fields.text_area :caption, rows: 2 %>
+            </div>
+          <% else %>
+            <% i += 1 %>
+            <div class="row image">
+              <%= images_fields.hidden_field :id %>
+              <div class="col-md-6 fields-container">
+                <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+                <%= images_fields.text_area :caption, rows: 2 %>
+                <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
+                <%= images_fields.check_box :_destroy, *checkbox_args  %>
+                <% if edition.image_disallowed_in_body_text?(i) %>
+                  <p>This image is shown automatically, and is not available for use inline in the body.</p>
+                <% else %>
+                  <p>Markdown to use:
+                    <input type="text" readonly="readonly" value="!!<%= i %>" />
+                  </p>
+                <% end %>
+              </div>
+              <div class="col-md-6">
+                <a href="<%= images_fields.object.url %>">
+                  <%= image_tag(images_fields.object.url, class: "img-responsive") %>
+                </a>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+  </div>
+</fieldset>

--- a/app/views/admin/editions/_image_fields.html.erb
+++ b/app/views/admin/editions/_image_fields.html.erb
@@ -1,64 +1,40 @@
-<fieldset class="image_section">
-  <div class="radio">
-    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
-      <%= form.radio_button(:image_display_option, "no_image") %>
-      <strong>Don't use an image</strong>
-      <p class="hint">No image will be shown on page</p>
-    <% end %>
-  </div>
-  <div class="radio">
-    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
-      <%= form.radio_button(:image_display_option, "organisation_image") %>
-      <strong>Use the default organisation image</strong>
-      <p class="hint">The image set in the organisation page will be shown</p>
-    <% end %>
-  </div>
-  <div class="radio">
-    <%= form.label :image_display_option, (form.object.image_display_option), class: 'radio' do %>
-      <%= form.radio_button(:image_display_option, "custom_image") %>
-      <strong>Use a custom image</strong>
-      <p class="hint">Upload a custom image</p>
-    <% end %>
-  </div>
-  <div class="js-show-image-uploader show-image-uploader">
-    <%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
-      <% i = 0 %>
-        <%= form.fields_for :images do |images_fields| %>
-          <% if images_fields.object.new_record? %>
-            <div class="file_upload well">
-              <h3 class="remove-top-margin">New image</h3>
-              <p>Images must be 960px wide and 640px tall.</p>
-              <%= images_fields.fields_for :image_data do |image_data_fields| %>
-                <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
-              <% end %>
-              <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
-              <%= images_fields.text_area :caption, rows: 2 %>
-            </div>
-          <% else %>
-            <% i += 1 %>
-            <div class="row image">
-              <%= images_fields.hidden_field :id %>
-              <div class="col-md-6 fields-container">
-                <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
-                <%= images_fields.text_area :caption, rows: 2 %>
-                <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
-                <%= images_fields.check_box :_destroy, *checkbox_args  %>
-                <% if edition.image_disallowed_in_body_text?(i) %>
-                  <p>This image is shown automatically, and is not available for use inline in the body.</p>
-                <% else %>
-                  <p>Markdown to use:
-                    <input type="text" readonly="readonly" value="!!<%= i %>" />
-                  </p>
-                <% end %>
-              </div>
-              <div class="col-md-6">
-                <a href="<%= images_fields.object.url %>">
-                  <%= image_tag(images_fields.object.url, class: "img-responsive") %>
-                </a>
-              </div>
-            </div>
-          <% end %>
+<%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
+  <legend class="add-bottom-margin">Images</legend>
+  <% i = 0 %>
+  <%= form.fields_for :images do |images_fields| %>
+    <% if images_fields.object.new_record? %>
+      <div class="file_upload well">
+        <h3 class="remove-top-margin">New image</h3>
+        <p>Images must be 960px wide and 640px tall.</p>
+        <%= images_fields.fields_for :image_data do |image_data_fields| %>
+          <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
         <% end %>
-      <% end %>
-  </div>
-</fieldset>
+        <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+        <%= images_fields.text_area :caption, rows: 2 %>
+      </div>
+    <% else %>
+      <% i += 1 %>
+      <div class="row image">
+        <%= images_fields.hidden_field :id %>
+        <div class="col-md-6 fields-container">
+          <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+          <%= images_fields.text_area :caption, rows: 2 %>
+          <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
+          <%= images_fields.check_box :_destroy, *checkbox_args  %>
+          <% if edition.image_disallowed_in_body_text?(i) %>
+            <p>This image is shown automatically, and is not available for use inline in the body.</p>
+          <% else %>
+            <p>Markdown to use:
+              <input type="text" readonly="readonly" value="!!<%= i %>" />
+            </p>
+          <% end %>
+        </div>
+        <div class="col-md-6">
+          <a href="<%= images_fields.object.url %>">
+            <%= image_tag(images_fields.object.url, class: "img-responsive") %>
+          </a>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/editions/_image_fields_case_studies.html.erb
+++ b/app/views/admin/editions/_image_fields_case_studies.html.erb
@@ -1,0 +1,64 @@
+<fieldset class="image_section">
+  <div class="radio">
+    <label>
+      <%= form.radio_button(:image_display_option, "no_image") %>
+      <strong>Don't use an image</strong>
+      <p class="hint">No image will be shown on page</p>
+    </label>
+  </div>
+  <div class="radio">
+    <label>
+      <%= form.radio_button(:image_display_option, "organisation_image") %>
+      <strong>Use the default organisation image</strong>
+      <p class="hint">The image set in the organisation page will be shown</p>
+    </label>
+  </div>
+  <div class="radio">
+    <label>
+      <%= form.radio_button(:image_display_option, "custom_image") %>
+      <strong>Use a custom image</strong>
+      <p class="hint">Upload a custom image</p>
+    <label>
+  </div>
+  <div class="js-show-image-uploader show-image-uploader">
+    <%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
+      <% i = 0 %>
+        <%= form.fields_for :images do |images_fields| %>
+          <% if images_fields.object.new_record? %>
+            <div class="file_upload well">
+              <h3 class="remove-top-margin">New image</h3>
+              <p>Images must be 960px wide and 640px tall.</p>
+              <%= images_fields.fields_for :image_data do |image_data_fields| %>
+                <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
+              <% end %>
+              <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+              <%= images_fields.text_area :caption, rows: 2 %>
+            </div>
+          <% else %>
+            <% i += 1 %>
+            <div class="row image">
+              <%= images_fields.hidden_field :id %>
+              <div class="col-md-6 fields-container">
+                <%= images_fields.text_field :alt_text, label_text: 'Alt text' %>
+                <%= images_fields.text_area :caption, rows: 2 %>
+                <% checkbox_args = nested_attribute_destroy_checkbox_options(images_fields, label_text: "(uncheck to remove)") %>
+                <%= images_fields.check_box :_destroy, *checkbox_args  %>
+                <% if edition.image_disallowed_in_body_text?(i) %>
+                  <p>This image is shown automatically, and is not available for use inline in the body.</p>
+                <% else %>
+                  <p>Markdown to use:
+                    <input type="text" readonly="readonly" value="!!<%= i %>" />
+                  </p>
+                <% end %>
+              </div>
+              <div class="col-md-6">
+                <a href="<%= images_fields.object.url %>">
+                  <%= image_tag(images_fields.object.url, class: "img-responsive") %>
+                </a>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+  </div>
+</fieldset>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -25,5 +25,9 @@
 <%= render partial: 'first_published_at', locals: { form: form, edition: edition } %>
 
 <% if form.object.allows_image_attachments? %>
-  <%= render partial: "image_fields", locals: {form: form, edition: form.object} %>
+  <% if edition.type == "CaseStudy" %>
+    <%= render partial: "image_fields_case_studies", locals: {form: form, edition: form.object} %>
+  <% else %>
+    <%= render partial: "image_fields", locals: {form: form, edition: form.object} %>
+  <% end %>
 <% end %>

--- a/app/views/admin/editions/_words_to_avoid_guidance.html.erb
+++ b/app/views/admin/editions/_words_to_avoid_guidance.html.erb
@@ -53,7 +53,7 @@
 
 <% if ENABLE_WORDS_TO_AVOID_HIGHLIGHTING %>
   <% initialise_script "GOVUK.WordsToAvoidGuide",
-      el: "form textarea",
+      el: ["form textarea[name='edition[summary]']", "form textarea[name='edition[body]']"],
       wordsToAvoidList: "#js-words-to-avoid-list",
       wordsToAvoidAlert: "#js-words-to-avoid-alert",
       wordsToAvoidCounter: "#js-words-to-avoid-count" %>

--- a/db/data_migration/20200924134112_update_image_display_option_for_editions.rb
+++ b/db/data_migration/20200924134112_update_image_display_option_for_editions.rb
@@ -1,0 +1,11 @@
+case_studies_with_images = Edition.find_by_sql(["SELECT e.* FROM editions e LEFT OUTER JOIN images ON e.id = images.edition_id WHERE type in ('CaseStudy') AND images.id IS NOT NULL"])
+
+case_studies_with_images.each do |case_study|
+  case_study.update_columns(image_display_option: "custom_image")
+end
+
+case_studies_without_images = Edition.find_by_sql(["SELECT e.* FROM editions e LEFT OUTER JOIN images ON e.id = images.edition_id WHERE type in ('CaseStudy') AND images.id IS NULL"])
+
+case_studies_without_images.each do |case_study|
+  case_study.update_columns(image_display_option: "organisation_image")
+end

--- a/db/migrate/20200909141147_add_image_display_option_to_editions.rb
+++ b/db/migrate/20200909141147_add_image_display_option_to_editions.rb
@@ -1,0 +1,9 @@
+class AddImageDisplayOptionToEditions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :editions, :image_display_option, :string
+  end
+
+  def down
+    remove_column :editions, :image_display_option, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200904104601) do
+ActiveRecord::Schema.define(version: 20200909141147) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -425,6 +425,7 @@ ActiveRecord::Schema.define(version: 20200904104601) do
     t.boolean "read_consultation_principles", default: false
     t.boolean "show_brexit_no_deal_content_notice", default: false
     t.boolean "all_nation_applicability"
+    t.string "image_display_option"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -18,4 +18,16 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_association_with_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
   should_send_drafts_to_content_preview_environment_for :case_study
+
+  view_test "case studies show image display options radio buttons" do
+    get :new
+    assert_select "form#new_edition" do
+      assert_select "#edition_image_display_option_no_image"
+      assert_select "#edition_image_display_option_organisation_image"
+      assert_select "#edition_image_display_option_custom_image"
+      assert_select "input[name='edition[images_attributes][0][alt_text]'][type='text']"
+      assert_select "textarea[name='edition[images_attributes][0][caption]']"
+      assert_select "input[name='edition[images_attributes][0][image_data_attributes][file]'][type='file']"
+    end
+  end
 end

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -97,6 +97,43 @@ var firstPublishedAtFieldset =
     '</div>' +
   '</fieldset>'
 
+var imageFieldsFieldSet =
+'<fieldset class="image_section">' +
+'<div class="radio">' +
+'  <label for="edition_image_display_option">' +
+'    <input type="radio" value="no_image" name="edition[image_display_option]" id="edition_image_display_option_no_image">' +
+'    <strong>Dont use an image</strong>' +
+'    <p class="hint">No image will be shown on page</p>' +
+'  </label>' +
+'  </div>' +
+'  <div class="radio">' +
+'  <label class="radio" for="edition_image_display_option">' +
+'    <input type="radio" value="custom_image" name="edition[image_display_option]" id="edition_image_display_option_custom_image">' +
+'    <strong>Use the default organisation image</strong>' +
+'    <p class="hint">The image set in the organisation page will be shown</p>' +
+'  </label>' +
+'  </div>' +
+'  <div class="radio">' +
+'  <label class="radio" for="edition_image_display_option">' +
+'    <input type="radio" value="organisation_image" name="edition[image_display_option]" id="edition_image_display_option_organisation_image">' +
+'    <strong>Use a custom image</strong>' +
+'    <p class="hint">Upload a custom image</p>' +
+'  </label>' +
+'  </div>' +
+'<div class="js-show-image-uploader show-image-uploader">' +
+'  <fieldset id="image_fields" class="images multiple_file_uploads">' +
+'        <div class="file_upload well">' +
+'          <h3 class="remove-top-margin">New image</h3>' +
+'          <p>Images must be 960px wide and 640px tall.</p>' +
+'            <div class="form-group"><label for="edition_images_attributes_0_image_data_attributes_file">File</label><input class="js-upload-image-input" type="file" name="edition[images_attributes][0][image_data_attributes][file]" id="edition_images_attributes_0_image_data_attributes_file"><input type="hidden" name="edition[images_attributes][0][image_data_attributes][file_cache]" id="edition_images_attributes_0_image_data_attributes_file_cache"></div>' +
+'          <div class="form-group"><label for="edition_images_attributes_0_alt_text">Alt text</label><input class="form-control" type="text" name="edition[images_attributes][0][alt_text]" id="edition_images_attributes_0_alt_text"></div>' +
+'          <div class="form-group"><label for="edition_images_attributes_0_caption">Caption</label><div class="highlightTextarea"><div class="highlighterContainer"><div class="highlighter"></div></div>' +
+'          <textarea rows="2" class="form-control" name="edition[images_attributes][0][caption]" id="edition_images_attributes_0_caption"></textarea></div></div>' +
+'        </div>' +
+'    </fieldset>' +
+'  </div>' +
+'</fieldset> '
+
 var roleAppointmentFieldset =
 '  <fieldset class="role-appointments">' +
 '    <label for="edition_role_appointment_ids">Ministers</label>' +
@@ -269,6 +306,32 @@ test("unselecting 'World news story' hides and resets the locale fields", functi
 
   equal($('#edition_primary_locale option:selected').val(), '', 'locale reset back to English');
   ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
+});
+
+module("admin-edition-image-fields: ", {
+  setup: function() {
+    $('#qunit-fixture').append(form)
+    $('#qunit-fixture form').append(imageFieldsFieldSet)
+
+    GOVUK.adminEditionsForm.init({
+      selector: 'form#non-english',
+      right_to_left_locales:["ar"]
+    });
+    $('.js-hidden').hide();
+  }
+});
+
+test("use_no_image radio buttons toggle visibility of image_uploader selector", function() {
+  ok($('.js-show-image-uploader').is(':hidden'), 'image uploader hidden by default');
+
+  $('#edition_image_display_option_no_image').click();
+  ok($('.js-show-image-uploader').is(':hidden'), 'image uploader shown when "image_display_option_no_image" selected');
+
+  $('#edition_image_display_option_custom_image').click();
+  ok($('.js-show-image-uploader').is(':visible'), 'image uploader hidden when "image_display_option_custom_image" selected');
+
+  $('#edition_image_display_option_organisation_image').click();
+  ok($('.js-show-image-uploader').is(':hidden'), 'image uploader shown when "image_display_option_organisation_image" selected');
 });
 
 module("admin-edition-form-first-published-at: ", {

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -32,6 +32,11 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: "case_study",
+        image: {
+          url: "",
+          caption: nil,
+          alt_text: "",
+        },
         first_public_at: case_study.first_public_at,
         change_history: [
           { public_timestamp: case_study.public_timestamp, note: "change-note" }.as_json,
@@ -106,6 +111,22 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       url: organisation_image.file.url(:s300),
+      alt_text: "",
+      caption: nil,
+    }
+    presented_item = present(case_study)
+
+    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_equal expected_hash, presented_item.content[:details][:image]
+  end
+
+  test "Adds an empty image field if the image display option is no_image" do
+    organisation = create(:organisation)
+
+    case_study = create(:published_case_study, lead_organisations: [organisation])
+
+    expected_hash = {
+      url: "",
       alt_text: "",
       caption: nil,
     }


### PR DESCRIPTION
We currently don't have the ability of not showing a main image on a case study. 
If an image is not added, the case study will use the default image (the default organisation image), but in some 
cases an image is not required, and does not feel relevant to the case study. This has been a specific request from 
a department (https://govuk.zendesk.com/agent/tickets/4105207)

Paired with @beccapearce 

Trello card: https://trello.com/c/HYtRDzzY/2093-make-case-study-images-optional-and-dont-use-default-image