### PR TITLE
Remove emails from Rake task for departments not in pilot

### DIFF
--- a/lib/tasks/republish_accessible_format_request_pilot_documents.rake
+++ b/lib/tasks/republish_accessible_format_request_pilot_documents.rake
@@ -1,11 +1,6 @@
 desc "Republish all documents with attachments for organisations in accessible format request pilot"
 task repubish_docs_with_attachments_for_accessible_format_request_pilot: :environment do
-  pilot_emails = %w[alternative.formats@education.gov.uk
-                    accessible.formats@dwp.gov.uk
-                    publications@dhsc.gov.uk
-                    different.format@hmrc.gov.uk
-                    gov.uk.publishing@dvsa.gov.uk
-                    publications@phe.gov.uk].freeze
+  pilot_emails = %w[different.format@hmrc.gov.uk].freeze
 
   organisations = Organisation.where(alternative_format_contact_email: [pilot_emails])
 


### PR DESCRIPTION
Currently only HMRC are taking part in the accessible request format pilot scheme. This change ensures only their documents will be republished to display the link to the form when the associated change in govuk_publishing_components is released.

https://github.com/alphagov/govuk_publishing_components/pull/2695

[trello](https://trello.com/c/7vyvANlE/1172-accessible-format-request-add-links-to-form-for-hmrc-documents-ready-for-user-testing)