### PR TITLE
Add event tracking to track how many times 'Request accessible format…

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -71,7 +71,15 @@
       <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
         <p><%= t('attachment.accessibility.intro') %></p>
         <%= render "govuk_publishing_components/components/details", {
-          title: t('attachment.accessibility.request_a_different_format')
+          title: t('attachment.accessibility.request_a_different_format'),
+          data_attributes: {
+            track_category: "Accessible Format Request",
+            track_action: "FormatRequestClicked",
+            track_options: {
+              value: attachment.title
+            },
+            module: "govuk-details"
+          }
         } do %>
           <%= t('attachment.accessibility.full_help_html',
           email: alternative_format_order_link(attachment, alternative_format_contact_email),


### PR DESCRIPTION
…' is clicked

## What

Add Google Analytics event tracking to 'request accessible format' so we know how many times it is clicked.

Here is an example https://www.gov.uk/government/publications/nhs-test-and-trace-england-and-coronavirus-testing-uk-statistics-1-october-to-7-october-2020

https://www.gov.uk/government/publications/face-coverings-when-to-wear-one-and-how-to-make-your-own

The mailto is already tracked so this will be similar. Let's track the accessible format link too. Following format as a suggestion.

Event Category: Accessible Format Request
Event Action: FormatRequestClicked
Event Label: [the name of the file requested]

## What

We know how many click on the mailto link to email. How many click on the request accessible format? How many users need accessible format and it is not provided

https://trello.com/c/3U1QEEK1/584-add-event-tracking-to-track-how-many-times-request-accessible-format-is-clicked