### PR TITLE
Refactor Edition audit trail methods

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -40,6 +40,8 @@ class Document < ApplicationRecord
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document, dependent: :destroy
 
+  has_many :edition_versions, through: :editions, source: :versions
+
   before_save { check_if_locked_document(document: self) unless locked_changed? }
 
   validates :content_id, presence: true
@@ -104,6 +106,10 @@ class Document < ApplicationRecord
 
   def first_published_date
     published_edition.first_public_at if published?
+  end
+
+  def first_published_on_govuk
+    edition_versions.where(state: "published").pick(:created_at)
   end
 
   def change_history

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -508,18 +508,15 @@ EXISTS (
   end
 
   def rejected_by
-    rejected_event = latest_version_audit_entry_for("rejected")
-    rejected_event && rejected_event.actor
+    versions_desc.where(state: "rejected").first.try(:user)
   end
 
   def published_by
-    published_event = latest_version_audit_entry_for("published")
-    published_event && published_event.actor
+    versions_desc.where(state: "published").first.try(:user)
   end
 
   def scheduled_by
-    scheduled_event = latest_version_audit_entry_for("scheduled")
-    scheduled_event && scheduled_event.actor
+    versions_desc.where(state: "scheduled").first.try(:user)
   end
 
   def submitted_by

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -28,6 +28,14 @@ module Edition::AuditTrail
     before_update :record_update
   end
 
+  def versions_asc
+    versions
+  end
+
+  def versions_desc
+    versions.reverse_order
+  end
+
   def edition_remarks_trail(edition_serial_number = 0)
     editorial_remarks.map { |r|
       EditorialRemarkAuditEntry.new(edition_serial_number, self, r)
@@ -53,18 +61,6 @@ module Edition::AuditTrail
 
   def latest_version_audit_entry_for(state)
     edition_version_trail.reverse.detect { |audit_entry| audit_entry.version.state == state }
-  end
-
-  def most_recent_submission_audit_entry
-    matching_entry = nil
-    edition_version_trail.reverse.map do |audit_entry|
-      if audit_entry.version.state == "submitted"
-        matching_entry = audit_entry
-      elsif matching_entry.present?
-        break
-      end
-    end
-    matching_entry
   end
 
   def publication_audit_entry

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -14,7 +14,7 @@ module Edition::AuditTrail
   end
 
   included do
-    has_many :versions, -> { order("created_at ASC, id ASC") }, as: :item
+    has_many :versions, -> { order(created_at: :asc, id: :asc) }, as: :item
 
     has_one :most_recent_version,
             -> { order("versions.created_at DESC, versions.id DESC") },
@@ -57,10 +57,6 @@ module Edition::AuditTrail
 
   def document_version_trail(superseded: true)
     document_trail(superseded: superseded, versions: true)
-  end
-
-  def publication_audit_entry
-    document_version_trail.detect { |audit_entry| audit_entry.version.state == "published" }
   end
 
 private

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -59,10 +59,6 @@ module Edition::AuditTrail
     document_trail(superseded: superseded, versions: true)
   end
 
-  def latest_version_audit_entry_for(state)
-    edition_version_trail.reverse.detect { |audit_entry| audit_entry.version.state == state }
-  end
-
   def publication_audit_entry
     document_version_trail.detect { |audit_entry| audit_entry.version.state == "published" }
   end

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -68,7 +68,7 @@ class DocumentListExportPresenter
   end
 
   def first_published_on_govuk
-    edition.publication_audit_entry.try(:created_at)
+    edition.document.first_published_on_govuk
   end
 
   def content_type

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -147,6 +147,22 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal publication, document.scheduled_edition
   end
 
+  test "#first_published_on_govuk returns first time it was published on GOV.UK" do
+    Timecop.freeze(Time.zone.now - 3.days)
+    edition = create(:submitted_edition)
+    Timecop.freeze(Time.zone.now + 1.day)
+    edition.major_change_published_at = Time.zone.now
+    edition.publish!
+    publication_date = edition.updated_at
+    Timecop.freeze(Time.zone.now + 1.day)
+    new_edition = edition.create_draft(edition.creator)
+    new_edition.change_note = "updated"
+    new_edition.submit!
+    new_edition.publish!
+
+    assert_equal publication_date, new_edition.document.first_published_on_govuk
+  end
+
   test "#ever_published_editions returns all editions that have ever been published or withdrawn" do
     document = create(:document)
     superseded = create(:superseded_edition, document: document)

--- a/test/unit/edition/audit_trail_test.rb
+++ b/test/unit/edition/audit_trail_test.rb
@@ -127,13 +127,6 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
     assert_equal @user, edition.latest_version_audit_entry_for("submitted").actor
   end
 
-  test "most_recent_submission_audit_entry returns entry for submission action" do
-    edition = create(:submitted_edition, creator: @user2)
-    edition.body = "updated-body"
-    edition.save!
-    assert_equal @user2, edition.most_recent_submission_audit_entry.actor
-  end
-
   test "publication_audit_entry returns entry when first edition was published" do
     Timecop.freeze(Time.zone.now - 3.days)
     edition = create(:submitted_edition)

--- a/test/unit/edition/audit_trail_test.rb
+++ b/test/unit/edition/audit_trail_test.rb
@@ -120,13 +120,6 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
     assert_not draft_edition.document_remarks_trail.map(&:object).map(&:class).include? Version
   end
 
-  test "latest_version_audit_entry_for returns most recent entry in a state" do
-    edition = create(:submitted_edition, creator: @user2)
-    edition.body = "updated-body"
-    edition.save!
-    assert_equal @user, edition.latest_version_audit_entry_for("submitted").actor
-  end
-
   test "publication_audit_entry returns entry when first edition was published" do
     Timecop.freeze(Time.zone.now - 3.days)
     edition = create(:submitted_edition)

--- a/test/unit/edition/audit_trail_test.rb
+++ b/test/unit/edition/audit_trail_test.rb
@@ -119,21 +119,4 @@ class Edition::AuditTrailTest < ActiveSupport::TestCase
     assert_not draft_edition.document_version_trail.map(&:object).map(&:class).include? EditorialRemark
     assert_not draft_edition.document_remarks_trail.map(&:object).map(&:class).include? Version
   end
-
-  test "publication_audit_entry returns entry when first edition was published" do
-    Timecop.freeze(Time.zone.now - 3.days)
-    edition = create(:submitted_edition)
-    Timecop.freeze(Time.zone.now + 1.day)
-    edition.major_change_published_at = Time.zone.now
-    edition.publish!
-    publication_date = edition.updated_at
-    Timecop.freeze(Time.zone.now + 1.day)
-    new_edition = edition.create_draft(edition.creator)
-    new_edition.change_note = "updated"
-    new_edition.submit!
-    new_edition.publish!
-
-    published_audit = new_edition.publication_audit_entry
-    assert_equal publication_date, published_audit.created_at
-  end
 end

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -14,7 +14,7 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
     ScheduledPublishingWorker.new.perform(edition.id)
 
     assert edition.reload.published?
-    assert_equal @publishing_robot, edition.latest_version_audit_entry_for("published").actor
+    assert_equal @publishing_robot, edition.published_by
   end
 
   test "#perform raises an error if the edition cannot be published" do


### PR DESCRIPTION
This PR refactors methods on Edition related to 'audit trails' (a.k.a. version history). In doing so, we've been able to improve code readability and performance/efficiency.

This refactor has come out of some [investigatory work][1] that I've been carrying out to try and reduce the performance impact of documents with a large edit history. Part of that work involves reducing our dependence on the [`AuditEntry` classes][1] which have thus far made it difficult to perform more efficient pagination of large document edit histories.

Special thanks to @kevindew for his determination to have `Edition#submitted_by` perform just one database query. 🧙🏻‍♂️

[1]: https://github.com/alphagov/whitehall/compare/limit-document-history
[2]: https://github.com/alphagov/whitehall/blob/1bc8e03611294427e0eb1c3c500f8c2272e8556a/app/models/edition/audit_trail.rb#L125-L206

Trello: https://trello.com/c/JTaGC5v0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
