### PR TITLE
Use MySQL in 'traditional' mode

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,8 @@ development:
   username: whitehall
   password: whitehall
   url: <%= ENV["DATABASE_URL"] %>
+  variables:
+    sql_mode: TRADITIONAL
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -16,12 +18,16 @@ test: &test
   username: whitehall
   password: whitehall
   url: <%= ENV["TEST_DATABASE_URL"] %><%= ENV['TEST_ENV_NUMBER'] if ENV["TEST_DATABASE_URL"] %>
+  variables:
+    sql_mode: TRADITIONAL
 
 production:
   encoding: utf8
   adapter: mysql2
   database: whitehall_production
   pool: 10
+  variables:
+    sql_mode: TRADITIONAL
 
 cucumber:
   <<: *test


### PR DESCRIPTION
MySQL 5.7.5 introduced new behaviour around its [handling of `GROUP BY` clauses][1]. This change resulted in some previously valid SQL queries in Whitehall to be deemed invalid and trigger MySQL errors. These errors were evident as failures in the app's test suite.

This change in behaviour can be reverted by removing `ONLY_FULL_GROUP_BY` from the `sql_mode` MySQL variable. It can also be achieved by setting the `sql_mode` to `TRADITIONAL`, which is a special '[combination SQL mode][2]' that excludes `ONLY_FULL_GROUP_BY`.

A reasonable amount of effort was put into refactoring the problematic SQL queries in the application to avoid needing to deviate from MySQL's now-default behaviour. However due to the complexity of the queries and their surrounding code, it was deemed more pragmatic to simply set the SQL mode to 'traditional'.

This commit therefore configures MySQL to operate in 'traditional' mode so it behaves as expected by the app.

[1]: https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
[2]: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-combo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
