### PR TITLE
Add AB Test for Explore Super Menu Header

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -1,0 +1,26 @@
+module ExploreMenuAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def explore_menu_test
+    @explore_menu_test ||= GovukAbTesting::AbTest.new(
+      "ExploreMenuAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+      )
+  end
+
+  def explore_menu_variant
+    explore_menu_test.requested_variant(request.headers)
+  end
+
+  def set_explore_menu_response
+    explore_menu_variant.configure_response(response) if explore_menu_testable?
+  end
+
+  def explore_menu_testable?
+    explore_menu_variant.variant?("B")
+  end
+end

--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -1,4 +1,4 @@
-module ExploreMenuAbTestable
+module AbTests::ExploreMenuAbTestable
   CUSTOM_DIMENSION = 47
 
   ALLOWED_VARIANTS = %w[A B Z].freeze
@@ -9,7 +9,7 @@ module ExploreMenuAbTestable
       dimension: CUSTOM_DIMENSION,
       allowed_variants: ALLOWED_VARIANTS,
       control_variant: "Z",
-      )
+    )
   end
 
   def explore_menu_variant

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Template
   include LocalisedUrlPathHelper
   include LegacyUrlHelper
+  include AbTests::ExploreMenuAbTestable
 
   protect_from_forgery
 
@@ -13,6 +14,9 @@ class ApplicationController < ActionController::Base
   before_action :set_slimmer_show_organisations_filter
   before_action :set_audit_trail_whodunnit
   before_action :set_authenticated_user_header
+  before_action :set_explore_menu_response
+
+  helper_method :explore_menu_variant, :explore_menu_testable?
 
   layout "frontend"
   after_action :set_slimmer_template
@@ -30,7 +34,11 @@ private
   end
 
   def set_slimmer_template
-    slimmer_template "header_footer_only"
+    if explore_menu_testable?
+      slimmer_template "header_footer_only_explore_header"
+    else
+      slimmer_template "header_footer_only"
+    end
   end
 
   def set_slimmer_application_name

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -26,6 +26,7 @@
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
     <%= tag :base, href: @page_base_href if @page_base_href %>
+    <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -1,87 +1,89 @@
 <%= render :layout => 'layouts/frontend_base' do %>
