### PR TITLE
Fix up withdrawn documents which erroneously have draft editions

### DIFF
--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -1,5 +1,4 @@
-class PublishingApiUnpublishingWorker
-  include Sidekiq::Worker
+class PublishingApiUnpublishingWorker < WorkerBase
   include LockedDocumentConcern
 
   sidekiq_options queue: "publishing_api"

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -274,6 +274,28 @@ namespace :publishing_api do
       end
       puts "Finished enqueueing items for Publishing API"
     end
+
+    desc "Remove any draft edition associated with Withdrawn editions and republish"
+    task fix_withdrawn_documents: :environment do
+      puts "Finding withdrawn editions that need fixing..."
+      unpublishings = Unpublishing.unscoped.
+        # we only want documents that were withdrawn
+        where(unpublishing_reason_id: UnpublishingReason::Withdrawn.id).filter do |unpublishing|
+          # the associated edition should be in a `withdrawn` state
+          unpublishing.edition.state == "withdrawn" &&
+            # the associated edition should be the latest edition
+            unpublishing.edition.id == unpublishing.edition.document.latest_edition.id
+        end
+      editions = unpublishings.map(&:edition)
+
+      editions.each do |edition|
+        edition.translations.pluck(:locale).each do |locale|
+          puts "Fixing edition #{edition.content_id}, locale #{locale}"
+          Services.publishing_api.discard_draft(edition.content_id, locale: locale)
+          PublishingApiUnpublishingWorker.perform_async_in_queue("bulk_republishing", edition.unpublishing.id, false)
+        end
+      end
+    end
   end
 
   desc "Manually unpublish content with a redirect"

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -292,6 +292,9 @@ namespace :publishing_api do
         edition.translations.pluck(:locale).each do |locale|
           puts "Fixing edition #{edition.content_id}, locale #{locale}"
           Services.publishing_api.discard_draft(edition.content_id, locale: locale)
+        rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+          puts "No draft exists for #{edition.content_id}, locale #{locale}. Skipping..."
+        ensure
           PublishingApiUnpublishingWorker.perform_async_in_queue("bulk_republishing", edition.unpublishing.id, false)
         end
       end

--- a/test/lib/tasks/publishing_api_test.rb
+++ b/test/lib/tasks/publishing_api_test.rb
@@ -22,6 +22,26 @@ class PublishingApiRake < ActiveSupport::TestCase
       task.invoke
     end
 
+    test "Fails gracefully if no draft exists (404 response)" do
+      create(:withdrawn_edition)
+
+      Services.publishing_api.expects(:discard_draft).raises(GdsApi::HTTPNotFound.new("No draft"))
+
+      assert_nothing_raised do
+        task.invoke
+      end
+    end
+
+    test "Fails gracefully if no draft exists (422 response)" do
+      create(:withdrawn_edition)
+
+      Services.publishing_api.expects(:discard_draft).raises(GdsApi::HTTPUnprocessableEntity.new("No draft"))
+
+      assert_nothing_raised do
+        task.invoke
+      end
+    end
+
     test "Triggers PublishingApiUnpublishingWorker after removing draft" do
       unpublished_edition = create(:withdrawn_edition)
       operations = sequence("operations")

--- a/test/lib/tasks/publishing_api_test.rb
+++ b/test/lib/tasks/publishing_api_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class PublishingApiRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  describe "when fixing up a withdrawn document" do
+    let(:task) { Rake::Task["publishing_api:bulk_republish:fix_withdrawn_documents"] }
+
+    test "Tells Publishing API to remove draft edition for all locales" do
+      unpublished_edition = create(
+        :withdrawn_edition,
+        translated_into: "fr",
+      )
+
+      Services.publishing_api.expects(:discard_draft).with(unpublished_edition.content_id, locale: "en").once
+      Services.publishing_api.expects(:discard_draft).with(unpublished_edition.content_id, locale: "fr").once
+
+      task.invoke
+    end
+
+    test "Triggers PublishingApiUnpublishingWorker after removing draft" do
+      unpublished_edition = create(:withdrawn_edition)
+      operations = sequence("operations")
+
+      Services.publishing_api.expects(:discard_draft).with(unpublished_edition.content_id, locale: "en")
+        .once.in_sequence(operations)
+      PublishingApiUnpublishingWorker.expects(:perform_async_in_queue)
+        .with("bulk_republishing", unpublished_edition.unpublishing.id, false)
+        .once.in_sequence(operations)
+
+      task.invoke
+    end
+
+    test "Skips over withdrawn documents if they actually have a draft edition" do
+      unpublished_edition = create(:withdrawn_edition)
+      create(:draft_edition, document_id: unpublished_edition.document.id)
+
+      Services.publishing_api.expects(:discard_draft).never
+      PublishingApiUnpublishingWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,8 @@ require "parallel_tests/test/runtime_logger"
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
+Whitehall::Application.load_tasks
+
 Mocha.configure do |c|
   c.reinstate_undocumented_behaviour_from_v1_9 = false
   c.stubbing_non_existent_method = :prevent

--- a/test/unit/tasks/reslugging_test.rb
+++ b/test/unit/tasks/reslugging_test.rb
@@ -3,8 +3,6 @@ require "rake"
 
 class ResluggingTest < ActiveSupport::TestCase
   setup do
-    Rake.application.rake_require "tasks/reslugging"
-    Rake::Task.define_task(:environment)
     Rake::Task["reslug:document"].reenable
   end
 


### PR DESCRIPTION
For years, we've been incorrectly saving a draft edition in
Publishing API after informing it of Withdrawn documents in
Whitehall. This was fixed in #5992, but we still have a number of
existing documents this affects which would currently be unable
to have their withdrawal explanations updated.

This commit adds a rake task to resync all withdrawn documents
with Publishing API, explicitly removing any draft editions that
exist. This should solve the issue once and for all.

I've had to change the `PublishingApiUnpublishingWorker` to
inherit from `WorkerBase` in order to get the
`perform_async_in_queue` method. I see no disadvantage to doing
so, and it should free up the main queue for more important
publishing.

I also had to remove some lines from `ResluggingTest`, which are
no longer needed now that we're loading all Rake tasks in
test_helper.rb.

Trello: https://trello.com/c/Oicf9IVG/2354-5-investigate-fix-withdrawn-explanations-not-updating-in-whitehall