### PR TITLE
Fix bug where organisation doesn't exist

### DIFF
--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -107,7 +107,7 @@ private
     if organisation.respond_to?(:acronym) && organisation.acronym.present?
       organisation.acronym
     else
-      organisation.name
+      organisation.try(:name).to_s
     end
   end
 end


### PR DESCRIPTION
Fixes bug seen in this card: https://govuk.zendesk.com/agent/tickets/4690055
Problem seen in logs in Kibana here: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/doc/*-*/filebeat-2021.09.01/log?id=AXuiMNrIxTPUjGK1gL_-&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
