### PR TITLE
DO NOT MERGE Brexit current state notice

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -14,6 +14,7 @@
       this.toggleWorldNewsStoryVisibility()
       this.resetWorldNewsStoryFields()
       this.toggleFirstPublishedDate()
+      this.toggleNotice()
       this.showImageUploaderIfCustomImage()
 
       GOVUK.formChangeProtection.init($('#edit_edition'), 'You have unsaved changes that will be lost if you leave this page.')
@@ -265,6 +266,22 @@
         $(this).parent().hide().next().removeClass('if-js-hide')
         e.preventDefault()
       })
+    },
+
+    toggleNotice: function toggleNotice () {
+      var $radioButtons = $('.js-toggle-notice input[type=radio]')
+      var $controlledElements = $('.js-toggle-notice-controlled')
+
+      function updateControlledElements (elements) {
+        $controlledElements.hide()
+        var $activeRadioButton = $('.js-toggle-notice input[type=radio]:checked')
+        var $controlledElementId = $activeRadioButton.data('controls')
+        if ($controlledElementId) {
+          $('#' + $controlledElementId).show()
+        }
+      }
+      $radioButtons.on('change', updateControlledElements)
+      updateControlledElements()
     },
 
     showImageUploaderIfCustomImage: function showImageUploaderIfCustomImage () {

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -253,3 +253,17 @@ fieldset.fatality-notice-casualties {
     opacity: .1;
   }
 }
+
+.notice-radio {
+  margin: 5px 0;
+
+  label {
+    font-weight: normal;
+  }
+}
+
+.toggle-notice-controlled {
+  border-left: 1px solid #999999;
+  padding: 10px 0 0 20px;
+  margin-left: 5px;
+}

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -243,6 +243,7 @@ private
       :all_nation_applicability,
       :image_display_option,
       brexit_no_deal_content_notice_links_attributes: %i[id title url],
+      brexit_current_state_content_notice_links_attributes: %i[id title url],
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -16,6 +16,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :limit_edition_access!, only: %i[show edit update revise diff destroy]
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :deduplicate_specialist_sectors, only: %i[create update]
+  before_action :set_transition_notices, only: %i[create update]
   before_action :forbid_editing_of_locked_documents, only: %i[edit update revise destroy]
 
   def enforce_permissions!
@@ -237,6 +238,8 @@ private
       :political,
       :read_consultation_principles,
       :show_brexit_no_deal_content_notice,
+      :show_brexit_current_state_content_notice,
+      :transition_content_notice,
       :all_nation_applicability,
       :image_display_option,
       brexit_no_deal_content_notice_links_attributes: %i[id title url],
@@ -450,6 +453,22 @@ private
 
     if edition_params[:secondary_specialist_sector_tags] && edition_params[:primary_specialist_sector_tag]
       edition_params[:secondary_specialist_sector_tags] -= [edition_params[:primary_specialist_sector_tag]]
+    end
+  end
+
+  def set_transition_notices
+    return if params.empty?
+
+    case params[:transition_content_notice]
+    when "no_notice"
+      edition_params[:show_brexit_no_deal_content_notice] = false
+      edition_params[:show_brexit_current_state_content_notice] = false
+    when "current_state"
+      edition_params[:show_brexit_no_deal_content_notice] = false
+      edition_params[:show_brexit_current_state_content_notice] = true
+    when "no_deal"
+      edition_params[:show_brexit_no_deal_content_notice] = true
+      edition_params[:show_brexit_current_state_content_notice] = false
     end
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -316,7 +316,7 @@ private
 
   def build_edition_dependencies
     build_blank_image
-    build_blank_brexit_no_deal_content_notice_links
+    build_blank_brexit_content_notice_links
   end
 
   def set_edition_defaults
@@ -354,8 +354,8 @@ private
     end
   end
 
-  def build_blank_brexit_no_deal_content_notice_links
-    @edition.build_no_deal_notice_links if @edition.allows_brexit_no_deal_content_notice?
+  def build_blank_brexit_content_notice_links
+    @edition.build_brexit_notice_links if @edition.allows_brexit_content_notice?
   end
 
   def default_filters

--- a/app/models/brexit_current_state_content_notice_link.rb
+++ b/app/models/brexit_current_state_content_notice_link.rb
@@ -1,4 +1,4 @@
-class BrexitNoDealContentNoticeLink < ApplicationRecord
+class BrexitCurrentStateContentNoticeLink < ApplicationRecord
   belongs_to :edition
 
   validates :title,

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -8,6 +8,7 @@ class CaseStudy < Edition
   include Edition::WorldLocations
   include Edition::WorldwideOrganisations
   include Edition::BrexitNoDealContentNoticeLinks
+  include Edition::BrexitCurrentStateContentNoticeLinks
 
   validates :first_published_at, presence: true, if: ->(e) { e.trying_to_convert_to_draft == true }
 

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -2,6 +2,7 @@ class DetailedGuide < Edition
   include Edition::Images
   include Edition::NationalApplicability
   include Edition::BrexitNoDealContentNoticeLinks
+  include Edition::BrexitCurrentStateContentNoticeLinks
 
   include ::Attachable
   include Edition::AlternativeFormatProvider

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -4,6 +4,7 @@ class DocumentCollection < Edition
 
   include Edition::TopicalEvents
   include Edition::BrexitNoDealContentNoticeLinks
