### PR TITLE
Update contacts partial to use govuk components and styling

### DIFF
--- a/app/assets/stylesheets/frontend/views/_worldwide-organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_worldwide-organisations.scss
@@ -115,80 +115,6 @@
     }
   }
 
-  .contact-us {
-    .contact {
-      min-width: 0; // to overide something from static
-      @include core-16;
-      margin-bottom: $gutter;
-
-      @include media(desktop) {
-        float: left;
-        width: $one-third;
-      }
-
-      &.clear-contact {
-        clear: both;
-      }
-
-      .content {
-        padding: 0 $gutter-half;
-      }
-
-      h2 {
-        @include core-19;
-        font-weight: bold;
-      }
-
-      .comments {
-        margin: $gutter-one-third 0;
-      }
-
-      .adr {
-        margin: $gutter-one-third 0;
-      }
-
-      .email-url-number {
-        p {
-          margin: $gutter-one-third 0;
-        }
-
-        .type {
-          display: block;
-        }
-      }
-    }
-
-    .contact.main {
-
-      @include media(desktop) {
-        width: $full-width;
-        margin: 0 0 $gutter;
-      }
-
-      .content {
-        margin: 0 $gutter-half;
-        @extend %contain-floats;
-        padding: $gutter 0;
-        border-bottom: 1px solid $border-colour;
-
-        .comments {
-          @include media(desktop) {
-            float: right;
-            width: $one-third;
-          }
-        }
-
-        .adr,
-        .email-url-number {
-          @include media(desktop) {
-            float: left;
-            width: $one-third;
-          }
-        }
-      }
-    }
-  }
-
   .contact-us,
   .corporate-information {
     .keyline-header {
@@ -214,4 +140,13 @@
       }
     }
   }
+}
+
+.contact-section {
+  border-top: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(6) 0;
+}
+
+.contact-section__address {
+  font-style: normal;
 }

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,40 +1,39 @@
-<%
-  extra_class = []
-  if local_assigns.include?(:contact_counter) and contact_counter % 3 == 0
-    extra_class << "clear-contact"
-  end
-  extra_class << 'main' if local_assigns[:is_main]
-  extra_class << 'contact' unless contact.is_a? Contact
-  extra_class << 'postal-address' if contact.has_postal_address?
-%>
-<%= content_tag_for(:div, contact, class: extra_class.join(' ')) do %>
-  <div class="content" <%= lang if local_assigns[:lang] %> >
+<%= content_tag_for(:div, contact, class: "contact-section", lang: local_assigns[:lang] ? lang : nil) do %>
+    <% unless local_assigns[:hide_title] %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: contact.title,
+        heading_level: 3,
+        font_size: "s",
+        margin_bottom: 2,
+      } %>
+    <% end %>
 
-    <div class="vcard contact-inner">
-      <% unless local_assigns[:hide_title] %>
-      <p><%= contact.title %></p>
-      <% end %>
+    <div class="govuk-grid-row">
       <% if contact.has_postal_address? %>
-        <%= render_hcard_address(contact) %>
+        <address class="govuk-grid-column-one-third contact-section__address">
+          <%= render_hcard_address(contact) %>
+        </address>
       <% end %>
 
       <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
-        <div class="email-url-number">
+        <div class="govuk-grid-column-one-third">
           <% if contact.email.present? %>
-            <p class="email">
-              <span class="type"><%= t('contact.email') %></span>
-              <%= mail_to contact.email, contact.email, class: "email govuk-link" %>
+            <p class="govuk-!-margin-bottom-4">
+              <%= t('contact.email') %><br />
+              <%= mail_to contact.email, contact.email, class: "govuk-link" %>
             </p>
           <% end %>
+
           <% if contact.contact_form_url.present? %>
-            <p class="contact_form_url">
-              <span class="type"><%= t('contact.contact_form') %></span>
+            <p class="govuk-!-margin-bottom-4">
+              <%= t('contact.contact_form') %><br />
               <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
             </p>
           <% end %>
+
           <% contact.contact_numbers.each do |number| %>
-            <p class="tel">
-              <span class="type"><%= number.label %></span>
+            <p class="govuk-!-margin-bottom-4">
+              <%= number.label %> <br />
               <%= number.number %>
             </p>
           <% end %>
@@ -42,18 +41,17 @@
       <% end %>
 
       <% if contact.comments.present? %>
-        <p class="comments">
+        <div class="govuk-grid-column-one-third">
           <%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %>
