### PR TITLE
Remove unused redirects from routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,6 @@ Whitehall::Application.routes.draw do
       # helper methods.
       root to: "home#get_involved", as: :get_involved, via: :get
 
-      get "take-part" => redirect("/get-involved#take-part")
       get "take-part/:id", to: "take_part_pages#show", as: "take_part_page"
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,6 @@ Whitehall::Application.routes.draw do
   get "/auth/failure", to: "admin/base#auth_failure", as: "auth_failure_fixed"
 
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
-    external_redirect "/organisations/ministry-of-defence-police-and-guarding-agency",
-                      "http://webarchive.nationalarchives.gov.uk/20121212174735/http://www.mod.uk/DefenceInternet/AboutDefence/WhatWeDo/SecurityandIntelligence/MDPGA/"
-
     root to: redirect("/", prefix: ""), via: :get, as: :main_root
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
     scope "/get-involved" do


### PR DESCRIPTION
This removes two redirects that are no longer routed to Whitehall Frontend, so these redirects are no longer required.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
