### PR TITLE
Update past prime ministers

### DIFF
--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -1,6 +1,7 @@
-.historic-people-index {
-  .clear-person {
-    clear: both;
+.historic-people-index__section-row-header {
+  @include govuk-media-query($from: "tablet") {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(4);
   }
 }
 

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -2,62 +2,6 @@
   .clear-person {
     clear: both;
   }
-
-  .featured-profiles {
-    margin-bottom: $gutter;
-
-    .profiles {
-      @include heading-36;
-      border-bottom: $gutter-one-sixth solid govuk-colour("black");
-      margin: 0 $gutter-half $gutter-half;
-    }
-
-    .name {
-      @include core-19;
-      font-weight: bold;
-    }
-
-    .term {
-      color: $govuk-secondary-text-colour;
-      display: block;
-    }
-
-    .person-excerpt {
-      .inner {
-        .image-holder {
-          @include govuk-media-query($until: tablet) {
-            margin-right: govuk-spacing(2);
-          }
-
-          img {
-            max-width: $full-width;
-          }
-        }
-      }
-    }
-
-    @include media(tablet) {
-      margin-bottom: $gutter * 2;
-    }
-  }
-
-  .foreign-secretaries {
-    .heading {
-      h3 {
-        @include heading-36;
-        font-weight: bold;
-        padding: 0 $gutter-half;
-
-        span {
-          @include core-19;
-          display: block;
-        }
-        @include media(tablet) {
-          padding-top: 0;
-        }
-      }
-    }
-  }
 }
 
 .historic-people-show {

--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -3,9 +3,9 @@ class HistoricAppointmentsController < PublicFacingController
   helper_method :previous_appointments_with_unique_people
 
   def index
-    @recent_appointments = previous_appointments.where("started_at > ?", Date.civil(1900)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
-    @nineteenth_century_appointments = previous_appointments.between(Date.civil(1800), Date.civil(1900)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
-    @eighteenth_century_appointments = previous_appointments.between(Date.civil(1700), Date.civil(1800)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
+    @recent_appointments = previous_appointments.where("started_at > ?", Date.civil(2001)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
+    @twentieth_century_appointments = previous_appointments.between(Date.civil(1901), Date.civil(2000)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
+    @eighteenth_and_nineteenth_century_appointments = previous_appointments.between(Date.civil(1701), Date.civil(1900)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
   end
 
   def past_chancellors; end

--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -3,9 +3,9 @@ class HistoricAppointmentsController < PublicFacingController
   helper_method :previous_appointments_with_unique_people
 
   def index
-    @recent_appointments = previous_appointments.where("started_at > ?", Date.civil(2001)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
-    @twentieth_century_appointments = previous_appointments.between(Date.civil(1901), Date.civil(2000)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
-    @eighteenth_and_nineteenth_century_appointments = previous_appointments.between(Date.civil(1701), Date.civil(1900)).map { |r| RoleAppointmentPresenter.new(r, view_context) }
+    @recent_appointments = individual_role_appointees(all_recent_appointments)
+    @twentieth_century_appointments = individual_role_appointees(all_twentieth_century_appointments)
+    @eighteenth_and_nineteenth_century_appointments = individual_role_appointees(all_historical_appointments)
   end
 
   def past_chancellors; end
@@ -17,6 +17,22 @@ class HistoricAppointmentsController < PublicFacingController
   end
 
 private
+
+  def all_recent_appointments
+    present_roles(previous_appointments.where("started_at > ?", Date.civil(2001)))
+  end
+
+  def all_twentieth_century_appointments
+    present_roles(previous_appointments.between(Date.civil(1901), Date.civil(2000)))
+  end
+
+  def all_historical_appointments
+    present_roles(previous_appointments.between(Date.civil(1701), Date.civil(1900)))
+  end
+
+  def present_roles(roles)
+    roles.map { |r| RoleAppointmentPresenter.new(r, view_context) }
+  end
 
   def load_role
     @role = Role.friendly.find(role_id)
@@ -32,5 +48,9 @@ private
 
   def previous_appointments_with_unique_people
     previous_appointments.distinct(&:person)
+  end
+
+  def individual_role_appointees(appointments)
+    appointments.uniq { |appointment| appointment.person.id }
   end
 end

--- a/app/helpers/historic_appointments_helper.rb
+++ b/app/helpers/historic_appointments_helper.rb
@@ -10,4 +10,12 @@ module HistoricAppointmentsHelper
          .map { |r| RoleAppointmentPresenter.new(r, self).date_range }
          .join(", ")
   end
+
+  def previous_dates_in_office_prime(role, person, party)
+    role.previous_appointments.for_person(person).map do |r|
+      {
+        text: "#{party} #{RoleAppointmentPresenter.new(r, self).date_range}",
+      }
+    end
+  end
 end

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter' do %>
+<%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
   <%= render "govuk_publishing_components/components/image_card", {
     href: historic_appointment_path(role.historic_param, role_appointment.person),
     image_src: role_appointment.person.image_url(:s216),

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,14 +1,11 @@
+<% political_membership = role_appointment.historical_account.try(:political_membership) %>
 <%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
   <%= render "govuk_publishing_components/components/image_card", {
     href: historic_appointment_path(role.historic_param, role_appointment.person),
     image_src: role_appointment.person.image_url(:s216),
     image_loading: "lazy",
     heading_text: role_appointment.person.name,
-    extra_links: [
-      {
-        text: "#{role_appointment.historical_account.try(:political_membership)} #{previous_dates_in_office(role, role_appointment.person)}",
-      }
-    ],
+    extra_links: previous_dates_in_office_prime(role, role_appointment.person, political_membership),
     extra_links_no_indent: true
   } %>
 <% end %>

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -6,7 +6,7 @@
     heading_text: role_appointment.person.name,
     extra_links: [
       {
-        text: "#{role_appointment.historical_account.try(:political_membership)} #{role_appointment.date_range}"
+        text: "#{role_appointment.historical_account.try(:political_membership)} #{previous_dates_in_office(role, role_appointment.person)}",
       }
     ],
     extra_links_no_indent: true

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,9 +1,14 @@
-<div class="govuk-grid-column-one-quarter">
-<%= render "govuk_publishing_components/components/image_card", {
-  href: historic_appointment_path(role.historic_param, role_appointment.person),
-  image_src: "https://via.placeholder.com/216x140",
-  image_alt: role_appointment.person.name,
-  heading_text: role_appointment.person.name,
-  description: "#{role_appointment.historical_account.try(:political_membership)} #{role_appointment.date_range}",
-} %>
-</div>
+<%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter' do %>
+  <%= render "govuk_publishing_components/components/image_card", {
+    href: historic_appointment_path(role.historic_param, role_appointment.person),
+    image_src: role_appointment.person.image_url(:s216),
+    image_loading: "lazy",
+    heading_text: role_appointment.person.name,
+    extra_links: [
+      {
+        text: "#{role_appointment.historical_account.try(:political_membership)} #{role_appointment.date_range}"
+      }
+    ],
+    extra_links_no_indent: true
+  } %>
+<% end %>

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,9 +1,9 @@
-<%= content_tag_for :li, role_appointment, class: 'person person-excerpt' do %>
-  <div class="inner">
-    <div class="image-holder">
-      <%= link_to_if role_appointment.has_historical_account?, role_appointment.person.image, historic_appointment_path(role.historic_param, role_appointment.person), class: "img", aria: {hidden: true}, tabindex: "-1" %>
-    </div>
-    <h3 class="name"><%= link_to_if role_appointment.has_historical_account?, role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person), class: "govuk-link" %></h3>
-    <p class="term"><%= role_appointment.historical_account.try(:political_membership) %> <%= role_appointment.date_range %></p>
-  </div>
-<% end %>
+<div class="govuk-grid-column-one-quarter">
+<%= render "govuk_publishing_components/components/image_card", {
+  href: historic_appointment_path(role.historic_param, role_appointment.person),
+  image_src: "https://via.placeholder.com/216x140",
+  image_alt: role_appointment.person.name,
+  heading_text: role_appointment.person.name,
+  description: "#{role_appointment.historical_account.try(:political_membership)} #{role_appointment.date_range}",
+} %>
+</div>

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -1,49 +1,96 @@
 <% page_title "Past #{@role.name.pluralize}" %>
 <% page_class "historic-appointments historic-appointments-index govuk-width-container" %>
+
 <%= render "govuk_publishing_components/components/breadcrumbs", {
-    breadcrumbs: [
-      {
-        title: "Home",
-        url: "/"
-      },
-      {
-        title: "History of the UK Government",
-        url: "/government/history"
-      }
-    ]
-  } %>
-<header class="govuk-grid-row">
+  collapse_on_mobile: true,
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/",
+    },
+    {
+      title: "How government works",
+      url: "/government/how-government-works",
+    },
+    {
+      title: "History of the UK government",
+      url: "/government/history",
+    },
+  ]
+} %>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {
-        context: "History",
-        title: "Past #{@role.name.pluralize}"
-      } %>
-  </div>
-</header>
-
-<%= render partial: 'role_appointments_list', locals: { role: @role } %>
-
-<div class="block featured-profiles">
-  <div class="inner-block floated-children">
-    <div class="year-block" id="modern-appointments">
-      <h2 class="profiles">20th &amp; 21st centuries</h2>
-      <ol>
-        <%= render partial: 'role_appointment', collection: @recent_appointments, locals: { role: @role } %>
-      </ol>
-    </div>
-
-    <div class="year-block" id="nineteenth-century-appointments">
-      <h2 class="profiles">19th century</h2>
-      <ol>
-        <%= render partial: 'role_appointment', collection: @nineteenth_century_appointments, locals: { role: @role } %>
-      </ol>
-    </div>
-
-    <div class="year-block" id="eighteenth-century-appointments">
-      <h2 class="profiles">18th century</h2>
-      <ol>
-        <%= render partial: 'role_appointment', collection: @eighteenth_century_appointments, locals: { role: @role } %>
-      </ol>
-    </div>
+      context: "History",
+      title: "Past #{@role.name.pluralize}",
+    } %>
   </div>
 </div>
+
+<%# 21st century section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "21st century",
+      padding: true,
+      border_top: 2,
+      font_size: "l"
+    } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<% @recent_appointments.in_groups_of(4, false) do |people| %>
+  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+    <%= render partial: 'role_appointment', collection: people, 
+      locals: { 
+        role: @role,  
+      } %>  
+  </div>
+<% end %>
+
+<%# 20th century section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "20th century",
+      padding: true,
+      border_top: 2,
+      font_size: "l",
+    } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<% @twentieth_century_appointments.in_groups_of(4, false) do |people| %>
+  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+    <%= render partial: 'role_appointment', collection: people, 
+      locals: { 
+        role: @role,  
+      } %>  
+  </div>
+<% end %>
+
+<%# 18th & 19th centuries section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "18th & 19th centuries",
+        padding: true,
+        border_top: 2,
+        font_size: "l",
+        margin_bottom: 2,
+      } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<% @eighteenth_and_nineteenth_century_appointments.in_groups_of(4, false) do |people| %>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <%= render partial: 'role_appointment', collection: people, 
+    locals: { 
+      role: @role,  
+    } %>  
+</div>
+<% end %>

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -42,7 +42,7 @@
 </div>
 
 <% @recent_appointments.in_groups_of(4, false) do |people| %>
-  <div class="govuk-grid-row govuk-!-margin-bottom-4" role="list">
+  <div class="govuk-grid-row historic-people-index__section-row-header" role="list">
     <%= render partial: 'role_appointment', collection: people, 
       locals: { 
         role: @role,  
@@ -65,7 +65,7 @@
 
 <div role="list">
   <% @twentieth_century_appointments.in_groups_of(4, false) do |people| %>
-    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+    <div class="govuk-grid-row historic-people-index__section-row-header">
       <%= render partial: 'role_appointment', collection: people, 
         locals: { 
           role: @role,  
@@ -90,7 +90,7 @@
 
 <div role="list">
   <% @eighteenth_and_nineteenth_century_appointments.in_groups_of(4, false) do |people| %>
-  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row historic-people-index__section-row-header">
     <%= render partial: 'role_appointment', collection: people, 
       locals: { 
         role: @role,  

--- a/app/views/historic_appointments/index.html.erb
+++ b/app/views/historic_appointments/index.html.erb
@@ -42,7 +42,7 @@
 </div>
 
 <% @recent_appointments.in_groups_of(4, false) do |people| %>
-  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row govuk-!-margin-bottom-4" role="list">
     <%= render partial: 'role_appointment', collection: people, 
       locals: { 
         role: @role,  
@@ -63,18 +63,20 @@
   </div>
 </div>
 
-<% @twentieth_century_appointments.in_groups_of(4, false) do |people| %>
-  <div class="govuk-grid-row govuk-!-margin-bottom-4">
-    <%= render partial: 'role_appointment', collection: people, 
-      locals: { 
-        role: @role,  
-      } %>  
-  </div>
-<% end %>
+<div role="list">
+  <% @twentieth_century_appointments.in_groups_of(4, false) do |people| %>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <%= render partial: 'role_appointment', collection: people, 
+        locals: { 
+          role: @role,  
+        } %>  
+    </div>
+  <% end %>
+</div>
 
 <%# 18th & 19th centuries section %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/heading", {
         text: "18th & 19th centuries",
         padding: true,
@@ -86,11 +88,13 @@
   </div>
 </div>
 
-<% @eighteenth_and_nineteenth_century_appointments.in_groups_of(4, false) do |people| %>
-<div class="govuk-grid-row govuk-!-margin-bottom-4">
-  <%= render partial: 'role_appointment', collection: people, 
-    locals: { 
-      role: @role,  
-    } %>  
+<div role="list">
+  <% @eighteenth_and_nineteenth_century_appointments.in_groups_of(4, false) do |people| %>
+  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+    <%= render partial: 'role_appointment', collection: people, 
+      locals: { 
+        role: @role,  
+      } %>  
+  </div>
+  <% end %>
 </div>
-<% end %>

--- a/features/step_definitions/historic_appointment_steps.rb
+++ b/features/step_definitions/historic_appointment_steps.rb
@@ -5,14 +5,15 @@ Given(/^there are previous prime ministers$/) do
   _current_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)
   _pm1_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm1.person)
   _pm2_historic_account = create(:historical_account, roles: [pm_role], person: previous_pm2.person)
-  nineteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1801), ended_at: Date.civil(1804))
+
+  twentieth_century_appointments = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1901), ended_at: Date.civil(2000))
   eighteenth_century_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1704))
   eighteenth_century_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1704), ended_at: Date.civil(1708))
 
