### PR TITLE
Add hardcoded logic to hide MHCLG

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -81,32 +81,34 @@
     </div>
     <% @ministers_by_organisation.each do |organisation, ministers| %>
       <%= content_tag_for :section, organisation do %>
-        <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: sanitize(format_with_html_line_breaks(organisation.logo_formatted_name)),
-              url: organisation_path(organisation),
-              brand: organisation[:slug],
-              crest: organisation.organisation_crest,
-            },
-            heading_level: 3,
-          } %>
-        </div>
-        <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
-          <ul class="minister-list govuk-list govuk-grid-row">
-            <% ministers.with_unique_people.each.with_index do |role, i| %>
-              <%= render partial: "people/person",
-                  locals: {
-                    extra_class: (i % 3 == 0) ? 'govuk-grid-column-one-third clear-column' : 'govuk-grid-column-one-third',
-                    hide_image: true,
-                    hlevel: "h4",
-                    person: PersonPresenter.new(role.current_person, self),
-                    prefix: "by-organisation-#{organisation.slug}",
-                    roles: ministers.roles_for(role.current_person),
-                  } %>
-            <% end %>
-          </ul>
-        </div>
+        <% unless organisation.slug == "ministry-of-housing-communities-and-local-government" %>
+          <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
+            <%= render "govuk_publishing_components/components/organisation_logo", {
+              organisation: {
+                name: sanitize(format_with_html_line_breaks(organisation.logo_formatted_name)),
+                url: organisation_path(organisation),
+                brand: organisation[:slug],
+                crest: organisation.organisation_crest,
+              },
+              heading_level: 3,
+            } %>
+          </div>
+          <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
+            <ul class="minister-list govuk-list govuk-grid-row">
+              <% ministers.with_unique_people.each.with_index do |role, i| %>
+                <%= render partial: "people/person",
+                    locals: {
+                      extra_class: (i % 3 == 0) ? 'govuk-grid-column-one-third clear-column' : 'govuk-grid-column-one-third',
+                      hide_image: true,
+                      hlevel: "h4",
+                      person: PersonPresenter.new(role.current_person, self),
+                      prefix: "by-organisation-#{organisation.slug}",
+                      roles: ministers.roles_for(role.current_person),
+                    } %>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
 </section>


### PR DESCRIPTION
The Ministry of Housing, Communities and Local Government is transforming into the Department for Levelling Up, Housing and Communities. But while they are migrating, we need to temporarily hide it from the /government/ministers page.

Paired with @hannako

https://trello.com/c/m19avrBm/1218-tbc-help-with-mhclg-machinery-of-government-change

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
