### PR TITLE
Spike - demonstration of paginated history/remarks on Admin::Edition#show

### DIFF
--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -3,6 +3,6 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
 
   def index
     @edition = Edition.find(params[:id])
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -190,7 +190,7 @@ private
   end
 
   def fetch_version_and_remark_trails
-    @edition_remarks = @edition.document_remarks_trail.reverse
+    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
     @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -191,7 +191,7 @@ private
 
   def fetch_version_and_remark_trails
     @edition_remarks = @edition.document_remarks_trail.reverse
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 
   def edition_class

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -26,21 +26,56 @@ module Admin::AuditTrailHelper
     )
   end
 
+  def paginated_remarks_url(page)
+    url_for(
+      params.to_unsafe_hash
+            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page))
+            .symbolize_keys,
+    )
+  end
+
   def render_editorial_remarks_in_sidebar(remarks, edition)
-    this_edition_remarks, other_edition_remarks = remarks.partition { |r| r.edition == edition }
+    # this_edition_remarks, other_edition_remarks = remarks.partition { |r| r.edition == edition }
+    # out = ""
+    # if this_edition_remarks.any?
+    #   out << tag.h2("On this edition")
+    #   out << tag.ul(class: "list-unstyled") do
+    #     render partial: "admin/editions/remark_entry", collection: this_edition_remarks
+    #   end
+    # end
+    # if other_edition_remarks.any?
+    #   out << tag.h2("On previous editions", class: "add-top-margin")
+    #   out << tag.ul(class: "list-unstyled") do
+    #     render partial: "admin/editions/remark_entry", collection: other_edition_remarks
+    #   end
+    # end
+    # out.html_safe
+    previous_state = nil
     out = ""
-    if this_edition_remarks.any?
-      out << tag.h2("On this edition")
-      out << tag.ul(class: "list-unstyled") do
-        render partial: "admin/editions/audit_trail_entry", collection: this_edition_remarks
+    list = ""
+    remarks.each do |remark|
+      current_state = if remark.edition_id > edition.id
+                        :newer
+                      elsif remark.edition_id < edition.id
+                        :previous
+                      else
+                        :current
+                      end
+
+      if current_state != previous_state
+        out << tag.ul(class: "list-unstyled") { list.html_safe }
+        list = ""
+        out << case current_state
+               when :newer then tag.h2("On newer editions")
+               when :previous then tag.h2("On previous editions")
+               when :current then tag.h2("On this edition")
+               end
       end
+
+      list << render(partial:"admin/editions/remark_entry", locals: { remark: remark })
+      previous_state = current_state
     end
-    if other_edition_remarks.any?
-      out << tag.h2("On previous editions", class: "add-top-margin")
-      out << tag.ul(class: "list-unstyled") do
-        render partial: "admin/editions/audit_trail_entry", collection: other_edition_remarks
-      end
-    end
+    out << tag.ul(class: "list-unstyled") { list.html_safe }
     out.html_safe
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -41,6 +41,7 @@ class Document < ApplicationRecord
   has_many :features, inverse_of: :document, dependent: :destroy
 
   has_many :edition_versions, through: :editions, source: :versions
+  has_many :editorial_remarks, through: :editions
 
   before_save { check_if_locked_document(document: self) unless locked_changed? }
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -40,6 +40,8 @@ class Document < ApplicationRecord
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document, dependent: :destroy
 
+  has_many :edition_versions, through: :editions, source: :versions
+
   before_save { check_if_locked_document(document: self) unless locked_changed? }
 
   validates :content_id, presence: true

