### PR TITLE
Remove `.call-to-action` from Whitehall stylesheets

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -253,8 +253,7 @@
     vertical-align: top;
   }
 
-  .information-block,
-  .call-to-action {
+  .information-block {
     margin: $gutter 0;
     background: $panel-colour none no-repeat 98% $gutter-two-thirds;
     padding: $gutter-one-third ($gutter * 2) $gutter-one-third $gutter-half;

--- a/app/assets/stylesheets/frontend/print/_document.scss
+++ b/app/assets/stylesheets/frontend/print/_document.scss
@@ -105,7 +105,6 @@ article {
   }
 }
 
-.call-to-action,
 .information-block {
   border: 1pt solid $border-colour;
   padding: $gutter-half;


### PR DESCRIPTION
## What

The CSS class for `call-to-action` was removed, allowing the correct styling from the `govuk_publishing_components` gem to be used instead.

Support is in place for the legacy `.govspeak` class name in `govuk_publishing_components`, but the selector for `.call-to-action` is not as specific as Whitehall.
https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss#L9


**GOVUK Publishing Components** 
`.govspeak .call-to-action`

**Whitehall**
`#wrapper .govspeak .call-to-action`

## Why

The `call-to-action` element background colour in Whitehall is not appropriate for the colour of text and a WCAG fail, reported on the GitHub issue below:
https://github.com/alphagov/govuk_publishing_components/issues/2706

After further investigation, other styling issues in the `call-to-action` component needed to be addressed, to ensure the design matched the component guide:
https://components.publishing.service.gov.uk/component-guide/govspeak/call_to_action

## Visual Changes

### Screen

- Background colour - from `#dee0e2` to `#f3f2f1`
- Padding updated - `2em (32px)` used for all padding values
- Top and bottom margin increased - from `30px` to `32px`

|**Before**|**After**|
| ---| --- |
|<img width="657" alt="cta-page-before" src="https://user-images.githubusercontent.com/28779939/169779413-0942690c-4f0e-457a-8379-9e03324158b9.png">| <img width="595" alt="cta-page-after" src="https://user-images.githubusercontent.com/28779939/169779412-b57e15ac-b1ce-42b3-b1a5-b6c98b4a094e.png">|
|<img width="730" alt="cta-spacing-before" src="https://user-images.githubusercontent.com/28779939/169782345-d52153a1-b4fb-405f-a7d2-9cbd5c4a7f8f.png">|<img width="739" alt="cta-spacing-after" src="https://user-images.githubusercontent.com/28779939/169782349-333d34b6-651f-47d0-9954-bd40f5fbfc63.png">|


### Print

- The border colour used is now `#b1b4b6` instead of `#bfc1c3`
- The paragraph text in the call to action will include padding at the bottom

|**Before**|**After**|
| ---| --- |
|<img width="737" alt="cta-print-before" src="https://user-images.githubusercontent.com/28779939/169779409-1e4259d9-0520-439d-b688-a7618e1d9257.png">|<img width="764" alt="cta-print-after" src="https://user-images.githubusercontent.com/28779939/169779405-b94a94b4-75ff-48cd-b3fb-4961db1e8d93.png">|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
