### PR TITLE
Covid travel prototype

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -18,6 +18,10 @@ class Admin::BaseController < ApplicationController
     forbidden! unless current_user.can_handle_fatalities?
   end
 
+  def require_coronavirus_travel_editor_permission!
+    forbidden! unless current_user.coronavirus_travel_editor?
+  end
+
   def require_import_permission!
     authorise_user!(User::Permissions::IMPORT)
   end

--- a/app/controllers/admin/world_location_coronavirus_travel_controller.rb
+++ b/app/controllers/admin/world_location_coronavirus_travel_controller.rb
@@ -26,6 +26,6 @@ private
   def coronavirus_travel_params
     params
       .require(:world_location_coronavirus_travel)
-      .permit(:rag_status, :watchlist_rag_status, :next_rag_status, :next_rag_applies_at)
+      .permit(:rag_status, :watchlist_rag_status, :next_rag_status, :next_rag_applies_at, :status_out_of_date)
   end
 end

--- a/app/controllers/admin/world_location_coronavirus_travel_controller.rb
+++ b/app/controllers/admin/world_location_coronavirus_travel_controller.rb
@@ -1,4 +1,5 @@
 class Admin::WorldLocationCoronavirusTravelController < Admin::BaseController
+  before_action :require_coronavirus_travel_editor_permission!
   before_action :load_world_location
 
   def edit

--- a/app/controllers/admin/world_location_coronavirus_travel_controller.rb
+++ b/app/controllers/admin/world_location_coronavirus_travel_controller.rb
@@ -11,6 +11,7 @@ class Admin::WorldLocationCoronavirusTravelController < Admin::BaseController
     @coronavirus_travel.assign_attributes(coronavirus_travel_params)
 
     if @coronavirus_travel.save
+      WorldLocationCoronavirusTravelWorker.perform_at(@coronavirus_travel.next_rag_applies_at, @world_location.id)
       redirect_to admin_coronavirus_travel_path(@world_location), notice: "Coronavirus travel updated successfully"
     else
       render :edit

--- a/app/controllers/admin/world_location_coronavirus_travel_controller.rb
+++ b/app/controllers/admin/world_location_coronavirus_travel_controller.rb
@@ -27,6 +27,6 @@ private
   def coronavirus_travel_params
     params
       .require(:world_location_coronavirus_travel)
-      .permit(:rag_status, :watchlist_rag_status, :next_rag_status, :next_rag_applies_at, :status_out_of_date)
+      .permit(:rag_status, :next_rag_status, :next_rag_applies_at, :status_out_of_date)
   end
 end

--- a/app/controllers/admin/world_location_coronavirus_travel_controller.rb
+++ b/app/controllers/admin/world_location_coronavirus_travel_controller.rb
@@ -1,0 +1,31 @@
+class Admin::WorldLocationCoronavirusTravelController < Admin::BaseController
+  before_action :load_world_location
+
+  def edit
+    @coronavirus_travel = WorldLocation::CoronavirusTravel.new(@world_location)
+  end
+
+  def update
+    @coronavirus_travel = WorldLocation::CoronavirusTravel.new(@world_location)
+
+    @coronavirus_travel.assign_attributes(coronavirus_travel_params)
+
+    if @coronavirus_travel.save
+      redirect_to admin_coronavirus_travel_path(@world_location), notice: "Coronavirus travel updated successfully"
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def load_world_location
+    @world_location = WorldLocation.friendly.find(params[:id] || params[:world_location_id])
+  end
+
+  def coronavirus_travel_params
+    params
+      .require(:world_location_coronavirus_travel)
+      .permit(:rag_status, :watchlist_rag_status, :next_rag_status, :next_rag_applies_at)
+  end
+end

