### PR TITLE
Add rake task to republish all documents with non-PDF attachments

### DIFF
--- a/lib/tasks/republish_attachments.rake
+++ b/lib/tasks/republish_attachments.rake
@@ -1,0 +1,15 @@
+desc "Republish all documents with non-pdf attachments"
+task republish_non_pdf_attachments: :environment do
+  document_ids = Attachment.joins(:attachment_data)
+                           .joins("JOIN editions ON editions.id = attachments.attachable_id AND attachments.attachable_type = 'Edition'")
+                           .where.not(deleted: true)
+                           .where.not(attachment_data: { content_type: "application/pdf" })
+                           .where.not(attachable: nil)
+                           .where(editions: { state: "published" }).distinct.pluck(:document_id)
+
+  puts "#{document_ids.length} items to republish"
+
+  document_ids.each do |document_id|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+  end
+end


### PR DESCRIPTION
In #6550 we replaced PNG attachment thumbnails with SVGs; however, attachments that have not been republished since then will still use PNGs.

This bulk-republishes all attachments with html attachments or with file attachments that are not PDFs. (PDFs still use PNG thumbnail images so are not affected by the change.)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
