### PR TITLE
Update database schema for Rails 6.1

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2021_08_09_141023) do
 
-  create_table "about_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "about_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"
     t.text "summary"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.string "content_id"
   end
 
-  create_table "access_and_opening_times", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "access_and_opening_times", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
     t.integer "accessible_id"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["accessible_id", "accessible_type"], name: "accessible_index"
   end
 
-  create_table "attachment_data", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "attachment_data", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "carrierwave_file"
     t.string "content_type"
     t.integer "file_size"
@@ -45,13 +45,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id"
   end
 
-  create_table "attachment_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "attachment_sources", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "attachment_id"
     t.string "url"
     t.index ["attachment_id"], name: "index_attachment_sources_on_attachment_id"
   end
 
-  create_table "attachments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "attachments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "title"
@@ -80,13 +80,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["ordering"], name: "index_attachments_on_ordering"
   end
 
-  create_table "classification_featuring_image_data", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "classification_featuring_image_data", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "classification_featurings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "classification_featurings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "classification_id"
     t.datetime "created_at"
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["offsite_link_id"], name: "index_classification_featurings_on_offsite_link_id"
   end
 
-  create_table "classification_memberships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "classification_memberships", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "classification_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_classification_memberships_on_edition_id"
   end
 
-  create_table "classification_policies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "classification_policies", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "classification_id"
     t.string "policy_content_id"
     t.datetime "created_at"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["policy_content_id"], name: "index_classification_policies_on_policy_content_id"
   end
 
-  create_table "classification_relations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "classification_relations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "classification_id", null: false
     t.integer "related_classification_id", null: false
     t.datetime "created_at"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["related_classification_id"], name: "index_classification_relations_on_related_classification_id"
   end
 
-  create_table "classifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "classifications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_classifications_on_slug"
   end
 
-  create_table "consultation_participations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "consultation_participations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.string "link_url"
     t.datetime "created_at"
@@ -157,20 +157,20 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_consultation_participations_on_edition_id"
   end
 
-  create_table "consultation_response_form_data", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "consultation_response_form_data", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "carrierwave_file"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "consultation_response_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "consultation_response_forms", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "consultation_response_form_data_id"
   end
 
-  create_table "contact_number_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_number_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "contact_number_id"
     t.string "locale"
     t.datetime "created_at", null: false
@@ -181,7 +181,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["locale"], name: "index_contact_number_translations_on_locale"
   end
 
-  create_table "contact_numbers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_numbers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "label"
     t.string "number"
@@ -190,7 +190,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["contact_id"], name: "index_contact_numbers_on_contact_id"
   end
 
-  create_table "contact_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "locale"
     t.datetime "created_at", null: false
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["locale"], name: "index_contact_translations_on_locale"
   end
 
-  create_table "contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contacts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.decimal "latitude", precision: 15, scale: 10
     t.decimal "longitude", precision: 15, scale: 10
     t.integer "contactable_id"
@@ -220,18 +220,18 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["contactable_id", "contactable_type"], name: "index_contacts_on_contactable_id_and_contactable_type"
   end
 
-  create_table "data_migration_records", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "data_migration_records", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "version"
     t.index ["version"], name: "index_data_migration_records_on_version", unique: true
   end
 
-  create_table "default_news_organisation_image_data", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "default_news_organisation_image_data", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "document_collection_group_memberships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_group_memberships", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "document_collection_group_id"
     t.integer "ordering"
@@ -243,7 +243,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
-  create_table "document_collection_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "document_collection_id"
     t.string "heading"
     t.text "body"
@@ -253,7 +253,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
   end
 
-  create_table "document_collection_non_whitehall_links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "document_collection_non_whitehall_links", charset: "utf8", force: :cascade do |t|
     t.string "content_id", null: false
     t.string "title", null: false
     t.text "base_path", null: false
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "document_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "document_sources", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "document_id"
     t.string "url", null: false
     t.integer "import_id"
@@ -272,7 +272,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["url"], name: "index_document_sources_on_url", unique: true
   end
 
