### PR TITLE
Add migration to backfill auth_bypass_ids for all editions

### DIFF
--- a/db/migrate/20220426132125_backfill_auth_bypass_id.rb
+++ b/db/migrate/20220426132125_backfill_auth_bypass_id.rb
@@ -1,0 +1,10 @@
+class BackfillAuthBypassId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    to_update = Edition.where(auth_bypass_id: nil)
+    to_update.find_each do |edition|
+      edition.update!(auth_bypass_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_25_112459) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_26_132125) do
   create_table "about_pages", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Now that newly created editions have auth bypass ids, the next step is to backfill existing editions with an auth_bypass_id each. This is done for all editions regardless of draft status. We will then perform a rake task to re-send draft editions to publishing api / content store to ensure auth bypass ids exist on the backend for all editions. 

This migration is [similar to one done for content publisher](https://github.com/alphagov/content-publisher/blob/main/db/migrate/20200701100346_backfill_auth_bypass_id.rb). I have made a few alterations as I believe some of the work done for the content publisher migration is unnecessary here. 


