### PR TITLE
Remove unused code from Publications controller

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -2,7 +2,6 @@ class PublicationsController < DocumentsController
   enable_request_formats index: %i[json atom]
   before_action :expire_cache_when_next_publication_published
   before_action :redirect_statistics_filtering, only: [:index]
-  before_action :redirect_statistics_documents, only: [:show]
   include PublicationsRoutes
 
   def index
@@ -104,12 +103,6 @@ private
         ),
         status: :moved_permanently,
       )
-    end
-  end
-
-  def redirect_statistics_documents
-    if @document.statistics?
-      redirect_to public_document_path(@document), status: :moved_permanently
     end
   end
 end


### PR DESCRIPTION
Looking into where we might have redirect_to problems I noticed that
this code isn't used as we removed this action in 2017 [1].

[1]:https://github.com/alphagov/whitehall/commit/b222692e9eca6ee82fe0013cc549f8cc8c86bde3

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
