### PR TITLE
Switch published attachment report to use attachment date

### DIFF
--- a/lib/reports/published_attachments_report.rb
+++ b/lib/reports/published_attachments_report.rb
@@ -28,7 +28,7 @@ module Reports
             attachment.attachable.organisations.map(&:name).join("; "),
             attachment.url,
             attachment.content_type,
-            attachment.attachable.first_published_at,
+            attachment.updated_at,
           ]
           print(".")
         end


### PR DESCRIPTION
The Data Standards Authority have asked us to change the date included in the published attachments report (introduced in
https://github.com/alphagov/whitehall/pull/6148) to be the attachment update date, rather than the date the edition was first published.

[Trello card](https://trello.com/c/BSt0Ya5M)