### PR TITLE
Make social media links translatable

### DIFF
--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -11,7 +11,11 @@ class Admin::SocialMediaAccountsController < Admin::BaseController
     @social_media_account = @socialable.social_media_accounts.build
   end
 
-  def edit; end
+  def edit
+    I18n.with_locale(params[:locale] || I18n.default_locale) do
+      render
+    end
+  end
 
   def update
     if @social_media_account.update(social_media_account_params)
@@ -66,7 +70,7 @@ private
 
   def social_media_account_params
     params.require(:social_media_account).permit(
-      :social_media_service_id, :url, :title
+      :social_media_service_id, :url, :title, :locale
     )
   end
 end

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -7,7 +7,6 @@ class SocialMediaAccount < ApplicationRecord
 
   validates :social_media_service_id, presence: true
   validates :url, presence: true, uri: true
-  validates :title, length: { maximum: 255 }
 
   include TranslatableModel
   translates :url, :title

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -9,6 +9,9 @@ class SocialMediaAccount < ApplicationRecord
   validates :url, presence: true, uri: true
   validates :title, length: { maximum: 255 }
 
+  include TranslatableModel
+  translates :url, :title
+
   def republish_organisation_to_publishing_api
     if socialable_type == "Organisation" && socialable.persisted?
       Whitehall::PublishingApi.republish_async(socialable)

--- a/app/models/social_media_account_translation.rb
+++ b/app/models/social_media_account_translation.rb
@@ -1,0 +1,1 @@
+class SocialMediaAccountTranslation < ApplicationRecord; end

--- a/app/models/social_media_account_translation.rb
+++ b/app/models/social_media_account_translation.rb
@@ -1,1 +1,4 @@
-class SocialMediaAccountTranslation < ApplicationRecord; end
+class SocialMediaAccountTranslation < ApplicationRecord
+  after_save :republish_organisation_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api
+end

--- a/app/views/admin/social_media_accounts/_form.html.erb
+++ b/app/views/admin/social_media_accounts/_form.html.erb
@@ -3,12 +3,15 @@
     <%= form_for [:admin, socialable, social_media_account], html: {class: "well"} do |form| %>
       <%= form.errors %>
       <fieldset class="social_media_account">