+  include Edition::BrexitCurrentStateContentNoticeLinks
 
   has_many :groups,
            -> { order("document_collection_groups.ordering") },

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -423,6 +423,10 @@ EXISTS (
     false
   end
 
+  def allows_brexit_current_state_content_notice?
+    false
+  end
+
   def can_be_grouped_in_collections?
     false
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -46,6 +46,7 @@ class Edition < ApplicationRecord
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
   validates_with TaxonValidator, on: :publish
+  validates_with BrexitContentNoticeValidator
 
   validates :creator, presence: true
   validates :title, presence: true, if: :title_required?, length: { maximum: 255 }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -419,7 +419,7 @@ EXISTS (
     false
   end
 
-  def allows_brexit_no_deal_content_notice?
+  def allows_brexit_content_notice?
     false
   end
 

--- a/app/models/edition/brexit_content_notice_link_builder.rb
+++ b/app/models/edition/brexit_content_notice_link_builder.rb
@@ -1,0 +1,25 @@
+module Edition::BrexitContentNoticeLinkBuilder
+  MAX_LINKS = 3
+
+  def allows_brexit_content_notice?
+    true
+  end
+
+  def build_brexit_notice_links
+    link_builder(brexit_no_deal_content_notice_links)
+    link_builder(brexit_current_state_content_notice_links)
+  end
+
+  def link_builder(content_notice_link)
+    count = MAX_LINKS - link_counter(content_notice_link)
+    count.times do
+      content_notice_link.build
+    end
+  end
+
+  def link_counter(content_notice_link)
+    content_notice_link.count do |link|
+      link.persisted? || link.new_record?
+    end
+  end
+end

--- a/app/models/edition/brexit_current_state_content_notice_links.rb
+++ b/app/models/edition/brexit_current_state_content_notice_links.rb
@@ -1,7 +1,6 @@
 module Edition::BrexitCurrentStateContentNoticeLinks
   extend ActiveSupport::Concern
-
-  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
+  include Edition::BrexitContentNoticeLinkBuilder
 
   class Trait < Edition::Traits::Trait
     def process_associations_before_save(edition)
@@ -17,25 +16,5 @@ module Edition::BrexitCurrentStateContentNoticeLinks
     accepts_nested_attributes_for :brexit_current_state_content_notice_links, allow_destroy: true, reject_if: :all_blank
 
     add_trait Trait
-  end
-
-  def allows_brexit_current_state_content_notice?
-    true
-  end
-
-  def build_current_state_notice_links
-    brexit_current_state_content_notice_links_available_count.times do
-      brexit_current_state_content_notice_links.build
-    end
-  end
-
-  def brexit_current_state_content_notice_links_available_count
-    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_current_state_content_notice_links_count
-  end
-
-  def brexit_current_state_content_notice_links_count
-    brexit_current_state_content_notice_links.count do |link|
-      link.persisted? || link.new_record?
-    end
   end
 end

--- a/app/models/edition/brexit_current_state_content_notice_links.rb
+++ b/app/models/edition/brexit_current_state_content_notice_links.rb
@@ -1,0 +1,41 @@
+module Edition::BrexitCurrentStateContentNoticeLinks
+  extend ActiveSupport::Concern
+
+  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
+
+  class Trait < Edition::Traits::Trait
+    def process_associations_before_save(edition)
+      @edition.brexit_current_state_content_notice_links.each do |link|
+        edition.brexit_current_state_content_notice_links.build(link.attributes.except("id"))
+      end
+    end
+  end
+
+  included do
+    has_many :brexit_current_state_content_notice_links, foreign_key: "edition_id", dependent: :destroy
+
+    accepts_nested_attributes_for :brexit_current_state_content_notice_links, allow_destroy: true, reject_if: :all_blank
+
+    add_trait Trait
+  end
+
+  def allows_brexit_current_state_content_notice?
+    true
+  end
+
+  def build_current_state_notice_links
+    brexit_current_state_content_notice_links_available_count.times do
+      brexit_current_state_content_notice_links.build
+    end
+  end
+
+  def brexit_current_state_content_notice_links_available_count
+    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_current_state_content_notice_links_count
+  end
+
+  def brexit_current_state_content_notice_links_count
+    brexit_current_state_content_notice_links.count do |link|
+      link.persisted? || link.new_record?
+    end
+  end
+end

--- a/app/models/edition/brexit_no_deal_content_notice_links.rb
+++ b/app/models/edition/brexit_no_deal_content_notice_links.rb
@@ -1,7 +1,6 @@
 module Edition::BrexitNoDealContentNoticeLinks
   extend ActiveSupport::Concern
-
-  MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS = 3
+  include Edition::BrexitContentNoticeLinkBuilder
 
   class Trait < Edition::Traits::Trait
     def process_associations_before_save(edition)
@@ -17,25 +16,5 @@ module Edition::BrexitNoDealContentNoticeLinks
     accepts_nested_attributes_for :brexit_no_deal_content_notice_links, allow_destroy: true, reject_if: :all_blank
 
     add_trait Trait
-  end
-
-  def allows_brexit_no_deal_content_notice?
-    true
-  end
-
-  def build_no_deal_notice_links
-    brexit_no_deal_content_notice_links_available_count.times do
-      brexit_no_deal_content_notice_links.build
-    end
-  end
-
-  def brexit_no_deal_content_notice_links_available_count
-    MAX_BREXIT_NO_DEAL_CONTENT_NOTICE_LINKS - brexit_no_deal_content_notice_links_count
-  end
-
-  def brexit_no_deal_content_notice_links_count
-    brexit_no_deal_content_notice_links.count do |link|
-      link.persisted? || link.new_record?
-    end
   end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -16,6 +16,7 @@ class Publication < Publicationesque
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
   include Edition::TopicalEvents
   include Edition::BrexitNoDealContentNoticeLinks
+  include Edition::BrexitCurrentStateContentNoticeLinks
 
   validates :first_published_at, presence: true, if: ->(e) { e.trying_to_convert_to_draft == true }
   validates :publication_type_id, presence: true

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -60,7 +60,7 @@ module PublishingApi
                                { url: "", caption: nil, alt_text: "" }
                              end
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
-      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitContentNotices.for(item))
     end
 
     def first_public_at

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -71,7 +71,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
-      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitContentNotices.for(item))
       details_hash.merge!(PayloadBuilder::Attachments.for(item))
     end
 

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -62,7 +62,7 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
-        details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+        details_hash.merge!(PayloadBuilder::BrexitContentNotices.for(item))
       end
     end
 

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -60,7 +60,7 @@ module PublishingApi
         public_timestamp: public_timestamp,
         first_published_version: first_published_version?,
       }
-      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(parent))
+      details_hash.merge!(PayloadBuilder::BrexitContentNotices.for(parent))
     end
 
     def body

--- a/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
@@ -14,16 +14,16 @@ module PublishingApi
       def call
         return {} if no_brexit_content_notices?
 
