### PR TITLE
Allow Consultations to change their primary_locale

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -180,6 +180,10 @@ class Consultation < Publicationesque
     newly_created ? false : all_nation_applicability
   end
 
+  def locale_can_be_changed?
+    true
+  end
+
 private
 
   def validate_closes_after_opens

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -184,6 +184,10 @@ class Consultation < Publicationesque
     true
   end
 
+  def string_for_slug
+    title
+  end
+
 private
 
   def validate_closes_after_opens

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,8 @@ Whitehall::Application.routes.draw do
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: VALID_LOCALES_REGEX }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: VALID_LOCALES_REGEX }
 
-    resources :consultations, only: %i[index show] do
+    get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: VALID_LOCALES_REGEX }
+    resources :consultations, only: %i[index] do
       collection do
         get :open
         get :closed

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -14,7 +14,7 @@ Scenario: Viewing only publications written by me
   Given I am a writer
   And there is a user called "Janice"
   And "Janice" drafts a new publication "Janice's Publication"
-  And I draft a new consultation "My Consultation"
+  And I draft a new "English" language consultation "My Consultation"
   And I visit the list of draft documents
 
   When I filter by author "Janice"

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -2,7 +2,7 @@ Feature: Consultations
 
 Scenario: Creating a new draft consultation
   Given I am a writer
-  When I draft a new consultation "Beard Length Review"
+  When I draft a new "English" language consultation "Beard Length Review"
   Then I should see the consultation "Beard Length Review" in the list of draft documents
 
 Scenario: Submitting a draft consultation to a second pair of eyes
@@ -42,3 +42,9 @@ Scenario: Associating an offsite consultation with topical events
   When I am on the edit page for consultation "Beard Length Review"
   And I mark the consultation as offsite
   Then the consultation can be associated with topical events
+
+@javascript
+Scenario: Creating a new draft consultation in another language
+  Given I am a writer
+  When I draft a new "Cymraeg" language consultation "Beard Length Review"
+  Then I can see the primary locale for consultation "Beard Length Review" is "cy"

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -6,8 +6,10 @@ Given(/^an unopened consultation exists$/) do
   create(:unopened_consultation)
 end
 
-When(/^I draft a new consultation "([^"]*)"$/) do |title|
-  begin_drafting_document type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider), all_nation_applicablity: false
+When(/^I draft a new "(.*?)" language consultation "(.*?)"$/) do |locale, title|
+  document_options = { type: "consultation", title: title, summary: "consultation-summary", alternative_format_provider: create(:alternative_format_provider), all_nation_applicablity: false }
+  document_options.merge!(locale: locale) unless locale == "English"
+  begin_drafting_document document_options
   fill_in "Link URL", with: "http://participate.com"
   fill_in "Email", with: "participate@gov.uk"
   select_date 1.day.ago.to_s, from: "Opening Date"
@@ -72,4 +74,11 @@ Then(/^I can see that the consultation has been published$/) do
   expected_message = "The document #{expected_title} has been published"
 
   assert_selector ".flash", text: expected_message
+end
+
+And(/^I can see the primary locale for consultation "(.*?)" is "(.*?)"$/) do |title, locale_code|
+  I18n.with_locale(locale_code) do
+    consultation = Consultation.find_by!(title: title)
+    assert_equal locale_code, consultation.primary_locale
+  end
 end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -19,6 +19,12 @@ class ConsultationTest < ActiveSupport::TestCase
       assert edition.valid?
     end
 
+    test "#{state} editions are valid with a non-English primary locale" do
+      edition = build(:consultation, state: state)
+      edition.primary_locale = "cy"
+      assert edition.valid?
+    end
+
     test "#{state} consultations with a blank opening at time have no first_public_at" do
       edition = build(:consultation, state: state, opening_at: nil)
       assert_nil edition.first_public_at

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -504,4 +504,13 @@ class ConsultationTest < ActiveSupport::TestCase
     published_with_excluded = create(:published_consultation_with_excluded_nations, nation_inapplicabilities: [create(:nation_inapplicability, nation: Nation.scotland, alternative_url: "http://scotland.com")])
     assert_not published_with_excluded.all_nation_applicability_selected?
   end
+
+  test "#string_for_slug returns title for slug string regardless of locale" do
+    en_consultation = create(:consultation, title: "title-en")
+    cy_consultation = create(:consultation, primary_locale: "cy", title: "title-cy")
+
+    [en_consultation, cy_consultation].each do |consultation|
+      assert_equal consultation.document.slug, consultation.title
+    end
+  end
 end

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -42,8 +42,14 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert [new_doc_collection, existing_doc_collection].all?(&:locale_can_be_changed?)
   end
 
+  test "locale_can_be_changed? returns true for new and existing Consultations" do
+    new_consulation = build(:consultation)
+    existing_consulation = create(:consultation)
+    assert [new_consulation, existing_consulation].all?(&:locale_can_be_changed?)
+  end
+
   test "locale_can_be_changed? returns false for other edition types" do
-    Edition.concrete_descendants.reject { |k| [NewsArticle, DocumentCollection].include?(k) }.each do |klass|
+    Edition.concrete_descendants.reject { |k| [NewsArticle, DocumentCollection, Consultation].include?(k) }.each do |klass|
       assert_not klass.new.locale_can_be_changed?, "Instance of #{klass} should not allow the changing of primary locale"
     end
   end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -180,6 +180,26 @@ module PublishingApi::ConsultationPresenterTest
     test "validity" do
       assert_valid_against_schema presented_content, "consultation"
     end
+
+    test "it presents the base_path if locale is :en" do
+      assert_equal "/government/consultations/consultation-title", presented_content[:base_path]
+    end
+
+    test "it presents the base_path with locale if non-english" do
+      with_locale("it") do
+        assert_equal "/government/consultations/consultation-title.it", presented_content[:base_path]
+      end
+    end
+
+    test "it presents the default global process wide locale as the locale of the consultation" do
+      assert_equal "en", presented_content[:locale]
+    end
+
+    test "it presents the selected global process wide locale as the locale of the consultation" do
+      with_locale("it") do
+        assert_equal "it", presented_content[:locale]
+      end
+    end
   end
 
   class UnopenedConsultationTest < TestCase


### PR DESCRIPTION
This allows a Consultation to be published with a custom locale.

This follows the same pattern as https://github.com/alphagov/whitehall/pull/5918

* Change the primary_locale of a Consultation.
* Display the locale_fields locale selection partial on the Consultation admin page
* Ensure that a non-:en localed Consultation will use their title for their slug (logic otherwise exists to use the id)
* Set the base_path to append .:locale where needed when sending to the PublishingAPI.

Trello card: https://trello.com/c/u1FYvrIZ/2241-5-allow-primarylocale-of-consultations-to-be-changed