### PR TITLE
Reslug document and attachment

### DIFF
--- a/db/data_migration/20210708152515_reslug_document_and_html_attachment.rb
+++ b/db/data_migration/20210708152515_reslug_document_and_html_attachment.rb
@@ -1,0 +1,18 @@
+# Reslug parent document & attached HTML attachment
+
+slug = "react-1-study-of-coronavirus-transmission-june-2021-final-results"
+new_slug = "react-1-study-of-coronavirus-transmission-may-2021-final-results"
+
+document = Document.find_by(slug: slug)
+edition = document.editions.published.last
+html_attachment = edition.attachments.find_by(slug: slug)
+
+html_attachment.update!(slug: new_slug)
+Whitehall::PublishingApi.republish_async(html_attachment)
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+Whitehall::SearchIndex.add(edition)


### PR DESCRIPTION
As per the Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/4623819

Run on integration:
https://www.integration.publishing.service.gov.uk/government/publications/react-1-study-of-coronavirus-transmission-may-2021-final-results