### PR TITLE
Remove `merge` from world location signup model

### DIFF
--- a/app/models/world_location_email_signup.rb
+++ b/app/models/world_location_email_signup.rb
@@ -20,12 +20,13 @@ private
 
   def criteria
     {
+      "title" => world_location.name,
       "links" => {
         "world_locations" => [
           world_location.content_id,
         ],
       },
-    }.merge("title" => world_location.name)
+    }
   end
 
   def world_location


### PR DESCRIPTION
We are merging a single value into a hash, which seems to serve no purpose.

Therefore removing the `merge` and just specifying the title in the hash itself.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
