### PR TITLE
Add help text for organisation details page

### DIFF
--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -19,7 +19,7 @@
           <tr><th>Superseded by</th><td><%= @organisation.superseding_organisations.map {|org| link_to org.name, admin_organisation_path(org) }.join(', ').html_safe %></td></tr>
         <% end %>
       <% end %>
-      <tr><th>Description</th><td><%= govspeak_to_html @organisation.summary %></td></tr>
+      <tr><th>Description<br>To edit this, select the 'Corporate Information pages' tab. Click on 'About us' and edit the 'Summary' field in a new edition.</th><td><%= govspeak_to_html @organisation.summary %></td></tr>
       <tr><th>Email address for ordering attached files in an alternative format</th><td><%= @organisation.alternative_format_contact_email %></td></tr>
       <tr><th>Organisation chart URL</th><td><%= link_to(@organisation.organisation_chart_url) if @organisation.organisation_chart_url.present? %></td></tr>
       <tr><th>Custom jobs URL</th><td><%= link_to(@organisation.custom_jobs_url, @organisation.custom_jobs_url) if @organisation.custom_jobs_url.present? %></td></tr>


### PR DESCRIPTION
Unless the user has read the guidance, it is not clear how to update
the 'Description' field  in the 'Details' tab. It's not shown when the
user clicks "edit" on the Details tab - which is what users expect.

This should hopefully make it clearer and reduce the number of tickets
coming through to 2nd line.

Before:
![Screenshot 2021-11-02 at 14 21 34](https://user-images.githubusercontent.com/19667619/139868516-79fa82c1-33c5-4f85-80a7-0a49754f123e.png)

After:
![Screenshot 2021-11-02 at 15 03 34](https://user-images.githubusercontent.com/19667619/139873433-37fee46f-2818-4699-8cc0-e18c369cc5ac.png)

Trello card: https://trello.com/c/InMSmXZ5/2749-update-the-help-text-for-organisation-pages-in-whitehall-3

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
