### PR TITLE
Add extra stub

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -46,6 +46,8 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       DatabaseCleaner.clean_with :truncation
       stub_request(:any, %r{#{Regexp.escape(Plek.find('publishing-api'))}/v2/content})
+      stub_request(:any, %r{#{Regexp.escape(Plek.find('publishing-api'))}/v2/links/})
+
       create(:world_location, :with_worldwide_organisations, slug: "france")
     end
   end


### PR DESCRIPTION
The Publishing API links endpoint was being called when verifying the
Pact without any stub. Not sure why this wasn't caught when I ran the
Pact tests prior but anyhow, the tests now pass, again.

Error:

```
GdsApi::EndpointNotFound:
Could not connect to http://publishing-api.dev.gov.uk/v2/links/c42ac2be-98f5-478d-82cb-85a872d937c6
```

Verified the Pact against my GDS API adapters branch `bundle exec rake pact:verify PACT_CONSUMER_VERSION=branch-update-jenkinsfile`.

## Pic
<img width="1328" alt="Screenshot 2021-07-26 at 16 29 08" src="https://user-images.githubusercontent.com/24479188/127016275-8b0bca77-4340-4642-91b4-b18b9e8e9536.png">