--- a/app/models/document/paginated_history.rb
+++ b/app/models/document/paginated_history.rb
@@ -1,0 +1,60 @@
+class Document::PaginatedHistory
+  attr_reader :document, :query
+  delegate :total_count, to: :query
+
+  def initialize(document, page)
+    @document = document
+    @query = document.edition_versions
+                     .includes(:user)
+                     .where.not(state: :superseded)
+                     .reorder(created_at: :desc, id: :desc)
+                     .page(page)
+                     .per(30)
+  end
+
+  def audit_trail
+    query.map.with_index do |version, index|
+      AuditTrailEntry.new(version,
+                          is_first_edition: version.item_id == first_edition&.id,
+                          previous_version: index == 0 ? nil : query[index - 1])
+    end
+  end
+
+private
+
+  def first_edition
+    # probably should be a method on document for this
+    @first_edition ||= document.editions.where.not(state: :deleted).order(id: :asc).first
+  end
+
+  class AuditTrailEntry
+    attr_reader :version, :is_first_edition, :preloaded_previous_version
+    delegate :created_at, to: :version
+
+    def initialize(version, is_first_edition:, previous_version: nil)
+      @version = version
+      @is_first_edition = is_first_edition
+      @preloaded_previous_version = previous_version
+    end
+
+    def actor
+      version.user
+    end
+
+    def previous_version
+      # we can avoid n+1 queries by using our preloaded_previous_version
+      @previous_version ||= preloaded_previous_version || version.previous
+    end
+
+    def action
+      case version.event
+      when "create"
+        "editioned"
+        is_first_edition ? "created" : "editioned"
+      else
+        previous_version&.state != version.state ? version.state : "updated"
+      end
+    end
+  end
+end
+

--- a/app/models/document/paginated_remarks.rb
+++ b/app/models/document/paginated_remarks.rb
@@ -1,0 +1,19 @@
+# not sure this actually needs a class, done quickly for consistency with PaginatedHistory
+class Document::PaginatedRemarks
+  attr_reader :document, :query
+  delegate :total_count, to: :query
+
+  def initialize(document, page)
+    @document = document
+    @query = document.editorial_remarks
+                     .includes(:author)
+                     .order(created_at: :desc, id: :desc)
+                     .page(page)
+                     .per(30)
+  end
+
+  def entries
+    query.to_a
+  end
+end
+

--- a/app/views/admin/edition_audit_trail/index.html.erb
+++ b/app/views/admin/edition_audit_trail/index.html.erb
@@ -1,8 +1,8 @@
 <div class="audit-trail-page">
   <h1>Activity</h1>
-  <%= paginate @edition_history, theme: 'audit_trail' %>
+  <%= paginate @document_history.query, theme: 'audit_trail' %>
   <ul class="list-unstyled">
-    <%= render partial: "audit_trail_entry", collection: @edition_history %>
+    <%= render partial: "audit_trail_entry", collection: @document_history.audit_trail %>
   </ul>
-  <%= paginate @edition_history, theme: 'audit_trail' %>
+  <%= paginate @document_history.query, theme: 'audit_trail' %>
 </div>

--- a/app/views/admin/editions/_audit_trail_entry.html.erb
+++ b/app/views/admin/editions/_audit_trail_entry.html.erb
@@ -1,5 +1,5 @@
-<%= content_tag_for(:li, audit_trail_entry) do %>
-  <% if audit_trail_entry.is_a?(Edition::AuditTrail::VersionAuditEntry) && audit_trail_entry.action == "published" %>
+<%= content_tag(:li, class: "version") do %>
+  <% if audit_trail_entry.action == "published" %>
     <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: audit_trail_entry.version.item_id) %>
   <% end %>
 

--- a/app/views/admin/editions/_remark_entry.html.erb
+++ b/app/views/admin/editions/_remark_entry.html.erb
@@ -1,0 +1,12 @@
+<%= content_tag(:li, class: "editorial_remark") do %>
+  <div class="image">
+    <%= gravatar_image(remark.author, ssl: request.ssl?) %>
+  </div>
+  <span class="body"><%= remark.body %></span>
+  <% if remark.author %>
+    <span class="actor"><%= linked_author(remark.author) %></span>
+  <% else %>
+    User (removed)
+  <% end %>
+  <%= absolute_time(remark.created_at, class: "created_at") %>
+<% end %>

