### PR TITLE
Install SimpleCov to measure code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem "mocha"
   gem "rack-test"
   gem "rails-controller-testing"
+  gem "simplecov", require: false
   gem "timecop"
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     database_cleaner (1.8.5)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     e2mmap (0.1.0)
@@ -597,6 +598,12 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     slimmer (15.5.1)
       activesupport
       json
@@ -750,6 +757,7 @@ DEPENDENCIES
   sassc-rails
   shared_mustache
   sidekiq-scheduler
+  simplecov
   slimmer
   sprockets-rails
   teaspoon-qunit

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
+
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,11 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+require "simplecov"
+SimpleCov.start "rails"
+SimpleCov.command_name "Cucumber"
+SimpleCov.merge_timeout 3600
+
 require "cucumber/rails"
 
 # frozen_string_literal: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,11 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 ENV["RAILS_ENV"] = "test"
 
+require "simplecov"
+SimpleCov.start "rails"
+SimpleCov.command_name "Unit Tests"
+SimpleCov.merge_timeout 3600
+
 require File.expand_path("../config/environment", __dir__)
 
 require "maxitest/autorun"


### PR DESCRIPTION
You can successfully measure test coverage locally by running:

`bundle exec rake test cucumber`

The test coverage for Whitehall is now higher than the required amount to enable CD, as a result of the following PR's: 

* https://github.com/alphagov/whitehall/pull/6175
* https://github.com/alphagov/whitehall/pull/6176
* https://github.com/alphagov/whitehall/pull/6177
* https://github.com/alphagov/whitehall/pull/6178

### 🎉 (Previously 89% & ignore the local failures cos Whitehall)

<img width="854" alt="Screenshot 2021-06-23 at 11 20 13" src="https://user-images.githubusercontent.com/24479188/123825455-d4486200-d8f6-11eb-989c-aff922eb8e75.png">

---

Trello:
https://trello.com/c/LCR0Am73/2541-5-enable-continuous-deployment-for-whitehall
