### PR TITLE
Fix login after editing an orphaned Corporate Information Page

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,8 +1,13 @@
 class Admin::DashboardController < Admin::BaseController
   def index
     if current_user.organisation
-      @draft_documents = Edition.authored_by(current_user).where(state: "draft").includes(:translations, :versions).in_reverse_chronological_order
-      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5)
+      @draft_documents = Edition.authored_by(current_user).where(state: "draft").includes(:translations, :versions).in_reverse_chronological_order.reject do |edition|
+        edition.respond_to?(:owning_organisation) && edition.owning_organisation.nil?
+      end
+
+      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5).reject do |edition|
+        edition.respond_to?(:owning_organisation) && edition.owning_organisation.nil?
+      end
     end
   end
 end


### PR DESCRIPTION
There may be cases when a `CorporateInformationPage` has no organisations (i.e. it is orphaned).  At the moment, users who have a draft CorporateInformationPage with no organisation(s) assigned cannot access the Whitehall homepage as the 'My Documents' section returns a 500 error.

The error is caused by the helper that forms the URL for the edit page, which requires the organisation's slug.  No with assigned organisation, the URL cannot be formed.

This removes the orphaned corporate information pages from appearing on the user's dashboard.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
