### PR TITLE
Add contextual copy to World page

### DIFF
--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -8,6 +8,8 @@
         title: sanitize("Help and services around the&nbsp;world")
       } %>
 
+      <p class="govuk-body">Find out what is help is available from the UK government if you're abroad.</p>
+
       <form class="js-filter-form">
         <%= render "govuk_publishing_components/components/input", {
           label: {
@@ -56,6 +58,9 @@
       </div>
     </section>
   <% end %>
+
+  <p class="govuk-body">See the complete <a href="/government/publications/list-of-foreign-office-posts">list of overseas Foreign, Commonwealth & Development Office posts</a>. This includes all embassies, high commissions and consulates.</p>
+
   <div class="js-filter-no-results">
     <p class="govuk-body"><%= t("document_filters.world_locations.no_locations_filter") %></p>
   </div>

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -8,7 +8,7 @@
         title: sanitize("Help and services around the&nbsp;world")
       } %>
 
-      <p class="govuk-body">Find out what is help is available from the UK government if you're abroad.</p>
+      <p class="govuk-body"><%= t('world_location.content.find_out') %></p>
 
       <form class="js-filter-form">
         <%= render "govuk_publishing_components/components/input", {
@@ -59,7 +59,7 @@
     </section>
   <% end %>
 
-  <p class="govuk-body">See the complete <a href="/government/publications/list-of-foreign-office-posts">list of overseas Foreign, Commonwealth & Development Office posts</a>. This includes all embassies, high commissions and consulates.</p>
+  <p class="govuk-body"><%= t('world_location.content.complete_list', href: link_to(t('world_location.content.list_link'), "/government/publications/list-of-foreign-office-posts", class: "govuk-link")).html_safe %></p>
 
   <div class="js-filter-no-results">
     <p class="govuk-body"><%= t("document_filters.world_locations.no_locations_filter") %></p>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -865,6 +865,10 @@ ar:
       unboxed:
       war_memorials_trust: صندوق النصب التذكاري للحرب
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: إعلاناتنا
       documents: المستندات

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -564,6 +564,10 @@ az:
       unboxed:
       war_memorials_trust: Müharibədə həlak olanların xatirəsini qoruma tresti
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Elanlarımız
       documents: Sənədlər

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -713,6 +713,10 @@ be:
       unboxed:
       war_memorials_trust: Фонд ваенных мемарыялаў
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Нашы аб'явы
       documents: Дакументы

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -563,6 +563,10 @@ bg:
       unboxed:
       war_memorials_trust: Тръст за военните паметници
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Нашите съобщения
       documents: Документи

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -563,6 +563,10 @@ bn:
       unboxed:
       war_memorials_trust: ইম্পেরিয়াল ওয়ার মিউজিয়াম
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: আমাদের ঘোষণাসমূহ
       documents: নথিপত্র

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -640,6 +640,10 @@ cs:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Naše oznámení
       documents: Dokumenty

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -867,6 +867,10 @@ cy:
       unboxed:
       war_memorials_trust: Ymddiriedaeth Cofebion Rhyfel
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Ein cyhoeddiadau
       documents: Dogfennau

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -564,6 +564,10 @@ da:
       unboxed:
       war_memorials_trust: Krigsmindesmærker stoler på
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Vores meddelelser
       documents: Dokumenter

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -563,6 +563,10 @@ de:
       unboxed:
       war_memorials_trust: Treuhandgesellschaft für Kriegsdenkmäler
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Unsere Ankündigungen
       documents: Dokumente

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -568,6 +568,10 @@ dr:
       unboxed:
       war_memorials_trust: امانت یادبود هایی جنگ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: اطلاعیه هایی ما
       documents: اسناد

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -563,6 +563,10 @@ el:
       unboxed:
       war_memorials_trust: Ταμείο War Trust Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Οι ανακοινώσεις μας
       documents: Έγγραφα

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -574,6 +574,10 @@ en:
       publications: Our publications
       search: Search by country or territory
       statistics: Our statistics
+    content:
+      find_out: Find out what is help is available from the UK government if you're abroad.
+      complete_list: See the complete %{href}. This includes all embassies, high commissions and consulates.
+      list_link: list of overseas Foreign, Commonwealth & Development Office posts
     type:
       international_delegation:
         one: International delegation

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -564,6 +564,10 @@ es-419:
       unboxed:
       war_memorials_trust: Fondo de Monumentos de Guerra
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Nuestros comunicados
       documents: Documentos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -561,6 +561,10 @@ es:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Nuestros anuncios
       documents: Documentos

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -563,6 +563,10 @@ et:
       unboxed:
       war_memorials_trust: Sõjamälestiste volikogu
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Meie teadaanded
       documents: Dokumendid

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -563,6 +563,10 @@ fa:
       unboxed:
       war_memorials_trust: بنیاد یادبودهای جنگ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: اطلاعیه‌های ما
       documents: اسناد

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -564,6 +564,10 @@ fi:
       unboxed:
       war_memorials_trust: Sotamuistomerkit Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Ilmoituksemme
       documents: Asiakirjat

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -564,6 +564,10 @@ fr:
       unboxed:
       war_memorials_trust: Fiducie des monuments commémoratifs de guerre
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Nos annonces
       documents: Documents

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -715,6 +715,10 @@ gd:
       unboxed:
       war_memorials_trust: Fondúireacht cuimhneacháin cogaidh
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Ár liostaí
       documents: Doiciméid

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -563,6 +563,10 @@ gu:
       unboxed:
       war_memorials_trust: વોર મેમોરિયલ્સ ટ્રસ્ટ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: અમારી જાહેરાતો
       documents: દસ્તાવેજો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -564,6 +564,10 @@ he:
       unboxed:
       war_memorials_trust: אמון זיכרון המלחמה
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ההודעות שלנו
       documents: מסמכים

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -564,6 +564,10 @@ hi:
       unboxed:
       war_memorials_trust: वार मेमोरियल ट्रस्ट
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: हमारी घोषणाएं
       documents: दस्तावेज़

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -716,6 +716,10 @@ hr:
       unboxed:
       war_memorials_trust: Zaklada za ratne spomenice
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Naše obavijesti
       documents: Dokumenti

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -563,6 +563,10 @@ hu:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Híreink
       documents: Dokumentumok

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -564,6 +564,10 @@ hy:
       unboxed:
       war_memorials_trust: Պատերազմական հուշահամալիրների հավատարմագրում (War Memorials Trust)
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Մեր հայտարարությունները
       documents: Փաստաթղթեր

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -487,6 +487,10 @@ id:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Pengumuman kami
       documents: Dokumen

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -563,6 +563,10 @@ is:
       unboxed:
       war_memorials_trust: Stríðsminnisvarða Ráðstöfun
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Okkar tilkynningar
       documents: Skjöl

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -564,6 +564,10 @@ it:
       unboxed:
       war_memorials_trust: Fiducia dei memoriali di guerra
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: I nostri annunci
       documents: Documenti

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -487,6 +487,10 @@ ja:
       unboxed:
       war_memorials_trust: 戦争記念トラスト
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: お知らせ
       documents: ドキュメント

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -564,6 +564,10 @@ ka:
       unboxed:
       war_memorials_trust: ომის მემორიალების ნდობა
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ჩვენი განცხადებები
       documents: დოკუმენტები

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -563,6 +563,10 @@ kk:
       unboxed:
       war_memorials_trust: Соғыс мемориалдарының сенімі
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Біздің хабарландыруларымыз
       documents: Құжаттар

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -487,6 +487,10 @@ ko:
       unboxed:
       war_memorials_trust: 전쟁기념관 신탁
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: 공지사항
       documents: 자료

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -639,6 +639,10 @@ lt:
       unboxed:
       war_memorials_trust: Karo memorialinis patikos fondas
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Mūsų skelbimai
       documents: Dokumentai

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -561,6 +561,10 @@ lv:
       unboxed:
       war_memorials_trust: Kara memoriālu trasts
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Paziņojumi
       documents: Dokumenti

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -488,6 +488,10 @@ ms:
       unboxed:
       war_memorials_trust: Amanah Peringatan Perang
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Pengumuman kami
       documents: Dokumen

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -713,6 +713,10 @@ mt:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: L-avviżi tagħna
       documents: Dokumenti

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -563,6 +563,10 @@ ne:
       unboxed:
       war_memorials_trust: युद्ध स्मारक ट्रस्ट
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: हाम्रा घोषणाहरु
       documents: कागजातहरु

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -561,6 +561,10 @@ nl:
       unboxed:
       war_memorials_trust: Oorlogsmonumenten Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Onze aankondigingen
       documents: Documenten

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -564,6 +564,10 @@
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Våre kunngjøringer
       documents: Dokumenter

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -563,6 +563,10 @@ pa-pk:
       unboxed:
       war_memorials_trust: وار میموریل ٹرسٹ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ساڈے اعلانات
       documents: دستاویزات تک پہنچ دی حکمت عملی

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -564,6 +564,10 @@ pa:
       unboxed:
       war_memorials_trust: ਵਾਰ ਮੈਮੋਰੀਅਲਜ਼ ਟਰੱਸਟ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ਸਾਡੀਆਂ ਘੋਸ਼ਣਾਵਾਂ
       documents: ਦਸਤਾਵੇਜ਼

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -713,6 +713,10 @@ pl:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Nasze ogłoszenia
       documents: Dokumenty

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -564,6 +564,10 @@ ps:
       unboxed:
       war_memorials_trust: د جنګ یادګار باور
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: زموږ اعلانونه
       documents: اسناد

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -564,6 +564,10 @@ pt:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Os nossos anúncios
       documents: Documentos

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -639,6 +639,10 @@ ro:
       unboxed:
       war_memorials_trust: Trustul Memorialelor de Război
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Anunțurile noastre
       documents: Documente

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -713,6 +713,10 @@ ru:
       unboxed:
       war_memorials_trust: Трест военных мемориалов
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Наши объявления
       documents: Документы

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -563,6 +563,10 @@ si:
       unboxed:
       war_memorials_trust: යුද අනුස්මරණ භාරය
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: අපේ නිවේදන
       documents: ලේඛන

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -640,6 +640,10 @@ sk:
       unboxed:
       war_memorials_trust: Vojnové pamätníky Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Naše oznámenia
       documents: Dokumenty

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -716,6 +716,10 @@ sl:
       unboxed:
       war_memorials_trust: War Memorials Trust (Sklad vojnega spomina)
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Naši razglasi
       documents: Dokumenti

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -563,6 +563,10 @@ so:
       unboxed:
       war_memorials_trust: Aaminaada Xasuusaha Degaalka
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Ku dhawaaqisahayaga
       documents: Dukumentiyada

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -564,6 +564,10 @@ sq:
       unboxed:
       war_memorials_trust: Trusti i Memorialeve të Luftës
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Njoftimet tona
       documents: Dokumentet

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -716,6 +716,10 @@ sr:
       unboxed:
       war_memorials_trust: Ratni memorijalni fond
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Naša saopštenja
       documents: Dokumenti

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -564,6 +564,10 @@ sv:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Våra tillkännagivanden
       documents: Dokument

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -563,6 +563,10 @@ sw:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Matangazo yetu
       documents: Hati

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -563,6 +563,10 @@ ta:
       unboxed:
       war_memorials_trust: போர் நினைவுச்சின்ன அறக்கட்டளை
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: எங்கள் அறிவிப்புகள்
       documents: ஆவணங்கள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -487,6 +487,10 @@ th:
       unboxed:
       war_memorials_trust: ทรัสต์อนุสรณ์สถานสงคราม
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ประกาศของเรา
       documents: เอกสาร

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -563,6 +563,10 @@ tk:
       unboxed:
       war_memorials_trust: Uruş ýadygärlikleri ynamy
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Biziň bildirişlerimiz
       documents: Resminamalar

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -563,6 +563,10 @@ tr:
       unboxed:
       war_memorials_trust: Savaş Anıtları Vakfı
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Duyurularımız
       documents: Belgeler

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -715,6 +715,10 @@ uk:
       unboxed:
       war_memorials_trust: Траст пам'ятників жертвам війни
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Наші оголошення
       documents: Документи

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -563,6 +563,10 @@ ur:
       unboxed:
       war_memorials_trust: وار میموریلز ٹرسٹ
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: ہمارے اعلانات
       documents: دستاویزات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -563,6 +563,10 @@ uz:
       unboxed:
       war_memorials_trust: Ҳарбий мемориаллар трести
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Бизнинг эълонлар
       documents: Ҳужжатлар

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -487,6 +487,10 @@ vi:
       unboxed:
       war_memorials_trust: War Memorials Trust
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: Thông báo của chúng tôi
       documents: Tài liệu

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -561,6 +561,10 @@ yi:
       unboxed:
       war_memorials_trust:
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements:
       documents: דאָקומענטן

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -563,6 +563,10 @@ zh-hk:
       unboxed:
       war_memorials_trust: 戰爭紀念基金會
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: 我們的公告
       documents: 文件

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -563,6 +563,10 @@ zh-tw:
       unboxed:
       war_memorials_trust: 戰爭紀念基金會
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: 我們的公告
       documents: 文檔

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -487,6 +487,10 @@ zh:
       unboxed:
       war_memorials_trust: 战争纪念碑馆
   world_location:
+    content:
+      complete_list:
+      find_out:
+      list_link:
     headings:
       announcements: 我们的公告
       documents: 文件

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,3 +49,10 @@ if WorldLocation.where(name: "Test World Location").blank?
     world_location_type_id: 1,
   )
 end
+
+if WorldLocation.where(name: "Test International Delegation").blank?
+  WorldLocation.create!(
+    name: "Test International Delegation",
+    world_location_type_id: 3,
+  )
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Adds some additional text to the World location page, as requested from FCDO.

[Trello](https://trello.com/c/WIdOvZXR/737-update-help-and-services-around-the-world-page)

## Screenshots

### Before

![Screenshot 2022-01-26 at 5 54 14 pm](https://user-images.githubusercontent.com/424772/151219693-abdb509a-8fd6-4f9e-88a6-f084aafad5f7.png)
![Screenshot 2022-01-26 at 5 54 33 pm](https://user-images.githubusercontent.com/424772/151219701-fa9f9e5c-0214-4f65-9541-408115d86284.png)


### After

![Screenshot 2022-01-26 at 5 53 55 pm](https://user-images.githubusercontent.com/424772/151219663-4560b312-f4f0-4077-971d-a07f409583cd.png)
![Screenshot 2022-01-26 at 5 54 04 pm](https://user-images.githubusercontent.com/424772/151219672-18bb5486-4f5e-41e0-8421-347d54eda6ec.png)



