### PR TITLE
Add a p tag around the comments section of the contacts partial

### DIFF
--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,57 +1,57 @@
 <%= content_tag_for(:div, contact, class: "contact-section", lang: local_assigns[:lang] ? lang : nil) do %>
-    <% unless local_assigns[:hide_title] %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: contact.title,
-        heading_level: 3,
-        font_size: "s",
-        margin_bottom: 2,
-      } %>
+  <% unless local_assigns[:hide_title] %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: contact.title,
+      heading_level: 3,
+      font_size: "s",
+      margin_bottom: 2,
+    } %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <% if contact.has_postal_address? %>
+      <address class="govuk-grid-column-one-third contact-section__address">
+        <%= render_hcard_address(contact) %>
+      </address>
     <% end %>
 
-    <div class="govuk-grid-row">
-      <% if contact.has_postal_address? %>
-        <address class="govuk-grid-column-one-third contact-section__address">
-          <%= render_hcard_address(contact) %>
-        </address>
-      <% end %>
+    <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
+      <div class="govuk-grid-column-one-third">
+        <% if contact.email.present? %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= t('contact.email') %><br />
+            <%= mail_to contact.email, contact.email, class: "govuk-link" %>
+          </p>
+        <% end %>
 
-      <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
-        <div class="govuk-grid-column-one-third">
-          <% if contact.email.present? %>
-            <p class="govuk-!-margin-bottom-4">
-              <%= t('contact.email') %><br />
-              <%= mail_to contact.email, contact.email, class: "govuk-link" %>
-            </p>
-          <% end %>
+        <% if contact.contact_form_url.present? %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= t('contact.contact_form') %><br />
+            <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
+          </p>
+        <% end %>
 
-          <% if contact.contact_form_url.present? %>
-            <p class="govuk-!-margin-bottom-4">
-              <%= t('contact.contact_form') %><br />
-              <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
-            </p>
-          <% end %>
-
-          <% contact.contact_numbers.each do |number| %>
-            <p class="govuk-!-margin-bottom-4">
-              <%= number.label %> <br />
-              <%= number.number %>
-            </p>
-          <% end %>
-        </div>
-      <% end %>
-
-      <% if contact.comments.present? %>
-        <div class="govuk-grid-column-one-third">
-          <%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %>
-        </div>
-      <% end %>
-    </div>
-
-    <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
-      <%
-        fallback = t_fallback('contact.access_and_opening_times')
-        lang = fallback if fallback && fallback != I18n.locale
-      %>
-      <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %>
+        <% contact.contact_numbers.each do |number| %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= number.label %> <br />
+            <%= number.number %>
+          </p>
+        <% end %>
+      </div>
     <% end %>
+
+    <% if contact.comments.present? %>
+      <div class="govuk-grid-column-one-third">
+        <p><%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %></p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
+    <%
+      fallback = t_fallback('contact.access_and_opening_times')
+      lang = fallback if fallback && fallback != I18n.locale
+    %>
+    <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
## What
Wraps the comments section of the contacts partial in a `p` tag.

## Why
Quality of life change for instances where the contacts partial is in govspeak on government frontend ([example](https://www.gov.uk/government/publications/attendance-allowance-claim-form))

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-04-21 at 16 18 12](https://user-images.githubusercontent.com/64783893/115579736-5b0d0d00-a2be-11eb-8d63-60e3acee4ef2.png) | ![Screenshot 2021-04-21 at 16 26 21](https://user-images.githubusercontent.com/64783893/115579755-5fd1c100-a2be-11eb-83aa-34af79489ee2.png) |

### Note
This is a very quick fix and does not solve the root problem that whitehall is using a single partial to render similar information for 2 different use cases ([the other use case](https://www.gov.uk/world/organisations/british-embassy-kabul)). Notably, the instance seen here is using a heading above the contacts section which has been agreed as bad for accessibility. This should be investigated and amended ASAP.