### PR TITLE
Remove unused pluralisation keys from locale files

### DIFF
--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -111,7 +111,6 @@ az:
     headings:
       applies_to_nations: tətbiq olunur
       attachments:
-        one:
         other:
       from:
       location:
@@ -133,10 +132,8 @@ az:
         one: Elan
         other: Elanlar
       authored_article:
-        one:
         other:
       blog_post:
-        one:
         other:
       case_study:
         one: Öyrənilib
@@ -157,7 +154,6 @@ az:
         one: Yazışmalar
         other: Yazışmalar
       decision:
-        one:
         other:
       detailed_guidance:
         one: ətraflı məlumat
@@ -175,7 +171,6 @@ az:
         one: Forma
         other: Formalar
       government_response:
-        one:
         other:
       guidance:
         one: İnstruksiya
@@ -184,16 +179,13 @@ az:
         one: Dəyərləndirmə
         other: Dəyərləndirmə
       imported:
-        one:
         other:
       independent_report:
         one: Müstəqil məruzə
         other: Müstəqil məruzələr
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: Xəritə
@@ -208,10 +200,8 @@ az:
         one: Xəbərlər
         other: Xəbərlər
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: statistika
@@ -235,7 +225,6 @@ az:
         one: Nəşrlər
         other: Nəşrlər
       regulation:
-        one:
         other:
       research:
         one: Tətqiqat və analiz
@@ -253,7 +242,6 @@ az:
         one: statistik məlumatlar bazası
         other: statistik məlumatlar bazaları
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Transkripsiya
@@ -262,7 +250,6 @@ az:
         one: Şəffaf məlumat
         other: Şəffaf məlumat
       world_news_story:
-        one:
         other:
       written_statement:
         one: Parlamentə yazılı müraciət
@@ -420,7 +407,6 @@ az:
         one: Beynəlxalq nümayəndəlik
         other: Beynəlxalq nümayəndəliklər
       world_location:
-        one:
         other:
   worldwide_organisation:
     corporate_information:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -129,130 +129,96 @@ az:
       written_on:
     type:
       announcement:
-        one: Elan
         other: Elanlar
       authored_article:
         other:
       blog_post:
         other:
       case_study:
-        one: Öyrənilib
         other: Öyrənilib
       closed_consultation:
-        one: Bağlı məslətləşmə
         other: Bağlı məslətləşmələr
       consultation:
-        one: Məsləhət
         other: məsləhətləşmələr
       consultation_outcome:
-        one: məsləhətləşmənin nəticəsi
         other: məsləhətləşmənin nəticələri
       corporate_report:
-        one: birgə məruzə
         other: birgə məruzələr
       correspondence:
-        one: Yazışmalar
         other: Yazışmalar
       decision:
         other:
       detailed_guidance:
-        one: ətraflı məlumat
         other: ətraflı məlumat
       document_collection:
-        one: növlər
         other:
       draft_text:
-        one: hazırlanmış mətn
         other: hazırlanmış mətn
       foi_release:
-        one: Məlumat azadlığı ilə bağlı açıqlama
         other: Məlumat azadlığı ilə bağlı açıqlamalar
       form:
-        one: Forma
         other: Formalar
       government_response:
         other:
       guidance:
-        one: İnstruksiya
         other: İnstruksiya
       impact_assessment:
-        one: Dəyərləndirmə
         other: Dəyərləndirmə
       imported:
         other:
       independent_report:
-        one: Müstəqil məruzə
         other: Müstəqil məruzələr
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: Xəritə
         other: xəritələr
       national_statistics:
-        one: Statistika - milli statistika
         other: Statistika - milli statistika
       news_article:
-        one: məqalə
         other: məqalələr
       news_story:
-        one: Xəbərlər
         other: Xəbərlər
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: statistika
         other: statistika
       open_consultation:
-        one: açıq məsləhətləşmələr
         other: açıq məsləhətləşmələr
       oral_statement:
-        one: Parliamentə açıq bəyanat
         other: Parlamentə açıq bəyanatlar
       policy_paper:
-        one: Siyasi sənədlər
         other: Siyasi sənədlər
       press_release:
-        one: mətbuat üçün açıqlama
         other: mətbuat üçün açıqlama
       promotional:
-        one: Təşviqedici materiallar
         other: Təşviqedici materiallar
       publication:
-        one: Nəşrlər
         other: Nəşrlər
       regulation:
         other:
       research:
-        one: Tətqiqat və analiz
         other: Tətqiqat və analiz
       speaking_notes:
-        one: Çıxış üçün  qeydləri
         other: Çıxış üçün  qeydləri
       speech:
-        one: çıxış
         other: Çıxışlar
       statement_to_parliament:
-        one: Parlamentə bəyanat
         other: Parlamentə bəyanatlar
       statistical_data_set:
-        one: statistik məlumatlar bazası
         other: statistik məlumatlar bazaları
       statutory_guidance:
         other:
       transcript:
-        one: Transkripsiya
         other: Transkripsiyalar
       transparency:
-        one: Şəffaf məlumat
         other: Şəffaf məlumat
       world_news_story:
         other:
       written_statement:
-        one: Parlamentə yazılı müraciət
         other: Parlamentə yazılı müraciət
     updated: yenilənib
     view:
@@ -404,7 +370,6 @@ az:
       statistics: Bizim statistika
     type:
       international_delegation:
