### PR TITLE
Update all pa-ur locales to pa-pk, and republish

### DIFF
--- a/db/data_migration/20210225103359_update_pa_ur_translations_to_pa_pk.rb
+++ b/db/data_migration/20210225103359_update_pa_ur_translations_to_pa_pk.rb
@@ -1,0 +1,9 @@
+translations = Edition::Translation.where(locale: "pa-ur")
+
+document_ids = Edition.distinct.where(id: translations.select(:edition_id)).pluck(:document_id)
+
+translations.update_all(locale: "pa-pk")
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+end


### PR DESCRIPTION
A small number of documents have been published with the incorrect locale tag `pa-ur`. Support for this is being removed.

This data migration updates to the new locale `pa-pk` and republishes.

[trello](https://trello.com/c/devOCero/2369-3-change-punjabi-pakistan-language-tag)