### PR TITLE
Set bulk_publishing with the bulk parameter

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -105,6 +105,7 @@ module Whitehall
       PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
         queue,
         document.id,
+        bulk,
       )
     end
 

--- a/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
@@ -7,8 +7,8 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
     WebMock.reset!
 
     expected_requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_put_content(presenter.content_id, presenter.content.merge(bulk_publishing: true)),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links, bulk_publishing: true),
       stub_publishing_api_publish(presenter.content_id, locale: "en", update_type: nil),
     ]
 


### PR DESCRIPTION
To republish_document_async, as this will more appropriately
prioritise the changes in the Publishing API.