-        <div class="form-group">
-          <%= form.label :social_media_service_id, 'Service', class: "control-label" %>
-          <%= form.select :social_media_service_id, options_from_collection_for_select(SocialMediaService.all, :id, :name, form.object.social_media_service_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media service…" } %>
-        </div>
+        <% if I18n.locale == I18n.default_locale %>
+          <div class="form-group">
+            <%= form.label :social_media_service_id, 'Service', class: "control-label" %>
+            <%= form.select :social_media_service_id, options_from_collection_for_select(SocialMediaService.all, :id, :name, form.object.social_media_service_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media service…" } %>
+          </div>
+        <% end %>
         <%= form.text_field :url %>
         <%= form.text_field :title %>
+        <%= form.hidden_field :locale, value: I18n.locale %>
       </fieldset>
 
       <%= form.save_or_cancel(cancel: [:admin, socialable, SocialMediaAccount]) %>

--- a/app/views/admin/social_media_accounts/_social_media_account.html.erb
+++ b/app/views/admin/social_media_accounts/_social_media_account.html.erb
@@ -8,5 +8,8 @@
           class: "btn btn-sm btn-danger",
           data: { confirm: "Delete '#{social_media_account.service_name}' social media account from #{socialable.class.name.underscore.humanize.downcase} '#{socialable.name}'?" } %>
     <%= link_to icon("Edit"), edit_polymorphic_path([:admin, socialable, social_media_account]), class: "btn btn-default add-left-margin" %>
+    <% social_media_account.socialable.non_english_translated_locales.each do |locale| %>
+      <%= link_to icon("Edit #{locale.native_and_english_language_name}"), edit_polymorphic_path([:admin, socialable, social_media_account], locale: locale), class: "btn btn-default add-left-margin" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/db/migrate/20210616135328_create_social_media_account_translations.rb
+++ b/db/migrate/20210616135328_create_social_media_account_translations.rb
@@ -1,0 +1,14 @@
+class CreateSocialMediaAccountTranslations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :social_media_account_translations, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+      t.text :url
+      t.text :title
+      t.string :locale, null: false
+      t.integer :social_media_account_id, null: false
+      t.timestamps
+
+      t.index :locale, name: :index_on_locale
+      t.index :social_media_account_id, name: :index_on_social_media_account
+    end
+  end
+end

--- a/db/migrate/20210621100917_move_social_media_accounts_to_social_media_account_translations.rb
+++ b/db/migrate/20210621100917_move_social_media_accounts_to_social_media_account_translations.rb
@@ -1,0 +1,22 @@
+class MoveSocialMediaAccountsToSocialMediaAccountTranslations < ActiveRecord::Migration[6.0]
+  def up
+    existing_social_media_accounts = ActiveRecord::Base.connection.execute("SELECT id, title, url, locale FROM social_media_accounts").to_a
+
+    existing_social_media_accounts.each do |account|
+      SocialMediaAccountTranslation.create!(
+        social_media_account_id: account[0],
+        title: account[1],
+        url: account[2],
+        locale: account[3],
+      )
+    end
+
+    change_table :social_media_accounts do |t|
+      t.remove :url, :title, :locale
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_11_161500) do
+ActiveRecord::Schema.define(version: 2021_06_16_135328) do
 
   create_table "about_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -933,6 +933,17 @@ ActiveRecord::Schema.define(version: 2021_01_11_161500) do
     t.text "govspeak"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "social_media_account_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.text "url"
+    t.text "title"
+    t.string "locale", null: false
+    t.integer "social_media_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["locale"], name: "index_on_locale"
+    t.index ["social_media_account_id"], name: "index_on_social_media_account"
   end
 
   create_table "social_media_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_135328) do
+ActiveRecord::Schema.define(version: 2021_06_21_100917) do
 
   create_table "about_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -949,12 +949,9 @@ ActiveRecord::Schema.define(version: 2021_06_16_135328) do
   create_table "social_media_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "socialable_id"
     t.integer "social_media_service_id"
-    t.string "url"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "socialable_type"
-    t.string "title"
-    t.string "locale", default: "en"
     t.index ["social_media_service_id"], name: "index_social_media_accounts_on_social_media_service_id"
     t.index ["socialable_id"], name: "index_social_media_accounts_on_organisation_id"
   end

--- a/features/step_definitions/social_media_steps.rb
+++ b/features/step_definitions/social_media_steps.rb
@@ -29,6 +29,19 @@ When(/^I add a "([^"]*)" social media link "([^"]*)" with the title "([^"]+)" to
   click_on "Save"
 end
 
+When(/^I edit a "([^"]*)" social media link "([^"]*)" with the title "([^"]+)" in "([^"]*)" for the (worldwide organisation|organisation)$/) do |_social_service, url, title, language, social_container|
+  if social_container == "worldwide organisation"
+    visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
+  else
+    visit admin_organisation_path(Organisation.last)
+  end
+  click_link "Social media accounts"
+  click_link "Edit #{language}"
+  fill_in "Url", with: url
+  fill_in "Title", with: title
+  click_on "Save"
+end
+
 Then(/^the "([^"]*)" social link should be shown on the public website for the (worldwide organisation|organisation)$/) do |social_service, social_container|
   if social_container == "worldwide organisation"
     social_container = WorldwideOrganisation.last
@@ -48,5 +61,16 @@ Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public 
     social_container = Organisation.last
     visit organisation_path(social_container)
   end
