### PR TITLE
Fix zoom overflow

### DIFF
--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -73,6 +73,10 @@
       line-height: 1;
     }
 
+    @media (max-width: 65em) {
+      font-size: .75em;
+    }
+
     @include govuk-media-query($from: tablet, $until: 815px) {
       &--small .feature-value__count {
         font-size: 3.85em;


### PR DESCRIPTION
### What & why:

https://trello.com/c/sH0fdbRR/547-text-overlapping-with-bigger-font-size-on-how-government-works
Affected page: https://www.gov.uk/government/how-government-works

The big numbers affected in this commit currently overflow into the surrounding
region when a user increases text size but doesn't otherwise zoom. This corrects
that by reducing the sizes of the big numbers as they run out of space, based on
em sizes. This will not make them illegible as they are still enormous in
comparison to the copy text.

Firefox is the easiest browser to test this in, go to View->zoom -> zoom text only and then adjust the zoom level as required.

### Screenshots before:
#### 150%
![Screenshot 2020-12-01 at 09 53 43](https://user-images.githubusercontent.com/31649453/100724895-4980a280-33bb-11eb-964f-641431029310.png)

#### 170%
![Screenshot 2020-12-01 at 09 54 01](https://user-images.githubusercontent.com/31649453/100724898-4ab1cf80-33bb-11eb-91db-77b5d184d496.png)

#### 200%
![Screenshot 2020-12-01 at 09 54 14](https://user-images.githubusercontent.com/31649453/100724900-4ab1cf80-33bb-11eb-85de-dc04d477df0a.png)

### Screenshots after:
#### 150%
![Screenshot 2020-12-01 at 09 58 13](https://user-images.githubusercontent.com/31649453/100725360-d88dba80-33bb-11eb-8a6f-347d816a41a4.png)

#### 170%
![Screenshot 2020-12-01 at 09 58 27](https://user-images.githubusercontent.com/31649453/100725361-d9265100-33bb-11eb-94d3-3cc4a648cbff.png)

#### 200%
![Screenshot 2020-12-01 at 09 58 38](https://user-images.githubusercontent.com/31649453/100725365-d9bee780-33bb-11eb-94ab-a9b8a7501e9b.png)
