### PR TITLE
Fix header section for topical events

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -21,6 +21,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';
+@import 'govuk_publishing_components/components/metadata';
 @import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/organisation-logo';
 @import 'govuk_publishing_components/components/share-links';

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -17,17 +17,11 @@
         </div>
       <% end %>
       <% if @topical_event.organisations.any? %>
-        <aside class="meta metadata-list">
-          <div class="inner-heading">
-            <dl>
-              <dt><%= t('document.headings.organisations', count: @topical_event.organisations.length) %>:</dt>
-              <dd>
-                <%= render  partial: 'organisations/organisations_name_list',
-                            locals: { organisations: @topical_event.organisations } %>
-              </dd>
-            </dl>
-          </div>
-        </aside>
+        <%= render "govuk_publishing_components/components/metadata", {
+          other: {
+            "Organisations": sanitize(array_of_links_to_organisations(@topical_event.organisations).to_sentence)
+          }
+        } %>
       <% end %>
     </div>
   </header>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -4,25 +4,29 @@
 
 <%= content_tag_for(:div, @topical_event, class: "classification #{@topical_event.class.name.underscore}") do %>
 
-  <header class="block headings-block">
-    <div class="inner-block floated-children">
-      <%= render partial: 'shared/heading',
-                locals: { heading: "#{h(@topical_event.name)}#{' <span class="archived">(Archived)</span>' if @topical_event.archived?}".html_safe,
-                          big: true, extra: true } %>
-      <% if @topical_event.logo_url.present? %>
-        <div class="heading-extra topical-event-logo">
-          <div class="heading-inner">
-            <%= image_tag(@topical_event.logo_url(:s300), alt: @topical_event.logo_alt_text) if @topical_event.logo_url %>
-          </div>
+  <header class="headings-block">
+    <div class="inner-block">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/title", {
+            title: "#{h(@topical_event.name)}#{' <span class="archived">(Archived)</span>' if @topical_event.archived?}".html_safe
+          } %>
+          <% if @topical_event.organisations.any? %>
+            <%= render "govuk_publishing_components/components/metadata", {
+              other: {
+                "Organisations": sanitize(array_of_links_to_organisations(@topical_event.organisations).to_sentence)
+              }
+            } %>
+          <% end %>
         </div>
-      <% end %>
-      <% if @topical_event.organisations.any? %>
-        <%= render "govuk_publishing_components/components/metadata", {
-          other: {
-            "Organisations": sanitize(array_of_links_to_organisations(@topical_event.organisations).to_sentence)
-          }
-        } %>
-      <% end %>
+        <div class="govuk-grid-column-one-third">
+          <% if @topical_event.logo_url.present? %>
+            <div class="topical-event-logo">
+              <%= image_tag(@topical_event.logo_url(:s300), alt: @topical_event.logo_alt_text) if @topical_event.logo_url %>
+            </div>
+          <% end %>
+        </div>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
 - Use components for rendering title and metadata. The current template renders `<span class="translation_missing" title="translation missing: en.document.headings.organisations, count: 3">Organisations</span>`
 - Remove `<aside>` as it must not be contained in another landmark (`<main>` in this case)
 - Refactor `<header>` layout to use `govuk-frontend` grid

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![topical-events-before](https://user-images.githubusercontent.com/788096/114378820-fea04400-9b7f-11eb-8da7-9240c3a93304.png)


</td><td valign="top">

![topical-events-after](https://user-images.githubusercontent.com/788096/114378832-019b3480-9b80-11eb-989e-5d65c68b27e2.png)


</td></tr>
</table>
