### PR TITLE
Present Topical Event 'about page link text' to Publishing API

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -35,6 +35,7 @@ module PublishingApi
 
     def details
       {}.tap do |details|
+        details[:about_page_link_text] = item.about_page.read_more_link_text if item.about_page && item.about_page.read_more_link_text
         details[:body] = body
         details[:start_date] = item.start_date.rfc3339 if item.start_date
         details[:end_date] = item.end_date.rfc3339 if item.end_date

--- a/test/functional/admin/about_pages_controller_test.rb
+++ b/test/functional/admin/about_pages_controller_test.rb
@@ -22,6 +22,7 @@ class Admin::AboutPagesControllerTest < ActionController::TestCase
     assert_difference "AboutPage.count" do
       post :create, params: { topical_event_id: @topical_event.to_param, about_page: attributes_for(:about_page) }
     end
+    @topical_event.reload
     assert_not_nil @topical_event.about_page, "expected topical event to have an about page"
   end
 

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -8,6 +8,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       name: "Humans going to Mars",
       description: "A topical event description with [a link](http://www.gov.uk)",
     )
+    create(:topical_event_about_page, topical_event: topical_event, read_more_link_text: "Read more about this event")
     public_path = "/government/topical-events/humans-going-to-mars"
 
     feature = create(:classification_featuring, classification: topical_event, ordering: 1)
@@ -36,6 +37,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       redirects: [],
       public_updated_at: topical_event.updated_at,
       details: {
+        about_page_link_text: topical_event.about_page.read_more_link_text,
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
         start_date: topical_event.start_date.rfc3339,
         end_date: topical_event.end_date.rfc3339,


### PR DESCRIPTION
This text is needed to allow us to include a link (with custom text, as defined in Whitehall) in the topical event.

The page is currently rendered by Whitehall, but will be migrated to Collections, which is why this now needs to be included in the content item.

This is dependent on https://github.com/alphagov/govuk-content-schemas/pull/1099 being merged and deployed.

Once merged and deployed, the following rake task will need to be run to republish existing topical events to Publishing API: `publishing_api:republish:all_topical_events`.


[Trello card](https://trello.com/c/zpFXy34H)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
