### PR TITLE
Temporary rake task to republish all statistics with HTML Attachments

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -251,6 +251,17 @@ namespace :publishing_api do
     end
   end
 
+  desc "Republish all statistics which have HTML attachments to the Publishing API"
+  task republish_stats_with_html_attachments: :environment do
+    document_ids = Publication
+      .statistical_publications
+      .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+      .pluck(:document_id)
+    document_ids.each do |document_id|
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+    end
+  end
+
   desc "Bulk republishing"
   namespace :bulk_republish do
     desc "Republish all documents of a given type, eg 'NewsArticle'"

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -53,6 +53,16 @@ namespace :search do
       index.commit
     end
 
+    desc "index all statistics with html attachments"
+    task stats_with_html_attachments: :environment do
+      stats = Publication.statistical_publications.where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+      stats.each do |stat|
+        puts "indexing #{stat.content_id}"
+        Whitehall::SearchIndex.add(stat)
+      end
+      puts "completed #{stats.count} reindexing"
+    end
+
     # useful if a topical event changes and we want to change related docs
     desc "indexes all topical events and related documents"
     task topical_event_editions: :environment do


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5962 introduces a change to ensure that HTMLAttachments for statistics pages are located at `/government/statistics` rather than `/government/publications`.

This PR adds two temporary rake tasks to republish all statistics publications with HTML Attachments to update their path, and then reindex so the HTMLAttachments appear appended in search results.

[trello](https://trello.com/c/l7Q4urHs/2295-5-fix-statistics-pages-html-attachment-base-paths-%F0%9F%8D%90)