### PR TITLE
Adds host to unpublishing redirect allow list

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,5 +1,7 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
+  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk].freeze
+
   def validate_each(record, attribute, value)
     unless self.class.matches_gov_uk?(value) || matches_allow_list?(value)
       record.errors.add(attribute, message: failure_message)
@@ -18,7 +20,7 @@ private
 
   def matches_allow_list?(value)
     uri = URI.parse(value)
-    uri.host&.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org")
+    uri.host&.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
   rescue URI::InvalidURIError
     false
   end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -69,6 +69,9 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.nhs.uk/")
     assert unpublishing.valid?
 
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.nationalhighways.co.uk/page")
+    assert unpublishing.valid?
+
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://some.random.site.uk/jelly-justice")
     assert_not unpublishing.valid?
   end


### PR DESCRIPTION
Content request came in from Highways England to enable unpublishing and
redirecting to their website for a document, due to a withdrawn
page causing confusion which needs to be unpublished with a redirect.

This isn't standard practice to redirect to an external host but has
been approved on our end.

Also moves the list of external hosts to a constant as this feels more
appropriate.

Zendesk: https://govuk.zendesk.com/agent/tickets/4803998

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
