### PR TITLE
Don't update attachment metadata for already-deleted attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -205,6 +205,6 @@ private
   end
 
   def attachment_updater
-    ServiceListeners::AttachmentUpdater.call(attachable: attachable.reload)
+    ServiceListeners::AttachmentUpdater.update_all_attachment_data_for(attachable.reload)
   end
 end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -81,7 +81,7 @@ class AttachmentData < ApplicationRecord
 
   def uploaded_to_asset_manager!
     update!(uploaded_to_asset_manager_at: Time.zone.now)
-    ServiceListeners::AttachmentUpdater.call(attachment_data: self)
+    ServiceListeners::AttachmentUpdater.update_attachment_data(self)
   end
 
   def uploaded_to_asset_manager?

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -1,25 +1,19 @@
 module ServiceListeners
   class AttachmentUpdater
     extend LockedDocumentConcern
-
-    def self.call(attachable: nil, attachment_data: nil)
+    def self.update_all_attachment_data_for(attachable)
       if attachable.is_a?(Edition)
         check_if_locked_document(edition: attachable)
       end
 
-      update_attachable! attachable if attachable
-      update_attachment_data! attachment_data if attachment_data
-    end
-
-    private_class_method def self.update_attachable!(attachable)
       Attachment.where(attachable: attachable.attachables).find_each do |attachment|
         next unless attachment.attachment_data
 
-        update_attachment_data! attachment.attachment_data
+        update_attachment_data(attachment.attachment_data)
       end
     end
 
-    private_class_method def self.update_attachment_data!(attachment_data)
+    def self.update_attachment_data(attachment_data)
       AssetManagerAttachmentMetadataWorker.perform_async(attachment_data.id)
     end
   end

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -14,7 +14,7 @@ module ServiceListeners
     end
 
     def self.update_attachment_data(attachment_data)
-      AssetManagerAttachmentMetadataWorker.perform_async(attachment_data.id)
+      AssetManagerAttachmentMetadataWorker.perform_async(attachment_data.id) unless FileAttachment.find_by(attachment_data_id: attachment_data.id).deleted?
     end
   end
 end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -1,6 +1,6 @@
 Whitehall.edition_services.tap do |coordinator|
   coordinator.subscribe do |_event, edition, _options|
-    ServiceListeners::AttachmentUpdater.call(attachable: edition)
+    ServiceListeners::AttachmentUpdater.update_all_attachment_data_for(edition)
   end
 
   coordinator.subscribe("unpublish") do |_event, edition, _options|

--- a/test/unit/services/service_listeners/attachment_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_updater_test.rb
@@ -4,13 +4,23 @@ require "test_helper"
 class AttachmentUpdaterTest < ActiveSupport::TestCase
   test "#update_attachment_data updates attachment_data" do
     attachment_data = create(:attachment_data, file: file_fixture("sample.rtf"))
+    create(:file_attachment, title: "Title", attachment_data: attachment_data)
 
     AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).once
     ServiceListeners::AttachmentUpdater.update_attachment_data(attachment_data)
   end
 
+  test "#update_attachment_data doesn't update attachment_data if attachment is deleted" do
+    attachment_data = create(:attachment_data, file: file_fixture("sample.rtf"))
+    attachment = create(:file_attachment, title: "Title", attachment_data: attachment_data)
+    attachment.update!(deleted: true)
+
+    AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).never
+    ServiceListeners::AttachmentUpdater.update_attachment_data(attachment_data)
+  end
+
   test "#update_all_attachment_data_for updates attachment data associated with an attachable's attachments" do
-    attachment_data = build(:attachment_data, file: file_fixture("sample.rtf"))
+    attachment_data = create(:attachment_data, file: file_fixture("sample.rtf"))
     attachment = FileAttachment.new(title: "Title", attachment_data: attachment_data)
     edition = create(
       :publication,

--- a/test/unit/services/service_listeners/attachment_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_updater_test.rb
@@ -1,0 +1,24 @@
+require "mocha"
+require "test_helper"
+
+class AttachmentUpdaterTest < ActiveSupport::TestCase
+  test "#call updates attachment_data that is passed directly" do
+    attachment_data = build(:attachment_data, file: file_fixture("sample.rtf"))
+
+    AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).once
+    ServiceListeners::AttachmentUpdater.call(attachment_data: attachment_data)
+  end
+
+  test "#call updates attachment data associated with an attachable's attachments" do
+    attachment_data = build(:attachment_data, file: file_fixture("sample.rtf"))
+    attachment = FileAttachment.new(title: "Title", attachment_data: attachment_data)
+    edition = create(
+      :publication,
+      :with_file_attachment,
+      attachments: [attachment],
+    )
+
+    AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).once
+    ServiceListeners::AttachmentUpdater.call(attachable: edition)
+  end
+end

--- a/test/unit/services/service_listeners/attachment_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_updater_test.rb
@@ -2,14 +2,14 @@ require "mocha"
 require "test_helper"
 
 class AttachmentUpdaterTest < ActiveSupport::TestCase
-  test "#call updates attachment_data that is passed directly" do
-    attachment_data = build(:attachment_data, file: file_fixture("sample.rtf"))
+  test "#update_attachment_data updates attachment_data" do
+    attachment_data = create(:attachment_data, file: file_fixture("sample.rtf"))
 
     AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).once
-    ServiceListeners::AttachmentUpdater.call(attachment_data: attachment_data)
+    ServiceListeners::AttachmentUpdater.update_attachment_data(attachment_data)
   end
 
-  test "#call updates attachment data associated with an attachable's attachments" do
+  test "#update_all_attachment_data_for updates attachment data associated with an attachable's attachments" do
     attachment_data = build(:attachment_data, file: file_fixture("sample.rtf"))
     attachment = FileAttachment.new(title: "Title", attachment_data: attachment_data)
     edition = create(
@@ -19,6 +19,6 @@ class AttachmentUpdaterTest < ActiveSupport::TestCase
     )
 
     AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(attachment_data.id).once
-    ServiceListeners::AttachmentUpdater.call(attachable: edition)
+    ServiceListeners::AttachmentUpdater.update_all_attachment_data_for(edition)
   end
 end


### PR DESCRIPTION
We're seeing lots of `AssetManager::ServiceHelper::AssetNotFound`
errors in Sentry (here's an [example][]), originating from
`AssetManagerAttachmentMetadataWorker`. Looking at the assets in
question, their respective 'attachment' always seems to be
`deleted: true`, which explains why the asset cannot be found.
It also begs the question: why are we trying to apply any workers
to them in the first place?

When an attachment is deleted, it shouldn't be touched again.
Once this commit is merged, we expect to see these kinds of errors
reduce by half. We still have to apply a similar fix to errors
originating from `AssetManagerAttachmentRedirectUrlUpdateWorker`,
which account for the other half.

Trello: https://trello.com/c/RethzUSW/2088-5-fix-assetmanagerservicehelperassetnotfound-errors-on-staging-integration

[example]: https://sentry.io/organizations/govuk/issues/1668643818/events/f1bf7ff83ede4822b9a781459d749760/?environment=staging&project=202259&query=error.type%3AAssetManager%3A%3AServiceHelper%3A%3AAssetNotFound+transaction%3ASidekiq%2FAssetManagerAttachmentMetadataWorker&statsPeriod=90d