### PR TITLE
Update page title to better describe the page

### DIFF
--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title "UK and the world" %>
+<% page_title "Help and services around the world" %>
 <% page_class "govuk-width-container world-locations-index index-list-page" %>
 
 <div class="govuk-grid-row">

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -1,11 +1,11 @@
-<% page_title "Help and services around the world" %>
+<% page_title sanitize(t("world_location.content.heading")) %>
 <% page_class "govuk-width-container world-locations-index index-list-page" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <header class="js-filter-list">
       <%= render "govuk_publishing_components/components/title", {
-        title: sanitize("Help and services around the&nbsp;world")
+        title: sanitize(t("world_location.content.heading"))
       } %>
 
       <p class="govuk-body"><%= t('world_location.content.find_out') %></p>

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title sanitize(t("world_location.content.heading")) %>
+<% page_title sanitize(t("world_location.content.heading").gsub!(/&nbsp;/, " ")) %>
 <% page_class "govuk-width-container world-locations-index index-list-page" %>
 
 <div class="govuk-grid-row">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -868,6 +868,7 @@ ar:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: إعلاناتنا

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -567,6 +567,7 @@ az:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Elanlarımız

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -716,6 +716,7 @@ be:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Нашы аб'явы

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -566,6 +566,7 @@ bg:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Нашите съобщения

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -566,6 +566,7 @@ bn:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: আমাদের ঘোষণাসমূহ

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -643,6 +643,7 @@ cs:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Naše oznámení

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -870,6 +870,7 @@ cy:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Ein cyhoeddiadau

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -567,6 +567,7 @@ da:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Vores meddelelser

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -566,6 +566,7 @@ de:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Unsere Ankündigungen

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -571,6 +571,7 @@ dr:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: اطلاعیه هایی ما

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -566,6 +566,7 @@ el:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Οι ανακοινώσεις μας

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -576,6 +576,7 @@ en:
       statistics: Our statistics
     content:
       find_out: Find out what is help is available from the UK government if you're abroad.
+      heading: Help and services around the&nbsp;world
       complete_list: See the complete %{href}. This includes all embassies, high commissions and consulates.
       list_link: list of overseas Foreign, Commonwealth & Development Office posts
     type:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -567,6 +567,7 @@ es-419:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Nuestros comunicados

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -564,6 +564,7 @@ es:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Nuestros anuncios

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -566,6 +566,7 @@ et:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Meie teadaanded

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -566,6 +566,7 @@ fa:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: اطلاعیه‌های ما

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -567,6 +567,7 @@ fi:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Ilmoituksemme

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -567,6 +567,7 @@ fr:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Nos annonces

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -718,6 +718,7 @@ gd:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Ár liostaí

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -566,6 +566,7 @@ gu:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: અમારી જાહેરાતો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -567,6 +567,7 @@ he:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ההודעות שלנו

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -567,6 +567,7 @@ hi:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: हमारी घोषणाएं

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -719,6 +719,7 @@ hr:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Naše obavijesti

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -566,6 +566,7 @@ hu:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Híreink

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -567,6 +567,7 @@ hy:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Մեր հայտարարությունները

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -490,6 +490,7 @@ id:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Pengumuman kami

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -566,6 +566,7 @@ is:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Okkar tilkynningar

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -567,6 +567,7 @@ it:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: I nostri annunci

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -490,6 +490,7 @@ ja:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: お知らせ

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -567,6 +567,7 @@ ka:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ჩვენი განცხადებები

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -566,6 +566,7 @@ kk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Біздің хабарландыруларымыз

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -490,6 +490,7 @@ ko:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: 공지사항

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -642,6 +642,7 @@ lt:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Mūsų skelbimai

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -564,6 +564,7 @@ lv:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Paziņojumi

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -491,6 +491,7 @@ ms:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Pengumuman kami

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -716,6 +716,7 @@ mt:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: L-avviżi tagħna

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -566,6 +566,7 @@ ne:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: हाम्रा घोषणाहरु

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -564,6 +564,7 @@ nl:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Onze aankondigingen

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -567,6 +567,7 @@
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Våre kunngjøringer

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -566,6 +566,7 @@ pa-pk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ساڈے اعلانات

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -567,6 +567,7 @@ pa:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ਸਾਡੀਆਂ ਘੋਸ਼ਣਾਵਾਂ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -716,6 +716,7 @@ pl:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Nasze ogłoszenia

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -567,6 +567,7 @@ ps:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: زموږ اعلانونه

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -567,6 +567,7 @@ pt:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Os nossos anúncios

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -642,6 +642,7 @@ ro:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Anunțurile noastre

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -716,6 +716,7 @@ ru:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Наши объявления

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -566,6 +566,7 @@ si:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: අපේ නිවේදන

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -643,6 +643,7 @@ sk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Naše oznámenia

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -719,6 +719,7 @@ sl:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Naši razglasi

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -566,6 +566,7 @@ so:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Ku dhawaaqisahayaga

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -567,6 +567,7 @@ sq:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Njoftimet tona

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -643,6 +643,7 @@ sr:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Naša saopštenja

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -567,6 +567,7 @@ sv:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Våra tillkännagivanden

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -566,6 +566,7 @@ sw:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Matangazo yetu

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -566,6 +566,7 @@ ta:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: எங்கள் அறிவிப்புகள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -490,6 +490,7 @@ th:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ประกาศของเรา

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -566,6 +566,7 @@ tk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Biziň bildirişlerimiz

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -566,6 +566,7 @@ tr:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Duyurularımız

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -718,6 +718,7 @@ uk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Наші оголошення

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -566,6 +566,7 @@ ur:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: ہمارے اعلانات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -566,6 +566,7 @@ uz:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Бизнинг эълонлар

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -490,6 +490,7 @@ vi:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: Thông báo của chúng tôi

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -564,6 +564,7 @@ yi:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -566,6 +566,7 @@ zh-hk:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: 我們的公告

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -566,6 +566,7 @@ zh-tw:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: 我們的公告

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -490,6 +490,7 @@ zh:
     content:
       complete_list:
       find_out:
+      heading:
       list_link:
     headings:
       announcements: 我们的公告


### PR DESCRIPTION
## What

Update the title of the "Help and services around the world" page to better describe the content - [https://www.gov.uk/world](https://www.gov.uk/world
)

## Why

The current page title of "UK and the world" is not descriptive enough to help users identify their current location without requiring users to read or interpret page content.

Further information - [WCAG - Understanding Success Criterion 2.4.2: Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️