### PR TITLE
Fix typo in Google Analytics tracking parameters

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -52,7 +52,7 @@ module PublicDocumentRoutesHelper
       token: edition.auth_bypass_token,
       utm_source: :share,
       utm_medium: :preview,
-      utm_name: :govuk_publishing,
+      utm_campaign: :govuk_publishing,
     }.to_query
     "#{preview_document_url(edition)}?#{params}"
   end

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -135,7 +135,7 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
     edition = create(:draft_case_study)
     token = edition.auth_bypass_token
     preview_url_with_auth_bypass_token = preview_document_url_with_auth_bypass_token(edition)
-    assert_equal "http://draft-origin.test.gov.uk/government/case-studies/case-study-title?token=#{token}&utm_medium=preview&utm_name=govuk_publishing&utm_source=share", preview_url_with_auth_bypass_token
+    assert_equal "http://draft-origin.test.gov.uk/government/case-studies/case-study-title?token=#{token}&utm_campaign=govuk_publishing&utm_medium=preview&utm_source=share", preview_url_with_auth_bypass_token
   end
 
   test "organisations have the correct path generated" do


### PR DESCRIPTION
The Google Analytics query string parameter in shareable preview URLs was `utm_name` when it should have been `utm_campaign`.

This meant it wasn't being picked up correctly in Analytics.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
