### PR TITLE
Use image card component

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -16,6 +16,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/heading';
 @import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/image-card';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';

--- a/app/presenters/classification_featuring_presenter.rb
+++ b/app/presenters/classification_featuring_presenter.rb
@@ -2,7 +2,6 @@ class ClassificationFeaturingPresenter < Whitehall::Decorators::Decorator
   delegate_instance_methods_of ClassificationFeaturing
 
   def image_tag(size)
-    image_url = model.image.file.url(size || :s630)
-    context.image_tag image_url, class: "featured-image", alt: model.alt_text
+    model.image.file.url(size || :s630)
   end
 end

--- a/app/views/classifications/_classification_featuring.html.erb
+++ b/app/views/classifications/_classification_featuring.html.erb
@@ -5,14 +5,12 @@
     link_attributes[:rel] = "external" if is_external?(classification_featuring.url)
   %>
   <div class="content">
-    <span class="image-holder">
-      <%= link_to classification_featuring.image_tag(:s465), classification_featuring.url, title: t("document.read", title: classification_featuring.title), class: "img", aria: { hidden: true }, tabindex: "-1" %>
-    </span>
-    <div class="text">
-      <h2><%= link_to classification_featuring.title, classification_featuring.url, link_attributes %></h2>
-      <% unless classification_featuring.summary.blank? %>
-        <p class="summary"><%= truncate(classification_featuring.summary, length: 160, separator: ' ') %></p>
-      <% end %>
-    </div>
+    <%= render "govuk_publishing_components/components/image_card", {
+      href: classification_featuring.url,
+      image_src: classification_featuring.image_tag(:s465),
+      image_alt: classification_featuring.alt_text,
+      heading_text: classification_featuring.title,
+      description: truncate(classification_featuring.summary, length: 160, separator: ' '),
+    } %>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -19,152 +19,112 @@
     <ol>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/edward-wood" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/edward-wood" class="govuk-link">
-              Edward Frederick Lindley Wood, Viscount Halifax
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-bottom-0 term">1938 to 1940</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/edward-wood",
+            image_src: image_path("history/past-foreign-secretaries/viscount-halifax.jpg"),
+            image_alt: "Edward Frederick Lindley Wood, Viscount Halifax",
+            heading_text: "Edward Frederick Lindley Wood, Viscount Halifax",
+            description: "1938 to 1940",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/austen-chamberlain">
-              Sir Austen Chamberlain
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1924 to 1929</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/austen-chamberlain",
+            image_src: image_path("history/past-foreign-secretaries/austen-chamberlain.jpg"),
+            image_alt: "Sir Austen Chamberlain",
+            heading_text: "Sir Austen Chamberlain",
+            description: "1924 to 1929",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/george-curzon" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-curzon">
-              George Nathaniel Curzon, Marquess of Kedleston
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1919 to 1924</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/george-curzon",
+            image_src: image_path("history/past-foreign-secretaries/george-nathaniel-curzon.jpg"),
+            image_alt: "George Nathaniel Curzon, Marquess of Kedleston",
+            heading_text: "George Nathaniel Curzon, Marquess of Kedleston",
+            description: "1919 to 1924",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/edward-grey" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/edward-grey">
-              Sir Edward Grey, Viscount Grey of Fallodon
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1905 to 1916</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/edward-grey",
+            image_src: image_path("history/past-foreign-secretaries/sir-edward-grey.jpg"),
+            image_alt: "Sir Edward Grey, Viscount Grey of Fallodon",
+            heading_text: "Sir Edward Grey, Viscount Grey of Fallodon",
+            description: "1905 to 1916",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">
-              Henry Petty-Fitzmaurice, Marquess of Lansdowne
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1900 to 1905</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/henry-petty-fitzmaurice",
+            image_src: image_path("history/past-foreign-secretaries/lord-landsowne.jpg"),
+            image_alt: "Henry Petty-Fitzmaurice, Marquess of Lansdowne",
+            heading_text: "Henry Petty-Fitzmaurice, Marquess of Lansdowne",
+            description: "1900 to 1905",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/robert-cecil">
-              Robert Cecil, Marquess of Salisbury
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1878 to 1880, 1885 to 1886,<br> 1887 to 1892 and 1895 to 1900</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/robert-cecil",
+            image_src: image_path("history/past-foreign-secretaries/marquess-of-salisbury.jpg"),
+            image_alt: "Robert Cecil, Marquess of Salisbury",
+            heading_text: "Robert Cecil, Marquess of Salisbury",
+            description: "1878 to 1880, 1885 to 1886, 1887 to 1892 and 1895 to 1900",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/george-gower" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gower">
-              George Leveson Gower, Earl Granville
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1851 to 1852, 1870 to 1874<br> and 1880 to 1885</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/george-gower",
+            image_src: image_path("history/past-foreign-secretaries/earl-granville.jpg"),
+            image_alt: "George Leveson Gower, Earl Granville",
+            heading_text: "George Leveson Gower, Earl Granville",
+            description: "1851 to 1852, 1870 to 1874 and 1880 to 1885",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/george-gordon" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/george-gordon">
-              George Hamilton Gordon, Earl of Aberdeen
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1828 to 1830 and 1841 to 1846</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/george-gordon",
+            image_src: image_path("history/past-foreign-secretaries/lord-aberdeen.jpg"),
+            image_alt: "George Hamilton Gordon, Earl of Aberdeen",
+            heading_text: "George Hamilton Gordon, Earl of Aberdeen",
+            description: "1828 to 1830 and 1841 to 1846",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt clear-person">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/charles-fox" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/charles-fox">
-              Charles James Fox
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1782, 1783 and 1806</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/charles-fox",
+            image_src: image_path("history/past-foreign-secretaries/charles-james-fox.jpg"),
+            image_alt: "Charles James Fox",
+            heading_text: "Charles James Fox",
+            description: "1782, 1783 and 1806",
+          } %>
         </div>
       </li>
       <li class="person person-excerpt">
         <div class="inner">
