### PR TITLE
Validate locale files as part of a test run

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -390,8 +390,12 @@ ar:
         two:
         zero:
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
+        two:
+        zero:
       national_statistics:
         few:
         many:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -314,6 +314,8 @@ be:
         one: Членства
         other: Членства
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -279,6 +279,7 @@ cs:
         one: Členství
         other: Členství
       modern_slavery_statement:
+        few:
         one:
         other:
       national_statistics:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -392,8 +392,12 @@ cy:
         two:
         zero:
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
+        two:
+        zero:
       national_statistics:
         few:
         many:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -316,8 +316,10 @@ gd:
         other: Staitisticí náisiúnta
         two:
       modern_slavery_statement:
+        few:
         one:
         other:
+        two:
       national_statistics:
         few:
         one: Staitisticí náisiúnta

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -317,6 +317,8 @@ hr:
         one: Članstvo
         other: Članstvo
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -126,232 +126,156 @@ id:
       written_on: 'Ditulis pada:'
     type:
       about:
-        one: Tentang
         other: Tentang
       about_our_services:
-        one: Tentang layanan kami
         other: Tentang layanan kami
       access_and_opening:
-        one: Akses dan buka
         other: Akses dan buka
       accessible_documents_policy:
-        one: Kebijakan dokumen yang dapat diakses
         other: Kebijakan dokumen yang dapat diakses
       alert:
-        one: Peringatan
         other: Peringatan
       announcement:
-        one: Pengumuman
         other: Pengumuman
       authored_article:
-        one: Artikel bersumber
         other: Artikel bersumber
       blog_post:
-        one: Posting blog
         other: Posting blog
       campaign:
-        one: Kampanye
         other: Kampanye
       careers:
-        one: Karier
         other: karier
       case_study:
-        one: Studi kasus
         other: Studi kasus
       closed_consultation:
-        one: Konsultasi tertutup
         other: Konsultasi tertutup
       complaints_procedure:
-        one: Prosedur keluhan
         other: Prosedur keluhan
       consultation:
-        one: Konsultasi
         other: Konsultasi
       consultation_outcome:
-        one: Hasil konsultasi
         other: Hasil konsultasi
       corporate_report:
-        one: Laporan korporat
         other: Laporan korporat
       correspondence:
-        one: Korespondensi
         other: Korespondensi
       decision:
-        one: Keputusan
         other: Keputusan
       detailed_guidance:
-        one: Panduan
         other: Panduan
       document_collection:
-        one: Koleksi
         other: Koleksi
       draft_text:
-        one: Teks rancangan
         other: Teks rancangan
       edition:
-        one: Edisi
         other: Edisi
       edition_with_appointment:
-        one: Edisi dengan penunjukan
         other: Edisi dengan penunjukan
       equality_and_diversity:
-        one: Kesetaraan dan keberagaman
         other: Kesetaraan dan keberagaman
       fatality_notice:
-        one: Pemberitahuan fatalitas
         other: Pemberitahuan fatalitas
       foi_release:
-        one: Rilis FOI
         other: Rilis FOI
       form:
-        one: Formulir
         other: Formulir
       generic_edition:
-        one: Edisi generik
         other: Edisi generik
       government_response:
-        one: Respons pemerintah
         other: Respons pemerintah
       guidance:
-        one: Panduan
         other: Panduan
       impact_assessment:
-        one: Penilaian dampak
         other: Penilaian dampak
       imported:
-        one: diimpor- menunggu jenis
         other: diimpor- menunggu jenis
       independent_report:
-        one: Laporan independen
         other: Laporan independen
       international_treaty:
-        one: Pakta internasional
         other: Pakta internasional
       manual:
-        one: Manual
         other: Manual
       map:
-        one: Peta
         other: Peta
       media_enquiries:
-        one: Pertanyaan media
         other: Pertanyaan media
       membership:
-        one: Keanggotaan
         other: Keanggotaan
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: Statistik Nasional
         other: Statistik Nasional
       news_article:
-        one: Artikel berita
         other: Artikel berita
       news_story:
-        one: Cerita berita
         other: Cerita berita
       nhs_content:
-        one: Konten Layanan Kesehatan Nasional
         other: Konten Layanan Kesehatan Nasional
       notice:
-        one: Pemberitahuan
         other: Pemberitahuan
       official_statistics:
-        one: Statistik Resmi
         other: Statistik Resmi
       open_consultation:
-        one: Konsultasi terbuka
         other: Konsultasi terbuka
       oral_statement:
-        one: Pernyataan lisan kepada Parlemen
         other: Pernyataan lisan kepada Parlemen
       our_energy_use:
-        one: Penggunaan energi kami
         other: Penggunaan energi kami
       our_governance:
-        one: Tata kelola kami
         other: Tata kelola kami
       personal_information_charter:
-        one: Pakta informasi pribadi
         other: Pakta informasi pribadi
       petitions_and_campaigns:
-        one: Petisi dan kampanye
         other: Petisi dan kampanye
       policy_paper:
-        one: Kertas kebijakan
         other: Kertas kebijakan
       press_release:
-        one: Siaran pers
         other: Siaran pers
       procurement:
-        one: Pengadaan
         other: Pengadaan
       promotional:
-        one: Bahan promosi
         other: Bahan promosi
       publication:
-        one: Publikasi
         other: Publikasi
       publication_scheme:
