### PR TITLE
Add lang="en" to person partial

### DIFF
--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -26,7 +26,7 @@
       <% end %>
     <% end %>
     <<%= hlevel %> class="current-appointee govuk-!-margin-bottom-1"><%= person.link %></<%= hlevel %>>
-    <p class="<%= roles_classes.join(" ") %>">
+    <p class="<%= roles_classes.join(" ") %>" lang="en">
       <%= joined_list(roles.map { |role| role.link }).html_safe %>
       <%= roles_footnotes(roles, display_cabinet_attendance) -%>
     </p>


### PR DESCRIPTION
## What
Adds `lang="en"` to the role under the person partial.

## Why
This is part of an ongoing piece of work to fix missing translations on world organisation pages. Example: https://www.gov.uk/world/organisations/british-embassy-cairo.ar This specifically is targeting the appointee title (under the people section down the page). This change doesn't fix the more pressing issue of a translation missing, however it will communicate to assistive tech that it's in a different language.

No visual changes.

**Card:** https://trello.com/c/1zFzbT2u/393-update-language-attribute-in-appointee-titles-on-world-organisation-embassy-pages