### PR TITLE
Fix a deprecation warning for to_s with parameters on Date objects

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -42,19 +42,19 @@ module OrganisationHelper
   def organisation_closed_govuk_status_description(organisation)
     if organisation.no_longer_exists?
       if organisation.closed_at.present?
-        "#{organisation.name} closed in #{organisation.closed_at.to_s(:one_month_precision)}"
+        "#{organisation.name} closed in #{organisation.closed_at.to_fs(:one_month_precision)}"
       else
         "#{organisation.name} has closed"
       end
     elsif organisation.replaced? || organisation.split?
       if organisation.closed_at.present?
-        "#{organisation.name} was replaced by #{superseding_organisations_text(organisation)} in #{organisation.closed_at.to_s(:one_month_precision)}".html_safe
+        "#{organisation.name} was replaced by #{superseding_organisations_text(organisation)} in #{organisation.closed_at.to_fs(:one_month_precision)}".html_safe
       else
         "#{organisation.name} was replaced by #{superseding_organisations_text(organisation)}".html_safe
       end
     elsif organisation.merged?
       if organisation.closed_at.present?
-        "#{organisation.name} became part of #{superseding_organisations_text(organisation)} in #{organisation.closed_at.to_s(:one_month_precision)}".html_safe
+        "#{organisation.name} became part of #{superseding_organisations_text(organisation)} in #{organisation.closed_at.to_fs(:one_month_precision)}".html_safe
       else
         "#{organisation.name} is now part of #{superseding_organisations_text(organisation)}".html_safe
       end

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -86,11 +86,11 @@ module Admin
 
     def date_range_string
       if from_date && to_date
-        "from #{from_date.to_date.to_s(:uk_short)} to #{to_date.to_date.to_s(:uk_short)}"
+        "from #{from_date.to_date.to_fs(:uk_short)} to #{to_date.to_date.to_fs(:uk_short)}"
       elsif from_date
-        "from #{from_date.to_date.to_s(:uk_short)}"
+        "from #{from_date.to_date.to_fs(:uk_short)}"
       elsif to_date
-        "before #{to_date.to_date.to_s(:uk_short)}"
+        "before #{to_date.to_date.to_fs(:uk_short)}"
       end
     end
 

--- a/app/models/statistics_announcement_date.rb
+++ b/app/models/statistics_announcement_date.rb
@@ -13,11 +13,11 @@ class StatisticsAnnouncementDate < ApplicationRecord
   def display_date
     case precision
     when PRECISION[:exact]
-      release_date.to_s(:date_with_time)
+      release_date.to_fs(:date_with_time)
     when PRECISION[:one_month]
-      release_date.to_s(:one_month_precision)
+      release_date.to_fs(:one_month_precision)
     when PRECISION[:two_month]
-      release_date.to_s(:two_month_precision)
+      release_date.to_fs(:two_month_precision)
     end
   end
 

--- a/app/presenters/document_filter_presenter.rb
+++ b/app/presenters/document_filter_presenter.rb
@@ -44,11 +44,11 @@ DocumentFilterPresenter = Struct.new(:filter, :context, :document_decorator) do 
   end
 
   def date_from
-    from_date ? from_date.to_s(:uk_short) : nil
+    from_date ? from_date.to_fs(:uk_short) : nil
   end
 
   def date_to
-    to_date ? to_date.to_s(:uk_short) : nil
+    to_date ? to_date.to_fs(:uk_short) : nil
   end
 
   def documents

--- a/app/presenters/filter_description_presenter.rb
+++ b/app/presenters/filter_description_presenter.rb
@@ -63,13 +63,13 @@ private
 
   def to_date_fragment
     @to_date_fragment ||= if filter.respond_to?(:to_date) && filter.to_date.present?
-                            "<strong>before #{filter.to_date.to_s(:long_ordinal)}</strong> #{remove_field_link(:to_date, filter.to_date, "#{date_prefix_text} before date")}"
+                            "<strong>before #{filter.to_date.to_fs(:long_ordinal)}</strong> #{remove_field_link(:to_date, filter.to_date, "#{date_prefix_text} before date")}"
                           end
   end
 
   def from_date_fragment
     @from_date_fragment ||= if filter.respond_to?(:from_date) && filter.from_date.present?
-                              "<strong>after #{filter.from_date.to_s(:long_ordinal)}</strong> #{remove_field_link(:from_date, filter.from_date, "#{date_prefix_text} after date")}"
+                              "<strong>after #{filter.from_date.to_fs(:long_ordinal)}</strong> #{remove_field_link(:from_date, filter.from_date, "#{date_prefix_text} after date")}"
                             end
   end
 

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -31,7 +31,7 @@
   <fieldset class="first-published-date">
     <div class="form-group">
       <%= form.label :first_published_at, "First published" %>
