### PR TITLE
Document the 'whitehall_fe' user

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,9 @@ development:
   url: <%= ENV["DATABASE_URL"] %>
   variables:
     sql_mode: TRADITIONAL
+  # Note that there is also a 'whitehall_fe' user, used
+  # by the 'whitehall_frontend' machines. It should have
+  # only 'SELECT' privileges on the database.
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
The whitehall_production database has two users: 'whitehall', and
'whitehall_fe'. See https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/govuk/manifests/apps/whitehall/db.pp#L12-L17.

We currently create these users with the MySQL puppetlabs plugin,
but that will change in the rollout of [RFC-143][], where the
simultaneous upgrade to MySQL 8 introduces a syntax error (and due
to the old version of Puppet we run, we can't simply upgrade the
puppetlabs plugin).

We'll therefore switch to creating the MySQL database and user(s)
manually. As a result, there'll be no need to store the database
name and username information in Puppet; we'll have a heavier
reliance on these users being properly documented in their
respective apps. Whitehall currently has no reference to the
'whitehall_fe' MySQL user, so this commit adds that documentation,
ready for the next time a developer has to manually create a
database with all the necessary users.

[RFC-143]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-143-split-database-instances.md

Trello: https://trello.com/c/HjK4AbUS/49-configure-puppet-for-new-db-admin-mysql-instances

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
