### PR TITLE
Use HTML attachment content-id in URLs

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -70,7 +70,12 @@ class HtmlAttachment < Attachment
     path_or_url = full_url ? "url" : "path"
     path_helper = "#{type}_html_attachment_#{path_or_url}"
 
-    Whitehall.url_maker.public_send(path_helper, attachable.slug, self, options)
+    # This depends on the rails url helpers to construct a url based on config/routes.rb:
+    # composed of document type, slug for the parent document, and identifier for the attachment;
+    # for non-english attachments the identifier is the content_id, for english
+    # attachments it is self i.e. the slug
+    identifier = sluggable_locale? ? self : content_id
+    Whitehall.url_maker.public_send(path_helper, attachable.slug, identifier, options)
   end
 
   def should_generate_new_friendly_id?

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -74,7 +74,11 @@ class HtmlAttachment < Attachment
     # composed of document type, slug for the parent document, and identifier for the attachment;
     # for non-english attachments the identifier is the content_id, for english
     # attachments it is self i.e. the slug
-    identifier = sluggable_locale? ? self : content_id
+    identifier = if attachable.updated_at < Time.zone.local(2021, 11, 29)
+                   self
+                 else
+                   sluggable_locale? ? self : content_id
+                 end
     Whitehall.url_maker.public_send(path_helper, attachable.slug, identifier, options)
   end
 

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -68,17 +68,18 @@ class HtmlAttachment < Attachment
 
     type = attachable.path_name
     path_or_url = full_url ? "url" : "path"
-    path_helper = "#{type}_html_attachment_#{path_or_url}"
 
     # This depends on the rails url helpers to construct a url based on config/routes.rb:
     # composed of document type, slug for the parent document, and identifier for the attachment;
     # for non-english attachments the identifier is the content_id, for english
     # attachments it is self i.e. the slug
-    identifier = if attachable.updated_at < Time.zone.local(2021, 11, 29)
-                   self
-                 else
-                   sluggable_locale? ? self : content_id
-                 end
+    if sluggable_locale? || attachable.updated_at < Time.zone.local(2021, 11, 29)
+      identifier = self
+      path_helper = "#{type}_html_attachment_#{path_or_url}"
+    else
+      identifier = content_id
+      path_helper = "#{type}_html_attachment_by_content_id_#{path_or_url}"
+    end
     Whitehall.url_maker.public_send(path_helper, attachable.slug, identifier, options)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,8 @@ Whitehall::Application.routes.draw do
 
     get "/publications(.:locale)", as: "publications", to: "publications#index", constraints: { locale: valid_locales_regex }
     get "/publications/:id(.:locale)", as: "publication", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/publications/:publication_id/:content_id" => "_#_", as: "publication_html_attachment"
+    get "/publications/:publication_id/:content_id" => "_#_", as: "publication_html_attachment_by_content_id"
+    get "/publications/:publication_id/:id" => "_#_", as: "publication_html_attachment"
 
     # TODO: Remove when paths can be generated without a routes entry
     get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }
@@ -122,7 +123,8 @@ Whitehall::Application.routes.draw do
     resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/statistics/:statistics_id/:content_id" => "_#_", as: "statistic_html_attachment"
+    get "/statistics/:statistics_id/:content_id" => "_#_", as: "statistic_html_attachment_by_content_id"
+    get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
 
     get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: valid_locales_regex }
     resources :consultations, only: %i[index] do
@@ -133,8 +135,10 @@ Whitehall::Application.routes.draw do
       end
     end
     get "/consultations/:consultation_id/:id" => "_#_", as: "consultation_html_attachment"
+    get "/consultations/:consultation_id/outcome/:content_id" => "_#_", as: "consultation_outcome_html_attachment_by_content_id"
     get "/consultations/:consultation_id/outcome/:id" => "_#_", as: "consultation_outcome_html_attachment"
