### PR TITLE
Revert moving AnnouncementFilterOption strings to locale files

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -841,8 +841,6 @@ ar:
     transcript: اطلع على كافة نصوص منسوخة
     transparency: اطلع على كافة بيانات تتعلق بالشفافية
     written_statement: اطلع على كافة تصريحات خطية
-  statements:
-    heading:
   support:
     array:
       last_word_connector: و

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -482,8 +482,6 @@ az:
     transcript: Bax bütün növ
     transparency: Bax bütün növ
     written_statement: Bax bütün növ
-  statements:
-    heading:
   support:
     array:
       last_word_connector: və

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -698,8 +698,6 @@ be:
     transcript:
     transparency: Паглядзець усе Адкрытыя дадзеныя
     written_statement: Паглядзець усе Пісьмовыя заявы ў парламенце
-  statements:
-    heading:
   support:
     array:
       last_word_connector: і

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -559,8 +559,6 @@ bg:
     transcript: Вижте всички наши Преписи
     transparency: Вижте всички наши Информация за прозрачността
     written_statement: Вижте всички наши Писмени изявления до парламента
-  statements:
-    heading:
   support:
     array:
       last_word_connector: и

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -559,8 +559,6 @@ bn:
     transcript: আমাদের সকল প্রতিলিপিসমূহ দেখুন
     transparency: আমাদের সকল স্বচ্ছতামূলক ডেটা দেখুন
     written_statement: সংসদে আমাদের সকল লিখিত বিবৃতিসমূহ দেখুন
-  statements:
-    heading:
   support:
     array:
       last_word_connector: এবং

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -626,8 +626,6 @@ cs:
     transcript: Podívejte se na
     transparency: Podívejte se na
     written_statement: Podívejte se na
-  statements:
-    heading:
   support:
     array:
       last_word_connector: a

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -843,8 +843,6 @@ cy:
     transcript: Gweld ein holl trawsgrifiadau
     transparency: Gweld ein holl data tryloywder
     written_statement: Gweld ein holl datganiadau ysgrifenedig i'r senedd
-  statements:
-    heading:
   support:
     array:
       last_word_connector: a

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -550,8 +550,6 @@ da:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -554,8 +554,6 @@ de:
     transcript: Alle unsere Mitschriften
     transparency: Alle unsere Transparenz-Daten
     written_statement: Alle unsere Schriftliche Erklärungen vor dem Parlament
-  statements:
-    heading:
   support:
     array:
       last_word_connector: und

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -553,8 +553,6 @@ dr:
     transcript: همه را ببینید نسخه ها
     transparency: همه را ببینید ارقام شفافیت
     written_statement: همه را ببینید بیانیه های تحریری به پارلمان
-  statements:
-    heading:
   support:
     array:
       last_word_connector: و

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -553,8 +553,6 @@ el:
     transcript: Δείτε τα Απομαγνητοφωνήσεις
     transparency: Δείτε τα Στοιχεία διαφάνειας
     written_statement: Δείτε τα Γραπτές δηλώσεις στη Βουλή
-  statements:
-    heading:
   support:
     array:
       last_word_connector: και

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,8 +565,6 @@ en:
     transcript: See all our transcripts
     transparency: See all our transparency data
     written_statement: See all our written statements to Parliament
-  statements:
-    heading: Statements
   support:
     download: Download
     field_of_operation: "Field of operation:"

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -554,8 +554,6 @@ es-419:
     transcript: Vea todos nuestros transcripciones
     transparency: Vea todos nuestros datos sobre transparencia
     written_statement: Vea todos nuestros declaraciones escritas al parlamento
-  statements:
-    heading:
   support:
     array:
       last_word_connector: y

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -552,8 +552,6 @@ es:
     transcript: Ver toda nuestra transcripciones
     transparency: Ver toda nuestra datos sobre transparencia
     written_statement: Ver toda nuestra declaraciones escritas
-  statements:
-    heading:
   support:
     array:
       last_word_connector: y

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -558,8 +558,6 @@ et:
     transcript: Vaadake kõiki meie protokolle
     transparency: Vaadake kõiki meie läbipaistvusteabe andmeid
     written_statement: Vaadake kõiki meie kirjalikke avaldusi Parlamendile
-  statements:
-    heading:
   support:
     array:
       last_word_connector: ja

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -485,8 +485,6 @@ fa:
     transcript: تمامی رونوشت ها ما را مشاهده کنید
     transparency: تمامی داده های شفاف سازی ما را مشاهده کنید
     written_statement: تمامی گزارش های کتبی به پارلمان ما را مشاهده کنید
-  statements:
-    heading:
   support:
     array:
       last_word_connector: و

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -550,8 +550,6 @@ fi:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -554,8 +554,6 @@ fr:
     transcript: Voir toutes nos transcriptions
     transparency: Voir toutes nos transparence des données
     written_statement: Voir toutes nos communiqués
