### PR TITLE
Setup Pact for GDS API Adapters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /failures
 /node_modules
 /yarn-error.log
+
+spec/reports/pacts

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,13 @@ ENV["LOG_LEVEL"] = "warn"
 require File.expand_path("config/application", __dir__)
 require "ci/reporter/rake/minitest" if Rails.env.test?
 
+begin
+  require "pact/tasks"
+rescue LoadError
+  # Pact isn't available in all environments
+end
+
 Whitehall::Application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test:in_parallel]
+task default: %i[lint test:in_parallel pact:verify]

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,0 +1,35 @@
+require "pact/provider/rspec"
+require "webmock/rspec"
+require "factory_bot"
+require "database_cleaner"
+
+require ::File.expand_path("../../config/environment", __dir__)
+
+Dir[Rails.root.join("test/factories/*.rb")].sort.each { |f| require f }
+
+Pact.configure do |config|
+  config.reports_dir = "spec/reports/pacts"
+  config.include WebMock::API
+  config.include WebMock::Matchers
+  config.include FactoryBot::Syntax::Methods
+end
+
+WebMock.allow_net_connect!
+
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
+Pact.service_provider "Whitehall" do
+  honours_pact_with "GDS API Adapters" do
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
+    else
+      base_url = "https://pact-broker.cloudapps.digital"
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-whitehall-api-pact-tests'))}"
+
+      pact_uri("#{base_url}/#{path}/#{version_modifier}")
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -33,3 +33,20 @@ Pact.service_provider "Whitehall" do
     end
   end
 end
+
+Pact.provider_states_for "GDS API Adapters" do
+  provider_state "a world location exists" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+      create(:world_location, name: "France", slug: "france")
+    end
+  end
+
+  provider_state "a worldwide organisation exists" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+      stub_request(:any, %r{#{Regexp.escape(Plek.find('publishing-api'))}/v2/content})
+      create(:world_location, :with_worldwide_organisations, slug: "france")
+    end
+  end
+end


### PR DESCRIPTION
Adds Pact setup configuration for testing Whitehall's world API endpoints. The consumer tests are located in [GDS API Adapters](https://github.com/alphagov/gds-api-adapters/pull/1099).  

Depends on:

- [x] https://github.com/alphagov/whitehall/pull/6203

---

Trello:
https://trello.com/c/LCR0Am73/2541-5-enable-continuous-deployment-for-whitehall