### PR TITLE
Add whips information to role presenter

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -52,12 +52,24 @@ module PublishingApi
       end
     end
 
+    def whip
+      return {} if item.whip_organisation_id == nil
+
+      whip_organisation = Whitehall::WhipOrganisation.find_by_id(item.whip_organisation_id) 
+
+      {
+        sort_order: whip_organisation.sort_order,
+        label: whip_organisation.label,
+      }
+    end
+
     def details
       {
         body: body,
         attends_cabinet_type: item.attends_cabinet_type&.name,
         role_payment_type: item.role_payment_type&.name,
         supports_historical_accounts: item.supports_historical_accounts,
+        whip_organisation: whip,
       }.merge(ministerial_role_details)
     end
 

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -42,6 +42,66 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
         role_payment_type: role.role_payment_type,
         supports_historical_accounts: role.supports_historical_accounts,
         seniority: 100,
+        whip_organisation: {},
+      },
+    }
+    expected_links = {
+      ordered_parent_organisations: [organisation.content_id],
+      ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f],
+    }
+
+    presented_item = present(role)
+
+    assert_equal expected_hash, presented_item.content
+    assert_hash_includes presented_item.links, expected_links
+    assert_equal "major", presented_item.update_type
+    assert_equal role.content_id, presented_item.content_id
+
+    assert_valid_against_schema(presented_item.content, "role")
+  end
+
+  test "presents a Ministerial Whip Role ready for adding to the Publishing API" do
+    organisation = create(:organisation)
+    role = create(
+      :ministerial_role,
+      organisations: [organisation],
+      responsibilities: "X and Y",
+      whip_organisation_id: 1,
+    )
+
+    expected_hash = {
+      base_path: "/government/ministers/#{role.slug}",
+      title: role.name,
+      description: "X and Y",
+      schema_name: "role",
+      document_type: "ministerial_role",
+      locale: "en",
+      publishing_app: "whitehall",
+      rendering_app: "collections",
+      public_updated_at: role.updated_at,
+      routes: [
+        {
+          path: "/government/ministers/#{role.slug}",
+          type: "exact",
+        },
+      ],
+      redirects: [],
+      update_type: "major",
+      details: {
+        body: [
+          {
+            content_type: "text/govspeak",
+            content: "X and Y",
+          },
+        ],
+        attends_cabinet_type: role.attends_cabinet_type,
+        role_payment_type: role.role_payment_type,
+        supports_historical_accounts: role.supports_historical_accounts,
+        seniority: 100,
+        whip_organisation: {
+          :sort_order => 1,
+          :label => "House of Commons",
+        },
       },
     }
     expected_links = {
@@ -85,6 +145,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
         attends_cabinet_type: role.attends_cabinet_type,
         role_payment_type: role.role_payment_type,
         supports_historical_accounts: role.supports_historical_accounts,
+        whip_organisation: {},
       },
     }
 


### PR DESCRIPTION
Adding the information about the given whip organisation for ministerial
roles that are whips.

Part of the work to migrate rendering of the ministers index page
to collections.

https://trello.com/c/loAlkIp7/2063-8-migrate-government-ministers-to-collections

The purpose of these changes is to allow collections to sort the list
of whips at a rendering level. This will eventually allow some of the
function of the `ministerial_roles_controller` to be removed out to
collections.

https://github.com/alphagov/whitehall/blob/1512033670b30512872b56fbf4801cb438be55ec/app/controllers/ministerial_roles_controller.rb#L43-L60