-  create_table "documents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "documents", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug"
@@ -283,7 +283,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug", "document_type"], name: "index_documents_on_slug_and_document_type", unique: true
   end
 
-  create_table "edition_authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "edition_authors", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "user_id"
     t.datetime "created_at"
@@ -292,14 +292,14 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["user_id"], name: "index_edition_authors_on_user_id"
   end
 
-  create_table "edition_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "edition_dependencies", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
   end
 
-  create_table "edition_organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "edition_organisations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "organisation_id"
     t.datetime "created_at"
@@ -310,7 +310,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["organisation_id"], name: "index_edition_organisations_on_organisation_id"
   end
 
-  create_table "edition_policies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "edition_policies", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.string "policy_content_id"
     t.datetime "created_at"
@@ -319,7 +319,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["policy_content_id"], name: "index_edition_policies_on_policy_content_id"
   end
 
-  create_table "edition_relations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "edition_relations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -328,21 +328,21 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_edition_relations_on_edition_id"
   end
 
-  create_table "edition_role_appointments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "edition_role_appointments", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "role_appointment_id"
     t.index ["edition_id"], name: "index_edition_role_appointments_on_edition_id"
     t.index ["role_appointment_id"], name: "index_edition_role_appointments_on_role_appointment_id"
   end
 
-  create_table "edition_statistical_data_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "edition_statistical_data_sets", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "document_id"
     t.index ["document_id"], name: "index_edition_statistical_data_sets_on_document_id"
     t.index ["edition_id"], name: "index_edition_statistical_data_sets_on_edition_id"
   end
 
-  create_table "edition_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "edition_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "locale"
     t.string "title"
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["locale"], name: "index_edition_translations_on_locale"
   end
 
-  create_table "edition_world_locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "edition_world_locations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "world_location_id"
     t.datetime "created_at"
@@ -364,7 +364,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["world_location_id"], name: "index_edition_world_locations_on_world_location_id"
   end
 
-  create_table "edition_worldwide_organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "edition_worldwide_organisations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "worldwide_organisation_id"
     t.datetime "created_at"
@@ -373,7 +373,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_edition_worldwide_orgs_on_worldwide_organisation_id"
   end
 
-  create_table "editions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "editions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "lock_version", default: 0
@@ -434,7 +434,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["type"], name: "index_editions_on_type"
   end
 
-  create_table "editorial_remarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "editorial_remarks", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.integer "edition_id"
     t.integer "author_id"
@@ -444,7 +444,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_editorial_remarks_on_edition_id"
   end
 
-  create_table "fact_check_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "fact_check_requests", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "key"
     t.datetime "created_at"
@@ -458,17 +458,17 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["requestor_id"], name: "index_fact_check_requests_on_requestor_id"
   end
 
-  create_table "fatality_notice_casualties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "fatality_notice_casualties", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "fatality_notice_id"
     t.text "personal_details"
   end
 
-  create_table "feature_flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "feature_flags", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "key"
     t.boolean "enabled", default: false
   end
 
-  create_table "feature_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "feature_lists", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "featurable_id"
     t.string "featurable_type"
     t.string "locale"
@@ -477,7 +477,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["featurable_id", "featurable_type", "locale"], name: "featurable_lists_unique_locale_per_featurable", unique: true
   end
 
-  create_table "featured_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "featured_links", id: :integer, charset: "utf8", force: :cascade do |t|
     t.text "url"
     t.string "title"
     t.integer "linkable_id"
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "features", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "feature_list_id"
     t.string "carrierwave_image"
@@ -503,7 +503,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["ordering"], name: "index_features_on_ordering"
   end
 
-  create_table "financial_reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "financial_reports", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.bigint "funding"
     t.bigint "spending"
@@ -513,7 +513,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["year"], name: "index_financial_reports_on_year"
   end
 
-  create_table "force_publication_attempts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "force_publication_attempts", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "import_id"
     t.integer "total_documents"
     t.integer "successful_documents"
