### PR TITLE
Add styles for `govuk-select` class used in world location

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -26,6 +26,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/organisation-logo';
 @import 'govuk_publishing_components/components/share-links';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/subscription-links';
 @import 'govuk_publishing_components/components/title';
 


### PR DESCRIPTION
Using the component class at a time where all style components were imported in all applications resulted later in an unstyled element.