### PR TITLE
Revert deletion of historic appointment styles

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -128,6 +128,7 @@ $govuk-new-link-styles: true;
   @import "views/get-involved";
   @import "views/groups";
   @import "views/history-people";
+  @import "views/historic-appointments";
   @import "views/how-gov-works";
   @import "views/layouts";
   @import "views/ministerial-roles";

--- a/app/assets/stylesheets/frontend/views/_historic-appointments.scss
+++ b/app/assets/stylesheets/frontend/views/_historic-appointments.scss
@@ -1,0 +1,98 @@
+.historic-appointments:not(.historical-past-chancellors) .featured-profiles .year-block {
+  @include govuk-media-query($until: tablet) {
+    h2.profiles {
+      margin: 0 0 govuk-spacing(1) 0;
+    }
+
+    .inner {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}
+
+.historic-appointments {
+  .historic-people-list {
+    @include media(tablet) {
+      float: left;
+      width: $one-quarter;
+    }
+
+    h3 {
+      @include govuk-font(19);
+      margin: govuk-spacing(6) 0;
+
+      span {
+        @include core-80;
+        font-weight: bold;
+        display: block;
+      }
+    }
+  }
+}
+
+.historic-appointments-index {
+  .featured-profiles {
+    @include media(tablet) {
+      width: 75%;
+      float: left;
+    }
+
+    .year-block {
+      @include media(tablet) {
+        width: $one-third;
+        float: left;
+      }
+
+      h2 {
+        @include core-19;
+        font-weight: bold;
+        border-bottom: $gutter-one-sixth solid;
+        margin: 0 $gutter-half $gutter-one-sixth;
+      }
+
+      .person-excerpt {
+        width: $full-width;
+        float: none;
+        @include media(tablet) {
+          min-height: 280px;
+        }
+
+        h3 {
+          @include core-19;
+          font-weight: bold;
+        }
+
+        p {
+          color: $secondary-text-colour;
+        }
+
+        img {
+          width: $full-width;
+        }
+
+        .govuk-link {
+          line-height: 1.16;
+        }
+      }
+    }
+  }
+}
+
+.historical-past-chancellors {
+  .featured-profiles {
+    @include media(tablet) {
+      width: $full-width;
+    }
+
+    .year-block {
+      @include media(tablet) {
+        width: $one-quarter;
+      }
+
+      .person-excerpt {
+        min-height: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/frontend/views/_history-people.scss
+++ b/app/assets/stylesheets/frontend/views/_history-people.scss
@@ -18,3 +18,90 @@
     @include govuk-responsive-margin(7, "bottom");
   }
 }
+
+.historic-people-show {
+  .person-info {
+    @include media(tablet) {
+      float: left;
+      width: $one-quarter;
+    }
+    .name-title,
+    .person-detail,
+    .person-profile {
+      .inner {
+        padding: 0 $gutter-half;
+      }
+      .person-profile {
+        @include core-14;
+        width: 218px;
+  
+        img {
+          max-width: $full-width;
+        }
+  
+        .info {
+          background-color: $grey-3;
+          padding-bottom: $gutter-half;
+          margin-bottom: $gutter;
+  
+          h3,
+          p {
+            padding: 0 $gutter-half;
+          }
+  
+          h3 {
+            font-weight: bold;
+            margin-top: $gutter-half;
+          }
+        }
+      }
+  
+      .name-title {
+        h2 {
+          @include heading-27;
+          font-weight: bold;
+          margin-bottom: $gutter;
+  
+          span {
+            @include core-19;
+            display: block;
+            color: $grey-1;
+            margin-top: $gutter-one-sixth;
+          }
+        }
+      }
+  
+      @include media(tablet) {
+        position: relative;
+        width: 75%;
+  
+        .person-profile {
+          float: left;
+          width: $one-third;
+  
+          img {
+            width: $full-width;
+          }
+  
+          .inner {
+            padding: 0 $gutter-half;
+          }
+        }
+  
+        .name-title,
+        .person-detail {
+          float: right;
+          width: $two-thirds;
+  
+          .inner {
+            padding: 0 $gutter 0 $gutter-half;
+          }
+        }
+      }
+
+      .past-foreign-secretaries-menu li {
+        border-bottom: 1px solid $govuk-border-colour;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What/Why
re-adds historic appointments scss, partially reverting https://github.com/alphagov/whitehall/pull/6264/files, in order to fix a broken [David Cameron page](https://www.gov.uk/government/history/past-prime-ministers/david-cameron).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