-        one: Beynəlxalq nümayəndəlik
         other: Beynəlxalq nümayəndəliklər
       world_location:
         other:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -138,7 +138,6 @@ fa:
         one: مقاله
         other: مقالات
       blog_post:
-        one:
         other:
       case_study:
         one: مطالعه ی موردی
@@ -159,7 +158,6 @@ fa:
         one: مکاتبه
         other: مکاتبات
       decision:
-        one:
         other:
       detailed_guidance:
         one: راهنمای تفصیلی
@@ -192,10 +190,8 @@ fa:
         one: گزارش مستقل
         other: گزارش های مستقل
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: نقشه
@@ -210,10 +206,8 @@ fa:
         one: خبر
         other: اخبار
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: آمار
@@ -237,7 +231,6 @@ fa:
         one: نشریه
         other: نشریات
       regulation:
-        one:
         other:
       research:
         one: پژوهش و تحلیل
@@ -255,7 +248,6 @@ fa:
         one: بسته ی داده های آماری
         other: بسته های داده های آماری
       statutory_guidance:
-        one:
         other:
       transcript:
         one: رونوشت
@@ -264,7 +256,6 @@ fa:
         one: داده های شفاف سازی
         other: داده های شفاف سازی
       world_news_story:
-        one:
         other:
       written_statement:
         one: گزارش کتبی به پارلمان

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -113,7 +113,6 @@ fa:
     headings:
       applies_to_nations: در ارتباط با
       attachments:
-        one: مدرک
         other: مدارک
       from:
       location:
@@ -132,133 +131,96 @@ fa:
       written_on: 'نوشته شده در:'
     type:
       announcement:
-        one: اعلامیه
         other: اعلامیه ها
       authored_article:
-        one: مقاله
         other: مقالات
       blog_post:
         other:
       case_study:
-        one: مطالعه ی موردی
         other: مطالعه های موردی
       closed_consultation:
-        one: رایزنی بسته
         other: رایزنی های بسته
       consultation:
-        one: رایزنی
         other: رایزنی ها
       consultation_outcome:
-        one: نتیجه رایزنی
         other: نتایج رایزنی
       corporate_report:
-        one: گزارش سازمانی
         other: گزارش های سازمانی
       correspondence:
-        one: مکاتبه
         other: مکاتبات
       decision:
         other:
       detailed_guidance:
-        one: راهنمای تفصیلی
         other: راهنمای تفصیلی
       document_collection:
-        one: ردیف
         other:
       draft_text:
-        one: متن پیش نویس
         other: متون پیش نویس
       foi_release:
-        one: انتشار آزاد اطلاعات
         other: انتشار آزاد اطلاعات
       form:
-        one: فرم
         other: فرم ها
       government_response:
-        one: جوابیه دولت
         other: جوابیه های دولت
       guidance:
-        one: راهنمایی
         other: راهنمایی
       impact_assessment:
-        one: ارزیابی تاثیرات
         other: ارزیابی های تاثیرات
       imported:
-        one: منتقل شده - در انتظار دسته بندی
         other: منتقل شده - در انتظار دسته بندی
       independent_report:
-        one: گزارش مستقل
         other: گزارش های مستقل
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: نقشه
         other: نقشه ها
       national_statistics:
-        one: آمار - آمار ملی
         other: آمار - آمار ملی
       news_article:
-        one: مقاله ی خبری
         other: مقالات خبری
       news_story:
-        one: خبر
         other: اخبار
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: آمار
         other: آمار
       open_consultation:
-        one: رایزنی باز
         other: رایزنی های باز
       oral_statement:
-        one: گزارش شفاهی به پارلمان
         other: گزارش های شفاهی به پارلمان
       policy_paper:
-        one: مقاله ی سیاسی
         other: مقاله های سیاسی
       press_release:
-        one: بیانیه
         other: بیانیه ها
       promotional:
-        one: مطالب تبلیغاتی
         other: مطالب تبلیغاتی
       publication:
-        one: نشریه
         other: نشریات
       regulation:
         other:
       research:
-        one: پژوهش و تحلیل
         other: پژوهش و تحلیل
       speaking_notes:
-        one: موضوعات سخنرانی
         other: موضوعات سخنرانی
       speech:
-        one: سخنرانی
         other: سخنرانی ها
       statement_to_parliament:
-        one: گزارش به پارلمان
         other: گزارش ها به پارلمان
       statistical_data_set:
-        one: بسته ی داده های آماری
         other: بسته های داده های آماری
       statutory_guidance:
         other:
       transcript:
-        one: رونوشت
         other: رونوشت ها
       transparency:
-        one: داده های شفاف سازی
         other: داده های شفاف سازی
       world_news_story:
         other:
       written_statement:
-        one: گزارش کتبی به پارلمان
         other: گزارش های کتبی به پارلمان
     updated: به روز رسانی شده
     view: مشاهده '%{title}'
@@ -411,10 +373,8 @@ fa:
       statistics: آمار ما
     type:
       international_delegation:
-        one: هیأت بین المللی
         other: هیأت های بین المللی
       world_location:
-        one: موقعیت جهانی
         other: موقعیت های جهانی
   worldwide_organisation:
     corporate_information:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -138,7 +138,6 @@ id:
         one: Artikel yang ditulis
         other: Artikel-artikel yang ditulis
       blog_post:
