### PR TITLE
Backfill auth bypass ids for editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -98,6 +98,7 @@ class Edition < ApplicationRecord
   # @!group Callbacks
   before_save :set_public_timestamp
   before_save { check_if_locked_document(edition: self) }
+  before_save :set_auth_bypass_id
   # @!endgroup
 
   class UnmodifiableValidator < ActiveModel::Validator
@@ -641,6 +642,10 @@ EXISTS (
                             else
                               major_change_published_at
                             end
+  end
+
+  def set_auth_bypass_id
+    self.auth_bypass_id = SecureRandom.uuid
   end
 
   def title_required?

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -24,6 +24,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: "case_study",
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/db/migrate/20220413181013_add_auth_bypass_id_to_editions.rb
+++ b/db/migrate/20220413181013_add_auth_bypass_id_to_editions.rb
@@ -1,0 +1,5 @@
+class AddAuthBypassIdToEditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :editions, :auth_bypass_id, :string
+  end
+end

--- a/db/migrate/20220425095700_backfill_auth_bypass_id.rb
+++ b/db/migrate/20220425095700_backfill_auth_bypass_id.rb
@@ -1,0 +1,10 @@
+class BackfillAuthBypassId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    to_update = Edition.where(auth_bypass_id: nil)
+    to_update.find_each do |edition|
+      edition.update!(auth_bypass_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2021_10_19_095600) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_13_181013) do
 
   create_table "about_pages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
@@ -418,6 +418,7 @@ ActiveRecord::Schema[6.1].define(version: 2021_10_19_095600) do
     t.boolean "read_consultation_principles", default: false
     t.boolean "all_nation_applicability"
     t.string "image_display_option"
+    t.string "auth_bypass_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     change_note { "change-note" }
     summary { "edition-summary" }
     previously_published { false }
-    auth_bypass_id { "52db85fc-0f30-42a6-afdd-c2b31ecc6a67" }
+    auth_bypass_id { SecureRandom.uuid }
 
     trait(:with_organisations) do
       transient do

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     change_note { "change-note" }
     summary { "edition-summary" }
     previously_published { false }
+    auth_bypass_id { "52db85fc-0f30-42a6-afdd-c2b31ecc6a67" }
 
     trait(:with_organisations) do
       transient do

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -2,10 +2,12 @@ require "test_helper"
 
 class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
   def present(edition)
+    edition.auth_bypass_id = '52db85fc-0f30-42a6-afdd-c2b31ecc6a67'
     PublishingApi::CaseStudyPresenter.new(edition)
   end
 
   test "case study presentation includes the correct values" do
+
     case_study = create(
       :published_case_study,
       title: "Case study title",
@@ -13,6 +15,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       body: "Some content",
     )
     public_path = Whitehall.url_maker.public_document_path(case_study)
+
     expected_content = {
       base_path: public_path,
       title: "Case study title",
@@ -28,6 +31,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       ],
       update_type: "major",
       redirects: [],
+      auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: "case_study",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
