### PR TITLE
Update headings to gem

### DIFF
--- a/app/assets/stylesheets/frontend/views/_embassies.scss
+++ b/app/assets/stylesheets/frontend/views/_embassies.scss
@@ -1,88 +1,8 @@
 .embassies-index {
-  .headings-block .heading h1,
-  .headings-block .heading-big-with-extra h1 {
-    max-width: 620px;
-  }
-
-  span.a-z-heading {
-    display: none;
-
-    @include media(tablet) {
-      display: block;
-      width: 18%;
-    }
-
-    h1 {
-      @include bold-36;
-      margin-bottom: 15px;
-      width: 100%;
-      margin-left: 0;
-    }
-  }
-
   ol.locations {
-    list-style: none;
-    display: inline-block;
-    float: none;
-    width: 100%;
-    margin: 20px 0 0;
-
-    @include media(tablet) {
-      width: 82%;
-      margin: -40px 0 0 18%;
-    }
-
     li {
       width: 100%;
-      margin-bottom: 20px;
       display: inline-block;
-      border-bottom: 1px solid $grey-2;
-    }
-
-    p {
-      margin-bottom: 20px;
-    }
-
-    h2,
-    h3 {
-      @include bold-24;
-      display: block;
-    }
-
-    h2 {
-      margin-bottom: 10px;
-      width: 100%;
-
-      @include media(tablet) {
-        clear: both;
-        float: left;
-        position: relative;
-        width: 31.33333%;
-        margin-right: 2%;
-      }
-    }
-
-    h3 {
-      margin-bottom: 6px;
-    }
-
-    ul {
-
-      @include media(tablet) {
-        display: inline-block;
-        float: left;
-        width: 66.66666%;
-        margin-left: 0;
-      }
-
-      li {
-        border: none;
-      }
-    }
-
-    a {
-      text-decoration: none;
-      @include bold-19;
     }
   }
 }

--- a/app/assets/stylesheets/frontend/views/_embassies.scss
+++ b/app/assets/stylesheets/frontend/views/_embassies.scss
@@ -29,7 +29,7 @@
 
     @include media(tablet) {
       width: 82%;
-      margin: -50px 0 0 18%;
+      margin: -40px 0 0 18%;
     }
 
     li {

--- a/app/assets/stylesheets/frontend/views/_operational-field.scss
+++ b/app/assets/stylesheets/frontend/views/_operational-field.scss
@@ -12,10 +12,6 @@
     }
   }
 
-  h2 {
-    @include ig-core-27;
-  }
-
   .meta {
     @include media(desktop) {
       margin-top: $gutter;

--- a/app/views/email_signup_information/show.html.erb
+++ b/app/views/email_signup_information/show.html.erb
@@ -13,7 +13,9 @@
   <p><%= @email_signup_information.summary %></p>
   <div class='choices'>
     <% @email_signup_information.email_signup_pages.each do |page| %>
-    <h2><%= page.text %></h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: page.text
+      } %>
     <p><%= page.description %></p>
     <% end %>
   </div>

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,7 +1,10 @@
 <% offices = Embassy.filter_offices(organisation) -%>
 <% if offices.any? -%>
   <li>
-    <h3><%= offices.first.contact.locality %></h3>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: offices.first.contact.locality,
+      heading_level: 3
+    } %>
     <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
   </li>
 <% end -%>

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,9 +1,10 @@
 <% offices = Embassy.filter_offices(organisation) -%>
 <% if offices.any? -%>
-  <li>
+  <li class="govuk-!-margin-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
       text: offices.first.contact.locality,
-      heading_level: 3
+      heading_level: 3,
+      margin_bottom: 1
     } %>
     <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
   </li>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,43 +1,53 @@
 <% page_title "Find a British embassy, High Commission or Consulate" %>
-<% page_class "worldwide-organisations embassies-index" %>
+<% page_class "worldwide-organisations embassies-index govuk-width-container" %>
 <header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render "govuk_publishing_components/components/title", {
-      context: "Worldwide",
-      title: "Find a British embassy, high commission or consulate",
-    } %>
-  </div>
+  <%= render "govuk_publishing_components/components/title", {
+    context: "Worldwide",
+    title: "Find a British embassy, high commission or consulate",
+  } %>
 </header>