-        one:
         other:
       case_study:
         one: Studi kasus
@@ -159,7 +158,6 @@ id:
         one: Koresponden
         other: Koresponden-koresponden
       decision:
-        one:
         other:
       detailed_guidance:
         one: Panduan lebih lanjut
@@ -192,10 +190,8 @@ id:
         one: Laporan independen
         other: Laporan-laporan independen
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: Peta
@@ -210,10 +206,8 @@ id:
         one: Berita
         other: Berita-berita
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: Statistik
@@ -237,7 +231,6 @@ id:
         one: Publikasi
         other: Publikasi-publikasi
       regulation:
-        one:
         other:
       research:
         one: Riset dan analisis
@@ -255,7 +248,6 @@ id:
         one: Set data statistik
         other: Set data statistik
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Transkrip
@@ -264,7 +256,6 @@ id:
         one: Transparansi data
         other: Transparansi data
       world_news_story:
-        one:
         other:
       written_statement:
         one: Pernyataan tertulis kepada parlemen

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -113,7 +113,6 @@ id:
     headings:
       applies_to_nations: Diterapkan pada
       attachments:
-        one: Dokumen
         other: Dokumen-dokumen
       from:
       location:
@@ -132,133 +131,96 @@ id:
       written_on: 'Dituliskan pada:'
     type:
       announcement:
-        one: Pengumuman
         other: Pengumuman-pengumuman
       authored_article:
-        one: Artikel yang ditulis
         other: Artikel-artikel yang ditulis
       blog_post:
         other:
       case_study:
-        one: Studi kasus
         other: Studi-studi kasus
       closed_consultation:
-        one: Konsultasi tertutup
         other: Konsultasi-konsultasi tertutup
       consultation:
-        one: Konsultasi
         other: Konsultasi-konsultasi
       consultation_outcome:
-        one: Hasil konsultasi
         other: Hasil-hasil konsultasi
       corporate_report:
-        one: Laporan korporat
         other: Laporan-laporan korporat
       correspondence:
-        one: Koresponden
         other: Koresponden-koresponden
       decision:
         other:
       detailed_guidance:
-        one: Panduan lebih lanjut
         other: Panduan lebih lanjut
       document_collection:
-        one: Serial
         other:
       draft_text:
-        one: Rancangan teks
         other: Rancangan tulisan
       foi_release:
-        one: Rilis FOI
         other: Rilis FOI
       form:
-        one: Formulir
         other: Formulir-formulir
       government_response:
-        one: Respon Pemerintah
         other: Respon-respon Pemerintah
       guidance:
-        one: Panduan
         other: Panduan
       impact_assessment:
-        one: Penilaian dampak
         other: Penilaian-penilaian dampak
       imported:
-        one: Diimpor-menunggu tipe
         other: Diimpor-menunggu tipe
       independent_report:
-        one: Laporan independen
         other: Laporan-laporan independen
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: Peta
         other: Peta-peta
       national_statistics:
-        one: Statistik-statistik nasional
         other: Statistik-statistik nasional
       news_article:
-        one: Artikel berita
         other: Artikel-artikel berita
       news_story:
-        one: Berita
         other: Berita-berita
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: Statistik
         other: Statistik-statistik
       open_consultation:
-        one: Konsultasi terbuka
         other: Konsultasi-konsultasi terbuka
       oral_statement:
-        one: Pernyataan langsung kepada parlemen
         other: Pernyataan-pernyataan langsung kepada parlemen
       policy_paper:
-        one: Laporan kebijakan
         other: Laporan-laporan kebijakan
       press_release:
-        one: Rilis pers
         other: Rilis pers
       promotional:
-        one: Materi promosi
         other: Materi promosi
       publication:
-        one: Publikasi
         other: Publikasi-publikasi
       regulation:
         other:
       research:
-        one: Riset dan analisis
         other: Riset dan analisis
       speaking_notes:
-        one: Naskah Pembicara
         other: Naskah Pembicara
       speech:
-        one: Pidato
         other: Pidato-pidato
       statement_to_parliament:
-        one: Pernyatan kepada Parlemen
         other: Pernyataan-pernyaatan kepada Parlemen
       statistical_data_set:
-        one: Set data statistik
         other: Set data statistik
       statutory_guidance:
         other:
       transcript:
-        one: Transkrip
         other: Transkrip-transkrip
       transparency:
-        one: Transparansi data
         other: Transparansi data
       world_news_story:
         other:
       written_statement:
-        one: Pernyataan tertulis kepada parlemen
         other: Pernyataan-pernyatan tertulis kepada parlemen
     updated: Terkini
     view: Lihat '%{title}'
@@ -411,10 +373,8 @@ id:
       statistics: Statistik-statistik kami
     type:
       international_delegation:
-        one: Delegasi internasional
         other: Delegasi-delegasi internasional
       world_location:
-        one: Lokasi dunia
         other: Lokasi-lokasi dunia
   worldwide_organisation:
     corporate_information:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -137,7 +137,6 @@ ja:
         one: Authored article
         other: Authored articles
       blog_post:
-        one:
         other:
       case_study:
         one: ケーススタディ
@@ -158,7 +157,6 @@ ja:
         one: 通信文書
         other: 通信文書
       decision:
-        one:
         other:
       detailed_guidance:
         one: 詳細説明
