### PR TITLE
Update csv preview

### DIFF
--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -48,7 +48,7 @@
       <% if @csv_preview %>
         <%= render(partial: 'truncated_message', locals: { csv_preview: @csv_preview, attachment: @attachment }) if @csv_preview.truncated? %>
         <div class="csv-preview">
-          <div class="csv-preview__inner" tabindex="0">
+          <div class="csv-preview__inner">
             <%= render "govuk_publishing_components/components/table", {
               head: @csv_preview.headings.map do |heading|
                 {


### PR DESCRIPTION
## What

Remove `tab-index`

## Why 

The CSV 'view online' is not accessible for keyboard readers. 

### Before 
User cannot access table

https://user-images.githubusercontent.com/71266765/156799836-cb59a415-f05f-40e1-95c6-88cf346ee388.mov

### After 

https://user-images.githubusercontent.com/71266765/156800204-e6c209c7-6a7a-4e4c-90b2-2bdd7da01190.mov

## Anything else

[On integration](https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/254670/ministers-interests-october-2013.csv/preview) might be overwritten at time of review.