### PR TITLE
Add aria label to site header navigation

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -1,5 +1,5 @@
 <%= render :layout => 'layouts/frontend_base' do %>
-  <nav id="proposition-menu" class="no-proposition-name">
+  <nav id="proposition-menu" class="no-proposition-name" aria-label="Departments and policy navigation">
     <ul id="proposition-links">
       <li><%= main_navigation_link_to "Departments", organisations_path %></li>
       <li><%= main_navigation_link_to "Worldwide", world_locations_path(locale: :en) %></li>


### PR DESCRIPTION
The site header links are a nav element, often appearing on pages which have other nav elements. When there are multiple navigation landmarks on a page, they should be labelled in order to help assistive tech users differentiate between them.

This adds `aria-label` to the site header nav. The suggested name was "Departments and policy navigation" because in the footer the section containing these links is called 'Departments and policy'.

No visual changes should occur as a result of this.

<img width="1680" alt="Screenshot 2020-09-18 at 13 03 21" src="https://user-images.githubusercontent.com/7116819/93796402-b4cb2d00-fc32-11ea-9e8a-86d26911c639.png">

https://trello.com/c/XFKhZwEI
