### PR TITLE
Remove deleted  partial

### DIFF
--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -21,8 +21,6 @@
   </div>
 </header>
 
-<%= render partial: 'role_appointments_list', locals: { role: @role } %>
-
 <%= content_tag_for(:div, @historical_account, class: "block person-info") do %>
   <div class="name-title">
     <div class="inner">


### PR DESCRIPTION
The historical appointments `role_appointments_list` partial was deleted in https://github.com/alphagov/whitehall/pull/6264

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
