### PR TITLE
Show all org logos similarly for CSV previews

### DIFF
--- a/app/assets/stylesheets/frontend/views/attachments/_preview.scss
+++ b/app/assets/stylesheets/frontend/views/attachments/_preview.scss
@@ -40,15 +40,19 @@
     margin: $gutter 0 $gutter * 2;
   }
 
-  .other-organisations {
-    @include core-16;
-    margin: $gutter-half 0;
-    @include media(tablet) {
-      margin-bottom: 0;
-      width: $half;
-    }
-    .show-other-content {
-      text-decoration: none;
-    }
+  .organisation-logos {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    list-style-type: none;
+    margin-top: govuk-spacing(2);
+  }
+
+  .organisation-logos__logo {
+    padding-bottom: govuk-spacing(3);
+    margin-right: govuk-spacing(3);
+    flex-basis: 25%;
+    min-width: 130px;
   }
 }

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -7,23 +7,18 @@
 %>
 
 <div class="block publication-external">
-  <div class="inner-block floated-children">
-    <%- if first_organisation -%>
-      <div class="<%= organisation_brand_colour_class(first_organisation) %>">
-        <%= link_to organisation_path(first_organisation),
-                    class: logo_classes(organisation: first_organisation, size: 'medium', stacked: true) do %>
-          <span><%= organisation_logo_name(first_organisation) %></span>
+  <div class="organisation-logos">
+    <%- @edition.organisations.each do |organisation| %>
+      <div class="organisation-logos__logo <%= organisation_brand_colour_class(organisation) %>">
+        <%= link_to organisation_path(organisation),
+                    class: logo_classes(organisation: organisation, size: 'medium', stacked: true) do %>
+          <span><%= organisation_logo_name(organisation) %></span>
         <%- end -%>
       </div>
-
-      <div class="other-organisations">
-        <%= array_of_links_to_organisations(other_organisations).to_sentence.html_safe %>
-      </div>
-
     <%- end -%>
-    <div class="return">
-      <p><%= link_to "See more information about #{with_this_determiner(@edition.display_type.downcase)}", public_document_url(@edition) %></p>
-    </div>
+  </div>
+  <div>
+    <p><%= link_to "See more information about #{with_this_determiner(@edition.display_type.downcase)}", public_document_url(@edition) %></p>
   </div>
 </div>
 <header class="publication-header" id="contents">


### PR DESCRIPTION
https://trello.com/c/3PbkxAcN/1022-sync-how-we-show-logos-for-csv-previews-with-html-attachments

This matches the behaviour for HTML attachments, and avoids the
confusion of an arbitrary organisation being shown with a logo,
while others are not. Note that the CSS is taken from a similar
view for HTML attachments in government-frontend [1].

[1]: https://github.com/alphagov/government-frontend/blob/fa2285ecad1143215c55f137381164dbd32242f5/app/assets/stylesheets/helpers/_organisation-logos.scss

## Before 

<img width="980" alt="Screenshot 2020-10-29 at 16 00 01" src="https://user-images.githubusercontent.com/9029009/97599376-d4a6fb00-19ff-11eb-8096-65190ccb34c4.png">

## After 

<img width="972" alt="Screenshot 2020-10-29 at 16 07 47" src="https://user-images.githubusercontent.com/9029009/97600393-e9d05980-1a00-11eb-818c-7aadf8cef24d.png">
