### PR TITLE
Fix 500s due to type not being available

### DIFF
--- a/app/views/latest/index.html.erb
+++ b/app/views/latest/index.html.erb
@@ -21,7 +21,7 @@
           },
         ]
       } %>
-    <% elsif subject&.type == "TopicalEvent" %>
+    <% elsif subject.is_a? TopicalEvent %>
         <%= render "govuk_publishing_components/components/breadcrumbs", {
           breadcrumbs: [
             {
@@ -35,6 +35,23 @@
             {
               title: "#{subject}",
               url: "/government/topical-events/#{subject['slug']}",
+            },
+          ]
+        } %>
+    <% else subject.is_a? WorldLocation %>
+      <%= render "govuk_publishing_components/components/breadcrumbs", {
+          breadcrumbs: [
+            {
+              title: "Home",
+              url: "/",
+            },
+            {
+              title: "Help and services around the world",
+              url: "/government/world",
+            },
+            {
+              title: "#{subject}",
+              url: "/government/world/#{subject['slug']}",
             },
           ]
         } %>


### PR DESCRIPTION
This is a fix for a number of errors Sentry is reporting. It changes the way the document types are detected and adds support for World Locations which had been overlooked initially.

Tested with branch on integration:
https://www.integration.publishing.service.gov.uk/government/latest?departments%5B%5D=department-for-education
https://www.integration.publishing.service.gov.uk/government/latest?world_locations%5B%5D=germany
https://www.integration.publishing.service.gov.uk/government/latest?topical_events%5B%5D=budget-2021

![image](https://user-images.githubusercontent.com/31649453/126656200-d8695b1b-daba-4ed3-8203-98e67ce51799.png)
