### PR TITLE
Change customised call to contents-list component

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -19,8 +19,6 @@
               }
             end,
             underline_links: true,
-            title: t('worldwide_organisation.headings.contents', default: 'Contents'),
-            title_lang: t_fallback('worldwide_organisation.headings.contents')
         } %>
       </nav>
     <% end %>

--- a/app/views/worldwide_offices/show.html.erb
+++ b/app/views/worldwide_offices/show.html.erb
@@ -20,8 +20,6 @@
               }
             end,
             underline_links: true,
-            title: t('worldwide_organisation.headings.contents', default: 'Contents'),
-            title_lang: t_fallback('worldwide_organisation.headings.contents')
         } %>
       </nav>
     <% end %>


### PR DESCRIPTION
The contents list component is being updated to remove the ability for hiding the title or customising it. It will detect the page language and apply the "lang=en" parameter if the translation isn't available, meaning there is no need to pass these values in from the calling app.

https://trello.com/c/LbVmpaK6/441-inconsistent-naming-of-table-of-contents

There are no visual changes intended as a result of this PR but if it is merged ahead of the gem update then pages such as www.gov.uk/world/organisations/british-embassy-paris/about/social-media-use will temporarily lose the translated title on the contents list component.