-    get "/consultations/:consultation_id/public-feedback/:content_id" => "_#_", as: "consultation_public_feedback_html_attachment"
+    get "/consultations/:consultation_id/public-feedback/:content_id" => "_#_", as: "consultation_public_feedback_html_attachment_by_content_id"
+    get "/consultations/:consultation_id/public-feedback/:id" => "_#_", as: "consultation_public_feedback_html_attachment"
 
     resources :topical_events, path: "topical-events", only: [:show] do
       # Controller removed. Whitehall frontend no longer serves these

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Whitehall::Application.routes.draw do
 
     get "/publications(.:locale)", as: "publications", to: "publications#index", constraints: { locale: valid_locales_regex }
     get "/publications/:id(.:locale)", as: "publication", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/publications/:publication_id/:id" => "_#_", as: "publication_html_attachment"
+    get "/publications/:publication_id/:content_id" => "_#_", as: "publication_html_attachment"
 
     # TODO: Remove when paths can be generated without a routes entry
     get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }
@@ -122,7 +122,7 @@ Whitehall::Application.routes.draw do
     resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
+    get "/statistics/:statistics_id/:content_id" => "_#_", as: "statistic_html_attachment"
 
     get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: valid_locales_regex }
     resources :consultations, only: %i[index] do
@@ -134,7 +134,7 @@ Whitehall::Application.routes.draw do
     end
     get "/consultations/:consultation_id/:id" => "_#_", as: "consultation_html_attachment"
     get "/consultations/:consultation_id/outcome/:id" => "_#_", as: "consultation_outcome_html_attachment"
-    get "/consultations/:consultation_id/public-feedback/:id" => "_#_", as: "consultation_public_feedback_html_attachment"
+    get "/consultations/:consultation_id/public-feedback/:content_id" => "_#_", as: "consultation_public_feedback_html_attachment"
 
     resources :topical_events, path: "topical-events", only: [:show] do
       # Controller removed. Whitehall frontend no longer serves these

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -1,246 +1,260 @@
 require "test_helper"
 
 class HtmlAttachmentTest < ActiveSupport::TestCase
-  test "#govspeak_content_body_html returns the computed HTML as an HTML safe string" do
-    Sidekiq::Testing.inline! do
-      attachment = create(:html_attachment, body: "Some govspeak")
+  extend Minitest::Spec::DSL
+  describe HtmlAttachment do
+    let(:to_the_future) { Time.zone.local(2022, 1, 1) }
 
-      assert attachment.reload.govspeak_content_body_html.html_safe?
-      assert_equivalent_html "<div class=\"govspeak\"><p>Some govspeak</p></div>",
-                             attachment.govspeak_content_body_html
+    test "#govspeak_content_body_html returns the computed HTML as an HTML safe string" do
+      Sidekiq::Testing.inline! do
+        attachment = create(:html_attachment, body: "Some govspeak")
+
+        assert attachment.reload.govspeak_content_body_html.html_safe?
+        assert_equivalent_html "<div class=\"govspeak\"><p>Some govspeak</p></div>",
+                               attachment.govspeak_content_body_html
+      end
     end
-  end
 
-  test "associated govspeak content is deleted with the html attachment" do
-    attachment = create(:html_attachment)
-    govspeak_content = attachment.govspeak_content
+    test "associated govspeak content is deleted with the html attachment" do
+      attachment = create(:html_attachment)
+      govspeak_content = attachment.govspeak_content
 
-    attachment.destroy!
+      attachment.destroy!
 
-    assert_not GovspeakContent.exists?(govspeak_content.id)
-  end
+      assert_not GovspeakContent.exists?(govspeak_content.id)
+    end
 
-  test "#deep_clone deep clones the HTML attachment, body, content_id and slug" do
-    attachment = create(:html_attachment)
+    test "#deep_clone deep clones the HTML attachment, body, content_id and slug" do
+      attachment = create(:html_attachment)
 
-    clone = attachment.deep_clone
+      clone = attachment.deep_clone
 
-    assert attachment.id != clone.id
-    assert clone.new_record?
-    assert_equal attachment.title, clone.title
-    assert_equal attachment.govspeak_content_body, clone.govspeak_content_body
-    assert_equal attachment.slug, clone.slug
-    assert_equal attachment.content_id, clone.content_id
-  end
+      assert attachment.id != clone.id
+      assert clone.new_record?
+      assert_equal attachment.title, clone.title
+      assert_equal attachment.govspeak_content_body, clone.govspeak_content_body
+      assert_equal attachment.slug, clone.slug
+      assert_equal attachment.content_id, clone.content_id
+    end
 