--- a/app/views/admin/editions/_remark_trail_entry.html.erb
+++ b/app/views/admin/editions/_remark_trail_entry.html.erb
@@ -1,0 +1,10 @@
+<%= content_tag(:li, class: "version") do %>
+  <% if audit_trail_entry.action == "published" %>
+    <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: audit_trail_entry.version.item_id) %>
+  <% end %>
+
+  <div class="image">
+    <%= gravatar_image(audit_trail_entry.actor, ssl: request.ssl?) %>
+  </div>
+  <%= describe_audit_trail_entry(audit_trail_entry) %>
+<% end %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -33,7 +33,7 @@
     </div>
 
     <div class="col-md-4">
-      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @edition_history.total_count, editing: true) do |tabs| %>
+      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @document_remarks.total_count, history_count: @document_history.total_count, editing: true) do |tabs| %>
         <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
           <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
                                       show_attachments_tab_help: true,
@@ -49,17 +49,19 @@
           <h1>Notes</h1>
           <p>To add a remark, save your changes.</p>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+            <%= render_editorial_remarks_in_sidebar(@document_remarks.entries, @edition)  %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>
           <div class="audit-trail-page">
             <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
             <ul class="list-unstyled">
               <%= render partial: "audit_trail_entry", collection: @edition_history %>
             </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
           </div>
         <% end %>
 

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -77,11 +77,13 @@
     <% if @edition.imported? %>
       <%= render partial: 'speed_tagging' %>
     <% else %>
-      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @document_history.total_count), class: 'remarks-history' do |tabs| %>
+      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @document_remarks.total_count, history_count: @document_history.total_count), class: 'remarks-history' do |tabs| %>
         <%= tabs.pane class: "audit-trail", id: "notes" do %>
           <h1>Notes</h1>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+            <%= render_editorial_remarks_in_sidebar(@document_remarks.entries, @edition)  %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -77,7 +77,7 @@
     <% if @edition.imported? %>
       <%= render partial: 'speed_tagging' %>
     <% else %>
-      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @edition_history.total_count), class: 'remarks-history' do |tabs| %>
+      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @document_history.total_count), class: 'remarks-history' do |tabs| %>
         <%= tabs.pane class: "audit-trail", id: "notes" do %>
           <h1>Notes</h1>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
@@ -87,11 +87,11 @@
         <%= tabs.pane class: "audit-trail", id: "history" do %>
           <div class="audit-trail-page">
             <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
             <ul class="list-unstyled">
-              <%= render partial: "audit_trail_entry", collection: @edition_history %>
+              <%= render partial: "audit_trail_entry", collection: @document_history.audit_trail %>
             </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
           </div>
         <% end %>
 

--- a/app/views/kaminari/remarks/_next_page.html.erb
+++ b/app/views/kaminari/remarks/_next_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% text = "Older >>".html_safe %>
+<li class="next"><%= link_to_unless current_page.last?, text, url, data: {'remote-pagination' => paginated_remarks_url(current_page + 1) } %></li>

--- a/app/views/kaminari/remarks/_paginator.html.erb
+++ b/app/views/kaminari/remarks/_paginator.html.erb
@@ -1,0 +1,16 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="remarks-nav" role="navigation">
+    <ul class="pager">
+      <%= prev_page_tag unless current_page.first? %>
+      <%= next_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/remarks/_prev_page.html.erb
+++ b/app/views/kaminari/remarks/_prev_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% text = "<< Newer".html_safe %>
+<li class="previous"><%= link_to_unless current_page.first?, text, url, data: {'remote-pagination' => paginated_remarks_url(current_page - 1) } %></li>


### PR DESCRIPTION
Trello: https://trello.com/c/JTaGC5v0/486-royal-courts-of-justice-incident

This is a prototype proof-of-concept of changing the approach to loading history/remarks when showing the show page of an Edition. 

The previous approach was to load all remarks and history from the database when displaying the page. For a page with a long history this would add a significant performance overhead (for example: https://www.gov.uk/government/publications/royal-courts-of-justice-cause-list has 1000's of updates).

This offers a like-for-like replacement of the history aspect - this was achievable as that already has pagination, albeit an inefficient approach.

For remarks there was not previously a pagination approach and on the live version there are semantic rendering issues on the presentation of which edition they are associated with. Therefore this offers an MVP style approach of this with pagination. 

More details in the commits.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
