### PR TITLE
Allow indexing AccessibleDocumentsPolicy documents of non-live organisations

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -53,12 +53,18 @@ class CorporateInformationPage < Edition
   def self.search_only
     live_govuk_status = super.with_organisation_govuk_status("live")
 
-    accessible_govuk_status = super
+    accessible_other_govuk_status = super
       .accessible_documents_policy
       .with_organisation_govuk_status(%w[joining exempt transitioning])
 
+    accessible_devolved_govuk_status = super
+      .accessible_documents_policy
+      .with_organisation_govuk_status("closed")
+      .where(organisations: { govuk_closed_status: "devolved" })
+
     live_govuk_status
-      .or(accessible_govuk_status)
+      .or(accessible_other_govuk_status)
+      .or(accessible_devolved_govuk_status)
   end
 
   def title_required?

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -27,6 +27,8 @@ class CorporateInformationPage < Edition
   validates :corporate_information_page_type_id, presence: true
   validate :only_one_organisation_or_worldwide_organisation
 
+  scope :with_organisation_govuk_status, ->(status) { joins(:organisation).where(organisations: { govuk_status: status }) }
+
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(owning_organisation) if owning_organisation.is_a?(Organisation)
   end
@@ -49,7 +51,7 @@ class CorporateInformationPage < Edition
 
   def self.search_only
     # Ensure only CIPs associated with a live Organisation are indexed in search.
-    super.joins(:organisation).where(organisations: { govuk_status: "live" })
+    super.with_organisation_govuk_status("live")
   end
 
   def title_required?

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -51,8 +51,14 @@ class CorporateInformationPage < Edition
   end
 
   def self.search_only
-    # Ensure only CIPs associated with a live Organisation are indexed in search.
-    super.with_organisation_govuk_status("live")
+    live_govuk_status = super.with_organisation_govuk_status("live")
+
+    accessible_govuk_status = super
+      .accessible_documents_policy
+      .with_organisation_govuk_status(%w[joining exempt transitioning])
+
+    live_govuk_status
+      .or(accessible_govuk_status)
   end
 
   def title_required?

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -28,6 +28,7 @@ class CorporateInformationPage < Edition
   validate :only_one_organisation_or_worldwide_organisation
 
   scope :with_organisation_govuk_status, ->(status) { joins(:organisation).where(organisations: { govuk_status: status }) }
+  scope :accessible_documents_policy, -> { where(corporate_information_page_type_id: CorporateInformationPageType::AccessibleDocumentsPolicy.id) }
 
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(owning_organisation) if owning_organisation.is_a?(Organisation)

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -93,4 +93,11 @@ FactoryBot.define do
     organisation { nil }
     association :worldwide_organisation, factory: :worldwide_organisation
   end
+
+  factory :accessible_documents_policy_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id do
+      CorporateInformationPageType::AccessibleDocumentsPolicy.id
+    end
+  end
 end

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -207,6 +207,33 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     corporate_information_page4.update_in_search_index
   end
 
+  test "will index accessible policy document even if the org is joining gov.uk" do
+    organisation = create(:organisation, govuk_status: "joining")
+    corporate_information_page = create(
+      :accessible_documents_policy_corporate_information_page, organisation: organisation
+    )
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page).once
+    corporate_information_page.update_in_search_index
+  end
+
+  test "will index accessible policy document even if the org is exempt on gov.uk" do
+    organisation = create(:organisation, govuk_status: "exempt")
+    corporate_information_page = create(
+      :accessible_documents_policy_corporate_information_page, organisation: organisation
+    )
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page).once
+    corporate_information_page.update_in_search_index
+  end
+
+  test "will index accessible policy document even if the org is transitioning to gov.uk" do
+    organisation = create(:organisation, govuk_status: "transitioning")
+    corporate_information_page = create(
+      :accessible_documents_policy_corporate_information_page, organisation: organisation
+    )
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page).once
+    corporate_information_page.update_in_search_index
+  end
+
   test "until we launch worldwide will not be indexed if the org it belongs to is a worldwide org" do
     world_org = create(:worldwide_organisation)
 

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -234,6 +234,17 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     corporate_information_page.update_in_search_index
   end
 
+  test "will index accessible policy document even if the org is devolved on gov.uk" do
+    organisation = create(
+      :closed_organisation, govuk_closed_status: "devolved", superseding_organisations: [create(:devolved_administration)]
+    )
+    corporate_information_page = create(
+      :accessible_documents_policy_corporate_information_page, organisation: organisation
+    )
+    Whitehall::SearchIndex.expects(:add).with(corporate_information_page).once
+    corporate_information_page.update_in_search_index
+  end
+
   test "until we launch worldwide will not be indexed if the org it belongs to is a worldwide org" do
     world_org = create(:worldwide_organisation)
 


### PR DESCRIPTION
We want to make it possible for corporate information pages of type `AccessibleDocumentsPolicy` to be indexed even when the parent organisation is in a different state to `live`.

This is part of the GOV.UK Accessibility work - this type of document needs to be available for all organisations that publish on GOV.UK.

[Trello Card](https://trello.com/c/T9yzMvXF/2141-5-make-accessible-documents-policies-from-non-live-organisations-available-to-users)