### PR TITLE
Allow document collections to change locale

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -50,6 +50,10 @@ class DocumentCollection < Edition
     groups.flat_map(&:content_ids)
   end
 
+  def locale_can_be_changed?
+    true
+  end
+
 private
 
   def create_default_group

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -56,6 +56,10 @@ class DocumentCollection < Edition
 
 private
 
+  def string_for_slug
+    title
+  end
+
   def create_default_group
     if groups.empty?
       groups << DocumentCollectionGroup.new(DocumentCollectionGroup.default_attributes)

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -2,7 +2,7 @@
   <fieldset class="foreign-language">
     <div class="checkbox">
       <%= label_tag :create_foreign_language_only, nil, class: [:checkbox, "js-toggle-scheduled-publication-date-picker"] do %>
-        <%= check_box_tag :create_foreign_language_only, "1", form.object.primary_locale != "en" %> Create a foreign language only news article
+        <%= check_box_tag :create_foreign_language_only, "1", form.object.primary_locale != "en" %> <%="Create a foreign language only #{edition.model_name.human.downcase}"%>
       <% end %>
     </div>
     <div class="form-group foreign-language-select js-hidden">
@@ -10,7 +10,9 @@
       <div class="form-inline add-label-margin">
         <%= form.select :primary_locale, options_for_foreign_language_locale(edition), {}, {class: 'form-control input-md-6'} %>
       </div>
-      <p class="warning">Warning: News stories without an English version cannot have other translations.</p>
+      <% if edition.is_a?(NewsArticle) %>
+        <p class="warning">Warning: News stories without an English version cannot have other translations.</p>
+      <% end %>
     </div>
   </fieldset>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,7 +144,7 @@ Whitehall::Application.routes.draw do
     end
 
     # TODO: Remove when paths can be generated without a routes entry
-    resources :document_collections, only: [:show], path: "collections"
+    get "/collections/:id(.:locale)", as: "document_collection", to: "document_collections#show", constraints: { locale: VALID_LOCALES_REGEX }
     get "/collections" => redirect("/publications")
 
     get "/organisations/:id(.:locale)", as: "organisation", to: "organisations#show", constraints: { locale: VALID_LOCALES_REGEX }

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -14,6 +14,14 @@ Feature: Grouping documents into a collection
     Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
 
   @javascript
+  Scenario: Admin creates a document collection in another language
+    Given a published publication "Wombats of Wimbledon" with locale "cy" exists
+    When I draft a new "Cymraeg" language document collection called "Wildlife of Wimbledon Common"
+    And I add the document "Wombats of Wimbledon" to the document collection
+    Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
+    And I can see the primary locale for document collection "Wildlife of Wimbledon Common" is "cy"
+
+  @javascript
   Scenario: Admin creates a document collection with non whitehall links.
     Given a document collection "Some super collection" exists
     And I add the non whitehall url "https://www.gov.uk/king-content-publisher" for "King Content Publisher" to the document collection

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -22,6 +22,23 @@ When(/^I draft a new document collection called "(.*?)"$/) do |title|
   @document_collection = DocumentCollection.find_by!(title: title)
 end
 
+When(/^I draft a new "(.*?)" language document collection called "(.*?)"$/) do |locale, title|
+  begin_drafting_document_collection(title: title, locale: locale)
+  click_on "Save"
+
+  locale_code = Locale.find_by_language_name(locale).code
+  I18n.with_locale locale_code do
+    @document_collection = DocumentCollection.find_by!(title: title)
+  end
+end
+
+And(/^I can see the primary locale for document collection "(.*?)" is "(.*?)"$/) do |title, locale_code|
+  I18n.with_locale locale_code do
+    @dc = DocumentCollection.find_by!(title: title)
+  end
+  assert_equal locale_code, @dc.primary_locale
+end
+
 When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -23,6 +23,11 @@ module DocumentHelper
       click_link options[:type].humanize
     end
 
