### PR TITLE
Use list component on how government works and foreign secretary profiles

### DIFF
--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -33,11 +33,14 @@
 
             <p class="govuk-body">The Prime Minister also:</p>
 
-            <ul class="govuk-list govuk-list--bullet">
-              <li>oversees the operation of the Civil Service and government agencies</li>
-              <li>appoints members of the government</li>
-              <li>is the principal government figure in the House of Commons</li>
-            </ul>
+            <%= render "govuk_publishing_components/components/list", {
+              visible_counters: true,
+              items: [
+                "oversees the operation of the Civil Service and government agencies",
+                "appoints members of the government",
+                "is the principal government figure in the House of Commons",
+              ]
+            } %>
 
             <% if @prime_minister.present? %>
               <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister), class: "govuk-link" %>.</p>
@@ -230,12 +233,15 @@
 
             <p class="govuk-body">Around half of all civil servants provide services direct to the public, including:</p>
 
-            <ul class="govuk-list govuk-list--bullet">
-              <li>paying benefits and pensions</li>
-              <li>running employment services</li>
-              <li>staffing prisons</li>
-              <li>issuing driving licences</li>
-            </ul>
+            <%= render "govuk_publishing_components/components/list", {
+              visible_counters: true,
+              items: [
+                "paying benefits and pensions",
+                "running employment services",
+                "staffing prisons",
+                "issuing driving licences",
+              ]
+            } %>
 
             <p class="govuk-body">The <%= link_to "Civil Service", "/government/organisations/civil-service", class: "govuk-link" %> is on GOV.UK.</p>
           </div>

--- a/app/views/past_foreign_secretaries/austen_chamberlain.html.erb
+++ b/app/views/past_foreign_secretaries/austen_chamberlain.html.erb
@@ -40,10 +40,13 @@
       <p class="govuk-body">Austen Chamberlain had a number of strengths, but some of these had unfortunate consequences. He behaved with integrity, but was taken by surprise when others failed to do so. He was intrinsically loyal, but would often back particularly unpopular people, or give too much leeway to people he liked, such as French Foreign Minister Briand. He fostered good relations with the French, who trusted him, but was dismissive of the Americans. His attention to detail included a desire for control that meant that he undermined others, such as his colleague Robert Cecil. In effect, he was very supportive and helpful to friends, but effectively blind to everything and everyone else.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Austen Chamberlain: Gentleman in politics by David Dutton (Ross Anderson Publications, 1985)</li>
-        <li>Choose Your Weapons by Douglas Hurd (Orion Books, 2010)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Austen Chamberlain: Gentleman in politics by David Dutton (Ross Anderson Publications, 1985)",
+          "Choose Your Weapons by Douglas Hurd (Orion Books, 2010)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/charles_fox.html.erb
+++ b/app/views/past_foreign_secretaries/charles_fox.html.erb
@@ -33,13 +33,16 @@
 
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>William Pitt the Younger by W Hague (London, 2005)</li>
-        <li>Charles James Fox by L G Mitchell (Oxford, 1997)</li>
-        <li>Entry for Charles James Fox in Oxford Dictionary of National Biography by L G Mitchell</li>
-        <li>The Foreign Office by Sir J Tilley and S. Gaselee (London, 1933)</li>
-        <li>The Cambridge History of British Foreign Policy: 1783–1919 by Sir A W Ward and G P Gooch (eds), (Cambridge, 1922)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "William Pitt the Younger by W Hague (London, 2005)",
+          "Charles James Fox by L G Mitchell (Oxford, 1997)",
+          "Entry for Charles James Fox in Oxford Dictionary of National Biography by L G Mitchell",
+          "The Foreign Office by Sir J Tilley and S. Gaselee (London, 1933)",
+          "The Cambridge History of British Foreign Policy: 1783–1919 by Sir A W Ward and G P Gooch (eds), (Cambridge, 1922)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/edward_grey.html.erb
+++ b/app/views/past_foreign_secretaries/edward_grey.html.erb
@@ -44,12 +44,15 @@
 
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)</li>
-        <li>Sir Edward Grey by Keith Robbins (1971)</li>
-        <li>The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)</li>
-        <li>Grey of Fallodon by GM Trevelyan (1937)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)",
+          "Sir Edward Grey by Keith Robbins (1971)",
+          "The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)",
+          "Grey of Fallodon by GM Trevelyan (1937)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/edward_wood.html.erb
+++ b/app/views/past_foreign_secretaries/edward_wood.html.erb
@@ -41,12 +41,15 @@
       <p class="govuk-body">Halifax remained as Foreign Secretary and has been identified with various peacemaking initiatives in the summer of 1940. Churchill then decided he wanted Eden back as Foreign Secretary and in January 1941 Halifax was persuaded to take up the ambassadorship to Washington. There, after an initially hesitant start, he formed a strong working relationship with President Roosevelt and remained until May 1946.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Halifax: The Life of Lord Halifax, by The Earl of Birkenhead (London, 1965)</li>
