### PR TITLE
Move image position in source

### DIFF
--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -213,13 +213,31 @@
     border-width: 0 0 1px;
   }
 
-  @media (min-width: 640px) and (max-width: 900px) {
-    .prime-minister,
+  .prime-minister,
+  .cabinet {
+    .one-half {
+      &:first-child {
+        float: right;
+      }
+
+    }
+  }
+
+  @include govuk-media-query($from: tablet, $until: desktop) {
     .history {
       .one-half {
         width: $two-thirds;
         &:first-child {
           width: $one-third;
+        }
+      }
+    }
+    .prime-minister {
+      .one-half {
+        width: $one-third;
+
+        &:first-child {
+          width: $two-thirds;
         }
       }
     }
@@ -253,6 +271,16 @@
       .one-third {
         width: $full-width;
       }
+    }
+  }
+
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    .prime-minister,
+    .cabinet {
+      display: flex;
+      display: -ms-flexbox;
+      flex-direction: column-reverse;
+      -ms-flex-direction: column-reverse;
     }
   }
 

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -23,15 +23,6 @@
       <div class="halves-width-section prime-minister">
         <div class="one-half">
           <div class="inner-block">
-            <% if @prime_minister.present? && @prime_minister.image_url(:s465).present? %>
-              <%= image_tag @prime_minister.image_url(:s465), { alt: @prime_minister.name } %>
-            <% else %>
-              <%= image_tag 'how-gov-works/10_Downing_Street.jpg', alt: 'Number 10, Downing Street' %>
-            <% end %>
-          </div>
-        </div>
-        <div class="one-half">
-          <div class="inner-block">
             <%= render "govuk_publishing_components/components/heading", {
               text: "The Prime Minister",
               heading_level: 3,
@@ -57,14 +48,18 @@
             </p>
           </div>
         </div>
+        <div class="one-half">
+          <div class="inner-block">
+            <% if @prime_minister.present? && @prime_minister.image_url(:s465).present? %>
+              <%= image_tag @prime_minister.image_url(:s465), { alt: @prime_minister.name } %>
+            <% else %>
+              <%= image_tag 'how-gov-works/10_Downing_Street.jpg', alt: 'Number 10, Downing Street' %>
+            <% end %>
+          </div>
+        </div>
       </div>
 
       <div class="halves-width-section cabinet">
-        <div class="one-half">
-          <div class="inner-block">
-            <%= image_tag 'how-gov-works/Cabinet_01.jpg', alt: 'The Cabinet' %>
-          </div>
-        </div>
         <div class="one-half">
           <div class="inner-block">
             <%= render "govuk_publishing_components/components/heading", {
@@ -76,6 +71,11 @@
             <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
 
             <p class="govuk-body"><%= link_to("See who is in the Cabinet", "/government/ministers", class: "govuk-link") %></p>
+          </div>
+        </div>
+        <div class="one-half">
+          <div class="inner-block">
+            <%= image_tag 'how-gov-works/Cabinet_01.jpg', alt: 'The Cabinet' %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
https://trello.com/c/997pjz76/370-misleading-source-order-image-before-heading

What:
This change affects: https://www.gov.uk/government/how-government-works
It moves the images for the PM section and Cabinet Office section and places them below the heading and text that they are related to in the source code. CSS is then used to float them into the original positions at tablet and desktop views, and to switch the order at mobile view. 

Why:
For accessibility reasons it is desirable to have images appearing below the heading they are related to. This offers better support for anyone using a screenreader or linearising the page.

No screenshots as there are no visual changes. 
