### PR TITLE
Implement paste to govspeak

### DIFF
--- a/app/assets/javascripts/admin/modules/paste_html_to_govspeak.js
+++ b/app/assets/javascripts/admin/modules/paste_html_to_govspeak.js
@@ -1,0 +1,11 @@
+//= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+
+(function (Modules) {
+  'use strict'
+
+  Modules.PasteHtmlToGovspeak = function () {
+    this.start = function (element) {
+      element[0].addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
+    }
+  }
+})(window.GOVUKAdmin.Modules)

--- a/app/views/admin/access_and_opening_times/_form.html.erb
+++ b/app/views/admin/access_and_opening_times/_form.html.erb
@@ -3,6 +3,8 @@
           admin_worldwide_organisation_access_and_opening_time_path(accessible) :
           admin_worldwide_organisation_worldwide_office_access_and_opening_time_path(accessible.worldwide_organisation, accessible) do |form| %>
   <%= form.errors %>
-  <%= form.text_area :body, rows: 20, label_text: "Body", class: "previewable", required: true %>
+  <%= form.text_area :body, rows: 20, label_text: "Body", class: "previewable", required: true, data: {
+    module: "paste-html-to-govspeak"
+  } %>
   <%= form.save_or_cancel cancel: accessible_path(accessible) %>
 <% end %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -26,7 +26,9 @@
        </div>
 
       <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
-        <%= govspeak_fields.text_area :body, rows: 20, class: "previewable" %>
+        <%= govspeak_fields.text_area :body, rows: 20, class: "previewable", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -13,7 +13,9 @@
   <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' }, required: false %>
   <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
-  <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: true %>
+  <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: true, data: {
+    module: "paste-html-to-govspeak"
+  } %>
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 <% end %>

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -29,7 +29,9 @@
     <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
     <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
-    <%= form.text_area :body, rows: 20, class: "previewable" %>
+    <%= form.text_area :body, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
 
     <%= form.label :lead_organisation_ids, 'Lead Organisations:' %>
     <%= form.select :lead_organisation_ids, options_for_select(taggable_organisations_container, @edition.lead_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose organisations which produced this document…" } %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -12,7 +12,9 @@
   <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' }, required: form.object.summary_required? %>
   <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
-  <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: form.object.body_required? %>
+  <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: form.object.body_required?, data: {
+    module: "paste-html-to-govspeak"
+  } %>
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -26,7 +26,9 @@
         </div>
         <%= form.text_field :born %>
         <%= form.text_field :died %>
-        <%= form.text_area :body, rows: 20, class: "previewable", required: true %>
+        <%= form.text_area :body, rows: 20, class: "previewable", required: true, data: {
+          module: "paste-html-to-govspeak"
+        } %>
         <%= form.text_area :major_acts, rows: 2 %>
         <%= form.text_area :interesting_facts, rows: 2 %>
 

--- a/app/views/admin/operational_fields/_form.html.erb
+++ b/app/views/admin/operational_fields/_form.html.erb
@@ -3,7 +3,9 @@
 
   <fieldset>
     <%= operational_field_form.text_field :name %>
-    <%= operational_field_form.text_area :description, rows: 20, class: "previewable" %>
+    <%= operational_field_form.text_area :description, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
   </fieldset>
   <p class="warning">Warning: changes to fields of operation appear instantly on the live site.</p>
   <%= operational_field_form.save_or_cancel cancel: admin_operational_fields_path %>

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -23,7 +23,9 @@
     </div>
   </fieldset>
   <fieldset>
-    <%= person_form.text_area :biography, rows: 20, class: "previewable" %>
+    <%= person_form.text_area :biography, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
   </fieldset>
 
   <p class="warning">

--- a/app/views/admin/policy_groups/_form.html.erb
+++ b/app/views/admin/policy_groups/_form.html.erb
@@ -5,7 +5,9 @@
     <%= policy_group_form.text_field :name %>
     <%= policy_group_form.text_field :email %>
     <%= policy_group_form.text_area :summary, rows: 20 %>
-    <%= policy_group_form.text_area :description, rows: 20, class: "previewable" %>
+    <%= policy_group_form.text_area :description, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
   </fieldset>
 
   <h3>Attachments</h3>

--- a/app/views/admin/responses/_form.html.erb
+++ b/app/views/admin/responses/_form.html.erb
@@ -5,7 +5,9 @@
 
   <%= form.label :published_on %>
   <%= form.date_select :published_on, { include_blank: true, start_year: 1997, end_year: Date.today.year + 5 }, { class: 'date' } %>
-  <%= form.text_area :summary, rows: 20, label_text: 'Detail/Summary', class: "previewable" %>
+  <%= form.text_area :summary, rows: 20, label_text: 'Detail/Summary', class: "previewable", data: {
+    module: "paste-html-to-govspeak"
+  } %>
 
   <%= form.save_or_cancel cancel: [:admin, consultation, consultation_response.singular_routing_symbol] %>
 <% end %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -36,7 +36,9 @@
   </fieldset>
 
   <fieldset>
-    <%= form.text_area :responsibilities, rows: 20, class: "previewable" %>
+    <%= form.text_area :responsibilities, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
   </fieldset>
   <p class="warning">
     <% if show_instantly_live_warning %>

--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -12,7 +12,9 @@
 
       <%= form.text_field :title %>
 
-      <%= form.text_area :mission_statement, rows: 20, class: "previewable" %>
+      <%= form.text_area :mission_statement, rows: 20, class: "previewable", data: {
+        module: "paste-html-to-govspeak"
+      } %>
 
       <%= form.check_box :active,
                 label_text: "Active (can visitors click through from the world location list?)" %>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     }
   },
   "dependencies": {
-    "jquery": "1.12.4"
+    "jquery": "1.12.4",
+    "paste-html-to-govspeak": "^0.2.6"
   },
   "devDependencies": {
     "jasmine-browser-runner": "^1.0.0",

--- a/spec/javascripts/admin/modules/paste_html_to_govspeak.spec.js
+++ b/spec/javascripts/admin/modules/paste_html_to_govspeak.spec.js
@@ -1,0 +1,29 @@
+describe('GOVUKAdmin.Modules.PasteHtmlToGovspeak', function () {
+  var textarea
+
+  function createHtmlPasteEvent (html = null) {
+    var event = new window.Event('paste')
+    event.clipboardData = {
+      getData: (type) => {
+        if (type === 'text/html') {
+          return html
+        }
+      }
+    }
+
+    return event
+  }
+
+  beforeEach(function () {
+    textarea = document.createElement('textarea')
+
+    var pasteHtmlToGovspeak = new GOVUKAdmin.Modules.PasteHtmlToGovspeak()
+    pasteHtmlToGovspeak.start($(textarea))
+  })
+
+  it('responds to a paste event by converting the HTML to Govspeak', function () {
+    textarea.dispatchEvent(createHtmlPasteEvent('<h2>This is a h2</h2>'))
+
+    expect(textarea.value).toEqual('## This is a h2')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,6 +1829,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+paste-html-to-govspeak@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.6.tgz#a7bbb5e2b7ce4b38a0fec68febf67001d4764163"
+  integrity sha512-vRF4DbxgVqaI5bCFWrNAxRHSPY1NYNAwKR9M1v0YB928kvrh0TOvPGY9R67nzRm44L8Fn/+TdILA/NldeN2RjQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
## What
Converts pasted formatted content to GovSpeak

## Why
This work will reduce the effort and time for publishers to create new content, including HTML attachments and as a result, increase interest in creating HTML attachments by default

https://trello.com/c/c6hcyFgA/432-add-paste-html-to-govspeak-to-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
