### PR TITLE
Add healthcheck endpoint for scheduled editions without a job

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -5,4 +5,13 @@ class HealthcheckController < ActionController::API
     logger.error "HealthcheckController#overdue: #{e.message}"
     render json: { overdue: nil }, status: :service_unavailable
   end
+
+  def unenqueued_scheduled_editions
+    render json: {
+      unenqueued_scheduled_editions: Healthcheck::ScheduledPublishing.new.unenqueued_editions,
+    }
+  rescue ActiveRecord::StatementInvalid => e
+    logger.error "HealthcheckController#unenqueued_scheduled_editions: #{e.message}"
+    render json: { unenqueued_scheduled_editions: nil }, status: :service_unavailable
+  end
 end

--- a/app/models/healthcheck/scheduled_publishing.rb
+++ b/app/models/healthcheck/scheduled_publishing.rb
@@ -19,6 +19,10 @@ module Healthcheck
       "#{edition_count} scheduled edition(s); #{queue_size} job(s) queued"
     end
 
+    def unenqueued_editions
+      edition_count - queue_size
+    end
+
   private
 
     def queue_size_matches_edition_count?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -425,6 +425,7 @@ Whitehall::Application.routes.draw do
       )
 
   get "healthcheck/overdue" => "healthcheck#overdue"
+  get "healthcheck/unenqueued_scheduled_editions" => "healthcheck#unenqueued_scheduled_editions"
 
   # TODO: Remove when paths for new content can be generated without a route helper
   get "/guidance/:id(.:locale)", as: "detailed_guide", to: "detailed_guides#show", constraints: { id: /[A-z0-9\-]+/, locale: VALID_LOCALES_REGEX }

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -41,4 +41,13 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
       assert_equal 1, json_response["overdue"]
     end
   end
+
+  test "GET /healthcheck/unenqueued_scheduled_editions shows number of scheduled editions without a scheduled job" do
+    with_real_sidekiq do
+      create(:scheduled_edition)
+
+      get "/healthcheck/unenqueued_scheduled_editions"
+      assert_equal 1, json_response["unenqueued_scheduled_editions"]
+    end
+  end
 end

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -7,12 +7,12 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     JSON.parse(response.body)
   end
 
-  test "returns success on request" do
+  test "GET /healthcheck returns success on request" do
     get "/healthcheck"
     assert_response :success
   end
 
-  test "includes an OK health check status when scheduled queue matches number of scheduled editions" do
+  test "GET /healthcheck includes an OK health check status when scheduled queue matches number of scheduled editions" do
     with_real_sidekiq do
       ScheduledPublishingWorker.queue(create(:scheduled_edition))
 
@@ -22,7 +22,7 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "includes WARNING health check status when scheduled queue does not match the number of scheduled editions" do
+  test "GET /healthcheck includes WARNING health check status when scheduled queue does not match the number of scheduled editions" do
     with_real_sidekiq do
       create(:scheduled_edition)
 
@@ -30,6 +30,15 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
       assert_equal "warning", json_response["status"]
       assert_equal "warning", json_response["checks"]["scheduled_queue"]["status"]
       assert_equal "1 scheduled edition(s); 0 job(s) queued", json_response["checks"]["scheduled_queue"]["message"]
+    end
+  end
+
+  test "GET /healthcheck/overdue shows number of overdue scheduled publications" do
+    with_real_sidekiq do
+      create(:scheduled_edition, scheduled_publication: 1.day.ago)
+
+      get "/healthcheck/overdue"
+      assert_equal 1, json_response["overdue"]
     end
   end
 end


### PR DESCRIPTION
This adds an endpoint `/healthcheck/unenqueued_scheduled_editions` to check for the number of scheduled editions that have not been queued in Sidekiq.

We already have this data included in the `/healthcheck` endpoint, but this is shown in Icinga for every host (rather than once per app). Once this change has been deployed and the alert set up, the old system can be removed.

Trello card: https://trello.com/c/UAbbL13x