### PR TITLE
Add fields to presented speech content items

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -42,7 +42,9 @@ module PublishingApi
         political: item.political,
         delivered_on: item.delivered_on.iso8601,
         change_history: changes_with_public_timestamps.as_json,
-      }
+        location: item.location,
+        speaker_without_profile: item.person_override,
+      }.compact
       details.merge!(speech_type_explanation)
       details.merge!(image_payload) if has_image?
       details.merge!(PayloadBuilder::PoliticalDetails.for(item))

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -50,6 +50,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
           summary: "The description",
           body: "# Woo!\nSome content",
           role_appointment: role_appointment,
+          location: "A location",
         )
       end
 
@@ -72,6 +73,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_not(details[:political])
         assert_equal(expected_body,     details[:body])
         assert_match(iso8601_regex,     details[:delivered_on])
+        assert_match("A location",      details[:location])
         assert_equal("Transcript of the speech, exactly as it was delivered", details[:speech_type_explanation])
 
         assert_equal("Tony",             details[:image][:alt_text])
@@ -134,6 +136,31 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
         it "presents an empty people link" do
           assert_empty(presented.links[:people])
+        end
+      end
+
+      context "speaker without profile" do
+        before do
+          speech.role_appointment = nil
+          speech.person_override = "A custom speaker"
+        end
+
+        it "doesn't present a speaker link" do
+          assert_not(presented.links.key?(:speaker))
+        end
+
+        it "includes the custom speaker as speaker_without_profile" do
+          assert("A custom speaker", presented.content.dig(:details, :speaker_without_profile))
+        end
+      end
+
+      context "speech without location" do
+        before do
+          speech.location = nil
+        end
+
+        it "doesn't present a speech location" do
+          assert_nil presented.content.dig(:details, :location)
         end
       end
     end


### PR DESCRIPTION
Currently the location field is not displayed on speeches in government-frontend, even when provided in Whitehall Admin. Speakers without profiles on GOV.UK, such as The Queen, are also not displayed ([example speech](https://www.integration.publishing.service.gov.uk/government/speeches/joint-statement-on-the-human-rights-situation-in-the-xinjiang)).

Government Frontend supports displaying both `location` and `speaker_without_profile` ([link](https://github.com/alphagov/government-frontend/blob/70981a31ae4561502afa9ada78e13999aa8d2bb8/app/presenters/speech_presenter.rb#L50-L52)), as do the content schemas ([link](https://github.com/alphagov/govuk-content-schemas/blob/ae16865a109d115bf96661b47b832c3978a10fb6/formats/speech.jsonnet#L28-L31)). The problem is that Whitehall doesn't present this data to Publishing API.

This commit adds `speaker_without_profile` and `location` to the Whitehall `SpeechPresenter` so that these fields will be displayed.

Requested in Zendesk by FCDO: https://govuk.zendesk.com/agent/tickets/4752509

Before:

![Screenshot 2021-10-25 at 11 45 45](https://user-images.githubusercontent.com/8124374/138684884-7dd619db-69a1-4d06-9173-a4ee2a661f7a.png)

After:

_See that **Location: New York** and **From .. Ambassador** were added_

![Screenshot 2021-10-25 at 11 45 51](https://user-images.githubusercontent.com/8124374/138684898-a58e4f5d-3bd1-464f-8568-a43825d56c5b.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
