### PR TITLE
Make Dockerfile more production focused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ RUN apt-get update -qq && apt-get upgrade -y
 RUN apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV GOVUK_APP_NAME whitehall
 ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
 ENV PORT 3020
-ENV REDIS_HOST redis
-ENV RAILS_ENV development
 ENV DATABASE_URL mysql2://root:root@mysql/whitehall_development
-ENV TEST_DATABASE_URL mysql2://root:root@mysql/whitehall_test
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
@@ -17,7 +17,9 @@ RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
 ADD .ruby-version $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 
 ADD . $APP_HOME
 
@@ -25,7 +27,6 @@ RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=www.gov.uk \
   GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
-  RAILS_ENV=production \
   bundle exec rake shared_mustache:compile assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1


### PR DESCRIPTION
This removes REDIS_HOST as GOV.UK no longer use that env var to
configure Redis. The rest of the Dockerfile is then updated in a
consistent manner to static [1], where it's tailored towards production
running - reflecting that no-one can use this for test environments (and
potentially development ones).

[1]: https://github.com/alphagov/static/pull/2327