-        one: Skema publikasi
         other: Skema publikasi
       recruitment:
-        one: Perekrutan
         other: Perekrutan
       regulation:
-        one: Regulasi
         other: Regulasi
       research:
-        one: Riset
         other: Riset
       service:
-        one: Layanan
         other: Layanan
       social_media_use:
-        one: Penggunaan media sosial
         other: Penggunaan media sosial
       speaking_notes:
-        one: Catatan bicara
         other: Catatan bicara
       speech:
-        one: Pidato
         other: Pidato
       staff_update:
-        one: Pembaruan staf
         other: Pembaruan staf
       standard:
-        one: Standar
         other: Standar
       statement_to_parliament:
-        one: Pernyataan kepada Parlemen
         other: Pernyataan kepada Parlemen
       statistical_data_set:
-        one: Set data statistik
         other: Set data statistik
       statistics:
-        one: Statistik
         other: Statistik
       statutory_guidance:
-        one: Panduan perundang-undangan
         other: Panduan perundang-undangan
       terms_of_reference:
-        one: Syarat referensi
         other: Syarat referensi
       transcript:
-        one: Transkrip
         other: Transkrip
       transparency:
-        one: Data transparansi
         other: Data transparansi
       welsh_language_scheme:
-        one: Skema bahasa Wales
         other: Skema bahasa Wales
       world_news_story:
-        one: Cerita berita dunia
         other: Cerita berita dunia
       written_statement:
-        one: Pernyataan tertulis kepada Parlemen
         other: Pernyataan tertulis kepada Parlemen
     updated: diperbarui
   document_filters:
@@ -575,10 +499,8 @@ id:
       statistics: Statistik kami
     type:
       international_delegation:
-        one: Delegasi internasional
         other: Delegasi internasional
       world_location:
-        one: Lokasi dunia
         other: Lokasi dunia
   world_news:
     uk_updates_in_country: Pembaruan, berita, dan peristiwa dalam pemerintahan Inggris Raya di %{country}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -126,232 +126,156 @@ ja:
       written_on: 日付：
     type:
       about:
-        one: 概要
         other: 概要
       about_our_services:
-        one: 本サービスについて
         other: 本サービスについて
       access_and_opening:
-        one: アクセスと利用時間
         other: アクセスと利用時間
       accessible_documents_policy:
-        one: 利用可能な文書に関する方針
         other: 利用可能な文書に関する方針
       alert:
-        one: 注意
         other: 注意
       announcement:
-        one: お知らせ
         other: お知らせ
       authored_article:
-        one: 執筆記事
         other: 執筆記事
       blog_post:
-        one: ブログ投稿
         other: ブログ投稿
       campaign:
-        one: キャンペーン
         other: キャンペーン
       careers:
-        one: キャリア
         other: キャリア
       case_study:
-        one: ケーススタディ
         other: ケーススタディ
       closed_consultation:
-        one: 非公開の審議
         other: 非公開の審議
       complaints_procedure:
-        one: 苦情手続き
         other: 苦情手続き
       consultation:
-        one: 審議
         other: 審議
       consultation_outcome:
-        one: 相談結果
         other: 相談結果
       corporate_report:
-        one: 企業報告書
         other: 企業報告書
       correspondence:
-        one: 対応
         other: 対応
       decision:
-        one: 決定事項
         other: 決定事項
       detailed_guidance:
-        one: ガイダンス
         other: ガイダンス
       document_collection:
-        one: コレクション
         other: コレクション
       draft_text:
-        one: 下書きテキスト
         other: 下書きテキスト
       edition:
-        one: 版
         other: 版
       edition_with_appointment:
-        one: 予約ありの版
         other: 予約ありの版
       equality_and_diversity:
-        one: 平等と多様性
         other: 平等と多様性
       fatality_notice:
-        one: 死亡通知
         other: 死亡通知
       foi_release:
-        one: FOI（情報公開）発表
         other: FOI（情報公開）発表
       form:
-        one: フォーム
         other: フォーム
       generic_edition:
-        one: ジェネリック版
         other: ジェネリック版
       government_response:
-        one: 政府の対応
         other: 政府の対応
       guidance:
-        one: ガイダンス
         other: ガイダンス
       impact_assessment:
-        one: 影響評価
         other: 影響評価
       imported:
-        one: インポート済み - 待機中の種別
         other: インポート済み - 待機中の種別
       independent_report:
-        one: 第三者による報告
         other: 第三者による報告
       international_treaty:
-        one: 国際条約
         other: 国際条約
       manual:
-        one: 取扱説明
         other: 取扱説明
       map:
-        one: 地図
         other: 地図
       media_enquiries:
-        one: 報道関係者の問い合わせ
         other: 報道関係者の問い合わせ
       membership:
-        one: メンバーシップ
         other: メンバーシップ
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: 国家統計
         other: 国家統計
       news_article:
-        one: ニュース記事
         other: ニュース記事
       news_story:
-        one: ニュースストーリー
         other: ニュースストーリー
       nhs_content:
-        one: NHSコンテンツ
         other: NHSコンテンツ
       notice:
-        one: 知らせ
         other: 知らせ
       official_statistics:
-        one: 公式統計
         other: 公式統計
       open_consultation:
-        one: 公開審議
         other: 公開審議
       oral_statement:
