### PR TITLE
Migrate Attachments with pa-ur locale to pa-pk

### DIFF
--- a/db/data_migration/20210304152459_update_pa_ur_attachments_to_pa_pk.rb
+++ b/db/data_migration/20210304152459_update_pa_ur_attachments_to_pa_pk.rb
@@ -1,0 +1,9 @@
+attachments = Attachment.where(locale: "pa-ur")
+
+document_ids = Edition.distinct.where(id: attachments.select(:attachable_id)).pluck(:document_id)
+
+attachments.update_all(locale: "pa-pk")
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+end


### PR DESCRIPTION
This PR adds a data migration to update Attachments with the old `pa-ur` locale to the updated `pa-pk`

[trello](https://trello.com/c/devOCero/2369-3-change-punjabi-pakistan-language-tag)