### PR TITLE
Use title to create slug only if locale uses a Latin script alphabet

### DIFF
--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -12,6 +12,6 @@ module LocaleHelper
 
   def options_for_foreign_language_locale(edition)
     options = [["Choose foreign language...", nil]] + options_for_locales(Locale.non_english)
-    options_for_select(options, edition.non_english_edition? ? edition.primary_locale : nil)
+    options_for_select(options, edition.non_english? ? edition.primary_locale : nil)
   end
 end

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -17,7 +17,7 @@ module PublicDocumentRoutesHelper
   def document_url(edition, options = {}, _builder_options = {})
     return edition.url if edition.is_a?(RummagerDocumentPresenter)
 
-    if edition.non_english_edition?
+    if edition.non_english?
       options[:locale] = edition.primary_locale
     elsif edition.translatable?
       options[:locale] ||= best_locale_for_edition(edition)

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -24,6 +24,6 @@ class CaseStudy < Edition
   end
 
   def translatable?
-    !non_english_edition?
+    !non_english?
   end
 end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -24,6 +24,6 @@ class CaseStudy < Edition
   end
 
   def translatable?
-    !non_english?
+    english?
   end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -173,7 +173,7 @@ class Consultation < Publicationesque
   end
 
   def string_for_slug
-    title
+    title if Locale.new(primary_locale).latin_script?
   end
 
 private

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -82,7 +82,7 @@ class CorporateInformationPage < Edition
   end
 
   def translatable?
-    !non_english?
+    english?
   end
 
   def owning_organisation

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -82,7 +82,7 @@ class CorporateInformationPage < Edition
   end
 
   def translatable?
-    !non_english_edition?
+    !non_english?
   end
 
   def owning_organisation

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -53,7 +53,7 @@ class DocumentCollection < Edition
 private
 
   def string_for_slug
-    title
+    title if Locale.new(primary_locale).latin_script?
   end
 
   def create_default_group

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -48,6 +48,6 @@ module Edition::Identifiable
 private
 
   def string_for_slug
-    non_english? ? nil : title(:en)
+    title(:en) if english?
   end
 end

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -48,6 +48,6 @@ module Edition::Identifiable
 private
 
   def string_for_slug
-    non_english_edition? ? nil : title(:en)
+    non_english? ? nil : title(:en)
   end
 end

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -45,7 +45,7 @@ module Edition::Translatable
   end
 
   def non_english_edition?
-    primary_locale.intern != :en
+    primary_locale.to_sym != :en
   end
 
   def rtl?
@@ -75,7 +75,7 @@ private
   end
 
   def locale_is_valid
-    unless I18n.available_locales.include?(primary_locale.intern)
+    unless I18n.available_locales.include?(primary_locale.to_sym)
       errors.add(:primary_locale, "is not valid")
     end
   end

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -44,6 +44,10 @@ module Edition::Translatable
     false
   end
 
+  def english?
+    primary_locale == "en"
+  end
+
   def non_english?
     primary_locale.to_sym != :en
   end

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -44,7 +44,7 @@ module Edition::Translatable
     false
   end
 
-  def non_english_edition?
+  def non_english?
     primary_locale.to_sym != :en
   end
 

--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -49,7 +49,7 @@ module Edition::Translatable
   end
 
   def non_english?
-    primary_locale.to_sym != :en
+    !english?
   end
 
   def rtl?

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -67,7 +67,7 @@ class NewsArticle < Announcement
   end
 
   def non_english_primary_locale_only_for_world_news_story
-    if non_english_edition? && !world_news_story?
+    if non_english? && !world_news_story?
       errors.add(:foreign_language, "is not allowed")
     end
   end
@@ -85,7 +85,7 @@ class NewsArticle < Announcement
   end
 
   def translatable?
-    !non_english_edition?
+    !non_english?
   end
 
 private

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -85,7 +85,7 @@ class NewsArticle < Announcement
   end
 
   def translatable?
-    !non_english?
+    english?
   end
 
 private

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -130,7 +130,7 @@ class Publication < Publicationesque
   end
 
   def translatable?
-    !non_english_edition?
+    !non_english?
   end
 
   def has_attachments?

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -130,7 +130,7 @@ class Publication < Publicationesque
   end
 
   def translatable?
-    !non_english?
+    english?
   end
 
   def has_attachments?

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -48,7 +48,7 @@ class Speech < Announcement
   end
 
   def translatable?
-    !non_english_edition?
+    !non_english?
   end
 
   def delivered_by_minister?

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -48,7 +48,7 @@ class Speech < Announcement
   end
 
   def translatable?
-    !non_english?
+    english?
   end
 
   def delivered_by_minister?

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -53,7 +53,7 @@
           <% end %>
           <td class="title">
             <span class="title"><%= link_to edition.title, admin_edition_path(edition), title: "View document #{edition.title}" %></span>
-            <% if edition.non_english_edition? %>
+            <% if edition.non_english? %>
               (<%= edition.primary_locale %>)
             <% end %>
             <% # TODO: remove unpublishing information once we have a separate state for unpublished editions

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -20,7 +20,7 @@
       <dd><%= joined_list(@edition.organisations.map { |o| o.name }) %></dd>
     <% end %>
   </dl>
-  <% if @edition.non_english_edition? %>
+  <% if @edition.non_english? %>
     <p><em>(This document is <%=@edition.primary_language_name %>-only)</em></p>
   <% end %>
 </div>

