### PR TITLE
Removes 'requeue_all_jobs' Rake task

### DIFF
--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -18,11 +18,6 @@ class ScheduledPublishingWorker < WorkerBase
         .map(&:delete)
     end
 
-    # Only used by the publishing:scheduled:requeue_all_jobs rake task.
-    def dequeue_all
-      queued_jobs.map(&:delete)
-    end
-
     def queue_size
       queued_jobs.size
     end

--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -70,23 +70,6 @@ namespace :publishing do
       end
     end
 
-    desc "Clears all jobs then requeues all scheduled editions (intended for use after a db restore)"
-    task requeue_all_jobs: :environment do
-      ScheduledPublishingWorker.dequeue_all
-
-      puts "Queueing #{Edition.scheduled.count} jobs"
-      Edition.scheduled.each do |edition|
-        ScheduledPublishingWorker.queue(edition)
-        print "."
-      end
-      puts ""
-
-      # Consultations work slightly different to scheduled editions
-      puts "Queuing consultation jobs"
-      Consultation.open.or(Consultation.upcoming)
-        .find_each(&:schedule_republishing_workers)
-    end
-
     desc "Finds editions that were meant to be published between 23:00 yesterday and 01:00 today - helps debug failed publications owing to British Summer Time"
     task around_midnight: :environment do
       yesterday = Date.yesterday

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -63,22 +63,6 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test ".dequeue_all removes all scheduled publishing jobs" do
-    edition1 = create(:scheduled_edition)
-    edition2 = create(:scheduled_edition)
-
-    with_real_sidekiq do
-      ScheduledPublishingWorker.queue(edition1)
-      ScheduledPublishingWorker.queue(edition2)
-
-      assert_equal 2, Sidekiq::ScheduledSet.new.size
-
-      ScheduledPublishingWorker.dequeue_all
-
-      assert_equal 0, Sidekiq::ScheduledSet.new.size
-    end
-  end
-
   test ".queue_size returns the number of queued ScheduledPublishingWorker jobs" do
     with_real_sidekiq do
       ScheduledPublishingWorker.perform_at(1.day.from_now, "null")


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-puppet/pull/10842.

When that is merged, we will no longer be using the Rake task
(or its associated 'dequeue_all' code) anywhere.

When _this_ PR is merged, I'll need to update [this doc](https://docs.publishing.service.gov.uk/manual/alerts/whitehall-app-healthcheck-not-ok.html#header).

Trello: https://trello.com/c/RethzUSW/2088-5-fix-assetmanagerservicehelperassetnotfound-errors-on-staging-integration