### PR TITLE
Increase test coverage

### DIFF
--- a/app/controllers/admin/classification_featurings_controller.rb
+++ b/app/controllers/admin/classification_featurings_controller.rb
@@ -1,8 +1,5 @@
 class Admin::ClassificationFeaturingsController < Admin::BaseController
   before_action :load_classification
-  before_action :load_featuring, only: %i[edit destroy]
-
-  def edit; end
 
   def index
     filter_params = params.slice(:page, :type, :author, :organisation, :title)
@@ -52,6 +49,8 @@ class Admin::ClassificationFeaturingsController < Admin::BaseController
   end
 
   def destroy
+    @classification_featuring = @classification.classification_featurings.find(params[:id])
+
     if featuring_a_document?
       edition = @classification_featuring.edition
       @classification_featuring.destroy!
@@ -73,10 +72,6 @@ private
 
   def load_classification
     @classification = Classification.find(params[:topical_event_id] || params[:topic_id])
-  end
-
-  def load_featuring
-    @classification_featuring = @classification.classification_featurings.find(params[:id])
   end
 
   def editions_to_show

--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -33,10 +33,6 @@ class Admin::OffsiteLinksController < Admin::BaseController
     redirect_to offsite_links_path
   end
 
-  def show
-    redirect_to offsite_link_path(@offsite_link)
-  end
-
 private
 
   def load_parent

--- a/test/factories/classification_featurings.rb
+++ b/test/factories/classification_featurings.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
   end
 
   factory :offsite_classification_featuring, class: ClassificationFeaturing do
+    offsite_link
     classification
     sequence(:ordering) { |index| index }
     association :image, factory: :classification_featuring_image_data

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -108,4 +108,30 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     assert_select "#classification_featuring_image_attributes_file"
     assert_select "#classification_featuring_alt_text"
   end
+
+  test "DELETE :destroy unfeatures edition and redirects to classification" do
+    featuring = create(:classification_featuring,
+                       classification: create(:classification, type: "TopicalEvent"))
+
+    assert_difference("ClassificationFeaturing.count", -1) do
+      delete :destroy, params: {
+        topical_event_id: featuring.classification.id, id: featuring.id
+      }
+    end
+
+    assert_response :redirect
+  end
+
+  test "DELETE :destroy unfeatures offsite link and redirects to classification" do
+    offsite_featuring = create(:offsite_classification_featuring,
+                               classification: create(:classification, type: "TopicalEvent"))
+
+    assert_difference("ClassificationFeaturing.count", -1) do
+      delete :destroy, params: {
+        topical_event_id: offsite_featuring.classification.id, id: offsite_featuring.id
+      }
+    end
+
+    assert_response :redirect
+  end
 end

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Admin::OffsiteLinksControllerTest < ActionController::TestCase
+  setup do
+    login_as :gds_editor
+    @world_location = create(:world_location)
+    @offsite_link = create(:offsite_link, parent_type: "WorldLocation", parent: @world_location)
+  end
+
+  should_be_an_admin_controller
+
+  view_test "GET :new should render new offsite links form" do
+    get :new, params: { world_location_id: @world_location.slug }
+
+    assert_select "h2", text: "Create a non-GOV.UK government link within ‘#{@world_location.name}’"
+
+    assert_offsite_links_form(
+      admin_world_location_offsite_links_path,
+    )
+  end
+
+  view_test "GET :edit should render existing offside links form" do
+    get :edit, params: { world_location_id: @world_location.slug, id: @offsite_link.id }
+
+    assert_select "h2", text: "Edit the offsite link within ‘#{@world_location.name}’"
+
+    assert_offsite_links_form(
+      admin_world_location_offsite_link_path(id: @offsite_link.id),
+    )
+
+    assert_select "div input[id=offsite_link_title][value='#{@offsite_link.title}']"
+  end
+
+  test "PUT :update updates current offsite link" do
+    form_param = { title: "Updated title" }
+
+    put :update, params: {
+      world_location_id: @world_location.slug, id: @offsite_link.id, offsite_link: form_param
+    }
+
+    assert_equal "Updated title", @offsite_link.reload.title
+    assert_response :redirect
+  end
+
+  test "DELETE :destroy removes offsite link" do
+    assert_difference("OffsiteLink.count", -1) do
+      delete :destroy, params: {
+        world_location_id: @world_location.slug, id: @offsite_link.id
+      }
+    end
+
+    assert_response :redirect
+  end
+
+  def assert_offsite_links_form(path)
+    assert_select "form[action=?] div", path do
+      assert_select "div input[id=offsite_link_title]"
+      assert_select "div textarea[id=offsite_link_summary]"
+      assert_select "div select[id=offsite_link_link_type]"
+      (1..3).each { |n| assert_select "div select[id=offsite_link_date_#{n}i]" }
+      assert_select "div input[id=offsite_link_url]"
+
+      assert_select "input[type=submit]"
+    end
+  end
+end