-  test "#url returns absolute path to the draft stack when previewing" do
-    edition = create(:draft_publication, :with_html_attachment)
-    attachment = edition.attachments.first
+    test "#url returns absolute path to the draft stack when previewing" do
+      edition = create(:draft_publication, :with_html_attachment)
+      attachment = edition.attachments.first
 
-    expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?preview=#{attachment.id}"
-    actual = attachment.url(preview: true, full_url: true)
+      expected = "https://draft-origin.test.gov.uk/government/publications/"
+      expected += "#{edition.slug}/#{attachment.slug}?preview=#{attachment.id}"
+      actual = attachment.url(preview: true, full_url: true)
 
-    assert_equal expected, actual
-  end
+      assert_equal expected, actual
+    end
 
-  test "#url returns absolute path to the draft stack when previewing for non-english locale" do
-    edition = create(:draft_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-    attachment.update!(locale: "fi")
+    test "#url returns absolute path to the draft stack when previewing for non-english locale" do
+      edition = create(:draft_publication, :with_html_attachment)
+      attachment = edition.attachments.first
+      attachment.update!(locale: "fi")
+      Timecop.travel(to_the_future) { edition.update!(updated_at: Time.zone.now) }
 
-    expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.content_id}?preview=#{attachment.id}"
-    actual = attachment.url(preview: true, full_url: true)
+      expected = "https://draft-origin.test.gov.uk/government/publications/"
+      expected += "#{edition.slug}/#{attachment.content_id}?preview=#{attachment.id}"
+      actual = attachment.url(preview: true, full_url: true)
 
-    assert_equal expected, actual
-  end
+      assert_equal expected, actual
+    end
 
-  test "#url returns absolute path to the live site when not previewing" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
+    test "#url returns absolute path to the live site when not previewing" do
+      edition = create(:published_publication, :with_html_attachment)
+      attachment = edition.attachments.first
 
-    expected = "https://www.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}"
-    actual = attachment.url(full_url: true)
+      expected = "https://www.test.gov.uk/government/publications/"
+      expected += "#{edition.slug}/#{attachment.slug}"
+      actual = attachment.url(full_url: true)
 
-    assert_equal expected, actual
-  end
+      assert_equal expected, actual
+    end
 
-  test "#url returns absolute path to the live site when not previewing for non-english locale" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-    attachment.update!(locale: "fi")
+    test "#url returns absolute path to the live site when not previewing for non-english locale" do
+      edition = create(:published_publication, :with_html_attachment)
+      attachment = edition.attachments.first
+      attachment.update!(locale: "fi")
+      Timecop.travel(to_the_future) { edition.update!(updated_at: Time.zone.now) }
 
-    expected = "https://www.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.content_id}"
-    actual = attachment.url(full_url: true)
+      expected = "https://www.test.gov.uk/government/publications/"
+      expected += "#{edition.slug}/#{attachment.content_id}"
+      actual = attachment.url(full_url: true)
 
-    assert_equal expected, actual
-  end
+      assert_equal expected, actual
+    end
 
-  test "#url returns relative path by default" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-    assert_equal "/government/publications/#{edition.slug}/#{attachment.slug}", attachment.url
-  end
+    test "#url returns relative path by default" do
+      edition = create(:published_publication, :with_html_attachment)
+      attachment = edition.attachments.first
+      assert_equal "/government/publications/#{edition.slug}/#{attachment.slug}", attachment.url
+    end
 
-  test "#url returns relative path by default for non-english locale" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-    attachment.update!(locale: "fi")
-    assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
-  end
+    test "#url returns relative path by default for non-english locale" do
+      edition = create(:published_publication, :with_html_attachment)
+      attachment = edition.attachments.first
+      attachment.update!(locale: "fi")
+      Timecop.travel(to_the_future) { edition.update!(updated_at: Time.zone.now) }
+      assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
+    end
 
-  test "#url works with statistics" do
-    statistics = create(:published_national_statistics)
-    attachment = statistics.attachments.last
-    assert_equal "/government/statistics/#{statistics.slug}/#{attachment.slug}", attachment.url
-  end
+    test "#url works with statistics" do
+      statistics = create(:published_national_statistics)
+      attachment = statistics.attachments.last
+      assert_equal "/government/statistics/#{statistics.slug}/#{attachment.slug}", attachment.url
+    end
 
