### PR TITLE
Update check_organisation_links_worker.rb

### DIFF
--- a/app/workers/check_organisation_links_worker.rb
+++ b/app/workers/check_organisation_links_worker.rb
@@ -9,7 +9,7 @@ class CheckOrganisationLinksWorker
   # task.
   sidekiq_retry_in do |retry_count, _exception|
     # First retry in 15 seconds, 6th (and last) retry at ~5 hours
-    ((0.5 * (retry_count + 1)**4) * 30)
+    (((retry_count + 1) * 0.5) * 30)
   end
 
   def perform(organisation_id)


### PR DESCRIPTION
**Bad binary expression operand order**
In a binary expression, the literal should preferably be on the right side of the expression. Yoda expressions, which are binary expressions spelled in reverse to how we normally speak, affect code readability & understandibility. This can be fixed by simply shifting the literal to the right and the variable to the left.