@@ -191,10 +189,8 @@ ja:
         one: 第三者機関によるレポート
         other: 第三者機関によるレポート
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: 地図
@@ -209,10 +205,8 @@ ja:
         one: ニュース
         other: ニュース
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: 統計
@@ -236,7 +230,6 @@ ja:
         one: 出版物
         other: 出版物
       regulation:
-        one:
         other:
       research:
         one: 調査と分析
@@ -254,7 +247,6 @@ ja:
         one: 統計データセット
         other: 統計データセット
       statutory_guidance:
-        one:
         other:
       transcript:
         one: スピーチ全文
@@ -263,7 +255,6 @@ ja:
         one: 透明性データ
         other: 透明性データ
       world_news_story:
-        one:
         other:
       written_statement:
         one: 閣僚声明文

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -112,7 +112,6 @@ ja:
     headings:
       applies_to_nations: 対象国
       attachments:
-        one: お知らせ
         other: お知らせ
       from:
       location:
@@ -131,133 +130,96 @@ ja:
       written_on:
     type:
       announcement:
-        one: ニュース
         other: ニュース
       authored_article:
-        one: Authored article
         other: Authored articles
       blog_post:
         other:
       case_study:
-        one: ケーススタディ
         other: ケーススタディ
       closed_consultation:
-        one: 非公開協議
         other: 非公開協議
       consultation:
-        one: 協議
         other: 協議
       consultation_outcome:
-        one: 協議結果
         other: 協議結果
       corporate_report:
-        one: 事業報告
         other: 事業報告
       correspondence:
-        one: 通信文書
         other: 通信文書
       decision:
         other:
       detailed_guidance:
-        one: 詳細説明
         other: 詳細説明
       document_collection:
-        one: シリーズ
         other:
       draft_text:
-        one: 草稿
         other: 草稿
       foi_release:
-        one: 情報公開に関するニュース
         other: 情報公開に関するニュース
       form:
-        one: フォーム
         other: フォーム
       government_response:
-        one: レスポンス
         other: レスポンス
       guidance:
-        one: ガイダンス
         other: ガイダンス
       impact_assessment:
-        one: 影響評価
         other: 影響評価
       imported:
-        one: 確認中
         other: 確認中
       independent_report:
-        one: 第三者機関によるレポート
         other: 第三者機関によるレポート
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: 地図
         other: 地図
       national_statistics:
-        one: 国家統計
         other: 国家統計
       news_article:
-        one: ニュース
         other: ニュース
       news_story:
-        one: ニュース
         other: ニュース
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: 統計
         other: 統計
       open_consultation:
-        one: 公開協議
         other: 公開協議
       oral_statement:
-        one: 議会に対する口頭陳述
         other: 議会に対する口頭陳述
       policy_paper:
-        one: 政策文書
         other: 政策文書
       press_release:
-        one: 新聞発表
         other: 新聞発表
       promotional:
-        one: 宣伝資料
         other: 宣伝資料
       publication:
-        one: 出版物
         other: 出版物
       regulation:
         other:
       research:
-        one: 調査と分析
         other: 調査と分析
       speaking_notes:
-        one: キーポイント
         other: キーポイント
       speech:
-        one: スピーチ
         other: スピーチ
       statement_to_parliament:
-        one: 閣僚声明
         other: 閣僚声明
       statistical_data_set:
-        one: 統計データセット
         other: 統計データセット
       statutory_guidance:
         other:
       transcript:
-        one: スピーチ全文
         other: スピーチ全文
       transparency:
-        one: 透明性データ
         other: 透明性データ
       world_news_story:
         other:
       written_statement:
-        one: 閣僚声明文
         other: 閣僚声明文
     updated: 更新
     view: "%{title}' を見る"
@@ -409,10 +371,8 @@ ja:
       statistics: 統計
     type:
       international_delegation:
-        one: 海外代表団
         other: 海外代表団
       world_location:
-        one: 地域
         other: 地域
   worldwide_organisation:
     corporate_information:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -111,7 +111,6 @@ ka:
     headings:
       applies_to_nations:
       attachments:
-        one:
         other:
       from:
       location:
@@ -130,142 +129,96 @@ ka:
       written_on:
     type:
       announcement:
-        one:
         other:
       authored_article:
-        one:
         other:
       blog_post:
-        one:
         other:
       case_study:
-        one:
         other:
       closed_consultation:
-        one:
         other:
       consultation:
-        one:
         other:
       consultation_outcome:
-        one:
         other:
       corporate_report:
-        one:
         other:
       correspondence:
-        one:
         other:
       decision:
-        one:
         other:
       detailed_guidance:
-        one:
         other:
       document_collection:
-        one:
         other:
       draft_text:
-        one:
         other:
       foi_release:
-        one:
         other:
       form:
-        one:
         other:
       government_response:
-        one:
         other:
       guidance:
-        one:
         other:
       impact_assessment:
-        one:
         other:
       imported:
-        one:
         other:
       independent_report:
-        one:
         other:
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
-        one:
         other:
       national_statistics:
-        one:
         other:
       news_article:
-        one:
         other:
       news_story:
-        one:
         other:
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
-        one:
         other:
       open_consultation:
-        one:
         other:
       oral_statement:
-        one:
         other:
       policy_paper:
-        one:
         other:
       press_release:
