### PR TITLE
Allow justice.gov.uk redirects

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -18,7 +18,7 @@ private
 
   def matches_allow_list?(value)
     uri = URI.parse(value)
-    uri.host&.end_with?(".judiciary.uk", "etl.beis.gov.uk")
+    uri.host&.end_with?(".judiciary.uk", "etl.beis.gov.uk", "justice.gov.uk")
   rescue URI::InvalidURIError
     false
   end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -47,7 +47,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert unpublishing.errors[:alternative_url].include?("cannot redirect to itself")
   end
 
-  test "alternative_url must not be external (must be in the form of https://www.gov.uk/example)" do
+  test "alternative_url must be internal (www.gov.uk) or present on the allowed list" do
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "http://example.com")
     assert_not unpublishing.valid?
 
@@ -59,6 +59,12 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://etl.beis.gov.uk/manufacturers")
     assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://justice.gov.uk/jelly-justice")
+    assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://some.random.site.uk/jelly-justice")
+    assert_not unpublishing.valid?
   end
 
   test "alternative_url is stripped before validate" do


### PR DESCRIPTION
We recently had a request to allow redirects to `justice.gov.uk`. This
adds the domain to the allowed list so content can be redirected to it.

[1]: https://github.com/alphagov/publishing-api/blob/main/app/validators/routes_and_redirects_validator.rb#L169

---

Trello:
https://trello.com/c/qbpw745H/2548-add-justicegovuk-site-to-list-of-sites-that-publishers-can-redirect-to