-          <div class="image-holder govuk-!-margin-bottom-1">
-            <a href="/government/history/past-foreign-secretaries/william-grenville" class="aspect-ratio-3:2" tabindex="-1" aria-hidden="true">
-              <%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville', loading: "lazy" %>
-            </a>
-          </div>
-          <p class="govuk-heading-s govuk-!-margin-bottom-1">
-            <a class="govuk-link" href="/government/history/past-foreign-secretaries/william-grenville">
-              William Wyndham Grenville, Lord Grenville
-            </a>
-          </p>
-          <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0 term">1791 to 1801</p>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: "/government/history/past-foreign-secretaries/william-grenville",
+            image_src: image_path("history/past-foreign-secretaries/lord-grenville.jpg"),
+            image_alt: "William Wyndham Grenville, Lord Grenville",
+            heading_text: "William Wyndham Grenville, Lord Grenville",
+            description: "1791 to 1801",
+          } %>
         </div>
       </li>
     </ol>

--- a/app/views/shared/_featured.html.erb
+++ b/app/views/shared/_featured.html.erb
@@ -8,37 +8,19 @@
       extra_class
     end
   image_size ||= :s300
-  show_meta ||= false
 %>
 <%= content_tag_for(:article, feature, nil, class: extra_classes.strip) do %>
   <div class="content">
-    <span class="image-holder">
-      <% if feature.offsite_link %>
-        <% feature_title = feature.title %>
-      <% else %>
-        <% feature_title = I18n.t("document.read", title: feature.title) %>
-      <% end %>
-      <%= link_to image_tag(feature.image(image_size), {class: 'featured-image', alt: feature.alt_text}), feature.public_path, class: 'img', tabindex: '-1', aria: {hidden:true} %>
-    </span>
-    <div class="text">
-      <% if show_meta %>
-        <p class="meta">
-          <% if feature.topical_event %>
-            <%= absolute_date(feature.time_stamp) %>
-          <% else %>
-            <% if feature.time_stamp %>
-              <%= absolute_date(feature.time_stamp) %><span <%= t_lang('document.type.' + feature.display_type_key, {count: 1}) %> > &mdash; <%= t_display_type feature %></span>
-            <% else %>
-              <span <%= t_lang('document.type.' + feature.display_type_key, {count: 1}) %> ><%= t_display_type feature %></span>
-            <% end %>
-          <% end %>
-        </p>
-      <% end %>
-      <% rel = is_external?(feature.public_path) ? "external" : "internal" %>
-      <h2><%= link_to feature.title, feature.public_path, rel: "#{rel}", class: "govuk-link" %></h2>
-      <% unless feature.summary.blank? %>
-        <p class="summary"><%= truncate(feature.summary, length: 160, separator: ' ') %></p>
-      <% end %>
-    </div>
+    <%= render "govuk_publishing_components/components/image_card", {
+      href: feature.public_path,
+      image_src: feature.image(image_size),
+      image_alt: feature.alt_text,
+      context: {
+        date: feature.time_stamp,
+        text: t_display_type(feature),
+      },
+      heading_text: feature.title,
+      description: truncate(feature.summary, length: 160, separator: ' '),
+    } %>
   </div>
 <% end %>

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -24,10 +24,9 @@
       <section class="featured-news items-<%= @feature_list.current_feature_count %>" id="featured-documents">
         <% if @feature_list.any_current_features? %>
           <%= render partial: 'shared/featured',