-        <li>Chamberlain and the Lost Peace by John Charmley (London, 1989)</li>
-        <li>The Holy Fox: A biography of Lord Halifax by Andrew Roberts (Bath, 1991)</li>
-        <li>An entry in the Oxford Dictionary of National Biography by DJ Dutton (2008)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Halifax: The Life of Lord Halifax, by The Earl of Birkenhead (London, 1965)",
+          "Chamberlain and the Lost Peace by John Charmley (London, 1989)",
+          "The Holy Fox: A biography of Lord Halifax by Andrew Roberts (Bath, 1991)",
+          "An entry in the Oxford Dictionary of National Biography by DJ Dutton (2008)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/george_curzon.html.erb
+++ b/app/views/past_foreign_secretaries/george_curzon.html.erb
@@ -38,14 +38,17 @@
       <p class="govuk-body">The relationship between Curzon and the Prime Minister was beyond repair, but by now others shared his frustration with Lloyd George. Conservative backbenchers voted to end the coalition, forcing Lloyd George to stand down. Andrew Bonar Law formed a new Conservative administration, retaining Curzon as Foreign Secretary, who operated much more independently. After Bonar Law&rsquo;s resignation in May 1923, Curzon was passed over for the job of Prime Minister in favour of Stanley Baldwin. Curzon remained as Foreign Secretary until January 1924, when the Conservative administration left office.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Curzon and British Imperialism in the Middle East, 1916-19 by John Fisher, (London, 1999)</li>
-        <li>Curzon by David Gilmour (London, 1994)</li>
-        <li>Lord Curzon: The Last of the British Moguls by Nayana Goradia (Oxford, 1993)</li>
-        <li>The Foreign Office and Foreign Policy, 1919-1926 by Ephraim Maisel (Brighton, 1994)</li>
-        <li>Curzon: The End of an Epoch by Leonard Mosley (London, 1960)</li>
-        <li>Curzon: The Last Phase, 1919-25 by Harold Nicholson (London, 1934)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Curzon and British Imperialism in the Middle East, 1916-19 by John Fisher, (London, 1999)",
+          "Curzon by David Gilmour (London, 1994)",
+          "Lord Curzon: The Last of the British Moguls by Nayana Goradia (Oxford, 1993)",
+          "The Foreign Office and Foreign Policy, 1919-1926 by Ephraim Maisel (Brighton, 1994)",
+          "Curzon: The End of an Epoch by Leonard Mosley (London, 1960)",
+          "Curzon: The Last Phase, 1919-25 by Harold Nicholson (London, 1934)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/george_gordon.html.erb
+++ b/app/views/past_foreign_secretaries/george_gordon.html.erb
@@ -35,10 +35,13 @@
       <p class="govuk-link">The treaties negotiated during his terms as Foreign Secretary, were seen as flawed, especially those with America because they give away too much Canadian territory. His speeches were not memorable or highly regarded. In fact he was a particularly bad public speaker, often inaudible, even when he held strong opinions on the policy in question. What he achieved was an improvement in foreign relations with America and France (at least initially).</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Lord Aberdeen, a political biography by Muriel Chamberlain (Longman Group Limited, 1983)</li>
-        <li>Choose Your Weapons by Douglas Hurd (Orion Books, 2010)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Lord Aberdeen, a political biography by Muriel Chamberlain (Longman Group Limited, 1983)",
+          "Choose Your Weapons by Douglas Hurd (Orion Books, 2010)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/george_gower.html.erb
+++ b/app/views/past_foreign_secretaries/george_gower.html.erb
@@ -36,10 +36,13 @@
       <p class="govuk-body">Granville&rsquo;s career faded disappointingly in 1885 as the public laid the blame for both the loss of the Sudan and the death of the hugely popular General Gordon at his feet. When Gladstone&rsquo;s government returned briefly to power in 1886 he was only offered the Colonial Office.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>entry for Granville George Leveson Gower in Oxford Dictionary of National Biography  by ME Chamberlain (Oxford University Press, 2004–10)</li>
-        <li>The Life of Granville George Leveson Gower, Second Earl Granville, 2 vols by Lord Edmund Fitzmaurice (Longmans, Green, &amp; Co., 1905)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "entry for Granville George Leveson Gower in Oxford Dictionary of National Biography  by ME Chamberlain (Oxford University Press, 2004–10)",
+          "The Life of Granville George Leveson Gower, Second Earl Granville, 2 vols by Lord Edmund Fitzmaurice (Longmans, Green, &amp; Co., 1905)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/henry_petty_fitzmaurice.html.erb
+++ b/app/views/past_foreign_secretaries/henry_petty_fitzmaurice.html.erb
@@ -39,13 +39,16 @@
       <p class="govuk-body">However this success brought its own problems. Although intended as a colonial settlement the entente pulled Britain further into European affairs. Lansdowne&rsquo;s success in bringing Britain out of isolation was achieved at the unintended cost of increasing Germany&rsquo;s own sense of isolation within Europe. Germany now replaced Russia as Britain&rsquo;s main cause for concern in foreign affairs.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Lord Lansdowne: A Biography by Lord Newton (London, 1929)</li>
