### PR TITLE
Add national applicability data to html attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -56,12 +56,20 @@ module PublishingApi
     end
 
     def details
-      {
+      details_hash = {
         body: body,
         public_timestamp: public_timestamp,
         first_published_version: first_published_version?,
         political: political?,
       }
+
+      maybe_add_national_applicability(details_hash)
+    end
+
+    def maybe_add_national_applicability(details_hash)
+      return details_hash unless item.attachable.try(:nation_inapplicabilities)&.any?
+
+      details_hash.merge(national_applicability: item.attachable.national_applicability)
     end
 
     def body


### PR DESCRIPTION
## Description

We're doing some work to expose national applicability data for html attachments. If a consultation or Publication only relates to some of the devolved nations, then it also renders for html attachments that belong to it.

This PR does the work to ensure that when applicable the devolved nations details are passed down in the details hash. These will then be exposed on the frontend.

## Related PRs 

GOVUK Content Schema - https://github.com/alphagov/govuk-content-schemas/pull/1100

Governement Frontend - https://github.com/alphagov/government-frontend/pull/2460

## Trello card

https://trello.com/c/pLnsviDN/402-implement-devolved-nations-national-applicability-banner-on-html-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
