### PR TITLE
Add constraint for publication_id in statistics announcements

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -46,6 +46,7 @@ class StatisticsAnnouncement < ApplicationRecord
               in: PublicationType.statistical.map(&:id),
               message: "must be a statistical type",
             }
+  validates :publication_id, uniqueness: true, if: -> { publication_id.present? }
 
   accepts_nested_attributes_for :current_release_date, reject_if: :persisted?
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -22,7 +22,7 @@ class StatisticsAnnouncement < ApplicationRecord
 
   belongs_to :creator, class_name: "User"
   belongs_to :cancelled_by, class_name: "User"
-  belongs_to :publication
+  belongs_to :publication, optional: true
 
   has_one  :current_release_date,
            -> { order("created_at DESC") },

--- a/db/migrate/20201021152850_add_index_to_statistics_announcement_publication_id.rb
+++ b/db/migrate/20201021152850_add_index_to_statistics_announcement_publication_id.rb
@@ -1,8 +1,8 @@
 class AddIndexToStatisticsAnnouncementPublicationId < ActiveRecord::Migration[5.1]
   def change
-    # rubocop:disable Rails/BulkChangeTable
-    remove_index :statistics_announcements, name: "index_statistics_announcements_on_publication_id", column: :publication_id
-    add_index :statistics_announcements, :publication_id, unique: true
-    # rubocop:enable Rails/BulkChangeTable
+    change_table :statistics_announcements, bulk: true do |t|
+      t.remove_index name: "index_statistics_announcements_on_publication_id", column: :publication_id
+      t.index :publication_id, unique: true
+    end
   end
 end

--- a/db/migrate/20201021152850_add_index_to_statistics_announcement_publication_id.rb
+++ b/db/migrate/20201021152850_add_index_to_statistics_announcement_publication_id.rb
@@ -1,0 +1,8 @@
+class AddIndexToStatisticsAnnouncementPublicationId < ActiveRecord::Migration[5.1]
+  def change
+    # rubocop:disable Rails/BulkChangeTable
+    remove_index :statistics_announcements, name: "index_statistics_announcements_on_publication_id", column: :publication_id
+    add_index :statistics_announcements, :publication_id, unique: true
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200909141147) do
+ActiveRecord::Schema.define(version: 20201021152850) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -1020,7 +1020,7 @@ ActiveRecord::Schema.define(version: 20200909141147) do
     t.string "content_id", null: false
     t.index ["cancelled_by_id"], name: "index_statistics_announcements_on_cancelled_by_id"
     t.index ["creator_id"], name: "index_statistics_announcements_on_creator_id"
-    t.index ["publication_id"], name: "index_statistics_announcements_on_publication_id"
+    t.index ["publication_id"], name: "index_statistics_announcements_on_publication_id", unique: true
     t.index ["slug"], name: "index_statistics_announcements_on_slug"
     t.index ["title"], name: "index_statistics_announcements_on_title"
     t.index ["topic_id"], name: "index_statistics_announcements_on_topic_id"

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -57,7 +57,7 @@ namespace :data_hygiene do
   task ensure_statistics_announcement_unique: :environment do
     announcements_by_id = StatisticsAnnouncement.where.not(publication_id: nil).group_by(&:publication_id).filter { |_s, p| p.count > 1 }
     announcements_by_id.each_value do |announcements|
-      announcements.sort_by(&:created_at)[1,].each do |announcement|
+      announcements.sort_by(&:created_at)[1..-1].each do |announcement|
         announcement.publication = nil
       end
     end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -52,4 +52,14 @@ namespace :data_hygiene do
       puts "#{sponsorship.worldwide_organisation.name} updated from FCO to FCDO."
     end
   end
+
+  desc "Ensure there is only one statistics announcement per publication"
+  task ensure_statistics_announcement_unique: :environment do
+    announcements_by_id = StatisticsAnnouncement.where.not(publication_id: nil).group_by(&:publication_id).filter { |_s, p| p.count > 1 }
+    announcements_by_id.each_value do |announcements|
+      announcements.sort_by(&:created_at)[1,].each do |announcement|
+        announcement.publication = nil
+      end
+    end
+  end
 end

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -30,7 +30,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
 
   test "organisations= parses slugs into real organisations" do
     org1, org2 = 2.times.map { create(:organisation) }
-    assert_equal [org1, org2], build_class_instance(organisations: [org1.slug, org2.slug]).organisations
+    assert_equal [org1, org2].sort, build_class_instance(organisations: [org1.slug, org2.slug]).organisations.sort
   end
 
   test "organisations= handles nil" do


### PR DESCRIPTION
Adds a unique index and a model validation to ensure that no two statistics announcements share the same publication

Does not currently ensure the existing records are unique (a rough check suggests there are about 150 affected) so the migration cannot be applied.

https://trello.com/c/he3gFWkI/2163-5-only-allow-one-statistics-announcement-to-be-linked-to-a-publication