### PR TITLE
Remove DWP from accessible request format pilot Rake task

### DIFF
--- a/lib/tasks/republish_accessible_format_request_pilot_documents.rake
+++ b/lib/tasks/republish_accessible_format_request_pilot_documents.rake
@@ -1,7 +1,6 @@
 desc "Republish all documents with attachments for organisations in accessible format request pilot"
 task repubish_docs_with_attachments_for_accessible_format_request_pilot: :environment do
   pilot_emails = %w[alternative.formats@education.gov.uk
-                    accessible.formats@dwp.gov.uk
                     gov.uk.publishing@dvsa.gov.uk].freeze
 
   organisations = Organisation.where(alternative_format_contact_email: [pilot_emails])


### PR DESCRIPTION
DWP have been removed from the Accessible Format Request pilot scheme so they can also be removed from this Rake task.

[trello](https://trello.com/c/RTiwn1cB/1251-make-live-after-12-april-330pm-remove-dwp-from-the-request-accessible-format-pilot)