-        one: 議会への口頭声明
         other: 議会への口頭声明
       our_energy_use:
-        one: エネルギーの使用
         other: エネルギーの使用
       our_governance:
-        one: ガバナンス
         other: ガバナンス
       personal_information_charter:
-        one: 個人情報憲章
         other: 個人情報憲章
       petitions_and_campaigns:
-        one: 請願とキャンペーン
         other: 請願とキャンペーン
       policy_paper:
-        one: 方針書
         other: 方針書
       press_release:
-        one: プレスリリース
         other: プレスリリース
       procurement:
-        one: 調達
         other: 調達
       promotional:
-        one: 販促資料
         other: 販促資料
       publication:
-        one: 出版物
         other: 出版物
       publication_scheme:
-        one: 出版体系
         other: 出版体系
       recruitment:
-        one: 募集
         other: 募集
       regulation:
-        one: 規制
         other: 規則
       research:
-        one: 研究
         other: 研究
       service:
-        one: サービス
         other: サービス
       social_media_use:
-        one: ソーシャルメディアの使用
         other: ソーシャルメディアの使用
       speaking_notes:
-        one: 発言ノート
         other: 発言ノート
       speech:
-        one: スピーチ
         other: スピーチ
       staff_update:
-        one: スタッフの最新情報
         other: スタッフの最新情報
       standard:
-        one: 標準
         other: 標準
       statement_to_parliament:
-        one: 議会への声明
         other: 議会への声明
       statistical_data_set:
-        one: 統計データセット
         other: 統計データセット
       statistics:
-        one: 統計
         other: 統計
       statutory_guidance:
-        one: 法定ガイダンス
         other: 法定ガイダンス
       terms_of_reference:
-        one: 付託条項
         other: 付託条項
       transcript:
-        one: 口述記録
         other: 口述記録
       transparency:
-        one: 透明度データ
         other: 透明度データ
       welsh_language_scheme:
-        one: ウェールズ語体系
         other: ウェールズ語体系
       world_news_story:
-        one: 世界的なニュース記事
         other: 世界的なニュース記事
       written_statement:
-        one: 議会への書面による声明
         other: 議会への書面による声明
     updated: 更新済み
   document_filters:
@@ -575,10 +499,8 @@ ja:
       statistics: 統計
     type:
       international_delegation:
-        one: 国際代表団
         other: 国際代表団
       world_location:
-        one: 世界の場所
         other: 世界の場所
   world_news:
     uk_updates_in_country: "％{country} の英国政府からの更新、ニュース、イベント"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -126,232 +126,156 @@ ko:
       written_on: '작성일시:'
     type:
       about:
-        one: 소개
         other: 소개
       about_our_services:
-        one: 저희 서비스 소개
         other: 저희 서비스 소개
       access_and_opening:
-        one: 액세스 및 운영
         other: 액세스 및 운영
       accessible_documents_policy:
-        one: 액세스 가능한 문서 정책
         other: 액세스 가능한 문서 정책
       alert:
-        one: 알림
         other: 알림
       announcement:
-        one: 공지사항
         other: 공지사항
       authored_article:
-        one: 저작물
         other: 저작물
       blog_post:
-        one: 블로그 포스트
         other: 블로그 포스트
       campaign:
-        one: 캠페인
         other: 캠페인
       careers:
-        one: 커리어
         other: 커리어
       case_study:
-        one: 사례 연구
         other: 사례 연구
       closed_consultation:
-        one: 종결된 상담
         other: 종결된 상담
       complaints_procedure:
-        one: 불만처리절차
         other: 불만처리절차
       consultation:
-        one: 상담
         other: 상담
       consultation_outcome:
-        one: 상담 결과
         other: 상담 결과
       corporate_report:
-        one: 기업 보고서
         other: 기업 보고서
       correspondence:
-        one: 통신
         other: 통신
       decision:
-        one: 판결
         other: 판결
       detailed_guidance:
-        one: 지침
         other: 지침
       document_collection:
-        one: 컬렉션
         other: 컬렉션
       draft_text:
-        one: 초안 텍스트
         other: 초안 텍스트
       edition:
-        one: 에디션
         other: 에디션
       edition_with_appointment:
-        one: 예약판
         other: 예약판
       equality_and_diversity:
-        one: 평등 및 다양성
         other: 평등 및 다양성
       fatality_notice:
-        one: 사망통지서
         other: 사망통지서
       foi_release:
-        one: 였다 공개
         other: 였다 공개
       form:
-        one: 양식
         other: 양식
       generic_edition:
-        one: 일반 에디션
         other: 일반 에디션
       government_response:
-        one: 정부 대응
         other: 정부 대응
       guidance:
-        one: 지침
         other: 지침
       impact_assessment:
-        one: 영향 평가
         other: 영향 평가
       imported:
-        one: 수입 - 대기 유형
         other: 수입 - 대기 유형
       independent_report:
-        one: 독립적 보고서
         other: 독립적 보고서
       international_treaty:
-        one: 국제 조약
         other: 국제 조약
       manual:
-        one: 매뉴얼
         other: 매뉴얼
       map:
-        one: 지도
         other: 지도
       media_enquiries:
-        one: 언론 문의
         other: 언론 문의
       membership:
-        one: 멤버십
         other: 멤버십
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: 국내 통계
         other: 국내 통계
       news_article:
