### PR TITLE
Add missing healthchecks - take 2

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -420,6 +420,8 @@ Whitehall::Application.routes.draw do
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
     GovukHealthcheck::SidekiqRedis,
+    GovukHealthcheck::RailsCache,
+    Healthcheck::S3,
   )
 
   get "healthcheck/overdue" => "healthcheck#overdue"

--- a/lib/healthcheck/s3.rb
+++ b/lib/healthcheck/s3.rb
@@ -5,8 +5,10 @@ module Healthcheck
     end
 
     def status
-      connection = S3FileHandler.connection
-      connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+      if ENV["RUN_S3_HEALTHCHECK_FOR_WHITEHALL_BACKEND"].present?
+        connection = S3FileHandler.connection
+        connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+      end
 
       GovukHealthcheck::OK
     rescue StandardError

--- a/lib/healthcheck/s3.rb
+++ b/lib/healthcheck/s3.rb
@@ -1,0 +1,16 @@
+module Healthcheck
+  class S3
+    def name
+      :s3
+    end
+
+    def status
+      connection = S3FileHandler.connection
+      connection.directories.get(ENV["AWS_S3_BUCKET_NAME"])
+
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end


### PR DESCRIPTION
These healthchecks (Memcached and S3) were missing from Whitehall, as
originally outlined in the CD compatibility document [1].

We've had to create a bespoke healthcheck for the connectivity to S3 [2]
which just opens a connection and fetches a bucket. If any errors occur
during this process, the healthcheck fails.

There is also a conditional to skip the S3 healthcheck if being run from the E2E 
tests or from Whitehall Frontend, see the 2nd commit for more details. 

Dependant on: 

- [x] https://github.com/alphagov/govuk-puppet/pull/11232  

[1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128/compatibility.md
[2]: https://github.com/alphagov/whitehall/blob/4d1de9a6818041994f555ae40164b08cd85f043e/lib/s3_file_handler.rb

## Healthcheck endpoint request

<img width="1085" alt="Screenshot 2021-08-06 at 15 00 22" src="https://user-images.githubusercontent.com/24479188/128522016-7a68fa62-8203-406a-a464-756e3d6bc30e.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️