### PR TITLE
Add Sidekiq::JobRetry::Skip to list of excluded exceptions

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -2,6 +2,7 @@ GovukError.configure do |config|
   config.excluded_exceptions += [
     "AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient",
     "Redis::CannotConnectError",
+    "Sidekiq::JobRetry::Skip",
   ]
 
   config.data_sync_excluded_exceptions += [


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

By adding sentry-sidekiq in 596aba9c8d we were able to get Sidekiq
errors sent to Sentry. However we got these in addition to the
Sidekiq::JobRetry::Skip ones, this occurs because they aren't an
excluded exception. I thought adding this wouldn't be needed as the gem
does it automatically [1], however I believe our custom configuration
prevents this setting from taking effect.

I intend to put this exception into the list of govuk_app_config [2],
however I thought I'd put it directly in Whitehall first so could
establish if it's beneficial before creating a new gem release.

[1]: https://github.com/getsentry/sentry-ruby/blob/0fe8d27e4f84fda11475437a1cdd16f016efd904/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb#L7

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