-  statements:
-    heading:
   support:
     array:
       last_word_connector: et

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -694,8 +694,6 @@ gd:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -550,8 +550,6 @@ gu:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -553,8 +553,6 @@ he:
     transcript: ראה כל תמלולים
     transparency: ראה כל שקיפות מידע
     written_statement: ראה כל הצהרות בכתב לפרלמנט
-  statements:
-    heading:
   support:
     array:
       last_word_connector: בנוסף

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -554,8 +554,6 @@ hi:
     transcript: देखें हमारे सभी प्रतिलिपियां
     transparency: देखें हमारे सभी पारदर्शिता आंकड़े
     written_statement: देखें हमारे सभी संसद में लिखित बयान
-  statements:
-    heading:
   support:
     array:
       last_word_connector: और

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -694,8 +694,6 @@ hr:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -553,8 +553,6 @@ hu:
     transcript: " Átiratok - mindegyik megtekintése"
     transparency: " Átláthatósági adatok - mindegyik megtekintése"
     written_statement: " Írásbeli parlamenti nyilatkozatok - mindegyik megtekintése"
-  statements:
-    heading:
   support:
     array:
       last_word_connector: és

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -555,8 +555,6 @@ hy:
     transcript: Տես՝ մեր բոլոր Վերծանումներ -ը
     transparency: Տես՝ մեր բոլոր Բաց տեղեկատվություններ -ը
     written_statement: Տես՝ մեր բոլոր Գրավոր դիմումներ խորհրդարան -ը
-  statements:
-    heading:
   support:
     array:
       last_word_connector: և

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -485,8 +485,6 @@ id:
     transcript: Lihat semua transkrip-transkrip
     transparency: Lihat semua transparansi data
     written_statement: Lihat semua pernyataan-pernyatan tertulis kepada parlemen
-  statements:
-    heading:
   support:
     array:
       last_word_connector: dan

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -550,8 +550,6 @@ is:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -553,8 +553,6 @@ it:
     transcript: Vedi tutte le nostre trascrizioni
     transparency: Vedi tutte le nostre dati sulla trasparenza
     written_statement: Vedi tutte le nostre dichiarazioni scritte al parlamento
-  statements:
-    heading:
   support:
     array:
       last_word_connector: e

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -483,8 +483,6 @@ ja:
     transcript: スピーチ全文 を全て見る
     transparency: 透明性データ を全て見る
     written_statement: 閣僚声明文 を全て見る
-  statements:
-    heading:
   support:
     array:
       last_word_connector: and

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -482,8 +482,6 @@ ka:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -550,8 +550,6 @@ kk:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -483,8 +483,6 @@ ko:
     transcript: 트랜스크립트 모두 둘러보기
     transparency: 투명성 데이타 모두 둘러보기
     written_statement: 의회로 서면 성명 모두 둘러보기
-  statements:
-    heading:
   support:
     array:
       last_word_connector: 그리고

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -625,8 +625,6 @@ lt:
     transcript: Pažiūrėkite  mūsų kalbų tekstai
     transparency: Pažiūrėkite  mūsų skaidrumo informacija
     written_statement: Pažiūrėkite  mūsų rašytiniai kreipimaisi į parlamentą
-  statements:
-    heading:
   support:
     array:
       last_word_connector: ir

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -552,8 +552,6 @@ lv:
     transcript: Skatīt visas noraksti
     transparency: Skatīt visas atklātības dati
     written_statement: Skatīt visas rakstiski ziņojumi parlamentam
-  statements:
-    heading:
   support:
     array:
       last_word_connector: un

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -482,8 +482,6 @@ ms:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -694,8 +694,6 @@ mt:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -550,8 +550,6 @@ ne:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -550,8 +550,6 @@ nl:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -550,8 +550,6 @@
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -558,8 +558,6 @@ pa-pk:
     transcript: ساڈے ساریاں نقلاں ویکھو
     transparency: ساڈا سارا شفافیت دا مواد ویکھو
     written_statement: ساڈی ساریاں پارلیمنٹ نوں دتے لکھے بیان ویکھو
-  statements:
-    heading:
   support:
     array:
       last_word_connector: تے

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -558,8 +558,6 @@ pa:
     transcript: ਸਾਡੀਆਂ ਸਾਰੀਆਂ ਪ੍ਰਤਿਲਿਪੀਆਂ ਦੇਖੋ
     transparency: ਸਾਡਾ ਸਾਰਾ ਪਾਰਦਰਸ਼ਤਾ ਡਾਟਾ ਦੇਖੋ
     written_statement: ਸਾਡੇ ਸਾਰੇ ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ ਦੇਖੋ
