### PR TITLE
Fix: Handle empty locations

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -44,7 +44,7 @@ module PublishingApi
         change_history: changes_with_public_timestamps.as_json,
         location: item.location,
         speaker_without_profile: item.person_override,
-      }.compact
+      }.compact_blank
       details.merge!(speech_type_explanation)
       details.merge!(image_payload) if has_image?
       details.merge!(PayloadBuilder::PoliticalDetails.for(item))

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -156,7 +156,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
       context "speech without location" do
         before do
-          speech.location = nil
+          speech.location = ""
         end
 
         it "doesn't present a speech location" do


### PR DESCRIPTION
It's possible for a speech.location to be an empty string, so this handles that case.

Before:
<img width="687" alt="Screenshot 2021-10-26 at 12 13 30" src="https://user-images.githubusercontent.com/8124374/138866809-5bfa2898-b626-49bc-8f24-8938d8b3c5ae.png">



After:

<img width="679" alt="Screenshot 2021-10-26 at 12 13 35" src="https://user-images.githubusercontent.com/8124374/138866820-d39fa156-4b04-4223-8905-8faaefb0a387.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
