### PR TITLE
Add lang="en" to publication dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,6 +182,7 @@ module ApplicationHelper
       l(time.to_date, format: :long_ordinal),
       class: [options[:class], "date"].compact.join(" "),
       datetime: time.iso8601,
+      lang: "en",
     )
   end
 


### PR DESCRIPTION
Publication time/date seems to always be in English regardless of current locale. As we are missing the config locales to display dates in every language, it makes sense to add `lang="en"` to the time element.

This ensures that screen readers might read would read that text correctly, even though it is in a different language than the main document. A more permanent solution would be to ensure that time and date translations exist for every language.

Example page: https://www.gov.uk/world/taiwan/news.zh-tw
Note that the dates are in English while the rest of the content is in Chinese.


https://trello.com/c/LppXa7a1/390-update-lang-attribute-of-publication-date-time-in-world-location-news-pages