@@ -526,7 +526,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["import_id"], name: "index_force_publication_attempts_on_import_id"
   end
 
-  create_table "governments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "governments", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "slug"
     t.string "name"
     t.date "start_date"
@@ -541,7 +541,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["start_date"], name: "index_governments_on_start_date"
   end
 
-  create_table "govspeak_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "govspeak_contents", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "html_attachment_id"
     t.text "body", size: :medium
     t.boolean "manually_numbered_headings"
@@ -552,7 +552,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["html_attachment_id"], name: "index_govspeak_contents_on_html_attachment_id"
   end
 
-  create_table "group_memberships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "group_memberships", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "group_id"
     t.integer "person_id"
     t.datetime "created_at"
@@ -561,7 +561,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["person_id"], name: "index_group_memberships_on_person_id"
   end
 
-  create_table "groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "groups", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "name"
     t.datetime "created_at"
@@ -572,7 +572,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_groups_on_slug"
   end
 
-  create_table "historical_account_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "historical_account_roles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "historical_account_id"
     t.datetime "created_at"
@@ -581,7 +581,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["role_id"], name: "index_historical_account_roles_on_role_id"
   end
 
-  create_table "historical_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "historical_accounts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.text "summary"
     t.text "body"
@@ -595,7 +595,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["person_id"], name: "index_historical_accounts_on_person_id"
   end
 
-  create_table "home_page_list_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "home_page_list_items", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "home_page_list_id", null: false
     t.integer "item_id", null: false
     t.string "item_type", null: false
@@ -607,7 +607,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["item_id", "item_type"], name: "index_home_page_list_items_on_item_id_and_item_type"
   end
 
-  create_table "home_page_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "home_page_lists", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "owner_id", null: false
     t.string "owner_type", null: false
     t.string "name"
@@ -616,13 +616,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["owner_id", "owner_type", "name"], name: "index_home_page_lists_on_owner_id_and_owner_type_and_name", unique: true
   end
 
-  create_table "image_data", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "image_data", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "images", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "image_data_id"
     t.integer "edition_id"
     t.string "alt_text"
@@ -633,7 +633,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["image_data_id"], name: "index_images_on_image_data_id"
   end
 
-  create_table "link_checker_api_report_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "link_checker_api_report_links", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "link_checker_api_report_id"
     t.text "uri", null: false
     t.string "status", null: false
@@ -648,7 +648,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id"
   end
 
-  create_table "link_checker_api_reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "link_checker_api_reports", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "batch_id"
     t.string "status", null: false
     t.string "link_reportable_type"
@@ -660,7 +660,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["link_reportable_type", "link_reportable_id"], name: "index_link_checker_api_reportable"
   end
 
-  create_table "nation_inapplicabilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "nation_inapplicabilities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "nation_id"
     t.integer "edition_id"
     t.datetime "created_at"
@@ -670,7 +670,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["nation_id"], name: "index_nation_inapplicabilities_on_nation_id"
   end
 
-  create_table "offsite_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "offsite_links", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "title"
     t.string "summary"
     t.string "url"
@@ -682,7 +682,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "operational_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "operational_fields", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -692,7 +692,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_operational_fields_on_slug"
   end
 
-  create_table "organisation_classifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "organisation_classifications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id", null: false
     t.integer "classification_id", null: false
     t.datetime "created_at"
@@ -705,7 +705,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["organisation_id"], name: "index_org_classifications_on_organisation_id"
   end
 
-  create_table "organisation_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "organisation_roles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.integer "role_id"
     t.datetime "created_at"
@@ -715,13 +715,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["role_id"], name: "index_organisation_roles_on_role_id"
   end
 
-  create_table "organisation_supersedings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "organisation_supersedings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "superseded_organisation_id"
     t.integer "superseding_organisation_id"
     t.index ["superseded_organisation_id"], name: "index_organisation_supersedings_on_superseded_organisation_id"
   end
 
-  create_table "organisation_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "organisation_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "locale"
     t.string "name"
@@ -734,7 +734,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["organisation_id"], name: "index_organisation_translations_on_organisation_id"
   end
 
