### PR TITLE
Add rake task for republishing historically_political documents with a html attachment

### DIFF
--- a/lib/tasks/republish_historically_political_html_attachments.rake
+++ b/lib/tasks/republish_historically_political_html_attachments.rake
@@ -1,0 +1,17 @@
+desc "Republish all documents with html attachments which are historically political"
+task republish_historically_political_html_attachments: :environment do
+  government_start_date = Government.current.start_date
+
+  document_ids = Edition
+    .publicly_visible
+    .where(id: HtmlAttachment.where("attachable_type = 'Edition' AND political = true AND first_published_at < ?", government_start_date).select(:attachable_id))
+    .pluck(:document_id)
+
+  puts "Enqueueing #{document_ids.count} documents with historically political html attachments"
+
+  document_ids.each do |document_id|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+  end
+
+  puts "Finished enqueueing documents with historically political HtmlAttachments for republishing"
+end

--- a/test/unit/tasks/republish_historically_political_html_attachments_test.rb
+++ b/test/unit/tasks/republish_historically_political_html_attachments_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+require "rake"
+class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCase
+  test "it republishes documents with historically political HtmlAttachments" do
+    create(:government, start_date: 5.years.ago, end_date: 1.year.ago - 1.day)
+    create(:government, start_date: 1.year.ago)
+
+    historically_political_edition = create(
+      :edition,
+      :with_document,
+      :published,
+      first_published_at: 2.years.ago,
+      political: true,
+    )
+    political_edition = create(
+      :edition,
+      :with_document,
+      :published,
+      first_published_at: 1.month.ago,
+      political: true,
+    )
+
+    historical_edition = create(
+      :edition,
+      :with_document,
+      :published,
+      first_published_at: 5.years.ago,
+      political: false,
+    )
+
+    unpublished_historically_political_edition = create(
+      :edition,
+      :with_document,
+      :unpublished,
+      first_published_at: 5.years.ago,
+      political: true,
+    )
+
+    create(:html_attachment, attachable: historically_political_edition)
+    create(:html_attachment, attachable: political_edition)
+    create(:html_attachment, attachable: historical_edition)
+    create(:html_attachment, attachable: unpublished_historically_political_edition)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      historically_political_edition.document_id,
+      true,
+    )
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      political_edition.document_id,
+      true,
+    ).never
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      historical_edition.document_id,
+      true,
+    ).never
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      unpublished_historically_political_edition.document_id,
+      true,
+    ).never
+
+    Rake.application.invoke_task "republish_historically_political_html_attachments"
+  end
+end


### PR DESCRIPTION
## Description

We've recently done some work to expose a banner on the frontend for HTML attachments which were published alongside an edition which is historically_political i.e. published under a previous government and their opinion.

This rake task finds all documents where the editions are political and historical with and have an associated html attachment and republishes them.


## Trello card 

https://trello.com/c/xWMcmTqb/409-implement-history-mode-banner-on-html-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
