### PR TITLE
Fix return in email signup controller

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -6,7 +6,8 @@ class EmailSignupsController < PublicFacingController
       redirect_to feed_url.sub(".atom", "")
     elsif feed_url.match?(%r{/world/.*\.atom$})
       email_signup = WorldLocationEmailSignup.new(feed_url)
-      head :not_found unless email_signup.valid?
+      return head :not_found unless email_signup.valid?
+
       redirect_to email_alert_frontend_signup_with_slug(email_signup.slug)
     else
       redirect_to "/"

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -57,4 +57,10 @@ class EmailSignupsControllerTest < ActionController::TestCase
 
     assert_redirected_to "http://test.host/"
   end
+
+  view_test "GET :new with an invalid world location feed returns a not found response" do
+    get :new, params: { email_signup: { feed: "http://www.gov.uk/world/does-not-exist.atom" } }
+
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
Where a user attempts to signup to an invalid World Location (e.g. because they have manually changed the URL), we return a not found response.
    
However because the `return` was missing from this line, we then also attempted to redirect them. This redirect called a method that then attempted to retrieve a content ID from a non-existent World Location, resulting in a `NoMethodError` being reported to Sentry.
    
Adding the `return` here solves that problem.  A test has been added for this scenario, which failed before the fix was implemented.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
