### PR TITLE
Revert "Allow linking to judiciary.uk"

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,7 +1,7 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless matches_gov_uk?(value) || matches_judiciary_uk?(value)
+    unless %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
       record.errors[attribute] << failure_message
     end
   end
@@ -10,16 +10,5 @@ private
 
   def failure_message
     options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
-  end
-
-  def matches_gov_uk?(value)
-    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
-  end
-
-  def matches_judiciary_uk?(value)
-    uri = URI.parse(value)
-    uri.host&.end_with?(".judiciary.uk")
-  rescue URI::InvalidURIError
-    false
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -53,9 +53,6 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
     assert unpublishing.valid?
-
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.judiciary.uk/about-the-judiciary/")
-    assert unpublishing.valid?
   end
 
   test "alternative_url is stripped before validate" do


### PR DESCRIPTION
Reverts alphagov/whitehall#5967

This isn't quite so easy, because Whitehall removes the host when it sends the unpublish to the Publishing API: https://github.com/alphagov/whitehall/blob/49ad55313a49b6d99469d2ee7fba0dfa2f970dc6/app/workers/publishing_api_unpublishing_worker.rb#L20