### PR TITLE
Allow managing editors to unpublish statistics announcements

### DIFF
--- a/lib/whitehall/authority/rules/statistics_announcement_rules.rb
+++ b/lib/whitehall/authority/rules/statistics_announcement_rules.rb
@@ -3,7 +3,7 @@ module Whitehall::Authority::Rules
     def can?(action)
       case action
       when :unpublish
-        actor.gds_editor?
+        actor.gds_editor? || actor.managing_editor?
       else
         true
       end

--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -16,6 +16,12 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
     assert_response 403
   end
 
+  test "Managing Editor permission allowed to unpublish" do
+    login_as :managing_editor
+    get :new, params: { statistics_announcement_id: @announcement.id }
+    assert_response 200
+  end
+
   view_test "GET :new renders a form" do
     get :new, params: { statistics_announcement_id: @announcement }
 


### PR DESCRIPTION
This is a feature requested by the content designers because they deal with a lot of these requests and we trust managing editors to be able to do this sensibly.

[Trello Card](https://trello.com/c/ZtvnMAgX/2225-3-give-departments-the-ability-to-unpublish-statistics-announcements)