### PR TITLE
Add environment agnostic asset lookup

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -132,7 +132,15 @@ module GovspeakHelper
 private
 
   def asset_exists?(path)
-    Rails.application.assets_manifest.files.values.map { |v| v["logical_path"] }.include?(path)
+    # This acts as environment agnostic look-up to Rails.application.assets
+    # to find whether a file is in Sprockets. In a prod environment
+    # Rails.application.assets is nil (and the asset manifest is used instead)
+    # whereas in dev/test using the Rails.application.asset_manifest only
+    # works if the developer has run assets:precompile rake task first (which
+    # can be a point of frustration for devs)
+    # Using the build_environment allows this to flip between either as per:
+    # https://github.com/rails/sprockets-rails/issues/237#issuecomment-308666272
+    Sprockets::Railtie.build_environment(Rails.application).find_asset(path)
   end
 
   def remove_extra_quotes_from_blockquotes(govspeak)


### PR DESCRIPTION
Trello: https://trello.com/c/U9duqlgV/82-make-sure-both-jenkins-and-the-default-rake-task-run-the-same-tests-the-same-way

The previous approach here required assets:precompile to be run before
the code would work. This meant that when running the application tests
you needed to do the extra manual step of running assets:precompile,
otherwise there were failing tests - this was a common point of
confusion for developers as there isn't a clue that you needed to do
this.

Rather than adding assets:precompile as a step on the default rake task,
I've instead looked up how we can change the code to not be dependent on
this extra check.

An alternative, if we see future problems with this, would be to just do
a basic `File.exists?(Rails.root.join("app/assets/images",
fraction_asset_path))`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
