### PR TITLE
Add Rake task for republishing all current Topical Events

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -108,6 +108,11 @@ namespace :publishing_api do
       puts "Finished republishing Policy Groups"
     end
 
+    desc "Republish all current Topical Events"
+    task all_topical_events: :environment do
+      TopicalEvent.current.each(&:publish_to_publishing_api)
+    end
+
     desc "Republish a person to the Publishing API"
     task :person_by_slug, [:slug] => :environment do |_, args|
       Person.find_by!(slug: args[:slug]).publish_to_publishing_api


### PR DESCRIPTION
The Topical Event rendering code is currently being moved out of Whitehall.

Part of this work involves populating the Topical Event content item with information that is currently missing.

By adding this rake task, we will be able to republish all existing content items after the `PublishingApi::TopicalEventPresenter` presenter is updated.

[Trello card](https://trello.com/c/fQxRyQ6A/60-add-featured-documents-to-topical-event-presenter)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
