### PR TITLE
Install sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "rinku", require: "rails_rinku"
 gem "ruby-progressbar", require: false
 gem "rubyzip"
 gem "sassc-rails"
+gem "sentry-sidekiq"
 gem "shared_mustache"
 gem "sidekiq-scheduler"
 gem "slimmer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -651,6 +651,9 @@ GEM
       sentry-ruby-core (= 5.2.1)
     sentry-ruby-core (5.2.1)
       concurrent-ruby
+    sentry-sidekiq (5.2.1)
+      sentry-ruby-core (~> 5.2.1)
+      sidekiq (>= 3.0)
     shared_mustache (1.0.1)
       execjs (>= 1.2.4)
       mustache (~> 1.0.2)
@@ -826,6 +829,7 @@ DEPENDENCIES
   ruby-progressbar
   rubyzip
   sassc-rails
+  sentry-sidekiq
   shared_mustache
   sidekiq-scheduler
   simplecov


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

This has been installed to resolve an issue where the exceptions that
are raised from Sidekiq are all wrapped in a Sidekiq::Job::Skip
exception wrapper and become hard to distinguish.

My understanding is that the cause of these was the switch from
sentry-raven to sentry-ruby in govuk_app_config [1]. In sentry-raven
there used to be handling for sidekiq [2], however this has now been
removed [3].

I'm adding the gem directly to Whitehall as a way to test out whether
this resolves the problem.

If this does resolve the problem, as I expect, I don't want to put
"sentry-sidekiq" as a dependency of govuk_app_config - as that will
require all clients of that gem to install Sidekiq (as Sidekiq is a
dependency). Instead I will plan to add a check to govuk_app_config that
can warn if this dependency isn't installed, and I'll then add this
dependency to govuk_sidekiq. Once that is done I can remove this manual
installation.

[1]: https://github.com/alphagov/govuk_app_config/pull/199
[2]: https://github.com/getsentry/sentry-ruby/blob/eb8c59861cc3dc29a17282d432309edd86db8286/sentry-raven/lib/raven/integrations/sidekiq.rb
[3]: https://docs.sentry.io/platforms/ruby/migration/#major-changes

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
