### PR TITLE
Use the title component on email signup information pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_email-signup-information.scss
+++ b/app/assets/stylesheets/frontend/views/_email-signup-information.scss
@@ -1,14 +1,4 @@
 .email-signup-information-show {
-  h1 {
-    @include heading-48;
-    font-weight: bold;
-    margin-top: $gutter;
-
-    @include media(tablet) {
-      margin: ($gutter * 2) 0 $gutter-half;
-    }
-  }
-
   h2 {
     @include heading-24;
     font-weight: bold;

--- a/app/views/email_signup_information/show.html.erb
+++ b/app/views/email_signup_information/show.html.erb
@@ -2,10 +2,11 @@
 <% page_class "email-signup-information-show" %>
 
 <div class="inner-block">
-  <h1>
-    <div class='category'>Email alert subscription</div>
-    <%= @email_signup_information.title %>
-  </h1>
+  <%= render "govuk_publishing_components/components/title", {
+    context: "Email alert subscription",
+    title: @email_signup_information.title,
+    margin_bottom: 4,
+  } %>
 </div>
 
 <div class="inner-block">


### PR DESCRIPTION
## What
Replaces the title on the email signup info view ([example](https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup)) with the [title component](https://components.publishing.service.gov.uk/component-guide/title).

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

## Visual changes
### Before
![Screenshot 2021-03-01 at 15 52 16](https://user-images.githubusercontent.com/64783893/109526183-35c40580-7aaa-11eb-9ec0-5623606b38d4.png)

### After
![Screenshot 2021-03-01 at 15 52 08](https://user-images.githubusercontent.com/64783893/109526202-39578c80-7aaa-11eb-8ffb-eb58389e1302.png)
