### PR TITLE
Add guidance for 'Paste and convert to Markdown'

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -34,6 +34,21 @@
 <div data-module="gem-track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
   <h3>Formatting</h3>
   <p>For details, read the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown">guide to using Markdown</a></p>
+  <h3><a data-toggle="collapse" href="#govspeak-paste-to-markdown" aria-expanded="false">Paste and convert to Markdown</a></h3>
+  <div class="collapse" id="govspeak-paste-to-markdown">
+    <p>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak. </p>
+    <p>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+    <p>It will convert:</p>
+    <ul>
+      <li>headings</li>
+      <li>bullets</li>
+      <li>numbered lists</li>
+      <li>links</li>
+      <li>email links</li>
+    </ul>
+    <p>Other formatting and content, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
+  </div>
+  
   <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>
   <div class="collapse" id="govspeak-headings">
     <pre>## Top level heading – H2

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -46,7 +46,7 @@
       <li>links</li>
       <li>email links</li>
     </ul>
-    <p>Other formatting and content, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
+    <p>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
   </div>
   
   <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -36,7 +36,7 @@
   <p>For details, read the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown">guide to using Markdown</a></p>
   <h3><a data-toggle="collapse" href="#govspeak-paste-to-markdown" aria-expanded="false">Paste and convert to Markdown</a></h3>
   <div class="collapse" id="govspeak-paste-to-markdown">
-    <p>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak. </p>
+    <p>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
     <p>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
     <p>It will convert:</p>
     <ul>


### PR DESCRIPTION
This pull request adds guidance about 'Paste and convert to Markdown' under the 'formatting' section of the in-app guidance when editing an edition in Whitehall publisher.

https://trello.com/c/LCh1cJN4

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
