### PR TITLE
Update the conditional to show the unboxed logos

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -190,7 +190,7 @@
               <% end %>
             </ul>
 
-            <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-festival-uk' %>
+            <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-unboxed' %>
             <ul class="organisations-list govuk-clearfix">
               <li class="organisations-list__item non-govuk birmingham_2022_commonwealth_games">
                 <a href="https://www.gov.uk/government/organisations/birmingham-organising-committee-for-the-2022-commonwealth-games-ltd"><%= t("topical_event.lead_organisations.birmingham_2022_commonwealth_games") %></a>


### PR DESCRIPTION
# What's changed and why?
The slug for the unboxed topical event was updated yesterday.
The conditional needs to be updated to use the new slug so that
the unboxed logos show up.

Follows on from: https://github.com/alphagov/whitehall/pull/6349

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