-  statements:
-    heading:
   support:
     array:
       last_word_connector: ਅਤੇ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -699,8 +699,6 @@ pl:
     transcript: Zobacz wszystkie nasze transkrypcje
     transparency: Zobacz wszystkie nasze dane o transparentności
     written_statement: Zobacz wszystkie nasze pisemne oświadczenia przed parlamentem
-  statements:
-    heading:
   support:
     array:
       last_word_connector: i

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -552,8 +552,6 @@ ps:
     transcript: ټول وګوری لیکنې
     transparency: ټول وګوری د روڼوالي اطلاعات
     written_statement: ټول وګوری پارلمان ته لیکلې اعلامیې
-  statements:
-    heading:
   support:
     array:
       last_word_connector: او

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -553,8 +553,6 @@ pt:
     transcript: Veja todos os nossos transcrições
     transparency: Veja todos os nossos dados de transparência
     written_statement: Veja todos os nossos declarações escritas ao parlamento
-  statements:
-    heading:
   support:
     array:
       last_word_connector: e

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -628,8 +628,6 @@ ro:
     transcript: Toate transcrieri
     transparency:
     written_statement: 'Toate declarații scrise către parlament '
-  statements:
-    heading:
   support:
     array:
       last_word_connector: și

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -696,8 +696,6 @@ ru:
     transcript: Посмотреть все наши Тексты
     transparency: Посмотреть все наши Прозрачность данных
     written_statement: Посмотреть все наши Письменные заявления парламенту
-  statements:
-    heading:
   support:
     array:
       last_word_connector: и

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -552,8 +552,6 @@ si:
     transcript: අපගේ සියලු  අනුපත් බලන්න
     transparency: අපගේ සියලු විනිවිධභාවයේ දත්ත බලන්න
     written_statement: අපගේ සියලු පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ බලන්න
-  statements:
-    heading:
   support:
     array:
       last_word_connector: සහ

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -622,8 +622,6 @@ sk:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -694,8 +694,6 @@ sl:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -555,8 +555,6 @@ so:
     transcript: Fiiri dhammaan qoraallo la soo guuriyey yadeenna
     transparency: Fiiri dhammaan xog daahfurnaan yadeenna
     written_statement: Fiiri dhammaan hadallo qoran oo loo gudbiyo baarlamaanka yadeenna
-  statements:
-    heading:
   support:
     array:
       last_word_connector: iyo

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -554,8 +554,6 @@ sq:
     transcript: Shiko te gjitha transkripte
     transparency: Shiko te gjitha te dhena per transparencen
     written_statement: Shiko te gjitha deklarata me shkrim per parlamentin
-  statements:
-    heading:
   support:
     array:
       last_word_connector: dhe

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -699,8 +699,6 @@ sr:
     transcript: Pogledajte sve naše transkripti
     transparency: Pogledajte sve naše podaci o transparentnosti
     written_statement: Pogledajte sve naše pisane predstavke parlamentu
-  statements:
-    heading:
   support:
     array:
       last_word_connector: i

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -550,8 +550,6 @@ sv:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -550,8 +550,6 @@ sw:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -557,8 +557,6 @@ ta:
     transparency: எங்களது அனைத்து வெளிப்படையான தரவு பார்க்கவும்
     written_statement: எங்களது அனைத்து பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்
       பார்க்கவும்
-  statements:
-    heading:
   support:
     array:
       last_word_connector: மற்றும்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -483,8 +483,6 @@ th:
     transcript: ดูทั้งหมดสำเนา
     transparency: ดูทั้งหมดข้อมูลโปร่งใส
     written_statement: 'ดูทั้งหมดแถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
-  statements:
-    heading:
   support:
     array:
       last_word_connector: และ

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -550,8 +550,6 @@ tk:
     transcript:
     transparency:
     written_statement:
-  statements:
-    heading:
   support:
     array:
       last_word_connector:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -551,8 +551,6 @@ tr:
     transcript: Tamamını görüntüle
     transparency: Tamamını görüntüle
     written_statement: Tamamını görüntüle
-  statements:
-    heading:
   support:
     array:
       last_word_connector: ve

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -697,8 +697,6 @@ uk:
     transcript: Дивіться всі наші Транскрипти
     transparency: Дивіться всі наші Прозорість інформації
     written_statement: Дивіться всі наші Письмові заяви у парламенті
-  statements:
-    heading:
   support:
     array:
       last_word_connector: та

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -553,8 +553,6 @@ ur:
     transcript: تما م دیکھئیے ٹرانسکرپٹس
     transparency: تما م دیکھئیے ٹرانسپیرنسی ڈیٹا
     written_statement: تما م دیکھئیے پارلیمنٹ میں تحریری بیانات
