### PR TITLE
Add link to accessible format request form for participating organisa…

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -14,6 +14,7 @@ module AttachmentsHelper
   end
 
   def block_attachments(attachments = [],
+                        organisation_in_accessible_format_request_pilot = nil,
                         alternative_format_contact_email = nil,
                         published_on = nil)
     attachments.collect do |attachment|
@@ -22,6 +23,7 @@ module AttachmentsHelper
         formats: :html,
         object: attachment,
         locals: {
+          organisation_in_accessible_format_request_pilot?: organisation_in_accessible_format_request_pilot,
           alternative_format_contact_email: alternative_format_contact_email,
           published_on: published_on,
         },

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -23,7 +23,7 @@ module AttachmentsHelper
         formats: :html,
         object: attachment,
         locals: {
-          organisation_in_accessible_format_request_pilot?: organisation_in_accessible_format_request_pilot,
+          organisation_in_accessible_format_request_pilot: organisation_in_accessible_format_request_pilot,
           alternative_format_contact_email: alternative_format_contact_email,
           published_on: published_on,
         },

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -19,8 +19,8 @@ module GovspeakHelper
     wrapped_in_govspeak_div(bare_govspeak_edition_to_html(edition))
   end
 
-  def govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
-    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body, attachments, alternative_format_contact_email))
+  def govspeak_with_attachments_to_html(body, attachments = [], organisation_in_accessible_format_request_pilot = nil, alternative_format_contact_email = nil)
+    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body, attachments, organisation_in_accessible_format_request_pilot, alternative_format_contact_email))
   end
 
   def bare_govspeak_edition_to_html(edition)
@@ -30,8 +30,8 @@ module GovspeakHelper
     bare_govspeak_to_html(partially_processed_govspeak, images, allowed_elements: allowed_elements)
   end
 
-  def bare_govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
-    partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(body, attachments, alternative_format_contact_email)
+  def bare_govspeak_with_attachments_to_html(body, attachments = [], organisation_in_accessible_format_request_pilot = nil, alternative_format_contact_email = nil)
+    partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(body, attachments, organisation_in_accessible_format_request_pilot, alternative_format_contact_email)
     bare_govspeak_to_html(partially_processed_govspeak, [], allowed_elements: %w[details])
   end
 
@@ -243,10 +243,10 @@ private
     doc.fragment(govspeak.to_html)
   end
 
-  def govspeak_with_attachments_and_alt_format_information(govspeak, attachments = [], alternative_format_contact_email = nil)
+  def govspeak_with_attachments_and_alt_format_information(govspeak, attachments = [], organisation_in_accessible_format_request_pilot = nil, alternative_format_contact_email = nil)
     govspeak = govspeak.gsub(/\n{0,2}^!@([0-9]+)\s*/) do
       if (attachment = attachments[Regexp.last_match(1).to_i - 1])
-        "\n\n#{render(partial: 'documents/attachment', formats: :html, object: attachment, locals: { alternative_format_contact_email: alternative_format_contact_email })}\n\n"
+        "\n\n#{render(partial: 'documents/attachment', formats: :html, object: attachment, locals: { organisation_in_accessible_format_request_pilot?: organisation_in_accessible_format_request_pilot, alternative_format_contact_email: alternative_format_contact_email })}\n\n"
       else
         "\n\n"
       end
@@ -262,7 +262,7 @@ private
 
   def edition_body_with_attachments_and_alt_format_information(edition)
     attachments = edition.allows_attachments? ? edition.attachments : []
-    govspeak_with_attachments_and_alt_format_information(edition.body, attachments, edition.alternative_format_contact_email)
+    govspeak_with_attachments_and_alt_format_information(edition.body, attachments, edition.organisation_in_accessible_format_request_pilot?, edition.alternative_format_contact_email)
   end
 
   def build_govspeak_document(govspeak, images = [], allowed_elements = [])

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -246,7 +246,7 @@ private
   def govspeak_with_attachments_and_alt_format_information(govspeak, attachments = [], organisation_in_accessible_format_request_pilot = nil, alternative_format_contact_email = nil)
     govspeak = govspeak.gsub(/\n{0,2}^!@([0-9]+)\s*/) do
       if (attachment = attachments[Regexp.last_match(1).to_i - 1])
-        "\n\n#{render(partial: 'documents/attachment', formats: :html, object: attachment, locals: { organisation_in_accessible_format_request_pilot?: organisation_in_accessible_format_request_pilot, alternative_format_contact_email: alternative_format_contact_email })}\n\n"
+        "\n\n#{render(partial: 'documents/attachment', formats: :html, object: attachment, locals: { organisation_in_accessible_format_request_pilot: organisation_in_accessible_format_request_pilot, alternative_format_contact_email: alternative_format_contact_email })}\n\n"
       else
         "\n\n"
       end
