### PR TITLE
Remove headline on govspeak

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -145,7 +145,6 @@ private
   def render_embedded_contacts(govspeak, heading_tag)
     return govspeak if govspeak.blank?
 
-    heading_tag ||= "h3"
     govspeak.gsub(Govspeak::EmbeddedContentPatterns::CONTACT) do
       if (contact = Contact.find_by(id: Regexp.last_match(1)))
         render(partial: "contacts/contact", locals: { contact: contact, heading_tag: heading_tag }, formats: %w[html])

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,5 +1,4 @@
 <%
-  heading_tag ||= 'h2'
   extra_class = []
   if local_assigns.include?(:contact_counter) and contact_counter % 3 == 0
     extra_class << "clear-contact"
@@ -10,9 +9,11 @@
 %>
 <%= content_tag_for(:div, contact, class: extra_class.join(' ')) do %>
   <div class="content" <%= lang if local_assigns[:lang] %> >
-    <% unless local_assigns[:hide_title] %><%= content_tag heading_tag, contact.title %><% end %>
 
     <div class="vcard contact-inner">
+      <% unless local_assigns[:hide_title] %>
+      <p><%= contact.title %></p>
+      <% end %>
       <% if contact.has_postal_address? %>
         <%= render_hcard_address(contact) %>
       <% end %>

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -111,7 +111,7 @@ end
 Then(/^I see the offices in my specified order including the new one under the main office on the home page of the worldwide organisation$/) do
   visit worldwide_organisation_path(@the_organisation)
 
-  contact_headings = all(".contact-us div.contact h2").map(&:text)
+  contact_headings = all(".contact-us div.contact div.vcard.contact-inner p:first-of-type:not(.email)").map(&:text)
 
   assert_equal @the_main_office.title, contact_headings[0]
   @the_ordered_offices.each.with_index do |contact, idx|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -112,7 +112,7 @@ Then(/^the "([^"]*)" office details should be shown on the public website$/) do 
   worldwide_office = worldwide_org.offices.joins(contact: :translations).where(contact_translations: { title: description }).first
 
   within "#{record_css_selector(worldwide_office)}.contact" do
-    assert_selector "h2", text: worldwide_office.contact.title
+    assert_selector "p:first-of-type", text: worldwide_office.contact.title
     within find(".vcard") do
       # new lines cause challenges in matching to the rendering
       address = worldwide_office.contact.street_address.gsub(/\s+/, " ")

--- a/test/unit/helpers/admin/admin_govspeak_helper_test.rb
+++ b/test/unit/helpers/admin/admin_govspeak_helper_test.rb
@@ -108,7 +108,7 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
     Contact.stubs(:find_by).with(id: "1").returns(contact)
     input = "[Contact:1]"
     output = govspeak_to_admin_html(input)
-    contact_html = render("contacts/contact", contact: contact, heading_tag: "h3")
+    contact_html = render("contacts/contact", contact: contact, heading_tag: "p")
     assert_equivalent_html "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
@@ -116,7 +116,7 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
     contact = build(:contact)
     Contact.stubs(:find_by).with(id: "1").returns(contact)
     input = "[Contact:1]"
-    contact_html = render("contacts/contact", contact: contact, heading_tag: "h3")
+    contact_html = render("contacts/contact", contact: contact, heading_tag: "p")
     @controller.lookup_context.formats = %i[atom]
     assert_nothing_raised do
       assert_equivalent_html "<div class=\"govspeak\">#{contact_html}</div>", govspeak_to_admin_html(input)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -360,7 +360,7 @@ class GovspeakHelperTest < ActionView::TestCase
     Contact.stubs(:find_by).with(id: "1").returns(contact)
     input = "[Contact:1]"
     output = govspeak_to_html(input)
-    contact_html = render("contacts/contact", contact: contact, heading_tag: "h3")
+    contact_html = render("contacts/contact", contact: contact, heading_tag: "p")
     assert_equivalent_html "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
@@ -368,8 +368,8 @@ class GovspeakHelperTest < ActionView::TestCase
     contact = build(:contact)
     Contact.stubs(:find_by).with(id: "1").returns(contact)
     input = "[Contact:1]"
-    output = govspeak_to_html(input, [], contact_heading_tag: "h4")
-    contact_html = render("contacts/contact", contact: contact, heading_tag: "h4")
+    output = govspeak_to_html(input, [], contact_heading_tag: "p")
+    contact_html = render("contacts/contact", contact: contact, heading_tag: "p")
     assert_equivalent_html "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
@@ -384,7 +384,7 @@ class GovspeakHelperTest < ActionView::TestCase
     contact = build(:contact)
     Contact.stubs(:find_by).with(id: "1").returns(contact)
     input = "[Contact:1]"
-    contact_html = render("contacts/contact", contact: contact, heading_tag: "h3")
+    contact_html = render("contacts/contact", contact: contact, heading_tag: "p")
     @controller.lookup_context.formats = %i[atom]
     assert_nothing_raised do
       assert_equivalent_html "<div class=\"govspeak\">#{contact_html}</div>", govspeak_to_html(input)


### PR DESCRIPTION
## What?

Altering headline on Contact address while using `govspeak` 

## Why?

This could appear anywhere in the page and therefore the heading tag might not be in a logical order causing an a11y issue.

## How to test

On the Whitehall publisher App:
[Integration Link](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/news/new)
[Dev link](http://whitehall-admin.dev.gov.uk/government/admin/news/new)

Use something like: `u[Contact:1]` in body to create a new Contact snippet and preview the result.

## Visuals 

After > Before
![Screenshot 2021-03-08 at 17 16 40](https://user-images.githubusercontent.com/71266765/110359208-1d696300-8035-11eb-8ee8-b64545c3f9f4.png)

## Anything else?

Other examples appear here:

[`/world/organisations/british-antarctic-territory`](https://www.gov.uk/world/organisations/british-antarctic-territory) ([Dev link)](http://whitehall-frontend.dev.gov.uk/world/organisations/british-antarctic-territory)

Before > After
![image](https://user-images.githubusercontent.com/71266765/110517667-0db85000-8103-11eb-9f0e-a43cdb20f7de.png)

[Related PR](https://github.com/alphagov/govspeak/pull/206)