### PR TITLE
Bump Govspeak version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       activemodel (>= 4.2, < 7.0)
       activerecord (>= 4.2, < 7.0)
       request_store (~> 1.0)
-    govspeak (6.7.7)
+    govspeak (6.7.8)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 23)


### PR DESCRIPTION
Bump contains a fix for a publishing bug
(https://github.com/alphagov/govspeak/pull/229).

Zendesk: https://govuk.zendesk.com/agent/tickets/4819383

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
