### PR TITLE
Fix HTML attachments having a www-origin link

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -63,7 +63,7 @@ class HtmlAttachment < Attachment
       options[:preview] = id
       options[:host] = URI(Plek.new.external_url_for("draft-origin")).host
     else
-      options[:host] = URI(Plek.new.external_url_for("www-origin")).host
+      options[:host] = URI(Plek.new.website_root).host
     end
 
     type = attachable.path_name

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -48,7 +48,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first
 
-    expected = "https://www-origin.test.gov.uk/government/publications/"
+    expected = "https://www.test.gov.uk/government/publications/"
     expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(full_url: true)
 


### PR DESCRIPTION
In the admin interface links to HTML attachments weren't operational as
they are set to the www-origin hostname which is only usable by people
on the GDS VPN.

I'm a bit baffled how this has been this way for so long, it looks like
it was questioned 3 years ago [1], however only today did I see a
support ticket for it: https://govuk.zendesk.com/agent/tickets/4606930

[1]: https://github.com/alphagov/whitehall/commit/095989f7e4cc6f280db25f876021ee5586aafbb5