### PR TITLE
World news story - fix up translations when changing primary locale

### DIFF
--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -69,7 +69,7 @@ private
   end
 
   def remove_other_translations_if_primary_locale_no_longer_english
-    if translations.first.locale != :en
+    if translations.count > 1 && translations.first.locale != :en
       translations[1..].each(&:destroy)
     end
   end

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -24,6 +24,10 @@ module Edition::Translatable
       :change_translations_locale_if_primary_locale_changed,
       on: :update,
     )
+    before_validation(
+      :remove_other_translations_if_primary_locale_no_longer_english,
+      on: :update,
+    )
 
     scope :in_default_locale, -> { joins(:translations).where("edition_translations.locale" => I18n.default_locale) }
     validate :locale_is_valid
@@ -61,6 +65,12 @@ private
   def change_translations_locale_if_primary_locale_changed
     if primary_locale_changed? && translations.count == 1
       translations.first.update(locale: primary_locale)
+    end
+  end
+
+  def remove_other_translations_if_primary_locale_no_longer_english
+    if translations.first.locale != :en
+      (translations - [translations.first]).each(&:destroy)
     end
   end
 

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -70,7 +70,7 @@ private
 
   def remove_other_translations_if_primary_locale_no_longer_english
     if translations.first.locale != :en
-      (translations - [translations.first]).each(&:destroy)
+      translations[1..].each(&:destroy)
     end
   end
 

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -17,7 +17,7 @@
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 
   <% if (edition.document and edition.document.published?) and can?(:mark_political, edition) %>
-    <%= form.check_box :political, label_text: "Associate with government of the time (currently set to #{edition.government.name}).", class: 'political-status' %>
+    <%= form.check_box :political, label_text: "Associate with government of the time (currently set to #{edition.government&.name}).", class: 'political-status' %>
     <p><a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode'>Read the history mode guidance</a> for more information as to what this means.</p>
   <% end %>
 <% end %>

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -18,9 +18,16 @@ Feature: News articles
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
     Then the news article "A thing happened in X" should have been created
 
+  Scenario: Create a news article of type 'World news story', then changing its locale from en
+    When I draft a valid news article of type "World news story" with title "A thing happened in X"
+    Then the news article "A thing happened in X" should have been created
+    And when I publish the article
+    And I subsequently change the primary locale
+    Then there should exist only one translation
+
   Scenario: Create a News article of type 'world news story' in a non-English language
     Given an international delegation "UK and the World Government" exists with a translation for the locale "Français"
     When I draft a French-only "World news story" news article associated with "UK and the World Government"
     Then I should see the news article listed in admin with an indication that it is in French
-    When I publish the French-only news article
+    And when I publish the article
     Then I should only see the news article on the French version of the public "UK and the World Government" location page

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -33,7 +33,7 @@ When(/^I draft a French\-only "World news story" news article associated with "(
   @news_article = find_news_article_in_locale!(:fr, "French-only news article")
 end
 
-When(/^I publish the French-only news article$/) do
+And(/^when I publish the article$/) do
   stub_publishing_api_links_with_taxons(@news_article.content_id, %w[a-taxon-content-id])
   visit admin_edition_path(@news_article)
   publish(force: true)
@@ -70,5 +70,20 @@ When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do
 end
 
 Then(/^the news article "([^"]*)" should have been created$/) do |title|
-  refute NewsArticle.find_by(title: title).nil?
+  @news_article = NewsArticle.find_by(title: title)
+  refute @news_article.nil?
+end
+
+Then('I subsequently change the primary locale') do
+  visit admin_edition_path(@news_article)
+  click_button "Create new edition to edit"
+  select "Deutsch (German)", from: "edition[primary_locale]"
+  choose "edition_minor_change_true"
+  click_button "Save and continue"
+  click_button "Save topic changes"
+end
+
+Then('there should exist only one translation') do
+  assert_equal ["published", "draft"], @news_article.document.editions.pluck(:state)
+  assert_equal 1, @news_article.document.latest_edition.translations.count
 end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -11,10 +11,6 @@ Given(/^a published news article "([^"]*)" associated with "([^"]*)"$/) do |titl
   )
 end
 
-Given(/^a published news article "([^"]*)" which isn't explicitly associated with "([^"]*)"$/) do |title, _thing|
-  create(:published_news_article, title: title)
-end
-
 When(/^I draft a new news article "([^"]*)"$/) do |title|
   begin_drafting_news_article title: title, summary: "here's a simple summary"
   within ".images" do
@@ -22,71 +18,6 @@ When(/^I draft a new news article "([^"]*)"$/) do |title|
     fill_in "Alt text", with: "An alternative description", match: :first
   end
   click_button "Save"