@@ -262,7 +262,7 @@ private
 
   def edition_body_with_attachments_and_alt_format_information(edition)
     attachments = edition.allows_attachments? ? edition.attachments : []
-    govspeak_with_attachments_and_alt_format_information(edition.body, attachments, edition.organisation_in_accessible_format_request_pilot?, edition.alternative_format_contact_email)
+    govspeak_with_attachments_and_alt_format_information(edition.body, attachments, edition.organisation_in_accessible_format_request_pilot, edition.alternative_format_contact_email)
   end
 
   def build_govspeak_document(govspeak, images = [], allowed_elements = [])

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -604,7 +604,7 @@ EXISTS (
     nil
   end
 
-  def organisation_in_accessible_format_request_pilot?
+  def organisation_in_accessible_format_request_pilot
     nil
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -604,6 +604,10 @@ EXISTS (
     nil
   end
 
+  def organisation_in_accessible_format_request_pilot?
+    nil
+  end
+
   def valid_as_draft?
     errors_as_draft.empty?
   end

--- a/app/models/edition/alternative_format_provider.rb
+++ b/app/models/edition/alternative_format_provider.rb
@@ -1,6 +1,10 @@
 module Edition::AlternativeFormatProvider
   extend ActiveSupport::Concern
 
+  # The following departments are taking place in a pilot scheme to use the accessible format
+  # request form. DFE(6), DWP(10), DHSC(12), HMRC(25), DVSA(570), UKHSA(1328)
+  ACCESSIBLE_FORMAT_REQUEST_PILOT_ORGANISATION_IDS = [6, 10, 12, 25, 570, 1328].freeze
+
   included do
     belongs_to :alternative_format_provider, class_name: Organisation.name # rubocop:disable Rails/ReflectionClassName
 
@@ -22,6 +26,10 @@ module Edition::AlternativeFormatProvider
 
   def default_alternative_format_contact_email
     "govuk-feedback@digital.cabinet-office.gov.uk"
+  end
+
+  def organisation_in_accessible_format_request_pilot?
+    ACCESSIBLE_FORMAT_REQUEST_PILOT_ORGANISATION_IDS.include?(alternative_format_provider&.id)
   end
 
 private

--- a/app/models/edition/alternative_format_provider.rb
+++ b/app/models/edition/alternative_format_provider.rb
@@ -28,7 +28,7 @@ module Edition::AlternativeFormatProvider
     "govuk-feedback@digital.cabinet-office.gov.uk"
   end
 
-  def organisation_in_accessible_format_request_pilot?
+  def organisation_in_accessible_format_request_pilot
     ACCESSIBLE_FORMAT_REQUEST_PILOT_ORGANISATION_IDS.include?(alternative_format_provider&.id)
   end
 

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -56,8 +56,8 @@ private
     nil
   end
 
-  def organisation_in_accessible_format_request_pilot?
-    attachable.organisation_in_accessible_format_request_pilot?
+  def organisation_in_accessible_format_request_pilot
+    attachable.organisation_in_accessible_format_request_pilot
   rescue NoMethodError
     nil
   end

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -56,6 +56,12 @@ private
     nil
   end
 
+  def organisation_in_accessible_format_request_pilot?
+    attachable.organisation_in_accessible_format_request_pilot?
+  rescue NoMethodError
+    nil
+  end
+
   def preview_url
     if csv? && attachable.is_a?(Edition)
       Whitehall.url_maker.csv_preview_url(

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -18,7 +18,7 @@ class Response < ApplicationRecord
 
   delegate :alternative_format_contact_email, to: :consultation
 
-  delegate :organisation_in_accessible_format_request_pilot?, to: :consultation
+  delegate :organisation_in_accessible_format_request_pilot, to: :consultation
 
   delegate :publicly_visible?, to: :parent_attachable
 

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -18,6 +18,8 @@ class Response < ApplicationRecord
 
   delegate :alternative_format_contact_email, to: :consultation
 
+  delegate :organisation_in_accessible_format_request_pilot?, to: :consultation
+
   delegate :publicly_visible?, to: :parent_attachable
 
   delegate :accessible_to?, to: :parent_attachable

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -134,6 +134,7 @@ module PublishingApi
       def documents
         renderer.block_attachments(
           consultation.attachments,
+          consultation.organisation_in_accessible_format_request_pilot?,
           consultation.alternative_format_contact_email,
         )
       end
@@ -198,6 +199,7 @@ module PublishingApi
 
         renderer.block_attachments(
           outcome.attachments,
+          outcome.organisation_in_accessible_format_request_pilot?,
           outcome.alternative_format_contact_email,
         )
       end
@@ -266,6 +268,7 @@ module PublishingApi
 
         renderer.block_attachments(
           public_feedback.attachments,
+          public_feedback.organisation_in_accessible_format_request_pilot?,
           public_feedback.alternative_format_contact_email,
           public_feedback.published_on,
         )

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -134,7 +134,7 @@ module PublishingApi
       def documents
         renderer.block_attachments(
           consultation.attachments,
-          consultation.organisation_in_accessible_format_request_pilot?,
+          consultation.organisation_in_accessible_format_request_pilot,
           consultation.alternative_format_contact_email,
         )
       end
@@ -199,7 +199,7 @@ module PublishingApi
 
         renderer.block_attachments(
           outcome.attachments,
-          outcome.organisation_in_accessible_format_request_pilot?,
+          outcome.organisation_in_accessible_format_request_pilot,
           outcome.alternative_format_contact_email,
         )
       end
@@ -268,7 +268,7 @@ module PublishingApi
 
         renderer.block_attachments(
           public_feedback.attachments,
-          public_feedback.organisation_in_accessible_format_request_pilot?,
+          public_feedback.organisation_in_accessible_format_request_pilot,
           public_feedback.alternative_format_contact_email,
           public_feedback.published_on,
         )

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -91,6 +91,7 @@ module PublishingApi
 
       Whitehall::GovspeakRenderer.new.block_attachments(
         attachments_for_current_locale,
+        organisation_in_accessible_format_request?,
         alternative_format_email,
       )
     end
@@ -114,6 +115,10 @@ module PublishingApi
 
     def alternative_format_email
       item.alternative_format_provider.try(:alternative_format_contact_email)
+    end
+
+    def organisation_in_accessible_format_request?
+      item.alternative_format_provider.try(:organisation_in_accessible_format_request_pilot?)
     end
   end
 end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -118,7 +118,7 @@ module PublishingApi
     end
 
     def organisation_in_accessible_format_request?
-      item.alternative_format_provider.try(:organisation_in_accessible_format_request_pilot?)
+      item.alternative_format_provider.try(:organisation_in_accessible_format_request_pilot)
     end
   end
 end

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <% if organisation_in_accessible_format_request_pilot? %>
+      <% if organisation_in_accessible_format_request_pilot %>
         <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.content_id}" %>
       <% else %>
         <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,23 +69,27 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
-        <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
-        <%= render "govuk_publishing_components/components/details", {
-          title: t('attachment.accessibility.request_a_different_format'),
-          data_attributes: {
-            track_category: "Accessible Format Request",
-            track_action: "FormatRequestClicked",
-            track_label: attachment.title,
-            module: "govuk-details"
-          }
-        } do %>
-          <%= t('attachment.accessibility.full_help_html',
-          email: alternative_format_order_link(attachment, alternative_format_contact_email),
-          title: attachment.title,
-          references: attachment_references(attachment)) %>
-        <% end %>
-      </div>
+      <% if organisation_in_accessible_format_request_pilot? %>
+        <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.content_id}" %>
+      <% else %>
+        <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
+          <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
+          <%= render "govuk_publishing_components/components/details", {
+            title: t('attachment.accessibility.request_a_different_format'),
+            data_attributes: {
+              track_category: "Accessible Format Request",
+              track_action: "FormatRequestClicked",
+              track_label: attachment.title,
+              module: "govuk-details"
+            }
+          } do %>
+            <%= t('attachment.accessibility.full_help_html',
+            email: alternative_format_order_link(attachment, alternative_format_contact_email),
+            title: attachment.title,
+            references: attachment_references(attachment)) %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/documents/_attachments.html.erb
+++ b/app/views/documents/_attachments.html.erb
@@ -1,6 +1,8 @@
 <% object_with_attachments.attachments.each do |attachment| %>
   <%= render partial: "documents/attachment", object: attachment, locals: {
-    alternative_format_contact_email: 
+    organisation_in_accessible_format_request_pilot?:
+      object_with_attachments.respond_to?(:organisation_in_accessible_format_request_pilot?) ? object_with_attachments.organisation_in_accessible_format_request_pilot? : nil,
+    alternative_format_contact_email:
       object_with_attachments.respond_to?(:alternative_format_contact_email) ? object_with_attachments.alternative_format_contact_email : nil
   } %>
 <% end %>

--- a/app/views/documents/_attachments.html.erb
+++ b/app/views/documents/_attachments.html.erb
@@ -1,7 +1,7 @@
 <% object_with_attachments.attachments.each do |attachment| %>
   <%= render partial: "documents/attachment", object: attachment, locals: {
-    organisation_in_accessible_format_request_pilot?:
-      object_with_attachments.respond_to?(:organisation_in_accessible_format_request_pilot?) ? object_with_attachments.organisation_in_accessible_format_request_pilot? : nil,
+    organisation_in_accessible_format_request_pilot:
+      object_with_attachments.respond_to?(:organisation_in_accessible_format_request_pilot) ? object_with_attachments.organisation_in_accessible_format_request_pilot : nil,
     alternative_format_contact_email:
       object_with_attachments.respond_to?(:alternative_format_contact_email) ? object_with_attachments.alternative_format_contact_email : nil
   } %>

--- a/test/unit/edition/alternative_format_provider_test.rb
+++ b/test/unit/edition/alternative_format_provider_test.rb
@@ -32,13 +32,13 @@ class Edition::AlternativeFormatProviderTest < ActiveSupport::TestCase
     organisation_in_pilot = build(:organisation, id: 6)
     edition = EditionWithAlternativeFormat.new
     edition.alternative_format_provider = organisation_in_pilot
-    assert_equal true, edition.organisation_in_accessible_format_request_pilot?
+    assert_equal true, edition.organisation_in_accessible_format_request_pilot
   end
 
   test "organisation providing publications is not taking part in the accessible format request pilot" do
     organisation_not_in_pilot = build(:organisation, id: 1)
     edition = EditionWithAlternativeFormat.new
     edition.alternative_format_provider = organisation_not_in_pilot
-    assert_equal false, edition.organisation_in_accessible_format_request_pilot?
+    assert_equal false, edition.organisation_in_accessible_format_request_pilot
   end
 end

--- a/test/unit/edition/alternative_format_provider_test.rb
+++ b/test/unit/edition/alternative_format_provider_test.rb
@@ -27,4 +27,18 @@ class Edition::AlternativeFormatProviderTest < ActiveSupport::TestCase
     edition.alternative_format_provider = build(:organisation, alternative_format_contact_email: "")
     assert_equal "govuk-feedback@digital.cabinet-office.gov.uk", edition.alternative_format_contact_email
   end
+
+  test "organisation providing publications is taking part in the accessible format request pilot" do
+    organisation_in_pilot = build(:organisation, id: 6)
+    edition = EditionWithAlternativeFormat.new
+    edition.alternative_format_provider = organisation_in_pilot
+    assert_equal true, edition.organisation_in_accessible_format_request_pilot?
+  end
+
+  test "organisation providing publications is not taking part in the accessible format request pilot" do
+    organisation_not_in_pilot = build(:organisation, id: 1)
+    edition = EditionWithAlternativeFormat.new
+    edition.alternative_format_provider = organisation_not_in_pilot
+    assert_equal false, edition.organisation_in_accessible_format_request_pilot?
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -360,6 +360,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.public_feedback.attachments,
+          consultation.public_feedback.organisation_in_accessible_format_request_pilot?,
           consultation.public_feedback.alternative_format_contact_email,
           consultation.public_feedback.published_on,
         )
