### PR TITLE
Limit document history

### DIFF
--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -99,7 +99,7 @@ private
   end
 
   def document_trail(superseded: true, versions: false, remarks: false)
-    scope = document.editions
+    scope = document.editions.order("first_published_at ASC").limit(3)
 
     scope = scope.includes(versions: [:user]) if versions
     scope = scope.includes(editorial_remarks: [:author]) if remarks


### PR DESCRIPTION
Currently we are unable to edit document with large histories (e.g. large number of editions) because the database query take too long and causes the page to time out. This is a temporary fix that breaks the history functionality in the sidebar for the admin pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
