### PR TITLE
Auth bypass ids for assets

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -150,6 +150,10 @@ class AttachmentData < ApplicationRecord
     attachments.reverse.detect { |a| (a.attachable || Attachable::Null.new).publicly_visible? }
   end
 
+  def auth_bypass_ids
+    attachable && attachable.respond_to?(:auth_bypass_id) ? [attachable.auth_bypass_id] : []
+  end
+
 private
 
   def filtered_attachments(include_deleted_attachables: false)

--- a/app/models/consultation_response_form_data.rb
+++ b/app/models/consultation_response_form_data.rb
@@ -4,4 +4,8 @@ class ConsultationResponseFormData < ApplicationRecord
   has_one :consultation_response_form
 
   validates :file, presence: true
+
+  def auth_bypass_ids
+    [consultation_response_form.consultation_participation.consultation.auth_bypass_id]
+  end
 end

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -7,4 +7,12 @@ class ImageData < ApplicationRecord
 
   validates :file, presence: true
   validates_with ImageValidator, size: [960, 640]
+
+  def auth_bypass_ids
+    images
+      .joins(:edition)
+      .where("editions.state in (?)", Edition::PRE_PUBLICATION_STATES)
+      .map { |e| e.edition.auth_bypass_id }
+      .uniq
+  end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -7,6 +7,7 @@ class Response < ApplicationRecord
   validates :summary, presence: { unless: :has_attachments }
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :summary
+  delegate :auth_bypass_id, to: :consultation
 
   def access_limited_object
     consultation

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -11,11 +11,15 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = ::File.join("/government/uploads", uploader.store_path)
     draft = uploader.assets_protected?
+
     if uploader.model.respond_to?(:attachable)
-      model_class = uploader.model.attachable && uploader.model.attachable.class.to_s
-      model_id = uploader.model.attachable && uploader.model.attachable.id
+      attachable_model_class = uploader.model.attachable && uploader.model.attachable.class.to_s
+      attachable_model_id = uploader.model.attachable && uploader.model.attachable.id
     end
-    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft, model_class, model_id)
+
+    auth_bypass_ids = uploader.model.respond_to?(:auth_bypass_ids) ? uploader.model.auth_bypass_ids : []
+
+    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
     File.new(uploader.store_path)
   end
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -166,7 +166,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   test "POST :create triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = valid_file_attachment_params
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: attachment }
   end
@@ -390,7 +390,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   test "PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = create(:file_attachment, attachable: @edition)
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     put :update,
         params: {

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -5,6 +5,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
 
   setup do
     login_as :writer
+    ConsultationResponseForm.any_instance.stubs(:consultation_participation).returns(stub(consultation: stub(auth_bypass_id: "auth bypass id")))
   end
 
   should_be_an_admin_controller

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -214,6 +214,7 @@ class AssetManagerIntegrationTest
   class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
     setup do
       @filename = "greenpaper.pdf"
+      ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns([])
       @consultation_response_form_data = FactoryBot.build(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(@filename)),
@@ -243,6 +244,7 @@ class AssetManagerIntegrationTest
     setup do
       filename = "greenpaper.pdf"
       @consultation_response_form_asset_id = "asset-id"
+      ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns([])
       @consultation_response_form_data = FactoryBot.create(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename)),
@@ -270,6 +272,7 @@ class AssetManagerIntegrationTest
     setup do
       filename = "greenpaper.pdf"
       @consultation_response_form_asset_id = "asset-id"
+      ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns([])
       @consultation_response_form_data = FactoryBot.create(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename)),

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -23,6 +23,14 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_match %r{empty file}, attachment.errors[:file].first
   end
 
+  test "returns its attachable's auth_bypass_id when it has one" do
+    auth_bypass_id = "86385d6a-f918-4c93-96bf-087218a48ced"
+    attachable = CaseStudy.new(auth_bypass_id: auth_bypass_id)
+    attachment = build(:attachment_data, attachable: attachable)
+
+    assert_equal [auth_bypass_id], attachment.auth_bypass_ids
+  end
+
   test "should return filename even after reloading" do
     attachment = create(:attachment_data)
     assert_not_nil attachment.filename

