### PR TITLE
Update Find in admin bookmarklet

### DIFF
--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -1,73 +1,87 @@
-function url_matcher(path_fragment) {
-  return function() { return window.location.toString().search(path_fragment) >= 0 }
-};
-function all_matcher() {
-  return true;
-};
+(function() {
+    function callback() {
+        (function($) {
+            var jQuery = $;
+            function url_matcher(path_fragment) {
+              return function() { return window.location.toString().search(path_fragment) >= 0 }
+            };
+            function all_matcher() {
+              return true;
+            };
 
-function id_from_url() {
-  return window.location.toString().split('/').pop();
-};
-function id_from_doc_page() {
-  document_page_id = $('.document-page, [id^=detailed_guide_]');
-  if (document_page_id == null) {
-    return false;
-  } else if (document_page_id.length > 0) {
-    return document_page_id.attr('id').split('_').pop();
-  }
-};
-function content_id_from_meta_tag() {
-  return document.querySelector('meta[name="govuk:content-id"]').content;
-};
+            function id_from_url() {
+              return window.location.toString().split('/').pop();
+            };
+            function id_from_doc_page() {
+              document_page_id = $('.document-page, [id^=detailed_guide_]');
+              if (document_page_id == null) {
+                return false;
+              } else if (document_page_id.length > 0) {
+                return document_page_id.attr('id').split('_').pop();
+              }
+            };
+            function content_id_from_meta_tag() {
+              return document.querySelector('meta[name="govuk:content-id"]').content;
+            };
 
-function path_builder(path_fragment) {
-  return function(id) { return path_fragment + id; };
-};
+            function path_builder(path_fragment) {
+              return function(id) { return path_fragment + id; };
+            };
 
-var mappings = [
-  {
-    matcher: url_matcher("announcements/"),
-    path_builder: path_builder("statistics_announcements/"),
-    id_finder: id_from_url
-  },
-  {
-    matcher: url_matcher("organisations/"),
-    path_builder: path_builder("organisations/"),
-    id_finder: id_from_url
-  },
-  {
-    matcher: url_matcher("topics/"),
-    path_builder: path_builder("topics/"),
-    id_finder: id_from_url
-  },
-  {
-    matcher: url_matcher("world/"),
-    path_builder: path_builder("world_locations/"),
-    id_finder: id_from_url
-  },
-  {
-    matcher: all_matcher,
-    path_builder: path_builder("editions/"),
-    id_finder: id_from_doc_page
-  }
-];
+            var mappings = [
+              {
+                matcher: url_matcher("announcements/"),
+                path_builder: path_builder("statistics_announcements/"),
+                id_finder: id_from_url
+              },
+              {
+                matcher: url_matcher("organisations/"),
+                path_builder: path_builder("organisations/"),
+                id_finder: id_from_url
+              },
+              {
+                matcher: url_matcher("topics/"),
+                path_builder: path_builder("topics/"),
+                id_finder: id_from_url
+              },
+              {
+                matcher: url_matcher("world/"),
+                path_builder: path_builder("world_locations/"),
+                id_finder: id_from_url
+              },
+              {
+                matcher: all_matcher,
+                path_builder: path_builder("editions/"),
+                id_finder: id_from_doc_page
+              }
+            ];
 
-function get_mapping() {
-  for(var i=0; i<mappings.length; i++) {
-    if (mappings[i].matcher()) return mappings[i];
-  }
-}
+            function get_mapping() {
+              for(var i=0; i<mappings.length; i++) {
+                if (mappings[i].matcher()) return mappings[i];
+              }
+            }
 
-function nav_to_backend() {
-  var mapping = get_mapping();
-  if (mapping){
-    admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
-    if(mapping.id_finder()){
-      window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());
-    }else{
-      window.location = admin_path + "/by-content-id/" + content_id_from_meta_tag();
-    };
-  }
-}
-
-nav_to_backend();
+            function nav_to_backend() {
+              var mapping = get_mapping();
+              if (mapping){
+                admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
+                if(mapping.id_finder()){
+                  window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());
+                }else{
+                  window.location = admin_path + "/by-content-id/" + content_id_from_meta_tag();
+                };
+              }
+            }
+            nav_to_backend();
+        })(jQuery.noConflict(true))
+    }
+    var s = document.createElement("script");
+    s.src = "https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js";
+    if (s.addEventListener) {
+        s.addEventListener("load", callback, false)
+    } else if(s.readyState) {
+        s.onreadystatechange = callback
+    }
+    document.body.appendChild(s);
+})();

--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -10,12 +10,14 @@ function id_from_url() {
 };
 function id_from_doc_page() {
   document_page_id = $('.document-page, [id^=detailed_guide_]');
-  if (document_page_id.length > 0) {
+  if (document_page_id == null) {
+    return false;
+  } else if (document_page_id.length > 0) {
     return document_page_id.attr('id').split('_').pop();
   }
 };
 function content_id_from_meta_tag() {
-  return $("meta[name='govuk:content-id']").attr('content');
+  return document.querySelector('meta[name="govuk:content-id"]').content;
 };
 
 function path_builder(path_fragment) {
@@ -58,7 +60,7 @@ function get_mapping() {
 
 function nav_to_backend() {
   var mapping = get_mapping();
-  if (mapping){ 
+  if (mapping){
     admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
     if(mapping.id_finder()){
       window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());


### PR DESCRIPTION
The Find in admin bookmark stopped working in Chrome: https://govuk.zendesk.com/agent/tickets/4923446

`document_page_id` was being returned as null and calling `length` on it was causing an error.

This also updates content_id_from_meta_tag() to fix `Uncaught TypeError: $(...).attr is not a function`

Tested in Chrome developer console in integration [on this page](https://www.integration.publishing.service.gov.uk/guidance/apply-for-an-advance-tariff-ruling). 
Line 64 replaced with:
 `admin_path = "https://whitehall-admin.integration.publishing.service.gov.uk/government/admin";`

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