-<div class="block-2">
-  <div class="inner-block embassy-listing">
-    <span class="a-z-heading"><span class="visuallyhidden">Countries ordered from </span>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "A–Z",
-        font_size: "l"
-      } %>
-    </span>
-    <ol class="locations">
-      <% @embassies_by_location.each do |embassy| -%>
-        <li>
-          <%= render "govuk_publishing_components/components/heading", {
-            text: embassy.name
-          } %>
-          <% if embassy.has_consular_service_in_location? && embassy.offices.empty? -%>
-            <p><%= embassy.text %></p>
-          <% else -%>
-            <ul>
-              <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? -%>
-                <li>
-                  <p><%= embassy.text %></p>
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+      <aside class="govuk-grid-column-one-quarter">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: raw("<span class=\" govuk-visually-hidden\">Countries ordered from </span> A–Z"),
+          font_size: "l",
+          margin_bottom: 6,
+        } %>
+      </aside>
+      <section class="govuk-grid-column-three-quarters">
+        <ol class="locations">
+          <% @embassies_by_location.each do |embassy| -%>
+          <li class="govuk-grid-row govuk-!-margin-bottom-4">
+            <div class="govuk-grid-column-one-third">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: embassy.name, margin_bottom: 1
+              } %>
+            </div>
+            <div class="govuk-grid-column-two-thirds">
+              <% if embassy.has_consular_service_in_location? && embassy.offices.empty? -%>
+              <p>
+                <%= embassy.text %>
+              </p>
+              <% else -%>
+              <ul>
+                <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? -%>
+                <li class="govuk-!-margin-bottom-4">
+                  <p class="govuk-!-padding-bottom-4">
+                    <%= embassy.text %>
+                  </p>
                   <%= embassy.embassy_path %>
                 </li>
-              <% else %>
-                <%= render partial: "organisation", collection: embassy.consular_services_organisations -%>
-              <% end %>
-            </ul>
+                <% else %>
+                <%= render partial:"organisation", collection: embassy.consular_services_organisations -%>
+                <% end %>
+              </ul>
+              <% end -%>
+            </div>
+          </li>
+          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4">
           <% end -%>
-        </li>
-      <% end -%>
-    </ol>
+        </ol>
+      </section>
   </div>
 </div>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,6 +1,5 @@
 <% page_title "Find a British embassy, High Commission or Consulate" %>
 <% page_class "worldwide-organisations embassies-index" %>
-
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <%= render "govuk_publishing_components/components/title", {
@@ -9,32 +8,35 @@
     } %>
   </div>
 </header>
-
 <div class="block-2">
   <div class="inner-block embassy-listing">
-
-    <span class="a-z-heading"><span class="visuallyhidden">Countries ordered from </span><h1>A&ndash;Z</h1></span>
-
+    <span class="a-z-heading"><span class="visuallyhidden">Countries ordered from </span>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "A–Z",
+        font_size: "l"
+      } %>
+    </span>
     <ol class="locations">
       <% @embassies_by_location.each do |embassy| -%>
-      <li>
-        <h2><%= embassy.name %></h2>
-
-        <% if embassy.has_consular_service_in_location? && embassy.offices.empty? -%>
-          <p><%= embassy.text %></p>
-        <% else -%>
-          <ul>
-            <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? -%>
-            <li>
-              <p><%= embassy.text %></p>
-              <%= embassy.embassy_path %>
-            </li>
-            <% else %>
-              <%= render partial: "organisation", collection: embassy.consular_services_organisations -%>
-            <% end %>
-          </ul>
-        <% end -%>
-      </li>
+        <li>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: embassy.name
+          } %>
+          <% if embassy.has_consular_service_in_location? && embassy.offices.empty? -%>
+            <p><%= embassy.text %></p>
+          <% else -%>
+            <ul>
+              <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? -%>
+                <li>
+                  <p><%= embassy.text %></p>
+                  <%= embassy.embassy_path %>
+                </li>
+              <% else %>
+                <%= render partial: "organisation", collection: embassy.consular_services_organisations -%>
+              <% end %>
+            </ul>
+          <% end -%>
+        </li>
       <% end -%>
     </ol>
   </div>

--- a/app/views/operational_fields/show.html.erb
+++ b/app/views/operational_fields/show.html.erb
@@ -4,23 +4,26 @@
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <%= render partial: 'shared/heading',
-              locals: { type: 'British fatalities',
-                        heading: "Operations in #{@operational_field.name}",
-                        big: true, extra: true } %>
+      locals: { type: 'British fatalities',
+      heading: "Operations in #{@operational_field.name}",
+      big: true, extra: true
+    } %>
     <div class="heading-extra">
       <div class="inner-heading">
         <div class="organisations-icon-list">
-          <%= content_tag_for(:div, @organisation, class: organisation_brand_colour_class(@organisation)) do %>
+          <%= content_tag_for(:div, @organisation,
+            class: organisation_brand_colour_class(@organisation)) do %>
             <%= link_to @organisation,
-                        class: logo_classes(organisation: @organisation, stacked: true, use_identity: true) do %>
+            class: logo_classes(organisation: @organisation, stacked: true, use_identity: true) do %>
               <span><%= organisation_logo_name(@organisation) %></span>
             <% end %>
           <% end %>
-       </div>
+        </div>
       </div>
     </div>
   </div>
 </header>
+
 <div class="block-2">
   <div class="inner-block">
     <div class="contextual-info">
@@ -28,19 +31,26 @@
         <h1>Contents</h1>
         <ol>
           <% unless @operational_field.description.blank? %>
-            <li><a href="#field-of-operation">Field of operation</a></li>
+            <li>
+              <a href="#field-of-operation">Field of operation</a>
+            </li>
           <% end %>
           <% govspeak_headers(@operational_field.description).each do |header| %>
