### PR TITLE
Add standard document type

### DIFF
--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -25,6 +25,7 @@ class PublicationType
     20 => "<p>Permit and licence applications published temporarily for public awareness.</p>",
     21 => "<p>Formal decisions by tribunals, regulators or adjudicators (including courts and Secretaries of State).</p>",
     22 => "<p>Regulations imposed by an independent regulatory authority only.</p><p>Do <em>not</em> use for: statutory guidance.</p>",
+    23 => "<p>Publishing a formally agreed standard that sets out requirements, specifications, guidelines or patterns that can be consistently applied to products, processes and services within government.</p>",
     999 => "<p>DO NOT USE. This is a legacy category for content created before sub-types existed.</p>",
     1000 => "<p>DO NOT USE. This is a holding category for content that has been imported automatically.</p>",
   }.to_json.freeze
@@ -110,6 +111,7 @@ class PublicationType
   InternationalTreaty    = create!(id: 18, key: "international_treaty", singular_name: "International treaty", plural_name: "International treaties", prevalence: :less_common)
   Notice                 = create!(id: 20, key: "notice", singular_name: "Notice", plural_name: "Notices", prevalence: :less_common)
   Decision               = create!(id: 21, key: "decision", singular_name: "Decision", plural_name: "Decisions", prevalence: :less_common)
+  Standard               = create!(id: 23, key: "standard", singular_name: "Standard", plural_name: "Standards", prevalence: :less_common)
 
   # Use is discouraged
   Correspondence         = create!(id: 8, key: "correspondence", singular_name: "Correspondence", plural_name: "Correspondence", prevalence: :discouraged)

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -286,6 +286,13 @@ ar:
         few:
         many:
         other: كلمات
+      standard:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       statement_to_parliament:
         zero:
         one: تصريح للبرلمان

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -206,6 +206,8 @@ az:
         other: Çıxış üçün  qeydləri
       speech:
         other: Çıxışlar
+      standard:
+        other:
       statement_to_parliament:
         other: Parlamentə bəyanatlar
       statistical_data_set:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -206,6 +206,11 @@ be:
         few:
         many:
         other: Выступы
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: Заява ў парламенце
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -126,6 +126,9 @@ bg:
       speech:
         one: Реч
         other: Речи
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Изявление в парламента
         other: Изявления в парламента

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -127,6 +127,9 @@ bn:
       speech:
         one: ভাষণ
         other: ভাষণসমূহ
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: সংসদে বিবৃতি
         other: সংসদে বিবৃতিসমূহ

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -166,6 +166,10 @@ cs:
         one: Proslov
         few:
         other: Proslovy
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one: Prohlášení v parlamentu
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -286,6 +286,13 @@ cy:
         few:
         many:
         other: Areithiau
+      standard:
+        zero:
+        one: Safon
+        two:
+        few:
+        many:
+        other: Safonau
       statement_to_parliament:
         zero:
         one: Datganiad i'r senedd

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -126,6 +126,9 @@ da:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -126,6 +126,9 @@ de:
       speech:
         one: Rede
         other: Reden
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Erklärung vor dem Parlament
         other: Erklärungen vor dem Parlament

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -126,6 +126,9 @@ dr:
       speech:
         one: سخنرانی
         other: سخنرانی ها
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: بیانیه به پارلمان
         other: بیانیه ها به پارلمان

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -126,6 +126,9 @@ el:
       speech:
         one: Ομιλία
         other: Ομιλίες
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Δήλωση στη Βουλή
         other: 'Δηλώσεις στη Βουλή '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,9 @@ en:
       speech:
         one: Speech
         other: Speeches
+      standard:
+        one: Standard
+        other: Standards
       statement_to_parliament:
         one: Statement to Parliament
         other: Statements to Parliament

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -126,6 +126,9 @@ es-419:
       speech:
         one: Discurso
         other: Discursos
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Declaración al Parlamento
         other: Declaraciones al Parlamento

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -126,6 +126,9 @@ es:
       speech:
         one: Discurso
         other: Discursos
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Declaración ante el parlamento
         other: Declaraciones ante el parlamento

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -126,6 +126,9 @@ et:
       speech:
         one: 'Kõne  '
         other: Kõned
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Avaldus parlamendis
         other: Avaldused parlamendis

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -208,6 +208,8 @@ fa:
         other: موضوعات سخنرانی
       speech:
         other: سخنرانی ها
