### PR TITLE
Add new Rake task to allow republishing of Take Part pages

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -149,6 +149,12 @@ namespace :publishing_api do
     puts "Finished queuing items for Publishing API"
   end
 
+  desc "Republish all Take Part pages"
+  task republish_all_take_part_pages: :environment do
+    TakePartPage.find_each(&:publish_to_publishing_api)
+    puts "Finished republishing Take Part pages"
+  end
+
   desc "Republish a person to the Publishing API"
   task :republish_person, [:slug] => :environment do |_, args|
     Person.find_by!(slug: args[:slug]).publish_to_publishing_api


### PR DESCRIPTION
We've added a new ordering option to the schema for Take Part pages that
allows us to store the ordering of the pages in the Publishing API. This
rake task simply gives us the ability to republish the pages with that
information.

https://github.com/alphagov/govuk-content-schemas/commit/67d3747ca50314d74f0e2990474f35c4c301f0b3

I think it may be worth keeping around after its initial use until we
complete migration work, in case of future needs.

Related to work in this Trello: https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend

