### PR TITLE
Update to strong arguments for save_draft call

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -122,7 +122,7 @@ module DataHygiene
         Whitehall::PublishingApi.save_draft(
           pre_publication_edition,
           "republish",
-          true, # bulk_publishing
+          bulk_publishing: true,
         )
       else
         PublishingApiDocumentRepublishingWorker.perform_async(


### PR DESCRIPTION
Updates call to `save_draft` to use strong arguments for the boolean
`bulk_publishing`. This was updated recently in some [linting] but this
class was missed out.

[linting]: https://github.com/alphagov/whitehall/commit/cd718bf2d90aa198767e8d4328d3f3fd1ef13e02#diff-ad557b01bff4cdd095969e53213f875102c1ccee959830d3e8758b30e03764baR52