-        one:
         other:
       promotional:
-        one:
         other:
       publication:
-        one:
         other:
       regulation:
-        one:
         other:
       research:
-        one:
         other:
       speaking_notes:
-        one:
         other:
       speech:
-        one:
         other:
       statement_to_parliament:
-        one:
         other:
       statistical_data_set:
-        one:
         other:
       statutory_guidance:
-        one:
         other:
       transcript:
-        one:
         other:
       transparency:
-        one:
         other:
       world_news_story:
-        one:
         other:
       written_statement:
-        one:
         other:
     updated:
     view:
@@ -417,10 +370,8 @@ ka:
       statistics:
     type:
       international_delegation:
-        one:
         other:
       world_location:
-        one:
         other:
   worldwide_organisation:
     corporate_information:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -137,7 +137,6 @@ ko:
         one: 기사
         other: 기사
       blog_post:
-        one:
         other:
       case_study:
         one: 케이스 스터디
@@ -158,7 +157,6 @@ ko:
         one: 서신
         other: 서신
       decision:
-        one:
         other:
       detailed_guidance:
         one: 상세 안내
@@ -191,10 +189,8 @@ ko:
         one: 독립 레포트
         other: 독립 레포트
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: 지도
@@ -209,10 +205,8 @@ ko:
         one: 뉴스 스토리
         other: 뉴스 스토리
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: 통계
@@ -236,7 +230,6 @@ ko:
         one: 간행물
         other: 간행물
       regulation:
-        one:
         other:
       research:
         one: 리써치 및 분석
@@ -254,7 +247,6 @@ ko:
         one: 통계 데이터 세트
         other: 통계 데이터 세트
       statutory_guidance:
-        one:
         other:
       transcript:
         one: 트랜스크립트
@@ -263,7 +255,6 @@ ko:
         one: 투명성 데이타
         other: 투명성 데이타
       world_news_story:
-        one:
         other:
       written_statement:
         one: 의회로 서면 성명

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -112,7 +112,6 @@ ko:
     headings:
       applies_to_nations: 적용
       attachments:
-        one: 문서
         other: 문서
       from:
       location:
@@ -131,133 +130,96 @@ ko:
       written_on: '작성일시:'
     type:
       announcement:
-        one: 공지
         other: 공지
       authored_article:
-        one: 기사
         other: 기사
       blog_post:
         other:
       case_study:
-        one: 케이스 스터디
         other: 케이스 스터디
       closed_consultation:
-        one: 비공개 협의
         other: 비공개 협의
       consultation:
-        one: 협의
         other: 협의
       consultation_outcome:
-        one: 협의 결과
         other: 협의 결과
       corporate_report:
-        one: 기업 레포트
         other: 기업 레포트
       correspondence:
-        one: 서신
         other: 서신
       decision:
         other:
       detailed_guidance:
-        one: 상세 안내
         other: 상세 안내
       document_collection:
-        one: 시리즈
         other:
       draft_text:
-        one: 드래프트 택스트
         other: 드래프트 택스트
       foi_release:
-        one: FOI 보도자료
         other: FOI 보도자료
       form:
-        one: 문서
         other: 문서
       government_response:
-        one: 정부 대책
         other: 정부 대책
       guidance:
-        one: 안내
         other: 안내
       impact_assessment:
-        one: 임팩트 평가
         other: 임팩트 평가
       imported:
-        one: 수입 - 대기
         other: 수입 - 대기
       independent_report:
-        one: 독립 레포트
         other: 독립 레포트
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: 지도
         other: 지도
       national_statistics:
-        one: 통계 - 국가 통계
         other: 통계 - 국가 통계
       news_article:
-        one: 뉴스
         other: 뉴스
       news_story:
-        one: 뉴스 스토리
         other: 뉴스 스토리
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: 통계
         other: 통계
       open_consultation:
-        one: 오픈 컨설테이션
         other: 오픈 컨설테이션
       oral_statement:
-        one: 의회로 구두 성명
         other: 의회로 구두 성명
       policy_paper:
-        one: 정책 논문
         other: 정책 논문
       press_release:
-        one: 보도자료
         other: 보도자료
       promotional:
-        one: 홍보물
         other: 홍보물
       publication:
-        one: 간행물
         other: 간행물
       regulation:
         other:
       research:
-        one: 리써치 및 분석
         other: 리써치 및 분석
       speaking_notes:
-        one: 요점사항
         other: 요점사항
       speech:
-        one: 연설문
         other: 연설문
       statement_to_parliament:
-        one: 의회로 성명
         other: 의회로 성명
       statistical_data_set:
-        one: 통계 데이터 세트
         other: 통계 데이터 세트
       statutory_guidance:
         other:
       transcript:
-        one: 트랜스크립트
         other: 트랜스크립트
       transparency:
-        one: 투명성 데이타
         other: 투명성 데이타
       world_news_story:
         other:
       written_statement:
-        one: 의회로 서면 성명
         other: 의회로 서면 성명
     updated: 업데이트
     view: "'%{title}' 을 확인하세요."
@@ -409,10 +371,8 @@ ko:
       statistics: 통계
     type:
       international_delegation:
-        one: 국제 사절단
         other: 국제 사절단
       world_location:
-        one: 월드 로케이션
         other: 월드 로케이션
   worldwide_organisation:
     corporate_information:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -111,7 +111,6 @@ ms:
     headings:
       applies_to_nations:
       attachments:
