### PR TITLE
Add trimming for URL strings in no deal notice link parsing

### DIFF
--- a/app/models/brexit_no_deal_content_notice_link.rb
+++ b/app/models/brexit_no_deal_content_notice_link.rb
@@ -47,6 +47,8 @@ private
   end
 
   def host
+    url.strip!
+
     return URI.parse("https://#{url}").host if url.start_with?("www.")
 
     URI.parse(url).host

--- a/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/brexit_no_deal_content_test.rb
@@ -87,6 +87,31 @@ module PublishingApi
 
         assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
       end
+
+      test "links with leading/trailing whitespace are trimmed" do
+        stubbed_item = stub(
+          show_brexit_no_deal_content_notice: true,
+          brexit_no_deal_content_notice_links: [
+            BrexitNoDealContentNoticeLink.new(title: "FrontSpaceLink", url: "   https://www.example.com"),
+            BrexitNoDealContentNoticeLink.new(title: "RearSpaceLink", url: "https://www.example.com   "),
+          ],
+        )
+
+        expected_hash = {
+          brexit_no_deal_notice: [
+            {
+              title: "FrontSpaceLink",
+              href: "https://www.example.com",
+            },
+            {
+              title: "RearSpaceLink",
+              href: "https://www.example.com",
+            },
+          ],
+        }
+
+        assert_equal expected_hash, BrexitNoDealContent.for(stubbed_item)
+      end
     end
   end
 end


### PR DESCRIPTION
A user error found in a Zendesk ticket brought to light that we had no
filtering for invalid URLs involving whitespace in the No Deal Content
Notice link fields.

What would occur would be that the regex test that exists in
`app/models/brexit_no_deal_content_notice_link` would see the valid URL
that was (most often) pasted into the field, and not complain at any
leading or trailing whitespace that may be present. The result is a
rather hard 500 error that gives the user - nor us - any indication as
to the fault in question.

I also observed that it is not very obvious that there is a leading or
trailing whitespace in the form, and we have no indication on a UX level
that the URL is invalid.

This pull request simply trims the URL of whitespace before parsing.

Please see Zendesk ticket for Kibana error URL:
https://govuk.zendesk.com/agent/tickets/4389013