### PR TITLE
Add stylelint to dependabot for updating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,13 @@ updates:
     schedule:
       interval: daily
     allow:
+      # Internal packages
+      - dependency-name: stylelint-config-gds
+        dependency-type: direct
       # Framework packages
       - dependency-name: standard
+        dependency-type: direct
+      - dependency-name: stylelint
         dependency-type: direct
 
   # Ruby needs to be upgraded manually in multiple places, so cannot


### PR DESCRIPTION
I forgot to add this as part of https://github.com/alphagov/whitehall/pull/5853, This makes our approach to SCSS linting dependency tracking consistent with Ruby and JS.