### PR TITLE
Use translated organisation name in organisation logo if available

### DIFF
--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -30,4 +30,12 @@ module LogoHelper
       tag.span(class: css_classes) { tag.span { linked_logo } }
     end
   end
+
+  def translated_organisation_logo_name(organisation)
+    if I18n.locale == "en"
+      format_with_html_line_breaks(ERB::Util.html_escape(organisation.logo_formatted_name))
+    else
+      organisation.name
+    end
+  end
 end

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds logo">
     <%= render "govuk_publishing_components/components/organisation_logo", {
       organisation: {
-        name: organisation_logo_name(organisation),
+        name: translated_organisation_logo_name(organisation),
         url: link_to_organisation ? worldwide_organisation_path(organisation) : nil,
         crest: "single-identity",
       },


### PR DESCRIPTION
Use the translated organisation name in the organisation logo on organisation pages, if it's not the English version of the organisation page. Organisation.

- organisation names on non-English pages seem to all be in English
- this change returns the translated organisation name instead of logo_formatted_name for the organisation logo, if the page language is not English
- shouldn't interfere with the existing code for organisation_logo_name, which is already in use in csv_preview, operational fields and topical_events (thanks @sihugh)

Example pages:

- https://www.gov.uk/world/organisations/british-consulate-general-montreal.fr
- https://www.gov.uk/world/organisations/british-consulate-general-guangzhou.zh

Before | After
------ | ------
<img width="938" alt="Screenshot 2020-09-22 at 13 55 15" src="https://user-images.githubusercontent.com/861310/93884822-4c845600-fcdb-11ea-8e5c-1501836c83fc.png"> | <img width="967" alt="Screenshot 2020-09-22 at 13 54 56" src="https://user-images.githubusercontent.com/861310/93884918-6aea5180-fcdb-11ea-82a4-c6e173ae73cf.png">

Trello card: https://trello.com/c/bQn51uw9/392-update-language-attribute-of-current-organisation-name-on-world-organisation-embassy-pages
