### PR TITLE
Add auth_bypass_id to the presenter for each edition type

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -278,6 +278,7 @@ private
         nation_inapplicabilities_attributes: %i[id nation_id alternative_url excluded],
         fatality_notice_casualties_attributes: %i[id personal_details _destroy],
       },
+      :auth_bypass_id,
     ]
   end
 

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -24,6 +24,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: "case_study",
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -27,6 +27,7 @@ module PublishingApi
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: SCHEMA_NAME,
           links: edition_links,
+          auth_bypass_ids: [consultation.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -27,6 +27,7 @@ module PublishingApi
           rendering_app: corporate_information_page.rendering_app,
           schema_name: SCHEMA_NAME,
           links: edition_links,
+          auth_bypass_ids: [corporate_information_page.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: "detailed_guide",
           links: edition_links,
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: "document_collection",
           links: edition_links,
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -23,6 +23,7 @@ module PublishingApi
           schema_name: "fatality_notice",
           details: details,
           links: edition_links,
+          auth_bypass_ids: [item.auth_bypass_id],
         )
         content.merge!(PayloadBuilder::AccessLimitation.for(item))
         content.merge!(PayloadBuilder::FirstPublishedAt.for(item))

--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -20,6 +20,7 @@ module PublishingApi
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "placeholder_#{item.class.name.underscore}",
+        auth_bypass_ids: [item.auth_bypass_id],
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -27,6 +27,7 @@ module PublishingApi
           public_updated_at: public_updated_at,
           rendering_app: news_article.rendering_app,
           schema_name: SCHEMA_NAME,
+          auth_bypass_ids: [news_article.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -21,6 +21,7 @@ module PublishingApi
         rendering_app: item.rendering_app,
         schema_name: "publication",
         links: edition_links,
+        auth_bypass_ids: [item.auth_bypass_id],
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: "speech",
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: item.rendering_app,
           schema_name: "statistical_data_set",
+          auth_bypass_ids: [item.auth_bypass_id],
         )
     end
 

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     change_note { "change-note" }
     summary { "edition-summary" }
     previously_published { false }
+    auth_bypass_id { SecureRandom.uuid }
 
     trait(:with_organisations) do
       transient do

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
   def present(edition)
+    edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
     PublishingApi::CaseStudyPresenter.new(edition)
   end
 
@@ -28,6 +29,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       ],
       update_type: "major",
       redirects: [],
+      auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: "case_study",

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -173,6 +173,10 @@ module PublishingApi::ConsultationPresenterTest
       assert_attribute :schema_name, "consultation"
     end
 
+    test "auth bypass id" do
+      assert_attribute :auth_bypass_ids, [consultation.auth_bypass_id]
+    end
+
     test "tags" do
       assert_details_payload "PublishingApi::PayloadBuilder::TagDetails"
     end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -136,6 +136,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_attribute :document_type, "publication_scheme"
     end
 
+    test "auth bypass id" do
+      assert_attribute :auth_bypass_ids, [corporate_information_page.auth_bypass_id]
+    end
+
     test "links" do
       expected_link_keys = %i[
         organisations

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -5,6 +5,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
   def present(edition)
+    edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
     PublishingApi::DetailedGuidePresenter.new(edition)
   end
 
@@ -51,6 +52,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" },
       ],
       redirects: [],
+      auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
       update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -66,6 +66,10 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   test "it presents the selected global process wide locale as the locale of the document_collection" do
     assert_equal "de", @presented_content[:locale]
   end
+
+  test "it presents the auth bypass id" do
+    assert_equal [@document_collection.auth_bypass_id], @presented_content[:auth_bypass_ids]
+  end
 end
 
 class PublishingApi::DocumentCollectionPresenterWithPublicTimestampTest < ActiveSupport::TestCase

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -65,6 +65,10 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
     assert_equal @first_published_at.utc, @presented_content[:first_published_at]
   end
 
+  test "it presents the auth bypass id" do
+    assert_equal [@fatality_notice.auth_bypass_id], @presented_content[:auth_bypass_ids]
+  end
+
   test "it presents edition links" do
     expected_links = {
       field_of_operation: [@fatality_notice.operational_field.content_id],

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -4,8 +4,9 @@ module PublishingApi
   class GenericEditionPresenterTest < ActiveSupport::TestCase
     include GovukContentSchemaTestHelpers::TestUnit
 
-    def present(...)
-      PublishingApi::GenericEditionPresenter.new(...)
+    def present(edition, update_type: nil)
+      edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
+      PublishingApi::GenericEditionPresenter.new(edition, update_type: update_type)
     end
 
     test "presents an Edition ready for adding to the publishing API" do
@@ -33,6 +34,7 @@ module PublishingApi
           { path: public_path, type: "exact" },
         ],
         redirects: [],
+        auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
         update_type: "major",
         details: {
           tags: {

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -176,6 +176,10 @@ module PublishingApi::NewsArticlePresenterTest
     test "validity" do
       assert_valid_against_schema presented_content, "news_article"
     end
+
+    test "auth bypass id" do
+      assert_attribute :auth_bypass_ids, [news_article.auth_bypass_id]
+    end
   end
 
   class GovernmentResponseTest < TestCase

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
   def present(edition)
+    edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
     PublishingApi::PublicationPresenter.new(edition)
   end
 
@@ -31,6 +32,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" },
       ],
       redirects: [],
+      auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
       first_published_at: publication.first_public_at,
       update_type: "major",
       details: {

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -64,10 +64,11 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       end
 
       it "contains the expected values" do
-        assert_equal("Speech title",        presented.content[:title])
-        assert_equal("The description",     presented.content[:description])
-        assert_equal("whitehall",           presented.content[:publishing_app])
-        assert_equal("government-frontend", presented.content[:rendering_app])
+        assert_equal("Speech title",          presented.content[:title])
+        assert_equal("The description",       presented.content[:description])
+        assert_equal("whitehall",             presented.content[:publishing_app])
+        assert_equal("government-frontend",   presented.content[:rendering_app])
+        assert_equal([speech.auth_bypass_id], presented.content[:auth_bypass_ids])
 
         details = presented.content[:details]
         assert_not(details[:political])

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -57,6 +57,10 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   test "it presents the global process wide locale as the locale of the statistical_data_set" do
     assert_equal "de", @presented_content[:locale]
   end
+
+  test "it presents the auth bypass id" do
+    assert_equal [@statistical_data_set.auth_bypass_id], @presented_content[:auth_bypass_ids]
+  end
 end
 
 class PublishingApi::StatisticalDataSetWithPublicTimestampTest < ActiveSupport::TestCase


### PR DESCRIPTION
Auth_bypass_id is added to presenters for each edition type to send through to the Publishing Api.

[Trello card](https://trello.com/c/MBi8s6Lh/374-ensure-all-newly-created-whitehall-editions-are-stored-with-auth-bypass-ids)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
