### PR TITLE
Add warning to dangerous rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -277,7 +277,7 @@ namespace :publishing_api do
     end
   end
 
-  desc "Republish all documents with HTML attachments to the Publishing API"
+  desc "⚠️  WARNING: this rake task republishes **all** documents with HTML attachments (this can block publishing for > 1 hour) ⚠️. Republish all documents with HTML attachments to the Publishing API."
   task republish_html_attachments: :environment do
     document_ids = Edition
       .publicly_visible


### PR DESCRIPTION
We ran this rake task in production, and it stuck 31,000 items on
publishing_api's downstream_high queue. Effectively blocking all
publishing for over an hour.

Until we've fixed the task so that it uses only low-priority queues, or
until we've come up with a less naïve way of republishing HTML
attachments let's put a warning in the task description.