-  test "#url works with statistics for non-english locale" do
-    statistics = create(:published_national_statistics)
-    attachment = statistics.attachments.last
-    attachment.update!(locale: "fi")
-    assert_equal "/government/statistics/#{statistics.slug}/#{attachment.content_id}", attachment.url
-  end
+    test "#url works with statistics for non-english locale" do
+      statistics = create(:published_national_statistics)
+      attachment = statistics.attachments.last
+      attachment.update!(locale: "fi")
+      Timecop.travel(to_the_future) { statistics.update!(updated_at: Time.zone.now) }
+      assert_equal "/government/statistics/#{statistics.slug}/#{attachment.content_id}", attachment.url
+    end
 
-  test "#url works with consultation outcomes" do
-    consultation = create(:consultation_with_outcome_html_attachment)
-    attachment = consultation.outcome.attachments.first
-    assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.slug}", attachment.url
-  end
+    test "#url works with consultation outcomes" do
+      consultation = create(:consultation_with_outcome_html_attachment)
+      attachment = consultation.outcome.attachments.first
+      assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.slug}", attachment.url
+    end
 
-  test "#url works with consultation outcomes for non-english locale" do
-    consultation = create(:consultation_with_outcome_html_attachment)
-    attachment = consultation.outcome.attachments.first
-    attachment.update!(locale: "fi")
-    assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.content_id}", attachment.url
-  end
+    test "#url works with consultation outcomes for non-english locale" do
+      Timecop.travel(to_the_future) do
+        consultation = create(:consultation_with_outcome_html_attachment)
+        attachment = consultation.outcome.attachments.first
+        attachment.update!(locale: "fi")
+        consultation.update!(updated_at: Time.zone.now)
+        assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.content_id}", attachment.url
+      end
+    end
 
-  test "#url works with consultation public feedback" do
-    consultation = create(:consultation_with_public_feedback_html_attachment)
-    attachment = consultation.public_feedback.attachments.first
-    assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.slug}", attachment.url
-  end
+    test "#url works with consultation public feedback" do
+      consultation = create(:consultation_with_public_feedback_html_attachment)
+      attachment = consultation.public_feedback.attachments.first
+      assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.slug}", attachment.url
+    end
 
-  test "#url works with consultation public feedback for non-english locale" do
-    consultation = create(:consultation_with_public_feedback_html_attachment)
-    attachment = consultation.public_feedback.attachments.first
-    attachment.update!(locale: "fi")
-    assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.content_id}", attachment.url
-  end
+    test "#url works with consultation public feedback for non-english locale" do
+      Timecop.travel(to_the_future) do
+        consultation = create(:consultation_with_public_feedback_html_attachment)
+        attachment = consultation.public_feedback.attachments.first
+        attachment.update!(locale: "fi")
+        assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.content_id}", attachment.url
+      end
+    end
 
-  test "slug is copied from previous edition's attachment" do
-    edition = create(
-      :published_publication,
-      attachments: [
-        build(:html_attachment, title: "an-html-attachment"),
-      ],
-    )
-    draft = edition.create_draft(create(:writer))
+    test "slug is copied from previous edition's attachment" do
+      edition = create(
+        :published_publication,
+        attachments: [
+          build(:html_attachment, title: "an-html-attachment"),
+        ],
+      )
+      draft = edition.create_draft(create(:writer))
 
-    assert_equal "an-html-attachment", draft.attachments.first.slug
-  end
+      assert_equal "an-html-attachment", draft.attachments.first.slug
+    end
 
-  test "slug is updated when the title is changed if document has never been published" do
-    attachment = build(:html_attachment, title: "an-html-attachment")
+    test "slug is updated when the title is changed if document has never been published" do
+      attachment = build(:html_attachment, title: "an-html-attachment")
 
-    create(:draft_publication, attachments: [attachment])
+      create(:draft_publication, attachments: [attachment])
 
