### PR TITLE
Make default rake task run all tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,4 @@ end
 Whitehall::Application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test jasmine pact:verify]
+task default: %i[lint test shared_mustache:compile cucumber jasmine pact:verify]


### PR DESCRIPTION
This will make Whitehall more consistent with the majority of other Rails apps on GOV.UK, and allow us to use the new [shared workflow](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/test-rails.yaml) to run our CI suite in Github Actions, rather than Jenkins.

Full details in the [Trello card](https://trello.com/c/U9duqlgV/82-make-sure-both-jenkins-and-the-default-rake-task-run-the-same-tests-the-same-way)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