-  create_table "organisational_relationships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "organisational_relationships", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "parent_organisation_id"
     t.integer "child_organisation_id"
     t.datetime "created_at"
@@ -743,7 +743,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["parent_organisation_id"], name: "index_organisational_relationships_on_parent_organisation_id"
   end
 
-  create_table "organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "organisations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug", null: false
@@ -779,7 +779,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "people", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "forename"
     t.string "surname"
@@ -793,7 +793,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 
-  create_table "person_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "person_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.string "locale"
     t.text "biography"
@@ -803,7 +803,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["person_id"], name: "index_person_translations_on_person_id"
   end
 
-  create_table "policy_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "policy_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -815,7 +815,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_policy_groups_on_slug"
   end
 
-  create_table "promotional_feature_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_items", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_id"
     t.text "summary"
     t.string "image"
@@ -828,7 +828,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["promotional_feature_id"], name: "index_promotional_feature_items_on_promotional_feature_id"
   end
 
-  create_table "promotional_feature_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_links", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_item_id"
     t.string "url"
     t.string "text"
@@ -837,7 +837,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["promotional_feature_item_id"], name: "index_promotional_feature_links_on_promotional_feature_item_id"
   end
 
-  create_table "promotional_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "promotional_features", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "title"
     t.datetime "created_at"
@@ -845,14 +845,14 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["organisation_id"], name: "index_promotional_features_on_organisation_id"
   end
 
-  create_table "recent_edition_openings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "recent_edition_openings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.integer "editor_id", null: false
     t.datetime "created_at", null: false
     t.index ["edition_id", "editor_id"], name: "index_recent_edition_openings_on_edition_id_and_editor_id", unique: true
   end
 
-  create_table "related_mainstreams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "related_mainstreams", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.string "content_id"
     t.boolean "additional", default: false
@@ -861,7 +861,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
   end
 
-  create_table "responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "responses", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "edition_id"
     t.text "summary"
     t.datetime "created_at"
@@ -872,7 +872,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id"], name: "index_responses_on_edition_id"
   end
 
-  create_table "role_appointments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "role_appointments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "person_id"
     t.datetime "created_at"
@@ -885,7 +885,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["role_id"], name: "index_role_appointments_on_role_id"
   end
 
-  create_table "role_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "role_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.string "locale"
     t.string "name"
@@ -897,7 +897,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["role_id"], name: "index_role_translations_on_role_id"
   end
 
-  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "roles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "type", null: false
@@ -917,7 +917,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["supports_historical_accounts"], name: "index_roles_on_supports_historical_accounts"
   end
 
-  create_table "sitewide_settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "sitewide_settings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "key"
     t.text "description"
     t.boolean "on"
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "social_media_account_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "social_media_account_translations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "url"
     t.text "title"
     t.string "locale", null: false
@@ -937,7 +937,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["social_media_account_id"], name: "index_on_social_media_account"
   end
 
-  create_table "social_media_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "social_media_accounts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "socialable_id"
     t.integer "social_media_service_id"
     t.datetime "created_at"
@@ -947,13 +947,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["socialable_id"], name: "index_social_media_accounts_on_organisation_id"
   end
 
-  create_table "social_media_services", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "social_media_services", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "specialist_sectors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "specialist_sectors", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.string "tag"
     t.datetime "created_at", null: false
@@ -963,7 +963,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["edition_id", "tag"], name: "index_specialist_sectors_on_edition_id_and_tag", unique: true
   end
 
-  create_table "sponsorships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "sponsorships", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "organisation_id"
     t.integer "worldwide_organisation_id"
     t.datetime "created_at"
@@ -972,7 +972,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_sponsorships_on_worldwide_organisation_id"
   end
 
-  create_table "statistics_announcement_dates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "statistics_announcement_dates", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.datetime "release_date"
     t.integer "precision"
@@ -985,7 +985,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["statistics_announcement_id", "created_at"], name: "statistics_announcement_release_date"
   end
 
