### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
   GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
   bundle exec rake shared_mustache:compile assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck/ready || exit 1
 
 CMD foreman run web

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -417,12 +417,6 @@ Whitehall::Application.routes.draw do
   get "/courts-tribunals(.:locale)", as: "courts", to: "organisations#index", courts_only: true, constraints: { locale: valid_locales_regex }
   get "/courts-tribunals/:id(.:locale)", as: "court", to: "organisations#show", courts_only: true, constraints: { locale: valid_locales_regex }
 
-  get "/healthcheck",
-      to: GovukHealthcheck.rack_response(
-        GovukHealthcheck::SidekiqRedis,
-        GovukHealthcheck::ActiveRecord,
-      )
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -7,11 +7,6 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     JSON.parse(response.body)
   end
 
-  test "GET /healthcheck returns success on request" do
-    get "/healthcheck"
-    assert_response :success
-  end
-
   test "GET /healthcheck/overdue shows number of overdue scheduled publications" do
     with_real_sidekiq do
       create(:scheduled_edition, scheduled_publication: 1.day.ago)


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