-        one: 뉴스 기사
         other: 뉴스 기사
       news_story:
-        one: 뉴스 스토리
         other: 뉴스 스토리
       nhs_content:
-        one: NHS 콘텐츠
         other: NHS 콘텐츠
       notice:
-        one: 공지
         other: 공지
       official_statistics:
-        one: 공식 통계
         other: 공식 통계
       open_consultation:
-        one: 공개 상담
         other: 공개 상담
       oral_statement:
-        one: 의회로 구두 성명
         other: 의회로 구두 성명
       our_energy_use:
-        one: 저희의 에너지 사용
         other: 저희의 에너지 사용
       our_governance:
-        one: 저희의 거버넌스
         other: 저희의 거버넌스
       personal_information_charter:
-        one: 개인정보 규정
         other: 개인정보 규정
       petitions_and_campaigns:
-        one: 청원 및 캠페인
         other: 청원 및 캠페인
       policy_paper:
-        one: 정책 문서
         other: 정책 문서
       press_release:
-        one: 보도자료
         other: 보도자료
       procurement:
-        one: 조달
         other: 조달
       promotional:
-        one: 홍보 자료
         other: 홍보 자료
       publication:
-        one: 발행
         other: 발행
       publication_scheme:
-        one: 발행 계획
         other: 발행 계획
       recruitment:
-        one: 채용
         other: 채용
       regulation:
-        one: 규제
         other: 규제
       research:
-        one: 연구
         other: 연구
       service:
-        one: 서비스
         other: 서비스
       social_media_use:
-        one: 소셜 미디어 사용
         other: 소셜 미디어 사용
       speaking_notes:
-        one: 연설문 메모
         other: 연설문 메모
       speech:
-        one: 연설문
         other: 연설문
       staff_update:
-        one: 직원 업데이트
         other: 직원 업데이트
       standard:
-        one: 표준
         other: 표준
       statement_to_parliament:
-        one: 의회로 성명
         other: 의회로 성명
       statistical_data_set:
-        one: 통계 데이터 세트
         other: 통계 데이터 세트
       statistics:
-        one: 통계
         other: 통계
       statutory_guidance:
-        one: 법정 지도
         other: 법정 지도
       terms_of_reference:
-        one: 참조 조건
         other: 참조 조건
       transcript:
-        one: 녹취록
         other: 녹취록
       transparency:
-        one: 투명성 데이터
         other: 투명성 데이터
       welsh_language_scheme:
-        one: 웨일스어 계획
         other: 웨일스어 계획
       world_news_story:
-        one: 전세계 뉴스 스토리
         other: 전세계 뉴스 스토리
       written_statement:
-        one: 국회로 서면 성명
         other: 국회로 서면 성명
     updated: 업데이트
   document_filters:
@@ -575,10 +499,8 @@ ko:
       statistics: 통계
     type:
       international_delegation:
-        one: 국제 대표단
         other: 국제 대표단
       world_location:
-        one: 월드 로케이션
         other: 월드 로케이션
   world_news:
     uk_updates_in_country: UK 정부의 %{country} 내 업데이트, 뉴스 및 이벤트

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -278,6 +278,7 @@ lt:
         one: Narystė
         other: Narystė
       modern_slavery_statement:
+        few:
         one:
         other:
       national_statistics:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -127,232 +127,156 @@ ms:
       written_on: 'Ditulis pada:'
     type:
       about:
-        one: Tentang
         other: Tentang
       about_our_services:
-        one: Tentang perkhidmatan kami
         other: Tentang perkhidmatan kami
       access_and_opening:
-        one: Akses dan pembukaan
         other: Akses dan pembukaan
       accessible_documents_policy:
-        one: Dasar dokumen boleh akses
         other: Dasar dokumen boleh akses
       alert:
-        one: Pemberitahuan
         other: Pemberitahuan
       announcement:
-        one: Pengumuman
         other: Pengumuman
       authored_article:
-        one: Artikel ditulis penulis
         other: Artikel ditulis penulis
       blog_post:
-        one: Siaran blog
         other: Siaran blog
       campaign:
-        one: Kempen
         other: Kempen
       careers:
-        one: Kerjaya
         other: kerjaya
       case_study:
-        one: Kajian kes
         other: Kajian kes
       closed_consultation:
-        one: Rundingan tertutup
         other: Rundingan tertutup
       complaints_procedure:
-        one: Prosedur aduan
         other: Prosedur aduan
       consultation:
-        one: Rundingan
         other: Rundingan
       consultation_outcome:
-        one: Hasil rundingan
         other: Hasil rundingan
       corporate_report:
-        one: Laporan korporat
         other: Laporan korporat
       correspondence:
-        one: Perwakilan
         other: Perwakilan
       decision:
-        one: Keputusan
         other: Keputusan
       detailed_guidance:
-        one: Panduan
         other: Panduan
       document_collection:
-        one: Koleksi
         other: Koleksi
       draft_text:
-        one: Teks draf
         other: Teks draf
       edition:
-        one: Suntingan
         other: Suntingan
       edition_with_appointment:
-        one: Disunting dengan perlantikan
         other: Disunting dengan perlantikan
       equality_and_diversity:
-        one: Kesamaan dan kepelbagaian
         other: Kesamaan dan kepelbagaian
       fatality_notice:
