### PR TITLE
Create noop Link Check report for Editions that contain no links

### DIFF
--- a/app/workers/check_organisation_links_worker.rb
+++ b/app/workers/check_organisation_links_worker.rb
@@ -23,6 +23,7 @@ class CheckOrganisationLinksWorker
         if LinkCheckerApiService.has_links?(edition)
           LinkCheckerApiService.check_links(edition, callback)
         else
+          LinkCheckerApiReport.create_noop_report(edition)
           ignored += 1
         end
       end

--- a/test/unit/workers/check_organisation_links_worker_test.rb
+++ b/test/unit/workers/check_organisation_links_worker_test.rb
@@ -61,6 +61,19 @@ class CheckOrganisationLinksWorkerTest < ActiveSupport::TestCase
     assert_not_requested existing_edition
   end
 
+  test "when an edition contains no links, it is given a passing link check report" do
+    org = create(:organisation)
+    publication = create(
+      :published_publication,
+      lead_organisations: [org],
+      body: "no links here",
+    )
+
+    CheckOrganisationLinksWorker.new.perform(org.id)
+    assert_equal(1, publication.link_check_reports.count)
+    assert_equal(false, publication.link_check_reports.last.has_problems?)
+  end
+
 private
 
   def assert_report_count_increased


### PR DESCRIPTION
This commit fixes a bug whereby an Edition that once contained broken links, but now contains no links at all, is reported as
containing broken links. This can happen when an Edition is created that contains a broken link, then a report is generated,
then the links are removed. The  [nightly broken link report worker](https://github.com/alphagov/whitehall/blob/79ce740d97c72779e71cb15a480a3b08a8029d4d/config/sidekiq.yml#L14-L16) ought to 'refresh' each Edition such that it always has an up to date link check report, but Editions without links are ignored by the `CheckOrganisationLinksWorker`. Therefore, we now create a noop report, which is synonymous with "there are no broken links for this edition".

An alternative could have been to delete all the `link_check_reports` associated with the Edition, but this feels lossy and could also be misconstrued as "this edition hasn't been checked yet". Instead, we seem to [rely on this noop report elsewhere in Whitehall](https://github.com/alphagov/whitehall/blob/9dcec7b76ed6617a293bf51fdca372b1abd085e1/app/services/link_checker_api_service.rb#L20-L22) when querying whether or not an Edition contains broken links  (creating one when the "Check again" button is clicked on an Edition which contains no links), so it seems reasonable that we use it here too.

Trello: https://trello.com/c/bVdSfMYp/2360-fix-some-problems-with-whitehall-broken-links-report