### PR TITLE
Reduce default cache max age to 5 minutes

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -60,6 +60,8 @@ private
   end
 
   def set_cache_control_headers
+    # TODO: Should honour Cache-Control max-age directive provided by
+    # Content Store, as stated in GOV.UK RFC 144.
     expires_in Whitehall.default_cache_max_age, public: true
   end
 

--- a/config/initializers/cache_max_age.rb
+++ b/config/initializers/cache_max_age.rb
@@ -1,4 +1,4 @@
-Whitehall.default_cache_max_age = 15.minutes
+Whitehall.default_cache_max_age = 5.minutes
 Whitehall.default_api_cache_max_age = 30.minutes
 Whitehall.uploads_cache_max_age = 4.hours
 Whitehall.document_collections_cache_max_age = 5.minutes


### PR DESCRIPTION
Implements [RFC 144][1], by reducing cache-control max-age directive to 5 minutes for GOV.UK pages served by Whitehall.

This does not honour the Cache Control set by Content Store. This was a pragmatic decision since it would take a fair amount of effort to update Whitehall and we are aiming to sunset whitehall-frontnd, so instead we've updated the configuration to match the configuration set in Puppet.

[1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md

https://trello.com/c/OaUhq6uI/722

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
