### PR TITLE
Allow linking to judiciary.uk

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,7 +1,7 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
+    unless matches_gov_uk?(value) || matches_judiciary_uk?(value)
       record.errors[attribute] << failure_message
     end
   end
@@ -10,5 +10,16 @@ private
 
   def failure_message
     options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
+  end
+
+  def matches_gov_uk?(value)
+    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
+  end
+
+  def matches_judiciary_uk?(value)
+    uri = URI.parse(value)
+    uri.host&.end_with?(".judiciary.uk")
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -53,6 +53,9 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
     assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.judiciary.uk/about-the-judiciary/")
+    assert unpublishing.valid?
   end
 
   test "alternative_url is stripped before validate" do


### PR DESCRIPTION
This follows on from the Publishing API change (https://github.com/alphagov/publishing-api/pull/1897) which adds support for this kind of redirect.

It's been approved by policy and engagement that documents can be redirected to a domain under judiciary.uk.

See https://govuk.zendesk.com/agent/tickets/4440152 for the background. A user wanted to unpublish some guidance and have it redirect to appropriate replacements hosted on judiciary.uk.