### PR TITLE
Switch from Standard to Standardx for JS linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,7 @@ updates:
       interval: daily
     allow:
       # Framework packages
-      - dependency-name: standard
+      - dependency-name: standardx
         dependency-type: direct
 
   # Ruby needs to be upgraded manually in multiple places, so cannot

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "scripts": {
     "lint": "yarn run lint:js && yarn run lint:scss",
-    "lint:js": "standard 'app/assets/javascripts/**/*.js' 'test/javascripts/**/*.js'",
+    "lint:js": "standardx 'app/assets/javascripts/**/*.js' 'test/javascripts/**/*.js'",
     "lint:scss": "stylelint app/assets/stylesheets/"
   },
-  "standard": {
+  "standardx": {
     "env": {
       "browser": true,
       "jquery": true,
@@ -25,8 +25,13 @@
       "test/javascripts/support/"
     ]
   },
+  "eslintConfig": {
+    "rules": {
+      "no-var": 0
+    }
+  },
   "devDependencies": {
-    "standard": "^16.0.3",
+    "standardx": "^7.0.0",
     "stylelint": "^13.7.2",
     "stylelint-config-gds": "^0.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,7 +2336,7 @@ standard-engine@^14.0.1:
     pkg-conf "^3.1.0"
     xdg-basedir "^4.0.0"
 
-standard@^16.0.3:
+standard@^16.0.1:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/standard/-/standard-16.0.3.tgz#a854c0dd2dea6b9f0b8d20c65260210bd0cee619"
   integrity sha512-70F7NH0hSkNXosXRltjSv6KpTAOkUkSfyu3ynyM5dtRUiLtR+yX9EGZ7RKwuGUqCJiX/cnkceVM6HTZ4JpaqDg==
@@ -2348,6 +2348,14 @@ standard@^16.0.3:
     eslint-plugin-node "~11.1.0"
     eslint-plugin-promise "~4.2.1"
     eslint-plugin-react "~7.21.5"
+    standard-engine "^14.0.1"
+
+standardx@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/standardx/-/standardx-7.0.0.tgz#d00a6a7ed4589abb814bff8ec161c6e94cf5cd64"
+  integrity sha512-Uh2LIWyMD0pMFn+zoAS52dforkE8MUWP6hK48iQhiohTC5DRqBgTdXdJbhSGyjamRxCfETBdfvJ7hvtme2M3jg==
+  dependencies:
+    standard "^16.0.1"
     standard-engine "^14.0.1"
 
 state-toggle@^1.0.0:


### PR DESCRIPTION
Standard 16 introduced a rule that disallowed the use of `var`, instead
preferring `let` or `const` [1]. This conflicts with the GOV.UK approach
where we tend to not embrace features that we know will break old
browsers even if they're not necessarily supported [2], disallowing var
will mean that < IE 11 will be unable to run any of the JS.

In order to customise standard rules this project has switched to using
standardx [3] which allows us to disallow rules. I've used this so we
can disallow the 'no-var' rule.

[1]: https://github.com/standard/standard/issues/633
[2]: https://github.com/alphagov/govuk_publishing_components/pull/1611#discussion_r456493365
[3]: https://github.com/standard/standardx