-        show_no_deal_notice? ? brexit_no_deal_notice_payload : brexit_current_state_notice_payload
+        show_no_deal_notice? ? no_deal_notice_payload : current_state_notice_payload
       end
 
     private
 
-      def brexit_no_deal_notice_payload
-        { brexit_no_deal_notice: links }
+      def no_deal_notice_payload
+        { brexit_no_deal_notice: no_deal_links }
       end
 
-      def brexit_current_state_notice_payload
+      def current_state_notice_payload
         { brexit_current_state_notice: current_state_links }
       end
 
@@ -31,32 +31,29 @@ module PublishingApi
         hide_no_deal_notice? && hide_current_state_notice?
       end
 
-      def links
-        non_blank_links.map do |link|
-          {
-            title: link.title,
-            href: href(link),
-          }
-        end
+      def no_deal_links
+        links_for_payload(item.brexit_no_deal_content_notice_links)
       end
 
       def current_state_links
-        non_blank_current_state_links.map do |link|
-          {
-            title: link.title,
-            href: href(link),
-          }
+        links_for_payload(item.brexit_current_state_content_notice_links)
+      end
+
+      def links_for_payload(links)
+        non_blank_links(links).map do |link|
+          to_hash(link)
         end
       end
 
-      def non_blank_links
-        item.brexit_no_deal_content_notice_links.reject do |link|
-          link.title.blank? && link.url.blank?
-        end
+      def to_hash(link)
+        {
+          title: link.title,
+          href: href(link),
+        }
       end
 
-      def non_blank_current_state_links
-        item.brexit_current_state_content_notice_links.reject do |link|
+      def non_blank_links(links)
+        links.reject do |link|
           link.title.blank? && link.url.blank?
         end
       end

--- a/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
@@ -24,7 +24,7 @@ module PublishingApi
       end
 
       def brexit_current_state_notice_payload
-        { brexit_current_state_notice: [] }
+        { brexit_current_state_notice: current_state_links }
       end
 
       def no_brexit_content_notices?
@@ -40,8 +40,23 @@ module PublishingApi
         end
       end
 
+      def current_state_links
+        non_blank_current_state_links.map do |link|
+          {
+            title: link.title,
+            href: href(link),
+          }
+        end
+      end
+
       def non_blank_links
         item.brexit_no_deal_content_notice_links.reject do |link|
+          link.title.blank? && link.url.blank?
+        end
+      end
+
+      def non_blank_current_state_links
+        item.brexit_current_state_content_notice_links.reject do |link|
           link.title.blank? && link.url.blank?
         end
       end

--- a/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
@@ -1,6 +1,6 @@
 module PublishingApi
   module PayloadBuilder
-    class BrexitNoDealContent
+    class BrexitContentNotices
       attr_reader :item
 
       def self.for(item)

--- a/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
+++ b/app/presenters/publishing_api/payload_builder/brexit_content_notices.rb
@@ -12,12 +12,24 @@ module PublishingApi
       end
 
       def call
-        return {} if hide_no_deal_notice?
+        return {} if no_brexit_content_notices?
 
-        { brexit_no_deal_notice: links }
+        show_no_deal_notice? ? brexit_no_deal_notice_payload : brexit_current_state_notice_payload
       end
 
     private
+
+      def brexit_no_deal_notice_payload
+        { brexit_no_deal_notice: links }
+      end
+
+      def brexit_current_state_notice_payload
+        { brexit_current_state_notice: [] }
+      end
+
+      def no_brexit_content_notices?
+        hide_no_deal_notice? && hide_current_state_notice?
+      end
 
       def links
         non_blank_links.map do |link|
@@ -40,8 +52,20 @@ module PublishingApi
         link.url
       end
 
+      def show_no_deal_notice?
+        item.try(:show_brexit_no_deal_content_notice)
+      end
+
       def hide_no_deal_notice?
-        !item.try(:show_brexit_no_deal_content_notice)
+        !show_no_deal_notice?
+      end
+
+      def show_current_state_notice?
+        item.try(:show_brexit_current_state_content_notice)
+      end
+
+      def hide_current_state_notice?
+        !show_current_state_notice?
       end
     end
   end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -80,7 +80,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
-      details_hash.merge!(PayloadBuilder::BrexitNoDealContent.for(item))
+      details_hash.merge!(PayloadBuilder::BrexitContentNotices.for(item))
       details_hash.merge!(PayloadBuilder::Attachments.for(item))
     end
 

--- a/app/validators/brexit_content_notice_validator.rb
+++ b/app/validators/brexit_content_notice_validator.rb
@@ -1,0 +1,11 @@
+class BrexitContentNoticeValidator < ActiveModel::Validator
+  def validate(record)
+    if record.show_brexit_no_deal_content_notice && record.show_brexit_current_state_content_notice
+      record.errors[:transition_content_notice] << message
+    end
+  end
+
+  def message
+    "cannot have both show_brexit_no_deal_content_notice and show_brexit_current_state_content_notice"
+  end
+end

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -12,6 +12,6 @@
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>
 
