### PR TITLE
Update template for worldwide organisation page

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -1,32 +1,40 @@
 <% page_title @corporate_information_page.title %>
-<% page_class "corporate-information-pages-show-worldwide-organisation" %>
+<% page_class "govuk-width-container corporate-information-pages-show-worldwide-organisation" %>
 
-<%= render partial: 'worldwide_organisations/header', locals: { organisation: @organisation, link_to_organisation: true, object_for_translation: @corporate_information_page } %>
-<article class="block article">
-  <div class="inner-block floated-children">
+<%= render partial: 'worldwide_organisations/header', locals: {
+  organisation: @organisation,
+  link_to_organisation: true,
+  object_for_translation: @corporate_information_page
+} %>
+<article class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
     <% headers = govspeak_headers(@corporate_information_page.body) %>
     <% if headers.any? %>
-      <nav>
-        <div class="content">
-          <h1><%= t('worldwide_organisation.headings.contents', default: 'Contents') %></h1>
-          <ol>
-            <% headers.each do |header| %>
-              <li><%= link_to header.text, "##{header.id}" %></li>
-            <% end %>
-          </ol>
-        </div>
+      <nav aria-label="Page navigation">
+        <%= render "govuk_publishing_components/components/contents_list", {
+          contents: headers.map do |header|
+              {
+                text: header.text,
+                href: "##{header.id}"
+              }
+            end,
+            underline_links: true,
+        } %>
       </nav>
     <% end %>
-    <div class="main-body">
-      <div class="content">
-        <h1 class="main"><%= @corporate_information_page.title(I18n.locale) %></h1>
-        <p class="description">
-          <%= @corporate_information_page.summary %>
-        </p>
-        <div class="body">
-          <%= govspeak_edition_to_html @corporate_information_page %>
-        </div>
-      </div>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @corporate_information_page.title(I18n.locale),
+      heading_level: 2,
+      font_size: "xl",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body-l"><%= @corporate_information_page.summary %></p>
+    <div class="body">
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        govspeak_edition_to_html(@corporate_information_page)
+      end %>
     </div>
   </div>
 </article>

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -57,6 +57,6 @@ Then(/^I should be able to read the translated "([^"]*)" corporate information p
   click_link corp_page
   click_link "Français"
 
-  assert_selector ".description", text: "Le summary"
+  assert_selector ".govuk-body-l", text: "Le summary"
   assert_selector ".body", text: "Le body"
 end


### PR DESCRIPTION
## What

Removes need for CSS (hastily) removed in https://github.com/alphagov/whitehall/pull/5816 by using components and the
layout from the design system.

## Why

The layout was broken by the changes in https://github.com/alphagov/whitehall/pull/5816; this page needed updating to have the correct focus states on the contest list; and the organisation logo was misaligned.

## Visual differences


Before:

![image](https://user-images.githubusercontent.com/1732331/93921813-fd551a00-fd08-11ea-8fb0-08ff66c555aa.png)

After:

![image](https://user-images.githubusercontent.com/1732331/93922261-9a17b780-fd09-11ea-9162-ec754a203215.png)

<hr>

Before:

![image](https://user-images.githubusercontent.com/1732331/93922092-62a90b00-fd09-11ea-893c-269f7b919b0e.png)


After:

![image](https://user-images.githubusercontent.com/1732331/93922134-73598100-fd09-11ea-80f2-25629d1567aa.png)

<hr>

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![image](https://user-images.githubusercontent.com/1732331/93922029-4ad18700-fd09-11ea-815b-a98b18d67273.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/93921913-22e22380-fd09-11ea-89b3-48477482d29d.png)

</td></tr>

</table>