### PR TITLE
Add special health authority as an Organisation Type

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -102,7 +102,7 @@ module OrganisationHelper
                       "#{name} is #{relationship}."
                     when "sub-organisation"
                       "#{name} is part of #{parents.to_sentence}."
-                    when "executive non-departmental public body", "advisory non-departmental public body", "tribunal non-departmental public body", "executive agency"
+                    when "executive non-departmental public body", "advisory non-departmental public body", "tribunal non-departmental public body", "executive agency", "special health authority"
                       "#{name} is #{relationship}, sponsored by #{parents.to_sentence}."
                     else
                       "#{name} is #{relationship} of #{parents.to_sentence}."

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -13,6 +13,7 @@ class OrganisationType
     non_ministerial_department: { name: "Non-ministerial department", analytics_prefix: "D", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     other: { name: "Other", analytics_prefix: "OT", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
     public_corporation: { name: "Public corporation", analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    special_health_authority: { name: "Special health authority", analytics_prefix: "SHA", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
     sub_organisation: { name: "Sub-organisation", analytics_prefix: "OT", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     tribunal: { name: "Tribunal", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
   }.freeze
@@ -24,6 +25,7 @@ class OrganisationType
     executive_agency
     executive_ndpb
     advisory_ndpb
+    special_health_authority
     tribunal
     public_corporation
     independent_monitoring_body
@@ -120,6 +122,10 @@ class OrganisationType
     get :court
   end
 
+  def self.special_health_authority
+    get :special_health_authority
+  end
+
   def self.agencies_and_public_bodies
     DATA.select { |_k, v| v[:agency_or_public_body] }
   end
@@ -202,5 +208,9 @@ class OrganisationType
 
   def court?
     key == :court
+  end
+
+  def special_health_authority?
+    key == :special_health_authority
   end
 end

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -1,20 +1,20 @@
 class OrganisationType
   DATA = {
-    executive_office: { name: "Executive office", analytics_prefix: "EO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },
-    ministerial_department: { name: "Ministerial department", analytics_prefix: "D", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    non_ministerial_department: { name: "Non-ministerial department", analytics_prefix: "D", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    executive_agency: { name: "Executive agency",                       analytics_prefix: "EA", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
-    executive_ndpb: { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
-    advisory_ndpb: { name: "Advisory non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
-    tribunal: { name: "Tribunal", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
-    public_corporation: { name: "Public corporation", analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    independent_monitoring_body: { name: "Independent monitoring body", analytics_prefix: "IM", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
     adhoc_advisory_group: { name: "Ad-hoc advisory group", analytics_prefix: "AG", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
-    devolved_administration: { name: "Devolved administration", analytics_prefix: "DA", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    sub_organisation: { name: "Sub-organisation", analytics_prefix: "OT", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    other: { name: "Other", analytics_prefix: "OT", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
+    advisory_ndpb: { name: "Advisory non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
     civil_service: { name: "Civil Service", analytics_prefix: "CS", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },
     court: { name: "Court", analytics_prefix: "CO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    devolved_administration: { name: "Devolved administration", analytics_prefix: "DA", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    executive_agency: { name: "Executive agency", analytics_prefix: "EA", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
+    executive_ndpb: { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
+    executive_office: { name: "Executive office", analytics_prefix: "EO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },
+    independent_monitoring_body: { name: "Independent monitoring body", analytics_prefix: "IM", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
+    ministerial_department: { name: "Ministerial department", analytics_prefix: "D", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    non_ministerial_department: { name: "Non-ministerial department", analytics_prefix: "D", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    other: { name: "Other", analytics_prefix: "OT", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
+    public_corporation: { name: "Public corporation", analytics_prefix: "PC", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    sub_organisation: { name: "Sub-organisation", analytics_prefix: "OT", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    tribunal: { name: "Tribunal", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
   }.freeze
 
   LISTING_ORDER = %i[

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -326,6 +326,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_relationship_type_is_described_as(:executive_agency, "{this_org_name} is an executive agency, sponsored by the {parent_org_name}.")
     assert_relationship_type_is_described_as(:executive_ndpb, "{this_org_name} is an executive non-departmental public body, sponsored by the {parent_org_name}.")
     assert_relationship_type_is_described_as(:advisory_ndpb, "{this_org_name} is an advisory non-departmental public body, sponsored by the {parent_org_name}.")
+    assert_relationship_type_is_described_as(:special_health_authority, "{this_org_name} is a special health authority, sponsored by the {parent_org_name}.")
     assert_relationship_type_is_described_as(:tribunal, "{this_org_name} is a tribunal of the {parent_org_name}.")
     assert_relationship_type_is_described_as(:public_corporation, "{this_org_name} is a public corporation of the {parent_org_name}.")
     assert_relationship_type_is_described_as(:independent_monitoring_body, "{this_org_name} is an independent monitoring body of the {parent_org_name}.")

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -67,6 +67,7 @@ class OrganisationTypeTest < ActiveSupport::TestCase
         executive_agency
         executive_ndpb
         advisory_ndpb
+        special_health_authority
         tribunal
         public_corporation
         independent_monitoring_body

--- a/test/unit/presenters/organisations_index_presenter_test.rb
+++ b/test/unit/presenters/organisations_index_presenter_test.rb
@@ -15,6 +15,7 @@ class OrganisationsIndexPresenterTest < ActiveSupport::TestCase
       adhoc_advisory_group: build(:organisation, organisation_type_key: :adhoc_advisory_group),
       devolved_administration: build(:organisation, organisation_type_key: :devolved_administration),
       other: build(:organisation, organisation_type_key: :other),
+      special_health_authority: build(:organisation, organisation_type_key: :special_health_authority),
     }
   end
 


### PR DESCRIPTION
Allows us to create organisations with the type `Special Health Authority`.

Requires https://github.com/alphagov/govuk-content-schemas/pull/1082 to be merged and deployed first.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/GArvRPWm)