-    <%= render("brexit_no_deal_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
+    <%= render("brexit_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -30,6 +30,6 @@
     </fieldset>
 
     <%= render partial: 'nation_fields', locals: { form: form, edition: edition } %>
-    <%= render "brexit_no_deal_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
+    <%= render "brexit_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -12,6 +12,6 @@
       <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>
 
-    <%= render("brexit_no_deal_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
+    <%= render("brexit_content_notice_fields", form: form, edition: edition) if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_brexit_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_content_notice_fields.html.erb
@@ -1,7 +1,7 @@
 <% error_keys = edition.errors.keys %>
 <% error_class = "alert-danger form-errors field_with_errors" %>
 
-<fieldset class=<%= error_class if error_keys.include?(:transition_content_notice) %>>
+<fieldset class="js-toggle-notice <%= error_class if error_keys.include?(:transition_content_notice) %>">
 
   <legend class="add-bottom-margin">
     Add a current state or post transition content notice
@@ -13,30 +13,34 @@
 
   <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :no_notice, !edition.show_brexit_no_deal_content_notice && !edition.show_brexit_current_state_content_notice %>
-    <%= label :no_notice, 'No notice required for this page' %>
+    <%= label_tag "transition_content_notice_no_notice", "No notice required for this page" %>
   </div>
 
   <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
-    <%= radio_button_tag :transition_content_notice, :current_state, edition.show_brexit_current_state_content_notice %>
-    <%= label :current_state, 'Show 2020 current state content notice' %>
+    <%= radio_button_tag :transition_content_notice, :current_state, true, :data => { :controls => "current-state-notice" } %>
+    <%= label_tag "transition_content_notice_current_state", "Show 2020 current state content notice" %>
+  </div>
+
+  <div class="js-toggle-notice-controlled js-hidden" id="current-state-notice">
+    <%= form.fields_for :brexit_current_state_content_notice_links do |links_fields| %>
+      <div class="well">
+        <%= links_fields.text_field :title, label_text: 'Link text' %>
+        <%= links_fields.text_field :url,  label_text: 'URL' %>
+      </div>
+    <% end %>
   </div>
 
   <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
-    <%= radio_button_tag :transition_content_notice, :no_deal, edition.show_brexit_no_deal_content_notice %>
-    <%= label :no_deal, 'Show 2021 post-transition content notice' %>
+    <%= radio_button_tag :transition_content_notice, :no_deal, edition.show_brexit_no_deal_content_notice, :data => { :controls => "no-deal-notice" } %>
+    <%= label_tag "transition_content_notice_no_deal", "Show 2021 post-transition content notice" %>
   </div>
-  
-  <%= form.fields_for :brexit_current_state_content_notice_links do |links_fields| %>
-    <div class="well">
-      <%= links_fields.text_field :title, label_text: 'Link text' %>
-      <%= links_fields.text_field :url,  label_text: 'URL' %>
-    </div>
-  <% end %>
 
-  <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
-    <div class="well">
-      <%= links_fields.text_field :title, label_text: 'Link text' %>
-      <%= links_fields.text_field :url,  label_text: 'URL' %>
-    </div>
-  <% end %>
+  <div class="js-toggle-notice-controlled js-hidden" id="no-deal-notice">
+    <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
+      <div class="well">
+        <%= links_fields.text_field :title, label_text: 'Link text' %>
+        <%= links_fields.text_field :url,  label_text: 'URL' %>
+      </div>
+    <% end %>
+  </div>
 </fieldset>

--- a/app/views/admin/editions/_brexit_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_content_notice_fields.html.erb
@@ -11,20 +11,27 @@
   <p>Read the <a href="https://www.gov.uk/guidance/content-design/helping-users-prepare-for-change#preparing-users-for-changes-related-to-the-end-of-the-transition-period-with-the-eu" target="_blank" rel="noopener noreferrer">guidance on post-transition content</a> (opens in a new tab).</p>
   <p>Use full URLs for external websites, for example https://www.example.com.</p>
 
-  <div class="add-bottom-margin">
+  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
+    <%= radio_button_tag :transition_content_notice, :no_notice, !edition.show_brexit_no_deal_content_notice && !edition.show_brexit_current_state_content_notice %>
+    <%= label :no_notice, 'No notice required for this page' %>
+  </div>
+
+  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :current_state, edition.show_brexit_current_state_content_notice %>
     <%= label :current_state, 'Show 2020 current state content notice' %>
   </div>
 
-  <div class="add-bottom-margin">
+  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :no_deal, edition.show_brexit_no_deal_content_notice %>
     <%= label :no_deal, 'Show 2021 post-transition content notice' %>
   </div>
-
-  <div class="add-bottom-margin">
-    <%= radio_button_tag :transition_content_notice, :no_notice, !edition.show_brexit_no_deal_content_notice && !edition.show_brexit_current_state_content_notice %>
-    <%= label :no_notice, 'No notice required for this page' %>
-  </div>
+  
+  <%= form.fields_for :brexit_current_state_content_notice_links do |links_fields| %>
+    <div class="well">
+      <%= links_fields.text_field :title, label_text: 'Link text' %>
+      <%= links_fields.text_field :url,  label_text: 'URL' %>
+    </div>
+  <% end %>
 
   <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
     <div class="well">

--- a/app/views/admin/editions/_brexit_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_content_notice_fields.html.erb
@@ -7,21 +7,21 @@
     Add a current state or post transition content notice
   </legend>
 
-  <p>Add links to current state guidance, which will appear in the call-out box.</p>
   <p>Read the <a href="https://www.gov.uk/guidance/content-design/helping-users-prepare-for-change#preparing-users-for-changes-related-to-the-end-of-the-transition-period-with-the-eu" target="_blank" rel="noopener noreferrer">guidance on post-transition content</a> (opens in a new tab).</p>
-  <p>Use full URLs for external websites, for example https://www.example.com.</p>
 
-  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
+  <div class="notice-radio <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :no_notice, !edition.show_brexit_no_deal_content_notice && !edition.show_brexit_current_state_content_notice %>
     <%= label_tag "transition_content_notice_no_notice", "No notice required for this page" %>
   </div>
 
-  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
+  <div class="notice-radio <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :current_state, true, :data => { :controls => "current-state-notice" } %>
     <%= label_tag "transition_content_notice_current_state", "Show 2020 current state content notice" %>
   </div>
 
-  <div class="js-toggle-notice-controlled js-hidden" id="current-state-notice">
+  <div class="toggle-notice-controlled js-toggle-notice-controlled js-hidden" id="current-state-notice">
+    <p>Add links to post-transition guidance, which will appear in the call-out box.</p>
+    <p>Use full URLs for external websites, for example: https://www.example.com.</p>
     <%= form.fields_for :brexit_current_state_content_notice_links do |links_fields| %>
       <div class="well">
         <%= links_fields.text_field :title, label_text: 'Link text' %>
@@ -30,12 +30,14 @@
     <% end %>
   </div>
 
-  <div class="add-bottom-margin <%= error_class if error_keys.include?(:transition_content_notice) %>">
+  <div class="notice-radio <%= error_class if error_keys.include?(:transition_content_notice) %>">
     <%= radio_button_tag :transition_content_notice, :no_deal, edition.show_brexit_no_deal_content_notice, :data => { :controls => "no-deal-notice" } %>
     <%= label_tag "transition_content_notice_no_deal", "Show 2021 post-transition content notice" %>
   </div>
 
-  <div class="js-toggle-notice-controlled js-hidden" id="no-deal-notice">
+  <div class="toggle-notice-controlled js-toggle-notice-controlled js-hidden" id="no-deal-notice">
+    <p>Add links to the current state guidance, which will appear in the call-out box.</p>
+    <p>Use full URLs for external websites, for example: https://www.example.com.</p>
     <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
       <div class="well">
         <%= links_fields.text_field :title, label_text: 'Link text' %>

--- a/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
+++ b/app/views/admin/editions/_brexit_no_deal_content_notice_fields.html.erb
@@ -1,16 +1,30 @@
-<fieldset class="<% if edition.errors[:brexit_no_deal_content_notice_links].any? %>alert-danger form-errors field_with_errors<% end %>" >
+<% error_keys = edition.errors.keys %>
+<% error_class = "alert-danger form-errors field_with_errors" %>
+
+<fieldset class=<%= error_class if error_keys.include?(:transition_content_notice) %>>
 
   <legend class="add-bottom-margin">
-    Post-transition content notice
+    Add a current state or post transition content notice
   </legend>
-
-  <div class="checkbox add-bottom-margin">
-    <%= form.check_box :show_brexit_no_deal_content_notice, label_text: "Display the post-transition call-out box on this page" %>
-  </div>
 
   <p>Add links to current state guidance, which will appear in the call-out box.</p>
   <p>Read the <a href="https://www.gov.uk/guidance/content-design/helping-users-prepare-for-change#preparing-users-for-changes-related-to-the-end-of-the-transition-period-with-the-eu" target="_blank" rel="noopener noreferrer">guidance on post-transition content</a> (opens in a new tab).</p>
   <p>Use full URLs for external websites, for example https://www.example.com.</p>
+
+  <div class="add-bottom-margin">
+    <%= radio_button_tag :transition_content_notice, :current_state, edition.show_brexit_current_state_content_notice %>
+    <%= label :current_state, 'Show 2020 current state content notice' %>
+  </div>
+
+  <div class="add-bottom-margin">
+    <%= radio_button_tag :transition_content_notice, :no_deal, edition.show_brexit_no_deal_content_notice %>
+    <%= label :no_deal, 'Show 2021 post-transition content notice' %>
+  </div>
+
+  <div class="add-bottom-margin">
+    <%= radio_button_tag :transition_content_notice, :no_notice, !edition.show_brexit_no_deal_content_notice && !edition.show_brexit_current_state_content_notice %>
+    <%= label :no_notice, 'No notice required for this page' %>
+  </div>
 
   <%= form.fields_for :brexit_no_deal_content_notice_links do |links_fields| %>
     <div class="well">

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -20,6 +20,6 @@
       <%= render 'nation_fields', form: form, edition: edition %>
     </fieldset>
 
-    <%= render "brexit_no_deal_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
+    <%= render "brexit_content_notice_fields", form: form, edition: edition if FeatureFlag.enabled?("no-deal-notice") %>
   <% end %>
 <% end %>

--- a/db/migrate/20201203144940_add_show_brexit_current_state_content_notice.rb
+++ b/db/migrate/20201203144940_add_show_brexit_current_state_content_notice.rb
@@ -1,0 +1,5 @@
+class AddShowBrexitCurrentStateContentNotice < ActiveRecord::Migration[5.1]
+  def change
+    add_column :editions, :show_brexit_current_state_content_notice, :boolean, default: false
+  end
+end

--- a/db/migrate/20201203145525_create_brexit_current_state_content_notice_links.rb
+++ b/db/migrate/20201203145525_create_brexit_current_state_content_notice_links.rb
@@ -1,0 +1,11 @@
+class CreateBrexitCurrentStateContentNoticeLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :brexit_current_state_content_notice_links do |t|
+      t.string :title
+      t.string :url
+      t.integer :edition_id, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201130161652) do
+ActiveRecord::Schema.define(version: 20201203144940) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -426,6 +426,7 @@ ActiveRecord::Schema.define(version: 20201130161652) do
     t.boolean "show_brexit_no_deal_content_notice", default: false
     t.boolean "all_nation_applicability"
     t.string "image_display_option"
+    t.boolean "show_brexit_current_state_content_notice", default: false
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201203144940) do
+ActiveRecord::Schema.define(version: 20201203145525) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -77,6 +77,14 @@ ActiveRecord::Schema.define(version: 20201203144940) do
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"
     t.index ["ordering"], name: "index_attachments_on_ordering"
+  end
+
+  create_table "brexit_current_state_content_notice_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title"
+    t.string "url"
+    t.integer "edition_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "brexit_no_deal_content_notice_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/gov_uk_url_identifier.rb
+++ b/lib/gov_uk_url_identifier.rb
@@ -1,0 +1,35 @@
+class GovUkUrlIdentifier
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def is_external?
+    !is_internal?
+  end
+
+  def is_internal?
+    has_govuk_host? || has_no_host?
+  end
+
+private
+
+  def has_govuk_host?
+    govuk_url_regex.match?(host)
+  end
+
+  def has_no_host?
+    host.blank?
+  end
+
+  def govuk_url_regex
+    /(publishing.service|www).gov.uk\Z/
+  end
+
+  def host
+    return URI.parse("https://#{url}").host if url.start_with?("www.")
+
+    URI.parse(url).host
+  end
+end

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -100,6 +100,25 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     end
   end
 
+  test "PUT #update when :transition_content_notice paramater is no_deal" do
+    document_collection = create(:document_collection)
+    put :update, params: { id: document_collection, transition_content_notice: "no_deal" }
+    assert_equal true, document_collection.reload.show_brexit_no_deal_content_notice
+  end
+
+  test "PUT #update when :transition_content_notice paramater is current_state " do
+    document_collection = create(:document_collection)
+    put :update, params: { id: document_collection, transition_content_notice: "current_state" }
+    assert_equal true, document_collection.reload.show_brexit_current_state_content_notice
+  end
+
+  test "PUT #update when :transition_content_notice paramater is no_notice" do
+    document_collection = create(:document_collection)
+    put :update, params: { id: document_collection, transition_content_notice: "no_notice" }
+    assert_equal false, document_collection.reload.show_brexit_no_deal_content_notice
+    assert_equal false, document_collection.show_brexit_current_state_content_notice
+  end
+
   test "DELETE #destroy deletes the document collection" do
     document_collection = create(:document_collection)
     delete :destroy, params: { id: document_collection }

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -97,6 +97,15 @@ var firstPublishedAtFieldset =
     '</div>' +
   '</fieldset>'
 
+var noticeFieldset =
+  '<fieldset class="js-toggle-notice">' +
+    '<input type="radio" name="transition_content_notice" id="transition_content_notice_no_notice" value="no_notice">' +
+    '<input type="radio" name="transition_content_notice" id="transition_content_notice_current_state" value="current_state" data-controls="current-state-notice" checked="checked">' +
+    '<div class="js-toggle-notice-controlled js-hidden" id="current-state-notice"></div>' +
+    '<input type="radio" name="transition_content_notice" id="transition_content_notice_no_deal" value="no_deal" data-controls="no-deal-notice">' +
+    '<div class="js-toggle-notice-controlled js-hidden" id="no-deal-notice"></div>' +
+  '</fieldset>'
+
 var imageFieldsFieldSet =
 '<fieldset class="image_section">' +
 '<div class="radio">' +
@@ -369,6 +378,31 @@ test('previously_published radio buttons toggle visibility of first_published da
 
   $('#edition_previously_published_false').click()
   ok($('.js-show-first-published').is(':hidden'), 'date selector hidden when "document is new" selected')
+})
+
+module('admin-edition-form-notice: ', {
+  setup: function () {
+    $('#qunit-fixture').append(form)
+    $('#qunit-fixture form').append(noticeFieldset)
+
+    GOVUK.adminEditionsForm.init({
+      selector: 'form#non-english',
+      right_to_left_locales: ['ar']
+    })
+    $('.js-hidden').hide()
+  }
+})
+
+test('on page load with selected notice', function () {
+  GOVUK.adminEditionsForm.toggleNotice()
+  ok($('#current-state-notice').is(':visible'), 'the controlled element is visible')
+})
+
+test('radio buttons toggle visibility of controlled element', function () {
+  ok($('#current-state-notice').is(':hidden'), 'element associated with non-selected radio is hidden')
+
+  $('#transition_content_notice_no_deal').click()
+  ok($('#no-deal-notice').is(':visible'), 'element associated with selected radio is visible')
 })
 
 module('admin-edition-form-policies-news-articles: ', {

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -17,9 +17,10 @@ class EditionTest < ActiveSupport::TestCase
     # which other callbacks then rely upon.
     edition.save # rubocop:disable Rails/SaveBang
 
-    edition.build_no_deal_notice_links
+    edition.build_brexit_notice_links
 
-    assert_equal 3, edition.brexit_no_deal_content_notice_links_count
+    assert_equal 3, edition.link_counter(edition.brexit_no_deal_content_notice_links)
+    assert_equal 3, edition.link_counter(edition.brexit_current_state_content_notice_links)
   end
 
   test "returns downcased humanized class name as format name" do

--- a/test/unit/models/brexit_current_state_content_notice_link_test.rb
+++ b/test/unit/models/brexit_current_state_content_notice_link_test.rb
@@ -1,0 +1,164 @@
+require "test_helper"
+
+class BrexitCurrentStateContentNoticeLinkTest < ActiveSupport::TestCase
+  setup do
+    @content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/test" => @content_id)
+    stub_publishing_api_has_item(
+      content_id: @content_id,
+      title: "Test",
+      base_path: "/test",
+      publishing_app: "content-publisher",
+    )
+  end
+
+  test "a link with both no title and URL is accepted (UI does not accomodate deletion of records)" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "", url: "").valid?
+  end
+
+  test "external link starting with www is invalid" do
+    link = BrexitCurrentStateContentNoticeLink.new(title: "External Link", url: "www.example.com/foo")
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url is not valid. Make sure it starts with http(s)"
+  end
+
+  test "internal link starting with www is valid" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "Internal link", url: "www.gov.uk/test").valid?
+  end
+
+  test "should be invalid with a malformed url" do
+    link = BrexitCurrentStateContentNoticeLink.new(title: "External Link", url: "htps://example.com/foo")
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url is not valid. Make sure it starts with http(s)"
+  end
+
+  test "is invalid if the title is longer than 255 characters" do
+    assert_not BrexitCurrentStateContentNoticeLink.new(title: "a" * 256, url: "https://www.gov.uk/test").valid?
+  end
+
+  test "an external link should be a valid URL" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "External Link", url: "https://www.google.com").valid?
+  end
+
+  test "should be invalid when a GOV.UK URL points to content that is absent from Publishing API" do
+    stub_any_publishing_api_call_to_return_not_found
+
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "Not an existing GOV.UK page",
+      url: "https://www.gov.uk/path-to-no-document",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url must reference a GOV.UK page"
+  end
+
+  test "should be valid when a GOV.UK URL points to content that exists in Publishing API" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "GOV.UK Test", url: "https://www.gov.uk/test").valid?
+  end
+
+  test "should be invalid when Publishing API is down" do
+    stub_publishing_api_isnt_available
+
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "GOV.UK Test",
+      url: "https://www.gov.uk/test",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Link lookup failed, please try again later"
+  end
+
+  test "link is considered internal if the host is GOV.UK" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "GOV.UK Test", url: "https://www.gov.uk/test").is_internal?
+  end
+
+  test "link is considered internal if it consists only of a path" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "GOV.UK Test", url: "/test").is_internal?
+  end
+
+  test "external link is not an internal one" do
+    assert_not BrexitCurrentStateContentNoticeLink.new(title: "External", url: "https://www.example.com").is_internal?
+  end
+
+  test "link title is not a URL" do
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "https://www.example.com/2",
+      url: "https://www.example.com/2",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Title can't be a URL"
+  end
+
+  test "title must be present if URL is specified" do
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "",
+      url: "https://www.example.com/2",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Title can't be blank"
+  end
+
+  test "URL must be present if title is specified" do
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "Link title",
+      url: "",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url can't be blank"
+  end
+
+  test "path is a valid internal URL" do
+    assert BrexitCurrentStateContentNoticeLink.new(title: "Internal Link", url: "/test").valid?
+  end
+
+  test "non-existent path is invalid internal URL" do
+    assert_not BrexitCurrentStateContentNoticeLink.new(title: "Internal Link", url: "/foobar").valid?
+  end
+
+  test "a subpage from a mainstream guide is a valid link" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(
+      content_id: content_id,
+      title: "Foo Bar",
+      base_path: "/foo",
+      document_type: "guide",
+      publishing_app: "content-publisher",
+    )
+
+    assert BrexitCurrentStateContentNoticeLink.new(title: "Internal Link", url: "/foo/subpage").valid?
+  end
+
+  test "a regular non-existent subpage fails validation" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(
+      content_id: content_id,
+      title: "Foo Bar",
+      base_path: "/foo",
+      document_type: "publication",
+      publishing_app: "content-publisher",
+    )
+
+    link = BrexitCurrentStateContentNoticeLink.new(
+      title: "Internal Link",
+      url: "/foo/subpage",
+    )
+
+    link.valid?
+
+    assert_includes link.errors.full_messages, "Url must reference a GOV.UK page"
+  end
+end

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module PublishingApi
   module PayloadBuilder
