### PR TITLE
Remove 'Get Involved' from rendering examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Whitehall is deployed in two modes:
 
 ## Live examples (frontend)
 
-- Get involved page: [https://www.gov.uk/government/get-involved](https://www.gov.uk/government/get-involved)
 - Field of Operation: [https://www.gov.uk/government/fields-of-operation/iraq](https://www.gov.uk/government/fields-of-operation/iraq)
 - World Embassies: [https://www.gov.uk/world/embassies](https://www.gov.uk/world/embassies)
 - Topical Events: [https://www.gov.uk/government/topical-events/cop26](https://www.gov.uk/government/topical-events/cop26)


### PR DESCRIPTION
The 'Get involved with government' page was migrated to be rendered by Government Frontend in https://trello.com/c/7BjH9PyC.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
