### PR TITLE
Reflect strong text in page semantics

### DIFF
--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -88,23 +88,23 @@
         <% if !@is_during_reshuffle %>
           <div class="feature-ministers">
             <a href="/government/ministers/prime-minister" class="feature-ministers__item">
-              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</span>
+              <strong class="count govuk-!-font-size-48 govuk-!-font-weight-bold">1</strong>
               <span class="caption">Prime Minister</span>
             </a>
             <span class="feature-ministers__symbol">&#43;</span>
             <a href="/government/ministers#cabinet-ministers" class="feature-ministers__item cabinet-ministers">
-              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @cabinet_minister_count %></span>
+              <strong class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @cabinet_minister_count %></strong>
               <span class="caption">Cabinet ministers</span>
             </a>
             <span class="feature-ministers__symbol">&#43;</span>
             <a href="/government/ministers#ministers-by-department" class="feature-ministers__item other-ministers">
-              <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @other_minister_count %></span>
+              <strong class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @other_minister_count %></strong>
               <span class="caption">Other ministers</span>
             </a>
             <span class="feature-ministers__equals-wrapper">
               <span class="feature-ministers__symbol">&#61;</span>
               <a href="/government/ministers" class="feature-ministers__item feature-ministers__item--invert all-ministers">
-                <span class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @all_ministers_count %></span>
+                <strong class="count govuk-!-font-size-48 govuk-!-font-weight-bold"><%= @all_ministers_count %></strong>
                 <span class="caption">Total ministers</span>
               </a>
             <span>


### PR DESCRIPTION
An info graphic on the How Government Works page has the numbers of ministers called out in bold text:

![Screenshot 2020-10-05 at 15 55 30](https://user-images.githubusercontent.com/31649453/95095768-62563a00-0723-11eb-927a-c7ee09c7601c.png)
The semantics of the page don't reflect this, anybody using custom styles will not get recognise the highlighting as captured here: https://trello.com/c/DiiPEdbd/409-ministers-infographic-looks-like-a-heading-but-isnt-one

This changes a span tag to a strong tag to fix this:

Before without styling:
![Screenshot 2020-10-05 at 15 53 30](https://user-images.githubusercontent.com/31649453/95095964-9cbfd700-0723-11eb-882e-3c652c6b867b.png)

After without styling:
![Screenshot 2020-10-05 at 15 55 15](https://user-images.githubusercontent.com/31649453/95095991-a47f7b80-0723-11eb-8fd9-b0fd3eabb821.png)