+    if options[:locale]
+      check "Create a foreign language only"
+      select options[:locale], from: "Document language"
+    end
+
     within "form" do
       fill_in "edition_title", with: options[:title]
       fill_in "edition_body", with: options.fetch(:body, "Any old iron")

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -36,8 +36,14 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert_not create(:news_article).locale_can_be_changed?
   end
 
+  test "locale_can_be_changed? returns true for new and existing DocumentCollections" do
+    new_doc_collection = DocumentCollection.new
+    existing_doc_collection = create(:document_collection)
+    assert [new_doc_collection, existing_doc_collection].all?(&:locale_can_be_changed?)
+  end
+
   test "locale_can_be_changed? returns false for other edition types" do
-    Edition.concrete_descendants.reject { |k| k == NewsArticle }.each do |klass|
+    Edition.concrete_descendants.reject { |k| [NewsArticle, DocumentCollection].include?(k) }.each do |klass|
       assert_not klass.new.locale_can_be_changed?, "Instance of #{klass} should not allow the changing of primary locale"
     end
   end

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -33,6 +33,12 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_valid build(:document_collection, body: nil)
   end
 
+  test "it should be valid with a non-English primary locale" do
+    doc_collection = build(:document_collection, groups: [])
+    doc_collection.primary_locale = "cy"
+    assert doc_collection.valid?
+  end
+
   test "it should create a group called 'Documents' when created if groups are empty" do
     doc_collection = create(:document_collection, groups: [])
     assert_equal 1, doc_collection.groups.length

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -97,6 +97,15 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal collection.slug, collection.search_index["slug"]
   end
 
+  test "returns the title for slug string regardless of locale" do
+    en_collection = create(:document_collection, groups: [])
+    cy_collection = create(:document_collection, groups: [], primary_locale: "cy")
+
+    [en_collection, cy_collection].each do |collection|
+      assert_equal collection.document.slug, collection.title
+    end
+  end
+
   test "indexes the body without markup as indexable_content" do
     collection = create(
       :document_collection,

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -12,6 +12,7 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
     )
 
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
+    @presented_en_content = @presented_document_collection.content
     @presented_content = I18n.with_locale("de") { @presented_document_collection.content }
   end
 
@@ -31,8 +32,12 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
     assert_equal "Document Collection summary", @presented_content[:description]
   end
 
-  test "it presents the base_path" do
-    assert_equal "/government/collections/document-collection-title", @presented_content[:base_path]
+  test "it presents the base_path if locale is :en" do
+    assert_equal "/government/collections/document-collection-title", @presented_en_content[:base_path]
+  end
+
+  test "it presents the base_path with locale if non-english" do
+    assert_equal "/government/collections/document-collection-title.de", @presented_content[:base_path]
   end
 
   test "it presents updated_at if public_timestamp is nil" do
@@ -55,7 +60,11 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
     assert_equal "document_collection", @presented_content[:document_type]
   end
 
-  test "it presents the global process wide locale as the locale of the document_collection" do
+  test "it presents the default global process wide locale as the locale of the document_collection" do
+    assert_equal "en", @presented_en_content[:locale]
+  end
+
+  test "it presents the selected global process wide locale as the locale of the document_collection" do
     assert_equal "de", @presented_content[:locale]
   end
 


### PR DESCRIPTION
This PR allows a DocumentCollection to be published with a custom locale. Currently we have issues where a collection of Welsh documents, with a Welsh language DocumentCollection, will still have a locale of `:en`.

This PR adapts logic used for `NewsArticleType::WorldNewsStory`, which are the only existing Edition type that may have a primary locale that is not `:en`. We can now:

* Change the primary_locale of a DocumentCollection.
* Display the `locale_fields` locale selection partial on the DocumentCollection admin page
* Ensure that a non-`:en` localed DocumentCollection will use their title for their slug (logic otherwise exists to use the id)
* Set the `base_path` to append `.:locale` where needed when sending to the PublishingAPI.

[Trello](https://trello.com/c/3MrqbQae/2200-5-allow-primarylocale-of-documentcollections-to-be-changed)