### PR TITLE
Add a link in the main readme to the migration readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See the [`docs/`](docs/) directory.
 - [Search setup guide](docs/search_setup_guide.md)
 - [Timestamps](docs/timestamps.md)
 - [Troubleshooting](docs/troubleshooting.md)
+- [Adding a data migration](db/data_migration/README.md)
 
 ## Licence
 

--- a/db/data_migration/README.md
+++ b/db/data_migration/README.md
@@ -27,7 +27,7 @@ own rake task and database table for tracking which ones have been run.
 Just like a normal migration, there is a Rails command:
 
 ```
-  bundle exec rails g data_migration MyDataMigrationName
+  bundle exec rails g migration MyDataMigrationName
 ```
 
 ## How to run them


### PR DESCRIPTION
## What
Add a link from the main readme to the data migrations readme and fix a typo in the migrations readme.

## Why
So we are effectively signposting features like data migration in whitehall to our devs.