+      standard:
+        other:
       statement_to_parliament:
         other: گزارش ها به پارلمان
       statistical_data_set:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -126,6 +126,9 @@ fi:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -126,6 +126,9 @@ fr:
       speech:
         one: Discours
         other: Discours
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Déclaration au Parlement
         other: Déclarations au Parlement

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -206,6 +206,11 @@ gd:
         two:
         few:
         other:
+      standard:
+        one:
+        two:
+        few:
+        other:
       statement_to_parliament:
         one:
         two:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -126,6 +126,9 @@ gu:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -126,6 +126,9 @@ he:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -126,6 +126,9 @@ hi:
       speech:
         one: भाषण
         other: भाषण
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: संसद में बयान
         other: संसद में बयान

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -206,6 +206,11 @@ hr:
         few:
         many:
         other:
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -126,6 +126,9 @@ hu:
       speech:
         one: Beszéd
         other: Beszédek
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Parlamenti nyilatkozat
         other: Parlamenti nyilatkozatok

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -126,6 +126,9 @@ hy:
       speech:
         one: Ելույթ
         other: Ելույթներ
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Դիմում խորհրդարան
         other: Դիմումներ խորհրդարան

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -208,6 +208,8 @@ id:
         other: Naskah Pembicara
       speech:
         other: Pidato-pidato
+      standard:
+        other:
       statement_to_parliament:
         other: Pernyataan-pernyaatan kepada Parlemen
       statistical_data_set:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -126,6 +126,9 @@ is:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -126,6 +126,9 @@ it:
       speech:
         one: Discorso
         other: Discorsi
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Dichiarazione in parlamento
         other: Dichiarazioni in parlamento

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -207,6 +207,8 @@ ja:
         other: キーポイント
       speech:
         other: スピーチ
+      standard:
+        other:
       statement_to_parliament:
         other: 閣僚声明
       statistical_data_set:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -206,6 +206,8 @@ ka:
         other:
       speech:
         other:
+      standard:
+        other:
       statement_to_parliament:
         other:
       statistical_data_set:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -126,6 +126,9 @@ kk:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -207,6 +207,8 @@ ko:
         other: 요점사항
       speech:
         other: 연설문
+      standard:
+        other:
       statement_to_parliament:
         other: 의회로 성명
       statistical_data_set:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -166,6 +166,10 @@ lt:
         one: Kalba
         few:
         other: Kalbos
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one: Kreipimasis į parlamentą
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -126,6 +126,9 @@ lv:
       speech:
         one: Runa
         other: Runas
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Ziņojums parlamentam
         other: Ziņojumi parlamentam

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -206,6 +206,8 @@ ms:
         other:
       speech:
         other:
+      standard:
+        other:
       statement_to_parliament:
         other:
       statistical_data_set:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -206,6 +206,11 @@ mt:
         few:
         many:
         other:
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -126,6 +126,9 @@ nl:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -126,6 +126,9 @@
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -127,6 +127,9 @@ pa-pk:
       speech:
         one: تقریر
         other: تقریراں
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: پارلیمنٹ نوں بیان
         other: پارلیمنٹ نوں بیانات

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -127,6 +127,9 @@ pa:
       speech:
         one: ਬੋਲਣਾ
         other: ਭਾਸ਼ਣ
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: ਸੰਸਦ ਨੂੰ ਬਿਆਨ
         other: ਸੰਸਦ ਨੂੰ ਬਿਆਨ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -206,6 +206,11 @@ pl:
         few:
         many:
         other: Przemówienia
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: Wystapienie przed parlamentem
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -126,6 +126,9 @@ ps:
       speech:
         one: وینا
         other: ویناوې
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: پارلمان ته اعلامیه
         other: پارلمان ته اعلامیې

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -126,6 +126,9 @@ pt:
       speech:
         one: Discurso
         other: Discursos
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Declaração ao Parlamento
         other: Declarações ao Parlamento

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -166,6 +166,10 @@ ro:
         one: Discurs
         few:
         other: Discursuri
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one: Declarație în Parlament
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -206,6 +206,11 @@ ru:
         few:
         many:
         other: Тексты выступлений
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: Заявление парламенту
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -126,6 +126,9 @@ si:
       speech:
         one: කථාව
         other: කථා
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: පාර්ලිමේන්තුවට කල ප්‍රකාශය
         other: පාර්ලිමේන්තුවට කල ප්‍රකාශ

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -166,6 +166,10 @@ sk:
         one:
         few:
         other:
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -206,6 +206,11 @@ sl:
         two:
         few:
         other:
