### PR TITLE
Warn that clicking save means publish on topical events

### DIFF
--- a/app/views/admin/classifications/index.html.erb
+++ b/app/views/admin/classifications/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title human_friendly_model_name.pluralize %>
 
 <h1><%= human_friendly_model_name.pluralize %></h1>
-<p class="warning remove-top-margin">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.</p>
+<p class="warning remove-top-margin">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
 <%= link_to "Create #{human_friendly_model_name.downcase}", [:new, :admin, model_name.to_sym], class: "btn btn-default new_resource", title: "Create a #{human_friendly_model_name.downcase}" %>
 
 <table class="<%= model_name %> table table-striped table-bordered add-top-margin">

--- a/app/views/admin/classifications/new.html.erb
+++ b/app/views/admin/classifications/new.html.erb
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="col-md-8">
     <h1>New <%= human_friendly_model_name.downcase %></h1>
-    <p class="warning">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.</p>
+    <p class="warning">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
     <%= render partial: "form", locals: {classification: @classification, show_consult_gds_warning: true} %>
   </div>
 </div>


### PR DESCRIPTION
A user was surprised that a topical event was immediately published when they clicked save.

This adds a quick fix in to warn users of the behaviour, while we investigate improving the publishing experience for this page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
