### PR TITLE
Adds Take Part Pages patch link to Get Involved item

### DIFF
--- a/test/integration/take_part_page_test.rb
+++ b/test/integration/take_part_page_test.rb
@@ -70,4 +70,107 @@ class TakePartPageTest < ActiveSupport::TestCase
       )
     end
   end
+
+  test "TakePartPage patches links in the correct order in the Get Involved Page when created" do
+    Sidekiq::Testing.inline! do
+      # Working with a specific ID
+      get_involved_content_id = "dbe329f1-359c-43f7-8944-580d4742aa91"
+
+      # Build a couple Take Part pages with different ordering
+      @take_part_page.attributes = { title: "First Page", ordering: 1 }
+      @take_part_page.save!
+
+      third_take_part_page = build(:take_part_page)
+      third_take_part_page.attributes = { title: "Third Page", ordering: 3 }
+      third_take_part_page.save!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [@take_part_page.content_id, third_take_part_page.content_id],
+        } },
+      )
+
+      second_take_part_page = build(:take_part_page)
+      second_take_part_page.attributes = { title: "Second Page", ordering: 2 }
+      second_take_part_page.save!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [@take_part_page.content_id, second_take_part_page.content_id, third_take_part_page.content_id],
+        } },
+      )
+    end
+  end
+
+  test "TakePartPage patches links in the correct order in the Get Involved Page when modified" do
+    Sidekiq::Testing.inline! do
+      # Working with a specific ID
+      get_involved_content_id = "dbe329f1-359c-43f7-8944-580d4742aa91"
+
+      # Build a couple Take Part pages with different ordering
+      @take_part_page.attributes = { title: "First Page", ordering: 2 }
+      @take_part_page.save!
+
+      third_take_part_page = build(:take_part_page)
+      third_take_part_page.attributes = { title: "Third Page", ordering: 3 }
+      third_take_part_page.save!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [@take_part_page.content_id, third_take_part_page.content_id],
+        } },
+      )
+
+      # Easiest way to check a patch on edit is to change the ordering
+      @take_part_page.attributes = { title: "First Page", ordering: 4 }
+      @take_part_page.save!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [third_take_part_page.content_id, @take_part_page.content_id],
+        } },
+      )
+    end
+  end
+
+  test "TakePartPage patches links in the correct order in the Get Involved Page when deleted" do
+    Sidekiq::Testing.inline! do
+      Services.asset_manager.stubs(:whitehall_asset).returns("id" => "http://asset-manager/assets/asset-id")
+      # Working with a specific ID
+      get_involved_content_id = "dbe329f1-359c-43f7-8944-580d4742aa91"
+
+      # Build a couple Take Part pages with different ordering
+      @take_part_page.attributes = { title: "First Page", ordering: 1 }
+      @take_part_page.save!
+
+      second_take_part_page = build(:take_part_page)
+      second_take_part_page.attributes = { title: "Second Page", ordering: 2 }
+      second_take_part_page.save!
+
+      third_take_part_page = build(:take_part_page)
+      third_take_part_page.attributes = { title: "Third Page", ordering: 3 }
+      third_take_part_page.save!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [@take_part_page.content_id, second_take_part_page.content_id, third_take_part_page.content_id],
+        } },
+      )
+
+      # Destroy the middle item
+      second_take_part_page.destroy!
+
+      assert_publishing_api_patch_links(
+        get_involved_content_id,
+        { links: {
+          take_part_pages: [@take_part_page.content_id, third_take_part_page.content_id],
+        } },
+      )
+    end
+  end
 end


### PR DESCRIPTION
The migration away from Whitehall for the Get Involved page needed more
detail from the Take Part Pages than what was supplied via API calls.
This is the most effective way to bring that information across.

This branch relies on other changes to be in place:
Publishing-API change: https://github.com/alphagov/publishing-api/pull/1969
Schema change: https://github.com/alphagov/govuk-content-schemas/pull/1069

Trello: https://trello.com/c/z6H3HPNw/2716-add-take-part-pages-as-links-to-government-get-involveds-content-item

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
