### PR TITLE
Redirect uk-national-screening-committee group to new organsation page

### DIFF
--- a/lib/tasks/redirect_nsca_group.rake
+++ b/lib/tasks/redirect_nsca_group.rake
@@ -1,0 +1,9 @@
+namespace :nsca_group_to_org do
+  desc "Unpublish and redirect the NSCA PolicyGroup"
+  task unpublish_and_redirect: :environment do
+    content_id = "eb6556f5-e0c9-4f26-a3d4-66e7f17657d8"
+    destination = "/government/organisations/uk-national-screening-committee"
+
+    PublishingApiRedirectWorker.new.perform(content_id, destination, "en")
+  end
+end


### PR DESCRIPTION
The UK National Screening Committee `PolicyGroup` page at `/groups/uk-national-screening-committee-uk-nsc` is to be redirected to the new `Organisation` page at `/organisations/uk-national-screening-committee`.

This new page will be live on Monday 17th May 2021 at 0900, so the rake task should not be run before then.