-    class BrexitNoDealContentTest < ActiveSupport::TestCase
+    class BrexitContentNoticesTest < ActiveSupport::TestCase
       test "builds Brexit no-deal content banner payload with links" do
         stubbed_item = stub(
           show_brexit_no_deal_content_notice: true,
@@ -25,7 +25,7 @@ module PublishingApi
           ],
         }
 
-        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
       end
 
       test "builds Brexit no-deal content banner payload with no links" do
@@ -39,7 +39,7 @@ module PublishingApi
 
         expected_hash = {}
 
-        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
       end
 
       test "internal links expose only the URL path" do
@@ -64,7 +64,7 @@ module PublishingApi
           ],
         }
 
-        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
       end
 
       test "blank links are filtered out" do
@@ -85,7 +85,7 @@ module PublishingApi
           ],
         }
 
-        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
       end
     end
   end

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
@@ -87,6 +87,18 @@ module PublishingApi
 
         assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
       end
+
+      test "returns {} if there are no brexit content notices" do
+        edition = create(:edition)
+        assert_equal({}, BrexitContentNotices.for(edition))
+      end
+
+      test "builds Brexit current state notice content banner payload" do
+        edition_with_current_state_notice = create(:edition, show_brexit_current_state_content_notice: true)
+        expected_payload = { brexit_current_state_notice: [] }
+
+        assert_equal expected_payload, BrexitContentNotices.for(edition_with_current_state_notice)
+      end
     end
   end
 end

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_content_notices_test.rb
@@ -3,101 +3,134 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class BrexitContentNoticesTest < ActiveSupport::TestCase
-      test "builds Brexit no-deal content banner payload with links" do
-        stubbed_item = stub(
-          show_brexit_no_deal_content_notice: true,
-          brexit_no_deal_content_notice_links: [
-            BrexitNoDealContentNoticeLink.new(title: "Link 1", url: "https://www.example.com/1"),
-            BrexitNoDealContentNoticeLink.new(title: "Link 2", url: "https://www.example.com/2"),
-          ],
-        )
+      extend Minitest::Spec::DSL
 