-  statements:
-    heading:
   support:
     array:
       last_word_connector: اور

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -553,8 +553,6 @@ uz:
     transcript: Bizning butun matnlar ko'ring
     transparency: Bizning butun ochiqlikka oid ma'lumotlar ko'ring
     written_statement: Bizning butun parlament uchun yozma hisobotlar ko'ring
-  statements:
-    heading:
   support:
     array:
       last_word_connector: va

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -486,8 +486,6 @@ vi:
     transparency: Xem tất cả dữ liệu kịch bản của chúng tôi
     written_statement: Xem tất cả các tuyên bố bằng văn bản tới quốc hội của chúng
       tôi
-  statements:
-    heading:
   support:
     array:
       last_word_connector: và

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -550,8 +550,6 @@ zh-hk:
     transcript: 查閱我們所有的其他談話副本
     transparency: 查閱我們所有的其他透明化數據
     written_statement: 查閱我們所有的提交國會的其他書面聲明
-  statements:
-    heading:
   support:
     array:
       last_word_connector: 和

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -550,8 +550,6 @@ zh-tw:
     transcript: 查閱我們所有的其他談話副本
     transparency: 查閱我們所有的透明化數據
     written_statement: 查閱我們所有的提交國會的其他書面聲明
-  statements:
-    heading:
   support:
     array:
       last_word_connector: 和

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -540,8 +540,6 @@ zh:
     transcript: 查阅我们所有的副本
     transparency: 查阅我们所有的透明化数据
     written_statement: 查阅我们所有的对议会的书面声明
-  statements:
-    heading:
   support:
     array:
       last_word_connector: 和

--- a/lib/whitehall/announcement_filter_option.rb
+++ b/lib/whitehall/announcement_filter_option.rb
@@ -2,11 +2,11 @@ module Whitehall
   class AnnouncementFilterOption < FilterOption
     attr_accessor :speech_types, :news_article_types
 
-    PressRelease = create!(id: 1, slug: "press-releases", label: I18n.t("document.type.press_release.one").pluralize, search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease], document_type: "press_release")
-    NewsStory = create!(id: 2, slug: "news-stories", label: I18n.t("document.type.news_story.one").pluralize, search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory], document_type: %w[news_article news_story])
-    FatalityNotice = create!(id: 3, slug: "fatality-notices", label: I18n.t("document.type.fatality_notice.one").pluralize, search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice], document_type: "fatality_notice")
-    Speech = create!(id: 4, slug: "speeches", label: I18n.t("document.type.speech.one").pluralize, search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements, document_type: "speech")
-    Statement = create!(id: 5, slug: "statements", label: I18n.t("statements.heading"), search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements, document_type: %w[written_statement oral_statement authored_article])
-    GovernmentResponse = create!(id: 6, slug: "government-responses", label: I18n.t("document.type.government_response.one").pluralize, search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse], document_type: "government_response")
+    PressRelease = create!(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease], document_type: "press_release")
+    NewsStory = create!(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory], document_type: %w[news_article news_story])
+    FatalityNotice = create!(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice], document_type: "fatality_notice")
+    Speech = create!(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements, document_type: "speech")
+    Statement = create!(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements, document_type: %w[written_statement oral_statement authored_article])
+    GovernmentResponse = create!(id: 6, label: "Government responses", search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse], document_type: "government_response")
   end
 end

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -173,7 +173,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
   view_test "index with locale shows selected announcement type filter option in the title" do
     get :index, params: { announcement_filter_option: "news-stories", locale: "fr" }
 
-    assert_select "h1 span", ": actualités"
+    assert_select "h1 span", ": news stories"
   end
 
   def assert_documents_appear_in_order_within(containing_selector, expected_documents)

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -171,11 +171,9 @@ class AnnouncementsControllerTest < ActionController::TestCase
   end
 
   view_test "index with locale shows selected announcement type filter option in the title" do
-    I18n.with_locale(:fr) do
-      get :index, params: { announcement_filter_option: "news-stories", locale: "fr" }
+    get :index, params: { announcement_filter_option: "news-stories", locale: "fr" }
 
-      assert_select "h1 span", ": actualités"
-    end
+    assert_select "h1 span", ": actualités"
   end
 
   def assert_documents_appear_in_order_within(containing_selector, expected_documents)


### PR DESCRIPTION
During some work to move hard-coded strings from the main codebase into locale files, we moved the labelling of the AnnouncementFilterOption.

Unfortunately this introduced a flaky test and so this section of the work should be reverted until the issue is resolved. 

I expect that AnnouncementFilterOption is initialised just once, with whichever locale happens to call it, and so the individual FilterOptions are then created in that language. So getting these to work with multiple translations is a larger job.

[trello](https://trello.com/c/DRMoZ8AM/2530-5-add-hardcoded-text-to-whitehall-frontend-locale-files)