### PR TITLE
Fix find in admin bookmarklet

### DIFF
--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -64,9 +64,9 @@ function nav_to_backend() {
   if (mapping){
     admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
     if(mapping.id_finder()){
-      window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());
+      window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder()) + "?utm_content=find-in-admin-bookmarklet";
     }else{
-      window.location = admin_path + "/by-content-id/" + content_id_from_meta_tag();
+      window.location = admin_path + "/by-content-id/" + content_id_from_meta_tag() + "?utm_content=find-in-admin-bookmarklet";
     };
   }
 }

--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -9,13 +9,16 @@ function id_from_url() {
   return window.location.toString().split('/').pop();
 };
 function id_from_doc_page() {
-  document_page_id = $('.document-page, [id^=detailed_guide_]');
-  if (document_page_id.length > 0) {
-    return document_page_id.attr('id').split('_').pop();
+  document_page_id = document.querySelector('.document-page') || document.querySelector('[id^=detailed_guide_]');
+  if (document_page_id) {
+    return document_page_id.getAttribute('id').split('_').pop();
   }
 };
 function content_id_from_meta_tag() {
-  return $("meta[name='govuk:content-id']").attr('content');
+  content_id = document.querySelector("meta[name='govuk:content-id']");
+  if (content_id) {
+    return content_id.getAttribute('content');
+  }
 };
 
 function path_builder(path_fragment) {
@@ -51,14 +54,14 @@ var mappings = [
 ];
 
 function get_mapping() {
-  for(var i=0; i<mappings.length; i++) {
+  for(var i = 0; i < mappings.length; i++) {
     if (mappings[i].matcher()) return mappings[i];
   }
 }
 
 function nav_to_backend() {
   var mapping = get_mapping();
-  if (mapping){ 
+  if (mapping){
     admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
     if(mapping.id_finder()){
       window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What/why

- in whitehall admin at '/government/admin/find-in-admin-bookmarklet/' there is a feature that allows users to drag a bookmarklet to their toolbar, that will then open a GOV.UK public page in whitehall publisher
- this broke recently because it relied upon jQuery and we removed jQuery from GOV.UK last week
- this fix removes the jQuery dependency from this script
- unfortunately users with the existing bookmarklet will need to delete and recreate it

## Visual changes
None.