-            <li><%= link_to header.text, "##{header.id}" %></li>
+            <li>
+              <%= link_to header.text, "##{header.id}" %>
+            </li>
           <% end %>
           <% if @fatality_notices.any? %>
-            <li><a href="#fatalities">Fatalities</a></li>
+            <li>
+              <a href="#fatalities">Fatalities</a>
+            </li>
           <% end %>
         </ol>
       </nav>
     </div>
   </div>
 </div>
+
 <div class="block-3">
   <div class="inner-block">
     <section id="field-of-operation" class="group">

--- a/app/views/operational_fields/show.html.erb
+++ b/app/views/operational_fields/show.html.erb
@@ -21,7 +21,6 @@
     </div>
   </div>
 </header>
-
 <div class="block-2">
   <div class="inner-block">
     <div class="contextual-info">
@@ -42,21 +41,24 @@
     </div>
   </div>
 </div>
-
 <div class="block-3">
   <div class="inner-block">
     <section id="field-of-operation" class="group">
-
       <% unless @operational_field.description.blank? %>
-        <h2>Field of operation</h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Field of operation",
+          margin_bottom: 2
+        } %>
         <div class="description">
           <%= govspeak_to_html @operational_field.description %>
         </div>
       <% end %>
-
       <div class="fatalities">
         <% if @fatality_notices.any? %>
-          <h2 id="fatalities">Fatalities</h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Fatalities",
+            id: "fatalities"
+          } %>
           <ul>
             <% @fatality_notices.each do |fatality_notice| %>
               <%= content_tag_for :li, fatality_notice, class: 'fatality-notice' do %>
@@ -66,15 +68,15 @@
                   </h3>
                 <% end %>
                 <ul class="casualties">
-                <% if fatality_notice.fatality_notice_casualties.any? %>
+                  <% if fatality_notice.fatality_notice_casualties.any? %>
                     <% fatality_notice.fatality_notice_casualties.each do |casualty| %>
                       <%= content_tag_for :li, casualty, class: 'casualty' do %>
                         <%= link_to casualty.personal_details, public_document_url(fatality_notice) %>
                       <% end %>
                     <% end %>
-                <% else %>
-                  <li class="casualty"><%= link_to fatality_notice.title, public_document_url(fatality_notice) %></li>
-                <% end %>
+                  <% else %>
+                    <li class="casualty"><%= link_to fatality_notice.title, public_document_url(fatality_notice) %></li>
+                  <% end %>
                 </ul>
               <% end %>
             <% end %>
@@ -83,7 +85,6 @@
           <p>There have been no fatality notices added for this field of operation yet.</p>
         <% end %>
       </div>
-
     </section>
   </div>
 </div>


### PR DESCRIPTION
## What?

Changing headings to gem components

## Why?

To align architecture, improve consistency and in turn improve a11y.

## Visuals

Links

[`/government/fields-of-operation/iraq`](http://www.gov.uk/government/fields-of-operation/iraq)
[`/world/embassies`](http://www.gov.uk/world/embassies)
[`/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup`](http://gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup)

(Before - left, After - right)

![Screenshot 2021-04-13 at 09 53 14](https://user-images.githubusercontent.com/71266765/114527206-99138c80-9c3f-11eb-82d9-758ddeaeaad6.png)

![Screenshot 2021-04-13 at 09 52 09](https://user-images.githubusercontent.com/71266765/114527214-9add5000-9c3f-11eb-9c2a-7e24d4adea6a.png)

![Screenshot 2021-04-07 at 09 35 08](https://user-images.githubusercontent.com/71266765/113836225-9965e080-9784-11eb-8c69-f215135baae7.png)

![Screenshot 2021-04-07 at 09 34 27](https://user-images.githubusercontent.com/71266765/113836236-9b2fa400-9784-11eb-8c43-31a24c5cf6ac.png)

![image](https://user-images.githubusercontent.com/71266765/113901989-524d0f00-97c7-11eb-8213-159c37c9bbe8.png)

![image](https://user-images.githubusercontent.com/71266765/113901918-3b0e2180-97c7-11eb-8cb7-fae53bcfb9c5.png)

## Anything else?

The vast majority of headings appears in sections in Whitehall that are due for Redesign or are within the internal user facing _admin_ section of Whitehall both of which has been deprioritised for component swaps.

These include headings that appear under:

`/world/france/news`
`/government/topical-events/cop26`
`/government/how-government-works`
`/government/get-involved`
`/government/fields-of-operation`
`/government/organisations/`
`/government/organisations/charity-Commission/about`
`/government/history/past-prime-ministers/william-pitt`
`/government/history/past-foreign-secretaries/william-grenville`
`/government/latest?page=2&world_locations%5B%5D=singapore`

&
`/views/admin`

## Also 

[`/world/embassies`](http://www.gov.uk/world/embassies)
Has had a first pass refactor to apply the [Design System](https://design-system.service.gov.uk/) to the page, however many a11y issues remain. This is out of scope of this PR. 

Notable changes:
- The visual link style has changed slightly 
- The heading "A-Z" is not longer hidden on mobile.