-      <p class="js-existing-first-published"><strong><%= edition.first_published_at.to_s(:govuk_date) %></strong> &mdash; <a href="#">Edit date</a></p>
+      <p class="js-existing-first-published"><strong><%= edition.first_published_at.to_fs(:govuk_date) %></strong> &mdash; <a href="#">Edit date</a></p>
       <div class="edit if-js-hide form-inline">
         <%= form.datetime_select :first_published_at, { start_year: Date.today.year, end_year: 1945 }, { class: 'date js-first-published-at-edit form-control' } %>
       </div>

--- a/app/views/admin/fact_check_requests/show.html.erb
+++ b/app/views/admin/fact_check_requests/show.html.erb
@@ -19,7 +19,7 @@
       <p class="details">
         <span class="from"><%= @fact_check_request.email_address %></span>
         on
-        <span class="time"><%= @fact_check_request.updated_at.to_s(:long_ordinal) %></span>
+        <span class="time"><%= @fact_check_request.updated_at.to_fs(:long_ordinal) %></span>
       </p>
 
       <div class="comments">

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -27,10 +27,10 @@
           <% end %>
         </td>
         <td>
-          <%= government.start_date.to_s(:govuk_date) %>
+          <%= government.start_date.to_fs(:govuk_date) %>
         </td>
         <td>
-          <%= government.end_date.to_s(:govuk_date) if government.end_date %>
+          <%= government.end_date.to_fs(:govuk_date) if government.end_date %>
         </td>
       <% end %>
     <% end %>

--- a/app/views/admin/responses/show.html.erb
+++ b/app/views/admin/responses/show.html.erb
@@ -11,7 +11,7 @@
         <div class="summary">
           <h3><%= @response.friendly_name.capitalize %> summary</h3>
           <%= govspeak_to_html @response.summary %>
-          <p>Published on <%= @response.published_on.to_s(:long_ordinal) %></p>
+          <p>Published on <%= @response.published_on.to_fs(:long_ordinal) %></p>
         </div>
 
         <ul class="actions">

--- a/app/views/admin/statistics_announcements/_document_status.html.erb
+++ b/app/views/admin/statistics_announcements/_document_status.html.erb
@@ -14,7 +14,7 @@
       <% if publication.pre_publication? %>
       When the connected document is published this announcement will redirect to it.
       <% else %>
-      The connected document replaced this announcement on <%= publication.public_timestamp.to_s(:long_ordinal) %>.
+      The connected document replaced this announcement on <%= publication.public_timestamp.to_fs(:long_ordinal) %>.
       <% end %>
       <span class="js-document-announcement-linker"></span>
     </p>

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -26,9 +26,9 @@
       <dt>Release date:</dt>
       <dd>
         <% if @statistics_announcement.cancelled? %>
-          <del><%= @statistics_announcement.release_date.to_s(:date_with_time) %></del> (Cancelled)
+          <del><%= @statistics_announcement.release_date.to_fs(:date_with_time) %></del> (Cancelled)
         <% else %>
-          <%= @statistics_announcement.release_date.to_s(:date_with_time) %>
+          <%= @statistics_announcement.release_date.to_fs(:date_with_time) %>
         <% end %>
         –
         <%= link_to "Change release date", new_admin_statistics_announcement_change_path(@statistics_announcement) %>

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -187,7 +187,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     _older_news_article = create(:draft_news_article, updated_at: 3.days.ago)
     newer_news_article = create(:draft_news_article, updated_at: 1.minute.ago)
 
-    assert_equal [newer_news_article], Admin::EditionFilter.new(Edition, @current_user, from_date: 2.days.ago.to_date.to_s(:short)).editions
+    assert_equal [newer_news_article], Admin::EditionFilter.new(Edition, @current_user, from_date: 2.days.ago.to_date.to_fs(:short)).editions
   end
 
   test "can filter by classifications" do

--- a/test/unit/edition/active_editors_test.rb
+++ b/test/unit/edition/active_editors_test.rb
@@ -18,7 +18,7 @@ class Edition::ActiveEditorsTest < ActiveSupport::TestCase
       edition.open_for_editing_as(user)
     end
     assert_equal user, edition.recent_edition_openings.first.editor
-    assert_equal Time.zone.now.to_s(:rfc822), edition.recent_edition_openings.first.created_at.in_time_zone.to_s(:rfc822)
+    assert_equal Time.zone.now.to_fs(:rfc822), edition.recent_edition_openings.first.created_at.in_time_zone.to_fs(:rfc822)
   end
 
   test "can check exclude a given editor from the list of recent edition openings" do

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -121,7 +121,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       update_type: "minor",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
-        previous_display_date: 7.days.from_now.to_s(:date_with_time),
+        previous_display_date: 7.days.from_now.to_fs(:date_with_time),
         latest_change_note: "Reasons",
         state: statistics_announcement.state,
         format_sub_type: "official",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
