### PR TITLE
Add sortability tagging for the Take Part pages in Search

### DIFF
--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -28,6 +28,7 @@ module Searchable
     logo_formatted_title
     metadata
     news_article_type
+    ordering
     operational_field
     organisation_brand
     organisation_closed_state

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -23,7 +23,8 @@ class TakePartPage < ApplicationRecord
              link: :search_link,
              content: :body_without_markup,
              description: :summary,
-             format: "take_part"
+             format: "take_part",
+             ordering: :ordering
 
   def search_link
     Whitehall.url_maker.take_part_page_path(slug)

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -169,8 +169,8 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test "returns search index data for all take part pages" do
-    create(:take_part_page, content_id: "845593d6-273d-4440-b44a-8c44ab530c9e", title: "Build a new polling station", summary: "Help people vote!", body: "Everyone can build a building.")
-    create(:take_part_page, content_id: "a7a3a7f3-f967-4723-8de3-1e2d8f9fb4cb", title: "Stand for election", summary: "Help govern this country!", body: "Maybe you can change the system from within?")
+    create(:take_part_page, content_id: "845593d6-273d-4440-b44a-8c44ab530c9e", title: "Build a new polling station", summary: "Help people vote!", body: "Everyone can build a building.", ordering: 1)
+    create(:take_part_page, content_id: "a7a3a7f3-f967-4723-8de3-1e2d8f9fb4cb", title: "Stand for election", summary: "Help govern this country!", body: "Maybe you can change the system from within?", ordering: 1)
 
     results = TakePartPage.search_index.to_a
 
@@ -181,7 +181,8 @@ class TakePartPageTest < ActiveSupport::TestCase
         "link" => "/government/get-involved/take-part/build-a-new-polling-station",
         "indexable_content" => "Everyone can build a building.",
         "format" => "take_part",
-        "description" => "Help people vote!" },
+        "description" => "Help people vote!",
+        "ordering" => 1 },
       results[0],
     )
     assert_equal(
@@ -190,7 +191,8 @@ class TakePartPageTest < ActiveSupport::TestCase
         "link" => "/government/get-involved/take-part/stand-for-election",
         "indexable_content" => "Maybe you can change the system from within?",
         "format" => "take_part",
-        "description" => "Help govern this country!" },
+        "description" => "Help govern this country!",
+        "ordering" => 1 },
       results[1],
     )
   end


### PR DESCRIPTION
Previously they could be found via the search API but the ordering of
the pages was not available to us. This PR allows us to access this
information once the take part pages have been reindexed.

Draft pull request for Jenkins test run visibility and easy share-ability during integration testing.