### PR TITLE
Revert plurals overrides

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,9 +1,1 @@
-GovukI18n.plurals.merge(
-  {
-    az: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
-    fa: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
-    ka: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
-    tr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
-    vi: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
-  },
-)
+GovukI18n.plurals

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -126,232 +126,156 @@ vi:
       written_on: 'Ngày viết:'
     type:
       about:
-        one: Giới thiệu
         other: Giới thiệu
       about_our_services:
-        one: Giới thiệu về các dịch vụ của chúng tôi
         other: Giới thiệu về các dịch vụ của chúng tôi
       access_and_opening:
-        one: Làm việc và mở cửa
         other: Làm việc và mở cửa
       accessible_documents_policy:
-        one: Chính sách tài liệu có thể truy cập
         other: Chính sách tài liệu có thể truy cập
       alert:
-        one: Cảnh báo
         other: Cảnh báo
       announcement:
-        one: Thông báo
         other: Thông báo
       authored_article:
-        one: Bài viết có tác giả
         other: Bài viết có tác giả
       blog_post:
-        one: Bài viết trên blog
         other: Bài viết trên blog
       campaign:
-        one: Chiến dịch
         other: Chiến dịch
       careers:
-        one: Nghề nghiệp
         other: nghề nghiệp
       case_study:
-        one: Nghiên cứu điển hình
         other: Nghiên cứu điển hình
       closed_consultation:
-        one: Tham vấn kín
         other: Tham vấn kín
       complaints_procedure:
-        one: Thủ tục khiếu nại
         other: Thủ tục khiếu nại
       consultation:
-        one: Tham vấn
         other: Tham vấn
       consultation_outcome:
-        one: Kết quả tham vấn
         other: Kết quả tham vấn
       corporate_report:
-        one: Báo cáo của doanh nghiệp
         other: Báo cáo của doanh nghiệp
       correspondence:
-        one: Thư từ
         other: Thư từ
       decision:
-        one: Quyết định
         other: Quyết định
       detailed_guidance:
-        one: Hướng dẫn
         other: Hướng dẫn
       document_collection:
-        one: Bộ sưu tập
         other: Bộ sưu tập
       draft_text:
-        one: Dự thảo
         other: Dự thảo
       edition:
-        one: Phiên bản
         other: Phiên bản
       edition_with_appointment:
-        one: Phiên bản có cuộc hẹn
         other: Phiên bản có cuộc hẹn
       equality_and_diversity:
-        one: Bình đẳng và đa dạng
         other: Bình đẳng và đa dạng
       fatality_notice:
-        one: Thông báo tử vong
         other: Thông báo tử vong
       foi_release:
-        one: Công bố FOI
         other: Công bố FOI
       form:
-        one: Biểu mẫu
         other: Biểu mẫu
       generic_edition:
-        one: Phiên bản chung
         other: Phiên bản chung
       government_response:
-        one: Phản hồi của chính phủ
         other: Phản hồi của chính phủ
       guidance:
-        one: Hướng dẫn
         other: Hướng dẫn
       impact_assessment:
-        one: Đánh giá tác động
         other: Đánh giá tác động
       imported:
-        one: loại đã nhập - đang chờ
         other: loại đã nhập - đang chờ
       independent_report:
-        one: Báo cáo độc lập
         other: Báo cáo độc lập
       international_treaty:
-        one: Hiệp ước quốc tế
         other: Hiệp ước quốc tế
       manual:
-        one: Hướng dẫn sử dụng
         other: Hướng dẫn sử dụng
       map:
-        one: Bản đồ
         other: Bản đồ
       media_enquiries:
-        one: Yêu cầu truyền thông
         other: Yêu cầu truyền thông
       membership:
-        one: Tư cách thành viên
         other: Tư cách thành viên
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: Thống kê Quốc gia
         other: Thống kê Quốc gia
       news_article:
-        one: Bài báo
         other: Bài viết thời sự
       news_story:
-        one: Bài phóng sự
         other: Bài phóng sự
       nhs_content:
-        one: Nội dung Dịch vụ Y tế Quốc gia
         other: Nội dung Dịch vụ Y tế Quốc gia
       notice:
