### PR TITLE
Upgrade CI to MySQL8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,4 +37,5 @@ node {
       }
     }
   )
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/whitehall_test")
 }


### PR DESCRIPTION
### Description

This changes the Jenkins CI configuration to use MySQL 8.

MySQL is [available at port `33068 `](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use) on the CI server. By explicitly setting the `TEST_DATABASE_URL`, we're telling Rails to use that MySQL server.

Previously, Rails implicitly used the default MySQL port `3306` which is a MySQL 5.5 server.

Trello ticket: https://trello.com/c/btcm7JyB/

### CD guidance
 
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