-  @modern_previous_pm_appointments = [previous_pm2, previous_pm1]
-  @nineteenth_century_pm_appointments = [nineteenth_century_pm]
-  @eighteenth_century_pm_appointments = [eighteenth_century_pm1, eighteenth_century_pm2]
   @most_recent_appointment = previous_pm2
+  @modern_previous_pm_appointments = [previous_pm2, previous_pm1]
+  @twentieth_century_appointments_appointments = [twentieth_century_appointments]
+  @eighteenth_century_pm_appointments = [eighteenth_century_pm1, eighteenth_century_pm2]
 end
 
 When(/^I view the past prime ministers page$/) do
@@ -20,7 +21,8 @@ When(/^I view the past prime ministers page$/) do
 end
 
 Then(/^I should see the previous prime ministers listed according the century in which they served$/) do
-  within "#modern-appointments" do
+  # On page check 21th Century
+  within ".historic-appointments-index" do
     @modern_previous_pm_appointments.each do |appointment|
       within record_css_selector(appointment) do
         expect(page).to have_link(appointment.person.name)
@@ -28,15 +30,17 @@ Then(/^I should see the previous prime ministers listed according the century in
     end
   end
 
-  within "#nineteenth-century-appointments" do
-    @nineteenth_century_pm_appointments.each do |appointment|
+  # On page check 20th century
+  within ".historic-appointments-index" do
+    @twentieth_century_appointments_appointments.each do |appointment|
       within record_css_selector(appointment) do
         expect(page).to have_content(appointment.person.name)
       end
     end
   end
 
-  within "#eighteenth-century-appointments" do
+  # On page check 18th & 19th centuries
+  within ".historic-appointments-index" do
     @eighteenth_century_pm_appointments.each do |appointment|
       within record_css_selector(appointment) do
         expect(page).to have_content(appointment.person.name)
@@ -46,7 +50,8 @@ Then(/^I should see the previous prime ministers listed according the century in
 end
 
 When(/^I view the most recent past prime minister$/) do
-  within "#modern-appointments" do
+  # On page check check the most recent past prime minster
+  within ".historic-appointments-index" do
     find("a", text: @most_recent_appointment.person.name).click
   end
 end

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -21,9 +21,10 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     )
   end
 
-  test "GET on :index loads the past appointments for the role and renders the index template" do
+  test "GET on :index loads the past appointments, excluding duplicate role holders, for the role and renders the index template" do
     previous_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
-    previous_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
+    previous_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.year.ago)
+    repeat_pm1 = create(:ministerial_role_appointment, person: previous_pm1.person, role: pm_role, started_at: 1.year.ago, ended_at: 1.day.ago)
     _current_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)
     eighteenth_and_nineteenth_century_appointments = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1900))
 
