### PR TITLE
Replace the prev/next and document list patterns with components gem on "latest" view

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -11,6 +11,7 @@ $govuk-use-legacy-palette: false;
 
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/contents-list';
+@import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
@@ -23,6 +24,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/organisation-logo';
 @import 'govuk_publishing_components/components/share-links';
+@import 'govuk_publishing_components/components/previous-and-next-navigation';
 @import 'govuk_publishing_components/components/subscription-links';
 @import 'govuk_publishing_components/components/title';
 
@@ -160,8 +162,8 @@ $govuk-use-legacy-palette: false;
 // When removing ensure all cases are captured - some rules in helpers/_headings.scss
 // are very specific, requiring the !important here
 #whitehall-wrapper {
-  a.govuk-link:not(.gem-c-title__context-link),
-  a[class^="gem-c-"]:not(.gem-c-title__context-link) {
+  a.govuk-link:not(.gem-c-title__context-link):not(.gem-c-pagination__link),
+  a[class^="gem-c-"]:not(.gem-c-title__context-link):not(.gem-c-pagination__link) {
     text-decoration: underline;
 
     &:focus,

--- a/app/assets/stylesheets/frontend/global/_links.scss
+++ b/app/assets/stylesheets/frontend/global/_links.scss
@@ -1,4 +1,4 @@
-a {
+a:not(a[class^="gem-c-"]) {
   color: $govuk-link-colour;
   text-decoration: none;
 

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,11 +6,25 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<%= paginator.render do -%>
-  <nav id="show-more-documents" role="navigation">
-    <ul class="previous-next-navigation">
-      <%= prev_page_tag unless current_page.first? %>
-      <%= next_page_tag unless current_page.last? %>
-    </ul>
-  </nav>
-<% end -%>
+
+<%
+  nav = {}
+
+  unless current_page.last?
+    nav[:next_page] = {
+      url: paginator.next_page_tag.url,
+      title: "Next page",
+      label: "#{current_page + 1} of #{total_pages}"
+    }
+  end
+
+  unless current_page.first?
+    nav[:previous_page] = {
+      url: paginator.prev_page_tag.url,
+      title: "Previous page",
+      label: "#{current_page - 1} of #{total_pages}"
+    }
+  end
+%>
+
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", nav %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
+
 <% text = "Previous <span class='visuallyhidden'>page</span> <span class='page-numbers'>#{current_page - 1} of #{total_pages}</span>".html_safe %>
 <li class="previous"><%= link_to_unless current_page.first?, text, url, rel: "prev" %></li>

--- a/app/views/latest/_rummager_documents.html.erb
+++ b/app/views/latest/_rummager_documents.html.erb
@@ -1,21 +1,16 @@
-<ol class="document-list">
-  <% documents.each do |document| %>
-    <li class="document-row">
-      <h3><%= link_to document.title, document.link %></h3>
-      <ul class="attributes">
-        <li class="date">
-          <%= document.publication_date %>
-        </li>
-        <li class="display-type"><%= document.display_type %></li>
-
-        <% if document.organisations.present? %>
-          <li class="organisations"><%= document.organisations.html_safe %></li>
-        <% end %>
-
-        <% if document.publication_collections.present? %>
-          <li class="document-collections"><%= document.publication_collections.html_safe %></li>
-        <% end %>
-      </ul>
-    </li>
-  <% end %>
-</ol>
+<%= render "govuk_publishing_components/components/document_list", {
+  items: documents.map do |document|
+    {
+      link: {
+        text: document.title,
+        path: document.link,
+      },
+      metadata: {
+        publication_date: document.publication_date,
+        display_type: document.display_type,
+        organisations: document.organisations.present? ? raw(document.organisations.html_safe) : nil,
+        document_collections: document.publication_collections.present? ? raw(document.publication_collections.html_safe) : nil,
+      },
+    }
+  end
+} %>

--- a/features/step_definitions/latest_document_steps.rb
+++ b/features/step_definitions/latest_document_steps.rb
@@ -19,10 +19,10 @@ end
 Then(/^I see all documents for that topical event with the most recent first$/) do
   docs = sample_document_types_and_titles
 
-  within(".document-list") do
-    assert_equal(body.scan("document-row").length, docs.length, "Can't see all the documents for the topical event")
+  within(".gem-c-document-list") do
+    assert_equal(all(".gem-c-document-list__item").length, docs.length, "Can't see all the documents for the topical event")
     docs.each_value do |title|
-      assert_selector ".document-row", text: title
+      assert_selector ".gem-c-document-list__item", text: title
     end
   end
 end


### PR DESCRIPTION
## What
Adds 2 components to the "latest" view:

- [The prev/next component](https://components.publishing.service.gov.uk/component-guide/previous_and_next_navigation)
- [The document list component](https://components.publishing.service.gov.uk/component-guide/document_list)

## Why
This is part of work by the govuk accessibility team to replace bespoke components with our supported publishing components in frontend apps to reduce the risk of tech debt, bugs and accessibility issues creeping into our apps.

[Page developed against](https://www.gov.uk/government/latest?page=11&world_locations%5B%5D=china)

[Card](https://trello.com/c/Q4tNd2Hx/593-use-components-in-whitehall)

## Visual changes
### Before
![Screenshot 2021-03-11 at 16 00 09](https://user-images.githubusercontent.com/64783893/110822666-323e3480-8289-11eb-8952-2dd20fc3ff0b.png)
![Screenshot 2021-03-11 at 16 00 48](https://user-images.githubusercontent.com/64783893/110822677-35d1bb80-8289-11eb-8be8-65f4157d4d64.png)

### After
![Screenshot 2021-03-11 at 16 00 31](https://user-images.githubusercontent.com/64783893/110822695-3a966f80-8289-11eb-9614-adc38586c9a7.png)
![Screenshot 2021-03-11 at 16 01 06](https://user-images.githubusercontent.com/64783893/110822708-3cf8c980-8289-11eb-9993-f9f60e1d97c0.png)