-        expected_hash = {
-          brexit_no_deal_notice: [
-            {
-              title: "Link 1",
-              href: "https://www.example.com/1",
-            },
-            {
-              title: "Link 2",
-              href: "https://www.example.com/2",
-            },
-          ],
-        }
-
-        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
-      end
-
-      test "builds Brexit no-deal content banner payload with no links" do
-        stubbed_item = stub(
-          show_brexit_no_deal_content_notice: false,
-          brexit_no_deal_content_notice_links: [
-            BrexitNoDealContentNoticeLink.new(title: "Link 1", url: "https://www.example.com/1"),
-            BrexitNoDealContentNoticeLink.new(title: "Link 2", url: "https://www.example.com/2"),
-          ],
-        )
-
-        expected_hash = {}
-
-        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
-      end
-
-      test "internal links expose only the URL path" do
-        stubbed_item = stub(
-          show_brexit_no_deal_content_notice: true,
-          brexit_no_deal_content_notice_links: [
-            BrexitNoDealContentNoticeLink.new(title: "Internal", url: "https://www.gov.uk/1"),
-            BrexitNoDealContentNoticeLink.new(title: "External", url: "https://www.example.com/2"),
-          ],
-        )
-
-        expected_hash = {
-          brexit_no_deal_notice: [
-            {
-              title: "Internal",
-              href: "/1",
-            },
-            {
-              title: "External",
-              href: "https://www.example.com/2",
-            },
-          ],
-        }
-
-        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
-      end
-
-      test "blank links are filtered out" do
-        stubbed_item = stub(
-          show_brexit_no_deal_content_notice: true,
-          brexit_no_deal_content_notice_links: [
-            BrexitNoDealContentNoticeLink.new(title: "", url: ""),
-            BrexitNoDealContentNoticeLink.new(title: "Link", url: "https://www.example.com"),
-          ],
-        )
-
-        expected_hash = {
-          brexit_no_deal_notice: [
-            {
-              title: "Link",
-              href: "https://www.example.com",
-            },
-          ],
-        }
-
-        assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
-      end
-
-      test "returns {} if there are no brexit content notices" do
-        edition = create(:edition)
+      test "returns {} if there are no transition content notices" do
+        edition = create(:edition,
+                         show_brexit_no_deal_content_notice: false,
+                         show_brexit_current_state_content_notice: false)
         assert_equal({}, BrexitContentNotices.for(edition))
       end
 