--- a/app/helpers/admin/world_location_helper.rb
+++ b/app/helpers/admin/world_location_helper.rb
@@ -2,6 +2,7 @@ module Admin::WorldLocationHelper
   def world_location_tabs(world_location)
     tabs = {
       "Details" => admin_world_location_path(world_location),
+      "Coronavirus Travel" => admin_coronavirus_travel_path(world_location),
       "Translations" => admin_world_location_translations_path(world_location),
       "Features (#{Locale.new(:en).native_language_name})" => features_admin_world_location_path(world_location, locale: I18n.default_locale),
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
     FORCE_PUBLISH_ANYTHING = "Force publish anything".freeze
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
+    CORONAVIRUS_TRAVEL_EDITOR = "Coronavirus Travel Editor".freeze
   end
 
   def role
@@ -100,6 +101,10 @@ class User < ApplicationRecord
 
   def can_handle_fatalities?
     gds_editor? || (organisation && organisation.handles_fatalities?)
+  end
+
+  def coronavirus_travel_editor?
+    has_permission?(Permissions::CORONAVIRUS_TRAVEL_EDITOR)
   end
 
   def fuzzy_last_name

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -3,7 +3,7 @@ class WorldLocation < ApplicationRecord
     red: "red",
     amber: "amber",
     green: "green",
-  }
+  }.freeze
 
   has_many :edition_world_locations, inverse_of: :world_location
   has_many :editions,

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,8 +1,8 @@
 class WorldLocation < ApplicationRecord
   CORONAVIRUS_RAG_STATUSES = {
     red: "red",
-    amber: "amber",
-    green: "green",
+    not_red: "not red",
+    another_status: "another status",
   }.freeze
 
   has_many :edition_world_locations, inverse_of: :world_location

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -47,6 +47,7 @@ class WorldLocation < ApplicationRecord
   include PublishesToPublishingApi
 
   enum coronavirus_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
+  enum coronavirus_watchlist_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
   enum coronavirus_next_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
 
   def publish_to_publishing_api

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -47,7 +47,6 @@ class WorldLocation < ApplicationRecord
   include PublishesToPublishingApi
 
   enum coronavirus_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
-  enum coronavirus_watchlist_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
   enum coronavirus_next_rag_status: CORONAVIRUS_RAG_STATUSES, _prefix: true
 
   def publish_to_publishing_api

--- a/app/models/world_location/coronavirus_travel.rb
+++ b/app/models/world_location/coronavirus_travel.rb
@@ -1,0 +1,37 @@
+class WorldLocation::CoronavirusTravel
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_reader :world_location
+  attribute :rag_status, :string
+  attribute :watchlist_rag_status, :string
+  attribute :next_rag_status, :string
+  attribute :next_rag_applies_at, :datetime
+
+  def initialize(world_location)
+    @world_location = world_location
+
+    if world_location.coronavirus_next_rag_applies?
+      super({ rag_status: world_location.coronavirus_next_rag_status })
+    else
+      super({
+        rag_status: world_location.coronavirus_rag_status,
+        watchlist_rag_status: world_location.coronavirus_watchlist_rag_status,
+        next_rag_status: world_location.coronavirus_next_rag_status,
+        next_rag_applies_at: world_location.coronavirus_next_rag_applies_at,
+      })
+    end
+  end
+
+  def save
+    return false unless valid?
+
+    @world_location.update!(
+      coronavirus_rag_status: rag_status,
+      coronavirus_watchlist_rag_status: watchlist_rag_status,
+      coronavirus_next_rag_status: next_rag_status,
+      coronavirus_next_rag_applies_at: next_rag_applies_at,
+    )
+  end
+end

--- a/app/models/world_location/coronavirus_travel.rb
+++ b/app/models/world_location/coronavirus_travel.rb
@@ -4,6 +4,7 @@ class WorldLocation::CoronavirusTravel
   include ActiveRecord::AttributeAssignment
 
   attr_reader :world_location
+
   attribute :rag_status, :string
   attribute :watchlist_rag_status, :string
   attribute :next_rag_status, :string

--- a/app/models/world_location/coronavirus_travel.rb
+++ b/app/models/world_location/coronavirus_travel.rb
@@ -8,6 +8,7 @@ class WorldLocation::CoronavirusTravel
   attribute :watchlist_rag_status, :string
   attribute :next_rag_status, :string
   attribute :next_rag_applies_at, :datetime
+  attribute :status_out_of_date, :boolean
 
   def initialize(world_location)
     @world_location = world_location
@@ -20,6 +21,7 @@ class WorldLocation::CoronavirusTravel
         watchlist_rag_status: world_location.coronavirus_watchlist_rag_status,
         next_rag_status: world_location.coronavirus_next_rag_status,
         next_rag_applies_at: world_location.coronavirus_next_rag_applies_at,
