### PR TITLE
Double the sort buffer size (again)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     i18n-coverage (0.2.0)
     i18n-tasks (0.9.37)

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,10 @@ default: &default
   variables:
     sql_mode: TRADITIONAL
     # We need to set `sort_buffer_size` to work around a bug in MySQL 8.0.27 [1]
-    # This doubles the default sort buffer size, which seems to provide enough headroom to allow sorting to work correctly with our dataset.
+    # This quadruples the default sort buffer size, which seems to provide enough headroom to allow sorting to work correctly with our dataset.
     # The bug is fixed in MySQL 8.0.28 (currently unreleased), so we should be able to remove this fix once we're on that version.
     # [1]: https://bugs.mysql.com/bug.php?id=105304
-    sort_buffer_size: 524288
+    sort_buffer_size: 1048576
 
 development:
   <<: *default


### PR DESCRIPTION
There's a bug with MySQL 8.0.27 which has reared its head in Sentry issue [APP-WHITEHALL-8S8](https://sentry.io/organizations/govuk/issues/2970128422/?project=202259).

We previously addressed this issue in PR #6414, but have since found another record which requires the memory to be increased again.

Until MySQL 8.0.28 is available in AWS RDS, we need to make sure this value is sufficiently large enough to avoid query errors that result in `500 Internal Server Error` messages to users.

We've doubled the memory limit again, so it's now 4x the default – sitting at ~1MB rather than the default ~256KB.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
