### PR TITLE
Separate out worldwide org contacts partial and govspeak contacts partial

### DIFF
--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,57 +1,45 @@
-<%= content_tag_for(:div, contact, class: "contact-section", lang: local_assigns[:lang] ? lang : nil) do %>
+<%= content_tag_for(:div, contact, class: "contact", lang: local_assigns[:lang] ? lang : nil) do %>
   <% unless local_assigns[:hide_title] %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: contact.title,
-      heading_level: 3,
-      font_size: "s",
-      margin_bottom: 2,
-    } %>
+    <p><%= contact.title %></p>
   <% end %>
 
-  <div class="govuk-grid-row">
-    <% if contact.has_postal_address? %>
-      <address class="govuk-grid-column-one-third contact-section__address">
-        <%= render_hcard_address(contact) %>
-      </address>
-    <% end %>
+  <% if contact.has_postal_address? %>
+    <p class="govuk-!-margin-bottom-4">
+      <%= render_hcard_address(contact) %>
+    </p>
+  <% end %>
 
-    <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
-      <div class="govuk-grid-column-one-third">
-        <% if contact.email.present? %>
-          <p class="govuk-!-margin-bottom-4">
-            <%= t('contact.email') %><br />
-            <%= mail_to contact.email, contact.email, class: "govuk-link" %>
-          </p>
-        <% end %>
+  <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
+    <div>
+      <% if contact.email.present? %>
+        <p class="govuk-!-margin-bottom-4">
+          <%= t('contact.email') %> <%= mail_to contact.email, contact.email, class: "govuk-link" %>
+        </p>
+      <% end %>
 
-        <% if contact.contact_form_url.present? %>
-          <p class="govuk-!-margin-bottom-4">
-            <%= t('contact.contact_form') %><br />
-            <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
-          </p>
-        <% end %>
+      <% if contact.contact_form_url.present? %>
+        <p class="govuk-!-margin-bottom-4">
+          <%= t('contact.contact_form') %> <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
+        </p>
+      <% end %>
 
-        <% contact.contact_numbers.each do |number| %>
-          <p class="govuk-!-margin-bottom-4">
-            <%= number.label %> <br />
-            <%= number.number %>
-          </p>
-        <% end %>
-      </div>
-    <% end %>
+      <% contact.contact_numbers.each do |number| %>
+        <p class="govuk-!-margin-bottom-4">
+          <%= number.label %> <%= number.number %>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
 
-    <% if contact.comments.present? %>
-      <div class="govuk-grid-column-one-third">
-        <p><%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %></p>
-      </div>
-    <% end %>
-  </div>
+  <% if contact.comments.present? %>
+    <p><%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %></p>
+  <% end %>
 
   <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
     <%
       fallback = t_fallback('contact.access_and_opening_times')
       lang = fallback if fallback && fallback != I18n.locale
     %>
-    <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %>
+    <p><%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %></p>
   <% end %>
 <% end %>

--- a/app/views/contacts/_organisation_contact.html.erb
+++ b/app/views/contacts/_organisation_contact.html.erb
@@ -1,0 +1,57 @@
+<%= content_tag_for(:div, contact, class: "contact-section", lang: local_assigns[:lang] ? lang : nil) do %>
+  <% unless local_assigns[:hide_title] %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: contact.title,
+      heading_level: 3,
+      font_size: "s",
+      margin_bottom: 2,
+    } %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <% if contact.has_postal_address? %>
+      <address class="govuk-grid-column-one-third contact-section__address">
+        <%= render_hcard_address(contact) %>
+      </address>
+    <% end %>
+
+    <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
+      <div class="govuk-grid-column-one-third">
+        <% if contact.email.present? %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= t('contact.email') %><br />
+            <%= mail_to contact.email, contact.email, class: "govuk-link" %>
+          </p>
+        <% end %>
+
+        <% if contact.contact_form_url.present? %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= t('contact.contact_form') %><br />
+            <%= link_to contact.contact_form_url.truncate(25), contact.contact_form_url, class: "govuk-link" %>
+          </p>
+        <% end %>
+
+        <% contact.contact_numbers.each do |number| %>
+          <p class="govuk-!-margin-bottom-4">
+            <%= number.label %> <br />
+            <%= number.number %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if contact.comments.present? %>
+      <div class="govuk-grid-column-one-third">
+        <p><%= auto_link(format_with_html_line_breaks(h(contact.comments)), html: { class: "govuk-link" }) %></p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
+    <%
+      fallback = t_fallback('contact.access_and_opening_times')
+      lang = fallback if fallback && fallback != I18n.locale
+    %>
+    <%= link_to t('contact.access_and_opening_times'), [contact.worldwide_organisation, contact], class: "govuk-link", lang: lang %>
+  <% end %>
+<% end %>

--- a/app/views/worldwide_offices/show.html.erb
+++ b/app/views/worldwide_offices/show.html.erb
@@ -32,7 +32,7 @@
       margin_bottom: 4,
     } %>
     <div class="contact-us govuk-clearfix">
-      <%= render partial: 'contacts/contact', locals: {
+      <%= render partial: "contacts/organisation_contact", locals: {
         contact: @worldwide_office.contact,
         hide_title: true,
       } %>

--- a/app/views/worldwide_organisations/_worldwide_organisation.html.erb
+++ b/app/views/worldwide_organisations/_worldwide_organisation.html.erb
@@ -14,5 +14,5 @@
     </div>
   </div>
 
-  <%= render('contacts/contact', contact: worldwide_organisation.main_office) if worldwide_organisation.main_office.present? %>
+  <%= render('contacts/organisation_contact', contact: worldwide_organisation.main_office) if worldwide_organisation.main_office.present? %>
 <% end %>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -74,13 +74,13 @@
       border_top: 5,
       padding: true,
     } %>
-    <%= render partial: "contacts/contact", locals: {
+    <%= render partial: "contacts/organisation_contact", locals: {
       contact: @main_office,
       is_main: true,
       lang: t_lang_translated_locales(@main_office.contact)
     } %>
     <% @home_page_offices.each do |home_page_office| %>
-      <%= render partial: "contacts/contact", locals: {
+      <%= render partial: "contacts/organisation_contact", locals: {
         contact: home_page_office,
         lang: t_lang_translated_locales(home_page_office.contact)
       } %>


### PR DESCRIPTION
## What
Copies the contacts partial on [worldwide org pages](https://www.gov.uk/world/organisations/british-embassy-kabul) in it's current state for use on worldwide org pages specifically and updates the contacts partial to not use the govuk grid.

## Why
In some [recent work](https://github.com/alphagov/whitehall/pull/6057) on govuk accessibility, I accidentally overwrite work done to ensure that headings were removed from contacts sections. This additionally addresses a [zendesk ticket](https://govuk.zendesk.com/agent/tickets/4539786) related to contact sections looking weird. This separation ensure that the 2 cases both meet their expected needs without impacting one another.

## Visual changes
It's difficult to test this on a live example as this would be rendered via govspeak in government frontend, so this is a like-for-like example to illustrate how the change will look on when deployed and republished.

| Before | After |
| --- | --- |
| ![Screenshot 2021-04-22 at 11 16 40](https://user-images.githubusercontent.com/64783893/115704976-e4c2e600-a363-11eb-9123-2b322d7acc51.png) | ![Screenshot 2021-04-22 at 11 53 19](https://user-images.githubusercontent.com/64783893/115704953-dd034180-a363-11eb-805f-aaf29950d3b8.png) |