### PR TITLE
Updated wording in Shareable Preview UI panel

### DIFF
--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -37,7 +37,8 @@
         </div>
         <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
           <div class="panel-body">
-            <p>Send the preview link to someone so they can see a preview of how the document will appear on GOV.UK. No password or GOV.UK Signon account is needed.</p>
+            <p>Send this preview link to someone so they can see the content and how the document will appear on GOV.UK.</p>
+            <p>No password is needed and anyone with the preview link can view it. You're responsible for who you share draft documents with. </p>
             <p>The preview link will expire on <%= Date.today.next_month.strftime('%-d %B %Y') %> or when the document is published.</p>
             <p><strong>Highlight or 'select all' and copy the link</strong></p>
             <textarea class="form-control" rows="3"><%= utm_uri %></textarea>


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/2YdZv8Fi/488-update-wording-in-shareable-preview-ui-panel)

The wording has been tweaked to clarify that publishers are responsible for who they share the preview link with.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
