### PR TITLE
Present Topical Event social media links to Publishing API

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -38,6 +38,7 @@ module PublishingApi
         details[:start_date] = item.start_date.rfc3339 if item.start_date
         details[:end_date] = item.end_date.rfc3339 if item.end_date
         details[:ordered_featured_documents] = ordered_featured_documents
+        details[:social_media_links] = social_media_links
       end
     end
 
@@ -51,6 +52,16 @@ module PublishingApi
             alt_text: feature.alt_text,
           },
           summary: feature.summary,
+        }
+      end
+    end
+
+    def social_media_links
+      item.social_media_accounts.map do |social_media_account|
+        {
+          href: social_media_account.url,
+          service_type: social_media_account.service_name.parameterize,
+          title: social_media_account.display_name,
         }
       end
     end

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -8,6 +8,10 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     feature = create(:classification_featuring, classification: topical_event, ordering: 1)
     offsite_feature = create(:offsite_classification_featuring, classification: topical_event, ordering: 0)
 
+    social_media_service = create(:social_media_service, name: "Facebook")
+    social_media_account = create(:social_media_account, social_media_service: social_media_service)
+    topical_event.social_media_accounts = [social_media_account]
+
     expected_hash = {
       base_path: public_path,
       publishing_app: "whitehall",
@@ -49,6 +53,13 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
             summary: feature.summary,
           },
         ],
+        social_media_links: [
+          {
+            href: social_media_account.url,
+            service_type: social_media_account.service_name.parameterize,
+            title: social_media_account.display_name,
+          },
+        ],
       },
     }
 
@@ -82,6 +93,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       public_updated_at: topical_event.updated_at,
       details: {
         ordered_featured_documents: [],
+        social_media_links: [],
       },
     }
 
@@ -96,7 +108,11 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
 
     presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
 
-    assert_equal({ start_date: Time.zone.today.rfc3339, ordered_featured_documents: [] }, presenter.content[:details])
+    assert_equal({
+      start_date: Time.zone.today.rfc3339,
+      ordered_featured_documents: [],
+      social_media_links: [],
+    }, presenter.content[:details])
     assert_valid_against_schema(presenter.content, "topical_event")
   end
 end


### PR DESCRIPTION
This adds social media links into the content item for Topical Events.

By doing this, we will be able to render the page outside of Whitehall.

This PR is dependent on https://github.com/alphagov/govuk-content-schemas/pull/1094 being merged and deployed.

Once merged and deployed, the following rake task will need to be run to republish existing topical events: `publishing_api:republish:all_topical_events`.

[Trello card](https://trello.com/c/DOsCLwQL)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