-                     collection: @feature_list.current_featured,
-                     as: :feature,
-                     locals: { show_meta: true,
-                               extra_class: "secondary" } %>
+            collection: @feature_list.current_featured,
+            as: :feature
+          %>
         <% end %>
 
         <%= render partial: 'shared/recently_updated',

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -27,10 +27,9 @@
       <section class="featured-news items-<%= @feature_list.current_feature_count %>" id="featured-documents">
         <% if @feature_list.any_current_features? %>
           <%= render partial: 'shared/featured',
-                     collection: @feature_list.current_featured,
-                     as: :feature,
-                     locals: { show_meta: true,
-                               extra_class: "secondary" } %>
+            collection: @feature_list.current_featured,
+            as: :feature
+          %>
         <% end %>
 
         <%= render partial: 'shared/recently_updated',

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -118,7 +118,7 @@ Then(/^I should see the featured (documents|offsite links) in the "([^"]*)" topi
   table = rows.collect do |row|
     [
       row.find("h2").text.strip,
-      File.basename(row.find(".featured-image")["src"]),
+      File.basename(row.find(".gem-c-image-card__image")["src"]),
     ]
   end
   expected_table.diff!(table)

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -130,7 +130,7 @@ Then(/^I should see the featured items of the (?:world location|international de
   table = rows.collect do |row|
     [
       row.find("h2").text.strip,
-      File.basename(row.find(".featured-image")["src"]),
+      File.basename(row.find(".gem-c-image-card__image")["src"]),
     ]
   end
   expected_table.diff!(table)


### PR DESCRIPTION
## What
Replace bespoke components with the [image card component](https://components.publishing.service.gov.uk/component-guide/image_card) where appropriate.

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

There are several places where this component could've theoretically been used but I made the choice to leave it alone. These reasons include:

- Strict data structure that doesn't lend itself to the flat data structure of the publishing component and would be too large a job to unpick as part of this PR. A perfect example is the [Person class](https://github.com/alphagov/whitehall/blob/master/app/presenters/person_presenter.rb) which is a candidate for the image card but is spitting out html in its calls and is used heavily across the app.
- Inability to replicate locally. There are several locations where image cards could be used but are very difficult to replicate locally due to a laundry list of specific needs. [Example page](https://www.gov.uk/world/france/news). I've made the choice after banging my head against these pages for a day or so to leave them be in the interest of progressing this work.

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

### Pages tested against
- https://www.gov.uk/government/history/past-foreign-secretaries
- https://www.gov.uk/world/france/news
- https://www.gov.uk/world/uk-mission-to-the-wto-un-and-other-international-organisations-geneva

## Visual changes
Visual changes here are negligible and principally boil down to slight spacing difference. The example below is illustrative of all locations where this change has taken place.

### Before
![Screenshot 2021-02-23 at 16 57 50](https://user-images.githubusercontent.com/64783893/109178578-e798c480-7780-11eb-8867-9b38c59dc12a.png)
![Screenshot 2021-03-04 at 16 04 28](https://user-images.githubusercontent.com/64783893/109992715-736f9b00-7d03-11eb-92f9-f3ca3416cb1f.png)

### After
![Screenshot 2021-02-23 at 16 57 32](https://user-images.githubusercontent.com/64783893/109178592-eb2c4b80-7780-11eb-9c43-f3d42f41b5b7.png)
![Screenshot 2021-03-04 at 16 04 18](https://user-images.githubusercontent.com/64783893/109992731-78344f00-7d03-11eb-99f4-09a1ce951072.png)
