### PR TITLE
Fix logo heights to improve wrapping on narrow screens

### DIFF
--- a/app/assets/stylesheets/frontend/views/_topical-events.scss
+++ b/app/assets/stylesheets/frontend/views/_topical-events.scss
@@ -76,14 +76,13 @@
       &.queens_platinum_jubilee a {
         background-image: image-url('topical-events/platinum_jubilee.png');
         width: 120px;
-        height: 117px;
+        height: 120px;
       }
 
       &.unboxed a {
         background-image: image-url('topical-events/unboxed.png');
         width: 250px;
-        height: 88px;
-        margin-top: 30px;
+        height: 120px;
       }
     }
   }


### PR DESCRIPTION
This fixes the height on the logos on this topical event page: https://www.gov.uk/government/topical-events/2022-events-platinum-jubilee-commonwealth-games-festival-uk

This will centre them better when in a row, and fixes the ugly wrapping they had on narrow screens:

### Before:

![image](https://user-images.githubusercontent.com/31649453/140048618-90340a6c-e878-4065-bc61-589515671eca.png)

### After: 
![image](https://user-images.githubusercontent.com/31649453/140048547-97d2642e-29de-4170-a597-76e6398e1a2d.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
