### PR TITLE
Use updated component filename

### DIFF
--- a/app/views/shared/_feeds.html.erb
+++ b/app/views/shared/_feeds.html.erb
@@ -1,7 +1,7 @@
 <% unless atom_url.blank? %>
   <div class="feeds">
     <span class="govuk-body" <%= t_lang("feeds.get_updates_to_this_list") %>><%= t("feeds.get_updates_to_this_list") %></span>
-    <%= render "govuk_publishing_components/components/subscription-links", {
+    <%= render "govuk_publishing_components/components/subscription_links", {
       hide_heading: true,
       email_signup_link: email_signup_path(atom_url),
       email_signup_link_text: t('feeds.email'),


### PR DESCRIPTION
Update component references following this change to correct component file names: https://github.com/alphagov/govuk_publishing_components/pull/1848