+        status_out_of_date: world_location.coronavirus_status_out_of_date,
       })
     end
   end
@@ -32,6 +34,7 @@ class WorldLocation::CoronavirusTravel
       coronavirus_watchlist_rag_status: watchlist_rag_status,
       coronavirus_next_rag_status: next_rag_status,
       coronavirus_next_rag_applies_at: next_rag_applies_at,
+      coronavirus_status_out_of_date: status_out_of_date,
     )
   end
 end

--- a/app/models/world_location/coronavirus_travel.rb
+++ b/app/models/world_location/coronavirus_travel.rb
@@ -6,7 +6,6 @@ class WorldLocation::CoronavirusTravel
   attr_reader :world_location
 
   attribute :rag_status, :string
-  attribute :watchlist_rag_status, :string
   attribute :next_rag_status, :string
   attribute :next_rag_applies_at, :datetime
   attribute :status_out_of_date, :boolean
@@ -19,7 +18,6 @@ class WorldLocation::CoronavirusTravel
     else
       super({
         rag_status: world_location.coronavirus_rag_status,
-        watchlist_rag_status: world_location.coronavirus_watchlist_rag_status,
         next_rag_status: world_location.coronavirus_next_rag_status,
         next_rag_applies_at: world_location.coronavirus_next_rag_applies_at,
         status_out_of_date: world_location.coronavirus_status_out_of_date,
@@ -32,7 +30,6 @@ class WorldLocation::CoronavirusTravel
 
     @world_location.update!(
       coronavirus_rag_status: rag_status,
-      coronavirus_watchlist_rag_status: watchlist_rag_status,
       coronavirus_next_rag_status: next_rag_status,
       coronavirus_next_rag_applies_at: next_rag_applies_at,
       coronavirus_status_out_of_date: status_out_of_date,

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -29,7 +29,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
   def england_coronavirus_travel
     if model.coronavirus_next_rag_applies_at && model.coronavirus_next_rag_applies_at < Time.zone.now
       {
-        rag_status: model.coronavirus_next_rag_status
+        rag_status: model.coronavirus_next_rag_status,
       }
     elsif model.coronavirus_rag_status
       {

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -37,6 +37,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
         watchlist_rag_status: model.coronavirus_watchlist_rag_status,
         next_rag_status: model.coronavirus_next_rag_status,
         next_rag_applies_at: model.coronavirus_next_rag_applies_at,
+        status_out_of_date: model.coronavirus_status_out_of_date,
       }
     else
       {}

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -16,6 +16,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
         web_url: Whitehall.url_maker.world_location_url(model, anchor: "organisations"),
       },
       content_id: model.content_id,
+      england_coronavirus_travel: england_coronavirus_travel,
     }
   end
 
@@ -23,5 +24,22 @@ class Api::WorldLocationPresenter < Api::BasePresenter
     [
       [context.api_world_location_url(model), { "rel" => "self" }],
     ]
+  end
+
+  def england_coronavirus_travel
+    if model.coronavirus_next_rag_applies_at && model.coronavirus_next_rag_applies_at < Time.zone.now
+      {
+        rag_status: model.coronavirus_next_rag_status
+      }
+    elsif model.coronavirus_rag_status
+      {
+        rag_status: model.coronavirus_rag_status,
+        watchlist_rag_status: model.coronavirus_watchlist_rag_status,
+        next_rag_status: model.coronavirus_next_rag_status,
+        next_rag_applies_at: model.coronavirus_next_rag_applies_at,
+      }
+    else
+      {}
+    end
   end
 end

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -34,7 +34,6 @@ class Api::WorldLocationPresenter < Api::BasePresenter
     elsif model.coronavirus_rag_status
       {
         rag_status: model.coronavirus_rag_status,
-        watchlist_rag_status: model.coronavirus_watchlist_rag_status,
         next_rag_status: model.coronavirus_next_rag_status,
         next_rag_applies_at: model.coronavirus_next_rag_applies_at,
         status_out_of_date: model.coronavirus_status_out_of_date,

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -29,13 +29,13 @@ class Api::WorldLocationPresenter < Api::BasePresenter
   def england_coronavirus_travel
     if model.coronavirus_next_rag_applies_at && model.coronavirus_next_rag_applies_at < Time.zone.now
       {
-        rag_status: model.coronavirus_next_rag_status,
+        covid_status: model.coronavirus_next_rag_status,
       }
     elsif model.coronavirus_rag_status
       {
-        rag_status: model.coronavirus_rag_status,
-        next_rag_status: model.coronavirus_next_rag_status,
-        next_rag_applies_at: model.coronavirus_next_rag_applies_at,
+        covid_status: model.coronavirus_rag_status,
+        next_covid_status: model.coronavirus_next_rag_status,
+        next_covid_status_applies_at: model.coronavirus_next_rag_applies_at,
         status_out_of_date: model.coronavirus_status_out_of_date,
       }
     else

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title "Edit Coronavirus travel for #{@world_location.name}" %>
-<% rag_options = [["Red", "red"], ["Amber", "amber"], ["Green", "green"]] %>
+<% rag_options = [["Red", "red"], ["Not red", "not red"], ["Another status", "another status"]] %>
 
 <div class="row">
   <section class="col-md-8">

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -31,8 +31,12 @@
           }, { class: 'date form-control' } %>
       </div>
 
-      <%= form.check_box :status_out_of_date, label_text: "Information is out of date" %>
-
+      <div class="form-group">
+        <br>
+        <%= form.label :status_out_of_date, "Guidance availability" %>
+        <p>Checking this box will display a 'Guidance is currently being updated' message</p>
+        <%= form.check_box :status_out_of_date, label_text: "Information is out of date" %>
+      </div>
       <%= form.save_or_cancel cancel: admin_coronavirus_travel_path(@world_location) %>
     <% end %>
   </section>

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -12,11 +12,6 @@
       </div>
 
       <div class="form-group">
-        <%= form.label :watchlist_rag_status, 'Watchlist COVID status' %>
-        <%= form.select :watchlist_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
-      </div>
-
-      <div class="form-group">
         <%= form.label :next_rag_status, 'Next COVID status' %>
         <%= form.select :next_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
       </div>

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -7,21 +7,21 @@
     <p class="warning">Warning: changes appear instantly on the live site.</p>
     <%= form_with url: admin_coronavirus_travel_path(@world_location), model: @coronavirus_travel, method: :put do |form| %>
       <div class="form-group">
-        <%= form.label :rag_status, 'Current RAG Status' %>
+        <%= form.label :rag_status, 'Current COVID status' %>
         <%= form.select :rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
       </div>
 
       <div class="form-group">
-        <%= form.label :watchlist_rag_status, 'Watchlist RAG Status' %>
+        <%= form.label :watchlist_rag_status, 'Watchlist COVID status' %>
         <%= form.select :watchlist_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
       </div>
 
       <div class="form-group">
-        <%= form.label :next_rag_status, 'Next RAG Status' %>
+        <%= form.label :next_rag_status, 'Next COVID status' %>
         <%= form.select :next_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
       </div>
 
-      <%= form.label :next_rag_applies_at, "Time next RAG Status takes affect" %>
+      <%= form.label :next_rag_applies_at, "Time next COVID Status takes effect" %>
       <div class="form-inline add-label-margin">
         <%= form.datetime_select :next_rag_applies_at, {
             start_year: Date.today.year,
@@ -33,7 +33,6 @@
 
       <%= form.check_box :status_out_of_date, label_text: "Information is out of date" %>
 
-      <p class="warning">Warning: changes appear instantly on the live site.</p>
       <%= form.save_or_cancel cancel: admin_coronavirus_travel_path(@world_location) %>
     <% end %>
   </section>

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -1,0 +1,38 @@
+<% page_title "Edit Coronavirus travel for #{@world_location.name}" %>
+<% rag_options = [["Red", "red"], ["Amber", "amber"], ["Green", "green"]] %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Edit Coronavirus Travel for <%= @world_location.name %></h1>
+    <p class="warning">Warning: changes appear instantly on the live site.</p>
+    <%= form_with url: admin_coronavirus_travel_path(@world_location), model: @coronavirus_travel, method: :put do |form| %>
+      <div class="form-group">
+        <%= form.label :rag_status, 'Current RAG Status' %>
+        <%= form.select :rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :watchlist_rag_status, 'Watchlist RAG Status' %>
+        <%= form.select :watchlist_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :next_rag_status, 'Next RAG Status' %>
+        <%= form.select :next_rag_status, rag_options, { include_blank: true }, { class: "form-control input-md-2" } %>
+      </div>
+
+      <%= form.label :next_rag_applies_at, "Time next RAG Status takes affect" %>
+      <div class="form-inline add-label-margin">
+        <%= form.datetime_select :next_rag_applies_at, {
+            start_year: Date.today.year,
+            end_year: Date.today.year + 5,
+            minute_step: 15,
+            include_blank: true,
+          }, { class: 'date form-control' } %>
+      </div>
+
+      <p class="warning">Warning: changes appear instantly on the live site.</p>
+      <%= form.save_or_cancel cancel: admin_coronavirus_travel_path(@world_location) %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/world_location_coronavirus_travel/edit.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/edit.html.erb
@@ -31,6 +31,8 @@
           }, { class: 'date form-control' } %>
       </div>
 
+      <%= form.check_box :status_out_of_date, label_text: "Information is out of date" %>
+
       <p class="warning">Warning: changes appear instantly on the live site.</p>
       <%= form.save_or_cancel cancel: admin_coronavirus_travel_path(@world_location) %>
     <% end %>

--- a/app/views/admin/world_location_coronavirus_travel/show.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/show.html.erb
@@ -14,18 +14,18 @@
 
     <% if @world_location.coronavirus_next_rag_applies? %>
       <p>
-        The current RAG status for <%= @world_location.name %> is
+        The current COVID status for <%= @world_location.name %> is
         <%= @world_location.coronavirus_next_rag_status %>. This took affect at
         <%= @world_location.coronavirus_next_rag_applies_at %>.
       </p>
     <% else %>
       <p>
         <% if @world_location.coronavirus_rag_status %>
-          The current RAG status for <%= @world_location.name %> is
+          The current COVID status for <%= @world_location.name %> is
           <%= @world_location.coronavirus_rag_status %>.
         <% else %>
-          <%= @world_location.name %> does not have a RAG status so will be treated
-          as amber.
+          <%= @world_location.name %> does not have a COVID status so will be treated
+          as non red.
         <% end %>
       </p>
 

--- a/app/views/admin/world_location_coronavirus_travel/show.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/show.html.erb
@@ -29,12 +29,6 @@
         <% end %>
       </p>
 
-      <% if @world_location.coronavirus_watchlist_rag_status %>
-        <p>
-          It is on the <%= @world_location.coronavirus_watchlist_rag_status %> watchlist.
-        </p>
-      <% end %>
-
       <% if @world_location.coronavirus_next_rag_status %>
         <p>
           It will be changing to <%= @world_location.coronavirus_next_rag_status %> at

--- a/app/views/admin/world_location_coronavirus_travel/show.html.erb
+++ b/app/views/admin/world_location_coronavirus_travel/show.html.erb
@@ -1,0 +1,50 @@
+<% page_title "#{@world_location.name} Coronavirus Travel" %>
+
+<%= content_tag_for(:div, @world_location) do %>
+  <div class="world-location-header">
+    <h1>
+      <span class="name"><%= @world_location.name %></span>
+    </h1>
+    <p>
+    <%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %>
+  </div>
+
+  <section class="world-location-details">
+    <%= tab_navigation_for(@world_location) %>
+
+    <% if @world_location.coronavirus_next_rag_applies? %>
+      <p>
+        The current RAG status for <%= @world_location.name %> is
+        <%= @world_location.coronavirus_next_rag_status %>. This took affect at
+        <%= @world_location.coronavirus_next_rag_applies_at %>.
+      </p>
+    <% else %>
+      <p>
+        <% if @world_location.coronavirus_rag_status %>
+          The current RAG status for <%= @world_location.name %> is
+          <%= @world_location.coronavirus_rag_status %>.
+        <% else %>
+          <%= @world_location.name %> does not have a RAG status so will be treated
+          as amber.
+        <% end %>
+      </p>
+
+      <% if @world_location.coronavirus_watchlist_rag_status %>
+        <p>
+          It is on the <%= @world_location.coronavirus_watchlist_rag_status %> watchlist.
+        </p>
+      <% end %>
+
+      <% if @world_location.coronavirus_next_rag_status %>
+        <p>
+          It will be changing to <%= @world_location.coronavirus_next_rag_status %> at
+          <%= @world_location.coronavirus_next_rag_applies_at %>.
+        </p>
+      <% end %>
+    <% end %>
+
+    <div class="form-actions">
+      <%= link_to "Edit", edit_admin_coronavirus_travel_path(@world_location), class: "btn btn-lg btn-primary"%>
+    </div>
+  </section>
+<% end %>

--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -7,7 +7,7 @@
     <%= form_for([:admin, @world_location]) do |form| %>
       <div class="form-group">
         <%= form.label :world_location_type_id, 'Type' %>
-        <%= form.select :world_location_type_id, options_from_collection_for_select(WorldLocationType.all, :id, :name, form.object.world_location_type_id), {}, {class: 'form-control input-md-3'} %>
+        <%= form.select :world_location_type_id, options_from_collection_for_select(WorldLocationType.all, :id, :name, form.object.world_location_type_id), {}, {class: 'form-control input-md-2'} %>
       </div>
 
       <%= form.text_field :title %>

--- a/app/workers/world_location_coronavirus_travel_worker.rb
+++ b/app/workers/world_location_coronavirus_travel_worker.rb
@@ -1,0 +1,16 @@
+class WorldLocationCoronavirusTravelWorker < WorkerBase
+  def perform(id)
+    world_location = WorldLocation.find(id)
+    new_rag_status = world_location.coronavirus_next_rag_status
+
+    world_location.lock!
+
+    WorldLocation.transaction do
+      world_location.coronavirus_rag_status = new_rag_status
+      world_location.coronavirus_next_rag_status = nil
+      world_location.coronavirus_next_rag_applies_at = nil
+
+      world_location.save!
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -370,6 +370,8 @@ Whitehall::Application.routes.draw do
         resources :world_locations, only: %i[index edit update show] do
           member do
             get "/features(.:locale)", as: "features", to: "world_locations#features", constraints: { locale: valid_locales_regex }
+
+            resource :coronavirus_travel, only: %i[show edit update], controller: "world_location_coronavirus_travel"
           end
           resources :translations, controller: "world_location_translations"
           resources :offsite_links

--- a/db/migrate/20210422173703_add_world_location_coronavirus_travel_status.rb
+++ b/db/migrate/20210422173703_add_world_location_coronavirus_travel_status.rb
@@ -1,0 +1,10 @@
+class AddWorldLocationCoronavirusTravelStatus < ActiveRecord::Migration[6.0]
+  def change
+    change_table :world_locations, bulk: true do |t|
+      t.string :coronavirus_rag_status
+      t.string :coronavirus_watchlist_rag_status
+      t.string :coronavirus_next_rag_status
+      t.datetime :coronavirus_next_rag_applies_at
+    end
+  end
+end

--- a/db/migrate/20211202144625_add_status_incorrect_field_to_world_location.rb
+++ b/db/migrate/20211202144625_add_status_incorrect_field_to_world_location.rb
@@ -1,0 +1,7 @@
+class AddStatusIncorrectFieldToWorldLocation < ActiveRecord::Migration[6.1]
+  def change
+    change_table :world_locations, bulk: true do |t|
+      t.boolean :coronavirus_status_out_of_date, default: false
+    end
+  end
+end

--- a/db/migrate/20211206184843_remove_coronavirus_watchlist_rag_status_from_world_locations.rb
+++ b/db/migrate/20211206184843_remove_coronavirus_watchlist_rag_status_from_world_locations.rb
@@ -1,0 +1,9 @@
+class RemoveCoronavirusWatchlistRagStatusFromWorldLocations < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :world_locations, :coronavirus_watchlist_rag_status, :string
+  end
+
+  def down
+    add_column :world_locations, :coronavirus_watchlist_rag_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_144625) do
+ActiveRecord::Schema.define(version: 2021_12_06_184843) do
 
   create_table "about_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -1132,7 +1132,6 @@ ActiveRecord::Schema.define(version: 2021_12_02_144625) do
     t.string "content_id"
     t.string "news_page_content_id"
     t.string "coronavirus_rag_status"