-        one: Notis kematian
         other: Notis kematian
       foi_release:
-        one: Hebahan Kebebasan Maklumat (FOI)
         other: Hebahan Kebebasan Maklumat (FOI)
       form:
-        one: Borang
         other: Borang
       generic_edition:
-        one: Suntingan generik
         other: Suntingan generik
       government_response:
-        one: Respons kerajaan
         other: Respons kerajaan
       guidance:
-        one: Panduan
         other: Panduan
       impact_assessment:
-        one: Penilaian Impak
         other: Penilaian Impak
       imported:
-        one: diimport - menunggu jenis
         other: diimport - menunggu jenis
       independent_report:
-        one: Laporan bebas
         other: Laporan bebas
       international_treaty:
-        one: Perjanjian antarabangsa
         other: Perjanjian antarabangsa
       manual:
-        one: Manual
         other: Manual
       map:
-        one: Peta
         other: Peta
       media_enquiries:
-        one: Pertanyaan media
         other: Pertanyaan media
       membership:
-        one: Keanggotaan
         other: Keanggotaan
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: Statistik Nasional
         other: Statistik Nasional
       news_article:
-        one: Artikel berita
         other: Artikel berita
       news_story:
-        one: Berita
         other: Berita
       nhs_content:
-        one: Kandungan Perkhidmatan Kesihatan Nasional (NHS)
         other: Kandungan Perkhidmatan Kesihatan Nasional (NHS)
       notice:
-        one: Notis
         other: Notis
       official_statistics:
-        one: Statistik Rasmi
         other: Statistik Rasmi
       open_consultation:
-        one: Rundingan terbuka
         other: Rundingan terbuka
       oral_statement:
-        one: Kenyataan lisan kepada Parlimen
         other: Kenyataan lisan kepada Parlimen
       our_energy_use:
-        one: Penggunaan tenaga kami
         other: Penggunaan tenaga kami
       our_governance:
-        one: Tadbir urus kami
         other: Tadbir urus kami
       personal_information_charter:
-        one: Carter maklumat peribadi
         other: Carter maklumat peribadi
       petitions_and_campaigns:
-        one: Petisyen dan kempen
         other: Petisyen dan kempen
       policy_paper:
-        one: Kertas dasar
         other: Kertas dasar
       press_release:
-        one: Siaran akhbar
         other: Siaran akhbar
       procurement:
-        one: Perolehan
         other: Perolehan
       promotional:
-        one: Bahan promosi
         other: Bahan promosi
       publication:
-        one: Penerbitan
         other: Penerbitan
       publication_scheme:
-        one: Skema penerbitan
         other: Skema penerbitan
       recruitment:
-        one: Pengambilan
         other: Pengambilan
       regulation:
-        one: Peraturan
         other: Peraturan
       research:
-        one: Penyelidikan
         other: Penyelidikan
       service:
-        one: Perkhidmatan
         other: Perkhidmatan
       social_media_use:
-        one: Penggunaan media sosial
         other: Penggunaan media sosial
       speaking_notes:
-        one: Nota perbincangan
         other: Nota perbincangan
       speech:
-        one: Ucapan
         other: Ucapan
       staff_update:
-        one: Kemas kini kakitangan
         other: Kemas kini kakitangan
       standard:
-        one: Standard
         other: Standard
       statement_to_parliament:
-        one: Kenyataan kepada Parlimen
         other: Kenyataan kepada Parlimen
       statistical_data_set:
-        one: Set data statistik
         other: Set data statistik
       statistics:
-        one: Statistik
         other: Statistik
       statutory_guidance:
-        one: Panduan berkanun
         other: Panduan berkanun
       terms_of_reference:
-        one: Terma rujukan
         other: Terma rujukan
       transcript:
-        one: Transkrip
         other: Transkrip
       transparency:
-        one: Data ketelusan
         other: Data ketelusan
       welsh_language_scheme:
-        one: Skema bahasa Wales
         other: Skema bahasa Wales
       world_news_story:
-        one: Berita seluruh dunia
         other: Berita seluruh dunia
       written_statement:
-        one: Kenyataan bertulis kepada Parlimen
         other: Kenyataan bertulis kepada Parlimen
     updated: dikemas kini
   document_filters:
@@ -576,10 +500,8 @@ ms:
       statistics: Statistik kami
     type:
       international_delegation:
-        one: Perwakilan antarabangsa
         other: Perwakilan antarabangsa
       world_location:
-        one: Lokasi dunia
         other: Lokasi dunia
   world_news:
     uk_updates_in_country: Kemas kini, berita dan peristiwa daripada kerajaan UK di %{country}

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -314,6 +314,8 @@ mt:
         one: Sħubija
         other: Sħubija
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -314,6 +314,8 @@ pl:
         one: Członkostwo
         other: Członkostwo
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,1 +1,9 @@
-GovukI18n.plurals
+GovukI18n.plurals.merge(
+  {
+    az: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+    fa: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+    ka: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+    tr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+    vi: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  },
+)

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -278,6 +278,7 @@ ro:
         one: Abonament
         other: Abonament
       modern_slavery_statement:
+        few:
         one:
         other:
       national_statistics:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -314,6 +314,8 @@ ru:
         one: Членство
         other: Членство
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -279,6 +279,7 @@ sk:
         one: Členstvo
         other: Členstvo
       modern_slavery_statement:
