### PR TITLE
Assign lead image alt text to empty string if not present

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -12,7 +12,7 @@ module LeadImagePresenterHelper
   end
 
   def lead_image_alt_text
-    if images.first
+    if images.first.try(:alt_text)
       images.first.alt_text.squish
     else
       ""

--- a/test/unit/lead_image_presenter_helper_test.rb
+++ b/test/unit/lead_image_presenter_helper_test.rb
@@ -7,6 +7,16 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
     assert_equal "", presenter.lead_image_alt_text
   end
 
+  test "should use empty string if no alt_text is provided" do
+    presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
+    file = stub("File", content_type: "image/jpg")
+    uploader = stub("Uploader", file: file)
+    image_data = stub("ImageData", file: uploader)
+    image = stub("Image", alt_text: nil, image_data: image_data)
+    presenter.stubs(images: [image])
+    assert_equal "", presenter.lead_image_alt_text
+  end
+
   test "should use first image with version :s300 if an image is present" do
     presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
     file = stub("File", content_type: "image/jpg")


### PR DESCRIPTION
It is now possible for Images to be created with a `nil` alt_text, for improved accessibility. https://github.com/alphagov/whitehall/pull/5756/files

This PR will prevent a NoMethodError being thrown and present the nil value as an empty string. 

This will assist with us republishing all Images that currently have inaccessible alt_text.

[trello](https://trello.com/c/GmO8zKt7/2142-3-update-certain-newsarticle-image-alt-texts-and-republish-newsarticles)


