### PR TITLE
Refresh markup on world embassies index page

### DIFF
--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,6 +1,6 @@
-<% offices = Embassy.filter_offices(organisation) -%>
-<% if offices.any? -%>
-  <li class="govuk-!-margin-bottom-4">
+<% offices = Embassy.filter_offices(organisation) %>
+<% if offices.any? %>
+  <li>
     <%= render "govuk_publishing_components/components/heading", {
       text: offices.first.contact.locality,
       heading_level: 3,
@@ -8,4 +8,4 @@
     } %>
     <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
   </li>
-<% end -%>
+<% end %>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,11 +1,9 @@
 <% page_title "Find a British embassy, High Commission or Consulate" %>
 <% page_class "worldwide-organisations embassies-index govuk-width-container" %>
-<header class="block headings-block">
-  <%= render "govuk_publishing_components/components/title", {
-    context: "Worldwide",
-    title: "Find a British embassy, high commission or consulate",
-  } %>
-</header>
+<%= render "govuk_publishing_components/components/title", {
+  context: "Worldwide",
+  title: "Find a British embassy, high commission or consulate",
+} %>
 <div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
       <aside class="govuk-grid-column-one-quarter">
@@ -16,37 +14,35 @@
         } %>
       </aside>
       <section class="govuk-grid-column-three-quarters">
-        <ol class="locations">
+        <ol class="govuk-list govuk-list--spaced">
           <% @embassies_by_location.each do |embassy| -%>
-          <li class="govuk-grid-row govuk-!-margin-bottom-4">
+          <li class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <%= render "govuk_publishing_components/components/heading", {
                 text: embassy.name, margin_bottom: 1
               } %>
             </div>
             <div class="govuk-grid-column-two-thirds">
-              <% if embassy.has_consular_service_in_location? && embassy.offices.empty? -%>
-              <p>
-                <%= embassy.text %>
-              </p>
-              <% else -%>
-              <ul>
-                <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? -%>
-                <li class="govuk-!-margin-bottom-4">
-                  <p class="govuk-!-padding-bottom-4">
-                    <%= embassy.text %>
-                  </p>
-                  <%= embassy.embassy_path %>
-                </li>
-                <% else %>
-                <%= render partial:"organisation", collection: embassy.consular_services_organisations -%>
-                <% end %>
-              </ul>
-              <% end -%>
+              <% if embassy.has_consular_service_in_location? && embassy.offices.empty? %>
+                <p class="govuk-body"><%= embassy.text %></p>
+              <% else %>
+                <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
+                  <% if !embassy.has_consular_service_in_location? || embassy.has_remote_service? %>
+                  <li>
+                    <p class="govuk-body">
+                      <%= embassy.text %>
+                    </p>
+                    <%= embassy.embassy_path %>
+                  </li>
+                  <% else %>
+                    <%= render partial:"organisation", collection: embassy.consular_services_organisations %>
+                  <% end %>
+                </ul>
+              <% end %>
             </div>
           </li>
-          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4">
-          <% end -%>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+          <% end %>
         </ol>
       </section>
   </div>

--- a/test/functional/embassies_controller_test.rb
+++ b/test/functional/embassies_controller_test.rb
@@ -31,12 +31,12 @@ class EmbassiesControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select "ol[class='locations'] h2", "Afghanistan"
-    assert_select "ol[class='locations'] h2", "Aruba"
-    assert_select "ol[class='locations'] h2", "Sealand"
-    assert_select "ol[class='locations'] ul a", /The British Embassy Kabul/
-    assert_select "ol[class='locations'] li p", /British nationals should contact the British Consulate General Amsterdam in Netherlands/
-    assert_select "ol[class='locations'] li p", /British nationals should contact the local authorities/
+    assert_select "ol.govuk-list h2", "Afghanistan"
+    assert_select "ol.govuk-list h2", "Aruba"
+    assert_select "ol.govuk-list h2", "Sealand"
+    assert_select "ol.govuk-list ul a", /The British Embassy Kabul/
+    assert_select "ol.govuk-list li p", /British nationals should contact the British Consulate General Amsterdam in Netherlands/
+    assert_select "ol.govuk-list li p", /British nationals should contact the local authorities/
   end
 
   view_test "UK doesn't appear in the page" do
@@ -44,7 +44,7 @@ class EmbassiesControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select "ol[class='locations'] h2", false, "This page shouldn't contain any embassies."
+    assert_select "ol.govuk-list h2", false, "This page shouldn't contain any embassies."
   end
 
   view_test "some countries have different remote consular services" do
@@ -57,9 +57,9 @@ class EmbassiesControllerTest < ActionController::TestCase
 
       get :index
 
-      assert_select "ol[class='locations'] h2", name
-      assert_select "ol[class='locations'] li p", /British nationals should contact the #{building} in #{building_location}/
-      assert_select "ol[class='locations'] li a", building
+      assert_select "ol.govuk-list h2", name
+      assert_select "ol.govuk-list li p", /British nationals should contact the #{building} in #{building_location}/
+      assert_select "ol.govuk-list li a", building
     end
   end
 end


### PR DESCRIPTION
## What
Updates the [world embassies index page](https://www.gov.uk/world/embassies) to use design system classes and reduce the number of override classes to adhere to the design of the page.

## Why
Part of ongoing work by the govuk accessibility team to ensure we are consuming our frontend tooling (the components gem and the design system) as often as possible to reduce the risk of legacy frontend in our apps.

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-26 at 09 46 00](https://user-images.githubusercontent.com/64783893/119644051-5d5e0c00-be14-11eb-86a4-ada0741a0789.png) | ![Screenshot 2021-05-26 at 09 45 50](https://user-images.githubusercontent.com/64783893/119644085-664edd80-be14-11eb-9903-0172d5859198.png) |