-end
-
-When(/^I publish a news article "([^"]*)" associated with "([^"]*)"$/) do |title, person_name|
-  begin_drafting_news_article title: title
-  fill_in_news_article_fields(first_published: Time.zone.today.to_s)
-  select person_name, from: "Ministers"
-  click_button "Save"
-  publish(force: true)
-end
-
-When(/^I publish a news article "([^"]*)" associated with the topical event "([^"]*)"$/) do |title, topic_name|
-  begin_drafting_news_article title: title
-
-  select topic_name, from: "Topical events"
-
-  fill_in_news_article_fields(first_published: Time.zone.today.to_s)
-  click_button "Save"
-  publish(force: true)
-end
-
-When(/^I publish a news article "(.*?)" associated with the organisation "(.*?)"$/) do |title, organisation_name|
-  begin_drafting_news_article title: title
-  fill_in_news_article_fields(first_published: Time.zone.today.to_s)
-  within ".lead-organisations" do
-    select organisation_name, from: "Organisation 1"
-  end
-  click_button "Save"
-  publish(force: true)
-end
-
-When(/^I attempt to add the article image into the markdown$/) do
-  fill_in "Body", with: "body copy\n!!1\nmore body"
-end
-
-Then(/^the news article tag is the same as the person in the text$/) do
-  visit admin_edition_path(NewsArticle.last)
-  click_button "Create new edition"
-  appointment = NewsArticle.last.role_appointments.first
-  assert_selector "select#edition_role_appointment_ids option[value='#{appointment.id}'][selected=selected]"
-end
-
-Then(/^I should see both the news articles for the Deputy Prime Minister role$/) do
-  assert_selector ".news_article", text: "News from Don, Deputy PM"
-  assert_selector ".news_article", text: "News from Harriet, Deputy PM"
-end
-
-Then(/^I should see both the news articles for Harriet Home$/) do
-  assert_text "First article"
-  assert_text "Second article"
-end
-
-Then(/^I should be informed I shouldn't use this image in the markdown$/) do
-  click_on "Edit draft"
-  assert_no_selector "fieldset#image_fields .image input[value='!!1']"
-end
-
-When(/^I browse to the announcements index$/) do
-  stub_content_item_from_content_store_for(announcements_path)
-  visit announcements_path
-end
-
-When(/^I publish a new news article of the type "(.*?)" called "(.*?)"$/) do |announcement_type, title|
-  begin_drafting_news_article(title: title, first_published: Time.zone.today.to_s, announcement_type: announcement_type)
-  click_button "Save"
-  publish(force: true)
 end
 
 When(/^I draft a French\-only "World news story" news article associated with "([^"]*)"$/) do |location_name|
@@ -105,13 +36,6 @@ end
 When(/^I publish the French-only news article$/) do
   stub_publishing_api_links_with_taxons(@news_article.content_id, %w[a-taxon-content-id])
   visit admin_edition_path(@news_article)
-  publish(force: true)
-end
-
-When(/^I publish a news article "(.*?)" for "(.*?)"$/) do |title, location_name|
-  begin_drafting_news_article(title: title, first_published: Time.zone.today.to_s)
-  select location_name, from: "Select the world locations this news article is about"
-  click_button "Save"
   publish(force: true)
 end
 

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -90,4 +90,15 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert french_edition.available_in_locale?(:fr)
     assert_not french_edition.available_in_locale?(:en)
   end
+
+  test "changing primary locale of world news story updates the primary locale of the translation" do
+    world_news_story = create(
+      :news_article_world_news_story,
+      primary_locale: "en",
+    )
+    world_news_story.update!(primary_locale: "fr")
+
+    assert world_news_story.available_in_locale?(:fr)
+    assert_not world_news_story.available_in_locale?(:en)
+  end
 end

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -27,6 +27,11 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert NewsArticle.new.locale_can_be_changed?
   end
 
+  test "locale_can_be_changed? returns true for an existing NewsArticleType::WorldNewsStory" do
+    world_news_story = create(:news_article_world_news_story)
+    assert world_news_story.locale_can_be_changed?
+  end
+
   test "locale_can_be_changed? returns false for a persisted new NewsArticle" do
     assert_not create(:news_article).locale_can_be_changed?
   end


### PR DESCRIPTION
A number of published world news stories have a `primary_locale` of `en`
when they are in fact in a different language. 

When a publisher changes the primary locale of a world news story to the
correct value, we end up in a strange state whereby the draft edition has two
translations: one with the old locale, and one with the new. When the publisher
attempts to publish the draft, Publishing API raises an error:
"Cannot publish an already published edition".

This happens because both translations are sent to publishing API,
and the translation with the old locale has already been published,
so cannot be published again. The simplest solution would be to
remove the redundant translation, so that it is automatically
[removed at time of publish](https://github.com/alphagov/whitehall/blob/277d3216a1009b69cd04b63a1185a7b19e7a4c26/lib/translatable_model.rb#L29-L31).

This PR adds some tests that evaluate the code added in #5832 (the PR designed
to enable the changing of locales for world news stories), and also recreates the issue
we're seeing on production. It then adds the code that removes the non-primary
translations when the primary translation is no longer English, as hinted by the UI:
"Warning: News stories without an English version cannot have other translations."

Finally, it also removes some unused step definitions I came across while writing the test.

Trello: https://trello.com/c/y9H3BLeG/2168-new-editions-of-foreign-language-only-world-news-stories-cant-be-published