### PR TITLE
Use traditional SQL mode

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,8 @@ development:
   username: whitehall
   password: whitehall
   url: <%= ENV["DATABASE_URL"] %>
+  variables:
+    sql_mode: TRADITIONAL
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -16,12 +18,16 @@ test: &test
   username: whitehall
   password: whitehall
   url: <%= ENV["TEST_DATABASE_URL"] %><%= ENV['TEST_ENV_NUMBER'] if ENV["TEST_DATABASE_URL"] %>
+  variables:
+    sql_mode: TRADITIONAL
 
 production:
   encoding: utf8
   adapter: mysql2
   database: whitehall_production
   pool: 10
+  variables:
+    sql_mode: TRADITIONAL
 
 cucumber:
   <<: *test


### PR DESCRIPTION
MySQL 5.7 changed the default SQL mode to `ONLY_FULL_GROUP_BY`, however there are multiple complex queries in this application that have been designed for `TRADITIONAL` mode.
    
Therefore, in order to unblock the upgrade from MySQL 5.6 to 8, we should explicitly switch to `TRADITIONAL` SQL mode so our existing queries continue to work as designed.

The code changes in this PR are compatible with both MySQL 5.6 and 8.  The tests have run against MySQL 5.6, but have also been run against MySQL 8 in [this build](https://ci.integration.publishing.service.gov.uk/job/whitehall/job/use-traditional-sql/1/console).

[Trello card](https://trello.com/c/TUzTsg9z)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