-    t.string "coronavirus_watchlist_rag_status"
     t.string "coronavirus_next_rag_status"
     t.datetime "coronavirus_next_rag_applies_at"
     t.boolean "coronavirus_status_out_of_date", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2021_10_19_095600) do
+=======
+ActiveRecord::Schema.define(version: 2021_04_22_173703) do
+>>>>>>> 84a1ed57e (Spike - exploring Coronavirus Travel data on world locations)
 
   create_table "about_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -1131,6 +1135,10 @@ ActiveRecord::Schema.define(version: 2021_10_19_095600) do
     t.string "analytics_identifier"
     t.string "content_id"
     t.string "news_page_content_id"
+    t.string "coronavirus_rag_status"
+    t.string "coronavirus_watchlist_rag_status"
+    t.string "coronavirus_next_rag_status"
+    t.datetime "coronavirus_next_rag_applies_at"
     t.index ["iso2"], name: "index_world_locations_on_iso2", unique: true
     t.index ["slug"], name: "index_world_locations_on_slug"
     t.index ["world_location_type_id"], name: "index_world_locations_on_world_location_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 2021_10_19_095600) do
-=======
-ActiveRecord::Schema.define(version: 2021_04_22_173703) do
->>>>>>> 84a1ed57e (Spike - exploring Coronavirus Travel data on world locations)
+ActiveRecord::Schema.define(version: 2021_12_02_144625) do
 
   create_table "about_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -1139,6 +1135,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_173703) do
     t.string "coronavirus_watchlist_rag_status"
     t.string "coronavirus_next_rag_status"
     t.datetime "coronavirus_next_rag_applies_at"
