### PR TITLE
Add missing republish_organisation_to_publishing_api method

### DIFF
--- a/app/models/social_media_account_translation.rb
+++ b/app/models/social_media_account_translation.rb
@@ -1,4 +1,12 @@
 class SocialMediaAccountTranslation < ApplicationRecord
+  belongs_to :social_media_account
+
   after_save :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
+
+  def republish_organisation_to_publishing_api
+    if social_media_account.socialable_type == "Organisation" && social_media_account.socialable.persisted?
+      Whitehall::PublishingApi.republish_async(social_media_account.socialable)
+    end
+  end
 end


### PR DESCRIPTION
This method was missed from https://github.com/alphagov/whitehall/pull/6173.

[Trello card](https://trello.com/c/RRvGDDmD)