+        few:
         one:
         other:
       national_statistics:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -317,8 +317,10 @@ sl:
         other: Članstvo
         two:
       modern_slavery_statement:
+        few:
         one:
         other:
+        two:
       national_statistics:
         few:
         one: Državna statistika

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -317,6 +317,8 @@ sr:
         one: Članstvo
         other: Članstvo
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -126,232 +126,156 @@ th:
       written_on: 'เขียนเมื่อ:'
     type:
       about:
-        one: เกี่ยวกับ
         other: เกี่ยวกับ
       about_our_services:
-        one: เกี่ยวกับบริการของเรา
         other: เกี่ยวกับบริการของเรา
       access_and_opening:
-        one: การเข้าถึงและเวลาเปิด
         other: การเข้าถึงและเวลาเปิด
       accessible_documents_policy:
-        one: นโยบายเอกสารที่เข้าถึงได้
         other: นโยบายเอกสารที่เข้าถึงได้
       alert:
-        one: การเตือน
         other: การเตือน
       announcement:
-        one: ประกาศ
         other: ประกาศ
       authored_article:
-        one: บทความที่มีผู้เขียน
         other: บทความที่มีผู้เขียน
       blog_post:
-        one: โพสต์บล็อก
         other: โพสต์บล็อก
       campaign:
-        one: การรณรงค์
         other: การรณรงค์
       careers:
-        one: อาชีพ
         other: อาชีพ
       case_study:
-        one: กรณีศึกษา
         other: กรณีศึกษา
       closed_consultation:
-        one: การให้คำปรึกษาที่ปิดแล้ว
         other: การให้คำปรึกษาที่ปิดแล้ว
       complaints_procedure:
-        one: ขั้นตอนการร้องเรียน
         other: ขั้นตอนการร้องเรียน
       consultation:
-        one: การให้คำปรึกษา
         other: การให้คำปรึกษา
       consultation_outcome:
-        one: ผลลัพธ์จากการให้คำปรึกษา
         other: ผลลัพธ์จากการให้คำปรึกษา
       corporate_report:
-        one: รายงานของบริษัท
         other: รายงานของบริษัท
       correspondence:
-        one: จดหมายโต้ตอบ
         other: จดหมายโต้ตอบ
       decision:
-        one: การตัดสินใจ
         other: การตัดสินใจ
       detailed_guidance:
-        one: คำแนะนำ
         other: คำแนะนำ
       document_collection:
-        one: คอลเล็กชั่น
         other: คอลเล็กชั่น
       draft_text:
-        one: ข้อความร่าง
         other: ข้อความร่าง
       edition:
-        one: ฉบับ
         other: ฉบับ
       edition_with_appointment:
-        one: ฉบับที่มีการนัดหมาย
         other: ฉบับที่มีการนัดหมาย
       equality_and_diversity:
-        one: ความเสมอภาคและความหลากหลาย
         other: ความเสมอภาคและความหลากหลาย
       fatality_notice:
-        one: การแจ้งตาย
         other: การแจ้งตาย
       foi_release:
-        one: การออก FOI
         other: การออก FOI
       form:
-        one: แบบฟอร์ม
         other: แบบฟอร์ม
       generic_edition:
-        one: ฉบับทั่วไป
         other: ฉบับทั่วไป
       government_response:
-        one: คำตอบของรัฐบาล
         other: คำตอบของรัฐบาล
       guidance:
-        one: คำแนะนำ
         other: คำแนะนำ
       impact_assessment:
-        one: การประเมินผลกระทบ
         other: การประเมินผลกระทบ
       imported:
-        one: นำเข้าแล้ว - รอการพิมพ์
         other: นำเข้าแล้ว - รอการพิมพ์
       independent_report:
-        one: รายงานอิสระ
         other: รายงานอิสระ
       international_treaty:
-        one: สนธิสัญญาระหว่างประเทศ
         other: สนธิสัญญาระหว่างประเทศ
       manual:
-        one: กำหนดเอง
         other: คู่มือ
       map:
-        one: แผนที่
         other: แผนที่
       media_enquiries:
-        one: คำถามจากสื่อมวลชน
         other: คำถามจากสื่อมวลชน
       membership:
-        one: สมาชิก
         other: สมาชิก
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: สถิติแห่งชาติ
         other: สถิติแห่งชาติ
       news_article:
-        one: บทความข่าว
         other: บทความข่าว
       news_story:
-        one: เนื้อหาข่าว
         other: เนื้อหาข่าว
       nhs_content:
-        one: เนื้อหาของ NHS
         other: เนื้อหาของ NHS
       notice:
-        one: ประกาศ
         other: ประกาศ
       official_statistics:
-        one: สถิติของราชการ
         other: สถิติของราชการ
       open_consultation:
-        one: การให้คำปรึกษาที่เปิดอยู่
         other: การให้คำปรึกษาที่เปิดอยู่
       oral_statement:
-        one: แถลงการณ์ด้วยวาจาต่อรัฐสภา
         other: แถลงการณ์ด้วยวาจาต่อรัฐสภา
       our_energy_use:
-        one: การใช้พลังงานของเรา
         other: การใช้พลังงานของเรา
       our_governance:
-        one: ธรรมาภิบาลของเรา
         other: ธรรมาภิบาลของเรา
       personal_information_charter:
