### PR TITLE
Enlarge font for accessible format link

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -70,7 +70,7 @@
 
     <% unless attachment.accessible? %>
       <% if attachment.attachable.respond_to?(:content_id) && attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
-        <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link"  %>
+        <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link govuk-!-font-size-19" %>
       <% else %>
         <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
           <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>


### PR DESCRIPTION
The default is 16px. We wan't to enlarge the font size to 19px to match
the equivalent attachment component size [1].

[1]: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss#L11

### Screenshot

<img width="1762" alt="Screenshot 2022-03-28 at 15 31 54" src="https://user-images.githubusercontent.com/24479188/160421447-fd1f05b2-41f3-4d8f-88a8-1236a96841b2.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
