### PR TITLE
Add auth bypass ids field to editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -96,6 +96,7 @@ class Edition < ApplicationRecord
   scope :future_scheduled_editions,     -> { scheduled.where(Edition.arel_table[:scheduled_publication].gteq(Time.zone.now)) }
 
   # @!group Callbacks
+  before_create :set_auth_bypass_id
   before_save :set_public_timestamp
   before_save { check_if_locked_document(edition: self) }
   # @!endgroup
@@ -641,6 +642,10 @@ EXISTS (
                             else
                               major_change_published_at
                             end
+  end
+
+  def set_auth_bypass_id
+    self.auth_bypass_id = SecureRandom.uuid
   end
 
   def title_required?

--- a/db/migrate/20220425112459_add_auth_bypass_id_to_editions.rb
+++ b/db/migrate/20220425112459_add_auth_bypass_id_to_editions.rb
@@ -1,0 +1,5 @@
+class AddAuthBypassIdToEditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :editions, :auth_bypass_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_10_19_095600) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_25_112459) do
   create_table "about_pages", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"
@@ -417,6 +417,7 @@ ActiveRecord::Schema[7.0].define(version: 2021_10_19_095600) do
     t.boolean "read_consultation_principles", default: false
     t.boolean "all_nation_applicability"
     t.string "image_display_option"
+    t.string "auth_bypass_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -21,6 +21,11 @@ class EditionTest < ActiveSupport::TestCase
     assert_kind_of Document, edition.document
   end
 
+  test "adds auth bypass id to a newly created edition" do
+    edition = create(:edition)
+    assert_not_nil edition.auth_bypass_id
+  end
+
   test "uses provided document if available" do
     document = build(:document)
     edition = build(:edition, document: document)


### PR DESCRIPTION
Ensure all newly created Whitehall editions are stored with auth bypass ids.

[Trello card](https://trello.com/c/MBi8s6Lh/374-ensure-all-newly-created-whitehall-editions-are-stored-with-auth-bypass-ids)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
