### PR TITLE
Add Topical Event links to Detailed Guide editions

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -43,6 +43,8 @@ module PublishingApi
       ).merge(
         related_guides: item.related_detailed_guide_content_ids,
         related_mainstream_content: related_mainstream_content_ids,
+      ).merge(
+        PayloadBuilder::TopicalEvents.for(item),
       )
     end
 

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -33,6 +33,9 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     )
     EditionPolicy.create!(edition_id: detailed_guide.id, policy_content_id: "dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8")
 
+    topical_event = create(:topical_event)
+    detailed_guide.classification_memberships.create!(classification_id: topical_event.id)
+
     public_path = Whitehall.url_maker.public_document_path(detailed_guide)
     expected_content = {
       base_path: public_path,
@@ -73,6 +76,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         related_guides: [],
         related_mainstream_content: [],
         government: [government.content_id],
+        topical_events: [topical_event.content_id],
       },
     }
     expected_links = {


### PR DESCRIPTION
Topical Event links were not being added to Detailed Guides, which resulted in the event not appearing in the footer of the guide when rendered by `government-frontend`.

Adding this link will allow us to republish this document type and show the topical event links.

All detailed guides will need republishing after this is merged, which will take some time to run (there around around 15,000 published detailed guides).  The following rake task can be used:
```
rake publishing_api:bulk_republish:document_type[DetailedGuide]
```

[Trello card](https://trello.com/c/aESDvbzE)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
