### PR TITLE
Pass 'ordering' information to Publishing API

### DIFF
--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -44,6 +44,7 @@ module PublishingApi
           url: item.image_url(:s300),
           alt_text: item.image_alt_text,
         },
+        ordering: item.ordering,
       }
     end
 

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -30,6 +30,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
           url: image_url,
           alt_text: "Image alt text",
         },
+        ordering: 1,
       },
       update_type: "major",
     }


### PR DESCRIPTION
Dependent on: https://github.com/alphagov/govuk-content-schemas/pull/1021
Depended on by: https://github.com/alphagov/govuk-content-schemas/pull/1022

Take Part pages save an order in the model in Whitehall so that
they can be displayed in a specific order on the "Get Involved"
page. However this ordering was not being exported to Publishing
API, limiting our ability to migrate away from Whitehall.

Storing the ordering in Publishing API allows us to migrate the
frontend parts away from Whitehall, as this key information would
now be in a centralised place.

Trello: https://trello.com/c/aAW8oqCk/2174-5add-ordering-to-take-part-pages-in-schema