### PR TITLE
Add a rake task to republish all documents with non-english attachments

### DIFF
--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -1,0 +1,9 @@
+desc "Republish all documents with non-english html attachments"
+task republish_non_english_html_attachments: :environment do
+  HtmlAttachment.where.not(deleted: true)
+  .where.not(locale: "en")
+  .where.not(locale: nil) # HtmlAttachment#sluggable_locale? treats nil locales the same as English
+  .each do |attachment|
+    PublishingApiDocumentRepublishingWorker.perform_async(attachment.attachable.document.id)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/3BeDlugo/2761-republish-whitehall-documents-containing-non-english-html-attachments-5