### PR TITLE
Add missing Modern Slavery Statement translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,6 +253,9 @@ en:
       membership:
         one: Membership
         other: Membership
+      modern_slavery_statement:
+        one: Modern Slavery Statement
+        other: Modern Slavery Statements
       national_statistics:
         one: National Statistics
         other: National Statistics


### PR DESCRIPTION
Adds a missing translation that is used on Corporate Information Pages 
Before:
![Screenshot 2021-11-08 at 17 14 23](https://user-images.githubusercontent.com/13475227/140787611-b3dde5f5-d2fd-416c-b5cb-750bf643b6f1.png)

After:
![Screenshot 2021-11-08 at 17 14 31](https://user-images.githubusercontent.com/13475227/140787602-2441a0b5-eac9-41ce-b515-940682f99fd3.png)

