### PR TITLE
Add big number component to the get involved page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_get-involved.scss
+++ b/app/assets/stylesheets/frontend/views/_get-involved.scss
@@ -50,39 +50,6 @@
       }
     }
 
-    .count {
-      @include govuk-media-query($from: desktop) {
-        width: $half;
-      }
-
-      display: block;
-      margin: $gutter-half;
-      @include heading-80;
-      font-weight: bold;
-      text-decoration: none;
-
-      .context {
-        display: block;
-        @include core-16;
-        margin-top: 0;
-        color: govuk-colour("black");
-        @include govuk-link-common;
-      }
-
-      &:hover {
-        .context {
-          text-underline-offset: .1em;
-          @include govuk-link-hover-decoration;
-        }
-      }
-
-      &:focus {
-        .context {
-          text-decoration: none;
-        }
-      }
-    }
-
     section {
       @include core-19;
       @extend %contain-floats;

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -31,17 +31,17 @@
     </section>
     <section class="consultations">
       <div class="head-section">
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: @open_consultation_count,
+          label: "Open consultations",
+          href: publications_filter_path(:publication_filter_option => 'open-consultations'),
+        } %>
 
-        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
-          <%= @open_consultation_count %>
-          <span class="context">Open consultations</span>
-        </a>
-
-        <a href="<%= publications_filter_path(:publication_filter_option => 'open-consultations') %>" class="govuk-link count">
-          <%= @closed_consultation_count %>
-          <span class="context">Closed consultations in the past 12 months</span>
-        </a>
-
+        <%= render "govuk_publishing_components/components/big_number", {
+          number: @closed_consultation_count,
+          label: "Closed consultations in the past 12 months",
+          href: publications_filter_path(:publication_filter_option => 'open-consultations'),
+        } %>
       </div>
       <div class="consultation-lists">
         <div class="consultation-closing-soon">


### PR DESCRIPTION
## What
Applies the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number) on the [get involved page](https://www.gov.uk/government/get-involved).

## Why
So that we're using components in as many places as we possibly can, reducing tech debt and risk of repeated implementation.

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-10-14 at 16 23 31](https://user-images.githubusercontent.com/64783893/137351111-c47372ee-93b4-435a-b073-1368cf95973f.png) | ![Screenshot 2021-10-14 at 16 37 10](https://user-images.githubusercontent.com/64783893/137351117-dcf16780-1a37-4120-812f-24dd7555265f.png) |