### PR TITLE
Remove limit on Topical Event Features

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -20,7 +20,7 @@ class TopicalEventsController < ClassificationsController
     @travel_advice = []
     afghanistan_travel_advice if @topical_event.slug == "afghanistan-uk-government-response"
     @detailed_guides = @topical_event.published_detailed_guides.includes(:translations, :document).limit(5)
-    @featurings = decorate_collection(@topical_event.classification_featurings.includes(:image, edition: :document).limit(5), ClassificationFeaturingPresenter)
+    @featurings = decorate_collection(@topical_event.classification_featurings.includes(:image, edition: :document), ClassificationFeaturingPresenter)
 
     set_slimmer_organisations_header(@topical_event.organisations)
     set_slimmer_page_owner_header(@topical_event.lead_organisations.first)


### PR DESCRIPTION
Currently there is a `.limit(5)` on the number of Features that are show for a Topical Event.

This was originally 6 - set [here](https://github.com/alphagov/whitehall/commit/b81f8fece4b80141740bc5aeab0f31fabb25834e) and changed to 5 [here](https://github.com/alphagov/whitehall/commit/aea2e46d1717db802543fbb69d5a77fee192facd).

We would like to show more Features for a Topical Event, and as there does not appear to be a reason given as to why it was originally limited or why that limit was changed. And as there appears to be no restriction on the number the can be added to a Topical Event - it seems sensible to simply remove the limit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