--- a/app/views/admin/editions/_standard_elements.html.erb
+++ b/app/views/admin/editions/_standard_elements.html.erb
@@ -1,4 +1,4 @@
-<% if edition.non_english_edition? %>
+<% if edition.non_english? %>
   <p><em>(This document is <%=edition.primary_language_name %>-only)</em></p>
 <% end %>
 

--- a/app/views/admin/editions/show_locked.html.erb
+++ b/app/views/admin/editions/show_locked.html.erb
@@ -23,7 +23,7 @@
       <dt>Organisations:</dt>
       <dd><%= joined_list(@edition.organisations.map { |o| o.name }) %></dd>
     </dl>
-    <% if @edition.non_english_edition? %>
+    <% if @edition.non_english? %>
       <p><em>(This document is <%=@edition.primary_language_name %>-only)</em></p>
     <% end %>
   </div>

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :consultation, class: Consultation, parent: :edition, traits: %i[with_organisations] do
-    title { "consultation-title" }
+    sequence(:title) { |index| "Consultation's title (##{index}): colon, comma and £ sign" }
     body { "consultation-body" }
     opening_at { 1.day.ago }
     closing_at { 6.weeks.from_now }

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -3,7 +3,7 @@ require_relative "../support/generic_edition"
 FactoryBot.define do
   factory :edition, class: GenericEdition, traits: [:translated] do
     creator
-    sequence(:title) { |index| "edition-title-#{index}" }
+    sequence(:title) { |index| "Edition's title (##{index}): colon, comma and £ sign" }
     body { "edition-body" }
     change_note { "change-note" }
     summary { "edition-summary" }

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -506,11 +506,12 @@ class ConsultationTest < ActiveSupport::TestCase
   end
 
   test "#string_for_slug returns title for slug string regardless of locale" do
-    en_consultation = create(:consultation, title: "title-en")
-    cy_consultation = create(:consultation, primary_locale: "cy", title: "title-cy")
+    en_consultation = create(:consultation)
+    cy_consultation = create(:consultation, primary_locale: "cy")
 
     [en_consultation, cy_consultation].each do |consultation|
-      assert_equal consultation.document.slug, consultation.title
+      document = consultation.document
+      assert_equal document.slug, document.normalize_friendly_id(consultation.title)
     end
   end
 end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -505,13 +505,19 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_not published_with_excluded.all_nation_applicability_selected?
   end
 
-  test "#string_for_slug returns title for slug string regardless of locale" do
-    en_consultation = create(:consultation)
-    cy_consultation = create(:consultation, primary_locale: "cy")
-
-    [en_consultation, cy_consultation].each do |consultation|
+  test "uses the title as slug string if the locale uses a latin script alphabet" do
+    Locale.all.select(&:latin_script?).map(&:to_param).each do |locale|
+      consultation = create(:consultation, primary_locale: locale)
       document = consultation.document
       assert_equal document.slug, document.normalize_friendly_id(consultation.title)
+    end
+  end
+
+  test "uses the id as slug string if the locale uses a non latin script alphabet" do
+    Locale.all.reject(&:latin_script?).map(&:to_param).each do |locale|
+      consultation = create(:consultation, primary_locale: locale)
+      document = consultation.document
+      assert_equal document.slug, document.id.to_s
     end
   end
 end

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -12,6 +12,11 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert_not build(:edition, primary_locale: "cy").english?
   end
 
+  test "#non_english? is only true when primary_locale is not 'en'" do
+    assert build(:edition, primary_locale: "cy").non_english?
+    assert_not build(:edition, primary_locale: "en").non_english?
+  end
+
   test "locale is validated as a locale" do
     edition = build(:edition, primary_locale: "123")
     assert_not edition.valid?

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -7,6 +7,11 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert_equal "en", Edition.new.primary_locale
   end
 
+  test "#english? is only true when primary_locale is 'en'" do
+    assert build(:edition, primary_locale: "en").english?
+    assert_not build(:edition, primary_locale: "cy").english?
+  end
+
   test "locale is validated as a locale" do
     edition = build(:edition, primary_locale: "123")
     assert_not edition.valid?

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -102,7 +102,8 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     cy_collection = create(:document_collection, groups: [], primary_locale: "cy")
 
     [en_collection, cy_collection].each do |collection|
-      assert_equal collection.document.slug, collection.title
+      document = collection.document
+      assert_equal document.slug, document.normalize_friendly_id(collection.title)
     end
   end
 

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -97,13 +97,19 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal collection.slug, collection.search_index["slug"]
   end
 
-  test "returns the title for slug string regardless of locale" do
-    en_collection = create(:document_collection, groups: [])
-    cy_collection = create(:document_collection, groups: [], primary_locale: "cy")
-
-    [en_collection, cy_collection].each do |collection|
+  test "uses the title as slug string if the locale uses a latin script alphabet" do
+    Locale.all.select(&:latin_script?).map(&:to_param).each do |locale|
+      collection = create(:document_collection, primary_locale: locale)
       document = collection.document
       assert_equal document.slug, document.normalize_friendly_id(collection.title)
+    end
+  end
+
+  test "uses the id as slug string if the locale uses a non latin script alphabet" do
+    Locale.all.reject(&:latin_script?).map(&:to_param).each do |locale|
+      collection = create(:document_collection, primary_locale: locale)
+      document = collection.document
+      assert_equal document.slug, document.id.to_s
     end
   end
 


### PR DESCRIPTION
These are some translations related changes. The two main goals are:
- use the title to create the slug only if the locale uses a Latin-script alphabet
- refactor some translations related code that could be improved

There are still a few tests failing, all due to the fact that I changed title creation in two factories to reflect what titles are in reality.