### PR TITLE
Updating Dockerfile with multistage build and streamlining.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 .git
+.gitignore
+Jenkinsfile
+README.md
+CONTRIBUTING.md
 asset-manager-tmp
 attachment-cache
 bulk-upload-zip-file-tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,36 @@
-FROM ruby:2.6.6
-RUN apt-get update -qq && apt-get upgrade -y
-RUN apt-get install -y build-essential nodejs && apt-get clean
-RUN gem install foreman
+# TODO: make this default to govuk-ruby once it's being pushed somewhere public
+# (unless we decide to use Bitnami instead)
+ARG base_image=ruby:2.6.6
 
+FROM $base_image AS builder
 # This image is only intended to be able to run this app in a production RAILS_ENV
-ENV RAILS_ENV production
-
-ENV GOVUK_APP_NAME whitehall
-ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
-ENV PORT 3020
-ENV DATABASE_URL mysql2://root:root@mysql/whitehall_development
-
-ENV APP_HOME /app
-RUN mkdir $APP_HOME
-
-WORKDIR $APP_HOME
-ADD Gemfile* $APP_HOME/
-ADD .ruby-version $APP_HOME/
-RUN bundle config set deployment 'true'
-RUN bundle config set without 'development test'
-RUN bundle install --jobs 4
-
-ADD . $APP_HOME
-
+ENV RAILS_ENV=production
+# TODO: have a separate build image which already contains the build-only deps.
+RUN apt-get update -qy && \
+    apt-get upgrade -y && \
+    apt-get install -y build-essential nodejs
+RUN mkdir /app
+WORKDIR /app
+COPY Gemfile Gemfile.lock .ruby-version /app/
+RUN bundle config set deployment 'true' && \
+    bundle config set without 'development test' && \
+    bundle install --jobs 4 --retry=2
+COPY . /app
+# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=www.gov.uk \
   GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
   bundle exec rake shared_mustache:compile assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck/ready || exit 1
-
-CMD foreman run web
+FROM $base_image
+ENV RAILS_ENV=production GOVUK_APP_NAME=whitehall
+# TODO: include nodejs in the base image (govuk-ruby).
+# TODO: apt-get upgrade in the base image
+RUN apt-get update -qy && \
+    apt-get upgrade -y && \
+    apt-get install -y nodejs
+WORKDIR /app
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app ./
+CMD bundle exec puma

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,11 +119,6 @@ Whitehall::Application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  # Enable JSON-style logging
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new(Rails.root.join("log/#{Rails.env}.json.log"))
-  config.logstasher.suppress_app_log = false
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
This commit streamlines the Whitehall image by installing dependencies etc in a new intermediate builder stage, before copying back the build outputs to the output image.
Please see previous commit for more details: https://github.com/alphagov/publisher/pull/1519

A few  values have been removed such as, Healthcheck, PORT and DATABASE_URL - These are not needed as part of the Build stage.

Adding Puma as part of the commit, given that we want to run Puma in production, we are instead configuring it via govuk_app_config

NodeJS is needed on runtime thus be included.

Enable JSON-style logging has been removed from production.rb, this seems to be old code and unused. Looking in Integration Whitehall EC2 this log file is empty.

https://trello.com/c/ZCL2pDyO/739-package-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
