### PR TITLE
Exclude Details elements from HTML sanitisation for documents with attachments

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -32,7 +32,7 @@ module GovspeakHelper
 
   def bare_govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
     partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(body, attachments, alternative_format_contact_email)
-    bare_govspeak_to_html(partially_processed_govspeak, [])
+    bare_govspeak_to_html(partially_processed_govspeak, [], allowed_elements: %w[details])
   end
 
   def govspeak_headers(govspeak, level = (2..2))

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -501,4 +501,12 @@ class GovspeakHelperTest < ActionView::TestCase
     html = govspeak_edition_to_html(document)
     assert_not html.include?("<details class=\"gem-c-details")
   end
+
+  test "should not sanitise Details element for documents with attachments" do
+    body = "#Heading\n\n!@1\n\n##Subheading"
+    document = build(:published_detailed_guide, :with_file_attachment, body: body)
+    attachments = document.attachments
+    html = govspeak_with_attachments_to_html(body, attachments, "email@example.com")
+    assert html.include?("<details class=\"gem-c-details")
+  end
 end


### PR DESCRIPTION
Inline attachments are wrapped in a `<details>` HTML element which is
being sanitized and removed by Govspeak. This is preventing a JS module
from attaching and results in the accessible format request block
always being expanded.

This change allows editions with inline attachments to request
that Govspeak excludes the `details` element from sanitization
by submitting it as a string in the optional
`allowed_elements` array

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
