### PR TITLE
Fix typo in DB seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ if Organisation.where(name: "HM Revenue & Customs").blank?
   Organisation.create!(
     name: "HM Revenue & Customs",
     slug: "hm-revenue-customs",
-    acronym: "HRMC",
+    acronym: "HMRC",
     organisation_type_key: :other,
     logo_formatted_name: "Test",
     content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",


### PR DESCRIPTION
HMRC is written as HRMC, which I believe is causing https://github.com/alphagov/publishing-e2e-tests/pull/406 to fail.