### PR TITLE
Add migration to convernt custom_jobs_url from string to text

### DIFF
--- a/db/migrate/20210812102237_add_new_custom_jobs_url_to_geospatial_commission_org.rb
+++ b/db/migrate/20210812102237_add_new_custom_jobs_url_to_geospatial_commission_org.rb
@@ -1,0 +1,5 @@
+class AddNewCustomJobsUrlToGeospatialCommissionOrg < ActiveRecord::Migration[6.0]
+  def change
+    change_column :organisations, :custom_jobs_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_09_141023) do
+ActiveRecord::Schema.define(version: 2021_08_12_102237) do
 
   create_table "about_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -767,7 +767,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.boolean "foi_exempt", default: false, null: false
     t.string "organisation_chart_url"
     t.string "govuk_closed_status"
-    t.string "custom_jobs_url"
+    t.text "custom_jobs_url"
     t.string "content_id"
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false


### PR DESCRIPTION
## What
Add a migration to swap the `custom_jobs_url` field from a `string` to a `text`.

## Why
A user wants to add a long link to this field however is running into issues as the length of the link is too long for the field. This will allow them to post their desired long link.

Ticket: https://govuk.zendesk.com/agent/tickets/4658595

This has been tested on integration by adding the long link in the above ticket to the custom jobs url field which I was able to do successfully.

![Screenshot 2021-08-13 at 11 05 36](https://user-images.githubusercontent.com/64783893/129341767-bf030197-52f2-45fe-81fd-319400fdb31a.png)