### PR TITLE
Updating list of government blogs

### DIFF
--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -118,8 +118,7 @@
             <li><a href="https://quarterly.blog.gov.uk" class="govuk-link" rel="external">Civil Service Quarterly</a></li>
             <li><a href="https://blogs.fcdo.gov.uk/" class="govuk-link" rel="external">FCDO bloggers</a></li>
             <li><a href="https://gds.blog.gov.uk/" class="govuk-link" rel="external">Government Digital Service</a></li>
-            <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" class="govuk-link"
-             rel="external">Head of the Civil Service</a></li>
+            <li><a href="https://civilservice.blog.gov.uk" class="govuk-link" rel="external">Civil Service</a></li>
           </ul>
         </div>
       </div>

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -116,7 +116,7 @@
           <ul class="index-list">
             <li><a href="https://history.blog.gov.uk" class="govuk-link" rel="external">History of Government</a></li>
             <li><a href="https://quarterly.blog.gov.uk" class="govuk-link" rel="external">Civil Service Quarterly</a></li>
-            <li><a href="http://blogs.fco.gov.uk" class="govuk-link" rel="external">FCO bloggers</a></li>
+            <li><a href="https://blogs.fcdo.gov.uk/" class="govuk-link" rel="external">FCDO bloggers</a></li>
             <li><a href="https://gds.blog.gov.uk/" class="govuk-link" rel="external">Government Digital Service</a></li>
             <li><a href="https://civilservice.blog.gov.uk/author/sir-jeremy-heywood/" class="govuk-link"
              rel="external">Head of the Civil Service</a></li>
@@ -153,7 +153,7 @@
       </div>
       <div class="column">
         <div class="content">
-          <p>Many people are already volunteering, donating and contributing, both in the UK and abroad. If you&rsquo;d like to join them, but don&rsquo;t know where to start, here&rsquo;s a list of suggestions:</p>
+          <p>Many people are already volunteering, donating and contributing, both in the UK and abroad. If you&rsquo;d like to join them, but do not know where to start, here&rsquo;s a list of suggestions:</p>
           <ul class="index-list">
             <li><a href="http://www.volunteerics.org/" class="govuk-link" rel="external">Join the International Citizen Service (18- to 25-year-olds)</a></li>
             <li><a href="http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/" class="govuk-link" rel="external">Take part in your local Neighbourhood Watch</a></li>


### PR DESCRIPTION
- updated 'FCO bloggers' to 'FCDO bloggers' and changed link
- fixed one negative contraction
- updated link to Civil Service blog to the main blog replacing the link to author profile

https://trello.com/c/J8UFotPy/1917-update-fco-reference-on-get-involved