### PR TITLE
Revert "Redirect uk-national-screening-committee group to new organsation page"

### DIFF
--- a/lib/tasks/redirect_nsca_group.rake
+++ b/lib/tasks/redirect_nsca_group.rake
@@ -1,9 +1,0 @@
-namespace :nsca_group_to_org do
-  desc "Unpublish and redirect the NSCA PolicyGroup"
-  task unpublish_and_redirect: :environment do
-    content_id = "eb6556f5-e0c9-4f26-a3d4-66e7f17657d8"
-    destination = "/government/organisations/uk-national-screening-committee"
-
-    PublishingApiRedirectWorker.new.perform(content_id, destination, "en")
-  end
-end


### PR DESCRIPTION
This temporary Rake task has now been run in Production and can be removed.

Reverts alphagov/whitehall#6108