-        one: Thông báo
         other: Thông báo
       official_statistics:
-        one: Thống kê Chính thức
         other: Thống kê Chính thức
       open_consultation:
-        one: Tham vấn mở
         other: Tham vấn mở
       oral_statement:
-        one: Tuyên bố bằng lời trước Quốc hội
         other: Tuyên bố bằng lời trước Quốc hội
       our_energy_use:
-        one: Mức sử dụng năng lượng của chúng tôi
         other: Mức sử dụng năng lượng của chúng tôi
       our_governance:
-        one: Cách quản trị của chúng tôi
         other: Cách quản trị của chúng tôi
       personal_information_charter:
-        one: Điều lệ thông tin cá nhân
         other: Điều lệ thông tin cá nhân
       petitions_and_campaigns:
-        one: Kiến nghị và chiến dịch
         other: Kiến nghị và chiến dịch
       policy_paper:
-        one: Tài liệu chính sách
         other: Tài liệu chính sách
       press_release:
-        one: Thông cáo báo chí
         other: Thông cáo báo chí
       procurement:
-        one: Mua sắm
         other: Mua sắm
       promotional:
-        one: Tài liệu quảng cáo
         other: Tài liệu quảng cáo
       publication:
-        one: Ấn phẩm
         other: Ấn phẩm
       publication_scheme:
-        one: Kế hoạch xuất bản
         other: Kế hoạch xuất bản
       recruitment:
-        one: Tuyển dụng
         other: Tuyển dụng
       regulation:
-        one: Quy định
         other: Quy định
       research:
-        one: Nghiên cứu
         other: Nghiên cứu
       service:
-        one: Dịch vụ
         other: Dịch vụ
       social_media_use:
-        one: Sử dụng mạng xã hội
         other: Sử dụng mạng xã hội
       speaking_notes:
-        one: Ghi chú cho bài nói
         other: Ghi chú cho bài nói
       speech:
-        one: Bài phát biểu
         other: Bài phát biểu
       staff_update:
-        one: Cập nhật của nhân viên
         other: Cập nhật của nhân viên
       standard:
-        one: Tiêu chuẩn
         other: Tiêu chuẩn
       statement_to_parliament:
-        one: Tuyên bố trước Quốc hội
         other: Tuyên bố trước Quốc hội
       statistical_data_set:
-        one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
       statistics:
-        one: Thống kê
         other: Thống kê
       statutory_guidance:
-        one: Hướng dẫn theo luật định
         other: Hướng dẫn theo luật định
       terms_of_reference:
-        one: Điều khoản tham chiếu
         other: Điều khoản tham chiếu
       transcript:
-        one: Bản ghi nội dung
         other: Bản ghi nội dung
       transparency:
-        one: Dữ liệu về tính minh bạch
         other: Dữ liệu về tính minh bạch
       welsh_language_scheme:
-        one: Kế hoạch ngôn ngữ xứ Wales
         other: Lược đồ ngôn ngữ xứ Wales
       world_news_story:
-        one: Bài phóng sự trên toàn thế giới
         other: Bài phóng sự trên toàn thế giới
       written_statement:
-        one: Tuyên bố bằng văn bản trước Quốc hội
         other: Tuyên bố bằng văn bản trước Quốc hội
     updated: đã cập nhật
   document_filters:
@@ -575,10 +499,8 @@ vi:
       statistics: Thống kê của chúng tôi
     type:
       international_delegation:
-        one: Phái đoàn quốc tế
         other: Phái đoàn quốc tế
       world_location:
-        one: Vị trí trên thế giới
         other: Các vị trí trên thế giới
   world_news:
     uk_updates_in_country: Cập nhật, tin tức và sự kiện từ chính phủ Vương quốc Anh tại %{country}


### PR DESCRIPTION
This is now done in govuk_app_config (https://github.com/alphagov/govuk_app_config/pull/219)

Also removes the duplicates in the Vietnamese translation, because alphagov/government-frontend#2343 and [the unicode documentation](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html) have helped to clarify that this is the right choice.

Depends on #6418

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
