### PR TITLE
Add lang to page contents title when untranslated

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -19,6 +19,8 @@
               }
             end,
             underline_links: true,
+            title: t('worldwide_organisation.headings.contents', default: 'Contents'),
+            title_lang: t_fallback('worldwide_organisation.headings.contents')
         } %>
       </nav>
     <% end %>

--- a/app/views/worldwide_offices/show.html.erb
+++ b/app/views/worldwide_offices/show.html.erb
@@ -20,6 +20,8 @@
               }
             end,
             underline_links: true,
+            title: t('worldwide_organisation.headings.contents', default: 'Contents'),
+            title_lang: t_fallback('worldwide_organisation.headings.contents')
         } %>
       </nav>
     <% end %>


### PR DESCRIPTION
In some instances, on translated world location pages, the "Contents" title will be in English and not marked as such using an appropriate `lang` attribute.

This adds `lang="en"` where "Contents" is in English, to ensure that screen readers read this word in an understandable fashion.

It also passes through the translated title, if a translation exists.

For instance, in French the translation for "Contents" is "Contenu". Therefore when viewing the French translated version of a page, the contents list title should be "Contenu", and should not have a `lang` attribute.

When viewing say, a German translation, where we don't have a config locale translation for the contents list title, the contents list title will be "Contents", and will have a `lang="en"` attribute to support that.

The component update that supports this change:  https://github.com/alphagov/govuk_publishing_components/pull/1710 



https://trello.com/c/D2lTyikn