### PR TITLE
Use real organisation slug

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ if User.where(name: "Test user").blank?
     name: "Test user",
     permissions: ["signin", "GDS Admin", "GDS Editor", "Managing Editor", "Export data"],
     organisation_content_id: gds_organisation_id,
-    organisation_slug: "test-organisation",
+    organisation_slug: "government-digital-service",
   )
 end
 
@@ -28,7 +28,7 @@ end
 if Organisation.where(name: "Test Organisation").blank?
   Organisation.create!(
     name: "Test Organisation",
-    slug: "test-organisation",
+    slug: "government-digital-service",
     acronym: "TO",
     organisation_type_key: :other,
     logo_formatted_name: "Test",


### PR DESCRIPTION
The organisational Seed data is [used by Manuals Publisher][1] as part
of its e2e tests. Manuals publisher fetches the organisation for the
publishing user based on the slug assigned to them.

A real organisation slug allows us to fully run Manuals Publisher
locally using GOV.UK Docker. More information can be found in [this
commit][2].

Related PR:
https://github.com/alphagov/manuals-publisher/pull/1731

[1]: https://github.com/alphagov/whitehall/commit/418fc7b89c3ce5f05efd5efd36964706a7125185
[2]: https://github.com/alphagov/manuals-publisher/pull/1731/commits/2a7e1d8caad975aafb09960c970799dd7de96833