-  assert_selector ".social-media-accounts .social-media-link.#{social_service.parameterize}", text: title
+  assert_selector ".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title
+end
+
+Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public website with locale "([^"]*)" for the (worldwide organisation|organisation)$/) do |social_service, title, locale, social_container|
+  if social_container == "worldwide organisation"
+    social_container = WorldwideOrganisation.last
+    visit worldwide_organisation_path(social_container, locale: locale)
+  else
+    social_container = Organisation.last
+    visit organisation_path(social_container, locale: locale)
+  end
+  assert_selector ".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title
 end

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -36,6 +36,14 @@ Feature: Administering worldwide organisation
     When I add a "Twooter" social media link "http://twooter.com/beards-in-france" to the worldwide organisation
     Then the "Twooter" social link should be shown on the public website for the worldwide organisation
 
+  Scenario: Managing social media links in multiple locales
+    Given a worldwide organisation "Department of Beards in France" exists with a translation for the locale "Français"
+    Given a social media service "Twooter"
+    When I add a "Twooter" social media link "http://twooter.com/beards-in-france" with the title "Link in English" to the worldwide organisation
+    Then the "Twooter" social link called "Link in English" should be shown on the public website for the worldwide organisation
+    When I edit a "Twooter" social media link "http://twooter.com/beards-in-france-in-french" with the title "Link in French" in "Français (French)" for the worldwide organisation
+    Then the "Twooter" social link called "Link in French" should be shown on the public website with locale "fr" for the worldwide organisation
+
   Scenario: Managing office information
     Given a worldwide organisation "Department of Beards in France"
     When I add an "Hair division" office for the home page with address, phone number, and some services

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -78,4 +78,40 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     assert_equal "#{social_media_account.service_name} account deleted successfully", flash[:notice]
     assert_not SocialMediaAccount.exists?(social_media_account.id)
   end
+
+  view_test "GET on :index displays edit button only for languages the organisation is translated in" do
+    organisation = create(:organisation, translated_into: %i[fr cy])
+    social_media_account = create(:social_media_account, socialable_id: organisation.id, socialable_type: "Organisation")
+    get :index, params: { organisation_id: organisation.id }
+    assert_select "a[href=?]", edit_admin_organisation_social_media_account_path(organisation_id: organisation.slug, id: social_media_account.id)
+    assert_select "a[href=?]", edit_admin_organisation_social_media_account_path(organisation_id: organisation.slug, id: social_media_account.id, params: { locale: "fr" })
+    assert_select "a[href=?]", edit_admin_organisation_social_media_account_path(organisation_id: organisation.slug, id: social_media_account.id, params: { locale: "cy" })
+    refute_select "a[href=?]", edit_admin_organisation_social_media_account_path(organisation_id: organisation.slug, id: social_media_account.id, params: { locale: "dk" })
+  end
+
+  test "PUT on :update with a locale updates only the translation of the social media account" do
+    worldwide_organisation = create(:worldwide_organisation, translated_into: [:cy])
+    social_media_account = worldwide_organisation.social_media_accounts.create!(social_media_service_id: @social_media_service.id, url: "http://english-url.com", title: "Title in English")
+
+    put :update,
+        params: {
+          id: social_media_account,
+          worldwide_organisation_id: worldwide_organisation,
+          social_media_account: {
+            url: "http://welsh-url.cy",
+            title: "Title in Welsh",
+            locale: "cy",
+          },
+        }
+
+    I18n.with_locale(:en) do
+      assert_equal "http://english-url.com", social_media_account.reload.url
+      assert_equal "Title in English", social_media_account.reload.title
+    end
+
+    I18n.with_locale(:cy) do
+      assert_equal "http://welsh-url.cy", social_media_account.reload.url
+      assert_equal "Title in Welsh", social_media_account.reload.title
+    end
+  end
 end

--- a/test/unit/social_media_account_test.rb
+++ b/test/unit/social_media_account_test.rb
@@ -48,4 +48,25 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
     account = build(:social_media_account, title: "", social_media_service: sms)
     assert_equal "Facebark", account.display_name
   end
