### PR TITLE
Do not display document type for Topical Events

### DIFF
--- a/app/views/shared/_featured.html.erb
+++ b/app/views/shared/_featured.html.erb
@@ -17,7 +17,7 @@
       image_alt: feature.alt_text,
       context: {
         date: feature.time_stamp,
-        text: t_display_type(feature),
+        text: feature.topical_event ? nil : t_display_type(feature),
       },
       heading_text: feature.title,
       description: truncate(feature.summary, length: 160, separator: ' '),


### PR DESCRIPTION
In [a previous commit](https://github.com/alphagov/whitehall/commit/e7192cf2e4b68f735ce31df50a8d64158dfa6e80#diff-4857b57b41ca369b284a13f65b2d171a6bd7a0bb7880c154be8841e82eb16cecL26-L34), the conditional for Topical Events was removed. This previously had the effect of not displaying the document type for Topical Events. As there is no published edition for these document types, the `display_type_key` method fails due to a `undefined method 'published_edition' for nil:NilClass` and a 500 error is returned.

Therefore adding the conditional back in so we don't attempt to show a document type for Topical Events.

Sentry issue: [APP-WHITEHALL-7XH](https://sentry.io/organizations/govuk/issues/2328381368/?referrer=github_plugin).

Trello card: https://trello.com/c/GL03zuU5