### PR TITLE
Escape special characters in filename when previewing CSVs

### DIFF
--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -16,7 +16,7 @@ class CsvFileFromPublicHost
       connection.basic_auth(basic_auth_user, basic_auth_password)
     end
 
-    connection.get(path) do |req|
+    connection.get(Addressable::URI.escape(path)) do |req|
       req.headers["Range"] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
     end
   end

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -114,11 +114,21 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     assert_nil CsvFileFromPublicHost.csv_preview_from(response)
   end
 
-  test "#csv_response uses basic authentication if set in the environment" do
+  test ".csv_response uses basic authentication if set in the environment" do
     stub_csv_request.with(basic_auth: %w[user password])
     env = { "BASIC_AUTH_CREDENTIALS" => "user:password" }
 
     response = CsvFileFromPublicHost.csv_response("some-path", env: env)
+    assert_equal 206, response.status
+  end
+
+  test ".csv_response escapes non-ASCII characters in the path" do
+    raw_path = "uploads/path/with-špëçîål-characters.csv"
+    url_encoded_path = "uploads/path/with-%C5%A1p%C3%AB%C3%A7%C3%AE%C3%A5l-characters.csv"
+
+    stub_csv_request(path: url_encoded_path)
+
+    response = CsvFileFromPublicHost.csv_response(raw_path)
     assert_equal 206, response.status
   end
 end


### PR DESCRIPTION
This fixes a bug where CSVs couldn't be previewed if their filenames included non-ASCII/special characters. This bug was observed in production as Sentry issue [APP-WHITEHALL-8SQ][sentry].

Special characters in file names were causing the following error:
```
URI::InvalidURIError: URI must be ascii only "/government/uploads/system/uploads/attachment_data/file/729119/page_60_details_of_closed_cases_over_u\u0301300_000.csv"
```

This was because the app was attempting to download the raw CSV file over HTTP, but without escaping the CSV filename first to make it URL safe.

[sentry]: https://sentry.io/organizations/govuk/issues/2986708524/events/a5b647ed215e44ae9d4807f6debe47bb/?project=202259

## Demonstration of the problem

The publication [Cabinet Office data sets: annual report and accounts 2017 to 2018](https://www.gov.uk/government/publications/cabinet-office-data-sets-annual-report-and-accounts-2017-to-2018) includes a CSV attachment called 'Page 60 Details of closed cases over £300,000'.

The CSV filename includes the special character `ú`:

```
page_60_details_of_closed_cases_over_ú300_000.csv
```

Whilst it's possible to download the raw CSV file, it's not possible to preview it.

The preview URL:
https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/729119/page_60_details_of_closed_cases_over_u%25CC%2581300_000.csv/preview

Triggers an error in Sentry, and returns an error response to the end user.

This PR should fix the issue and allow the CSV to be previewed at the above URL.

---

Trello: https://trello.com/c/rhR7l3dj/458-whitehall-cant-preview-csv-files-with-special-characters-in-their-filename

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
