### PR TITLE
Only limit history for one specific document

### DIFF
--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -99,7 +99,14 @@ private
   end
 
   def document_trail(superseded: true, versions: false, remarks: false)
-    scope = document.editions.order("first_published_at ASC").limit(3)
+    scope = document.editions
+
+    # Temporary fix to limit history on document:
+    # /government/publications/royal-courts-of-justice-cause-list
+    # which is known to cause timeouts due to the size of its history
+    if document.content_id == "c7346901-13fe-47df-a1f0-b583b78bf6e7"
+      scope = scope.order("first_published_at ASC").limit(3)
+    end
 
     scope = scope.includes(versions: [:user]) if versions
     scope = scope.includes(editorial_remarks: [:author]) if remarks


### PR DESCRIPTION
This is a temporary short-term fix being applied to resolve an incident.

There is a known problem with one specific document that causes the Whitehall interface to timeout, due to the size of the document's version history.

The fix applied in 2346aa1829ab31c0471a63c3e1fbcad2e2a8a839 added a limit to the history of all documents. This solved the initial problem for that one document, but it's resulted in other documents having a limited history too.

This commit adapts the original fix so that it only applies to the affected document, identified by its Content ID. All other documents will have a regular, un-limited version history.

Trello: https://trello.com/c/JTaGC5v0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
