### PR TITLE
Add ministers_index page republishing logic

### DIFF
--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -4,11 +4,22 @@ class SitewideSetting < ApplicationRecord
   validates :key, uniqueness: true # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates_with SafeHtmlValidator
 
+  after_save :republish_ministers_if_reshuffle
+
   def human_status
     on ? "On" : "Off"
   end
 
   def name
     key.humanize
+  end
+
+  def republish_ministers_if_reshuffle 
+    return unless key == "minister_reshuffle_mode"
+
+    payload = PublishingApi::MinistersIndexPresenter.new
+
+    Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.publish(payload.content_id, nil, locale: "en")
   end
 end

--- a/test/unit/models/sitewide_setting_test.rb
+++ b/test/unit/models/sitewide_setting_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class SitewideSettingTest < ActiveSupport::TestCase
+ 
+  test "toggling reshuffle mode republished the ministers index page" do
+    payload = PublishingApi::MinistersIndexPresenter.new
+
+    create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+
+    requests = [
+      stub_publishing_api_put_content(payload.content_id, payload.content),
+      stub_publishing_api_publish(payload.content_id, locale: "en", update_type: nil),
+    ]
+
+    assert_all_requested(requests)
+
+  end
+end


### PR DESCRIPTION
Added logic to republish the ministers index page whenever reshuffle
mode is toggled on or off. This is needed to display the reshuffle
message on the page while a minister reshuffle is happening.

Part of the work to migrate the ministers index page to Collections.

https://trello.com/c/loAlkIp7/2063-8-migrate-government-ministers-to-collections