### PR TITLE
Ignore Mysql2::Error exceptions during data sync

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -6,5 +6,6 @@ GovukError.configure do |config|
 
   config.data_sync_excluded_exceptions += [
     "ActiveRecord::Deadlocked",
+    "Mysql2::Error",
   ]
 end


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

When staging and integration reset their databases overnight, there can
be MySQL errors (example [1]). These errors can't be avoided, because of
our configuration, however they can be ignored by specifying them as
exceptions to be excluded during the data sync.

[1]: https://sentry.io/organizations/govuk/issues/3231309323/?project=202259&referrer=slack

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
