### PR TITLE
Update foreign secretaries

### DIFF
--- a/app/controllers/past_foreign_secretaries_controller.rb
+++ b/app/controllers/past_foreign_secretaries_controller.rb
@@ -4,8 +4,7 @@ class PastForeignSecretariesController < PublicFacingController
   def index
     @twenty_first_century = {
       "Dominic Raab" => {
-        link: "/government/people/dominic-raab/",
-        service: "2019 to present",
+        service: "2019 to 2021",
       },
       "Jeremy Hunt" => {
         service: "2018 to 2019",

--- a/app/controllers/past_foreign_secretaries_controller.rb
+++ b/app/controllers/past_foreign_secretaries_controller.rb
@@ -11,7 +11,7 @@ class PastForeignSecretariesController < PublicFacingController
         service: "2018 to 2019",
       },
       "Boris Johnson" => {
-        service: "2019",
+        service: "2016 to 2018",
       },
       "Philip Hammond" => {
         service: "2014 to 2016",


### PR DESCRIPTION
Following the Sept 2021 reshuffle, we have an end date for the first
entry on the page.

It was also decided that, for consisentency, this page, past chancellors
and past prime ministers should only deal with past holders of the
position.

In this case a foreign secretary was listed as incumbant and with a link
to their biography.

We have decided current holders of the post should only be represented
on pages about current government.

Also fix an inaccuracy with a past foreign secretary who had not had their
end date correcly applied.