-    attachment.title = "a-new-title"
-    attachment.save!
-    attachment.reload
+      attachment.title = "a-new-title"
+      attachment.save!
+      attachment.reload
 
-    assert_equal "a-new-title", attachment.slug
-  end
+      assert_equal "a-new-title", attachment.slug
+    end
 
-  test "slug on old attachment is not updated when the title is changed if document is published" do
-    edition = create(
-      :published_publication,
-      attachments: [
-        build(:html_attachment, title: "an-html-attachment"),
-      ],
-    )
-    draft = edition.create_draft(create(:writer))
-    attachment = draft.attachments.first
+    test "slug on old attachment is not updated when the title is changed if document is published" do
+      edition = create(
+        :published_publication,
+        attachments: [
+          build(:html_attachment, title: "an-html-attachment"),
+        ],
+      )
+      draft = edition.create_draft(create(:writer))
+      attachment = draft.attachments.first
 
-    attachment.title = "a-new-title"
-    attachment.save!
-    attachment.reload
+      attachment.title = "a-new-title"
+      attachment.save!
+      attachment.reload
 
-    assert_equal "an-html-attachment", attachment.slug
-  end
+      assert_equal "an-html-attachment", attachment.slug
+    end
 
-  test "slug on new attachment is updated when the title is changed if document is published" do
-    edition = create(
-      :published_publication,
-    )
-    draft = edition.create_draft(create(:writer))
-    attachment = build(:html_attachment, title: "an-html-attachment")
-    draft.attachments = [attachment]
+    test "slug on new attachment is updated when the title is changed if document is published" do
+      edition = create(
+        :published_publication,
+      )
+      draft = edition.create_draft(create(:writer))
+      attachment = build(:html_attachment, title: "an-html-attachment")
+      draft.attachments = [attachment]
 
-    attachment.title = "a-new-title"
-    attachment.save!
-    attachment.reload
+      attachment.title = "a-new-title"
+      attachment.save!
+      attachment.reload
 
-    assert_equal "a-new-title", attachment.slug
-  end
+      assert_equal "a-new-title", attachment.slug
+    end
 
-  test "slug is not updated when the title has been changed in a prior published edition" do
-    edition = create(
-      :published_publication,
-      attachments: [
-        build(:html_attachment, title: "an-html-attachment"),
-      ],
-    )
-    draft = edition.create_draft(create(:writer))
-    attachment = draft.attachments.first
+    test "slug is not updated when the title has been changed in a prior published edition" do
+      edition = create(
+        :published_publication,
+        attachments: [
+          build(:html_attachment, title: "an-html-attachment"),
+        ],
+      )
+      draft = edition.create_draft(create(:writer))
+      attachment = draft.attachments.first
 
-    attachment.title = "a-new-title"
-    attachment.save!
-    attachment.reload
+      attachment.title = "a-new-title"
+      attachment.save!
+      attachment.reload
 
-    draft.change_note = "Edited HTML attachment title"
-    force_publish(draft)
+      draft.change_note = "Edited HTML attachment title"
+      force_publish(draft)
 
-    second_draft = draft.create_draft(create(:writer))
-    second_draft_attachment = second_draft.attachments.first
+      second_draft = draft.create_draft(create(:writer))
+      second_draft_attachment = second_draft.attachments.first
 
-    assert_equal "an-html-attachment", attachment.slug
-    assert_equal "an-html-attachment", second_draft_attachment.slug
-  end
+      assert_equal "an-html-attachment", attachment.slug
+      assert_equal "an-html-attachment", second_draft_attachment.slug
+    end
 
-  test "slug is not created for non-english attachments" do
-    # Additional attachment to ensure the duplicate detection behaviour isn't triggered
-    create(:html_attachment, locale: "fr")
-    attachment = create(:html_attachment, locale: "ar", title: "المملكة المتحدة والمملكة العربية السعودية")
+    test "slug is not created for non-english attachments" do
+      # Additional attachment to ensure the duplicate detection behaviour isn't triggered
+      create(:html_attachment, locale: "fr")
+      attachment = create(:html_attachment, locale: "ar", title: "المملكة المتحدة والمملكة العربية السعودية")
 
-    assert attachment.slug.blank?
-    assert_equal attachment.id.to_s, attachment.to_param
-  end
+      assert attachment.slug.blank?
+      assert_equal attachment.id.to_s, attachment.to_param
+    end
 
