### PR TITLE
Fix path for attachment report directory

### DIFF
--- a/lib/reports/published_attachments_report.rb
+++ b/lib/reports/published_attachments_report.rb
@@ -1,7 +1,7 @@
 module Reports
   class PublishedAttachmentsReport
     def report
-      path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
+      path = "/tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv"
       csv_headers = ["Organisation", "Filename", "Filetype", "Published Date"]
 
       attachments = Attachment.find_by_sql([


### PR DESCRIPTION
A slash was missed from the start of the path, so the output file for the published attachment report was being written to the application deployment directory, rather than the machine's /tmp directory.

[Trello card](https://trello.com/c/BSt0Ya5M)