### PR TITLE
Add rake task to reslug a `TopicalEvent`

### DIFF
--- a/lib/data_hygiene/topical_event_reslugger.rb
+++ b/lib/data_hygiene/topical_event_reslugger.rb
@@ -1,0 +1,50 @@
+module DataHygiene
+  class TopicalEventReslugger
+    def initialize(topical_event, new_slug)
+      @topical_event = topical_event
+      @new_slug = new_slug
+      @old_slug = @topical_event.slug
+      @editions = @topical_event.editions
+    end
+
+    def run!
+      delete_from_search_index
+      update_slug
+      republish
+      add_to_search_index
+      update_atom_feed_url
+    end
+
+  private
+
+    attr_reader :topical_event, :new_slug, :old_slug, :editions
+
+    def delete_from_search_index
+      topical_event.remove_from_search_index
+      editions.each(&:remove_from_search_index)
+    end
+
+    def update_slug
+      topical_event.update!(slug: new_slug)
+    end
+
+    def republish
+      Whitehall::PublishingApi.republish_async(topical_event)
+    end
+
+    def add_to_search_index
+      topical_event.update_in_search_index
+      editions.each(&:update_in_search_index)
+    end
+
+    def update_atom_feed_url
+      old_atom_feed_path = "/government/topical-events/#{old_slug}.atom"
+      new_atom_feed_path = "/government/topical-events/#{new_slug}.atom"
+      redirects = [{ path: old_atom_feed_path, type: "exact", destination: new_atom_feed_path }]
+      content_id = SecureRandom.uuid
+      redirect = Whitehall::PublishingApi::Redirect.new(old_atom_feed_path, redirects)
+      Services.publishing_api.put_content(content_id, redirect.as_json)
+      Services.publishing_api.publish(content_id, nil, locale: "en")
+    end
+  end
+end

--- a/test/unit/data_hygiene/topical_event_reslugger_test.rb
+++ b/test/unit/data_hygiene/topical_event_reslugger_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+require "gds_api/test_helpers/search"
+
+class TopicalEventResluggerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Search
+  include FeedHelper
+
+  setup do
+    @old_slug = "old-slug"
+    @new_slug = "new-slug"
+    @topical_event = FactoryBot.create(:topical_event, slug: @old_slug)
+
+    @detailed_guide = FactoryBot.create(:published_detailed_guide)
+    @news_article = FactoryBot.create(:published_news_article)
+    @topical_event.expects(:editions).returns([@detailed_guide, @news_article])
+
+    @reslugger = DataHygiene::TopicalEventReslugger.new(@topical_event, @new_slug)
+  end
+
+  test "updates the topical_event's slug" do
+    assert_changes -> { @topical_event.slug }, from: @old_slug, to: @new_slug do
+      @reslugger.run!
+    end
+  end
+
+  test "republishes the topical_event to Publishing API" do
+    Whitehall::PublishingApi.expects(:republish_async).with(@topical_event)
+
+    @reslugger.run!
+  end
+
+  test "reindexes the topical_event and all its linked editions" do
+    [@topical_event, @detailed_guide, @news_article].each do |object|
+      object.stubs(:remove_from_search_index)
+      object.stubs(:update_in_search_index)
+
+      object.expects(:remove_from_search_index)
+      object.expects(:update_in_search_index)
+    end
+
+    @reslugger.run!
+  end
+
+  test "updates the topical_event's atom feed's url" do
+    base_url = "https://www.test.gov.uk"
+    old_atom_feed_url = "#{base_url}/government/topical-events/#{@old_slug}.atom"
+    new_atom_feed_url = "#{base_url}/government/topical-events/#{@new_slug}.atom"
+
+    assert_changes -> { atom_feed_url_for(@topical_event) }, from: old_atom_feed_url, to: new_atom_feed_url do
+      @reslugger.run!
+    end
+  end
+end


### PR DESCRIPTION
We had a request to reslug a topical_event page in 2nd line. The
functionality wasn't present so this adds it, following the pattern of
similar rake tasks to reslug Person and Role.