-        one:
         other:
       from:
       location:
@@ -130,142 +129,96 @@ ms:
       written_on:
     type:
       announcement:
-        one:
         other:
       authored_article:
-        one:
         other:
       blog_post:
-        one:
         other:
       case_study:
-        one:
         other:
       closed_consultation:
-        one:
         other:
       consultation:
-        one:
         other:
       consultation_outcome:
-        one:
         other:
       corporate_report:
-        one:
         other:
       correspondence:
-        one:
         other:
       decision:
-        one:
         other:
       detailed_guidance:
-        one:
         other:
       document_collection:
-        one:
         other:
       draft_text:
-        one:
         other:
       foi_release:
-        one:
         other:
       form:
-        one:
         other:
       government_response:
-        one:
         other:
       guidance:
-        one:
         other:
       impact_assessment:
-        one:
         other:
       imported:
-        one:
         other:
       independent_report:
-        one:
         other:
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
-        one:
         other:
       national_statistics:
-        one:
         other:
       news_article:
-        one:
         other:
       news_story:
-        one:
         other:
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
-        one:
         other:
       open_consultation:
-        one:
         other:
       oral_statement:
-        one:
         other:
       policy_paper:
-        one:
         other:
       press_release:
-        one:
         other:
       promotional:
-        one:
         other:
       publication:
-        one:
         other:
       regulation:
-        one:
         other:
       research:
-        one:
         other:
       speaking_notes:
-        one:
         other:
       speech:
-        one:
         other:
       statement_to_parliament:
-        one:
         other:
       statistical_data_set:
-        one:
         other:
       statutory_guidance:
-        one:
         other:
       transcript:
-        one:
         other:
       transparency:
-        one:
         other:
       world_news_story:
-        one:
         other:
       written_statement:
-        one:
         other:
     updated:
     view:
@@ -417,10 +370,8 @@ ms:
       statistics:
     type:
       international_delegation:
-        one:
         other:
       world_location:
-        one:
         other:
   worldwide_organisation:
     corporate_information:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -137,7 +137,6 @@ th:
         one: บทความที่เขียน
         other: บทความที่เขียน
       blog_post:
-        one:
         other:
       case_study:
         one: กรณีศึกษา
@@ -158,7 +157,6 @@ th:
         one: จดหมาย
         other: จดหมาย
       decision:
-        one:
         other:
       detailed_guidance:
         one: คู่มือโดยละเอียด
@@ -191,10 +189,8 @@ th:
         one: รายงานอิสระ
         other: รายงานอิสระ
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: แผนที่
@@ -209,10 +205,8 @@ th:
         one: ข่าว
         other: ข่าว
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: สถิติ
@@ -236,7 +230,6 @@ th:
         one: สิ่งพิมพ์
         other: สิ่งพิมพ์
       regulation:
-        one:
         other:
       research:
         one: บทวิจัยและบทวิเคราะห์
@@ -254,7 +247,6 @@ th:
         one: ชุดข้อมูลสถิติ
         other: ชุดข้อมูลสถิติ
       statutory_guidance:
-        one:
         other:
       transcript:
         one: สำเนา
@@ -263,7 +255,6 @@ th:
         one: ข้อมูลโปร่งใส
         other: ข้อมูลโปร่งใส
       world_news_story:
-        one:
         other:
       written_statement:
         one: 'แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -112,7 +112,6 @@ th:
     headings:
       applies_to_nations: นำไปใช้กับ
       attachments:
-        one: เอกสาร
         other: เอกสารต่างๆ
       from:
       location:
@@ -131,133 +130,96 @@ th:
       written_on: เขียนเมือ
     type:
       announcement:
-        one: ข่าวสาร
         other: ข่าวสาร
       authored_article:
-        one: บทความที่เขียน
         other: บทความที่เขียน
       blog_post:
         other:
       case_study:
-        one: กรณีศึกษา
         other: กรณีศึกษา
       closed_consultation:
-        one: การศึกษาแบบปิด
         other: การศึกษาแบบปิด
       consultation:
-        one: การปรึกษา
         other: การปรึกษา
       consultation_outcome:
-        one: ผลการปรึกษา
         other: ผลการปรึกษา
       corporate_report:
-        one: รายงานบริษัท
         other: รายงานบริษัท
       correspondence:
-        one: จดหมาย
         other: จดหมาย
       decision:
         other:
       detailed_guidance:
-        one: คู่มือโดยละเอียด
         other: คู่มือโดยละเอียด
       document_collection:
-        one: ตอน
         other:
       draft_text:
-        one: ร่างข้อความ
         other: ร่างข้อความ
       foi_release:
-        one: ข้อมูลที่เปิดเผยได้
         other: ข้อมูลที่เปิดเผยได้
       form:
-        one: แบบฟอร์ม
         other: แบบฟอร์ม
       government_response:
-        one: การตอบสนองของรัฐบาล
         other: การตอบสนองของรัฐบาล
       guidance:
-        one: คู่มือ
         other: คู่มือ
       impact_assessment:
-        one: การประเมินผลกระทบ
         other: การประเมินผลกระทบ
       imported:
-        one: ประเภทรอนำเข้า
         other: ประเภทรอนำเข้า
       independent_report:
-        one: รายงานอิสระ
         other: รายงานอิสระ
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: แผนที่
         other: แผนที่
       national_statistics:
-        one: สถิติ-สถิติแห่งชาน
         other: สถิติ-สถิติแห่งชาติ
       news_article:
-        one: บทความข่าว
         other: บทความข่าว
       news_story:
-        one: ข่าว
         other: ข่าว
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: สถิติ
         other: สถิติ
       open_consultation:
-        one: การให้คำปรึกษาเปิด
         other: การให้คำปรึกษาเปิด
       oral_statement:
-        one: แถลงการณ์ด้วยวาจาต่อรัฐสภา
         other: แถลงการณ์ด้วยวาจาต่อรัฐสภา
       policy_paper:
-        one: เอกสารนโยบาย
         other: เอกสารนโยบาย
       press_release:
-        one: ข่าวประชาสัมพันธ์
         other: ข่าวประชาสัมพันธ์
       promotional:
-        one: เอกสารเพี่อการประชาสัมพันธ์
         other: เอกสารเพือการประชาสัมพันธ์
       publication:
-        one: สิ่งพิมพ์
         other: สิ่งพิมพ์
       regulation:
         other:
       research:
-        one: บทวิจัยและบทวิเคราะห์
         other: บทวิจัยและบทวิเคราะห์
       speaking_notes:
-        one: ประเด็นการพูด
         other: ประเด็นการพูด
       speech:
-        one: สุนทรพจน์
         other: สุนทรพจน์
       statement_to_parliament:
-        one: แถลงการณ์ต่อรัฐสภา
         other: แถลงการณ์ต่อรัฐสภา
       statistical_data_set:
-        one: ชุดข้อมูลสถิติ
         other: ชุดข้อมูลสถิติ
       statutory_guidance:
         other:
       transcript:
-        one: สำเนา
         other: สำเนา
       transparency:
-        one: ข้อมูลโปร่งใส
         other: ข้อมูลโปร่งใส
       world_news_story:
         other:
       written_statement:
-        one: 'แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
         other: 'แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
     updated: ปรับปรุง
     view: ดู '%{title}'
@@ -409,10 +371,8 @@ th:
       statistics: สถิติของเรา
     type:
       international_delegation:
-        one: ผู้แทนนานาประเทศ
         other: คณะผู้แทนนานาประเทศ
       world_location:
-        one: ที่ตั้ง
         other: ทีตั้ง
   worldwide_organisation:
     corporate_information:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -113,7 +113,6 @@ vi:
     headings:
       applies_to_nations: Áp dụngng cho
       attachments:
-        one: Tài liệu
         other: Tài liệu
       from:
       location:
@@ -132,133 +131,96 @@ vi:
       written_on: 'Viết vào:'
     type:
       announcement:
-        one: Thông báo
         other: Các thông báo
       authored_article:
-        one: bài viết do tác giả
         other: Các bài viết do tác giả
       blog_post:
         other:
       case_study:
-        one: Trường hợp cụ thể
         other: Các Trường hợp cụ thể
       closed_consultation:
-        one: Kết thúc tham vấn
         other: Kết thúc các cuộc tham vấn
       consultation:
-        one: Tham vấn
         other: Các cuộc tham vấn
       consultation_outcome:
-        one: Kết quả tham vấn
         other: Các Kết quả tham vấn
       corporate_report:
-        one: báo cáo tổng hợp
         other: Các báo cáo tổng hợp
       correspondence:
-        one: Liên hệ
         other: Liên hệ
       decision:
         other:
       detailed_guidance:
-        one: Hướng dẫn chi tiết
         other: Hướng dẫn chi tiết
       document_collection:
-        one: Chuỗi
         other:
       draft_text:
-        one: Nội dung dự thảo
         other: Các nội dung dự thảo
       foi_release:
-        one: Thông cáo FOI
         other: Thông cáo FOI
       form:
-        one: Mẫu đơn
         other: Các mẫu đơn
       government_response:
-        one: Phản ứng của Chính phủ
         other: các phản hồi của Chính phủ
       guidance:
-        one: hướng dẫn
         other: hướng dẫn
       impact_assessment:
-        one: Đánh giá tác động
         other: Đánh giá tác động
       imported:
-        one: Loại tài liệu đính kèm
         other: Loại tài liệu đính kèm
       independent_report:
-        one: Báo cáo độc lập
         other: Các báo cáo độc lập
       international_treaty:
         other:
       manual:
         other:
       map:
-        one: Bản đồ
         other: Các bản đồ
       national_statistics:
-        one: Thống kê - Thống kê quốc gia
         other: Thống kê - Thống kê quốc gia
       news_article:
-        one: Tin tức
         other: Tin tức
       news_story:
-        one: Câu chuyện tin tức
         other: Câu chuyện tin tức
       nhs_content:
         other:
       notice:
         other:
       official_statistics:
-        one: Thống kê
         other: Thống kê
       open_consultation:
-        one: Tham vấn mở rộng
         other: Tham vấn mở rộng
       oral_statement:
-        one: Tuyên bố bằng lời nói tới quốc hội
         other: Tuyên bố bằng lời nói tới quốc hội
       policy_paper:
-        one: Tài liệu chính sách
         other: Tài liệu chính sách
       press_release:
-        one: Thông cáo báo chí
         other: Thông cáo báo chí
       promotional:
