### PR TITLE
Refactor non-english html attachment task

### DIFF
--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -1,12 +1,18 @@
 desc "Republish all documents with non-english html attachments"
 task republish_non_english_html_attachments: :environment do
-  HtmlAttachment.where.not(deleted: true)
-  .where.not(locale: "en")
-  .where.not(locale: nil) # HtmlAttachment#sluggable_locale? treats nil locales the same as English
-  .each do |attachment|
+  document_ids = HtmlAttachment.where.not(deleted: true)
+    .where.not(locale: "en")
+    .where.not(locale: nil) # HtmlAttachment#sluggable_locale? treats nil locales the same as English
+    .map { |attachment|
+      attachment.attachable.document.id
+    }.uniq
+
+  puts "#{document_ids.length} items to republish"
+
+  document_ids.each do |document_id|
     PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
       "bulk_republishing",
-      attachment.attachable.document.id,
+      document_id,
       true,
     )
   end


### PR DESCRIPTION
Collect document IDs before executing queue to avoid locking.

https://trello.com/c/3BeDlugo/2761-republish-whitehall-documents-containing-non-english-html-attachments-5