### PR TITLE
Re-slug HTML attachments if they are unpublished

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -108,7 +108,9 @@ class Attachment < ApplicationRecord
   end
 
   def deep_clone
-    dup
+    dup.tap do |clone|
+      clone.safely_resluggable = false
+    end
   end
 
   def external?

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -76,7 +76,7 @@ class HtmlAttachment < Attachment
   def should_generate_new_friendly_id?
     return false unless sluggable_locale?
 
-    slug.nil? || attachable.nil? || !attachable.document.published?
+    slug.nil? || attachable.nil? || safely_resluggable?
   end
 
   def deep_clone

--- a/db/migrate/20210111161500_add_safely_resluggable_to_attachment.rb
+++ b/db/migrate/20210111161500_add_safely_resluggable_to_attachment.rb
@@ -1,0 +1,6 @@
+class AddSafelyResluggableToAttachment < ActiveRecord::Migration[5.1]
+  def change
+    add_column :attachments, :safely_resluggable, :boolean, default: true
+    Attachment.update_all(safely_resluggable: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201130161652) do
+ActiveRecord::Schema.define(version: 20210111161500) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20201130161652) do
     t.string "external_url"
     t.string "content_id"
     t.boolean "deleted", default: false, null: false
+    t.boolean "safely_resluggable", default: true
     t.index ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type"
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -85,7 +85,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "an-html-attachment", draft.attachments.first.slug
   end
 
-  test "slug is updated when the title is changed if edition is unpublished" do
+  test "slug is updated when the title is changed if document has never been published" do
     attachment = build(:html_attachment, title: "an-html-attachment")
 
     create(:draft_publication, attachments: [attachment])
@@ -97,7 +97,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "a-new-title", attachment.slug
   end
 
-  test "slug is not updated when the title is changed if edition is published" do
+  test "slug on old attachment is not updated when the title is changed if document is published" do
     edition = create(
       :published_publication,
       attachments: [
@@ -112,6 +112,21 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment.reload
 
     assert_equal "an-html-attachment", attachment.slug
+  end
+
+  test "slug on new attachment is updated when the title is changed if document is published" do
+    edition = create(
+      :published_publication,
+    )
+    draft = edition.create_draft(create(:writer))
+    attachment = build(:html_attachment, title: "an-html-attachment")
+    draft.attachments = [attachment]
+
+    attachment.title = "a-new-title"
+    attachment.save!
+    attachment.reload
+
+    assert_equal "a-new-title", attachment.slug
   end
 
   test "slug is not updated when the title has been changed in a prior published edition" do


### PR DESCRIPTION
It appears we have long standing logic (added in c45922d) that will do the following with HTML attachments:
- if a document has never been published before, the URL slug will be updated automatically each time the attachment title is changed
- if a document has previously been published, the URL slug for new (or modified existing) attachments will never be updated after the title has been entered for the first time

This behaviour was added to ensure links to previously published HTML attachments continue functioning even if the attachment's title is changed in a subsequent edition.

However, this causes confusion if a publisher adds a new attachment in a later edition and finds the slug does not get updated (e.g. from a placeholder). Therefore we need to handle both scenarios correctly.

This adds an additional scenario, so placeholder titles can be used in subsequent editions:
- if a document has never been published before, the URL slug for attachments will be updated automatically each time the attachment title is changed
- if a document has previously been published, the URL slug for existing attachments will never be updated after the title has been entered for the first time (to ensure users who have bookmarked the attachment can still access it)
- if a document has previously been published, the URL slug for new attachments will be updated automatically each time the attachment title is changed until the attachment has been published

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4420527