### PR TITLE
Increase Asset Manager timeout to 60s

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -15,6 +15,7 @@ module Services
     @asset_manager ||= GdsApi::AssetManager.new(
       Plek.find("asset-manager"),
       bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "12345678"),
+      timeout: 60,
     )
   end
 


### PR DESCRIPTION
We are finding that large attachments are not being uploaded to asset manager due to a timeout during the upload. Therefore increasing this from the [default 4s](https://github.com/alphagov/gds-api-adapters/blob/abb2f4c9d21550b311b1b107686239adccfc0f53/lib/gds_api/json_client.rb#L41) to 60s.

Depends on https://github.com/alphagov/govuk-puppet/pull/10968.

Trello card: https://trello.com/c/R2z5S45l