### PR TITLE
Add link to accessible format request form for pilot organisations

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -13,6 +13,13 @@ module AttachmentsHelper
     csv_preview_path(id: attachment.attachment_data.id, file: attachment.filename_without_extension, extension: attachment.file_extension)
   end
 
+  def participating_in_accessible_format_request_pilot?(contact_email)
+    # A small number of organisations are taking part in a pilot scheme for accessible
+    # format requests to be submitted by a form rather than a direct email
+    pilot_addresses = GovukPublishingComponents::Presenters::Attachment::EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT
+    pilot_addresses.include?(contact_email)
+  end
+
   def block_attachments(attachments = [],
                         alternative_format_contact_email = nil,
                         published_on = nil)

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -60,6 +60,10 @@ class PolicyGroup < ApplicationRecord
     true
   end
 
+  def alternative_format_provider
+    nil
+  end
+
   extend FriendlyId
   friendly_id
 

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -18,6 +18,8 @@ class Response < ApplicationRecord
 
   delegate :alternative_format_contact_email, to: :consultation
 
+  delegate :alternative_format_provider, to: :consultation
+
   delegate :publicly_visible?, to: :parent_attachable
 
   delegate :accessible_to?, to: :parent_attachable

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,23 +69,27 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
-        <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
-        <%= render "govuk_publishing_components/components/details", {
-          title: t('attachment.accessibility.request_a_different_format'),
-          data_attributes: {
-            track_category: "Accessible Format Request",
-            track_action: "FormatRequestClicked",
-            track_label: attachment.title,
-            module: "govuk-details"
-          }
-        } do %>
-          <%= t('attachment.accessibility.full_help_html',
-          email: alternative_format_order_link(attachment, alternative_format_contact_email),
-          title: attachment.title,
-          references: attachment_references(attachment)) %>
-        <% end %>
-      </div>
+      <% if attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
+        <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link"  %>
+      <% else %>
+        <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
+          <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>p
+          <%= render "govuk_publishing_components/components/details", {
+            title: t('attachment.accessibility.request_a_different_format'),
+            data_attributes: {
+              track_category: "Accessible Format Request",
+              track_action: "FormatRequestClicked",
+              track_label: attachment.title,
+              module: "govuk-details"
+            }
+          } do %>
+            <%= t('attachment.accessibility.full_help_html',
+            email: alternative_format_order_link(attachment, alternative_format_contact_email),
+            title: attachment.title,
+            references: attachment_references(attachment)) %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/test/unit/helpers/attachments_helper_test.rb
+++ b/test/unit/helpers/attachments_helper_test.rb
@@ -15,4 +15,16 @@ class AttachmentsHelperTest < ActionView::TestCase
     csv_on_policy_group = create(:csv_attachment, attachable: create(:policy_group))
     assert_not previewable?(csv_on_policy_group)
   end
+
+  test "Attachments belonging to organisations taking part in the accessible format request pilot can be identified" do
+    GovukPublishingComponents::Presenters::Attachment.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, ["in_pilot@example.com"]) do
+      assert participating_in_accessible_format_request_pilot?("in_pilot@example.com")
+    end
+  end
+
+  test "Attachments belonging to organisations not taking part in the accessible format request pilot can be identified" do
+    GovukPublishingComponents::Presenters::Attachment.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, []) do
+      assert_not participating_in_accessible_format_request_pilot?("not_in_pilot@example.com")
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -150,12 +150,25 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     assert_equal [location.content_id], presented_item.content[:links][:world_locations]
   end
 
-  test "documents include the alternative format contact email" do
+  test "documents include the alternative format contact email with a direct email link" do
     publication = create(:publication, :with_command_paper)
-    presented_item = present(publication)
-    document = presented_item.content[:details][:documents].first
-    assert document.include?("This file may not be suitable for users of assistive technology.")
-    assert document.include?("mailto:#{publication.alternative_format_provider.alternative_format_contact_email}")
+    GovukPublishingComponents::Presenters::Attachment.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, []) do
+      presented_item = present(publication)
+      document = presented_item.content[:details][:documents].first
+      assert document.include?("This file may not be suitable for users of assistive technology.")
+      assert document.include?("mailto:#{publication.alternative_format_provider.alternative_format_contact_email}")
+    end
+  end
+
+  test "documents belonging to organisations in the accessible format request pilot include the form link" do
+    publication = create(:publication, :with_command_paper)
+    email_address = publication.alternative_format_provider.alternative_format_contact_email
+    GovukPublishingComponents::Presenters::Attachment.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, [email_address]) do
+      presented_item = present(publication)
+      document = presented_item.content[:details][:documents].first
+      assert document.include?("Request an accessible format of this document")
+      assert document.include?("/contact/govuk/request-accessible-format?content_id=#{publication.content_id}&amp;attachment_id=#{publication.attachments.first.id}")
+    end
   end
 
   test "it uses the PayloadBuilder::FirstPublishedAt helper" do


### PR DESCRIPTION
A pilot scheme for a limited number of organisations is soon to run,
allowing users to submit accessible format requests via a form in
the Feedback app rather than sending an email.

This commit adds a link to attachments owned by organisations in the
pilot, replacing the current toggled "send an email" text.

As not all document types making use of the attachments partial have
an owning, or alternative_format_provider, organisation we have added
the method to PolicyGroups (also known as WorkingGroups) and for Responses
delegated this method to their associated Consultation.

[Trello](https://trello.com/c/EDLOlTnt/892-create-an-allowed-list-of-departments-for-the-pilot)

Before
<img width="689" alt="Screenshot 2022-02-21 at 10 11 47" src="https://user-images.githubusercontent.com/13475227/154934460-0c266e00-2d9b-4cd3-82a2-a4674cc37fbb.png">

After
<img width="631" alt="Screenshot 2022-02-21 at 10 11 56" src="https://user-images.githubusercontent.com/13475227/154934504-7533e8d5-c3ab-4fa8-9bae-3713dafef83f.png">