-        one: กฎบัตรข้อมูลส่วนบุคคล
         other: กฎบัตรข้อมูลส่วนบุคคล
       petitions_and_campaigns:
-        one: การเข้าชื่อและการรณรงค์
         other: การเข้าชื่อและการรณรงค์
       policy_paper:
-        one: เอกสารนโยบาย
         other: เอกสารนโยบาย
       press_release:
-        one: ข่าวประชาสัมพันธ์
         other: ข่าวประชาสัมพันธ์
       procurement:
-        one: การจัดซื้อจัดจ้าง
         other: การจัดซื้อจัดจ้าง
       promotional:
-        one: สื่อวัสดุส่งเสริมการขาย
         other: สื่อวัสดุส่งเสริมการขาย
       publication:
-        one: สิ่งพิมพ์
         other: สิ่งพิมพ์
       publication_scheme:
-        one: โครงการสิ่งพิมพ์
         other: โครงการสิ่งพิมพ์
       recruitment:
-        one: การสรรหา
         other: การสรรหา
       regulation:
-        one: ระเบียบข้อบังคับ
         other: ระเบียบข้อบังคับ
       research:
-        one: การวิจัย
         other: การวิจัย
       service:
-        one: บริการ
         other: บริการ
       social_media_use:
-        one: การใช้โซเชียลมีเดีย
         other: การใช้โซเชียลมีเดีย
       speaking_notes:
-        one: บันทึกสุนทรพจน์
         other: บันทึกสุนทรพจน์
       speech:
-        one: สุนทรพจน์
         other: สุนทรพจน์
       staff_update:
-        one: ข่าวสารพนักงาน
         other: ข่าวสารพนักงาน
       standard:
-        one: มาตรฐาน
         other: มาตรฐาน
       statement_to_parliament:
-        one: แถลงการณ์ต่อรัฐสภา
         other: แถลงการณ์ต่อรัฐสภา
       statistical_data_set:
-        one: ชุดข้อมูลสถิติ
         other: ชุดข้อมูลสถิติ
       statistics:
-        one: สถิติ
         other: สถิติ
       statutory_guidance:
-        one: คำแนะนำทางกฎหมาย
         other: คำแนะนำทางกฎหมาย
       terms_of_reference:
-        one: เงื่อนไขการอ้างอิง
         other: เงื่อนไขการอ้างอิง
       transcript:
-        one: การถอดเสียง
         other: การถอดเสียง
       transparency:
-        one: ข้อมูลความโปร่งใส
         other: ข้อมูลความโปร่งใส
       welsh_language_scheme:
-        one: โครงการภาษาเวลส์
         other: โครงการภาษาเวลส์
       world_news_story:
-        one: ข่าวสารทั่วโลก
         other: ข่าวสารทั่วโลก
       written_statement:
-        one: แถลงการณ์เป็นลายลักษณ์อักษรต่อรัฐสภา
         other: แถลงการณ์เป็นลายลักษณ์อักษรต่อรัฐสภา
     updated: อัปเดตแล้ว
   document_filters:
@@ -575,10 +499,8 @@ th:
       statistics: สถิติของเรา
     type:
       international_delegation:
-        one: คณะผู้แทนระหว่างประเทศ
         other: คณะผู้แทนระหว่างประเทศ
       world_location:
-        one: สถานที่ทั่วโลก
         other: สถานที่ทั่วโลก
   world_news:
     uk_updates_in_country: อัปเดต ข่าวสาร และกิจกรรมจากรัฐบาลสหราชอาณาจักรใน %{country}

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -316,6 +316,8 @@ uk:
         one: Членство
         other: Членство
       modern_slavery_statement:
+        few:
+        many:
         one:
         other:
       national_statistics:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -126,232 +126,156 @@ zh:
       written_on: 书写日期：
     type:
       about:
-        one: 约
         other: 约
       about_our_services:
-        one: 关于我们的服务
         other: 关于我们的服务
       access_and_opening:
-        one: 访问和打开
         other: 访问和打开
       accessible_documents_policy:
-        one: 可获取的文件政策
         other: 可获取的文件政策
       alert:
-        one: 警告
         other: 警告
       announcement:
-        one: 公告
         other: 公告
       authored_article:
-        one: 撰写文章
         other: 撰写文章
       blog_post:
-        one: 博客帖子
         other: 博客帖子
       campaign:
-        one: 活动
         other: 活动
       careers:
-        one: 招聘
         other: 招聘
       case_study:
-        one: 案例研究
         other: 案例研究
       closed_consultation:
-        one: 封闭咨询
         other: 封闭咨询
       complaints_procedure:
-        one: 投诉程序
         other: 投诉程序
       consultation:
-        one: 咨询
         other: 咨询
       consultation_outcome:
-        one: 咨询结果
         other: 咨询结果
       corporate_report:
-        one: 公司报告
         other: 公司报告
       correspondence:
-        one: 通信
         other: 通信
       decision:
-        one: 决策
         other: 决策
       detailed_guidance:
-        one: 指南
         other: 指南
       document_collection:
-        one: 待整理
         other: 待整理
       draft_text:
-        one: 草拟文本
         other: 草拟文本
       edition:
-        one: 功能版本
         other: 功能版本
       edition_with_appointment:
-        one: 版本和任命
         other: 版本和任命
       equality_and_diversity:
