### PR TITLE
Create manual reslugging db migration for guidance document

### DIFF
--- a/db/data_migration/20210302154339_reslug_list_of_countries_accepted_towards_issuing_a_uk_cec.rb
+++ b/db/data_migration/20210302154339_reslug_list_of_countries_accepted_towards_issuing_a_uk_cec.rb
@@ -1,0 +1,10 @@
+document = Document.find_by_content_id("28a17ff2-bc8e-4237-a8f1-6ac290d9b6eb")
+
+edition = document.editions.published.last
+Whitehall::SearchIndex.delete(edition)
+
+document.update!(slug: "list-of-countries-accepted-towards-issuing-a-uk-FSE")
+
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+Whitehall::SearchIndex.add(edition)


### PR DESCRIPTION
## What
Manual DB migration to reslug [this page](https://www.gov.uk/guidance/list-of-countries-accepted-towards-issuing-a-uk-cec) to [this URL](https://www.gov.uk/guidance/list-of-countries-accepted-towards-issuing-a-uk-FSE).

## Why
Required for [this ticket](https://govuk.zendesk.com/agent/tickets/4484109). The child slug of the 2nd URL is being used [here](https://whitehall-admin.publishing.service.gov.uk/government/admin/publications/1094608) which is [upsetting the reslug rake task](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/223246/console).