### PR TITLE
Add a rake task to remove duplicate statistics announcements

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -52,4 +52,14 @@ namespace :data_hygiene do
       puts "#{sponsorship.worldwide_organisation.name} updated from FCO to FCDO."
     end
   end
+
+  desc "Ensure there is only one statistics announcement per publication"
+  task ensure_statistics_announcement_unique: :environment do
+    announcements_by_id = StatisticsAnnouncement.where.not(publication_id: nil).group_by(&:publication_id).filter { |_s, p| p.count > 1 }
+    announcements_by_id.each_value do |announcements|
+      announcements.sort_by(&:created_at)[1..-1].each do |announcement|
+        announcement.publication = nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a rake task that ensures that there is a one-to-one relationship between statistics announcements and publications.

Originally part of #5849 

https://trello.com/c/he3gFWkI/2163-5-only-allow-one-statistics-announcement-to-be-linked-to-a-publication