### PR TITLE
Add tracking attributes to the header menu elements

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -1,13 +1,85 @@
 <%= render :layout => 'layouts/frontend_base' do %>
   <nav id="proposition-menu" class="no-proposition-name" aria-label="Departments and policy navigation">
-    <ul id="proposition-links">
-      <li><%= main_navigation_link_to "Departments", organisations_path %></li>
-      <li><%= main_navigation_link_to "Worldwide", world_locations_path(locale: :en) %></li>
-      <li><%= main_navigation_link_to 'How government works', how_government_works_path %></li>
-      <li><%= main_navigation_link_to "Get involved", get_involved_path %></li>
-      <li class="clear-child"><a href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">Consultations</a></li>
-      <li><a href="/search/research-and-statistics">Statistics</a></li>
-      <li><a href="/news-and-communications">News and communications</a></li>
+    <ul id="proposition-links" data-module="gem-track-click">
+      <li>
+        <%= main_navigation_link_to "Departments",
+            organisations_path,
+            data: {
+              track_category: "headerClicked",
+              track_action: "departmentsLink",
+              track_label: organisations_path,
+              track_dimension: "Departments",
+              track_dimension_index: "29",
+            }
+        %>
+      </li>
+      <li>
+        <%= main_navigation_link_to "Worldwide",
+            world_locations_path(locale: :en),
+            data: {
+              track_category: "headerClicked",
+              track_action: "worldwideLink",
+              track_label: world_locations_path(locale: :en),
+              track_dimension: "Worldwide",
+              track_dimension_index: "29",
+            }
+        %>
+      </li>
+      <li>
+        <%= main_navigation_link_to "How government works",
+            how_government_works_path,
+            data: {
+              track_category: "headerClicked",
+              track_action: "governmentactivityLink",
+              track_label: how_government_works_path,
+              track_dimension: "How government works",
+              track_dimension_index: "29",
+            }
+        %>
+      </li>
+      <li>
+        <%= main_navigation_link_to "Get involved",
+            get_involved_path,
+            data: {
+              track_category: "headerClicked",
+              track_action: "governmentactivityLink",
+              track_label: get_involved_path,
+              track_dimension: "Get involved",
+              track_dimension_index: "29",
+            }
+        %>
+      </li>
+      <% consultations_path = CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>
+      <li class="clear-child">
+        <a href="<%= consultations_path %>"
+           data-track-category="headerClicked"
+           data-track-action="governmentactivityLink"
+           data-track-label="<%= consultations_path %>"
+           data-track-dimension="Consultations"
+           data-track-dimension-index="29">
+          Consultations
+        </a>
+      </li>
+      <li>
+        <a href="/search/research-and-statistics"
+           data-track-category="headerClicked"
+           data-track-action="governmentactivityLink"
+           data-track-label="/search/research-and-statistics"
+           data-track-dimension="Statistics"
+           data-track-dimension-index="29">
+          Statistics
+        </a>
+      </li>
+      <li>
+        <a href="/search/news-and-communications"
+           data-track-category="headerClicked"
+           data-track-action="governmentactivityLink"
+           data-track-label="/search/news-and-communications"
+           data-track-dimension="News and communications"
+           data-track-dimension-index="29">
+          News and communications
+        </a>
+      </li>
     </ul>
   </nav>
   <main id="content" role="main" class="whitehall-content"<%= " lang=#{I18n.locale.to_s}" unless I18n.locale == :en %>>


### PR DESCRIPTION
## What

Add tracking data attributes to elements in the menu header.

## Why

As part of gathering some baseline data ahead of updating the header design.

## Visual changes?

None

[Trello](https://trello.com/c/CwPwNE60/321-implement-analytics-tracking-on-the-existing-headers)

Note that this menu [is mirrored in the `government_navigation` in the components gem](https://github.com/alphagov/govuk_publishing_components/pull/2127) and used by government-frontend.