### PR TITLE
Auth bypass ids for existing assets

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -21,9 +21,7 @@ class AssetManager::AssetUpdater
     attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes["deleted"]
 
-    if asset_deleted && asset_data.deleted?
-      return
-    elsif asset_deleted && !asset_data.deleted?
+    if asset_deleted
       raise AssetAlreadyDeleted.new(asset_data.id, legacy_url_path)
     end
 

--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -17,14 +17,14 @@ class AssetManager::AssetUpdater
     new.call(*args)
   end
 
-  def call(attachment_data, legacy_url_path, new_attributes = {})
+  def call(asset_data, legacy_url_path, new_attributes = {})
     attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes["deleted"]
 
-    if asset_deleted && attachment_data.deleted?
+    if asset_deleted && asset_data.deleted?
       return
-    elsif asset_deleted && !attachment_data.deleted?
-      raise AssetAlreadyDeleted.new(attachment_data.id, legacy_url_path)
+    elsif asset_deleted && !asset_data.deleted?
+      raise AssetAlreadyDeleted.new(asset_data.id, legacy_url_path)
     end
 
     if (replacement_path = new_attributes.delete("replacement_legacy_url_path"))
@@ -33,7 +33,7 @@ class AssetManager::AssetUpdater
 
     keys = new_attributes.keys
 
-    raise AssetAttributesEmpty.new(attachment_data.id, legacy_url_path) if new_attributes.empty?
+    raise AssetAttributesEmpty.new(asset_data.id, legacy_url_path) if new_attributes.empty?
 
     unless attributes.slice(*keys) == new_attributes.slice(*keys)
       asset_manager.update_asset(attributes["id"], new_attributes)

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -7,6 +7,8 @@ class AssetManager::AttachmentUpdater
     redirect_url: false,
     replacement_id: false
   )
+    return if attachment_data.deleted?
+
     updates = []
 
     updates += AccessLimitedUpdates.call(attachment_data).to_a if access_limited

--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -2,4 +2,6 @@ class ConsultationResponseFormUploader < WhitehallUploader
   def extension_allowlist
     %w[pdf csv rtf doc docx xls xlsx odt ods]
   end
+
+  delegate :asset_manager_path, to: :file
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -9,6 +9,8 @@ class ImageUploader < WhitehallUploader
     %w[jpg jpeg gif png svg]
   end
 
+  delegate :asset_manager_path, to: :file
+
   version :s960, if: :bitmap? do
     process resize_to_fill: [960, 640]
   end

--- a/app/workers/asset_manager_update_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_update_whitehall_asset_worker.rb
@@ -1,0 +1,19 @@
+class AssetManagerUpdateWhitehallAssetWorker < WorkerBase
+  sidekiq_options queue: "asset_manager_updater"
+
+  def perform(attachment_data_global_id, attributes)
+    asset_data = GlobalID::Locator.locate(attachment_data_global_id)
+    path = asset_data.file.asset_manager_path
+    AssetManager::AssetUpdater.call(asset_data, path, attributes)
+
+    # Update any other versions of the file (e.g. PDF thumbnail, or resized versions of an image)
+    asset_versions = asset_data.file.versions.values.select(&:present?)
+    asset_versions.each do |version|
+      AssetManager::AssetUpdater.call(asset_data, version.asset_manager_path, attributes)
+    end
+  rescue AssetManager::ServiceHelper::AssetNotFound,
+         AssetManager::AssetUpdater::AssetAlreadyDeleted,
+         ActiveRecord::RecordNotFound => e
+    logger.error "AssetManagerUpdateWhitehallAssetWorker: #{e.message}"
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,7 @@
   - default
   - publishing_api
   - asset_manager
