### PR TITLE
DRY-up the database configuration file

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,15 @@
-development:
+default: &default
   encoding: utf8
   adapter: mysql2
+  variables:
+    sql_mode: TRADITIONAL
+
+development:
+  <<: *default
   database: whitehall_development
   username: whitehall
   password: whitehall
   url: <%= ENV["DATABASE_URL"] %>
-  variables:
-    sql_mode: TRADITIONAL
   # Note that there is also a 'whitehall_fe' user, used
   # by the 'whitehall_frontend' machines. It should have
   # only 'SELECT' privileges on the database.
@@ -15,22 +18,16 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test: &test
-  encoding: utf8
-  adapter: mysql2
+  <<: *default
   database: whitehall_test<%= "_executor_#{ENV['EXECUTOR_NUMBER']}_" if ENV['EXECUTOR_NUMBER']%><%= ENV['TEST_ENV_NUMBER'] %>
   username: whitehall
   password: whitehall
   url: <%= ENV["TEST_DATABASE_URL"] %><%= ENV['TEST_ENV_NUMBER'] if ENV["TEST_DATABASE_URL"] %>
-  variables:
-    sql_mode: TRADITIONAL
 
 production:
-  encoding: utf8
-  adapter: mysql2
+  <<: *default
   database: whitehall_production
   pool: 10
-  variables:
-    sql_mode: TRADITIONAL
 
 cucumber:
   <<: *test


### PR DESCRIPTION
This change moves common config keys into a 'default' block which is reused across the development, test and production database configurations.

This makes it easier to spot configuration that remains the same between different environments, and avoids having to maintain multiple copies of it.

### Rationale for change

I'm soon going to need to apply a new variable to the database connection settings to [fix a bug with MySQL 8.0.27](https://trello.com/c/LNKQ5rmj/). This should only be a temporary workaround which can be removed once the MySQL bug is fixed (scheduled in the next patch release of MySQL).

Ideally I'd be able to configure it in one place and have it apply to all Rails environments.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
