### PR TITLE
Add a rake task to create attachment report

### DIFF
--- a/lib/reports/published_attachments_report.rb
+++ b/lib/reports/published_attachments_report.rb
@@ -1,0 +1,40 @@
+module Reports
+  class PublishedAttachmentsReport
+    def report
+      path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
+      csv_headers = ["Organisation", "Filename", "Filetype", "Published Date"]
+
+      attachments = Attachment.find_by_sql([
+        "SELECT a.*
+          FROM attachments a
+          WHERE a.attachable_type = 'Edition'
+          AND a.attachment_data_id IS NOT NULL
+          AND EXISTS(
+            SELECT e.id
+            FROM editions e
+            WHERE e.state = 'published'
+            AND a.attachable_id = e.id
+          )
+          AND EXISTS(
+            SELECT ad.id
+            FROM attachment_data ad
+            WHERE ad.id = a.attachment_data_id
+          )",
+      ])
+
+      CSV.open(path, "wb", headers: csv_headers, write_headers: true) do |csv|
+        attachments.each do |attachment|
+          csv << [
+            attachment.attachable.organisations.map(&:name).join("; "),
+            attachment.url,
+            attachment.content_type,
+            attachment.attachable.first_published_at,
+          ]
+          print(".")
+        end
+      end
+
+      puts "Finished! Report available at #{path}"
+    end
+  end
+end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -14,4 +14,9 @@ namespace :reporting do
 
     Reports::OrganisationAttachmentsReport.new(args[:organisation_slug]).report
   end
+
+  desc "A CSV report of non-HTML attachments uploads published by all organisations"
+  task published_attachments_report: :environment do
+    Reports::PublishedAttachmentsReport.new.report
+  end
 end


### PR DESCRIPTION
This adds a rake task that produces a CSV file containing a list of all published attachments and some related metadata.

Trello card: https://trello.com/c/BSt0Ya5M