-        <li>The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)</li>
-        <li>The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)</li>
-        <li>An entry in the Oxford Dictionary of National Biography by Andrew Adonis  (2004)</li>
-        <li>British Documents on the Origins of the War, 1898–1914, by GP Gooch and H Temperley</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Lord Lansdowne: A Biography by Lord Newton (London, 1929)",
+          "The End of Isolation: British Foreign Policy 1900-1907 by George Monger (London, 1963)",
+          "The Foreign Office and Foreign Policy, 1898-1914 by Zara Steiner (London, 1969)",
+          "An entry in the Oxford Dictionary of National Biography by Andrew Adonis (2004)",
+          "British Documents on the Origins of the War, 1898–1914, by GP Gooch and H Temperley",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/robert_cecil.html.erb
+++ b/app/views/past_foreign_secretaries/robert_cecil.html.erb
@@ -35,14 +35,17 @@
       <p class="govuk-body">Nevertheless, his tenure saw a huge expansion of imperial territory, including Nigeria, New Guinea, Rhodesia, Upper Burma, Zanzibar and the Transvaal. He fended off German and French endeavours in East and West Africa respectively in the face of the Franco-Russian Alliance without war, and having only to lean to the triple Alliance. His was a policy of engagement with room to manoeuvre. In 1864, Salisbury lamented Britain's position &ldquo;without a single ally and without a shred of influence&rdquo;. By 1900, Britain was still without an ally, singularly thanks to Salisbury, but without influence she was not.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Choose Your Weapons: The British Foreign Secretary, 200 Years of Argument Success and Failure by D Hurd (London, 2010)</li>
-        <li>Salisbury 1830–1903: Portrait of a Statesman by AL Kennedy (London, 1953)</li>
-        <li>‘The Principles and Methods of Lord Salisbury's Foreign Policy’ in the Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106, LM Penson ‘The Principles and Methods of Lord Salisbury’s Foreign Policy’ in Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106</li>
-        <li>Salisbury: Victorian Titan, A Roberts (London, 1999)</li>
-        <li>‘Cecil, Robert Arthur Talbot Gascoyne’ in Oxford Dictionary of National Biography by P. Smith, (Oxford, 2004)</li>
-        <li>Lord Salisbury: A Political Biography by D Steele (UCL, 1999)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Choose Your Weapons: The British Foreign Secretary, 200 Years of Argument Success and Failure by D Hurd (London, 2010)",
+          "Salisbury 1830–1903: Portrait of a Statesman by AL Kennedy (London, 1953)",
+          "‘The Principles and Methods of Lord Salisbury's Foreign Policy’ in the Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106, LM Penson ‘The Principles and Methods of Lord Salisbury’s Foreign Policy’ in Cambridge Historical Journal Vol. 5 No. 1 (1935), p.87-106",
+          "Salisbury: Victorian Titan, A Roberts (London, 1999)",
+          "‘Cecil, Robert Arthur Talbot Gascoyne’ in Oxford Dictionary of National Biography by P. Smith, (Oxford, 2004)",
+          "Lord Salisbury: A Political Biography by D Steele (UCL, 1999)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>

--- a/app/views/past_foreign_secretaries/william_grenville.html.erb
+++ b/app/views/past_foreign_secretaries/william_grenville.html.erb
@@ -33,12 +33,15 @@
       <p class="govuk-body">In 1802 Grenville broke with Pitt, following the Treaty of Amiens with France, and formed his own opposition group. Grenville allied himself with Charles James Fox and briefly led the &lsquo;Ministry of all the Talents&rsquo; in 1806 to 1807 which secured the abolition of the slave trade.</p>
 
       <h3 class="govuk-heading-s govuk-!-margin-0">Further reading</h3>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>The Influence of Grenville on Pitt’s Foreign Policy: 1787–1798, by E Douglass Adams (Carnegie Institute of Washington, 1904)</li>
-        <li>William Pitt the Younger by W Hague (Harper Perennial, 2005)</li>
-        <li>Lord Grenville: 1758–1834 by P Jupp (OUP, 1985)</li>
-        <li>Entry in Oxford Dictionary of National Biography by P Jupp (OUP, 2004–10)</li>
-      </ul>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "The Influence of Grenville on Pitt’s Foreign Policy: 1787–1798, by E Douglass Adams (Carnegie Institute of Washington, 1904)",
+          "William Pitt the Younger by W Hague (Harper Perennial, 2005)",
+          "Lord Grenville: 1758–1834 by P Jupp (OUP, 1985)",
+          "Entry in Oxford Dictionary of National Biography by P Jupp (OUP, 2004–10)",
+        ]
+      } %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
## What
Replace instances of html lists with the [list component](https://components.publishing.service.gov.uk/component-guide/list).

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

### Pages tested against
- https://www.gov.uk/government/how-government-works
- https://www.gov.uk/government/history/past-foreign-secretaries/charles-fox

No visual changes.