-      test "builds Brexit current state notice content banner payload" do
-        edition_with_current_state_notice = create(:edition, show_brexit_current_state_content_notice: true)
-        expected_payload = { brexit_current_state_notice: [] }
+      context "no-deal content notices" do
+        test "builds Brexit no-deal content banner payload with links" do
+          title = "Link 1"
+          url = "https://www.example.com/1"
+          stubbed_item = stub(
+            show_brexit_no_deal_content_notice: true,
+            brexit_no_deal_content_notice_links: [
+              BrexitNoDealContentNoticeLink.new(title: title, url: url),
+            ],
+            show_brexit_current_state_content_notice: false,
+          )
 
-        assert_equal expected_payload, BrexitContentNotices.for(edition_with_current_state_notice)
+          expected_hash = {
+            brexit_no_deal_notice: [
+              {
+                title: title,
+                href: url,
+              },
+            ],
+          }
+
+          assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
+        end
+
+        test "builds Brexit no-deal content banner payload with no links" do
+          stubbed_item = stub(
+            show_brexit_no_deal_content_notice: false,
+            brexit_no_deal_content_notice_links: [
+              BrexitNoDealContentNoticeLink.new(title: "Link 1", url: "https://www.example.com/1"),
+              BrexitNoDealContentNoticeLink.new(title: "Link 2", url: "https://www.example.com/2"),
+            ],
+            show_brexit_current_state_content_notice: false,
+          )
+
+          expected_hash = {}
+
+          assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
+        end
+
+        test "internal links expose only the URL path" do
+          stubbed_item = stub(
+            show_brexit_no_deal_content_notice: true,
+            brexit_no_deal_content_notice_links: [
+              BrexitNoDealContentNoticeLink.new(title: "Internal", url: "https://www.gov.uk/1"),
+              BrexitNoDealContentNoticeLink.new(title: "External", url: "https://www.example.com/2"),
+            ],
+            show_brexit_current_state_content_notice: false,
+          )
+
+          expected_hash = {
+            brexit_no_deal_notice: [
+              {
+                title: "Internal",
+                href: "/1",
+              },
+              {
+                title: "External",
+                href: "https://www.example.com/2",
+              },
+            ],
+          }
+
+          assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
+        end
+
+        test "blank links are filtered out" do
+          stubbed_item = stub(
+            show_brexit_no_deal_content_notice: true,
+            brexit_no_deal_content_notice_links: [
+              BrexitNoDealContentNoticeLink.new(title: "", url: ""),
+              BrexitNoDealContentNoticeLink.new(title: "Link", url: "https://www.example.com"),
+            ],
+            show_brexit_current_state_content_notice: false,
+          )
+
+          expected_hash = {
+            brexit_no_deal_notice: [
+              {
+                title: "Link",
+                href: "https://www.example.com",
+              },
+            ],
+          }
+
+          assert_equal expected_hash, BrexitContentNotices.for(stubbed_item)
+        end
+      end
+
+      context "current state content notices" do
+        test "builds Brexit current state notice content payload with links" do
+          stubbed_item = stub(
+            show_brexit_current_state_content_notice: true,
+            brexit_current_state_content_notice_links: [
+              BrexitCurrentStateContentNoticeLink.new(title: "Link", url: "https://www.example.com"),
+            ],
+            show_brexit_no_deal_content_notice: false,
+          )
+          expected_payload = {
+            brexit_current_state_notice: [
+              {
+                title: "Link",
+                href: "https://www.example.com",
+              },
+            ],
+          }
+          assert_equal expected_payload, BrexitContentNotices.for(stubbed_item)
+        end
+
+        test "does not add links to the payload if show_current_state_notice is false" do
+          stubbed_item = stub(
+            show_brexit_current_state_content_notice: false,
+            brexit_current_state_content_notice_links: [
+              BrexitCurrentStateContentNoticeLink.new(title: "Link", url: "https://www.example.com"),
+            ],
+            show_brexit_no_deal_content_notice: false,
+          )
+          expected_payload = {}
+          assert_equal expected_payload, BrexitContentNotices.for(stubbed_item)
+        end
       end
     end
   end

