### PR TITLE
Make Docker image run as non-root.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
+.dockerignore
 .git
 .gitignore
+Dockerfile
 Jenkinsfile
+Procfile
 README.md
 CONTRIBUTING.md
 asset-manager-tmp
@@ -8,6 +11,9 @@ attachment-cache
 bulk-upload-zip-file-tmp
 carrierwave-tmp
 clean-uploads
+docs
+features
 incoming-uploads
 infected-uploads
-tmp/*
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,91 @@
-# (unless we decide to use Bitnami instead)
-ARG base_image=ruby:3.0.4
+ARG ruby_version=3.0.4
+ARG base_image=ruby:$ruby_version-slim-bullseye
+ARG gem_home=/usr/local/bundle
 
 FROM $base_image AS builder
-# This image is only intended to be able to run this app in a production RAILS_ENV
-ENV RAILS_ENV=production
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# TODO: have a separate build image which already contains the build-only deps.
+ARG gem_home
+ENV RAILS_ENV=production \
+    RAILS_LOG_TO_STDOUT=1 \
+    NODE_ENV=production \
+    GEM_HOME=$gem_home \
+    BUNDLE_PATH=$gem_home \
+    BUNDLE_BIN=$gem_home/bin \
+    PATH=$gem_home/bin:$PATH \
+    BUNDLE_WITHOUT="development test cucumber" \
+    BOOTSNAP_CACHE_DIR=/var/cache/bootsnap
 
-# Add yarn to apt sources
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# TODO: set these in the builder image.
+ENV BUNDLE_IGNORE_MESSAGES=1 \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_JOBS=12 \
+    MAKEFLAGS=-j12
 
+ENV ASSETS_PREFIX=/assets/whitehall \
+    GOVUK_APP_DOMAIN=unused \
+    GOVUK_WEBSITE_ROOT=unused
+
+# TODO: have an up-to-date builder image and stop running apt-get upgrade.
+# TODO: have a separate builder image which already contains the build-only deps.
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs yarn && \
-    apt-get clean
-RUN mkdir /app
+    apt-get install -y --no-install-recommends \
+        g++ make libc-dev curl yarnpkg libmariadb-dev-compat && \
+    ln -s /usr/bin/yarnpkg /usr/bin/yarn
+
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version package.json yarn.lock /app/
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install --jobs 4 --retry=2
-RUN yarn install --production --frozen-lockfile
+RUN echo 'install: --no-document' >> /etc/gemrc && gem update --system --silent && gem cleanup
+COPY Gemfile Gemfile.lock .ruby-version /app/
+# Make the installed version of bundler match the one that wrote Gemfile.lock.
+RUN gem install bundler \
+        --silent \
+        --version "$(sed -e '1,/BUNDLED WITH/d' Gemfile.lock | grep -Eo '[0-9.]+')" && \
+    bundle install
+COPY package.json yarn.lock /app/
+RUN yarnpkg install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . /app
-# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
-  GOVUK_APP_DOMAIN=www.gov.uk \
-  GOVUK_WEBSITE_ROOT=www.gov.uk \
-  GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
-  JWT_AUTH_SECRET=secret \
-  bundle exec rake assets:precompile
+RUN bundle exec bootsnap precompile --gemfile .
+RUN bundle exec rails assets:precompile && rm -fr log bulk-upload-zip-file-tmp
+
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=whitehall
-# TODO: include nodejs in the base image (govuk-ruby).
-# TODO: apt-get upgrade in the base image
+
+# TODO: set these in the base image.
+ARG gem_home
+ENV RAILS_ENV=production \
+    RAILS_LOG_TO_STDOUT=1 \
+    NODE_ENV=production \
+    GEM_HOME=/usr/local/bundle \
+    BUNDLE_PATH=$gem_home \
+    BUNDLE_BIN=$gem_home/bin \
+    PATH=$gem_home/bin:$PATH \
+    BUNDLE_WITHOUT="development test cucumber" \
+    BOOTSNAP_CACHE_DIR=/var/cache/bootsnap \
+    GOVUK_PROMETHEUS_EXPORTER=true
+
+ENV ASSETS_PREFIX=/assets/whitehall \
+    GOVUK_APP_NAME=whitehall \
+    BULK_UPLOAD_ZIPFILE_DIR=/tmp/bulk_uploads
+
+# TODO: have an up-to-date base image and stop running apt-get here.
 RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs
+    apt-get upgrade -y --purge && \
+    apt-get install -y --no-install-recommends libmariadb3 && \
+    apt-get clean && \
+    rm -fr /var/lib/apt/lists
+
 WORKDIR /app
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app && \
+    echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
+COPY --from=builder /usr/bin/node* /usr/bin/
+COPY --from=builder /usr/lib/nodejs/ /usr/lib/nodejs/
+COPY --from=builder /usr/share/nodejs/ /usr/share/nodejs/
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app ./
-CMD GOVUK_PROMETHEUS_EXPORTER=true bundle exec puma
+
+RUN groupadd -g 1001 app && \
+    useradd -u 1001 -g app app
+USER 1001
+CMD ["bundle", "exec", "puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,10 @@ RUN apt-get update -qy && \
         g++ make libc-dev curl yarnpkg libmariadb-dev-compat && \
     ln -s /usr/bin/yarnpkg /usr/bin/yarn
 
-RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 WORKDIR /app
+RUN ln -fs /tmp /app/tmp && \
+    ln -fs /tmp /app/asset-manager-tmp && \
+    ln -fs /tmp /home/app
 RUN echo 'install: --no-document' >> /etc/gemrc && gem update --system --silent && gem cleanup
 COPY Gemfile Gemfile.lock .ruby-version /app/
 # Make the installed version of bundler match the one that wrote Gemfile.lock.
@@ -79,7 +81,7 @@ RUN apt-get update -qy && \
     rm -fr /var/lib/apt/lists
 
 WORKDIR /app
-RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app && \
+RUN ln -fs /tmp /app/tmp && ln -fs /tmp /home/app && \
     echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
 COPY --from=builder /usr/bin/node* /usr/bin/
 COPY --from=builder /usr/lib/nodejs/ /usr/lib/nodejs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV ASSETS_PREFIX=/assets/whitehall \
 # TODO: have an up-to-date base image and stop running apt-get here.
 RUN apt-get update -qy && \
     apt-get upgrade -y --purge && \
-    apt-get install -y --no-install-recommends libmariadb3 && \
+    apt-get install -y --no-install-recommends imagemagick libmariadb3 && \
     apt-get clean && \
     rm -fr /var/lib/apt/lists
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV BUNDLE_IGNORE_MESSAGES=1 \
     MAKEFLAGS=-j12
 
 ENV ASSETS_PREFIX=/assets/whitehall \
+    GOVUK_UPLOADS_ROOT=/tmp/uploads \
     GOVUK_APP_DOMAIN=unused \
     GOVUK_WEBSITE_ROOT=unused
 
@@ -47,7 +48,7 @@ COPY package.json yarn.lock /app/
 RUN yarnpkg install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . /app
 RUN bundle exec bootsnap precompile --gemfile .
-RUN bundle exec rails assets:precompile && rm -fr log bulk-upload-zip-file-tmp
+RUN bundle exec rails assets:precompile && rm -fr log
 
 
 FROM $base_image
@@ -67,7 +68,7 @@ ENV RAILS_ENV=production \
 
 ENV ASSETS_PREFIX=/assets/whitehall \
     GOVUK_APP_NAME=whitehall \
-    BULK_UPLOAD_ZIPFILE_DIR=/tmp/bulk_uploads
+    GOVUK_UPLOADS_ROOT=/uploads
 
 # TODO: have an up-to-date base image and stop running apt-get here.
 RUN apt-get update -qy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ RUN apt-get update -qy && \
 
 WORKDIR /app
 RUN ln -fs /tmp /app/tmp && \
-    ln -fs /tmp /app/asset-manager-tmp && \
-    ln -fs /tmp /home/app
+    ln -fs /tmp /app/asset-manager-tmp
 RUN echo 'install: --no-document' >> /etc/gemrc && gem update --system --silent && gem cleanup
 COPY Gemfile Gemfile.lock .ruby-version /app/
 # Make the installed version of bundler match the one that wrote Gemfile.lock.
@@ -81,7 +80,7 @@ RUN apt-get update -qy && \
     rm -fr /var/lib/apt/lists
 
 WORKDIR /app
-RUN ln -fs /tmp /app/tmp && ln -fs /tmp /home/app && \
+RUN ln -fs /tmp /app/tmp && \
     echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
 COPY --from=builder /usr/bin/node* /usr/bin/
 COPY --from=builder /usr/lib/nodejs/ /usr/lib/nodejs/
@@ -90,6 +89,6 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app ./
 
 RUN groupadd -g 1001 app && \
-    useradd -u 1001 -g app app
+    useradd -u 1001 -g app -d /app app
 USER 1001
 CMD ["bundle", "exec", "puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN apt-get update -qy && \
     ln -s /usr/bin/yarnpkg /usr/bin/yarn
 
 WORKDIR /app
-RUN ln -fs /tmp /app/tmp && \
-    ln -fs /tmp /app/asset-manager-tmp
+RUN ln -fs /tmp /app/tmp
 RUN echo 'install: --no-document' >> /etc/gemrc && gem update --system --silent && gem cleanup
 COPY Gemfile Gemfile.lock .ruby-version /app/
 # Make the installed version of bundler match the one that wrote Gemfile.lock.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV BUNDLE_IGNORE_MESSAGES=1 \
 ENV ASSETS_PREFIX=/assets/whitehall \
     GOVUK_UPLOADS_ROOT=/tmp/uploads \
     GOVUK_APP_DOMAIN=unused \
-    GOVUK_WEBSITE_ROOT=unused
+    GOVUK_WEBSITE_ROOT=unused \
+    JWT_AUTH_SECRET=unused
 
 # TODO: have an up-to-date builder image and stop running apt-get upgrade.
 # TODO: have a separate builder image which already contains the build-only deps.

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -107,7 +107,7 @@ private
     end
 
     def temp_dir
-      @temp_dir ||= Dir.mktmpdir(nil, BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY)
+      @temp_dir ||= Dir.mktmpdir(nil, Whitehall.bulk_upload_tmp_dir)
     end
 
     def store_temporarily

--- a/config/initializers/bulk_upload_zip_file.rb
+++ b/config/initializers/bulk_upload_zip_file.rb
@@ -1,4 +1,6 @@
-BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY = if Rails.env.test?
+BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY = if !ENV.fetch("BULK_UPLOAD_ZIPFILE_DIR", "").empty?
+                                               ENV["BULK_UPLOAD_ZIPFILE_DIR"]
+                                             elsif Rails.env.test?
                                                Rails.root.join("tmp/test/bulk-upload-zip-file-tmp")
                                              else
                                                Rails.root.join("bulk-upload-zip-file-tmp")

--- a/config/initializers/bulk_upload_zip_file.rb
+++ b/config/initializers/bulk_upload_zip_file.rb
@@ -1,9 +1,0 @@
-BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY = if !ENV.fetch("BULK_UPLOAD_ZIPFILE_DIR", "").empty?
-                                               ENV["BULK_UPLOAD_ZIPFILE_DIR"]
-                                             elsif Rails.env.test?
-                                               Rails.root.join("tmp/test/bulk-upload-zip-file-tmp")
-                                             else
-                                               Rails.root.join("bulk-upload-zip-file-tmp")
-                                             end
-
-FileUtils.mkdir_p(BULK_UPLOAD_ZIPFILE_DEFAULT_ROOT_DIRECTORY)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,3 +1,4 @@
+require "pathname"
 require "whitehall/asset_manager_storage"
 require "carrier_wave/sanitized_file"
 
@@ -5,7 +6,12 @@ CarrierWave.configure do |config|
   config.storage_engines[:asset_manager] = "Whitehall::AssetManagerStorage"
   config.storage Whitehall::AssetManagerStorage
   config.enable_processing = false if Rails.env.test?
-  config.cache_dir = Rails.root.join "carrierwave-tmp"
+  uploads_root = if ENV["GOVUK_UPLOADS_ROOT"].present?
+                   Pathname.new(ENV["GOVUK_UPLOADS_ROOT"])
+                 else
+                   Rails.root
+                 end
+  config.cache_dir = uploads_root.join "carrierwave-tmp"
   config.cache_storage = :file
   config.validate_integrity = false
   config.validate_processing = false

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -135,7 +135,11 @@ module Whitehall
 
   # The base folder where uploads live.
   def self.uploads_root
-    (Rails.env.test? ? uploads_root_for_test_env : Rails.root).to_s
+    if Rails.env.test?
+      uploads_root_for_test_env.to_s
+    else
+      (ENV["GOVUK_UPLOADS_ROOT"].presence || Rails.root).to_s
+    end
   end
 
   def self.uploads_root_for_test_env
@@ -145,6 +149,10 @@ module Whitehall
 
   def self.asset_manager_tmp_dir
     File.join(uploads_root, "asset-manager-tmp")
+  end
+
+  def self.bulk_upload_tmp_dir
+    @bulk_upload_tmp_dir ||= FileUtils.mkdir_p(File.join(uploads_root, "bulk-upload-zipfile-tmp"))
   end
 
   def self.edition_classes


### PR DESCRIPTION
Not using the govuk-ruby common base/builder images just yet, but that's the next step once this lands.

- Use Debian 11 (bullseye) because it makes it way easier to install compatible versions of Node.js and Yarn that are still supported (at least for now).
- Make the path for uploaded temp files configurable via an environment variable instead of hardcoding them to paths inside the app's source directory. Defaults remain the same so there's no change to the old EC2 deployments.
    - This affects the `asset-manager-tmp`, `bulk-upload-zip-file-tmp`, `carrierwave-tmp` dirs. There are a bunch of others (`attachment-cache`, `clean`, `incoming` etc.) but those are all disused since 2018.
- Fix a bunch of lints (found using hadolint, which is too rough around the edges to enable as a pre-commit/pre-merge but somewhat useful if taken with a pinch of salt).
- Use the right version of bundler. Turns out the feature where it tries to reinstall the right version of itself doesn't always do the right thing. Otherwise the app fails at runtime because the default bundler is still the wrong version.
- Avoid installing perl during build. (We don't need it.)

Also contains all the same fixes as alphagov/feedback#1432:

- Add some files to `.dockerignore`.
- Run as an unprivileged user by default (uid 1001, which is fairly common and consistent with Bitnami images because might as well).
- Set `RAILS_LOG_TO_STDOUT` because we always want that when running in a container.
- Symlink `/app/tmp` to `/tmp` so that third-party gems don't try to write to the (read-only) image filesystem. (Ruby/Rails doesn't seem to have a consistent convention for telling gems where to write temp files, but some default to `tmp` under the Rails root.)
- Run `rails assets:precompile` in the build stage.
- Avoid installing "suggested" and "recommended" dependencies of Debian packages.
- Avoid installing gem documentation when building the container image.
- Avoid including the Debian APT cache in the container image.
- Increase build parallelism (saves a couple of minutes on a 2019 MBP).

https://trello.com/c/Jef1t4xU

Tested: `docker build -t whitehall . && docker run -it --rm -e GOVUK_APP_DOMAIN=x -e GOVUK_WEBSITE_ROOT=x -e JWT_AUTH_SECRET=x whitehall`. Also tested manually in the integration environment; created a publication, uploaded images and attachments etc.

Rollout: this app is push-on-green and test coverage is sketchy, so look out when merging. Requires https://github.com/alphagov/publishing-e2e-tests/pull/494 to be merged first.