### PR TITLE
Add ordering to Take Part search tests

### DIFF
--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -133,13 +133,14 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test "returns search index data suitable for Rummageable" do
-    page = create(:take_part_page, title: "Build a new polling station", summary: "Help people vote!")
+    page = create(:take_part_page, title: "Build a new polling station", summary: "Help people vote!", ordering: 1)
 
     assert_equal "Build a new polling station", page.search_index["title"]
     assert_equal "/government/get-involved/take-part/build-a-new-polling-station", page.search_index["link"]
     assert_equal page.body, page.search_index["indexable_content"]
     assert_equal "Help people vote!", page.search_index["description"]
     assert_equal "take_part", page.search_index["format"]
+    assert_equal 1, page.search_index["ordering"]
   end
 
   test "adds page to search index on creating" do


### PR DESCRIPTION
Ordering was added to the available fields in the Take Part search, yet
the test was not updated. This commit fixes that oversight.

Related to work on https://trello.com/c/EZt2QYbz/2717-migrate-rendering-of-government-get-involved-from-whitehall-frontend-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
