### PR TITLE
Remove patch to RSS feed for Afghanistan topical event

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -84,7 +84,7 @@ private
     RummagerDocumentPresenter.new(
       afghan_feed.stringify_keys.merge(
         "display_type" => "Atom feed",
-        "description" => "Latest travel advice for Afghanistan",
+        "description" => "This RSS feed is for the Afghanistan Topical Event",
       ),
     )
   end

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -54,10 +54,7 @@ private
   def atom_documents
     return [closed_feed_document] if closed_feed
 
-    docs = find_documents(count: 10)["results"]
-    docs << afghanistan_travel_feed if @travel_advice.any?
-
-    docs
+    find_documents(count: 10)["results"]
   end
 
   def closed_feed
@@ -69,22 +66,6 @@ private
       closed_feed.stringify_keys.merge(
         "display_type" => "Replacement feed",
         "description" => "This #{closed_feed[:title]} RSS feed is being replaced with a new feed from Search - GOV.UK",
-      ),
-    )
-  end
-
-  def afghanistan_travel_feed
-    advice = @travel_advice.first
-    afghan_feed = {
-      public_timestamp: Time.zone.iso8601(advice["public_updated_at"]),
-      title: advice["title"],
-      link: "https://www.gov.uk/#{advice['base_path']}",
-    }
-
-    RummagerDocumentPresenter.new(
-      afghan_feed.stringify_keys.merge(
-        "display_type" => "Atom feed",
-        "description" => "This RSS feed is for the Afghanistan Topical Event",
       ),
     )
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -96,7 +96,7 @@
 
       <% if @travel_advice.any? %>
         <section id="travel-advice" class="document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Travel Advice</h1>
+          <h1 class="label">Travel advice</h1>
           <div class="content">
             <ol class="document-list">
               <% @travel_advice.each do |travel_advice| %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -96,7 +96,7 @@
 
       <% if @travel_advice.any? %>
         <section id="travel-advice" class="document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Travel advice</h1>
+          <h1 class="label">Travel Advice</h1>
           <div class="content">
             <ol class="document-list">
               <% @travel_advice.each do |travel_advice| %>


### PR DESCRIPTION
We're replacing this patch by tagging the travel advice page with the topical event so that it gets genuine updates.

Related: alphagov/govuk-content-schemas#1070

https://trello.com/c/SjNGmv0i/1204-tag-topical-event-for-uk-gov-response-to-situation-in-afghanistan

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