-        </p>
-      <% end %>
-
-      <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
-        <%
-          fallback = t_fallback('contact.access_and_opening_times')
-          lang = fallback if fallback && fallback != I18n.locale
-        %>
-        <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "url govuk-link", lang: lang %>
+        </div>
       <% end %>
     </div>
-  </div>
+
+    <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
+      <%
+        fallback = t_fallback('contact.access_and_opening_times')
+        lang = fallback if fallback && fallback != I18n.locale
+      %>
+      <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %>
+    <% end %>
 <% end %>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -68,10 +68,12 @@
 <% end %>
 
 <% if @main_office %>
-  <section class="govuk-grid-row contact-us" id="contact-us">
-    <h2 class="keyline-header">
-      <%= t("worldwide_organisation.headings.contact_us" ) %>
-    </h2>
+  <section id="contact-us">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("worldwide_organisation.headings.contact_us"),
+      border_top: 5,
+      padding: true,
+    } %>
     <%= render partial: "contacts/contact", locals: {
       contact: @main_office,
       is_main: true,

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -111,7 +111,7 @@ end
 Then(/^I see the offices in my specified order including the new one under the main office on the home page of the worldwide organisation$/) do
   visit worldwide_organisation_path(@the_organisation)
 
-  contact_headings = all(".contact-us div.contact div.vcard.contact-inner p:first-of-type:not(.email)").map(&:text)
+  contact_headings = all(".contact-section .gem-c-heading").map(&:text)
 
   assert_equal @the_main_office.title, contact_headings[0]
   @the_ordered_offices.each.with_index do |contact, idx|
@@ -134,8 +134,8 @@ end
 Then(/^that office is no longer visible on the home page of the worldwide organisation$/) do
   visit worldwide_organisation_path(@the_organisation)
 
-  within ".contact-us" do
-    assert_no_selector "div.contact h2", text: @the_removed_office.title
+  within ".contact-section:first-of-type" do
+    assert_no_selector "h2", text: @the_removed_office.title
   end
 end
 

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -259,7 +259,7 @@ end
 Then(/^I should see the "([^"]*)" contact in the admin interface with address "([^"]*)"$/) do |contact_description, address|
   within ".contact" do
     assert_selector "h3", text: contact_description
-    assert_selector ".adr .street-address", text: address
+    assert_selector ".vcard", text: address
   end
 end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -111,14 +111,13 @@ Then(/^the "([^"]*)" office details should be shown on the public website$/) do 
   visit worldwide_organisation_path(worldwide_org)
   worldwide_office = worldwide_org.offices.joins(contact: :translations).where(contact_translations: { title: description }).first
 
-  within "#{record_css_selector(worldwide_office)}.contact" do
-    assert_selector "p:first-of-type", text: worldwide_office.contact.title
-    within find(".vcard") do
-      # new lines cause challenges in matching to the rendering
-      address = worldwide_office.contact.street_address.gsub(/\s+/, " ")
-      assert_text address, normalize_ws: true
-    end
-    assert_selector ".tel", text: worldwide_office.contact.contact_numbers.first.number
+  within record_css_selector(worldwide_office) do
+    assert_selector ".gem-c-heading", text: worldwide_office.contact.title
+    # new lines cause challenges in matching to the rendering
+    address = worldwide_office.contact.street_address.gsub(/\s+/, " ")
+    assert_text address, normalize_ws: true
+
+    assert_selector "p:nth-of-type(2)", text: worldwide_office.contact.contact_numbers.first.number
   end
 end
 
@@ -159,7 +158,7 @@ Then(/^the "([^"]*)" should be shown as the main office on the public website$/)
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: contact_title }).first
   visit worldwide_organisation_path(worldwide_organisation)
-  within "#{record_css_selector(worldwide_office)}.main" do
+  within record_css_selector(worldwide_office) do
     assert_text contact_title
   end
 end

--- a/lib/address_formatter/h_card.rb
+++ b/lib/address_formatter/h_card.rb
@@ -5,7 +5,7 @@ require "address_formatter/formatter"
 module AddressFormatter
   class HCard < Formatter
     def render
-      "<p class=\"adr\">\n#{interpolate_address_template}\n</p>\n".html_safe
+      interpolate_address_template.html_safe
     end
 
     def interpolate_address_template
@@ -14,7 +14,7 @@ module AddressFormatter
 
     def interpolate_address_property(property_name)
       value = super
-      value.present? ? "<span class=\"#{property_name}\">#{ERB::Util.html_escape(value)}</span>" : ""
+      value.present? ? ERB::Util.html_escape(value).html_safe : ""
     end
 
   private
@@ -23,7 +23,7 @@ module AddressFormatter
       string
         .gsub(/^\n/, "")        # get rid of blank lines
         .strip                  # get rid of any trailing whitespace
-        .gsub(/\n/, "<br />\n") # add break tags where appropriate
+        .gsub(/\n/, "<br />") # add break tags where appropriate
     end
   end
 end

--- a/test/unit/address_formatter/h_card_test.rb
+++ b/test/unit/address_formatter/h_card_test.rb
@@ -119,61 +119,32 @@ class AddressFormatter::HCardTest < ActiveSupport::TestCase
   end
 
   def gb_addr
-    <<-GB_ADDR.strip_heredoc
-    <p class="adr">
-    <span class="fn">Recipient</span><br />
-    <span class="street-address">Street</span><br />
-    <span class="locality">Locality</span><br />
-    <span class="region">Region</span><br />
-    <span class="postal-code">Postcode</span><br />
-    <span class="country-name">Country</span>
-    </p>
+    <<-GB_ADDR.strip_heredoc.gsub(/\n/, "")
+      Recipient<br />Street<br />Locality<br />Region<br />Postcode<br />Country
     GB_ADDR
   end
 
   def es_addr
-    <<-ES_ADDR.strip_heredoc
-    <p class="adr">
-    <span class="fn">Recipient</span><br />
-    <span class="street-address">Street</span><br />
-    <span class="postal-code">Postcode</span> <span class="locality">Locality</span> <span class="region">Region</span><br />
-    <span class="country-name">Country</span>
-    </p>
+    <<-ES_ADDR.strip_heredoc.gsub(/\n/, "")
+      Recipient<br />Street<br />Postcode Locality Region<br />Country
     ES_ADDR
   end
 
   def jp_addr
-    <<-JP_ADDR.strip_heredoc
-    <p class="adr">
-    〒<span class="postal-code">Postcode</span><br />
-    <span class="region">Region</span><span class="locality">Locality</span><span class="street-address">Street</span><br />
-    <span class="fn">Recipient</span><br />
-    <span class="country-name">Country</span>
-    </p>
+    <<-JP_ADDR.strip_heredoc.gsub(/\n/, "")
+      〒Postcode<br />RegionLocalityStreet<br />Recipient<br />Country
     JP_ADDR
   end
 
   def addr_without_region
-    <<-ADDR_WITHOUT_REGION.strip_heredoc
-    <p class="adr">
-    <span class="fn">Recipient</span><br />
-    <span class="street-address">Street</span><br />
-    <span class="locality">Locality</span><br />
-    <span class="postal-code">Postcode</span><br />
-    <span class="country-name">Country</span>
-    </p>
+    <<-ADDR_WITHOUT_REGION.strip_heredoc.gsub(/\n/, "")
+      Recipient<br />Street<br />Locality<br />Postcode<br />Country
     ADDR_WITHOUT_REGION
   end
 
   def addr_without_country
-    <<-ADDR_WITHOUT_COUNTRY.strip_heredoc
-    <p class="adr">
-    <span class="fn">Recipient</span><br />
-    <span class="street-address">Street</span><br />
-    <span class="locality">Locality</span><br />
-    <span class="region">Region</span><br />
-    <span class="postal-code">Postcode</span>
-    </p>
+    <<-ADDR_WITHOUT_COUNTRY.strip_heredoc.gsub(/\n/, "")
+      Recipient<br />Street<br />Locality<br />Region<br />Postcode
     ADDR_WITHOUT_COUNTRY
   end
 end


### PR DESCRIPTION
## What
Updates the contacts partial on world organisation pages with the following changes:

- Replaces Whitehall's default grid styling with the [Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system)
- Replaces headings with the [heading component](https://components.publishing.service.gov.uk/component-guide/heading)
- Generally cleans up the markup and design to be closer in line with [other contact sections on govuk](https://www.gov.uk/government/organisations/department-of-health-and-social-care)

## Why
Part of ongoing work by the govuk accessibility team to ensure that we are consuming our components gem in as many places as possible to reduce the risk of hidden tech debt across our frontend apps.

[Card](https://trello.com/c/8uj38k8J/617-update-csv-preview-page)

[Page developed against](https://www.gov.uk/world/organisations/british-embassy-kabul)

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-04-09 at 13 57 32](https://user-images.githubusercontent.com/64783893/114183484-a547d300-993b-11eb-821b-c193cc169b6e.png) | ![Screenshot 2021-04-09 at 13 57 50](https://user-images.githubusercontent.com/64783893/114183501-abd64a80-993b-11eb-8b78-57b80e7657ab.png) |

