### PR TITLE
Update Whitehall's service provider name

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -20,7 +20,7 @@ def url_encode(str)
   ERB::Util.url_encode(str)
 end
 
-Pact.service_provider "Whitehall" do
+Pact.service_provider "Whitehall API" do
   honours_pact_with "GDS API Adapters" do
     if ENV["PACT_URI"]
       pact_uri(ENV["PACT_URI"])


### PR DESCRIPTION
This now matches the provider name referenced in GDS API Adapters [1].

[1]: https://github.com/alphagov/gds-api-adapters/blob/master/test/test_helpers/pact_helper.rb#L74