### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,14 +8,9 @@ DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-whitehall")
   govuk.buildProject(
-    sassLint: false,
     publishingE2ETests: true,
     brakeman: true,
     beforeTest: {
-      stage("Install node dependencies") {
-        sh("yarn")
-      }
-
       stage("Generate directories for upload tests") {
         sh ("mkdir -p ./incoming-uploads")
         sh ("mkdir -p ./clean-uploads")


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82