### PR TITLE
Add missing document type

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,9 @@ en:
       accessible_documents_policy:
         one: Accessible documents policy
         other: Accessible documents policies
+      service:
+        one: Service
+        other: Services
     updated: updated
     view: View '%{title}'
     read: Read the %{title} article


### PR DESCRIPTION
This was left out of #6062.

https://trello.com/c/zcGuMJpt/2467-add-missing-english-translations-for-document-types
