### PR TITLE
Add lang attribute to page contents title

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -8,7 +8,9 @@
     <% if headers.any? %>
       <nav>
         <div class="content">
-          <h1><%= t('worldwide_organisation.headings.contents', default: 'Contents') %></h1>
+          <h1 <%= "lang=#{t_fallback('worldwide_organisation.headings.contents')}" if t_fallback('worldwide_organisation.headings.contents') %>>
+            <%= t('worldwide_organisation.headings.contents', default: 'Contents') %>
+          </h1>
           <ol>
             <% headers.each do |header| %>
               <li><%= link_to header.text, "##{header.id}" %></li>

--- a/app/views/worldwide_offices/show.html.erb
+++ b/app/views/worldwide_offices/show.html.erb
@@ -8,7 +8,7 @@
     <% if headers.any? %>
       <nav>
         <div class="content">
-          <h1>Contents</h1>
+          <h1 lang="en">Contents</h1>
           <ol>
             <% headers.each do |header| %>
               <li><%= link_to header.text, "##{header.id}" %></li>


### PR DESCRIPTION
In some instances, on translated world location pages, the "Contents" title will be in English and not marked as such using an appropriate lang attribute.

![image](https://user-images.githubusercontent.com/7116819/93910496-13f37500-fcf9-11ea-9c56-15ca0d6fe51d.png)


This adds `lang="en"` where "Contents" is in English, to ensure that screen readers read this word in an understandable fashion.

Example of a page where this problem occurs: https://www.gov.uk/world/organisations/british-embassy-moscow/office/british-embassy-moscow-main-contact.ru 