### PR TITLE
Add data migration to move PHE contacts to UKHSA

### DIFF
--- a/db/data_migration/20211129114611_move_phe_contacts_to_ukhsa.rb
+++ b/db/data_migration/20211129114611_move_phe_contacts_to_ukhsa.rb
@@ -1,0 +1,7 @@
+phe = Organisation.find_by!(slug: "public-health-england")
+ukhsa = Organisation.find_by!(slug: "uk-health-security-agency")
+
+phe.contacts.update_all(contactable_id: ukhsa.id)
+
+Whitehall::PublishingApi.republish_async(phe)
+Whitehall::PublishingApi.republish_async(ukhsa)


### PR DESCRIPTION
UKHSA is a new organisation which replaces PHE.  We have a support
ticket to move all the PHE contacts to UKHSA, because there are far
too many of them (200+) to do it by hand.

I've run these commands in a staging console with no issues.

---

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4786263)
