### PR TITLE
Unpublish withdrawn docs with redirect

### DIFF
--- a/db/data_migration/20211012111236_unpublish_withdrawn_documents.rb
+++ b/db/data_migration/20211012111236_unpublish_withdrawn_documents.rb
@@ -1,0 +1,129 @@
+redirect_data = [
+  {
+    redirect: "https://www.england.nhs.uk/estates/health-technical-memoranda/",
+    withdrawn_urls: [
+      "https://www.gov.uk/government/publications/guidance-policies-and-principles-of-healthcare-engineering",
+      "https://www.gov.uk/government/publications/medical-gas-pipeline-systems-part-a-design-installation-validation-and-verification",
+      "https://www.gov.uk/government/publications/hot-and-cold-water-supply-storage-and-distribution-systems-for-healthcare-premises",
+      "https://www.gov.uk/government/publications/managing-healthcare-fire-safety",
+      "https://www.gov.uk/government/publications/guidance-in-support-of-functional-provisions-for-healthcare-premises",
+      "https://www.gov.uk/government/publications/guidance-on-electrical-services-supply-and-distribution-within-healthcare-premises",
+      "https://www.gov.uk/government/publications/electrical-safety-guidance-for-low-voltage-systems-in-healthcare-premises",
+      "https://www.gov.uk/government/publications/electrical-safety-guidance-for-high-voltage-systems-in-healthcare-premises",
+      "https://www.gov.uk/government/publications/guidance-on-the-safe-management-of-healthcare-waste",
+      "https://www.gov.uk/government/publications/making-energy-work-in-healthcare-htm-07-02",
+      "https://www.gov.uk/government/publications/nhs-car-parking-management-htm-07-03",
+      "https://www.gov.uk/government/publications/water-management-and-water-efficiency-best-practice-advice-for-the-healthcare-sector",
+      "https://www.gov.uk/government/publications/sustainable-health-and-social-care-buildings-planning-design-construction-and-refurbishment",
+      "https://www.gov.uk/government/publications/guidance-on-acoustic-requirements-in-the-design-of-healthcare-facilities",
+      "https://www.gov.uk/government/publications/guidance-concerning-the-planning-installation-and-operation-of-lifts-in-healthcare-buildings",
+      "https://www.gov.uk/government/publications/health-technical-memorandum-for-bedhead-services",
+      "https://www.gov.uk/government/publications/guidance-on-design-and-specifications-of-cubicle-curtain-track-in-health-buildings",
+      "https://www.gov.uk/government/publications/guidance-for-fitting-out-laboratories",
+      "https://www.gov.uk/government/publications/management-and-decontamination-of-surgical-instruments-used-in-acute-care",
+      "https://www.gov.uk/government/publications/decontamination-of-linen-for-health-and-social-care",
+      "https://www.gov.uk/government/publications/decontamination-in-primary-care-dental-practices",
+      "https://www.gov.uk/government/publications/management-and-decontamination-of-flexible-endoscopes",
+    ],
+  },
+  {
+    redirect: "https://www.england.nhs.uk/estates/health-building-notes/",
+    withdrawn_urls: [
+      "https://www.gov.uk/government/collections/health-building-notes-core-elements",
+      "https://www.gov.uk/government/publications/general-design-principles-for-health-and-community-care-buildings",
+      "https://www.gov.uk/government/publications/guidance-on-the-design-and-layout-of-sanitary-spaces",
+      "https://www.gov.uk/government/publications/design-and-layout-of-generic-clinical-and-clinical-support-spaces",
+      "https://www.gov.uk/government/publications/guidance-on-the-design-of-circulation-and-communication-spaces-in-healthcare-buildings",
+      "https://www.gov.uk/government/publications/resilience-planning-for-nhs-facilities",
+      "https://www.gov.uk/government/publications/the-efficient-management-of-healthcare-estates-and-facilities-health-building-note-00-08",
+      "https://www.gov.uk/government/publications/guidance-for-infection-control-in-the-built-environment",
+      "https://www.gov.uk/government/publications/guidance-on-flooring-walls-and-ceilings-and-sanitary-assemblies-in-healthcare-facilities",
+      "https://www.gov.uk/government/publications/guidance-for-design-and-planning-of-cardiac-facilities",
+      "https://www.gov.uk/government/publications/guidance-for-the-planning-and-design-of-cancer-treatment-facilities",
+      "https://www.gov.uk/government/publications/best-practice-design-and-planning-adult-acute-mental-health-units",
+      "https://www.gov.uk/government/publications/facilities-for-child-and-adolescent-mental-health-services-hbn-03-02",
+      "https://www.gov.uk/government/publications/adult-in-patient-facilities",
+      "https://www.gov.uk/government/publications/guidance-for-the-planning-and-design-of-critical-care-units",
+      "https://www.gov.uk/government/publications/facilities-for-diagnostic-imaging-and-interventional-radiology",
+      "https://www.gov.uk/government/publications/accommodation-guidance-for-satellite-dialysis-unit",
+      "https://www.gov.uk/government/publications/guidance-for-the-planning-and-design-of-a-main-renal-unit",
+      "https://www.gov.uk/government/publications/dementia-friendly-health-and-social-care-environments-hbn-08-02",
+      "https://www.gov.uk/government/publications/guidance-for-the-planning-and-design-of-maternity-care-facilities",
+      "https://www.gov.uk/government/publications/guidance-on-the-planning-and-design-of-neonatal-units",
+      "https://www.gov.uk/government/publications/day-surgery-facilities-buildings-guidance",
+      "https://www.gov.uk/government/publications/guidance-for-facilities-for-providing-primary-and-community-care-services",
+      "https://www.gov.uk/government/publications/guidance-on-the-design-of-an-out-patients-department",
+      "https://www.gov.uk/government/publications/the-planning-and-design-of-sterile-services-departments",
+      "https://www.gov.uk/government/publications/guidance-on-the-design-and-layout-of-pharmacy-and-radiopharmacy-facilities",
+      "https://www.gov.uk/government/publications/best-practice-guidance-for-the-planning-and-design-of-facilities-for-pathology-services",
+      "https://www.gov.uk/government/publications/hospital-accident-and-emergency-departments-planning-and-design",
+      "https://www.gov.uk/government/publications/hospital-accommodation-for-children-and-young-people",
+      "https://www.gov.uk/government/publications/facilities-guidance-for-surgical-procedures-in-acute-general-hospitals",
+      "https://www.gov.uk/government/collections/health-building-notes-core-elements",
+    ],
+  },
+  {
+    redirect: "https://www.england.nhs.uk/estates/other-guidance/",
+    withdrawn_urls: [
+      "https://www.gov.uk/government/publications/a-place-to-de-with-dignity-creating-a-supportive-environment",
+      "https://www.gov.uk/government/publications/an-operational-risk-management-strategy-for-trusts",
+      "https://www.gov.uk/government/publications/asset-management-guide-for-non-technical-nhs-managers",
+      "https://www.gov.uk/government/publications/celebrating-achievement-enhancing-the-healing-environment-programme",
+      "https://www.gov.uk/government/publications/improving-the-design-quality-of-nhs-trust-buildings",
+      "https://www.gov.uk/government/publications/developing-an-estate-strategy",
+      "https://www.gov.uk/government/publications/developing-bedside-communications-and-entertainment-in-nhs-hospitals",
+      "https://www.gov.uk/government/publications/enhancing-privacy-and-dignity-achieving-single-sex-accomodation",
+      "https://www.gov.uk/government/publications/raising-the-quality-of-design-briefing-for-hospitals",
+    ],
+  },
+]
+
+withdraw_urls = {
+  redirect: "https://www.england.nhs.uk/estates/health-technical-memoranda/",
+  urls:
+    [
+      "https://www.gov.uk/government/publications/suite-of-guidance-on-fire-safety-throughout-healthcare-premises-parts-a-to-m",
+      "https://www.gov.uk/government/collections/health-technical-memorandum-disinfection-and-sterilization",
+    ],
+}
+
+user = User.find_by(id: 8627)
+redirect_data.each do |data|
+  data[:withdrawn_urls].each do |withdrawn_url|
+    slug = withdrawn_url.split("/").last
+    document = Document.find_by(slug: slug)
+
+    next puts "No document for URL: #{withdrawn_url}" unless document
+
+    withdrawn_edition = document.editions.withdrawn.last
+
+    next puts "No withdrawn edition for URL: #{withdrawn_url}" unless withdrawn_edition
+
+    Whitehall.edition_services.unwithdrawer(withdrawn_edition, user: user).perform!
+
+    published_edition = document.editions.published.last
+
+    unpublishing_params = {
+      unpublishing_reason_id: UnpublishingReason::CONSOLIDATED_ID, alternative_url: data[:redirect], redirect: true, explanation: nil
+    }
+
+    Whitehall.edition_services.unpublisher(published_edition, user: user, remark: "Reset to draft", unpublishing: unpublishing_params).perform!
+
+    puts "Unpublished and redirected: #{withdrawn_url} to #{data[:redirect]}"
+  end
+end
+
+withdraw_urls[:urls].each do |url|
+  slug = url.split("/").last
+  document = Document.find_by(slug: slug)
+
+  published_edition = document.editions.published.last
+
+  unpublishing_params = {
+    unpublishing_reason_id: UnpublishingReason::CONSOLIDATED_ID, alternative_url: withdraw_urls[:redirect], redirect: true, explanation: nil
+  }
+
+  Whitehall.edition_services.unpublisher(published_edition, user: user, remark: "Reset to draft", unpublishing: unpublishing_params).perform!
+
+  puts "Unpublished and redirected: #{url} to #{withdraw_urls[:redirect]}"
+end


### PR DESCRIPTION
These pages have been withdrawn, but the publisher actually wants them
to be unpublished with a redirect as their withdrawn status is causing
confusion. The migration re-publishes each document, and then
unpublishes them with a redirect. Doing the migration this way keeps
Whitehall in sync with the rest of the stack.

This has been tested in Integration.

Zendesk: https://govuk.zendesk.com/agent/tickets/4724480

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
