### PR TITLE
Add rule for vip_editor permission

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -1,5 +1,7 @@
 class Admin::PeopleController < Admin::BaseController
   before_action :load_person, only: %i[show edit update destroy]
+  before_action :enforce_permissions!, only: %i[edit update destroy]
+
   def index
     @people = Person.order(:surname, :forename).includes(:translations)
   end
@@ -53,5 +55,9 @@ private
       :biography,
       :privy_counsellor,
     )
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:edit, @person)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
     DEPARTMENTAL_EDITOR = "Editor".freeze
     MANAGING_EDITOR = "Managing Editor".freeze
     GDS_EDITOR = "GDS Editor".freeze
+    VIP_EDITOR = "VIP Editor".freeze
     PUBLISH_SCHEDULED_EDITIONS = "Publish scheduled editions".freeze
     IMPORT = "Import CSVs".freeze
     WORLD_WRITER = "World Writer".freeze
@@ -48,6 +49,10 @@ class User < ApplicationRecord
 
   def gds_editor?
     has_permission?(Permissions::GDS_EDITOR)
+  end
+
+  def vip_editor?
+    has_permission?(Permissions::VIP_EDITOR)
   end
 
   def world_editor?

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -3,6 +3,7 @@ require "whitehall/authority/rules/edition_rules"
 require "whitehall/authority/rules/fatality_notice_rules"
 require "whitehall/authority/rules/document_rules"
 require "whitehall/authority/rules/ministerial_role_rules"
+require "whitehall/authority/rules/person_rules"
 require "whitehall/authority/rules/policy_group_rules"
 require "whitehall/authority/rules/miscellaneous_rules"
 
@@ -41,6 +42,7 @@ module Whitehall::Authority
     "Edition" => Rules::EditionRules,
     "FatalityNotice" => Rules::FatalityNoticeRules,
     "MinisterialRole" => Rules::MinisterialRoleRules,
+    "Person" => Rules::PersonRules,
     "PolicyGroup" => Rules::PolicyGroupRules,
     "Organisation" => Rules::OrganisationRules,
     "Government" => Rules::GovernmentRules,

--- a/lib/whitehall/authority/rules/person_rules.rb
+++ b/lib/whitehall/authority/rules/person_rules.rb
@@ -1,0 +1,11 @@
+module Whitehall::Authority::Rules
+  PersonRules = Struct.new(:actor, :subject) do
+    def can?(_action)
+      if subject.slug == "boris-johnson"
+        actor.vip_editor? || actor.gds_admin?
+      else
+        true
+      end
+    end
+  end
+end

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -2,4 +2,8 @@ FactoryBot.define do
   factory :person, traits: [:translated] do
     sequence(:forename) { |index| "George #{index}" }
   end
+
+  factory :pm, parent: :person do
+    slug { "boris-johnson" }
+  end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
   factory :writer, parent: :user, aliases: %i[author creator fact_check_requestor] do
   end
 
+  factory :vip_editor, parent: :user do
+    permissions { [User::Permissions::SIGNIN, User::Permissions::VIP_EDITOR] }
+  end
+
   factory :departmental_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::DEPARTMENTAL_EDITOR] }
   end


### PR DESCRIPTION
We want to limit who can edit certain people. This is a functional start that may be expanded to be more configurable through the UI.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