+    t.boolean "coronavirus_status_out_of_date", default: false
     t.index ["iso2"], name: "index_world_locations_on_iso2", unique: true
     t.index ["slug"], name: "index_world_locations_on_slug"
     t.index ["world_location_type_id"], name: "index_world_locations_on_world_location_type_id"

--- a/test/functional/admin/world_location_coronavirus_travel_controller_test.rb
+++ b/test/functional/admin/world_location_coronavirus_travel_controller_test.rb
@@ -1,0 +1,6 @@
+require "test_helper"
+
+class Admin::WorldLocationCoronavirusTravelControllerTest < ActionController::TestCase
+  should_be_an_admin_controller
+  should_require_coronavirus_travel_permission_to_access :world_location, :edit
+end

--- a/test/support/controller_test_helpers.rb
+++ b/test/support/controller_test_helpers.rb
@@ -24,6 +24,17 @@ module ControllerTestHelpers
         end
       end
     end
+
+    def should_require_coronavirus_travel_permission_to_access(edition_type, *actions)
+      test "requires the ability to edit coronavirus travel to access" do
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        login_as :writer
+        actions.each do |action|
+          get action, params: { id: edition.id }
+          assert_response 403
+        end
+      end
+    end
   end
 
   def govspeak_transformation_fixture(transformation)

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -81,7 +81,7 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
 
   test "json includes Coronavirus RAG status when there is a Coronavirus RAG status" do
     @location.stubs(:coronavirus_rag_status).returns("red")
