### PR TITLE
Allow CorporateInformationPages to respond to alternative_format_provider methods

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -166,6 +166,14 @@ class CorporateInformationPage < Edition
     false
   end
 
+  def alternative_format_provider
+    owning_organisation
+  end
+
+  def alternative_format_provider_required?
+    attachments.any? { |a| a.is_a?(FileAttachment) }
+  end
+
 private
 
   def string_for_slug

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -73,7 +73,7 @@
         <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link"  %>
       <% else %>
         <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
-          <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>p
+          <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
           <%= render "govuk_publishing_components/components/details", {
             title: t('attachment.accessibility.request_a_different_format'),
             data_attributes: {

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -143,10 +143,36 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     assert_equal email, corporate_information_page.alternative_format_contact_email
   end
 
+  test "#alternative_format_provider should be the owning organisaiton" do
+    corporate_information_page = build(:corporate_information_page)
+
+    assert_equal corporate_information_page.alternative_format_provider, corporate_information_page.owning_organisation
+  end
+
   test "should support attachments" do
     organisation = build(:organisation_with_alternative_format_contact_email)
     corporate_information_page = build(:corporate_information_page, organisation: organisation)
     corporate_information_page.attachments << build(:file_attachment)
+  end
+
+  test "#alternative_format_provider_required? should be true if an attachment is a file attachment" do
+    corporate_information_page = build(:corporate_information_page)
+    corporate_information_page.attachments << build(:file_attachment)
+
+    assert corporate_information_page.alternative_format_provider_required?
+  end
+
+  test "#alternative_format_provider_required? should be false if there are no file attachments" do
+    corporate_information_page = build(:corporate_information_page)
+    corporate_information_page.attachments << build(:html_attachment)
+
+    assert_not corporate_information_page.alternative_format_provider_required?
+  end
+
+  test "#alternative_format_provider_required? should be false if there are no attachments" do
+    corporate_information_page = build(:corporate_information_page)
+
+    assert_not corporate_information_page.alternative_format_provider_required?
   end
 
   test "should be able to get corporate information pages for a particular menu" do


### PR DESCRIPTION
This will allow CorporateInformationPages to use links to the accessible format request form introduced in
https://github.com/alphagov/whitehall/pull/6445 for attachments that are inaccessible.