@@ -429,6 +430,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.outcome.attachments,
+          consultation.outcome.organisation_in_accessible_format_request_pilot?,
           consultation.outcome.alternative_format_contact_email,
         )
         .returns([attachments_double])
@@ -474,6 +476,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.attachments,
+          consultation.organisation_in_accessible_format_request_pilot?,
           consultation.alternative_format_contact_email,
         )
         .returns([attachments_double])

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -360,7 +360,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.public_feedback.attachments,
-          consultation.public_feedback.organisation_in_accessible_format_request_pilot?,
+          consultation.public_feedback.organisation_in_accessible_format_request_pilot,
           consultation.public_feedback.alternative_format_contact_email,
           consultation.public_feedback.published_on,
         )
@@ -430,7 +430,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.outcome.attachments,
-          consultation.outcome.organisation_in_accessible_format_request_pilot?,
+          consultation.outcome.organisation_in_accessible_format_request_pilot,
           consultation.outcome.alternative_format_contact_email,
         )
         .returns([attachments_double])
@@ -476,7 +476,7 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.attachments,
-          consultation.organisation_in_accessible_format_request_pilot?,
+          consultation.organisation_in_accessible_format_request_pilot,
           consultation.alternative_format_contact_email,
         )
         .returns([attachments_double])


### PR DESCRIPTION
…tions

A pilot scheme for a limited number of organisations is soon to run,
allowing users to submit accessible format requests via a form in
the Feedback app rather than sending an email.

This commit adds a link to attachments owned by organisations in the
pilot, replacing the current toggled "send an email" text.

To enable this, all Editions, Consultations and Responses now have access
to an organisation_in_accessible_format_request_pilot?. This defaults to nil
in most cases, but editions with eligable attachments will have access to
the alternative_format_provider where the method can identify if the owning
organisation is taking part in the pilot.

Throughout the new method is added as a parameter to the block_attachments method
which govspeak_helper uses to render the html. The _attachment partial then has access
to organisation_in_accessible_format_request_pilot? in order to render the link as needed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
