### PR TITLE
Remove Whitehall sentry_context unsetting logic

### DIFF
--- a/config/initializers/gds_api_base_error.rb
+++ b/config/initializers/gds_api_base_error.rb
@@ -1,5 +1,0 @@
-require "gds_api/exceptions"
-
-class GdsApi::BaseError
-  remove_method :sentry_context
-end

--- a/test/unit/gds_api_base_error_test.rb
+++ b/test/unit/gds_api_base_error_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class GdsApiBaseErrorTest < ActiveSupport::TestCase
-  test "removes sentry_context method to avoid grouping unrelated exceptions" do
-    assert_not GdsApi::BaseError.new.respond_to?(:sentry_context)
-  end
-end


### PR DESCRIPTION
gds-api-adapters tells Sentry it should group errors by class
name, rather than by stack trace, which would otherwise lead
to too many duplicate 'issues':
https://github.com/alphagov/gds-api-adapters/blob/d05134bbd18a33fe946edeb1144cdb97ce6c8153/lib/gds_api/exceptions.rb#L11

Whitehall 'unsets' this logic to fall back to the Sentry
default, which is to group issues by stack trace. However,
this hasn't been working very well.

Whitehall has been on the govuk_app_config v4 pre-release for
a while now, meaning it's pulling in the sentry-ruby gem rather
than the sentry-raven gem. And the sentry-ruby gem looks for
the `sentry_context` rather than the `raven_context`.
Whitehall was on gds-api-adapters v71, which defines a
`raven_context`. In other words, gds-api-adapters has been
telling Sentry to group by class name, but Sentry has been
ignoring it, even without Whitehall telling Sentry to ignore
gds-api-adapters.

So we're already in a situation where Whitehall is grouping
by stack trace instead of class name, as is intended by the
unsetting here. And it's leading to some strange results -
see below:

![](https://user-images.githubusercontent.com/5111927/128831993-a023bd07-4dae-4385-a36d-7a1e847ae678.png)

All those AssetManagerAttachmentSetUploadedToWorker exceptions are
of the same class, but have different stack traces, so we're seeing
a lot of duplication in the Sentry UI. See [1](https://user-images.githubusercontent.com/5111927/128832990-f1ca4b85-63c4-4821-8ef7-c2bb1c05507a.png)
and [2](https://user-images.githubusercontent.com/5111927/128833022-6aa489b0-182e-46a2-a5d1-0f60a41d7f53.png).

As the unsetting doesn't seem to be adding much value, this seems
a good time to just remove it.

EDIT: looking at some of the other Issues, we have some pretty
generic errors (`NoMethodError` etc) that apply to multiple different
controllers, so actually grouping by class name may not be a great
long term strategy for Whitehall.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
