### PR TITLE
Bugfix: don't hide nations fields on consultations admin view

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -51,9 +51,7 @@
 
       <%= render 'topical_event_fields', form: form, edition: edition %>
 
-      <div class="js-external-url-set">
-        <%= render 'nation_fields', form: form, edition: edition %>
-      </div>
+      <%= render 'nation_fields', form: form, edition: edition %>
 
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>


### PR DESCRIPTION
The nations field is always required, but when a user clicks
'Held on another website' this hides the nations section.

Since the nations field is required the user is still
prevented from saving their work, and they see an error
'Excluded nations - you must select whether this content
applies to all UK nations or which ones it excludes'
but they are not shown the field to fill in, since we've
hidden it with JS.

This change prevents the field from ever being hidden.

Ticket reporting: https://govuk.zendesk.com/agent/tickets/4460320