### PR TITLE
Fix missing route for groups atom feed

### DIFF
--- a/lib/finders/groups.json
+++ b/lib/finders/groups.json
@@ -20,6 +20,10 @@
   "routes": [
     {
       "type": "exact",
+      "path": "/government/groups.atom"
+    },
+    {
+      "type": "exact",
       "path": "/government/groups"
     },
     {


### PR DESCRIPTION
This is currently a 404