### PR TITLE
Adds locale to social media links

### DIFF
--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -72,7 +72,7 @@ private
       :end_date,
       related_classification_ids: [],
       classification_memberships_attributes: %i[id ordering],
-      social_media_accounts_attributes: %i[social_media_service_id url _destroy id],
+      social_media_accounts_attributes: %i[social_media_service_id url _destroy id locale],
       featured_links_attributes: %i[title url _destroy id],
       organisation_classifications_attributes: %i[id lead lead_ordering],
     )

--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -66,7 +66,7 @@ private
 
   def social_media_account_params
     params.require(:social_media_account).permit(
-      :social_media_service_id, :url, :title
+      :social_media_service_id, :url, :title, :locale
     )
   end
 end

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -69,4 +69,11 @@ module TranslationHelper
     page.extend(UseSlugAsParam)
     link_to(t_corporate_information_page_type_link_text(page), [organisation, page])
   end
+
+  def t_social_media_accounts(social, req)
+    return unless social && req
+
+    request_locale = req.filtered_parameters["locale"] || "en"
+    social.select { |k, _| k["locale"] == request_locale }
+  end
 end

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -8,6 +8,7 @@ class SocialMediaAccount < ApplicationRecord
   validates :social_media_service_id, presence: true
   validates :url, presence: true, uri: true
   validates :title, length: { maximum: 255 }
+  validates :locale, presence: true
 
   def republish_organisation_to_publishing_api
     if socialable_type == "Organisation" && socialable.persisted?

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -410,7 +410,7 @@ module PublishingApi
     end
 
     def social_media_links
-      item.social_media_accounts.map do |account|
+      item.social_media_accounts.where(locale: I18n.locale).map do |account|
         {
           service_type: account.service_name.parameterize,
           title: account.display_name,

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -36,5 +36,15 @@ module PublishingApi
     def description
       item.summary
     end
+
+    def social_media_links
+      item.social_media_accounts.where(locale: I18n.locale).map do |account|
+        {
+          service_type: account.service_name.parameterize,
+          title: account.display_name,
+          href: account.url,
+        }
+      end
+    end
   end
 end

--- a/app/views/admin/social_media_accounts/_form.html.erb
+++ b/app/views/admin/social_media_accounts/_form.html.erb
@@ -9,6 +9,10 @@
         </div>
         <%= form.text_field :url %>
         <%= form.text_field :title %>
+        <div class="form-group">
+          <%= form.label :locale, 'Display language', class: "control-label" %>
+          <%= form.select :locale, options_for_locales(I18n.available_locales), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media locale…" } %>
+        </div>
       </fieldset>
 
       <%= form.save_or_cancel(cancel: [:admin, socialable, SocialMediaAccount]) %>

--- a/app/views/admin/topical_events/_custom_form_fields.html.erb
+++ b/app/views/admin/topical_events/_custom_form_fields.html.erb
@@ -31,5 +31,9 @@
       <%= account_form.select :social_media_service_id, options_from_collection_for_select(SocialMediaService.all, :id, :name, account_form.object.social_media_service_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media service…" } %>
     </div>
     <%= account_form.text_field :url %>
+    <div class="form-group">
+          <%= account_form.label :locale, 'Display language', class: "control-label" %>
+          <%= account_form.select :locale, options_for_locales(I18n.available_locales), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media locale…" } %>
+        </div>
   <% end %>
 </fieldset>

--- a/app/views/shared/_social_media_accounts.html.erb
+++ b/app/views/shared/_social_media_accounts.html.erb
@@ -1,18 +1,18 @@
 <% followus ||= false %>
-<% if socialable.social_media_accounts.any? %>
-  <section lang="en">
-    <% unless followus %>
-      <h2 class="label">Follow on social media</h2>
-    <% end %>
-    <ul class="social-media-accounts js-hide-extra-social-media">
-      <% socialable.social_media_accounts.each do |account| %>
-        <%= content_tag_for(:li, account) do %>
-          <%= link_to account.url,
-                      class: "social-media-link #{account.service_name.parameterize} govuk-link" do %>
-            <span class="connect"></span><%= account.display_name %>
-          <% end %>
+
+<section>
+  <% unless followus %>
+    <h2 class="label"><%= t('social_media.follow_us') %></h2>
+  <% end %>
+  <ul class="social-media-accounts js-hide-extra-social-media">
+    <% socialable.each do |account| %>
+      <%= content_tag_for(:li, account) do %>
+        <%= link_to account.url,
+                    class: "social-media-link #{account.service_name.parameterize} govuk-link",
+                    lang: account.locale do %>
+          <span class="connect"></span><%= account.display_name %>
         <% end %>
       <% end %>
-    </ul>
-  </section>
-<% end %>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -42,9 +42,10 @@
               <%= link_to @topical_event.about_page.read_more_link_text, topical_event_about_pages_path(@topical_event), class: "govuk-link" %>
             </p>
           <% end %>
-          <% if @topical_event.social_media_accounts.any? %>
+          <% social = t_social_media_accounts(@topical_event.social_media_accounts, @_request) %>
+          <% if social.any? %>
             <%= render partial: 'shared/social_media_accounts',
-                       locals: { socialable: @topical_event, followus: true } %>
+                       locals: { socialable: social, followus: true } %>
           <% end %>
         </section>
       </div>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -17,11 +17,12 @@
       <% end %>
     </div>
   </div>
-  <% if @worldwide_organisation.social_media_accounts.any? %>
+  <% social = t_social_media_accounts(@worldwide_organisation.social_media_accounts, @_request) %>
+  <% if social.any? %>
     <aside class="social-media-links govuk-grid-column-one-third">
       <div class="content">
         <h2><%= t("worldwide_organisation.headings.follow_us") %></h2>
-        <%= render "shared/social_media_accounts", socialable: @worldwide_organisation, followus: true %>
+        <%= render "shared/social_media_accounts", socialable: social, followus: true %>
       </div>
     </aside>
   <% end %>


### PR DESCRIPTION
Adds the option to select a language when adding or editing social media
links. These links are only shown when the locale of the document
matches the locale of the social media account.

[Trello](https://trello.com/c/RRvGDDmD/2243-5-make-whitehall-social-media-links-translatable)