### PR TITLE
Fix incorrect parameter names on image card components

### DIFF
--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -1,22 +1,22 @@
 <% political_membership = role_appointment.historical_account.try(:political_membership) %>
   <%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
     <%# Content for "theresa-may' does not exist at present, temporary check to remove link %>
-    <% if historic_appointment_path(role.historic_param, role_appointment.person) != "/government/history/past-prime-ministers/theresa-may" %> 
+    <% if historic_appointment_path(role.historic_param, role_appointment.person) != "/government/history/past-prime-ministers/theresa-may" %>
       <%= render "govuk_publishing_components/components/image_card", {
         href: historic_appointment_path(role.historic_param, role_appointment.person),
         image_src: role_appointment.person.image_url(:s216),
         image_loading: "lazy",
         heading_text: role_appointment.person.name,
-        extra_links: previous_dates_in_office_prime(role, role_appointment.person, political_membership),
-        extra_links_no_indent: true
+        extra_details: previous_dates_in_office_prime(role, role_appointment.person, political_membership),
+        extra_details_no_indent: true
       } %>
     <% else %>
       <%= render "govuk_publishing_components/components/image_card", {
         image_src: role_appointment.person.image_url(:s216),
         image_loading: "lazy",
         heading_text: role_appointment.person.name,
-        extra_links: previous_dates_in_office_prime(role, role_appointment.person, political_membership),
-        extra_links_no_indent: true
+        extra_details: previous_dates_in_office_prime(role, role_appointment.person, political_membership),
+        extra_details_no_indent: true
       } %>
     <% end %>
 <% end %>

--- a/app/views/past_foreign_secretaries/_past_foreign_secretaries_image.html.erb
+++ b/app/views/past_foreign_secretaries/_past_foreign_secretaries_image.html.erb
@@ -1,7 +1,7 @@
 <div class="historic-people-index__section-row-header" role="list">
   <%= past_foreign_secretaries_image.each_slice(4) do |row| %>
   <div class="govuk-grid-row">
-    <% row.each do | name, info| %>    
+    <% row.each do | name, info| %>
       <div role="listitem" class="govuk-grid-column-one-quarter">
         <%= render "govuk_publishing_components/components/image_card", {
           href: info[:href],
@@ -9,11 +9,11 @@
           image_loading: "lazy",
           heading_text: info[:heading_text],
           heading_level: 3,
-          extra_links: service_date(info[:service]), 
-          extra_links_no_indent: true
+          extra_details: service_date(info[:service]),
+          extra_details_no_indent: true
         } %>
       </div>
     <%end%>
-  </div> 
-  <% end %> 
+  </div>
+  <% end %>
 <div>


### PR DESCRIPTION
This change fixes two issues:
- A Prime Minister went missing from the historic Prime Ministers page
- Details were missing from the past foreign secretaries page

Around a week ago we modernised the views on these pages to use [image card](https://components.publishing.service.gov.uk/component-guide/image_card), After which govuk publishing components release v27, which changes the parameters that are required here.

The combination of the missing parameters and a lack of href on one PM caused them to go missing.

By updating the parameter names to those required by v27 of the publishing componenets we see the past PM return, and past foreign secretaries get their details back