### PR TITLE
Return AB response headers with all variants

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -17,10 +17,10 @@ module AbTests::ExploreMenuAbTestable
   end
 
   def set_explore_menu_response
-    explore_menu_variant.configure_response(response) if explore_menu_testable?
+    explore_menu_variant.configure_response(response)
   end
 
-  def explore_menu_testable?
+  def explore_menu_variant_b?
     explore_menu_variant.variant?("B")
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   before_action :set_authenticated_user_header
   before_action :set_explore_menu_response
 
-  helper_method :explore_menu_variant, :explore_menu_testable?
+  helper_method :explore_menu_variant, :explore_menu_variant_b?
 
   layout "frontend"
   after_action :set_slimmer_template
@@ -34,7 +34,7 @@ private
   end
 
   def set_slimmer_template
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "header_footer_only_explore_header"
     else
       slimmer_template "header_footer_only"

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -26,7 +26,7 @@
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
     <%= tag :base, href: @page_base_href if @page_base_href %>
-    <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+    <%= explore_menu_variant.analytics_meta_tag.html_safe %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -1,5 +1,5 @@
 <%= render :layout => 'layouts/frontend_base' do %>
-  <% unless explore_menu_testable? %>
+  <% unless explore_menu_variant_b? %>
     <nav id="proposition-menu" class="no-proposition-name" aria-label="Departments and policy navigation">
       <ul id="proposition-links" data-module="gem-track-click">
         <li>

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -1,7 +1,42 @@
 require "test_helper"
 
 class CorporateInformationPagesControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
   should_be_a_public_facing_controller
+
+  view_test "AB testing of Explore menu variant A" do
+    with_variant ExploreMenuAbTestable: "A" do
+      @corporate_information_page = create(:corporate_information_page, :published, body: "## Title\n\npara1\n\n")
+      get :show, params: { organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug }
+
+      assert response.successful?
+      assert_equal "header_footer_only", response.headers["X-Slimmer-Template"]
+      assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "A", 47)
+    end
+  end
+
+  view_test "AB testing of Explore menu variant B" do
+    with_variant ExploreMenuAbTestable: "B" do
+      @corporate_information_page = create(:corporate_information_page, :published, body: "## Title\n\npara1\n\n")
+      get :show, params: { organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug }
+
+      assert response.successful?
+      assert_equal "header_footer_only_explore_header", response.headers["X-Slimmer-Template"]
+      assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "B", 47)
+    end
+  end
+
+  view_test "AB testing of Explore menu variant Z" do
+    with_variant ExploreMenuAbTestable: "Z" do
+      @corporate_information_page = create(:corporate_information_page, :published, body: "## Title\n\npara1\n\n")
+      get :show, params: { organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug }
+
+      assert response.successful?
+      assert_equal "header_footer_only", response.headers["X-Slimmer-Template"]
+      assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "Z", 47)
+    end
+  end
 
   view_test "show renders the summary as plain text" do
     @corporate_information_page = create(:corporate_information_page, :published, summary: "Just plain text")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,10 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.project_root = Rails.root
 end
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActiveSupport::TestCase
   include AssetManagerTestHelpers
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
At present we're only returning Vary response headers when we get a B variant. We want to do this all the time or it's confusing for Fastly to know how to cache.

I've added a couple of tests for the other variants to make sure it's working.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
