### PR TITLE
Fix context hashes

### DIFF
--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -1,6 +1,17 @@
 <% page_title "Past #{@role.name.pluralize}" %>
 <% page_class "historic-appointments historic-appointments-index govuk-width-container" %>
-
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: "Home",
+        url: "/"
+      },
+      {
+        title: "History of the UK Government",
+        url: "/government/history"
+      }
+    ]
+  } %>
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -4,10 +4,7 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {
-        context: {
-          text: "History",
-          href: "/government/history",
-        },
+        context: "History",
         title: "Past #{@role.name.pluralize}"
       } %>
   </div>

--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -15,9 +15,7 @@
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "Past Chancellors of the Exchequer",
     } %>
   </div>

--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -15,9 +15,7 @@
 <header class="block headings-block">
   <div class="govuk-width-container">
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "Past #{@role.name.pluralize}",
     } %>
   </div>

--- a/app/views/latest/index.html.erb
+++ b/app/views/latest/index.html.erb
@@ -57,9 +57,7 @@
         } %>
     <% end %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: subject,
-      },
+      context: subject,
       title: t("document.latest"),
     } %>
   </div>

--- a/app/views/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/past_foreign_secretaries/_show_person.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "Past Foreign Secretaries",
     } %>
   </div>


### PR DESCRIPTION
In the pre-emptive work to fix calls to context that used the href parameter in the title component, one item was overlooked and the syntax left spurious hashes lying around in the rest. This fixes that issue and will fix the currently broken Past Prime Ministers title on live:

![image](https://user-images.githubusercontent.com/31649453/128984281-4a7d9891-151b-42a8-93ef-bc59c48bd022.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