-        one: 平等和多样性
         other: 平等和多样性
       fatality_notice:
-        one: 死亡通知
         other: 死亡通知
       foi_release:
-        one: FOI 发布
         other: FOI 发布
       form:
-        one: 表格
         other: 表格
       generic_edition:
-        one: 通用版本
         other: 通用版本
       government_response:
-        one: 政府回应
         other: 政府回应
       guidance:
-        one: 指南
         other: 指南
       impact_assessment:
-        one: 影响评估
         other: 影响评估
       imported:
-        one: 进口-等待型
         other: 进口-等待型
       independent_report:
-        one: 独立报告
         other: 独立报告
       international_treaty:
-        one: 国际条约
         other: 国际条约
       manual:
-        one: 手册
         other: 手册
       map:
-        one: 地图
         other: 地图
       media_enquiries:
-        one: 媒体疑问
         other: 媒体疑问
       membership:
-        one: 会员身份
         other: 会员身份
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: 国家统计局
         other: 国家统计局
       news_article:
-        one: 新闻报道
         other: 新闻报道
       news_story:
-        one: 新闻故事
         other: 新闻故事
       nhs_content:
-        one: NHS内容
         other: NHS内容
       notice:
-        one: 通知
         other: 通知
       official_statistics:
-        one: 官方统计
         other: 官方统计
       open_consultation:
-        one: 公开协商
         other: 公开协商
       oral_statement:
-        one: 议会口头声明
         other: 议会口头声明
       our_energy_use:
-        one: 我们的能源使用
         other: 我们的能源使用
       our_governance:
-        one: 我们的治理
         other: 我们的治理
       personal_information_charter:
-        one: 个人信息宪章
         other: 个人信息宪章
       petitions_and_campaigns:
-        one: 请愿书和活动
         other: 请愿书和活动
       policy_paper:
-        one: 政策文件
         other: 政策文件
       press_release:
-        one: 新闻稿
         other: 新闻稿
       procurement:
-        one: 采购
         other: 采购
       promotional:
-        one: 宣传资料
         other: 宣传资料
       publication:
-        one: 公布
         other: 公布
       publication_scheme:
-        one: 发布计划
         other: 发布计划
       recruitment:
-        one: 招聘
         other: 招聘
       regulation:
-        one: 条例
         other: 条例
       research:
-        one: 研究
         other: 研究
       service:
-        one: 服务
         other: 服务
       social_media_use:
-        one: 社交媒体使用
         other: 社交媒体使用
       speaking_notes:
-        one: 发言讲稿
         other: 发言讲稿
       speech:
-        one: 演讲
         other: 演讲
       staff_update:
-        one: 员工最新消息
         other: 员工最新消息
       standard:
-        one: 标准
         other: 标准
       statement_to_parliament:
-        one: 议会声明
         other: 议会声明
       statistical_data_set:
-        one: 统计数据集
         other: 统计数据集
       statistics:
-        one: 统计数据
         other: 统计数据
       statutory_guidance:
-        one: 法定指南
         other: 法定指南
       terms_of_reference:
-        one: 职责范围
         other: 职责范围
       transcript:
-        one: 文字记录
         other: 文字记录
       transparency:
-        one: 透明度数据
         other: 透明度数据
       welsh_language_scheme:
-        one: 威尔士语言计划
         other: 威尔士语言计划
       world_news_story:
-        one: 世界新闻故事
         other: 世界新闻故事
       written_statement:
-        one: 议会口头声明
         other: 议会口头声明
     updated: 已更新
   document_filters:
@@ -575,10 +499,8 @@ zh:
       statistics: 我们的统计数据
     type:
       international_delegation:
-        one: 国际代表处
         other: 国际代表处
       world_location:
-        one: 世界地点
         other: 世界地点
   world_news:
     uk_updates_in_country: 英国政府在 %{country} 的更新、新闻和事件

--- a/test/unit/locales_validation_test.rb
+++ b/test/unit/locales_validation_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class LocalesValidationTest < ActiveSupport::TestCase
+  test "should validate all locale files" do
+    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml")
+    assert checker.validate_locales
+  end
+end


### PR DESCRIPTION
Adds a test that calls the RTM `LocaleChecker`, and aligns the locale files with the pluralisation rules in order to make this test past.

Where the pluralisation rule says only plural should exist, and the    singular and plural are identical, the singular has been removed; if    this is incorrect for a given language it would require a translator to    fix anyway: `id`, `ja`, `ko`, `ms`, `th`, `zh`.

However where the singular and plural forms are different, to err on the    side of caution the pluralisation rules have been updated rather than    deleting translations in order to make the tests pass: `az`, `fa`, `ka`, `tr`.

For Vietnamese, though most of the singulars are identical to the    plurals, a small number are different; so again, I've chosen to err on    the side of caution and update the pluralisation rules.

For some blank translations, it's also been necessary to add some extra blank entries (for languages that have more than just `:one` and    `:other` forms): `ar`, `be`, `cs`, `cy`, `gd`, `hr`, `lt`, `mt`, `pl`, `ro`, `ru`, `sk`, `sl`, `sr`, `uk`.

A small number of singulars have been deleted that appeared to be either    errors, or differing only by capitalisation from the plural.


https://trello.com/c/pPw5e9me/2828-apply-locale-file-validation-to-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
