### PR TITLE
Fix incorrect word

### DIFF
--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -61,7 +61,7 @@ class HistoricalAccount < ApplicationRecord
         text: major_acts,
       },
       {
-        title: "Interested facts",
+        title: "Interesting facts",
         text: interesting_facts,
       },
     ]


### PR DESCRIPTION
This is a simple word replacement for an incorrect heading spotted by people at Number 10. Ideally this should be in a translations file but that's out of scope of fixing the immediate issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
