### PR TITLE
Add a rake command to republish all drafts

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -234,6 +234,18 @@ namespace :publishing_api do
       puts "Finished queuing items for Publishing API"
     end
 
+    desc "Republish all documents with draft editions"
+    task all_drafts: :environment do
+      editions = Edition.in_pre_publication_state.includes(:document)
+
+      puts "Enqueueing #{editions.count} documents"
+      editions.find_each do |edition|
+        document_id = edition.document.id
+        PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+      end
+      puts "Finished enqueueing items for Publishing API"
+    end
+
     desc "Republish all editions which have attachments to the Publishing API"
     task editions_with_attachments: :environment do
       editions = Edition.publicly_visible.where(

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -230,6 +230,46 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#all_drafts" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:all_drafts"] }
+
+      test "republishes all draft editions" do
+        # A draft document which hasn't been published yet
+        draft_only = create(:draft_detailed_guide).document
+
+        # A published document with no draft edition
+        # This document should *not* be republished
+        create(:published_detailed_guide).document
+
+        # A published document with a newer draft edition
+        published_with_draft = create(:published_detailed_guide).document
+        create(:draft_detailed_guide, document: published_with_draft)
+
+        # A scheduled document which isn't live yet
+        scheduled = create(:scheduled_detailed_guide).document
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          draft_only.id,
+          true, # Publishing API will queue as low priority
+        )
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          published_with_draft.id,
+          true, # Publishing API will queue as low priority
+        )
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          scheduled.id,
+          true, # Publishing API will queue as low priority
+        )
+
+        task.invoke
+      end
+    end
+
     describe "#editions_with_attachments" do
       let(:task) { Rake::Task["publishing_api:bulk_republish:editions_with_attachments"] }
 


### PR DESCRIPTION
This extends the existing collection of Publishing API rake tasks to include one which will bulk republish all documents which have an active draft edition.

This will be needed once the auth_bypass_id fields have been backfilled for existing Edition records. The changes need to be sent to the Publishing API so that shared preview links can be supported for exising drafts.

Trello: https://trello.com/c/PAZNzo4z/382-ensure-existing-whitehall-draft-editions-are-stored-with-authbypassids

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
