### PR TITLE
Internationalise display_type methods

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -118,18 +118,6 @@ class Consultation < Publicationesque
     consultation_participation.present?
   end
 
-  def display_type
-    if outcome_published?
-      "Consultation outcome"
-    elsif closed?
-      "Closed consultation"
-    elsif open?
-      "Open consultation"
-    else
-      "Consultation"
-    end
-  end
-
   def display_type_key
     if outcome_published?
       "consultation_outcome"

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -81,10 +81,6 @@ class CorporateInformationPage < Edition
     true
   end
 
-  def display_type
-    "Corporate information"
-  end
-
   def translatable?
     !non_english_edition?
   end

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -74,10 +74,6 @@ class DetailedGuide < Edition
     additional_related_mainstream_content_url.present?
   end
 
-  def display_type
-    "Detailed guide"
-  end
-
   def display_type_key
     "detailed_guidance"
   end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -38,10 +38,6 @@ class DocumentCollection < Edition
     ].flatten.join("\n")
   end
 
-  def display_type
-    "Collection"
-  end
-
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -593,7 +593,7 @@ EXISTS (
   end
 
   def display_type
-    format_name.capitalize
+    I18n.t("document.type.#{display_type_key}.one")
   end
 
   def display_type_key

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -35,10 +35,6 @@ class NewsArticle < Announcement
     self.news_article_type_id = news_article_type && news_article_type.id
   end
 
-  def display_type
-    news_article_type.singular_name
-  end
-
   def display_type_key
     news_article_type.key
   end

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -34,11 +34,11 @@ class OffsiteLink < ApplicationRecord
     def self.display_type(link_type)
       case link_type
       when "content_publisher_news_story"
-        "News story"
+        I18n.t("document.type.news_story.one")
       when "content_publisher_press_release"
-        "Press release"
+        I18n.t("document.type.press_release.one")
       else
-        humanize(link_type)
+        I18n.t("document.type.#{link_type}.one")
       end
     end
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -79,10 +79,6 @@ class Publication < Publicationesque
     newly_created ? false : all_nation_applicability
   end
 
-  def display_type
-    publication_type.try(:singular_name)
-  end
-
   def display_type_key
     publication_type.key
   end

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -41,9 +41,9 @@ class Speech < Announcement
 
   def display_type
     if speech_type.statement_to_parliament?
-      "Statement to Parliament"
+      I18n.t("document.type.statement_to_parliament.one")
     else
-      super
+      I18n.t("document.type.speech.one")
     end
   end
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -131,7 +131,11 @@ class StatisticsAnnouncement < ApplicationRecord
   end
 
   def display_type
-    publication_type.singular_name
+    I18n.t("document.type.#{display_type_key}.one")
+  end
+
+  def display_type_key
+    publication_type.key
   end
 
   def publication_type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,12 +153,24 @@ en:
       draft_text:
         one: Draft text
         other: Draft texts
+      edition:
+        one: Edition
+        other: Editions
+      edition_with_appointment:
+        one: Edition with appointment
+        other: Editions with appointment
+      fatality_notice:
+        one: Fatality notice
+        other: Fatality notices
       foi_release:
         one: FOI release
         other: FOI releases
       form:
         one: Form
         other: Forms
+      generic_edition:
+        one: Generic edition
+        other: Generic editions
       guidance:
         one: Guidance
         other: Guidance
@@ -219,6 +231,9 @@ en:
       publication:
         one: Publication
         other: Publications
+      publication_scheme:
+        one: Publication scheme
+        other: Publication schemes
       government_response:
         one: Government response
         other: Government responses
@@ -246,6 +261,9 @@ en:
       official_statistics:
         one: Official Statistics
         other: Official Statistics
+      terms_of_reference:
+        one: Terms of reference
+        other: Terms of reference
       transcript:
         one: Transcript
         other: Transcripts

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -39,7 +39,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
     get :index, params: { state: :draft }
 
-    assert_select_object(guide) { assert_select ".type", text: "Detailed guide" }
+    assert_select_object(guide) { assert_select ".type", text: "Detailed guide: Guidance" }
     assert_select_object(publication) { assert_select ".type", text: "Publication: Policy paper" }
   end
 

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -111,13 +111,13 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index, params: { locale: "fr" }
 
     assert_select "#news_article_#{news.id}" do
-      assert_select ".display-type", text: "News story"
+      assert_select ".display-type", text: "Actualités"
     end
     assert_select "#speech_#{speech.id}" do
-      assert_select ".display-type", text: "Speech"
+      assert_select ".display-type", text: "Discours"
     end
     assert_select "#speech_#{written_statement.id}" do
-      assert_select ".display-type", text: "Statement to Parliament"
+      assert_select ".display-type", text: "Déclaration au Parlement"
     end
   end
 

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -123,7 +123,7 @@ class StatisticsControllerTest < ActionController::TestCase
       assert_equal statistic_path(statistics_publication.document), json["url"]
       assert_equal "org-name et other-org", json["organisations"]
       assert_equal %(<time class="public_timestamp" datetime="2011-03-14T00:00:00+00:00">mars 14, 2011</time>), json["display_date_microformat"]
-      assert_equal "Official Statistics", json["display_type"]
+      assert_equal "Statistiques", json["display_type"]
     end
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -33,12 +33,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "format name", Edition.new.format_name
   end
 
-  test "returns capitalized format name as default display type" do
-    edition = Edition.new
-    edition.stubs(:format_name).returns("format name")
-    assert_equal "Format name", edition.display_type
-  end
-
   test "adds a document before validation if none provided" do
     edition = build(:edition)
     edition.valid?


### PR DESCRIPTION
Use I18n for display_type methods, and fix tests to used translated texts as appropriate.

https://trello.com/c/8Y98ExuW/2456-normalise-how-the-document-type-is-presented-to-publishing-api-for-organisation-pages-5
