### PR TITLE
Add ActiveRecord::Deadlocked to list of datasync excluded errors

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -3,4 +3,8 @@ GovukError.configure do |config|
     "AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient",
     "Redis::CannotConnectError",
   ]
+
+  config.data_sync_excluded_exceptions += [
+    "ActiveRecord::Deadlocked",
+  ]
 end


### PR DESCRIPTION
We're seeing errors during the data sync:
https://sentry.io/organizations/govuk/issues/2388146076/?project=202259&referrer=slack