### PR TITLE
Remove DVSA from accessible format request republish task

### DIFF
--- a/lib/tasks/republish_accessible_format_request_pilot_documents.rake
+++ b/lib/tasks/republish_accessible_format_request_pilot_documents.rake
@@ -1,7 +1,6 @@
 desc "Republish all documents with attachments for organisations in accessible format request pilot"
 task repubish_docs_with_attachments_for_accessible_format_request_pilot: :environment do
-  pilot_emails = %w[alternative.formats@education.gov.uk
-                    gov.uk.publishing@dvsa.gov.uk].freeze
+  pilot_emails = %w[alternative.formats@education.gov.uk].freeze
 
   organisations = Organisation.where(alternative_format_contact_email: [pilot_emails])
 


### PR DESCRIPTION
DVSA are opting out of the pilot so can be removed from the republish task