### PR TITLE
Use content-id in URLs for non-English HTML attachments

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -70,7 +70,12 @@ class HtmlAttachment < Attachment
     path_or_url = full_url ? "url" : "path"
     path_helper = "#{type}_html_attachment_#{path_or_url}"
 
-    Whitehall.url_maker.public_send(path_helper, attachable.slug, self, options)
+    # This depends on the rails url helpers to construct a url based on config/routes.rb:
+    # composed of document type, slug for the parent document, and identifier for the attachment;
+    # for non-english attachments the identifier is the content_id, for english
+    # attachments it is self i.e. the slug
+    identifier = sluggable_locale? ? self : content_id
+    Whitehall.url_maker.public_send(path_helper, attachable.slug, identifier, options)
   end
 
   def should_generate_new_friendly_id?

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -44,6 +44,18 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url returns absolute path to the draft stack when previewing for non-english locale" do
+    edition = create(:draft_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+
+    expected = "https://draft-origin.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.content_id}?preview=#{attachment.id}"
+    actual = attachment.url(preview: true, full_url: true)
+
+    assert_equal expected, actual
+  end
+
   test "#url returns absolute path to the live site when not previewing" do
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first
@@ -55,10 +67,29 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url returns absolute path to the live site when not previewing for non-english locale" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+
+    expected = "https://www.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.content_id}"
+    actual = attachment.url(full_url: true)
+
+    assert_equal expected, actual
+  end
+
   test "#url returns relative path by default" do
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first
     assert_equal "/government/publications/#{edition.slug}/#{attachment.slug}", attachment.url
+  end
+
+  test "#url returns relative path by default for non-english locale" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
   end
 
   test "#url works with statistics" do
@@ -67,16 +98,37 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "/government/statistics/#{statistics.slug}/#{attachment.slug}", attachment.url
   end
 
+  test "#url works with statistics for non-english locale" do
+    statistics = create(:published_national_statistics)
+    attachment = statistics.attachments.last
+    attachment.update!(locale: "fi")
+    assert_equal "/government/statistics/#{statistics.slug}/#{attachment.content_id}", attachment.url
+  end
+
   test "#url works with consultation outcomes" do
     consultation = create(:consultation_with_outcome_html_attachment)
     attachment = consultation.outcome.attachments.first
     assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.slug}", attachment.url
   end
 
+  test "#url works with consultation outcomes for non-english locale" do
+    consultation = create(:consultation_with_outcome_html_attachment)
+    attachment = consultation.outcome.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/consultations/#{consultation.slug}/outcome/#{attachment.content_id}", attachment.url
+  end
+
   test "#url works with consultation public feedback" do
     consultation = create(:consultation_with_public_feedback_html_attachment)
     attachment = consultation.public_feedback.attachments.first
     assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.slug}", attachment.url
+  end
+
+  test "#url works with consultation public feedback for non-english locale" do
+    consultation = create(:consultation_with_public_feedback_html_attachment)
+    attachment = consultation.public_feedback.attachments.first
+    attachment.update!(locale: "fi")
+    assert_equal "/government/consultations/#{consultation.slug}/public-feedback/#{attachment.content_id}", attachment.url
   end
 
   test "slug is copied from previous edition's attachment" do


### PR DESCRIPTION
Every time you make an edit to a piece of guidance, it creates a
new edition of its associated HTML attachments. This works fine
in most cases.

However, for non-English HTML attachments, the edition ID is used
in the attachment URL. (English HTML attachments have a path
generated from its title, but fears around non-Latin characters
mean we can't apply the same technique to non-English attachments.
See #5963 for an investigation into this).

The result is that non-English HTML attachments get a new URL
every time the parent document is published. The previous URL is
set to redirect to the new URL. Over time, this causes a long
chain of redirects, which causes a `ERR_TOO_MANY_REDIRECTS` in
browsers once the chain reaches a certain length.

We've decided to switch from using edition IDs (which change
constantly) to content IDs (which are constant). This will solve
the browser chain redirect issue. English HTML attachments will
continue to have a path based on their title.

Supersedes #6363.

Trello: https://trello.com/c/rmphfmD6/2760-change-whitehall-html-attachments-to-use-content-ids-in-url-5

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
