### PR TITLE
Remove Rails 7 cookie migration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -90,22 +90,5 @@ module Whitehall
     # allow overriding the asset host with an enironment variable, useful for
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Whitehall::Application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
In #6449 / #6483 some code was introduced to migrate cookies to the new format used by Rails 7; once that PR has been deployed and the old cookies expired/migrated, this can be merged to remove that.

https://trello.com/c/n6D8yVSh/253-upgrade-whitehall-from-rails-61x-to-70x

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
