### PR TITLE
Add rake task to republish all draft editions with HTML attachments

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -273,6 +273,17 @@ namespace :publishing_api do
       end
     end
 
+    desc "Republish all draft editions with HTML attachments to the Publishing API"
+    task drafts_with_html_attachments: :environment do
+      document_ids = Edition
+        .in_pre_publication_state
+        .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+        .pluck(:document_id)
+      document_ids.each do |document_id|
+        PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+      end
+    end
+
     desc "Republish all documents of a given type, eg 'NewsArticle'"
     task :document_type, [:document_type] => :environment do |_, args|
       documents = Document.where(document_type: args[:document_type])

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -300,6 +300,36 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#publication_drafts_with_html_attachments" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:drafts_with_html_attachments"] }
+
+      test "republishes draft publication documents with HMTL attachments" do
+        edition = create(:draft_publication, :with_html_attachment)
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          edition.document_id,
+          true,
+        )
+        task.invoke
+      end
+    end
+
+    describe "#consultation_drafts_with_html_attachments" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:drafts_with_html_attachments"] }
+
+      test "republishes draft consultation documents with HMTL attachments" do
+        edition = create(:draft_consultation, :with_html_attachment)
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          edition.document_id,
+          true,
+        )
+        task.invoke
+      end
+    end
+
     describe "#document_type" do
       let(:task) { Rake::Task["publishing_api:bulk_republish:document_type"] }
 


### PR DESCRIPTION
This is to enable editions with a type of Publication/Consultation to be previewed with any attachments.

[Trello card](https://trello.com/c/49YsQTjg/448-enable-editions-with-a-type-of-publication-consultation-to-be-previewed-with-any-attachments)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