@@ -34,7 +35,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     assert_template :index
     assert_equal pm_role, assigns(:role)
 
-    assert_equal_role_presenters [previous_pm2, previous_pm1], assigns(:recent_appointments)
+    assert_equal_role_presenters [repeat_pm1, previous_pm2], assigns(:recent_appointments)
     assert_equal_role_presenters [eighteenth_and_nineteenth_century_appointments], assigns(:eighteenth_and_nineteenth_century_appointments)
   end
 

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -25,8 +25,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     previous_pm1 = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
     previous_pm2 = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
     _current_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)
-    nineteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1801), ended_at: Date.civil(1804))
-    eighteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1704))
+    eighteenth_and_nineteenth_century_appointments = create(:ministerial_role_appointment, role: pm_role, started_at: Date.civil(1701), ended_at: Date.civil(1900))
 
     create(:historical_account, roles: [chancellor_role])
     get :index, params: { role: "past-prime-ministers" }
@@ -36,8 +35,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     assert_equal pm_role, assigns(:role)
 
     assert_equal_role_presenters [previous_pm2, previous_pm1], assigns(:recent_appointments)
-    assert_equal_role_presenters [nineteenth_century_pm], assigns(:nineteenth_century_appointments)
-    assert_equal_role_presenters [eighteenth_century_pm], assigns(:eighteenth_century_appointments)
+    assert_equal_role_presenters [eighteenth_and_nineteenth_century_appointments], assigns(:eighteenth_and_nineteenth_century_appointments)
   end
 
   test "GET on :past_chancellors renders the template" do