+  - asset_manager_updater
   - email_alert_api_signup
   - bulk_republishing
   - link_checks

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -1,0 +1,61 @@
+namespace :asset_manager do
+  desc "Update draft file attachments with auth_bypass_ids"
+  task update_attachments_with_auth_bypass_ids: :environment do
+    # republish assets who's editions are draft with an auth bypass id
+    latest_draft_editions = Edition.in_pre_publication_state.latest_edition
+
+    latest_draft_editions.find_each do |edition|
+      next unless edition.respond_to?(:attachments)
+
+      edition.attachments.files.each do |file_attachment|
+        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        attachment_data_id = file_attachment.attachment_data.to_global_id
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+      end
+    end
+  end
+
+  desc "Update draft consultation response form attachments with auth_bypass_ids"
+  task update_consultation_response_forms_with_auth_bypass_ids: :environment do
+    latest_draft_consultations = Consultation.in_pre_publication_state.latest_edition
+
+    latest_draft_consultations.find_each do |consultation|
+      if consultation.consultation_participation&.consultation_response_form.present?
+        response_form = consultation.consultation_participation.consultation_response_form
+        response_form_data_id = response_form.consultation_response_form_data.to_global_id
+        new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", response_form_data_id, new_attributes)
+      end
+
+      if consultation.outcome.present?
+        consultation.outcome.attachments.files.each do |file_attachment|
+          new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+          attachment_data_id = file_attachment.attachment_data.to_global_id
+          AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+        end
+      end
+
+      next if consultation.public_feedback.blank?
+
+      consultation.public_feedback.attachments.files.each do |file_attachment|
+        new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+        attachment_data_id = file_attachment.attachment_data.to_global_id
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+      end
+    end
+  end
+
+  desc "Update draft images with auth_bypass_ids"
+  task update_images_with_auth_bypass_ids: :environment do
+    latest_draft_editions = Edition.in_pre_publication_state.latest_edition
+
+    latest_draft_editions.find_each do |edition|
+      edition.images.each do |image|
+        image_data_id = image.image_data.to_global_id
+        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", image_data_id, new_attributes)
+      end
+    end
+  end
+end

--- a/test/factories/consultation_participations.rb
+++ b/test/factories/consultation_participations.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :consultation_participation do
+    association :consultation
   end
 end

--- a/test/unit/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/services/asset_manager/asset_updater_test.rb
@@ -10,17 +10,6 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
     @attachment_data = FactoryBot.build(:attachment_data)
   end
 
-  test "no-op if the attachment_data has been deleted and the asset has been deleted in asset manager" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_url, "deleted" => true)
-
-    @attachment_data.stubs(:deleted?).returns(true)
-
-    Services.asset_manager.expects(:update_asset).never
-
-    @worker.call(@attachment_data, @legacy_url_path, "draft" => false)
-  end
-
   test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
     @worker.stubs(:find_asset_by).with(@legacy_url_path)
       .returns("id" => @asset_url, "deleted" => true)

--- a/test/unit/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater_test.rb
@@ -14,5 +14,17 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
       subject.call(attachment_data, redirect_url: true, draft_status: true)
     end
+
+    context "when the attachment has been deleted" do
+      before do
+        attachment.delete
+      end
+
+      it "does not update the asset" do
+        AssetManager::AssetUpdater.expects(:call).never
+
+        subject.call(attachment_data, redirect_url: true, draft_status: true)
+      end
+    end
   end
 end