-  <nav id="proposition-menu" class="no-proposition-name" aria-label="Departments and policy navigation">
-    <ul id="proposition-links" data-module="gem-track-click">
-      <li>
-        <%= main_navigation_link_to "Departments",
-            organisations_path,
-            data: {
-              track_category: "headerClicked",
-              track_action: "departmentsLink",
-              track_label: organisations_path,
-              track_dimension: "Departments",
-              track_dimension_index: "29",
-            }
-        %>
-      </li>
-      <li>
-        <%= main_navigation_link_to "Worldwide",
-            world_locations_path(locale: :en),
-            data: {
-              track_category: "headerClicked",
-              track_action: "worldwideLink",
-              track_label: world_locations_path(locale: :en),
-              track_dimension: "Worldwide",
-              track_dimension_index: "29",
-            }
-        %>
-      </li>
-      <li>
-        <%= main_navigation_link_to "How government works",
-            how_government_works_path,
-            data: {
-              track_category: "headerClicked",
-              track_action: "governmentactivityLink",
-              track_label: how_government_works_path,
-              track_dimension: "How government works",
-              track_dimension_index: "29",
-            }
-        %>
-      </li>
-      <li>
-        <%= main_navigation_link_to "Get involved",
-            get_involved_path,
-            data: {
-              track_category: "headerClicked",
-              track_action: "governmentactivityLink",
-              track_label: get_involved_path,
-              track_dimension: "Get involved",
-              track_dimension_index: "29",
-            }
-        %>
-      </li>
-      <% consultations_path = CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>
-      <li class="clear-child">
-        <a href="<%= consultations_path %>"
-           data-track-category="headerClicked"
-           data-track-action="governmentactivityLink"
-           data-track-label="<%= consultations_path %>"
-           data-track-dimension="Consultations"
-           data-track-dimension-index="29">
-          Consultations
-        </a>
-      </li>
-      <li>
-        <a href="/search/research-and-statistics"
-           data-track-category="headerClicked"
-           data-track-action="governmentactivityLink"
-           data-track-label="/search/research-and-statistics"
-           data-track-dimension="Statistics"
-           data-track-dimension-index="29">
-          Statistics
-        </a>
-      </li>
-      <li>
-        <a href="/search/news-and-communications"
-           data-track-category="headerClicked"
-           data-track-action="governmentactivityLink"
-           data-track-label="/search/news-and-communications"
-           data-track-dimension="News and communications"
-           data-track-dimension-index="29">
-          News and communications
-        </a>
-      </li>
-    </ul>
-  </nav>
+  <% unless explore_menu_testable? %>
+    <nav id="proposition-menu" class="no-proposition-name" aria-label="Departments and policy navigation">
+      <ul id="proposition-links" data-module="gem-track-click">
+        <li>
+          <%= main_navigation_link_to "Departments",
+              organisations_path,
+              data: {
+                track_category: "headerClicked",
+                track_action: "departmentsLink",
+                track_label: organisations_path,
+                track_dimension: "Departments",
+                track_dimension_index: "29",
+              }
+          %>
+        </li>
+        <li>
+          <%= main_navigation_link_to "Worldwide",
+              world_locations_path(locale: :en),
+              data: {
+                track_category: "headerClicked",
+                track_action: "worldwideLink",
+                track_label: world_locations_path(locale: :en),
+                track_dimension: "Worldwide",
+                track_dimension_index: "29",
+              }
+          %>
+        </li>
+        <li>
+          <%= main_navigation_link_to "How government works",
+              how_government_works_path,
+              data: {
+                track_category: "headerClicked",
+                track_action: "governmentactivityLink",
+                track_label: how_government_works_path,
+                track_dimension: "How government works",
+                track_dimension_index: "29",
+              }
+          %>
+        </li>
+        <li>
+          <%= main_navigation_link_to "Get involved",
+              get_involved_path,
+              data: {
+                track_category: "headerClicked",
+                track_action: "governmentactivityLink",
+                track_label: get_involved_path,
+                track_dimension: "Get involved",
+                track_dimension_index: "29",
+              }
+          %>
+        </li>
+        <% consultations_path = CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>
+        <li class="clear-child">
+          <a href="<%= consultations_path %>"
+             data-track-category="headerClicked"
+             data-track-action="governmentactivityLink"
+             data-track-label="<%= consultations_path %>"
+             data-track-dimension="Consultations"
+             data-track-dimension-index="29">
+            Consultations
+          </a>
+        </li>
+        <li>
+          <a href="/search/research-and-statistics"
+             data-track-category="headerClicked"
+             data-track-action="governmentactivityLink"
+             data-track-label="/search/research-and-statistics"
+             data-track-dimension="Statistics"
+             data-track-dimension-index="29">
+            Statistics
+          </a>
+        </li>
+        <li>
+          <a href="/search/news-and-communications"
+             data-track-category="headerClicked"
+             data-track-action="governmentactivityLink"
+             data-track-label="/search/news-and-communications"
+             data-track-dimension="News and communications"
+             data-track-dimension-index="29">
+            News and communications
+          </a>
+        </li>
+      </ul>
+    </nav>
+  <% end %>
   <main id="content" role="main" class="whitehall-content"<%= " lang=#{I18n.locale.to_s}" unless I18n.locale == :en %>>
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>


### PR DESCRIPTION
Static has a new header that the GOV.UK Explore team want to AB test as part of their beta.

See https://github.com/alphagov/static/pull/2515

Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk

## Visual changes

https://user-images.githubusercontent.com/424772/123700813-deb41e80-d858-11eb-9013-e83a1a26d2c3.mov