-  test "slug is created for english-only attachments" do
-    attachment = create(:html_attachment, locale: "en", title: "We have a bias for action")
+    test "slug is created for english-only attachments" do
+      attachment = create(:html_attachment, locale: "en", title: "We have a bias for action")
 
-    expected_slug = "we-have-a-bias-for-action"
-    assert_equal expected_slug, attachment.slug
-    assert_equal expected_slug, attachment.to_param
-  end
+      expected_slug = "we-have-a-bias-for-action"
+      assert_equal expected_slug, attachment.slug
+      assert_equal expected_slug, attachment.to_param
+    end
 
-  test "slug is cleared when changing from english to non-english" do
-    attachment = create(:html_attachment, locale: "en")
+    test "slug is cleared when changing from english to non-english" do
+      attachment = create(:html_attachment, locale: "en")
 
-    attachment.update!(locale: "fr")
-    assert attachment.slug.blank?
-  end
+      attachment.update!(locale: "fr")
+      assert attachment.slug.blank?
+    end
 
-  test "#translated_locales lists only the attachment's locale" do
-    assert_equal %w[en], HtmlAttachment.new.translated_locales
-    assert_equal %w[cy], HtmlAttachment.new(locale: "cy").translated_locales
-  end
+    test "#translated_locales lists only the attachment's locale" do
+      assert_equal %w[en], HtmlAttachment.new.translated_locales
+      assert_equal %w[cy], HtmlAttachment.new(locale: "cy").translated_locales
+    end
 
-  test "#rendering_app returns government_frontend" do
-    assert_equal "government-frontend", HtmlAttachment.new.rendering_app
+    test "#rendering_app returns government_frontend" do
+      assert_equal "government-frontend", HtmlAttachment.new.rendering_app
+    end
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -44,6 +44,18 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url returns absolute path to the draft stack when previewing for non-english locale" do
+    edition = create(:draft_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+
+    expected = "https://draft-origin.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.content_id}?preview=#{attachment.id}"
+    actual = attachment.url(preview: true, full_url: true)
+
+    assert_equal expected, actual
+  end
+
   test "#url returns absolute path to the live site when not previewing" do
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first
@@ -55,10 +67,29 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url returns absolute path to the live site when not previewing for non-english locale" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+
+    expected = "https://www.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.content_id}"
+    actual = attachment.url(full_url: true)
+
+    assert_equal expected, actual
+  end
+
   test "#url returns relative path by default" do
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first
     assert_equal "/government/publications/#{edition.slug}/#{attachment.slug}", attachment.url
+  end
+
+  test "#url returns relative path by default for non-english locale" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
   end
 
   test "#url works with statistics" do
@@ -67,16 +98,37 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "/government/statistics/#{statistics.slug}/#{attachment.slug}", attachment.url
   end
 
+  test "#url works with statistics for non-english locale" do
+    statistics = create(:published_national_statistics)
+    attachment = statistics.attachments.last
+    attachment.update!(locale: "fi")
+    assert_equal "/government/statistics/#{statistics.slug}/#{attachment.content_id}", attachment.url
+  end
+
   test "#url works with consultation outcomes" do
     consultation = create(:consultation_with_outcome_html_attachment)
     attachment = consultation.outcome.attachments.first
     assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.slug}", attachment.url
   end
 
+  test "#url works with consultation outcomes for non-english locale" do
+    consultation = create(:consultation_with_outcome_html_attachment)
+    attachment = consultation.outcome.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.content_id}", attachment.url
+  end
+
   test "#url works with consultation public feedback" do
     consultation = create(:consultation_with_public_feedback_html_attachment)
     attachment = consultation.public_feedback.attachments.first
     assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.slug}", attachment.url
+  end
+
+  test "#url works with consultation public feedback for non-english locale" do
+    consultation = create(:consultation_with_public_feedback_html_attachment)
+    attachment = consultation.public_feedback.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.content_id}", attachment.url
   end
 
   test "slug is copied from previous edition's attachment" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/rmphfmD6/2760-change-whitehall-html-attachments-to-use-content-ids-in-url-5
