### PR TITLE
Stop creating draft editions when republishing withdrawn editions

### DIFF
--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -30,6 +30,7 @@ class PublishingApiUnpublishingWorker
             allow_draft,
           )
         end
+        Whitehall::PublishingApi.save_draft(edition)
       when UnpublishingReason::CONSOLIDATED_ID
         PublishingApiRedirectWorker.new.perform(
           content_id,
@@ -37,6 +38,7 @@ class PublishingApiUnpublishingWorker
           locale,
           allow_draft,
         )
+        Whitehall::PublishingApi.save_draft(edition)
       when UnpublishingReason::WITHDRAWN_ID
         PublishingApiWithdrawalWorker.new.perform(
           content_id,
@@ -47,7 +49,5 @@ class PublishingApiUnpublishingWorker
         )
       end
     end
-
-    Whitehall::PublishingApi.save_draft(edition)
   end
 end

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -95,6 +95,15 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
   end
 
+  test "doesn't resend draft to the publishing api if unpublishing reason was withdrawn" do
+    unpublished_edition = create(
+      :withdrawn_edition,
+    )
+
+    Whitehall::PublishingApi.expects(:save_draft).with(unpublished_edition).never
+    PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
+  end
+
   test "passes allow_draft if supplied" do
     unpublished_edition = create(
       :withdrawn_edition,


### PR DESCRIPTION
According to Whitehall's [edition workflow][], documents that are
unpublished (due to `PublishedInError` or `Consolidated`) have a
a latest edition in `draft` state. Documents that are _withdrawn_
have a latest edition in a `withdrawn` state.

The `PublishingApiUnpublishingWorker` correctly processes 'Gone'
and 'Redirect' instructions to Publishing API, followed by saving
a draft edition. But it incorrectly applies the same behaviour to
'Withdraw' instructions. This has been a bug in the implementation
since [at least August 2016][commit].

If a withdrawn document has been re-presented to Publishing API
via this worker, which can happen as a result of calling any number
of [rake tasks][], then the document incorrectly gains a draft
edition. If the publisher subsequently attempts to edit the
withdrawal explanation, the update does not succeed. The UI
doesn't indicate an issue, and the underlying record in Whitehall
is updated, but the asynchronous call to Publishing API fails.
We can see this in action by invoking the worker directly, twice
in a row:

```
PublishingApiUnpublishingWorker.new.perform(Edition.find(1170859).unpublishing.id)
=> [:en]
```

^ Publishing API is contacted, and a draft edition is erroneously
created.

```
PublishingApiUnpublishingWorker.new.perform(Edition.find(1170859).unpublishing.id)
{
  "request_uri":"https://publishing-api.integration.govuk-internal.digital/v2/content/53d25865-6696-406c-b251-c7560a1c9f23/unpublish",
  "start_time":1613646106.5406241,
  "status":422,
  "end_time":1613646106.568803,
  "body":"{\"error\":{\"code\":422,\"message\":\"Cannot unpublish with a draft present\",\"fields\":{}}}"
}
=> [:en]
```

^ Publishing API refuses to update a document which has a draft
edition.

This commit fixes the issue. We now explicitly create a draft
only when the unpublishing reason allows it.

Trello: https://trello.com/c/Oicf9IVG/2354-5-investigate-fix-withdrawn-explanations-not-updating-in-whitehall

[commit]: https://github.com/alphagov/whitehall/commit/f671e3714c9c989deb42f69c92d32d6535ec0dda
[edition workflow]: https://github.com/alphagov/whitehall/blob/master/docs/edition_workflow.md#unpublishing--withdrawal
[rake tasks]: https://github.com/alphagov/whitehall/blob/24adcc24cd66f8f3ad50b532174c39e988591f34/lib/tasks/publishing_api.rake