### PR TITLE
Correct backfill migration to migrate only for pre-publication states

### DIFF
--- a/db/migrate/20220426132125_backfill_auth_bypass_id.rb
+++ b/db/migrate/20220426132125_backfill_auth_bypass_id.rb
@@ -4,7 +4,7 @@ class BackfillAuthBypassId < ActiveRecord::Migration[7.0]
   def up
     to_update = Edition.where(auth_bypass_id: nil)
     to_update.find_each do |edition|
-      edition.update!(auth_bypass_id: SecureRandom.uuid)
+      edition.update_column(:auth_bypass_id, SecureRandom.uuid)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

The migration as previously written was failing because it did not allow modifications to editions not in pre-publication states (e.g. already published). This modifies the migration to only migrate content in pre-publication state.