### PR TITLE
Use lead paragraph component

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -18,6 +18,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/lead-paragraph';
 @import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/organisation-logo';
 @import 'govuk_publishing_components/components/subscription-links';

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -8,7 +8,9 @@
     } %>
 
     <% unless @is_during_reshuffle %>
-      <p class="govuk-body-l">Read biographies and responsibilities of <a href="#cabinet-ministers" class="govuk-link">Cabinet ministers</a> and all <a href="#ministers-by-department" class="govuk-link">ministers by department</a>, as well as the <a href="#whips" class="govuk-link">whips</a> who help co-ordinate parliamentary business.</p>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: sanitize("Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.")
+      } %>
     <% end %>
   </div>
 </header>


### PR DESCRIPTION
## What
Use the [lead paragraph component](https://components.publishing.service.gov.uk/component-guide/lead_paragraph) on the [ministers page](https://www.gov.uk/government/ministers).

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

### Pages tested against
- https://www.gov.uk/government/ministers

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

No visual changes.