### PR TITLE
Re-introduce linting build step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,10 @@ gem "whenever", "~> 1.0.0", require: false
 
 group :development, :test do
   gem "parallel_tests"
+  gem "phantomjs"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rubocop-govuk", "~> 3"
-  gem "phantomjs"
   gem "teaspoon-qunit"
   gem "test-queue", "~> 0.2.13"
   # teaspoon has coffee assets that mean we need coffee script in order

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.8.0)
       parser (>= 2.7.1.5)
-    rubocop-govuk (3.17.1)
+    rubocop-govuk (3.17.2)
       rubocop (= 0.87.1)
       rubocop-ast (= 0.8.0)
       rubocop-rails (= 2.8.1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,6 @@ node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-whitehall")
   govuk.buildProject(
     sassLint: false,
-    rubyLintDiff: false,
-    rubyLintDirs: "",
     publishingE2ETests: true,
     brakeman: true,
     beforeTest: {
@@ -23,6 +21,10 @@ node {
       }
     },
     overrideTestTask: {
+      stage("Lint") {
+        sh("bundle exec rubocop")
+      }
+
       stage("Run tests") {
         if (params.IS_SCHEMA_TEST) {
           echo "Running a subset of the tests to check the content schema changes"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,13 @@ require File.expand_path("config/application", __dir__)
 require "ci/reporter/rake/minitest" if Rails.env.test?
 
 Whitehall::Application.load_tasks
+
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Rubocop isn't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop test:in_parallel]

--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -1,6 +1,6 @@
 module Admin::ContentDataRoutesHelper
   def content_data_home_url
-    @content_data_home_url ||= "#{content_data_base_url}/content" # rubocop:disable Rails/HelperInstanceVariable
+    @content_data_home_url ||= "#{content_data_base_url}/content"
   end
 
   def content_data_page_data_url(edition)

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -274,7 +274,7 @@ module Admin::EditionsHelper
   end
 
   def specialist_sector_options_for_select
-    @specialist_sector_options_for_select ||= LinkableTopics.new.topics # rubocop:disable Rails/HelperInstanceVariable
+    @specialist_sector_options_for_select ||= LinkableTopics.new.topics
   end
 
   def specialist_sector_names(sector_content_ids)
@@ -282,7 +282,7 @@ module Admin::EditionsHelper
   end
 
   def raw_specialist_sectors
-    @raw_specialist_sectors ||= LinkableTopics.new.raw_topics # rubocop:disable Rails/HelperInstanceVariable
+    @raw_specialist_sectors ||= LinkableTopics.new.raw_topics
   end
 
   def specialist_sector_name(sector_content_id)

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -128,21 +128,20 @@ module Admin::TaggableContentHelper
   # events. This will change if any of the Topics should change or if a new
   # topic event is added.
   def taggable_topical_events_cache_digest
-    @taggable_topical_events_cache_digest ||= calculate_digest(TopicalEvent.order(:id), "topical-events") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_topical_events_cache_digest ||= calculate_digest(TopicalEvent.order(:id), "topical-events")
   end
 
   # Returns an MD5 digest representing the current set of taggable
   # organisations. This will change if any of the Topics should change or if a
   # new organisation is added.
   def taggable_organisations_cache_digest
-    @taggable_organisations_cache_digest ||= calculate_digest(Organisation.order(:id), "organisations") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_organisations_cache_digest ||= calculate_digest(Organisation.order(:id), "organisations")
   end
 
   # Returns an MD5 digest representing the current set of taggable ministerial
   # role appointments. This will change if any role appointments are added or
   # changed, and also if an occupied MinisterialRole is updated.
   def taggable_ministerial_role_appointments_cache_digest
-    # rubocop:disable Rails/HelperInstanceVariable
     @taggable_ministerial_role_appointments_cache_digest ||= begin
       calculate_digest(
         RoleAppointment
@@ -152,59 +151,58 @@ module Admin::TaggableContentHelper
         "ministerial-role-appointments",
       )
     end
-    # rubocop:enable Rails/HelperInstanceVariable
   end
 
   # Returns an MD5 digest representing the current set of taggable ministerial
   # role appointments. This will change if any role appointments are added or
   # changed, and also if an occupied Role is updated.
   def taggable_role_appointments_cache_digest
-    @taggable_role_appointments_cache_digest ||= calculate_digest(RoleAppointment.order(:id), "role-appointments") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_role_appointments_cache_digest ||= calculate_digest(RoleAppointment.order(:id), "role-appointments")
   end
 
   # Returns an MD5 digest representing the current set of taggable ministerial
   # rile appointments. THis will change if any ministerial role is added or
   # updated.
   def taggable_ministerial_roles_cache_digest
-    @taggable_ministerial_roles_cache_digest ||= calculate_digest(MinisterialRole.order(:id), "ministerial-roles") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_ministerial_roles_cache_digest ||= calculate_digest(MinisterialRole.order(:id), "ministerial-roles")
   end
 
   # Returns an MD5 digest representing all the detailed guides. This wil change
   # if any detailed guides are added or updated.
   def taggable_detailed_guides_cache_digest
-    @taggable_detailed_guides_cache_digest ||= calculate_digest(Document.where(document_type: "DetailedGuide").order(:id), "detailed-guides") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_detailed_guides_cache_digest ||= calculate_digest(Document.where(document_type: "DetailedGuide").order(:id), "detailed-guides")
   end
 
   # Returns an MD5 digest representing the taggable statistical data sets. This
   # will change if any statistical data set is added or updated.
   def taggable_statistical_data_sets_cache_digest
-    @taggable_statistical_data_sets_cache_digest ||= calculate_digest(Document.where(document_type: "StatisticalDataSet").order(:id), "statistical-data-sets") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_statistical_data_sets_cache_digest ||= calculate_digest(Document.where(document_type: "StatisticalDataSet").order(:id), "statistical-data-sets")
   end
 
   # Returns an MD5 digest representing the taggable world locations. This will
   # change if any world locations are added or updated.
   def taggable_world_locations_cache_digest
-    @taggable_world_locations_cache_digest ||= calculate_digest(WorldLocation.order(:id), "world-locations") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_world_locations_cache_digest ||= calculate_digest(WorldLocation.order(:id), "world-locations")
   end
 
   # Returns an MD5 digest representing the taggable alternative format
   # providers. This will change if any alternative format providers are
   # changed.
   def taggable_alternative_format_providers_cache_digest
-    @taggable_alternative_format_providers_cache_digest ||= calculate_digest(Organisation.order(:id), "alternative-format-providers") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_alternative_format_providers_cache_digest ||= calculate_digest(Organisation.order(:id), "alternative-format-providers")
   end
 
   # Returns an MD5 digest representing the taggable document collection
   # groups. This will change if any document collection or group within
   # the collection is changed or any new ones are added.
   def taggable_document_collection_groups_cache_digest
-    @taggable_document_collection_groups_cache_digest ||= calculate_digest(Document.where(document_type: "DocumentCollection").order(:id), "document-collection-groups") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_document_collection_groups_cache_digest ||= calculate_digest(Document.where(document_type: "DocumentCollection").order(:id), "document-collection-groups")
   end
 
   # Returns an MD5 digest representing the taggable worldwide organisations.
   # This will change if any worldwide organisations are added or updated.
   def taggable_worldwide_organisations_cache_digest
-    @taggable_worldwide_organisations_cache_digest ||= calculate_digest(WorldwideOrganisation.order(:id), "worldwide-organisations") # rubocop:disable Rails/HelperInstanceVariable
+    @taggable_worldwide_organisations_cache_digest ||= calculate_digest(WorldwideOrganisation.order(:id), "worldwide-organisations")
   end
 
 private

--- a/app/helpers/cache_control_helper.rb
+++ b/app/helpers/cache_control_helper.rb
@@ -1,6 +1,6 @@
 module CacheControlHelper
   def cache_max_age(cache_max_age = Whitehall.default_cache_max_age)
-    @cache_max_age ||= cache_max_age # rubocop:disable Rails/HelperInstanceVariable
+    @cache_max_age ||= cache_max_age
   end
 
   def expire_on_next_scheduled_publication(scheduled_editions)

--- a/app/helpers/document_filter_helper.rb
+++ b/app/helpers/document_filter_helper.rb
@@ -129,7 +129,7 @@ protected
   end
 
   def filter_options
-    @filter_options ||= Whitehall::DocumentFilter::Options.new # rubocop:disable Rails/HelperInstanceVariable
+    @filter_options ||= Whitehall::DocumentFilter::Options.new
   end
 
   def filter_option_html(options, selected_value)

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -64,7 +64,7 @@ private
 
   def change_translations_locale_if_primary_locale_changed
     if primary_locale_changed? && translations.count == 1
-      translations.first.update(locale: primary_locale)
+      translations.first.update!(locale: primary_locale)
     end
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -26,7 +26,7 @@ class Role < ApplicationRecord
 
   has_many :organisation_roles, inverse_of: :role
   has_many :organisations, through: :organisation_roles,
-            after_remove: :republish_organisation_to_publishing_api
+                           after_remove: :republish_organisation_to_publishing_api
 
   has_many :worldwide_organisation_roles, inverse_of: :role
   has_many :worldwide_organisations, through: :worldwide_organisation_roles

--- a/app/presenters/api/page_presenter.rb
+++ b/app/presenters/api/page_presenter.rb
@@ -37,7 +37,7 @@ Api::PagePresenter = Struct.new(:page, :context) do
     (page.current_page - 1) * page.limit_value + 1
   end
 
-private
+  private
 
   def url(override_params)
     context.url_for(context.params.permit(

--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -53,9 +53,9 @@ module PublishingApi
     end
 
     def whip
-      return {} if item.whip_organisation_id == nil
+      return {} if item.whip_organisation_id.nil?
 
-      whip_organisation = Whitehall::WhipOrganisation.find_by_id(item.whip_organisation_id) 
+      whip_organisation = Whitehall::WhipOrganisation.find_by_id(item.whip_organisation_id)
 
       {
         sort_order: whip_organisation.sort_order,
@@ -75,6 +75,7 @@ module PublishingApi
 
     def ministerial_role_details
       return {} unless item.is_a?(MinisterialRole)
+
       { seniority: item.seniority }
     end
 

--- a/app/services/service_listeners/search_indexer.rb
+++ b/app/services/service_listeners/search_indexer.rb
@@ -16,7 +16,7 @@ module ServiceListeners
       reindex_collection_documents
     end
 
-  private
+    private
 
     def reindex_collection_documents
       if edition.is_a?(DocumentCollection)

--- a/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
+++ b/db/data_migration/20200817081009_add_all_nation_applicability_to_editions.rb
@@ -1,5 +1,5 @@
 PUBLISHED_AND_PUBLISHABLE_STATES = %w[published draft archived submitted rejected scheduled].freeze
-EDITIONS_WITH_NATIONAL_APPLICABILITY = ['DetailedGuide', 'Publication', 'Consultation'].freeze
+EDITIONS_WITH_NATIONAL_APPLICABILITY = %w[DetailedGuide Publication Consultation].freeze
 
 edition_scope = Edition.where(type: EDITIONS_WITH_NATIONAL_APPLICABILITY).where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
 
@@ -9,4 +9,4 @@ def update_all_nation_applicability(edition)
   end
 end
 
-edition_scope.find_each {|edition| update_all_nation_applicability(edition)}
+edition_scope.find_each { |edition| update_all_nation_applicability(edition) }

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -74,7 +74,7 @@ Then(/^the news article "([^"]*)" should have been created$/) do |title|
   refute @news_article.nil?
 end
 
-Then('I subsequently change the primary locale') do
+Then("I subsequently change the primary locale") do
   visit admin_edition_path(@news_article)
   click_button "Create new edition to edit"
   select "Deutsch (German)", from: "edition[primary_locale]"
@@ -83,7 +83,7 @@ Then('I subsequently change the primary locale') do
   click_button "Save topic changes"
 end
 
-Then('there should exist only one translation') do
-  assert_equal ["published", "draft"], @news_article.document.editions.pluck(:state)
+Then("there should exist only one translation") do
+  assert_equal %w[published draft], @news_article.document.editions.pluck(:state)
   assert_equal 1, @news_article.document.latest_edition.translations.count
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -74,7 +74,7 @@ module DocumentHelper
       title: title,
       summary: "Some summary of the content",
       alternative_format_provider: create(:alternative_format_provider),
-      all_nation_applicability: options.key?(:all_nation_applicability) ? options[:all_nation_applicability] : true
+      all_nation_applicability: options.key?(:all_nation_applicability) ? options[:all_nation_applicability] : true,
     )
     fill_in_publication_fields(options.slice(:first_published, :publication_type))
   end

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -67,7 +67,7 @@ module DataHygiene
       rescue ActiveRecord::RecordNotFound
         puts "error: couldn't find organisation: #{slug.strip}"
 
-        exit 1
+        raise
       end
     end
 

--- a/lib/tasks/test_parallel.rake
+++ b/lib/tasks/test_parallel.rake
@@ -30,7 +30,7 @@ task test_queue: :environment do
     Dir["unit/**/*_test.rb", "functional/**/*_test.rb", "integration/**/*_test.rb"]
   end
   # Ensure the number of workers matches the number of PARALLEL_TEST_PROCESSORS
-  ENV["TEST_QUEUE_WORKERS"] ||= ENV["PARALLEL_TEST_PROCESSORS"]
+  ENV["TEST_QUEUE_WORKERS"] ||= ENV.fetch("PARALLEL_TEST_PROCESSORS", "6")
   puts "Running unit, functional and integration tests from #{files.size} files across #{ENV['TEST_QUEUE_WORKERS']} processors."
   command = "./script/test_queue"
   abort unless system(command, *files)

--- a/lib/whitehall/authority/rules/organisation_rules.rb
+++ b/lib/whitehall/authority/rules/organisation_rules.rb
@@ -15,7 +15,7 @@ module Whitehall::Authority::Rules
       end
     end
 
-  private
+    private
 
     def managing_editor_for_org?(actor, subject)
       actor.managing_editor? && actor_is_from_organisation_or_parent?(actor, subject)

--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -59,7 +59,7 @@ module Whitehall
       def repeatedly
         @attempts.times do |i|
           return yield
-        rescue RestClient::RequestFailed, RestClient::RequestTimeout, RestClient::ServerBrokeConnection => e
+        rescue RestClient::RequestFailed, RestClient::ServerBrokeConnection => e
           @logger.warn e.message
           raise if @attempts == i + 1
 

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -87,7 +87,6 @@ FactoryBot.define do
   factory :published_publication_with_excluded_nations, parent: :published_publication, traits: [:has_excluded_nations]
   factory :draft_publication_with_excluded_nations, parent: :draft_publication, traits: [:has_excluded_nations]
 
-
   factory :draft_corporate_publication, parent: :publication, traits: %i[draft corporate]
   factory :submitted_corporate_publication, parent: :publication, traits: %i[submitted corporate]
   factory :published_corporate_publication, parent: :publication, traits: %i[published corporate]

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -111,7 +111,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
   end
 
   test "raise an error if an email cannot be sent via notify" do
-    raises_exception = ->(request, params) {
+    raises_exception = lambda { |_request, _params|
       response = MiniTest::Mock.new
       response.expect :code, 400
       response.expect :body, "Can't send to this recipient using a team-only API key"

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -71,8 +71,8 @@ module TestsForNationalApplicability
         Nation.england => "http://www.example.com/england.",
         Nation.scotland => "http://www.example.com/scotland",
         Nation.wales => "http://www.example.com/wales",
-        Nation.northern_ireland => "http://www.example.com/ni"
-        })
+        Nation.northern_ireland => "http://www.example.com/ni",
+      })
 
       post :create, params: { edition: attributes.merge(all_nations) }
 
@@ -84,7 +84,7 @@ module TestsForNationalApplicability
     view_test "creating with no applicability options should fail validation" do
       create(:government)
 
-      post :create, params: { edition: attributes_for_edition(all_nation_applicability: "0")}
+      post :create, params: { edition: attributes_for_edition(all_nation_applicability: "0") }
 
       assert_nil Edition.last
 
@@ -97,8 +97,8 @@ module TestsForNationalApplicability
       post :create, params: {
         edition: attributes_for_edition.merge(
           nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.example.com/scotland"),
-          all_nation_applicability: "1"
-        )
+          all_nation_applicability: "1",
+        ),
       }
 
       assert_page_has_error("Excluded nations - you cannot select all UK nations and also exclude nations")
@@ -156,7 +156,7 @@ module TestsForNationalApplicability
       edition = create_edition(all_nation_applicability: "1")
       edition.update_column(:all_nation_applicability, false)
       northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.example.com/ni")
-      edition.save
+      edition.save!
 
       assert_equal [Nation.northern_ireland], edition.inapplicable_nations
       assert_equal "http://www.example.com/ni", edition.nation_inapplicabilities.for_nation(Nation.northern_ireland).first.alternative_url
@@ -173,7 +173,7 @@ module TestsForNationalApplicability
       edition.update_column(:all_nation_applicability, false)
       scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.example.com/scotland")
       wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.example.com/wales")
-      edition.save
+      edition.save!
 
       attributes = nation_inapplicabilities_attributes_for({ Nation.northern_ireland => "http://www.example.com/ni" }, scotland_inapplicability, wales_inapplicability).merge(title: "")
 
@@ -193,7 +193,7 @@ module TestsForNationalApplicability
       edition.update_column(:all_nation_applicability, false)
       scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.example.com/scotland")
       wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.example.com/wales")
-      edition.save
+      edition.save!
 
       put :update,
           params: { id: edition,
@@ -290,7 +290,6 @@ private
     end
     { nation_inapplicabilities_attributes: result }
   end
-
 
   def assert_page_has_error(error)
     assert_select(".errors", text: error)

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -75,7 +75,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         related_guides: [],
         related_mainstream_content: [],
         government: [government.content_id],
-      }
+      },
     }
     expected_links = {
       topics: [],

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -99,8 +99,8 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
         supports_historical_accounts: role.supports_historical_accounts,
         seniority: 100,
         whip_organisation: {
-          :sort_order => 1,
-          :label => "House of Commons",
+          sort_order: 1,
+          label: "House of Commons",
         },
       },
     }

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -233,7 +233,7 @@ class RoleTest < ActiveSupport::TestCase
 
     Whitehall::PublishingApi.expects(:republish_async).with(organisation).twice
 
-    role.update(organisations: [organisation])
-    role.update(organisations: [])
+    role.update!(organisations: [organisation])
+    role.update!(organisations: [])
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

It looks like we accidentally lost linting as part of a build step in https://github.com/alphagov/govuk-jenkinslib/pull/74, which means we've rapidly built up a variety of linting issues 😱 . This PR brings linting back and does a little bit of extra TLC in the rake sphere.