### PR TITLE
Add organisation colour for Department for Levelling Up, Housing and Communities (DLUHC)

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -157,4 +157,9 @@ class OrganisationBrandColour
     title: "Foreign, Commonwealth & Development Office",
     class_name: "foreign-commonwealth-development-office",
   )
+  DepartmentForLevellingUpHousingAndCommunities = create!(
+    id: 31,
+    title: "Department for Levelling Up, Housing & Communities",
+    class_name: "department-for-levelling-up-housing-and-communities",
+  )
 end


### PR DESCRIPTION
Adds the brand colour as an option for the organisation in Whitehall.

Not to be merged until https://github.com/alphagov/govuk_publishing_components/pull/2454 has been merged and the gem bumped in `collections`, `government-frontend` and `whitehall`.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4712566)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
