### PR TITLE
Catch Notify BadErrorRequest in AuthorNotifierService

### DIFF
--- a/app/services/author_notifier_service.rb
+++ b/app/services/author_notifier_service.rb
@@ -18,6 +18,11 @@ class AuthorNotifierService
         edition_admin_url,
         public_document_url,
       ).deliver_now
+    rescue Notifications::Client::BadRequestError => e
+      # in production we care about all errors
+      # in staging and integration the team-only error is unrecoverable when running asynchronously
+      # (team-only error is unrecoverable in production too, but almost certainly impossible)
+      raise if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/ || e.message !~ /team-only API key/
     end
   end
 

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -16,12 +16,10 @@ private
   def send_mail(csv_filename, user, filter)
     MailNotifications.document_list(csv_filename, user.email, filter.page_title).deliver_now
   rescue Notifications::Client::BadRequestError => e
-    if !%w[integration staging].include?(ENV["SENTRY_CURRENT_ENV"]) || e.message !~ /team-only API key/
-      # in production we care about all errors
-      # in staging and integration the team-only error is unrecoverable when running asynchronously
-      # (team-only error is unrecoverable in production too, but almost certainly impossible)
-      raise
-    end
+    # in production we care about all errors
+    # in staging and integration the team-only error is unrecoverable when running asynchronously
+    # (team-only error is unrecoverable in production too, but almost certainly impossible)
+    raise if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/ || e.message !~ /team-only API key/
   end
 
   def upload_file(csv, type)

--- a/test/unit/services/author_notifier_service.rb
+++ b/test/unit/services/author_notifier_service.rb
@@ -82,4 +82,40 @@ class AuthorNotifierTest < ActiveSupport::TestCase
     production_notification = ActionMailer::Base.deliveries.third
     assert_no_match pattern, production_notification.to_s
   end
+
+  test "does not raise an error if an email cannot be sent via notify in integration" do
+    raises_exception = lambda { |_author, _edition, _edition_admin_url, _public_document_url|
+      response = MiniTest::Mock.new
+      ENV["SENTRY_CURRENT_ENV"] = "integration-blue-aws"
+      response.expect :code, 400
+      response.expect :body, "Can't send to this recipient using a team-only API key"
+      raise Notifications::Client::BadRequestError, response
+    }
+
+    MailNotifications.stub(:edition_published, raises_exception) do
+      ActionMailer::Base.deliveries.clear
+      edition = create(:edition)
+      assert_nothing_raised do
+        AuthorNotifierService.new(edition).notify!
+      end
+    end
+  end
+
+  test "it raises an error if an email cannot be sent via notify in Production" do
+    raises_exception = lambda { |_author, _edition, _edition_admin_url, _public_document_url|
+      response = MiniTest::Mock.new
+      ENV["SENTRY_CURRENT_ENV"] = "production"
+      response.expect :code, 400
+      response.expect :body, "Can't send to this recipient using a team-only API key"
+      raise Notifications::Client::BadRequestError, response
+    }
+
+    MailNotifications.stub(:edition_published, raises_exception) do
+      ActionMailer::Base.deliveries.clear
+      edition = create(:edition)
+      assert_raises do
+        AuthorNotifierService.new(edition).notify!
+      end
+    end
+  end
 end

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -56,7 +56,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   test "does not raise an error if an email cannot be sent via notify" do
     raises_exception = lambda { |_url, _address, _title|
       response = MiniTest::Mock.new
-      ENV["SENTRY_CURRENT_ENV"] = "integration"
+      ENV["SENTRY_CURRENT_ENV"] = "integration-blue-aws"
       response.expect :code, 400
       response.expect :body, "Can't send to this recipient using a team-only API key"
       raise Notifications::Client::BadRequestError, response


### PR DESCRIPTION
The AuthorNotifierWorker is currently raising `Notifications::Client::BadRequestError` in staging and integration environments. This is expected behaviour as our Notify service has restricted e-mail recipient lists in these environments, so it is safe to rescue from these errors.
 
Based on https://github.com/alphagov/whitehall/pull/5897

[trello](https://trello.com/c/8YKMuGwk/2320-2-fix-notificationsclientbadrequesterror-in-whitehall)