### PR TITLE
Add government_id and political to the HtmlAttachmentPresenter

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -40,6 +40,7 @@ module PublishingApi
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
         organisations: parent.organisations.pluck(:content_id).uniq,
         primary_publishing_organisation: primary_publishing_organisation,
+        government: government_id,
       }
     end
 
@@ -58,6 +59,7 @@ module PublishingApi
         body: body,
         public_timestamp: public_timestamp,
         first_published_version: first_published_version?,
+        political: political?,
       }
     end
 
@@ -67,6 +69,10 @@ module PublishingApi
 
     def first_published_version?
       parent.first_published_version?
+    end
+
+    def political?
+      item&.attachable.is_a?(Edition) ? item&.attachable&.political : false
     end
 
     def public_timestamp
@@ -99,6 +105,10 @@ module PublishingApi
 
     def locale
       item.translated_locales.first
+    end
+
+    def government_id
+      [parent.try(:government).try(:content_id)]
     end
   end
 end

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -12,11 +12,15 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
   end
 
   test "HtmlAttachment presentation includes the correct values" do
+    government = create(:government)
     edition = create(
       :publication,
       :with_html_attachment,
       :published,
+      political: true,
     )
+
+    edition.stubs(:government).returns(government)
 
     html_attachment = HtmlAttachment.last
 
@@ -40,6 +44,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
           .govspeak_to_html(html_attachment.govspeak_content.body),
         public_timestamp: edition.public_timestamp,
         first_published_version: html_attachment.attachable.first_published_version?,
+        political: true,
       },
     }
     presented_item = present(html_attachment)
@@ -56,7 +61,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     expected_content = expected_hash.merge(links: presented_item.links)
     assert_equal expected_content, presented_content
 
-    %i[organisations parent primary_publishing_organisation].each { |k| assert_includes(expected_content[:links].keys, k) }
+    %i[organisations parent primary_publishing_organisation government].each { |k| assert_includes(expected_content[:links].keys, k) }
   end
 
   test "HtmlAttachment presentation includes the correct locale" do


### PR DESCRIPTION
## Description 

We're doing some work to expose a history banner on html attachments to let the user know that a publication was published under a previous government. This means that we need to expose whether a html publication is political and which government it was published under on the object passed to the frontend.

This PR adds whether the attachable (parent object) is political or not to the hmtl and the government it was published under.

This allows us to render the history banner for html attachments whose parent edition is histoically political (and already renders the banner)

You can read about contract testing and  how to affect changes to a schema here https://github.com/alphagov/govuk-content-schemas/blob/main/docs/changing-an-existing-content-schema.md

In essence this PR needs to be deployed, then the govuk-content-schema PR can be merged and finally the frontend PR

### GOVUK Content Schema PR

https://github.com/alphagov/govuk-content-schemas/pull/1096

### Government Frontend PR

https://github.com/alphagov/government-frontend/pull/2446

## Trello card

https://trello.com/c/xWMcmTqb/409-implement-history-mode-banner-on-html-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
