### PR TITLE
Allow Responses to access their owning Consultation's content_id

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -41,7 +41,7 @@ class Response < ApplicationRecord
     to_model.class.name.underscore
   end
 
-  delegate :public_timestamp, :first_published_version?, :slug, :document, :images, to: :consultation
+  delegate :public_timestamp, :first_published_version?, :slug, :document, :images, :content_id, to: :consultation
 
 private
 

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <% if attachment.attachable.respond_to?(:content_id) && attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
+      <% if attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
         <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link govuk-!-font-size-19" %>
       <% else %>
         <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -129,6 +129,13 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal consultation, response.access_limited_object
   end
 
+  test "returns its consultation content_id" do
+    consultation = create(:consultation)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert_equal consultation.content_id, response.content_id
+  end
+
   test "returns no access limited object if its consultation is nil" do
     response = build(:consultation_outcome, consultation: nil)
 


### PR DESCRIPTION
The accessible format request form requires a content_id.

Response objects, and models that inherit from Response (ConsultationOutcome and ConsultationPublicFeedback) do not have content_ids as they are closely tied and owned by a Consultation which is a "standard" Publicationesque Edition.

This PR delegates the Response content_id to the owning consultation, and removes a guard clause preventing documents without a content id from using the Accessible Format Request form.

As a result all Whitehall documents with inaccessible attachments will be able to link to the new Accessible Format Request form.

[trello](https://trello.com/c/EotfMMsy/1165-allow-consultationoutcomes-to-use-the-new-accessible-format-request-form-whitehall)