### PR TITLE
Fix colour contrast issues

### DIFF
--- a/app/assets/stylesheets/admin/_alerts.scss
+++ b/app/assets/stylesheets/admin/_alerts.scss
@@ -8,7 +8,7 @@ $notice-color: #1d5b25;
 $notice-background: #b1e7b9;
 $notice-border-color: #39b54a;
 
-$orange: #f47738;
+$red: #d0160c;
 
 %flash-alert {
   color: $alert-color;
@@ -77,7 +77,7 @@ div.info {
 }
 
 .required span {
-  color: $orange;
+  color: $red;
   padding: 3px 5px;
 }
 

--- a/app/assets/stylesheets/admin/_layout.scss
+++ b/app/assets/stylesheets/admin/_layout.scss
@@ -1,3 +1,5 @@
+$dark-blue: #054472;
+
 html {
   // Required to set the css `rem` sise for the font stacks currently used
   // in document-preview.
@@ -172,7 +174,7 @@ $collapse-tabs-width: 710px;
 }
 
 .masthead-menu-item a {
-  color: $link-colour;
+  color: $dark-blue;
   padding: $gutter-one-sixth;
   display: inline-block;
 }


### PR DESCRIPTION
There's a few issues with colour contrast on Whitehall that made it non-WCAG compliant

1. The mandatory stars are orange and don't contrast enough with the background 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151989576-d85e212a-d1bc-460b-aabd-1422bb3fe982.png)|![image](https://user-images.githubusercontent.com/42515961/151989071-654c50ad-117b-450f-a7e4-2b614e8e39f6.png)|

2. the links in the navbar don't contrast enough with the light blue background

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151989646-25879d63-f4be-4788-81ba-48019d0be5ad.png)|![image](https://user-images.githubusercontent.com/42515961/151989194-ebc32d6a-68da-4d9e-95c5-a84c0c12c75e.png)|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