-    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:rag_status]
+    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:covid_status]
   end
 
   test "json includes Coronavirus next RAG status information when there is a Coronavirus next RAG status" do
@@ -90,8 +90,8 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
     rag_status_date = Time.zone.tomorrow.noon
     @location.stubs(:coronavirus_next_rag_applies_at).returns(rag_status_date)
 
-    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:next_rag_status]
-    assert_equal rag_status_date, @presenter.as_json[:england_coronavirus_travel][:next_rag_applies_at]
+    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:next_covid_status]
+    assert_equal rag_status_date, @presenter.as_json[:england_coronavirus_travel][:next_covid_status_applies_at]
   end
 
   test "json includes Coronavirus RAG status out of date when Coronavirus RAG status is out of date" do

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -78,4 +78,25 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   test "json includes public location url (anchored on organisations) organisations web_url" do
     assert_equal Whitehall.url_maker.world_location_url(@location, anchor: "organisations"), @presenter.as_json[:organisations][:web_url]
   end
+
+  test "json includes Coronavirus RAG status when there is a Coronavirus RAG status" do
+    @location.stubs(:coronavirus_rag_status).returns("red")
+    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:rag_status]
+  end
+
+  test "json includes Coronavirus next RAG status information when there is a Coronavirus next RAG status" do
+    @location.stubs(:coronavirus_rag_status).returns("green")
+    @location.stubs(:coronavirus_next_rag_status).returns("red")
+    rag_status_date = Time.zone.tomorrow.noon
+    @location.stubs(:coronavirus_next_rag_applies_at).returns(rag_status_date)
+
+    assert_equal "red", @presenter.as_json[:england_coronavirus_travel][:next_rag_status]
+    assert_equal rag_status_date, @presenter.as_json[:england_coronavirus_travel][:next_rag_applies_at]
+  end
+
+  test "json includes Coronavirus RAG status out of date when Coronavirus RAG status is out of date" do
+    @location.stubs(:coronavirus_rag_status).returns("red")
+    @location.stubs(:coronavirus_status_out_of_date).returns(true)
+    assert @presenter.as_json[:england_coronavirus_travel][:status_out_of_date]
+  end
 end

