### PR TITLE
Exclude attachables without content_ids from accessible request form pilot

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <% if attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
+      <% if attachment.attachable.respond_to?(:content_id) && attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
         <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link"  %>
       <% else %>
         <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">


### PR DESCRIPTION
ConsultationOutcomes are not able to access their consultation's
content_id at the time of building the attachment html.

While this is resolved, to prevent errors any attachables without access to
the content_id will be excluded from the pilot scheme for the accessible format
request form.
