### PR TITLE
Bring Whitehall redirects into line with Publishing API

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -18,7 +18,7 @@ private
 
   def matches_allow_list?(value)
     uri = URI.parse(value)
-    uri.host&.end_with?(".judiciary.uk", "etl.beis.gov.uk", "justice.gov.uk", "ukri.org")
+    uri.host&.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org")
   rescue URI::InvalidURIError
     false
   end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -63,7 +63,10 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://justice.gov.uk/jelly-justice")
     assert unpublishing.valid?
 
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://ukri.org/raisin-research")
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.ukri.org/raisin-research")
+    assert unpublishing.valid?
+
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.nhs.uk/")
     assert unpublishing.valid?
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://some.random.site.uk/jelly-justice")


### PR DESCRIPTION
The hosts that Whitehall accepts previously differed from what the
Publishing API accepted [1], this meant that Whitehall couldn't provide
the same redirect capabilities as other apps. By bringing this
up-to-date Whitehall users can achieve the same redirects as the
Publishing API accepts. The motivation for this change is to allow
Whitehall to redirect to nhs.uk hostnames

This duplication of logic between Publishing API and other applications
is proving to be a real pain point. Earlier this week the Coronavirus
product team had to make a similar change to Short URL Manager to also
allow NHS redirects [2].

I'm not too sure right now what the best path forward for the future
would be, it certainly seems desirable to have a mechanism that the
rules of these URLs can be changed without trying to keep multiple
applications in sync. Perhaps it's something content schemas can help
with? hmm...

[1]: https://github.com/alphagov/publishing-api/blob/b4f2125da502ea1a8ff9d40e75cc4272e09fd6d7/app/validators/routes_and_redirects_validator.rb#L169
[2]: https://github.com/alphagov/short-url-manager/pull/631

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
