### PR TITLE
Restore removed partial

### DIFF
--- a/app/views/historic_appointments/_role_appointments_list.html.erb
+++ b/app/views/historic_appointments/_role_appointments_list.html.erb
@@ -1,0 +1,23 @@
+<div class="block historic-people-list">
+  <%# TODO: remove the govuk-!-padding-0 when re-implement this template with components/grid layout %>
+  <div class="inner-block govuk-!-padding-0">
+    <a href="#contents" class="js-showhide contents-toggle govuk-link">Show past <%= @role.name.pluralize %></a>
+    <div id="contents">
+      <h3>
+        <span><%= previous_appointments_with_unique_people.size %></span>
+        <%= link_to_unless_current "Past #{@role.name.pluralize}", historic_appointments_path(role.historic_param), class: "govuk-link" %>
+      </h3>
+      <ol>
+        <% previous_appointments_with_unique_people.each do |role_appointment| %>
+          <li>
+            <% if role_appointment.has_historical_account? %>
+              <%= link_to_unless_current role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person), class: "govuk-link" %>
+            <% else %>
+              <%= role_appointment.person.name %>
+            <% end %>
+          </li>
+        <% end %>
+      </ol>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
The historical appointments `role_appointments_list` partial was deleted in https://github.com/alphagov/whitehall/pull/6264
but is still used by https://github.com/alphagov/whitehall/blob/e058ef02acb7942511b202a15515b7ade82a673e/app/views/historic_appointments/show.html.erb#L24

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