--- a/test/functional/past_foreign_secretaries_controller_test.rb
+++ b/test/functional/past_foreign_secretaries_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class PastForeignSecretariesControllerTest < ActionController::TestCase
+  view_test "GET :show renders a past foreign secretary" do
+    get :show, params: { id: "edward-wood" }
+
+    assert_select "h2.govuk-heading-m", text: "Edward Frederick Lindley Wood, Viscount Halifax"
+  end
+
+  view_test "GET :index renders past foreign secretaries" do
+    get :index
+
+    assert_select "h1", text: "Past Foreign Secretaries"
+
+    assert_select "div.featured-profiles" do
+      assert_select "h2.profiles", text: "Selection of profiles"
+      assert_select "li.person", 10
+    end
+  end
+
+  test "GET :show renders 'not found' for invalid foreign secretary name" do
+    get :show, params: { id: "pete" }
+
+    assert_equal @controller.status, 404
+  end
+end

--- a/test/unit/helpers/past_foreign_secretaries_helper_test.rb
+++ b/test/unit/helpers/past_foreign_secretaries_helper_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PastForeignSecretariesHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "returns past foreign secretaries navigation list" do
+    html_string = past_foreign_secretary_nav("edward-wood")
+    html = Nokogiri::HTML.fragment(html_string)
+
+    all_people = (html / "li")
+    people_with_links = (html / "li").select do |person|
+      person.children.to_s =~ /href="\/government\/history\/past-foreign-secretaries\/.*/
+    end
+
+    assert_equal 9, people_with_links.count
+    assert_equal 10, all_people.count
+    assert people_with_links.map(&:text).include?("Sir Edward Grey")
+    assert_not people_with_links.map(&:text).include?("Edward Frederick Lindley Wood")
+  end
+end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -160,6 +160,14 @@ class PersonTest < ActiveSupport::TestCase
     assert person.reload.can_have_historical_accounts?
   end
 
+  test "#name_with_disambiguator returns string with containing a persons name, role and org" do
+    person = create(:person)
+    role_appointment = create(:role_appointment, person: person)
+
+    assert "#{person.name} - #{role_appointment.role.name} - #{person.organisations.first.name}",
+           person.name_with_disambiguator
+  end
+
   test "touches any person appointments after being updated" do
     person = create(:person)
     role_appointment = create(:role_appointment, person: person)

--- a/test/unit/presenters/edition_collection_presenter_test.rb
+++ b/test/unit/presenters/edition_collection_presenter_test.rb
@@ -33,6 +33,11 @@ class EditionCollectionPresenterTest < PresenterTestCase
     assert_kind_of FatalityNoticePresenter, collection.first
   end
 
+  test "should wrap announcements in an announcements presenter" do
+    collection = EditionCollectionPresenter.new([Announcement.new], @view_context)
+    assert_kind_of AnnouncementPresenter, collection.first
+  end
+
   test "should wrap instances within methods that return arrays" do
     collection = EditionCollectionPresenter.new([DetailedGuide.new, NewsArticle.new], @view_context)
     assert_kind_of NewsArticlePresenter, collection[1, 1].first

--- a/test/unit/workers/asset_manager_attachment_set_uploaded_to_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_set_uploaded_to_worker_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class AssetManagerAttachmentSetUploadedToWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe AssetManagerAttachmentSetUploadedToWorker do
+    let(:publication) { create(:publication) }
+    let(:attachment) { create(:file_attachment, attachable: publication) }
+    let(:worker) { AssetManagerAttachmentSetUploadedToWorker.new }
+
+    it "marks attachment as uploaded to Asset Manager" do
+      AttachmentData.any_instance.expects(:uploaded_to_asset_manager!)
+
+      worker.perform("Publication", publication.id, attachment.attachment_data.path)
+    end
+
+    it "doesn't mark the attachment as uploaded to Asset Manager if only the thumbnail is uploaded" do
+      AttachmentData.any_instance.expects(:uploaded_to_asset_manager!).never
+
+      worker.perform("Publication", publication.id, attachment.attachment_data.file.thumbnail.path)
+    end
+
+    it "raises an error if attachment isn't found" do
+      assert_raises AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient do
+        worker.perform("Publication", publication.id, "some-unknown-path")
+      end
+    end
+  end
+end

--- a/test/unit/workers/publishing_api_links_worker_test.rb
+++ b/test/unit/workers/publishing_api_links_worker_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class PublishingApiLinksWorkerTest < ActiveSupport::TestCase
+  test "#perform sends a patch links request to Publishing API" do
+    publication = create(:publication)
+    Services.publishing_api
+      .expects(:patch_links)
+      .with(publication.content_id,
+            links: PublishingApiPresenters.presenter_for(publication).links,
+            bulk_publishing: true)
+
+    PublishingApiLinksWorker.new.perform(publication.id)
+  end
+
   test "raises an error if an edition's document is locked" do
     edition = create(:unpublished_edition, :with_locked_document)
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do


### PR DESCRIPTION
General test coverage in Whitehall is fairly decent overall, now that a lump of code has been removed - https://github.com/alphagov/whitehall/pull/6175. This PR adds miscellaneous tests, whereas https://github.com/alphagov/whitehall/pull/6176 and https://github.com/alphagov/whitehall/pull/6177 also add tests but are a bit more focused.

I tried not to add any more cucumber tests as they are expensive and Whitehall's test suite is already painfully slow.

See https://github.com/alphagov/whitehall/pull/6174 for some numbers concerning coverage.

---

Trello:
https://trello.com/c/LCR0Am73/2541-5-enable-continuous-deployment-for-whitehall