### PR TITLE
Fix checking of environment for scheduled job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH << "."
-require "active_support"
+require "active_support/all"
 require "lib/whitehall"
 
 # default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -212,6 +212,7 @@ module Whitehall
   private_class_method :secrets_path
 
   def self.integration_or_staging?
-    (ENV.fetch("GOVUK_WEBSITE_ROOT", "") =~ /integration|staging/).present?
+    website_root = ENV.fetch("GOVUK_WEBSITE_ROOT", "")
+    %w[integration staging].any? { |environment| website_root.include?(environment) }
   end
 end

--- a/test/unit/whitehall_test.rb
+++ b/test/unit/whitehall_test.rb
@@ -23,4 +23,19 @@ class WhitehallTest < ActiveSupport::TestCase
   ensure
     ENV["TEST_ENV_NUMBER"] = before
   end
+
+  test "Whitehall.integration_or_staging? tells us if we are in the right env" do
+    before = ENV["GOVUK_WEBSITE_ROOT"]
+
+    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.integration.publishing.service.gov.uk"
+    assert Whitehall.integration_or_staging?
+
+    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.staging.publishing.service.gov.uk"
+    assert Whitehall.integration_or_staging?
+
+    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.publishing.service.gov.uk"
+    assert_equal false, Whitehall.integration_or_staging?
+  ensure
+    ENV["GOVUK_WEBSITE_ROOT"] = before
+  end
 end


### PR DESCRIPTION
We were seeing a failure to deploy and an error[1] of:

```
bundler: failed to load command: whenever
...
NoMethodError: undefined method `present?' for 12:Integer
```
because we weren't loading the right `.present?` method from ActiveSupport.

[1] https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/36679/console

Paired with @bilbof 