### PR TITLE
Avoid redirecting to absolute URLS

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -52,7 +52,7 @@ private
   end
 
   def redirect_to_news_and_communications(format = "")
-    base_path = "#{Plek.new.website_root}/search/news-and-communications#{format}"
+    base_path = "/search/news-and-communications#{format}"
     redirect_to("#{base_path}?#{news_and_communications_query_string}")
   end
 

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -71,6 +71,6 @@ private
     # Cache is explicitly 1 minute to prevent the virus redirect beng
     # cached by CDNs.
     expires_in(1.minute, public: true)
-    redirect_to placeholder_url
+    redirect_to placeholder_path
   end
 end

--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -30,10 +30,9 @@ private
   end
 
   def email_alert_frontend_signup_with_slug(slug)
-    base_path = Plek.new.website_root
     path = "/email/subscriptions/new?"
     params = { topic_id: slug }
 
-    base_path + path + params.to_query
+    path + params.to_query
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -53,7 +53,7 @@ private
   end
 
   def redirect_to_finder_frontend_finder(format = "")
-    base_path = "#{Plek.new.website_root}/#{publications_base_path}#{format}"
+    base_path = "/#{publications_base_path}#{format}"
     if publications_query_string == ""
       redirect_to(base_path)
     else

--- a/app/controllers/statistics_announcements_controller.rb
+++ b/app/controllers/statistics_announcements_controller.rb
@@ -8,7 +8,7 @@ class StatisticsAnnouncementsController < PublicFacingController
 private
 
   def redirect_to_research_and_statistics
-    base_path = "#{Plek.new.website_root}/search/research-and-statistics"
+    base_path = "/search/research-and-statistics"
     redirect_to("#{base_path}?#{research_and_statistics_query_string}")
   end
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -24,7 +24,7 @@ private
   end
 
   def redirect_to_research_and_statistics(format = "")
-    base_path = "#{Plek.new.website_root}/search/research-and-statistics#{format}"
+    base_path = "/search/research-and-statistics#{format}"
     redirect_to("#{base_path}?#{research_and_statistics_query_string}")
   end
 

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -51,7 +51,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
       topical_events: %w[one two],
     }.to_query
 
-    assert_redirected_to "#{Plek.new.website_root}/search/news-and-communications?#{redirect_params_query}"
+    assert_redirected_to "/search/news-and-communications?#{redirect_params_query}"
   end
 
   test "when locale is english it redirects and atom feed with params for finder-frontend" do
@@ -81,7 +81,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
       public_timestamp: { from: "01/01/2014", to: "01/01/2014" },
     }.to_query
 
-    assert_redirected_to "#{Plek.new.website_root}/search/news-and-communications.atom?#{redirect_params_query}"
+    assert_redirected_to "/search/news-and-communications.atom?#{redirect_params_query}"
   end
 
   view_test "index with locale shows a mix of news and speeches" do

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -28,7 +28,7 @@ class EmailSignupsControllerTest < ActionController::TestCase
 
     get :new, params: { email_signup: { feed: atom_feed_url_for(world_location) } }
 
-    assert_redirected_to "https://www.test.gov.uk/email/subscriptions/new?topic_id=some-slug"
+    assert_redirected_to "http://test.host/email/subscriptions/new?topic_id=some-slug"
   end
 
   view_test "GET :new redirects to publications controller if signup is for a publication finder" do

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -49,42 +49,42 @@ class PublicationsControllerTest < ActionController::TestCase
 
   test "when locale is English it redirects with params for finder-frontend" do
     get :index, params: @default_params
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.to_query}"
   end
 
   test "when locale is English it redirects an atom feed request with params for finder-frontend" do
     get :index, params: @default_params, format: :atom
-    assert_redirected_to "#{Plek.new.website_root}/search/all.atom?#{@default_converted_params.to_query}"
+    assert_redirected_to "/search/all.atom?#{@default_converted_params.to_query}"
   end
 
   test "when official_document_status is specified redirects with params for official-documents finder" do
     get :index, params: @default_params.merge(official_document_status: "command_and_act_papers")
-    assert_redirected_to "#{Plek.new.website_root}/official-documents?#{@default_converted_params.to_query}"
+    assert_redirected_to "/official-documents?#{@default_converted_params.to_query}"
   end
 
   test "strips out 'all' taxons from query string in redirect" do
     get :index, params: @default_params.merge(taxons: %w[all])
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(level_one_taxon: nil).compact.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.merge(level_one_taxon: nil).compact.to_query}"
   end
 
   test "strips out 'all' subtaxons from query string in redirect" do
     get :index, params: @default_params.merge(subtaxons: %w[all])
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(level_two_taxon: nil).compact.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.merge(level_two_taxon: nil).compact.to_query}"
   end
 
   test "strips out 'all' departments from query string in redirect" do
     get :index, params: @default_params.merge(departments: %w[all])
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(organisations: nil).compact.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.merge(organisations: nil).compact.to_query}"
   end
 
   test "strips out 'all' people from query string in redirect" do
     get :index, params: @default_params.merge(people: %w[all])
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.to_query}"
   end
 
   test "strips out 'all' world locations from query string in redirect" do
     get :index, params: @default_params.merge(world_locations: %w[all])
-    assert_redirected_to "#{Plek.new.website_root}/search/all?#{@default_converted_params.merge(world_locations: nil).compact.to_query}"
+    assert_redirected_to "/search/all?#{@default_converted_params.merge(world_locations: nil).compact.to_query}"
   end
 
   view_test "#index only displays *published* publications" do

--- a/test/functional/statistics_announcements_controller_test.rb
+++ b/test/functional/statistics_announcements_controller_test.rb
@@ -24,6 +24,6 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
       public_timestamp: { from: "01/01/2014", to: "01/01/2014" },
     }.to_query
 
-    assert_redirected_to "#{Plek.new.website_root}/search/research-and-statistics?#{redirect_params_query}"
+    assert_redirected_to "/search/research-and-statistics?#{redirect_params_query}"
   end
 end

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -48,6 +48,6 @@ class StatisticsControllerTest < ActionController::TestCase
       public_timestamp: { from: "01/01/2014", to: "01/01/2014" },
     }.to_query
 
-    assert_redirected_to "#{Plek.new.website_root}/search/research-and-statistics?#{redirect_params_query}"
+    assert_redirected_to "/search/research-and-statistics?#{redirect_params_query}"
   end
 end


### PR DESCRIPTION
In all of these cases we're redirecting to the same domain, so prefixing with the fully-qualified domain gets us nothing. In Rails 7 this will be an error and needs to be specifically permitted; better to rewrite them instead.

(These are all the cases where the existing tests raise exceptions when run under Rails 7, e.g. in #6449. There may be others that are untested.)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
