### PR TITLE
Remove renamed Rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -84,12 +84,6 @@ namespace :publishing_api do
     end
   end
 
-  # TODO: Remove task after https://github.com/alphagov/publishing-e2e-tests/pull/422 has been merged
-  desc "Republish all organisations"
-  task republish_all_organisations: :environment do
-    Organisation.find_each(&:publish_to_publishing_api)
-  end
-
   namespace :republish do
     desc "Republish all organisations"
     task all_organisations: :environment do


### PR DESCRIPTION
This Rake task was renamed to `republish:all_organisations` but
Publishing e2e tests used this Rake task and so it had to be renamed
there first [1], and then removed from Whitehall.

[1]: https://github.com/alphagov/publishing-e2e-tests/pull/422

---

Trello:
https://trello.com/c/LCR0Am73/2541-5-enable-continuous-deployment-for-whitehall