### PR TITLE
Auth bypass ids for html attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -24,6 +24,7 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: schema_name,
           links: edition_links,
+          auth_bypass_ids: [parent.auth_bypass_id],
         )
     end
 

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -106,6 +106,29 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
         end
       end
 
+      context "given an edition with an html attachment" do
+        let(:edition) { create(:publication, :policy_paper) }
+
+        before do
+          setup_publishing_api_for(edition)
+          visit admin_publication_path(edition)
+          click_link "Modify attachments"
+          click_link "Add new HTML attachment"
+          fill_in "Title", with: "html-attachment"
+          fill_in "Body", with: "some html content"
+        end
+
+        it "sends an html attachment to publishing api with its edition's auth_bypass_id" do
+          Services.publishing_api.expects(:put_content)
+                  .with(anything, has_entries(
+                                    title: "html-attachment",
+                                    auth_bypass_ids: [edition.auth_bypass_id],
+                                  ))
+
+          click_button "Save"
+        end
+      end
+
       context "when bulk uploaded to draft document" do
         before do
           visit admin_news_article_path(edition)

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -41,6 +41,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
         public_timestamp: edition.public_timestamp,
         first_published_version: html_attachment.attachable.first_published_version?,
       },
+      auth_bypass_ids: [edition.auth_bypass_id],
     }
     presented_item = present(html_attachment)
 
@@ -109,13 +110,15 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
   end
 
   test "HtmlAttachment presents primary_publishing_organisation from 1st org when lead_organisations is not implemented" do
-    create(:consultation_outcome, :with_html_attachment)
+    outcome = create(:consultation_outcome, :with_html_attachment)
 
     html_attachment = HtmlAttachment.last
     # if an organisation has multiple translations, pluck returns
     # duplicate content_ids because it constructs a left outer join
 
+    presenter = present(html_attachment)
+    assert_hash_includes presenter.content, { auth_bypass_ids: [outcome.auth_bypass_id] }
     assert_equal [html_attachment.attachable.organisations.first.content_id],
-                 present(html_attachment).links[:primary_publishing_organisation]
+                 presenter.links[:primary_publishing_organisation]
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR adds auth_bypass_ids to html attachments to enable shareable previews for them. This will enable them to be previewed as part of the work on shareable previews.

Work to turn shareable previews on in the UI will be done in a follow-up PR.

Card: https://trello.com/c/49YsQTjg/448-enable-editions-with-a-type-of-publication-consultation-to-be-previewed-with-any-attachments