### PR TITLE
Fix stray p tag issue

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,16 +69,15 @@
 
     <% unless attachment.accessible? %>
       <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
-        <p><%= t('attachment.accessibility.intro') %>
-          <%= render "govuk_publishing_components/components/details", {
-            title: t('attachment.accessibility.request_a_different_format')
-          } do %>
-            <%= t('attachment.accessibility.full_help_html',
-            email: alternative_format_order_link(attachment, alternative_format_contact_email),
-            title: attachment.title,
-            references: attachment_references(attachment)) %>
-          <% end %>
-        </p>
+        <p><%= t('attachment.accessibility.intro') %></p>
+        <%= render "govuk_publishing_components/components/details", {
+          title: t('attachment.accessibility.request_a_different_format')
+        } do %>
+          <%= t('attachment.accessibility.full_help_html',
+          email: alternative_format_order_link(attachment, alternative_format_contact_email),
+          title: attachment.title,
+          references: attachment_references(attachment)) %>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## What


This moves the details component out of the  "accessibility intro" paragraph.


## Why

It has been flagged that there are stray `p` tags on pages with accessible format requests. It seems like this is happening because the details component is contained inside the paragraph, when the paragraph should really only be wrapping the intro text.

Example page where this is occurring: https://www.gov.uk/government/publications/register-of-licensed-sponsors-students

**The markup issue (note the stray `<p></p>` after the details component 😬):**

<img width="1220" alt="Screenshot 2020-09-22 at 14 38 41" src="https://user-images.githubusercontent.com/7116819/93889694-6d4faa00-fce1-11ea-8701-464e80e86302.png">

Validation fail: https://validator.w3.org/nu/?showsource=yes&showoutline=yes&showimagereport=yes&doc=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications%2Fregister-of-licensed-sponsors-students#l347c22

## Complication
The pages where this is occurring are rendered by `government-frontend`, but the source markup for that particular section of the code lives in `whitehall`. The code is consumed by `government-frontend` pre-rendered.
In order for changes to this snippet of code to take effect on existing content, pages that consume it have to be republished.  