+      standard:
+        one:
+        two:
+        few:
+        other:
       statement_to_parliament:
         one:
         two:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -126,6 +126,9 @@ so:
       speech:
         one: Hadal
         other: Hadallo
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Hadal loo jeediyo baarlamaanka
         other: hadallo loo jeediyo baarlamaanka

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -126,6 +126,9 @@ sq:
       speech:
         one: Fjalim
         other: Fjalime
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Deklarate per Parliamentin
         other: Deklarata per Parlamentin

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -206,6 +206,11 @@ sr:
         few:
         many:
         other: Govori
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: obraćanje Parlamentu
         few:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -126,6 +126,9 @@ sv:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -126,6 +126,9 @@ sw:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -126,6 +126,9 @@ ta:
       speech:
         one: உரை
         other: உரைகள்
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: பாராளுமன்றத்துக்கான அறிக்கை
         other: பாராளுமன்றத்துக்கான அறிக்கைகள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -207,6 +207,8 @@ th:
         other: ประเด็นการพูด
       speech:
         other: สุนทรพจน์
+      standard:
+        other:
       statement_to_parliament:
         other: แถลงการณ์ต่อรัฐสภา
       statistical_data_set:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -126,6 +126,9 @@ tk:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -248,6 +248,8 @@ tr:
       speech:
         one: Konuşma
         other: Konuşmalar
+      standard:
+        other:
       statement_to_parliament:
         one: Parlamento'ya yapılan açıklama
         other: Parlamento'ya yapılan açıklamalar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -206,6 +206,11 @@ uk:
         few:
         many:
         other: Промови
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: Заява у парламенті
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -126,6 +126,9 @@ ur:
       speech:
         one: تقریر
         other: تقاریر
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: پارلیمنٹ میں بیان
         other: پارلیمنٹ میں بیانات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -126,6 +126,9 @@ uz:
       speech:
         one: Nutq
         other: Nutqlar
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Parlament uchun hisobot
         other: Parlament uchun hisobotlar

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -208,6 +208,8 @@ vi:
         other: Bài phát biểu
       speech:
         other: Các bài phát biểu
+      standard:
+        other:
       statement_to_parliament:
         other: Tuyên bố tới Quốc hội
       statistical_data_set:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -246,6 +246,9 @@ zh-hk:
       speech:
         one: 演講
         other: 其他演講
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: 提交國會的聲明
         other: 提交國會的其他聲明

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -246,6 +246,9 @@ zh-tw:
       speech:
         one: 演講
         other: 其他演講
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: 議會聲明
         other: 議會聲明

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -239,6 +239,8 @@ zh:
       speech:
         one: 演讲
         other: 演讲
+      standard:
+        other:
       statement_to_parliament:
         one: 对议会的声明
         other: 对议会的声明


### PR DESCRIPTION
Add Standard document type.

I've tagged the document type as 'less common' which means it doesn't feature at the top of the publications list when creating a publication. This can be changed to 'primary' if the new type is deemed sufficiently important. 

<img width="1409" alt="Screenshot 2021-03-23 at 15 48 59" src="https://user-images.githubusercontent.com/6329861/112175639-51c14f80-8bef-11eb-8d96-c1c4b6d64ef9.png">

Trello:
https://trello.com/c/ugeapNY0/2318-5-create-new-standard-document-sub-type-in-whitehall