--- a/test/unit/consultation_participation_test.rb
+++ b/test/unit/consultation_participation_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class ConsultationParticipationTest < ActiveSupport::TestCase
+  setup do
+    ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns(["auth bypass id"])
+  end
+
   test "should be invalid with malformed link url" do
     participation = build(:consultation_participation, link_url: "invalid-url")
     assert_not participation.valid?
@@ -82,6 +86,7 @@ class ConsultationParticipationTest < ActiveSupport::TestCase
 
   test "does not destroy attached file when if more participations are associated" do
     participation = create(:consultation_participation)
+
     form = create(:consultation_response_form, consultation_participation: participation)
     _other_participation = create(:consultation_participation, consultation_response_form: form)
 

--- a/test/unit/consultation_response_form_data_test.rb
+++ b/test/unit/consultation_response_form_data_test.rb
@@ -5,4 +5,14 @@ class ConsultationResponseFormDataTest < ActiveSupport::TestCase
     consultation_response_form_data = build(:consultation_response_form_data, file: nil)
     assert_not consultation_response_form_data.valid?
   end
+
+  test "should return its consultation's auth_bypass_id" do
+    auth_bypass_id = "86385d6a-f918-4c93-96bf-087218a48ced"
+    consultation = Consultation.new(id: 1, auth_bypass_id: auth_bypass_id)
+    consultation_participation = build(:consultation_participation, consultation: consultation)
+    consultation_response_form = build(:consultation_response_form, consultation_participation: consultation_participation)
+    consultation_response_form_data = build(:consultation_response_form_data, consultation_response_form: consultation_response_form)
+
+    assert_equal consultation_response_form_data.auth_bypass_ids, [auth_bypass_id]
+  end
 end

--- a/test/unit/consultation_response_form_test.rb
+++ b/test/unit/consultation_response_form_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class ConsultationResponseFormTest < ActiveSupport::TestCase
+  setup do
+    ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns(["auth bypass id"])
+  end
+
   test "should be invalid without a title" do
     form = build(:consultation_response_form, title: nil)
     assert_not form.valid?

--- a/test/unit/image_data_test.rb
+++ b/test/unit/image_data_test.rb
@@ -7,4 +7,15 @@ class ImageDataTest < ActiveSupport::TestCase
     image_data = build(:image_data, file: nil)
     assert_not image_data.valid?
   end
+
+  test "returns unique auth_bypass_ids from its image's editions" do
+    case_study_1 =  create(:case_study)
+    case_study_2 =  create(:case_study)
+    images_from_first_edition = (1..3).map { |i| Image.new(id: i, edition: case_study_1) }
+    images_from_second_edition = (4..6).map { |i| Image.new(id: i, edition: case_study_2) }
+
+    image_data = create(:image_data, images: images_from_first_edition + images_from_second_edition)
+
+    assert_equal [case_study_1.auth_bypass_id, case_study_2.auth_bypass_id], image_data.auth_bypass_ids
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -6,6 +6,7 @@ module PublishingApi::ConsultationPresenterTest
 
     setup do
       create(:current_government)
+      ConsultationResponseFormData.any_instance.stubs(:auth_bypass_ids).returns(["auth bypass id"])
     end
 
     def presented_consultation

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -80,6 +80,17 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @legacy_url_path, true, policy_group.class.to_s, policy_group.id)
   end
 
+  test "sends auth bypass ids to asset manager when these are passed through in the params" do
+    consultation = FactoryBot.create(:consultation)
+    response = FactoryBot.create(:consultation_outcome, consultation: consultation)
+    attachment = FactoryBot.create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id]))
+
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id, [consultation.auth_bypass_id])
+  end
+
   test "doesn't run if the file is missing (e.g. job ran twice)" do
     path = @file.path
     FileUtils.rm(@file)


### PR DESCRIPTION
Trello: https://trello.com/c/udy9k9H4/364-ensure-that-assets-in-whitehall-for-draft-editions-are-stored-with-authbypassids

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR adds functionality to send auth bypass ids to asset manager from their respective editions. This is so that an edition's assets can be viewed as part of the shareable preview.