### PR TITLE
Fix Statistics pages' HTML attachment base paths

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -29,12 +29,7 @@ module PublicDocumentRoutesHelper
     when CorporateInformationPage
       build_url_for_corporate_information_page(edition, options)
     else
-      path_name = if edition.statistics?
-                    "statistic"
-                  else
-                    edition.to_model.class.name.underscore
-                  end
-      polymorphic_url(path_name, options.reverse_merge(id: edition.document))
+      polymorphic_url(edition.path_name, options.reverse_merge(id: edition.document))
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -458,6 +458,10 @@ EXISTS (
     false
   end
 
+  def path_name
+    to_model.class.name.underscore
+  end
+
   def has_been_tagged?
     api_response = Services.publishing_api.get_links(content_id)
 

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -66,7 +66,7 @@ class HtmlAttachment < Attachment
       options[:host] = URI(Plek.new.external_url_for("www-origin")).host
     end
 
-    type = attachable.class.name.underscore
+    type = attachable.try(:html_attachment_type) || attachable.class.name.underscore
     path_or_url = full_url ? "url" : "path"
     path_helper = "#{type}_html_attachment_#{path_or_url}"
 

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -66,7 +66,7 @@ class HtmlAttachment < Attachment
       options[:host] = URI(Plek.new.external_url_for("www-origin")).host
     end
 
-    type = attachable.try(:html_attachment_type) || attachable.class.name.underscore
+    type = attachable.path_name
     path_or_url = full_url ? "url" : "path"
     path_helper = "#{type}_html_attachment_#{path_or_url}"
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -148,6 +148,10 @@ class Publication < Publicationesque
     )
   end
 
+  def html_attachment_type
+    statistics? ? "statistics" : "publication"
+  end
+
   def allows_html_attachments?
     true
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -148,8 +148,8 @@ class Publication < Publicationesque
     )
   end
 
-  def html_attachment_type
-    statistics? ? "statistics" : "publication"
+  def path_name
+    statistics? ? "statistic" : "publication"
   end
 
   def allows_html_attachments?

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -34,6 +34,10 @@ class Response < ApplicationRecord
     true
   end
 
+  def path_name
+    to_model.class.name.underscore
+  end
+
   delegate :public_timestamp, :first_published_version?, :slug, :document, :images, to: :consultation
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Whitehall::Application.routes.draw do
     resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: VALID_LOCALES_REGEX }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: VALID_LOCALES_REGEX }
+    get "/statistics/:statistics_id/:id" => "_#_", as: "statistics_html_attachment"
 
     get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: VALID_LOCALES_REGEX }
     resources :consultations, only: %i[index] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ Whitehall::Application.routes.draw do
     resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: VALID_LOCALES_REGEX }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: VALID_LOCALES_REGEX }
-    get "/statistics/:statistics_id/:id" => "_#_", as: "statistics_html_attachment"
+    get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
 
     get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: VALID_LOCALES_REGEX }
     resources :consultations, only: %i[index] do

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -61,6 +61,12 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "/government/publications/#{edition.slug}/#{attachment.slug}", attachment.url
   end
 
+  test "#url works with statistics" do
+    statistics = create(:published_national_statistics)
+    attachment = statistics.attachments.last
+    assert_equal "/government/statistics/#{statistics.slug}/#{attachment.slug}", attachment.url
+  end
+
   test "#url works with consultation outcomes" do
     consultation = create(:consultation_with_outcome_html_attachment)
     attachment = consultation.outcome.attachments.first

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -178,6 +178,16 @@ class PublicationTest < ActiveSupport::TestCase
     assert publication.has_changed_publication_type?
   end
 
+  test "#html_attachment_type returns 'publication' by default" do
+    publication = create(:publication)
+    assert_equal publication.html_attachment_type, "publication"
+  end
+
+  test "#html_attachment_type returns 'statistics' for statistical types" do
+    statistics = create(:published_national_statistics)
+    assert_equal statistics.html_attachment_type, "statistics"
+  end
+
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:publication)
     assert_not unsaved_publication.all_nation_applicability_selected?

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -178,14 +178,14 @@ class PublicationTest < ActiveSupport::TestCase
     assert publication.has_changed_publication_type?
   end
 
-  test "#html_attachment_type returns 'publication' by default" do
+  test "#path_name returns 'publication' by default" do
     publication = create(:publication)
-    assert_equal publication.html_attachment_type, "publication"
+    assert_equal publication.path_name, "publication"
   end
 
-  test "#html_attachment_type returns 'statistics' for statistical types" do
+  test "#path_name returns 'statistic' for statistical types" do
     statistics = create(:published_national_statistics)
-    assert_equal statistics.html_attachment_type, "statistics"
+    assert_equal statistics.path_name, "statistic"
   end
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -156,4 +156,12 @@ class ResponseTest < ActiveSupport::TestCase
     public_feedback = build(:consultation_public_feedback)
     assert public_feedback.allows_html_attachments?
   end
+
+  test "sets path_name based on model name" do
+    outcome = build(:consultation_outcome)
+    assert_equal outcome.path_name, "consultation_outcome"
+
+    public_feedback = build(:consultation_public_feedback)
+    assert_equal public_feedback.path_name, "consultation_public_feedback"
+  end
 end


### PR DESCRIPTION
Statistics are available at "/government/statistics/:slug", but associated
HTMLAttachments are given the base path "/government/publication/:slug/:attachment".

This is due to the HTMLAttachment class using the Attachable's class name to form
the url, and OfficialStatistics and NationalStatistics are subtypes of Publication.

This PR adds an `html_attachment_type` method to Publication, allowing the class
to differentiate between different subtypes and allow HTMLAttachment to
set the  basepath to "/government/statistics".

If this method is not available to a class, HTMLAttachment will continue to
fallback to the Attachable's class name.

[Trello](https://trello.com/c/l7Q4urHs/2295-5-fix-statistics-pages-html-attachment-base-paths-%F0%9F%8D%90)