### PR TITLE
Update topical event page to use organisation logo component

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -153,16 +153,23 @@
               border_top: 2,
             } %>
 
-            <ul class="organisations-list govuk-clearfix">
+            <div class="govuk-grid-row">
               <% @topical_event.lead_organisations.each do |organisation| %>
-                <%= content_tag_for(:li, organisation, class: "organisations-list__item #{organisation_brand_colour_class(organisation)}") do %>
-                  <%= link_to organisation_path(organisation),
-                        class: "#{logo_classes(organisation: organisation, stacked: true)} govuk-link" do %>
-                    <span><%= organisation_logo_name(organisation) %></span>
-                  <% end %>
-                <% end %>
+                <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
+                  <%= render "govuk_publishing_components/components/organisation_logo", {
+                    organisation: {
+                      name: organisation,
+                      url: organisation_path(organisation),
+                      brand: organisation[:slug],
+                      crest: organisation.organisation_crest,
+                    }
+                  } %>
+                </div>
               <% end %>
-              <% if @topical_event.slug == 'first-world-war-centenary' %>
+            </div>
+              
+            <% if @topical_event.slug == 'first-world-war-centenary' %>
+              <ul class="organisations-list govuk-clearfix">            
                 <li class="organisations-list__item non-govuk imperial-war-museums">
                   <a href="http://www.iwm.org.uk"><%= t("topical_event.lead_organisations.iwm") %></a>
                 </li>
@@ -187,23 +194,22 @@
                 <li class="organisations-list__item non-govuk war-memorials-trust">
                   <a href="http://www.warmemorials.org"><%= t("topical_event.lead_organisations.war_memorials_trust") %></a>
                 </li>
-              <% end %>
-            </ul>
-
-            <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-unboxed' %>
-            <ul class="organisations-list govuk-clearfix">
-              <li class="organisations-list__item non-govuk birmingham_2022_commonwealth_games">
-                <a href="https://www.gov.uk/government/organisations/birmingham-organising-committee-for-the-2022-commonwealth-games-ltd"><%= t("topical_event.lead_organisations.birmingham_2022_commonwealth_games") %></a>
-              </li>
-              <li class="organisations-list__item non-govuk queens_platinum_jubilee">
-                <a href="https://www.royal.uk/platinumjubilee"><%= t("topical_event.lead_organisations.queens_platinum_jubilee") %><%= t("topical_event.lead_organisations.queens_platinum_jubilee") %></a></a>
-              </li>
-              <li class="organisations-list__item non-govuk unboxed">
-                <a href="https://unboxed2022.uk/"><%= t("topical_event.lead_organisations.unboxed") %><%= t("topical_event.lead_organisations.unboxed") %></a>
-              </li>
-            </ul>
+              </ul>
             <% end %>
 
+            <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-unboxed' %>
+              <ul class="organisations-list govuk-clearfix">
+                <li class="organisations-list__item non-govuk birmingham_2022_commonwealth_games">
+                  <a href="https://www.gov.uk/government/organisations/birmingham-organising-committee-for-the-2022-commonwealth-games-ltd"><%= t("topical_event.lead_organisations.birmingham_2022_commonwealth_games") %></a>
+                </li>
+                <li class="organisations-list__item non-govuk queens_platinum_jubilee">
+                  <a href="https://www.royal.uk/platinumjubilee"><%= t("topical_event.lead_organisations.queens_platinum_jubilee") %><%= t("topical_event.lead_organisations.queens_platinum_jubilee") %></a></a>
+                </li>
+                <li class="organisations-list__item non-govuk unboxed">
+                  <a href="https://unboxed2022.uk/"><%= t("topical_event.lead_organisations.unboxed") %><%= t("topical_event.lead_organisations.unboxed") %></a>
+                </li>
+              </ul>
+            <% end %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## What
https://trello.com/c/F05x6Sgn/1109-update-to-org-logos-ukraine-uk-government-response

Update topical event page to replace custom organisation logo markup with organisation logo component.

## Why
- It's not consistent with Component Guide and the Design System

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before (desktop)</th>
<th>After (desktop)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159951214-1e3645d2-f0a4-4140-b3d0-31a77982e1a9.png"><img src="https://user-images.githubusercontent.com/87758239/159951214-1e3645d2-f0a4-4140-b3d0-31a77982e1a9.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159950952-e94c8ab2-8c48-48c0-8411-2734a9c3b7eb.png"><img src="https://user-images.githubusercontent.com/87758239/159950952-e94c8ab2-8c48-48c0-8411-2734a9c3b7eb.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (mobile)</th>
<th>After (mobile)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159951207-153cca2b-3866-41f1-801e-ab35b00ecb75.png"><img src="https://user-images.githubusercontent.com/87758239/159951207-153cca2b-3866-41f1-801e-ab35b00ecb75.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159950944-0e88af97-6284-4834-8814-c12a3d350308.png"><img src="https://user-images.githubusercontent.com/87758239/159950944-0e88af97-6284-4834-8814-c12a3d350308.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

## Anything else

With this change, I'd hoped to be able to delete some old code (e.g. helpers and custom logo styles) but I find that the helper `def logo_classes(options = {})`, used previously to build the class list for each logo, is referenced elsewhere in `def organisation_logo(organisation, options = {})` and which is used by other methods / helpers in Whitehall https://github.com/alphagov/whitehall/search?q=logo_classes.

Likewise, `organisation_brand_colour_class` is used by other methods - https://github.com/alphagov/whitehall/search?q=organisation_brand_colour_class

Unfortunately feels a bit risky to try and remove these methods at the moment.