### PR TITLE
Run JavaScript and Cucumber tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,9 @@ node {
           govuk.runRakeTask("test:publishing_schemas --trace")
         } else {
           govuk.runRakeTask("ci:setup:minitest test --trace")
+          govuk.runRakeTask("shared_mustache:compile")
+          sh("bundle exec cucumber")
+          govuk.runRakeTask("test:javascript")
         }
       }
     }

--- a/features/support/deprecation_warning.rb
+++ b/features/support/deprecation_warning.rb
@@ -1,0 +1,23 @@
+# Chaining multiple scopes that use the same column is deprecated.
+# We are seeing the warning:
+##########
+# DEPRECATION WARNING: Merging (`editions`.`state` != 'deleted') and (`editions`.`state` IN (?, ?))
+# no longer maintain both conditions, and will be replaced by the latter in Rails 6.2.
+# To migrate to Rails 6.2's behavior, use `relation.merge(other, rewhere: true)
+#########
+# This is because we have a default scope on the Edition model:
+# `default_scope -> { where(arel_table[:state].not_eq("deleted")) }`
+# So for example, Edition.first.force_published equates to
+# Edition.where.not(state:"deleted").where(state: "published", force_published: true)
+# and as of Rails 6.2 only the second condition will be maintained.
+# Silencing temporarily because only using the second condition is fine and
+# adding the recommended code breaks everything.
+
+rewhere_warning = "no longer maintain both conditions, and will be replaced by "\
+"the latter in Rails 6.2. To migrate to Rails 6.2's behavior, "\
+"use `relation.merge(other, rewhere: true)`."
+ActiveSupport::Deprecation.behavior = lambda do |msg, _stack|
+  unless msg.include?(rewhere_warning)
+    ActiveSupport::Deprecation.behavior = :stderr
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,6 +11,9 @@ SimpleCov.merge_timeout 3600
 
 require "cucumber/rails"
 
+World DocumentHelper
+World PersonHelper
+
 # frozen_string_literal: true
 
 # Capybara defaults to CSS3 selectors rather than XPath.


### PR DESCRIPTION
These were accidentally removed in the switch to
[native parallelisation](https://github.com/alphagov/whitehall/pull/6244).
See https://github.com/alphagov/whitehall/pull/6244/commits/e34ad54761e74795b94a934b9b41f57b1720f3ad#diff-02ae33fe846ac6852102d8ed2adbed8c908b33c85b2413164001e52869f96d56L11

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

([Trello](https://trello.com/c/SOYSnGLg/2683-fix-whitehall-cucumber-tests-5))