--- a/test/unit/validators/brexit_content_notice_validator_test.rb
+++ b/test/unit/validators/brexit_content_notice_validator_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class BrexitContentNoticeValidatorTest < ActiveSupport::TestCase
+  setup do
+    @validator = BrexitContentNoticeValidator.new
+  end
+
+  test "is valid when an edition has a show_brexit_no_deal_content_notice" do
+    edition = create(:edition, show_brexit_no_deal_content_notice: true)
+    @validator.validate(edition)
+    assert_equal 0, edition.errors.count
+  end
+
+  test "is valid when an edition has a show_brexit_current_state_content_notice" do
+    edition = create(:edition, show_brexit_current_state_content_notice: true)
+    @validator.validate(edition)
+    assert_equal 0, edition.errors.count
+  end
+
+  test "is invalid when an edition has both transition content notices" do
+    edition = build(:edition, show_brexit_current_state_content_notice: true, show_brexit_no_deal_content_notice: true)
+    message = "cannot have both show_brexit_no_deal_content_notice and show_brexit_current_state_content_notice"
+    @validator.validate(edition)
+    assert_equal 1, edition.errors.count
+    assert_equal(
+      message,
+      edition.errors[:transition_content_notice].first,
+    )
+  end
+end


### PR DESCRIPTION
## What

Allow publishers to add a Brexit current state call out box to relevant pages on gov.uk.

<img width="617" alt="Screenshot 2020-11-30 at 12 40 12" src="https://user-images.githubusercontent.com/17908089/100611429-39a88600-3309-11eb-97d2-b5d5e7d72013.png">

## Context

- We currently allow publishers to add a call out box - referred to in the product domain as the "post transition call out box." An example can be seen on [this page](https://www.gov.uk/guidance/driving-in-the-eu-from-1-january-2021). In the code this is called a `brexit-no-deal-content-notice`.

- We want publishers to be able to add an alternative call out box, which gives information on the current state of the guidance. Referred to as a "current state notice"

##  Roll out

- The form will add the new fields to the payload for publishing api, which will be present in the content item as:
```
"brexit_current_state_notice": [
  {
    "href": "/interesting-stuff",
    "title": "Interesting Stuff"
  }
 ]
```
- We should deploy the [changes to government frontend](https://github.com/alphagov/government-frontend/pull/1924) that will pick up this new field and display the current state content notice before we allow publishers to add it. 


## TO DO

- Add the js to show/hide the form based on the radio button selection.
- Content to be finalised
- Update content-schema so the new field is allowed to be included in the details hash

---

https://trello.com/c/IwXzb5FM/589-design-whitehall-publisher-functionality-to-generate-current-state-notice