### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -31,7 +31,7 @@
   <%= render 'admin/link_check_reports/link_check_report', report: link_check_report %>
 <% end %>
 
-<div data-module="track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
+<div data-module="gem-track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
   <h3>Formatting</h3>
   <p>For details, read the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown">guide to using Markdown</a></p>
   <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -1,5 +1,5 @@
 {{#results_any?}}
-  <ol class="js-document-list document-list" data-module="track-click">
+  <ol class="js-document-list document-list" data-module="gem-track-click">
     {{#results}}
       <li id="{{result.type}}_{{result.id}}" class="document-row">
         <h3>

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -304,9 +304,9 @@ class AnnouncementsControllerTest < ActionController::TestCase
       results_list = css_select("ol.document-list").first
 
       assert_equal(
-        "track-click",
+        "gem-track-click",
         results_list.attributes["data-module"].value,
-        "Expected the document list to have the 'track-click' module",
+        "Expected the document list to have the 'gem-track-click' module",
       )
 
       article_link = css_select("li.document-row a").first

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -258,9 +258,9 @@ private
         results_list = css_select("ol.document-list").first
 
         assert_equal(
-          "track-click",
+          "gem-track-click",
           results_list.attributes["data-module"].value,
-          "Expected the document list to have the 'track-click' module",
+          "Expected the document list to have the 'gem-track-click' module",
         )
 
         publication_link = css_select("li.document-row a").first

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -176,9 +176,9 @@ class StatisticsControllerTest < ActionController::TestCase
         results_list = css_select("ol.document-list").first
 
         assert_equal(
-          "track-click",
+          "gem-track-click",
           results_list.attributes["data-module"].value,
-          "Expected the document list to have the 'track-click' module",
+          "Expected the document list to have the 'gem-track-click' module",
         )
 
         statistics_link = css_select("li.document-row a").first


### PR DESCRIPTION
### What

Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.