--- a/test/unit/workers/world_location_coronavirus_travel_worker_test.rb
+++ b/test/unit/workers/world_location_coronavirus_travel_worker_test.rb
@@ -6,8 +6,8 @@ class WorldLocationCoronavirusTravelWorkerTest < ActiveSupport::TestCase
       :world_location,
       name: "France",
       news_page_content_id: "id-123",
-      coronavirus_rag_status: "green",
-      coronavirus_next_rag_status: "red",
+      coronavirus_rag_status: "red",
+      coronavirus_next_rag_status: "not red",
       coronavirus_next_rag_applies_at: Time.zone.tomorrow.noon,
     )
   end

--- a/test/unit/workers/world_location_coronavirus_travel_worker_test.rb
+++ b/test/unit/workers/world_location_coronavirus_travel_worker_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class WorldLocationCoronavirusTravelWorkerTest < ActiveSupport::TestCase
+  setup do
+    @world_location = FactoryBot.create(
+      :world_location,
+      name: "France",
+      news_page_content_id: "id-123",
+      coronavirus_rag_status: "green",
+      coronavirus_next_rag_status: "red",
+      coronavirus_next_rag_applies_at: Time.zone.tomorrow.noon,
+    )
+  end
+
+  test "it updates the world location api" do
+    WorldLocationCoronavirusTravelWorker.new.perform(@world_location.id)
+
+    @world_location.reload
+    assert_equal "not_red", @world_location.coronavirus_rag_status
+    assert_nil @world_location.coronavirus_next_rag_status
+    assert_nil @world_location.coronavirus_next_rag_applies_at
+  end
+
+  test "it enqueues a job" do
+    assert_equal 0, WorldLocationCoronavirusTravelWorker.jobs.size
+
+    WorldLocationCoronavirusTravelWorker.perform_at(
+      @world_location.coronavirus_next_rag_applies_at,
+      @world_location.id,
+    )
+
+    assert_equal 1, WorldLocationCoronavirusTravelWorker.jobs.size
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/99pkgton

# What's changed?
Builds on the original spike: https://github.com/alphagov/whitehall/pull/6083

Adds:

1. A checkbox to declare emergency changes to travel status are imminent - `status_out_of_date`
2. Adds presenter tests for World Location API
3. Adds a worker to change current RAG status to next RAG status at the date/time that the next status applies.

# Expected Changes
## Admin screen

<img width="708" alt="spain-edit" src="https://user-images.githubusercontent.com/5963488/145027752-e491d0a3-55b9-49f8-968f-9d1065651962.png">

## API

<img width="972" alt="covid-api-spain" src="https://user-images.githubusercontent.com/5963488/145039631-4c5cea54-f1f9-499b-ad4a-8b29998804b1.png">

# Examples of status auto updating via the worker
## Initial values in API
<img width="832" alt="Screenshot 2021-12-03 at 14 59 59" src="https://user-images.githubusercontent.com/5793815/144624358-b9190d15-f0df-45ad-880e-ee4402fb601b.png">

## Auto-update of status (from red to green)
<img width="831" alt="Screenshot 2021-12-03 at 15 00 23" src="https://user-images.githubusercontent.com/5793815/144624354-17323577-2a72-4f9d-b03a-2e58dca2ef12.png">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
