### PR TITLE
Stop queueing workers exponentially to process attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -18,7 +18,7 @@ class Admin::AttachmentsController < Admin::BaseController
 
   def create
     if save_attachment
-      attachment_updater
+      attachment_updater(attachment.attachment_data)
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       render :new
@@ -31,7 +31,7 @@ class Admin::AttachmentsController < Admin::BaseController
       attachment.attachment_data.attachable = attachable
     end
     if save_attachment
-      attachment_updater
+      attachment_updater(attachment.attachment_data)
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
@@ -45,7 +45,7 @@ class Admin::AttachmentsController < Admin::BaseController
       attachment = attachable.attachments.find(id)
       attachment.assign_attributes(attributes.permit(:title))
       if attachment.save(context: :user_input)
-        attachment_updater
+        attachment_updater(attachment.attachment_data)
       else
         errors[id] = attachment.errors.full_messages
       end
@@ -59,8 +59,9 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def destroy
+    attachment_data = attachment.attachment_data
     attachment.destroy!
-    attachment_updater
+    attachment_updater(attachment_data)
     redirect_to attachable_attachments_path(attachable), notice: "Attachment deleted"
   end
 
@@ -196,7 +197,7 @@ private
     result
   end
 
-  def attachment_updater
-    ServiceListeners::AttachmentUpdater.call(attachable: attachable.reload)
+  def attachment_updater(attachment_data)
+    ServiceListeners::AttachmentUpdater.call(attachment_data: attachment_data)
   end
 end


### PR DESCRIPTION
This PR changes the behaviour of the admin attachments controller so that it only queues up Sidekiq jobs for attachments that have changed.

Prior to this, making a change to one attachment would cause `AssetManagerAttachmentMetadataWorker` workers to be queued up for every attachment in the parent document.

In extreme cases, for example when one document has hundreds of attachments, it meant that a single change to one attachment would result in hundreds of jobs being added to the Sidekiq queue. This had the potential to overwhelm the queue if multiple attachments were changed in quick succession – i.e. quicker than Sidekiq could process all the workers.

Instead, we'll now only queue up workers for the individual attachment that has been changed.

## Results from testing in integration

I've performed a before & after test in integration to confirm that this resolves the problem.

I found a document which has 994 attachments. Whilst this is an extreme example to use, it should very clearly demonstrate the problem and prove that the fix resolves the queue build-up issue.

### Before (`main` branch deployed)

Deleting 1 attachment caused several hundred jobs to be added to the Sidekiq queue.

**Note:** the 'processed' total has jumped by over 1000, and ~500 jobs got stuck in a retry loop. The retry loop isn't surprising – this edition is very old, and had already been 'unpublished', so the Asset Manager API was unhappy with us trying to update them.

| Before | After |
| --- | --- |
| <img width="1203" alt="Sidekiq dashboard before" src="https://user-images.githubusercontent.com/7735945/168583879-ca669203-af86-4bfa-ab38-82ae508d05cd.png"> | <img width="1207" alt="Sidekiq dashboard after" src="https://user-images.githubusercontent.com/7735945/168583928-73d08451-ecc2-4eb1-bbe9-8126e3fb855c.png"> |

### Before (this PR deployed)

Deleting 1 attachment caused 1 job to be queued up. In the screenshots below, I've deleted 2 attachments and the 'processed' count increased by 2. This is expected behaviour.

| Before | After |
| --- | --- |
| <img width="1211" alt="601 62M" src="https://user-images.githubusercontent.com/7735945/168584584-f4eee76f-6668-499f-9cc4-45d200bf88c9.png"> | <img width="1214" alt="540 52M" src="https://user-images.githubusercontent.com/7735945/168584609-8c2a139f-b500-4e9f-a832-efe48300f617.png"> |


---

Trello: https://trello.com/c/EDPncQak/435-remediation-following-whitehall-incident

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
