### PR TITLE
Fix local docker dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,6 @@ Whitehall::Application.configure do
 
   config.assets.cache_store = :null_store
   config.sass.cache = false
+
+  config.hosts.clear
 end


### PR DESCRIPTION
Custom alias domains such as http://whitehall-admin.dev.gov.uk do not work in any apps running Rails 6, due to the addition of "Host Authorisation" middleware. To fix this, we need to either:
- explicitly add the local domain to `config.hosts`
- allow requests from any domain

The former approach is what we used when first upgrading apps to Rails 6 (see https://github.com/alphagov/frontend/pull/2236/commits/ee9a266f54791a3777d05d046bf85d3f01db2635) but the second approach is more flexible and now preferred (see https://github.com/alphagov/support-api/commit/2cbd2688bdad9284d6fd38fc5c39164071331623).

Issue on govuk-docker: https://github.com/alphagov/govuk-docker/issues/176