+
+  test "should accept multiple translations" do
+    account = create(:social_media_account)
+
+    I18n.with_locale(:en) do
+      account.update(url: "https://example.com", title: "Title in English")
+    end
+    I18n.with_locale(:cy) do
+      account.update(url: "https://example.cy", title: "Title in Welsh")
+    end
+
+    I18n.with_locale(:en) do
+      assert_equal "https://example.com", account.url
+      assert_equal "Title in English", account.title
+    end
+
+    I18n.with_locale(:cy) do
+      assert_equal "https://example.cy", account.url
+      assert_equal "Title in Welsh", account.title
+    end
+  end
 end

--- a/test/unit/social_media_account_test.rb
+++ b/test/unit/social_media_account_test.rb
@@ -29,15 +29,6 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
     assert_includes account.errors.full_messages, "Social media service can't be blank"
   end
 
-  test "is invalid if the title is longer than 255 characters" do
-    account = create(:social_media_account, title: "a" * 254) # just under
-    assert account.valid?
-    account.title = "a" * 255 # exactly maximum
-    assert account.valid?
-    account.title = "a" * 256 # just over
-    assert_not account.valid?
-  end
-
   test "display_name is the title if present" do
     account = build(:social_media_account, title: "My face")
     assert_equal "My face", account.display_name


### PR DESCRIPTION
Makes the fields on the social media links in Whitehall translatable.  If a translation is not available for a link, the link from the default locale is used.

Users can add/edit translations for social media links in any language that the socialable (i.e. Organisation or Worldwide Organisation) page is available in.

We do not need to make any changes in Publishing API or Collections, as Whitehall will handle the translation and only present the relevant links to Publishing API for the language of the content it is publishing (using the `globalize` gem).

All existing social media links will be labelled as English and will need to be manually edited by the departmental editors if they wish to add translations.

### Screenshots

#### Organisation

Editing an Organisation's social media links where the organisation has an English and Welsh translation:
![Screenshot 2021-06-30 at 11 30 42](https://user-images.githubusercontent.com/6329861/123946044-ae729a00-d996-11eb-8ada-23b72bd4a5a2.png)

Editing the English social media link for an Organisation:
![Screenshot 2021-06-30 at 11 30 50](https://user-images.githubusercontent.com/6329861/123946069-b3374e00-d996-11eb-8091-5c9321747dd0.png)

Editing the Welsh translation of the social media link from above:
![Screenshot 2021-06-30 at 11 31 04](https://user-images.githubusercontent.com/6329861/123946091-ba5e5c00-d996-11eb-86f1-d09c0128506a.png)

English version of Organisation page:
![Screenshot 2021-06-30 at 09 25 38](https://user-images.githubusercontent.com/6329861/123927866-30f25e00-d985-11eb-8fd3-928eb71552f7.png)

Welsh version of Organisation page:
![Screenshot 2021-06-30 at 09 25 45](https://user-images.githubusercontent.com/6329861/123927901-39e32f80-d985-11eb-8b5a-6a8ceb0ca19c.png)

#### Worldwide Organisation

Editing a Worldwide Organisation's social media links where the organisation has an English and Greek translation:
![Screenshot 2021-06-30 at 11 28 07](https://user-images.githubusercontent.com/6329861/123945612-42903180-d996-11eb-8e9c-4daad646c139.png)

Editing the English social media link for a Worldwide Organisation:
![Screenshot 2021-06-30 at 11 29 51](https://user-images.githubusercontent.com/6329861/123945896-87b46380-d996-11eb-91ab-5650fc7767f3.png)

Editing the Greek translation of the social media link from above:
![Screenshot 2021-06-30 at 11 30 01](https://user-images.githubusercontent.com/6329861/123945910-8be08100-d996-11eb-8376-6b27fb5027cf.png)

English version of Worldwide Organisation page:
![Screenshot 2021-06-30 at 11 28 32](https://user-images.githubusercontent.com/6329861/123945737-5d62a600-d996-11eb-86f4-81eafc78576a.png)

Greek version of Worldwide Organisation page:
![Screenshot 2021-06-30 at 11 28 38](https://user-images.githubusercontent.com/6329861/123945766-6489b400-d996-11eb-9034-9d9ace323cfe.png)

[Trello card](https://trello.com/c/RRvGDDmD)