### PR TITLE
Replace shared heading with title component where possible

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -159,8 +159,8 @@ $govuk-use-legacy-palette: false;
 // When removing ensure all cases are captured - some rules in helpers/_headings.scss
 // are very specific, requiring the !important here
 #whitehall-wrapper {
-  a.govuk-link,
-  a[class^="gem-c-"] {
+  a.govuk-link:not(.gem-c-title__context-link),
+  a[class^="gem-c-"]:not(.gem-c-title__context-link) {
     text-decoration: underline;
 
     &:focus,

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -9,8 +9,9 @@
 
 <header class="block headings-block">
   <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { big: true, heading: heading } %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: heading,
+    } %>
   </div>
 </header>
 

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -2,10 +2,11 @@
 <% page_class "worldwide-organisations embassies-index" %>
 
 <header class="block headings-block">
- <div class="inner-block floated-children">
-   <%= render partial: 'shared/heading',
-             locals: { heading: "Find a British embassy, high commission or consulate",
-                       type: "Worldwide" } %>
+  <div class="inner-block floated-children">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "Worldwide",
+      title: "Find a British embassy, high commission or consulate",
+    } %>
   </div>
 </header>
 

--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -3,9 +3,13 @@
 
 <header class="block headings-block">
   <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', "/government/history"),
-                        heading: "Past Chancellors of the Exchequer" } %>
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: "History",
+        href: "/government/history",
+      },
+      title: "Past Chancellors of the Exchequer",
+    } %>
   </div>
 </header>
 

--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -2,11 +2,14 @@
 <% page_class "historic-appointments historic-people-show" %>
 
 <header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: link_to('History', "/government/history", class: "govuk-link"),
-                        heading: "Past #{@role.name.pluralize}",
-                        big: true } %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: "History",
+        href: "/government/history",
+      },
+      title: "Past #{@role.name.pluralize}",
+    } %>
   </div>
 </header>
 

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -2,11 +2,17 @@
 <% page_class "get-involved" %>
 
 <header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { big: true,
-                        heading: "Get involved" } %>
-    <p class="intro-paragraph">Find out how you can <a class="govuk-link" href="#engage-with-government">engage with government</a> directly, and <a class="govuk-link" href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Get involved",
+      margin_bottom: 4
+    } %>
+
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: raw("Find out how you can <a class=\"govuk-link\" href=\"#engage-with-government\">engage with government</a> directly, and <a class=\"govuk-link\" href=\"#take-part\">take&nbsp;part</a> locally, nationally or internationally."),
+      margin_bottom: 6,
+    } %>
+    <p class="intro-paragraph"></p>
   </div>
 </header>
 

--- a/app/views/latest/index.html.erb
+++ b/app/views/latest/index.html.erb
@@ -3,11 +3,14 @@
 <% atom_discovery_link_tag filter_atom_feed_url, "Recent documents" %>
 
 <header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render 'shared/heading',
-               type: link_to(subject, subject),
-               heading: 'Latest documents',
-               big: true %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/title", {
+      context: {
+        text: subject,
+        href: subject,
+      },
+      title: "Latest documents",
+    } %>
   </div>
 </header>
 

--- a/app/views/operational_fields/index.html.erb
+++ b/app/views/operational_fields/index.html.erb
@@ -2,11 +2,11 @@
 <% page_class "fields-of-operation-index" %>
 
 <header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { type: 'British fatalities',
-                        heading: "Fields of operation",
-                        big: true } %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "British fatalities",
+      title: "Fields of operation",
+    } %>
   </div>
 </header>
 

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -9,9 +9,9 @@
 
 <header class="block headings-block">
   <div class="inner-block floated-children">
-    <%= render partial: 'shared/heading',
-              locals: { big: true,
-                        heading: heading } %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: heading,
+    } %>
   </div>
 </header>
 


### PR DESCRIPTION
## What
Where possible, replace the shared heading bespoke component with the [publishing components title component](https://components.publishing.service.gov.uk/component-guide/title).

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

The ideal here is that shared heading is completely removed in favour of the title component, however there are several instances where the shared heading is too bespoke to remove without design input. These include:

- Some headings display inline with logos and list elements whilst the title component is intended to be full width. Replacing these instances negatively impacts the design of the page.
- There are several views that I wasn't able to find used on prod to effectively test. I suspect a lot of these views have been superseded by other frontend apps.

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

### Pages tested against
- https://www.gov.uk/world/embassies
- https://www.gov.uk/government/history/past-chancellors
- https://www.gov.uk/government/history/past-prime-ministers/robert-walpole
- https://www.gov.uk/government/get-involved

## Visual changes
### Before examples
![Screenshot 2021-02-22 at 16 58 35](https://user-images.githubusercontent.com/64783893/108833461-c1c6c080-75c4-11eb-87a9-b668670ac8d7.png)
![Screenshot 2021-02-22 at 16 59 20](https://user-images.githubusercontent.com/64783893/108833469-c55a4780-75c4-11eb-9f6c-304b22148e7d.png)
![Screenshot 2021-02-22 at 16 59 50](https://user-images.githubusercontent.com/64783893/108833505-d2773680-75c4-11eb-9675-44a652963157.png)
![Screenshot 2021-02-22 at 17 01 35](https://user-images.githubusercontent.com/64783893/108833515-d6a35400-75c4-11eb-9c96-d69c56300cbe.png)

### After examples
![Screenshot 2021-02-22 at 16 58 26](https://user-images.githubusercontent.com/64783893/108833560-ea4eba80-75c4-11eb-9814-0a1a7e933c48.png)
![Screenshot 2021-02-22 at 16 59 00](https://user-images.githubusercontent.com/64783893/108833568-ecb11480-75c4-11eb-96b1-36b7fba2e0a9.png)
![Screenshot 2021-02-22 at 16 59 30](https://user-images.githubusercontent.com/64783893/108833588-f20e5f00-75c4-11eb-924c-5fe3a92ae425.png)
![Screenshot 2021-02-22 at 17 01 28](https://user-images.githubusercontent.com/64783893/108833603-f63a7c80-75c4-11eb-8207-93e402be06e9.png)
