### PR TITLE
Change role appointment ordering

### DIFF
--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -147,7 +147,7 @@ module Admin::TaggableContentHelper
         RoleAppointment
                                 .joins(:role)
                                 .where(roles: { type: "MinisterialRole" })
-                                .order("role_appointments.id"),
+                                .order("role_appointments.started_at"),
         "ministerial-role-appointments",
       )
     end
@@ -217,7 +217,7 @@ private
       .includes(:person)
       .with_translations_for(:organisations)
       .with_translations_for(:role)
-      .alphabetical_by_person.map { |appointment| [role_appointment_label(appointment), appointment.id] }
+      .ascending_start_date.map { |appointment| [role_appointment_label(appointment), appointment.id] }
   end
 
   def role_appointment_label(appointment)

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -62,6 +62,7 @@ class RoleAppointment < ApplicationRecord
   scope :current, -> { where(CURRENT_CONDITION) }
   scope :for_ministerial_roles, -> { includes(role: :organisations).merge(Role.ministerial).references(:roles) }
   scope :alphabetical_by_person, -> { includes(:person).order("people.surname", "people.forename") }
+  scope :ascending_start_date, -> { order("started_at DESC") }
 
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable

--- a/test/unit/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/helpers/admin/taggable_content_helper_test.rb
@@ -60,6 +60,7 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
 
     joe = create(:person, forename: "Joe", surname: "Rockhead")
     slate = create(:person, forename: "Mr.", surname: "Slate")
+    granite = create(:person, forename: "Karen", surname: "Granite")
 
     old_leader_appointment = create(
       :role_appointment,
@@ -68,11 +69,20 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
       started_at: Date.new(2006, 5, 12),
       ended_at: Date.new(2011, 5, 11),
     )
+
+    older_leader_appointment = create(
+      :role_appointment,
+      role: leader,
+      person: granite,
+      started_at: Date.new(2003, 5, 12),
+      ended_at: Date.new(2006, 5, 11),
+    )
     current_leader_appointment = create(:role_appointment, role: leader, person: slate)
 
     assert_equal [
-      ["Joe Rockhead, Leader (12 May 2006 to 11 May 2011), Ministry for Rocks and Bones", old_leader_appointment.id],
       ["Mr. Slate, Leader, Ministry for Rocks and Bones", current_leader_appointment.id],
+      ["Joe Rockhead, Leader (12 May 2006 to 11 May 2011), Ministry for Rocks and Bones", old_leader_appointment.id],
+      ["Karen Granite, Leader (12 May 2003 to 11 May 2006), Ministry for Rocks and Bones", older_leader_appointment.id],
     ],
                  taggable_ministerial_role_appointments_container
   end


### PR DESCRIPTION
Change ordering of role appointments in the admin interface in whitehall,
so when tagging a role appointment to a new publication, the appointments
are presented in descending order. This is that so when a user searches a
minister name the appointments that minister currently holds will appear
first, then previous appointments in descending order by start date.

https://trello.com/c/dFGjneqv/2190-change-ordering-when-selecting-a-minister-in-whitehall-content

![image](https://user-images.githubusercontent.com/24547183/98649194-37b55d80-232f-11eb-964e-80e7f0d02e81.png)

