### PR TITLE
Always present telephone numbers as left-to-right

### DIFF
--- a/app/views/contacts/_organisation_contact.html.erb
+++ b/app/views/contacts/_organisation_contact.html.erb
@@ -34,7 +34,7 @@
         <% contact.contact_numbers.each do |number| %>
           <p class="govuk-!-margin-bottom-4">
             <%= number.label %> <br />
-            <%= number.number %>
+            <span dir="ltr"><%= number.number %></span>
           </p>
         <% end %>
       </div>

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -116,7 +116,7 @@ Then(/^the "([^"]*)" office details should be shown on the public website$/) do 
     address = worldwide_office.contact.street_address.gsub(/\s+/, " ")
     expect(page).to have_content(address, normalize_ws: true)
 
-    expect(page).to have_selector("p:nth-of-type(2)", text: worldwide_office.contact.contact_numbers.first.number)
+    expect(page).to have_selector("span[dir='ltr']", text: worldwide_office.contact.contact_numbers.first.number)
   end
 end
 


### PR DESCRIPTION
When a telephone number is included in the contact details of an organisation page's translation for a right-to-left language, we are incorrectly applying this to the phone number too.

This resulted in `+972 (0) 2 541 4100` being presented as `4100 541 2 (0) 972+`, which is incorrect.

By always including the telephone number as left-to-right, we will ensure the correct number is displayed.

The alternative was to replaces the spaces in the phone number with non-breaking spaces, but this still results in issues where parentheses and dashes are used.

There are multiple other issues with English content being presented as right-to-left on worldwide organisation pages, but these can be dealt with separately, as the phone number is the more pressing issue (i.e. the number is completely wrong).

Before:
![Screenshot 2021-07-26 at 17 24 18](https://user-images.githubusercontent.com/6329861/127024531-80136d4f-6451-4836-a5fe-7a7bbfbfcd23.png)

After:
![Screenshot 2021-07-26 at 17 25 52](https://user-images.githubusercontent.com/6329861/127024552-ae9f3349-ad5c-45ff-b373-f46b2d6d8300.png)

[Trello card](https://trello.com/c/9VmNiMU7)