-        one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       publication:
-        one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       regulation:
         other:
       research:
-        one: Nghiên cứu và phân tích
         other: Nghiên cứu và phân tích
       speaking_notes:
-        one: Bài phát biểu
         other: Bài phát biểu
       speech:
-        one: Bài phát biểu
         other: Các bài phát biểu
       statement_to_parliament:
-        one: Tuyên bố tới Quốc hội
         other: Tuyên bố tới Quốc hội
       statistical_data_set:
-        one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
       statutory_guidance:
         other:
       transcript:
-        one: Kịch bản
         other: Kịch bản
       transparency:
-        one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
       world_news_story:
         other:
       written_statement:
-        one: Tuyên bố bằng văn bản tới quốc hội
         other: Các Tuyên bố bằng văn bản tới quốc hội
     updated: Cập nhật
     view: Xem '%{title}'
@@ -412,10 +374,8 @@ vi:
       statistics: Thống kê của chúng tôi
     type:
       international_delegation:
-        one: Phái đoàn quốc tế
         other: Các phái đoàn quốc tế
       world_location:
-        one: Địa điểm trên thế giới
         other: Các địa điểm trên thế giới
   worldwide_organisation:
     corporate_information:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -138,7 +138,6 @@ vi:
         one: bài viết do tác giả
         other: Các bài viết do tác giả
       blog_post:
-        one:
         other:
       case_study:
         one: Trường hợp cụ thể
@@ -159,7 +158,6 @@ vi:
         one: Liên hệ
         other: Liên hệ
       decision:
-        one:
         other:
       detailed_guidance:
         one: Hướng dẫn chi tiết
@@ -192,10 +190,8 @@ vi:
         one: Báo cáo độc lập
         other: Các báo cáo độc lập
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: Bản đồ
@@ -210,10 +206,8 @@ vi:
         one: Câu chuyện tin tức
         other: Câu chuyện tin tức
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: Thống kê
@@ -237,7 +231,6 @@ vi:
         one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       regulation:
-        one:
         other:
       research:
         one: Nghiên cứu và phân tích
@@ -255,7 +248,6 @@ vi:
         one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Kịch bản
@@ -264,7 +256,6 @@ vi:
         one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
       world_news_story:
-        one:
         other:
       written_statement:
         one: Tuyên bố bằng văn bản tới quốc hội

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -136,7 +136,6 @@ zh:
         one: 撰写的文章
         other: 撰写的文章
       blog_post:
-        one:
         other:
       case_study:
         one: 实例研究
@@ -157,7 +156,6 @@ zh:
         one: 交流
         other: 交流
       decision:
-        one:
         other:
       detailed_guidance:
         one: 详细指导
@@ -190,10 +188,8 @@ zh:
         one: 独立报告
         other: 独立报告
       international_treaty:
-        one:
         other:
       manual:
-        one:
         other:
       map:
         one: 地图
@@ -208,10 +204,8 @@ zh:
         one: 新闻报道
         other: 新闻报道
       nhs_content:
-        one:
         other:
       notice:
-        one:
         other:
       official_statistics:
         one: 统计数据
@@ -235,7 +229,6 @@ zh:
         one: 发布的报告
         other: 发布的报告
       regulation:
-        one:
         other:
       research:
         one: 研究及分析
@@ -253,7 +246,6 @@ zh:
         one: 统计数据集
         other: 统计数据集
       statutory_guidance:
-        one:
         other:
       transcript:
         one: 副本
@@ -262,7 +254,6 @@ zh:
         one: 透明化数据
         other: 透明化数据
       world_news_story:
-        one:
         other:
       written_statement:
         one: 对议会的书面声明

--- a/test/unit/i18n_key_test.rb
+++ b/test/unit/i18n_key_test.rb
@@ -7,9 +7,9 @@ class I18nKeyTest < ActiveSupport::TestCase
     assert_not any_nil_values?(default_translation_data), "Default translation #{I18n.default_locale}.yml contains keys with nil values."
   end
 
-  test "all locale files are up-to-date" do
+  test "all locale files have the same keys as the default, excluding plural forms" do
     default_keys = keys_in_locale_file(default_locale_file_path)
-    required_keys = default_keys - optional_keys
+    required_keys = (default_keys - optional_keys).compact.reject { |key| key.match?(Regexp.union(all_plural_keys)) }
     locale_files = Dir[Rails.root.join("config/locales/*.yml")] - [default_locale_file_path.to_s]
 
     locale_files.each do |locale_file|
@@ -93,6 +93,10 @@ private
   def keys_in_locale_file(locale_file)
     yaml = YAML.load_file(locale_file)
     flatten_keys(yaml, [])
+  end
+
+  def all_plural_keys
+    %w[one zero two few many other]
   end
 
   def optional_keys


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/6029, we updated the plural rules for each language that we support that is not included [in the ruby-i18n gem](https://github.com/ruby-i18n/i18n/blob/master/test/test_data/locales/plurals.rb).

This removes the keys that are no longer required in each language from their locale files.

Trello card: https://trello.com/c/lkVB57ri

I have not made any changes to `zh-hk` and `zh-tw` as there are problems with the translations, which will be addressed in https://trello.com/c/mbFPEn9h.  Also not made any changes to `tr` as I believe the i18n rules for this could be wrong, so will write a card to look into this.