### PR TITLE
Fix failing Pact test by using correct branch

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -27,7 +27,7 @@ Pact.service_provider "Whitehall API" do
     else
       base_url = "https://pact-broker.cloudapps.digital"
       path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-whitehall-api-pact-tests'))}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-master'))}"
 
       pact_uri("#{base_url}/#{path}/#{version_modifier}")
     end


### PR DESCRIPTION
This change configures the Pact tests to default to reading the `branch-master` version from the Pact Broker. Previously it was using a temporary branch which no longer exists, which was resulting in 404 Not Found responses from the broker.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
