### PR TITLE
Update style for non-Whitehall content group

### DIFF
--- a/app/assets/stylesheets/admin/views/_document-collection-groups.scss
+++ b/app/assets/stylesheets/admin/views/_document-collection-groups.scss
@@ -8,6 +8,8 @@
         margin-bottom: $gutter / 2;
         @include border-radius(3px);
         border: 1px solid transparent;
+        cursor: pointer;
+        display: list-item;
       }
 
       summary:focus {


### PR DESCRIPTION
There is currently a [details disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) with a summary on the "Add document to a group" view.

The styling currently means there is no pointer cursor, so users are not aware this can be clicked on to expand the form.

Adding a pointer cursor to the summary and also adding the arrow alongside to make it clearer that this element opens on click.

----

Before:
![Before update with no pointer cursor and no expansion arrow icon](https://user-images.githubusercontent.com/6329861/128838935-8db7f039-e5e3-49bd-bd38-1c514f35006c.png)

----

After (unexpanded):
![Unexpanded after update with pointer cursor and expansion arrow icon](https://user-images.githubusercontent.com/6329861/128838963-445e52f7-dc23-4056-96fa-128be75df533.png)

----

After (expanded):
![Expanded after update with pointer cursor and expansion arrow icon](https://user-images.githubusercontent.com/6329861/128839043-cf7be196-bfec-4bc2-8c60-286df4a669b9.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/AqstqPc4)