### PR TITLE
Fix links on world location news

### DIFF
--- a/app/views/shared/_list_description_for_rummager_list.html.erb
+++ b/app/views/shared/_list_description_for_rummager_list.html.erb
@@ -5,12 +5,12 @@
         <%=
           link_to(
             edition.title,
-            edition.link,
+            edition.url,
             class: 'govuk-link',
             data: {
               track_category: 'navPolicyAreaLinkClicked',
               track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",
-              track_label: edition.link,
+              track_label: edition.url,
               track_options: {
                 dimension28: documents_count.to_s,
                 dimension29: edition.title


### PR DESCRIPTION
### What
Fix links and tracking for document lists from rummager on world location news.

### Why
Because they are broken.

### Note
`edition.link` returns an anchor tag, whereas `edition.url` returns a path

Before: [production](https://www.gov.uk/world/germany/news.de#unsere-meldungen)
After: [this branch deployed in integration](https://www.integration.publishing.service.gov.uk/world/germany/news.de#unsere-meldungen)

[Trello card](https://trello.com/c/yb3d3Wum)