### PR TITLE
Remove link from heading context and replace with breadcrumb

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -10,6 +10,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/component_support';
 
 @import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/contents-list';
 @import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';

--- a/app/assets/stylesheets/frontend/global/_links.scss
+++ b/app/assets/stylesheets/frontend/global/_links.scss
@@ -1,4 +1,4 @@
-a:not(a[class^="gem-c-"]) {
+a:not(a[class^="gem-c-"]):not(a[class^="govuk-breadcrumbs"]) {
   color: $govuk-link-colour;
   text-decoration: none;
 

--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -1,12 +1,22 @@
 <% page_title "Past Chancellors" %>
 <% page_class "historic-appointments historic-appointments-index historical-past-chancellors" %>
-
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: "Home",
+        url: "/"
+      },
+      {
+        title: "History of the UK Government",
+        url: "/government/history"
+      }
+    ]
+  } %>
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "Past Chancellors of the Exchequer",
     } %>

--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -1,12 +1,22 @@
 <% page_title "History of #{@person.name}" %>
 <% page_class "historic-appointments historic-people-show" %>
-
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/"
+    },    
+    {
+      title: "History of the UK Government",
+      url: "/government/history"
+    }
+  ]
+} %>
 <header class="block headings-block">
   <div class="govuk-width-container">
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "Past #{@role.name.pluralize}",
     } %>

--- a/app/views/latest/index.html.erb
+++ b/app/views/latest/index.html.erb
@@ -4,16 +4,49 @@
 
 <header class="block headings-block">
   <div class="govuk-width-container">
+    <% if  subject.is_a? Organisation %>
+      <%= render "govuk_publishing_components/components/breadcrumbs", {
+        breadcrumbs: [
+          {
+            title: "Home",
+            url: "/",
+          },
+          {
+            title: "Organisations",
+            url: "/government/organisations",
+          },
+          {
+            title: "#{subject}",
+            url: "/government/organisations/#{subject['slug']}",
+          },
+        ]
+      } %>
+    <% elsif subject&.type == "TopicalEvent" %>
+        <%= render "govuk_publishing_components/components/breadcrumbs", {
+          breadcrumbs: [
+            {
+              title: "Home",
+              url: "/",
+            },
+            {
+              title: "Topical events",
+              url: "/government/topical-events",
+            },
+            {
+              title: "#{subject}",
+              url: "/government/topical-events/#{subject['slug']}",
+            },
+          ]
+        } %>
+    <% end %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: subject,
-        href: subject,
       },
       title: t("document.latest"),
     } %>
   </div>
 </header>
-
 <div class="block results">
   <div class="inner-block">
     <%= render "shared/feeds", atom_url: atom_feed_url_for(subject) %>

--- a/app/views/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/past_foreign_secretaries/_show_person.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/"
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history"
+        }
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "Past Foreign Secretaries",
     } %>

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -1,13 +1,21 @@
 <% page_title "Past Foreign Secretaries" %>
 <% page_class "historic-people-index govuk-width-container" %>
-
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/"
+    },
+    {
+      title: "History of the UK Government",
+      url: "/government/history"
+    }
+  ]
+} %>
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-        href: "/government/history",
-      },
+      context:"History",
       title: "Past Foreign Secretaries",
     } %>
   </div>


### PR DESCRIPTION
https://trello.com/c/3ENWcE93/729-confusing-contextual-link-on-some-pages

This removes a link from the contextual text that sits above a header, and replaces it with breadcrumbs. This is to preserve the links back to parent content but to make the link more obvious and usable. We will later remove the ability to link contextual text as it is too difficult for users to recognise as a link.

To deal with the breadcrumbs I've had to bring in the CSS and do some overrides of greedy CSS selectors elsewhere. 

Sample URLs:
https://www.gov.uk/government/latest?topical_events%5B%5D=cop26
https://www.gov.uk/government/latest?departments%5B%5D=department-for-education&t=3
https://www.gov.uk/government/history/past-foreign-secretaries
https://www.gov.uk/government/history/past-foreign-secretaries/robert-cecil

I'm particularly interested to know if there's a better way to detect whether the latests documents (app/views/latest/index.html.erb) screen is showing topical events content or organisational content as the "subject" didn't seem to share much commonality.

## Before
![Screenshot 2021-07-05 at 13 55 58](https://user-images.githubusercontent.com/31649453/124476401-a94c8b00-dd9a-11eb-8ee0-7b7138098db5.png)
## After
![Screenshot 2021-07-05 at 13 53 07](https://user-images.githubusercontent.com/31649453/124476377-a0f45000-dd9a-11eb-8d2e-fa10805490d8.png)

