### PR TITLE
Optimise 'republish_non_english_html_attachments' for bulk publish

### DIFF
--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -4,6 +4,10 @@ task republish_non_english_html_attachments: :environment do
   .where.not(locale: "en")
   .where.not(locale: nil) # HtmlAttachment#sluggable_locale? treats nil locales the same as English
   .each do |attachment|
-    PublishingApiDocumentRepublishingWorker.perform_async(attachment.attachable.document.id)
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+      "bulk_republishing",
+      attachment.attachable.document.id,
+      true,
+    )
   end
 end


### PR DESCRIPTION
Without this, running the rake task would trigger ~10k items for
the Sidekiq queue and would process around 2.5k of them before
stagnating. Looking at the Sidekiq web monitoring, we can see
the workers all begin to fail with the same error:

```
ActiveRecord::LockWaitTimeout: Mysql2::Error::TimeoutError: Lock wait timeout exceeded; try restarting transaction
```

> <img width="1408" alt="Screenshot from Grafana, showing processing rates stagnating at around the 7.5k mark" src="https://user-images.githubusercontent.com/5111927/146927550-bc226b2c-e24a-4fac-a9f7-5d48e409b9dc.png">

We must have come across this problem before. Whilst we're
calling `perform_async`, which hands the workers off to a queue,
we've not been setting the `bulk_publishing` parameter to true
(it [defaults to false][]). I've taken inspiration from elsewhere
in the codebase ([1][]) to fix this up.

[1]: https://github.com/alphagov/whitehall/blob/508c1e9fe332966f1e962c07ad6238590962057e/app/models/corporate_information_page.rb
[defaults to false]: https://github.com/alphagov/whitehall/blob/cd718bf2d90aa198767e8d4328d3f3fd1ef13e02/app/workers/publishing_api_document_republishing_worker.rb#L21

Trello: https://trello.com/c/3BeDlugo/2761-republish-whitehall-documents-containing-non-english-html-attachments-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
