### PR TITLE
Compact the government_id for html attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -109,7 +109,7 @@ module PublishingApi
     end
 
     def government_id
-      [parent.try(:government).try(:content_id)]
+      [parent.try(:government).try(:content_id)].compact
     end
   end
 end


### PR DESCRIPTION
## Description 

This is causing issues downstream at the moment as it passes nil within a blank array which causes the publishing API to blow up downstream.

## Sentry error

Example sentry error: https://gds.slack.com/archives/C02L13S214K/p1654082398471929

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