--- a/test/unit/tasks/asset_manager_test.rb
+++ b/test/unit/tasks/asset_manager_test.rb
@@ -1,0 +1,239 @@
+require "test_helper"
+
+class AssetManagerRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  describe "update_attachments_with_auth_bypass_ids" do
+    let(:task) { Rake::Task["asset_manager:update_attachments_with_auth_bypass_ids"] }
+
+    test "updates attachments with auth_bypass_ids when its latest edition is a draft" do
+      edition = create(:draft_detailed_guide)
+      file_attachment = create(:file_attachment, attachable: edition)
+      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      task.invoke
+    end
+
+    test "does not update attachments with auth_bypass_ids when latest edition is not draft" do
+      edition = create(:published_detailed_guide)
+      create(:file_attachment, attachable: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update attachments with auth_bypass_ids when latest edition is deleted" do
+      edition = create(:deleted_detailed_guide)
+      create(:file_attachment, attachable: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not attempt to update html attachments via the update whitehall asset worker" do
+      edition = create(:draft_detailed_guide)
+      create(:html_attachment, attachable: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update attachments where the latest edition isn't draft" do
+      document = create(:document)
+      scheduled_edition = create(:scheduled_detailed_guide, document: document)
+      published_edition = create(:published_detailed_guide, document: document)
+
+      assert_equal published_edition, document.latest_edition
+
+      create(:file_attachment, attachable: scheduled_edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "skips over editions which do not have ability to have attachments" do
+      create(:draft_fatality_notice)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+  end
+
+  describe "update_consultation_response_forms_with_auth_bypass_ids" do
+    let(:task) { Rake::Task["asset_manager:update_consultation_response_forms_with_auth_bypass_ids"] }
+
+    test "updates a consultation response form asset with auth_bypass_id when it is part of the latest edition which is a draft" do
+      edition = create(:consultation)
+      participation = create(:consultation_participation, consultation: edition)
+      consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
+
+      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        consultation_response_form.consultation_response_form_data.to_global_id,
+        expected_attributes,
+      )
+
+      task.invoke
+    end
+
+    test "does not update attachments with auth_bypass_ids when latest edition is not draft" do
+      edition = create(:published_consultation)
+      participation = create(:consultation_participation, consultation: edition)
+      create(:consultation_response_form, consultation_participation: participation)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update attachments with auth_bypass_ids when latest edition is deleted" do
+      edition = create(:deleted_consultation)
+      participation = create(:consultation_participation, consultation: edition)
+      create(:consultation_response_form, consultation_participation: participation)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update attachments where the latest edition isn't draft" do
+      document = create(:document)
+      scheduled_edition = create(:scheduled_consultation, document: document)
+      published_edition = create(:published_consultation, document: document)
+      participation = create(:consultation_participation, consultation: scheduled_edition)
+      create(:consultation_response_form, consultation_participation: participation)
+
+      assert_equal published_edition, document.latest_edition
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update auth bypass ids when no consultation response form exists" do
+      document = create(:document)
+      edition = create(:scheduled_consultation, document: document)
+      create(:consultation_participation, consultation: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update auth bypass ids when no consultation participation exists" do
+      document = create(:document)
+      create(:scheduled_consultation, document: document)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "updates a consultation outcome's attachments with auth_bypass_id" do
+      edition = create(:draft_consultation)
+      outcome = create(:consultation_outcome, consultation: edition)
+      file_attachment = create(:file_attachment, attachable: outcome)
+
+      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      task.invoke
+    end
+
+    test "updates a consultation's public feedback attachments with auth_bypass_id" do
+      edition = create(:draft_consultation)
+      feedback = create(:consultation_public_feedback, consultation: edition)
+      file_attachment = create(:file_attachment, attachable: feedback)
+
+      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      task.invoke
+    end
+  end
+
+  describe "update_consultation_response_forms_with_auth_bypass_ids" do
+    let(:task) { Rake::Task["asset_manager:update_images_with_auth_bypass_ids"] }
+
+    test "updates an image with auth_bypass_id when it is part of the latest edition which is a draft" do
+      edition = create(:draft_case_study)
+      image = create(:image, edition: edition)
+      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        image.image_data.to_global_id,
+        expected_attributes,
+      )
+
+      task.invoke
+    end
+
+    test "does not call the update worker when an edition has no images" do
+      create(:draft_case_study)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update image with auth_bypass_ids when latest edition is not draft" do
+      edition = create(:published_case_study)
+      create(:image, edition: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update image with auth_bypass_ids when latest edition is deleted" do
+      edition = create(:deleted_case_study)
+      create(:image, edition: edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+
+    test "does not update image where the latest edition isn't draft" do
+      document = create(:document)
+      scheduled_edition = create(:scheduled_case_study, document: document)
+      published_edition = create(:published_case_study, document: document)
+
+      assert_equal published_edition, document.latest_edition
+
+      create(:image, edition: scheduled_edition)
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      task.invoke
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_update_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_whitehall_asset_worker_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
+  @auth_bypass_id_attributes = { auth_bypass_ids: [SecureRandom.uuid] }
+
+  def expected_legacy_url(data_type, data_id, file_name)
+    "/government/uploads/system/uploads/#{data_type}/file/#{data_id}/#{file_name}"
+  end
+
+  test "updates a file attachment" do
+    attachment_data = FactoryBot.create(:attachment_data, file: File.open(Rails.root.join("test/fixtures/sample.csv")))
+    expected_legacy_url_path = expected_legacy_url("attachment_data", attachment_data.id, "sample.csv")
+
+    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "updates a PDF attachment and its preview thumbnail" do
+    attachment_data = FactoryBot.create(:attachment_data)
+    expected_legacy_url_path = expected_legacy_url("attachment_data", attachment_data.id, "greenpaper.pdf")
+    expected_legacy_url_thumbnail_path = expected_legacy_url("attachment_data", attachment_data.id, "thumbnail_greenpaper.pdf.png")
+
+    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_thumbnail_path, @auth_bypass_id_attributes)
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "updates an image and its resized thumbnail versions" do
+    image_data = FactoryBot.create(:image_data)
+    %w[
+      minister-of-funk.960x640.jpg
+      s960_minister-of-funk.960x640.jpg
+      s712_minister-of-funk.960x640.jpg
+      s630_minister-of-funk.960x640.jpg
+      s465_minister-of-funk.960x640.jpg
+      s300_minister-of-funk.960x640.jpg
+      s216_minister-of-funk.960x640.jpg
+    ].each do |filename|
+      path = expected_legacy_url("image_data", image_data.id, filename)
+      AssetManager::AssetUpdater.expects(:call).with(image_data, path, @auth_bypass_id_attributes).once
+    end
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", image_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "updates a consultation response form" do
+    response_form = FactoryBot.create(:consultation_response_form)
+    form_data = response_form.consultation_response_form_data
+    expected_legacy_url_path = expected_legacy_url("consultation_response_form_data", form_data.id, "two-pages.pdf")
+    AssetManager::AssetUpdater.expects(:call).with(form_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", form_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "ignores missing assets in Asset Manager" do
+    attachment_data = FactoryBot.create(:attachment_data)
+
+    expected_error = AssetManager::ServiceHelper::AssetNotFound.new(attachment_data.file.asset_manager_path)
+    AssetManager::AssetUpdater.expects(:call).once.raises(expected_error)
+    Logger.any_instance.stubs(:error).once # suppress log output
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "ignores assets that have been deleted in Asset Manager" do
+    attachment_data = FactoryBot.create(:attachment_data)
+
+    expected_error = AssetManager::AssetUpdater::AssetAlreadyDeleted.new(attachment_data.id, attachment_data.file.asset_manager_path)
+    AssetManager::AssetUpdater.expects(:call).once.raises(expected_error)
+    Logger.any_instance.stubs(:error).once # suppress log output
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data.to_global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "ignores assets that have been deleted in Whitehall" do
+    attachment_data = FactoryBot.create(:attachment_data)
+    global_id = attachment_data.to_global_id
+
+    Logger.any_instance.stubs(:error).once # suppress log output
+    attachment_data.destroy!
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", global_id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR is part of work for shareable previews to ensure that a draft edition's assets are viewable via the preview functionality. We have already implemented this for assets linked to new editions, but for assets for existing drafts (i.e. ones that were created prior to us deploying the last PR) we need to resend these to asset-manager with their edition's auth_bypass_id.

There are two elements to this PR:

1) The introduction of a generic "UpdateWhitehallAsset" worker (and an associated queue) that resends an asset to asset manager with any associated attributes. This is currently only used by the rake task but the aim of this is to introduce something that might be able to be more widely used in the codebase later (currently updates to assets are done synchronously, unlike creating assets)

2) Rake tasks to republish various draft assets with their edition's auth_bypass_id

Trello: https://trello.com/c/Lm9RyCuP/397-ensure-existing-draft-assets-have-authbypassids