### PR TITLE
Update data migration

### DIFF
--- a/db/data_migration/20211011140013_reslug_publication.rb
+++ b/db/data_migration/20211011140013_reslug_publication.rb
@@ -5,7 +5,7 @@ new_slug = "accessing-government-secured-flu-vaccines-guidance-for-primary-care-
 
 document = Document.find_by(slug: slug)
 edition = document.editions.published.last
-html_attachment = edition.attachments.find_by(slug: slug)
+html_attachment = edition.attachments.last
 
 html_attachment.update!(slug: new_slug)
 Whitehall::PublishingApi.republish_async(html_attachment)


### PR DESCRIPTION
The data migration previously failed as the HTML attachment couldn't be
found by the slug. This edition only has one attachment so just calling
`.last` is sufficient.

```
Error:
E, [2021-10-11T15:52:31.671483 #4438] ERROR -- : Migration failed due to undefined method `update!' for nil:NilClass
16:52:31 E, [2021-10-11T15:52:31.671577 #4438] ERROR -- :   /data/vhost/whitehall-admin/releases/20211011150810/db/data_migration/20211011140013_reslug_publication.rb:10:in `block in run'
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