### PR DESCRIPTION
## What 

Update Past Prime Minster's page to apply [new Design](https://www.figma.com/file/UjCeRTxle1bLQv3VFNz9Wt/Redesign-of-history-pages?node-id=11%3A138) + Design system + use Components 

## Why 

On-going work to align architecture, have pages benefit from Accessibility improvements

## Visuals 

| Before      | After* |
| ----------- | ----------- |
| ![www gov uk_government_history_past-prime-ministers(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/71266765/131499115-c3d17f72-3367-4a0e-ad07-b3c87d179cfc.png) | ![1www gov uk_government_history_past-prime-ministers(iPhone-6_7_8-Plus)](https://user-images.githubusercontent.com/71266765/131499737-66461a67-1e86-4879-822a-e7a1e0f6e173.jpg) |
|  |
| ![www gov uk_government_history_past-prime-ministers (1)](https://user-images.githubusercontent.com/71266765/129364906-94721798-67a6-40bd-a81b-ccdd622d5757.png)  | ![screenshot-www integration publishing service gov uk-2021 08 31-12_55_10](https://user-images.githubusercontent.com/71266765/131498715-dafab46e-bcc0-4c28-bcd3-7aedb87d49a3.png) |

## Anything else

* `image_card` was extended to factor in a [new Design](https://github.com/alphagov/govuk_publishing_components/pull/2286) and 
* [lazy loading](https://github.com/alphagov/govuk_publishing_components/pull/2270) was added to the `image_card` as this maintains existing performance benefits.

[Discussion around Design System layout + lists can be found here](https://github.com/alphagov/whitehall/pull/6236#discussion_r695518441), [an issue capturing the concerns can be found here](https://github.com/alphagov/govuk-frontend/issues/2328)

### Grouped related PRs
https://github.com/alphagov/whitehall/pull/6236
https://github.com/alphagov/whitehall/pull/6243
https://github.com/alphagov/whitehall/pull/6241

## Done when

- [x] Confirm IA of breadcrumbs
- [x] Confirm [not WCAG failure of 2.4.5](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-mult-loc.html)
- [x] Add `loading="lazy"` to image card within `govuk_publishing_gem`
PR: https://github.com/alphagov/govuk_publishing_components/pull/2270
- [x] Gem [released](https://github.com/alphagov/govuk_publishing_components/pull/2271) with `loading="lazy"` update
- [x] Design reviewed
- [x] Extend [`image_card`](https://components.publishing.service.gov.uk/component-guide/image_card) to give more options to match Design
PR: https://github.com/alphagov/govuk_publishing_components/pull/2286
- [x] [Gem released](https://github.com/alphagov/whitehall/pull/6253)
- [x] QA Content