-  create_table "statistics_announcement_organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "statistics_announcement_organisations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "organisation_id"
     t.datetime "created_at", null: false
@@ -994,7 +994,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["statistics_announcement_id", "organisation_id"], name: "index_on_statistics_announcement_id_and_organisation_id"
   end
 
-  create_table "statistics_announcement_topics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "statistics_announcement_topics", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "topic_id"
     t.datetime "created_at", null: false
@@ -1003,7 +1003,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["topic_id"], name: "index_statistics_announcement_topics_on_topic_id"
   end
 
-  create_table "statistics_announcements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "statistics_announcements", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "title"
     t.string "slug"
     t.text "summary"
@@ -1027,7 +1027,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["topic_id"], name: "index_statistics_announcements_on_topic_id"
   end
 
-  create_table "take_part_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "take_part_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.string "slug", null: false
     t.string "summary", null: false
@@ -1042,7 +1042,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_take_part_pages_on_slug", unique: true
   end
 
-  create_table "unpublishings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unpublishings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "unpublishing_reason_id"
     t.text "explanation"
@@ -1057,13 +1057,13 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["unpublishing_reason_id"], name: "index_unpublishings_on_unpublishing_reason_id"
   end
 
-  create_table "user_world_locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_world_locations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "world_location_id"
     t.index ["user_id", "world_location_id"], name: "index_user_world_locations_on_user_id_and_world_location_id", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1078,7 +1078,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["organisation_slug"], name: "index_users_on_organisation_slug"
   end
 
-  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -1089,7 +1089,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "world_location_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "world_location_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "world_location_id"
     t.string "locale"
     t.string "name"
@@ -1101,7 +1101,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["world_location_id"], name: "index_world_location_translations_on_world_location_id"
   end
 
-  create_table "world_locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "world_locations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug"
@@ -1116,14 +1116,14 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["world_location_type_id"], name: "index_world_locations_on_world_location_type_id"
   end
 
-  create_table "worldwide_office_worldwide_services", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "worldwide_office_worldwide_services", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "worldwide_office_id", null: false
     t.integer "worldwide_service_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "worldwide_offices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_offices", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "worldwide_organisation_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1133,7 +1133,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_worldwide_offices_on_worldwide_organisation_id"
   end
 
-  create_table "worldwide_organisation_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_organisation_roles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "worldwide_organisation_id"
     t.integer "role_id"
     t.datetime "created_at"
@@ -1142,7 +1142,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_worldwide_org_roles_on_worldwide_organisation_id"
   end
 
-  create_table "worldwide_organisation_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_organisation_translations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "worldwide_organisation_id"
     t.string "locale"
     t.string "name"
@@ -1153,7 +1153,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_worldwide_org_translations_on_worldwide_organisation_id"
   end
 
-  create_table "worldwide_organisation_world_locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "worldwide_organisation_world_locations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "worldwide_organisation_id"
     t.integer "world_location_id"
     t.datetime "created_at"
@@ -1162,7 +1162,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["worldwide_organisation_id"], name: "index_worldwide_org_world_locations_on_worldwide_organisation_id"
   end
 
-  create_table "worldwide_organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "worldwide_organisations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "url"
     t.string "slug"
     t.string "logo_formatted_name"
@@ -1176,7 +1176,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_141023) do
     t.index ["slug"], name: "index_worldwide_organisations_on_slug", unique: true
   end
 
-  create_table "worldwide_services", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "worldwide_services", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "service_type_id", null: false
     t.datetime "created_at"


### PR DESCRIPTION
Since ActiveRecord 6.1.0, the Default engine `ENGINE=InnoDB` [is no longer dumped to make schema more agnostic](https://github.com/rails/rails/commit/3c6be5e502e203be17373f30336d59a7511ef31b).

Running `rails db:migrate` with no new migrations to update the schema file.

Not doing this now will result in this diff appearing the next time a migration is added (therefore adding this code into an unrelated PR).

[Trello card](https://trello.com/c/XOB88Gcp)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️