### PR TITLE
Permit withdrawn redirects to allow listed external URLs

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -61,6 +61,8 @@ class Unpublishing < ApplicationRecord
   def alternative_path
     return if alternative_uri.nil?
 
+    return alternative_uri.to_s unless GovUkUrlFormatValidator.matches_gov_uk?(alternative_uri)
+
     path = alternative_uri.path
     path << "##{alternative_uri.fragment}" if alternative_uri.fragment.present?
     path

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,19 +1,19 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless matches_gov_uk?(value) || matches_allow_list?(value)
+    unless self.class.matches_gov_uk?(value) || matches_allow_list?(value)
       record.errors[attribute] << failure_message
     end
+  end
+
+  def self.matches_gov_uk?(value)
+    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
   end
 
 private
 
   def failure_message
     options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
-  end
-
-  def matches_gov_uk?(value)
-    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
   end
 
   def matches_allow_list?(value)

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,7 +1,7 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
+    unless matches_gov_uk?(value) || matches_allow_list?(value)
       record.errors[attribute] << failure_message
     end
   end
@@ -10,5 +10,16 @@ private
 
   def failure_message
     options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
+  end
+
+  def matches_gov_uk?(value)
+    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
+  end
+
+  def matches_allow_list?(value)
+    uri = URI.parse(value)
+    uri.host&.end_with?(".judiciary.uk", "etl.beis.gov.uk")
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -68,9 +68,14 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal "https://gov.uk/guidance", unpublishing.alternative_url
   end
 
-  test "alternative_path returns the path of alternative_url" do
+  test "alternative_path returns the path of alternative_url when on GOV.UK" do
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.test.gov.uk/guidance/document-path")
     assert_equal "/guidance/document-path", unpublishing.alternative_path
+  end
+
+  test "alternative_path returns the full URL of alternative_url when not on GOV.UK" do
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.judiciary.uk/about")
+    assert_equal "https://www.judiciary.uk/about", unpublishing.alternative_path
   end
 
   test "alternative_path returns nil if alternative_url is nil" do

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -53,6 +53,12 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
     assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.judiciary.uk/about-the-judiciary/")
+    assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://etl.beis.gov.uk/manufacturers")
+    assert unpublishing.valid?
   end
 
   test "alternative_url is stripped before validate" do


### PR DESCRIPTION
Energy Technology List and Courts & Tribunals Judiciary have been given exemption from publishing on GOV.UK, so we need the ability to unpublish documents and redirect to their own domains.

Requires https://github.com/alphagov/publishing-api/pull/1898 to be merged.

Trello card: https://trello.com/c/138P3vIk