### PR TITLE
Fixup last DB migration that missed some records

### DIFF
--- a/db/migrate/20220429152937_backfill_auth_bypass_id_unscoped.rb
+++ b/db/migrate/20220429152937_backfill_auth_bypass_id_unscoped.rb
@@ -1,0 +1,13 @@
+# This supplements the previous migration, BackfillAuthBypassId.
+# It acts upon Edition.unscoped to bypass the default scope that Edition::Workflow introduces.
+# Without unscoping the model, the migration excludes Editions in the 'deleted' state.
+class BackfillAuthBypassIdUnscoped < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    to_update = Edition.unscoped.where(auth_bypass_id: nil)
+    to_update.find_each do |edition|
+      edition.update_column(:auth_bypass_id, SecureRandom.uuid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_26_132125) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_29_152937) do
   create_table "about_pages", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"


### PR DESCRIPTION
This supplements the previous database migration (added in #6530 and #6537), [BackfillAuthBypassId][], which intended to populate the `auth_bypass_id` column for all existing Edition records.

Unfortunately the last migration missed some Editions because the model has a [default scope configured by Edition::Workflow][default_scope]. This excludes all Editions in the 'deleted' state by default, which means they were missed from the backfill data migration.

This commit adds another migration, essentially the same as the previous one, but it acts upon `Edition.unscoped` to bypass the default scope.

This should result in all remaining Editions to be backfilled correctly (i.e. all 'deleted' Editions).

[BackfillAuthBypassId]: https://github.com/alphagov/whitehall/blob/69e14c046620e8a2f86e960f761fe8c73d7f8c2a/db/migrate/20220426132125_backfill_auth_bypass_id.rb
[default_scope]: https://github.com/alphagov/whitehall/blob/69e14c046620e8a2f86e960f761fe8c73d7f8c2a/app/models/edition/workflow.rb#L21

Trello: https://trello.com/c/PAZNzo4z/382-ensure-existing-whitehall-draft-editions-are-stored-with-authbypassids

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
