### PR TITLE
Add Rake task to republish all PolicyGroups

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -101,6 +101,13 @@ namespace :publishing_api do
       puts "Finished republishing Take Part pages"
     end
 
+    desc "Republish all PolicyGroup pages"
+    task all_policy_group: :environment do
+      republisher = DataHygiene::PublishingApiRepublisher.new(PolicyGroup.all)
+      republisher.perform
+      puts "Finished republishing Policy Groups"
+    end
+
     desc "Republish a person to the Publishing API"
     task :person_by_slug, [:slug] => :environment do |_, args|
       Person.find_by!(slug: args[:slug]).publish_to_publishing_api


### PR DESCRIPTION
Add Rake task to republish all PolicyGroups

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
