### PR TITLE
Enable shareable previews for publications and consultations

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -720,7 +720,7 @@ EXISTS (
 
   # conditions for document types will be removed after enabling shareable preview for them
   def has_enabled_shareable_preview?(user)
-    state == "draft" && user.can_share_previews? && type != "Consultation" && type != "Publication" && type != "DocumentCollection"
+    state == "draft" && user.can_share_previews? && type != "DocumentCollection"
   end
 
   delegate :locked?, to: :document

--- a/test/integration/shareable_preview_test.rb
+++ b/test/integration/shareable_preview_test.rb
@@ -50,35 +50,7 @@ class ShareablePreviewIntegrationTest < ActionDispatch::IntegrationTest
       end
     end
 
-    #  tests below will be removed after enabling shareable preview for those doccument types
-    context "for excluded type of documents - consultation" do
-      let(:edition) { create(:draft_consultation) }
-
-      before do
-        create_setup(edition)
-        visit admin_consultation_path(edition)
-      end
-
-      test "it does not show shareable preview feature" do
-        get admin_consultation_path(edition)
-        assert_no_selector "section", text: "Share document preview"
-      end
-    end
-
-    context "for excluded type of documents - publication" do
-      let(:edition) { create(:draft_publication) }
-
-      before do
-        create_setup(edition)
-        visit admin_publication_path(edition)
-      end
-
-      test "it does not show shareable preview feature" do
-        get admin_publication_path(edition)
-        assert_no_selector "section", text: "Share document preview"
-      end
-    end
-
+    #  test below will be removed after enabling shareable preview for those doccument types
     context "for excluded type of documents - document collection" do
       let(:edition) { create(:draft_document_collection) }
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -57,22 +57,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal edition.has_enabled_shareable_preview?(user), false
   end
 
-  #  test below will be removed after enabling shareable preview for this doccument type
-  test "edition has shareable preview disabled if it has consultation type" do
-    edition = create(:draft_consultation)
-    user = create(:gds_editor)
-    user.permissions << "can share previews"
-    assert_equal edition.has_enabled_shareable_preview?(user), false
-  end
-
-  # test below will be removed after enabling shareable preview for this doccument type
-  test "edition has shareable preview disabled if it has publication type" do
-    edition = create(:draft_publication)
-    user = create(:gds_editor)
-    user.permissions << "can share previews"
-    assert_equal edition.has_enabled_shareable_preview?(user), false
-  end
-
   # test below will be removed after enabling shareable preview for this doccument type
   test "edition has shareable preview disabled if it has document collection type" do
     edition = create(:draft_document_collection)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This follows on from [work to add auth_bypass_ids to html attachments](https://github.com/alphagov/whitehall/pull/6571), to make them previewable. Now that this is done, we can enable the UI for these document types.

Follow up PR coming to add a rake task to resend html attachments attached to draft editions so that existing html attachments are stored with the relevant auth_bypass_id.

Trello: https://trello.com/c/49YsQTjg/448-enable-editions-with-a-type-of-publication-consultation-to-be-previewed-with-any-attachments