### PR TITLE
Add lang to attachment page length metadata

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -194,7 +194,7 @@ Please tell us:
     else
       attributes << tag.span(humanized_content_type(attachment.file_extension), class: "type")
       attributes << tag.span(number_to_human_size(attachment.file_size), class: "file-size")
-      attributes << tag.span(pluralize(attachment.number_of_pages, "page"), class: "page-length") if attachment.number_of_pages.present?
+      attributes << tag.span(pluralize(attachment.number_of_pages, "page"), class: "page-length", lang: "en") if attachment.number_of_pages.present?
     end
     attributes.join(", ").html_safe
   end


### PR DESCRIPTION
Some of the attachment metadata is in English on translated pages. Attachment page length is one of those attributes that is always in English. 

Example page: https://www.gov.uk//world/organisations/british-embassy-rome/about/recruitment.it
Another example from a Welsh language page. Note that "42 pages" is in English.

![image](https://user-images.githubusercontent.com/7116819/93914146-02609c00-fcfe-11ea-9228-9c34aa27e222.png)


This adds `lang="en"` to the page length element, to ensure that screen readers can interpret this element in an understandable way.

https://trello.com/c/QPmn5bXO