### PR TITLE
Add jQuery to whitehall frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/govspeak
 //
+//= require jquery/dist/jquery
 //= require jquery_ujs
 //= require jquery.ui.all
 //= require vendor/jquery/jquery.player.min.js

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
       "no-var": 0
     }
   },
+  "dependencies": {
+    "jquery": "1.12.4"
+  },
   "devDependencies": {
     "standardx": "^7.0.0",
     "stylelint": "^13.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,6 +1427,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+jquery@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Give whitehall frontend its own copy of jQuery, instead of getting it from the components gem via static.

The reason for this is that we're removing jQuery from GOV.UK and there's far too much of it in whitehall to convert it to vanilla JS right now. Instead, the approach we're taking is to give some applications their own copy of jQuery, allowing us to remove it from the rest of GOV.UK and deal with those problematic applications later.

This PR doesn't change whitehall admin, but that seems to already have its own jQuery somehow (I don't really understand how, but it does). Have tested this against a branch of the components gem without jQuery, and it appears to function normally.

I've already checked what happens if you include two copies of jQuery inside an application and it seems to be fine, but I don't think this should be merged until we're ready to also remove jQuery from the components gem, as it will increase the asset size unnecessarily. Better to have only a short time when whitehall has two jQuerys.

## Visual changes
None.

Trello card: https://trello.com/c/DUaKxWvl/101-remove-jquery-from-govuk-javascript
