### PR TITLE
Put quotes around reserved work in raw SQL

### DIFF
--- a/app/controllers/admin/export/document_controller.rb
+++ b/app/controllers/admin/export/document_controller.rb
@@ -45,7 +45,7 @@ private
       .joins("INNER JOIN edition_organisations eo ON eo.edition_id = editions.id
         AND eo.organisation_id = (
           SELECT organisation_id FROM edition_organisations
-          WHERE lead = true AND
+          WHERE `lead` IS true AND
                 edition_organisations.edition_id = editions.id
           ORDER BY lead_ordering ASC
           LIMIT 1


### PR DESCRIPTION
The word `LEAD` [became a reserved word in MySQL 8.0.2](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-L), so we need to add quotes around the field name in order to be able to upgrade to MySQL 8.

Additionally, we are currently using `=` to compare a boolean field. This should [use `IS`](https://dev.mysql.com/doc/refman/8.0/en/comparison-operators.html#operator_is) instead.

The branch build is against MySQL 5.6.  I have also tested this change using MySQL 8 in [this build](https://ci.integration.publishing.service.gov.uk/job/whitehall/job/fix-mysql-syntax-error/4/console).  The other failures remain, but this one is no longer present.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/g0sPoMEy/91-fix-whitehall-issues-for-db-upgrade-2-syntax-error)