### PR TITLE
Present Topical Event image (logo) to Publishing API

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -37,6 +37,7 @@ module PublishingApi
       {}.tap do |details|
         details[:about_page_link_text] = item.about_page.read_more_link_text if item.about_page && item.about_page.read_more_link_text
         details[:body] = body
+        details[:image] = image if item.logo_url
         details[:start_date] = item.start_date.rfc3339 if item.start_date
         details[:end_date] = item.end_date.rfc3339 if item.end_date
         details[:ordered_featured_documents] = ordered_featured_documents
@@ -46,6 +47,13 @@ module PublishingApi
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_to_html(item.description)
+    end
+
+    def image
+      {
+        url: item.logo_url(:s300),
+        alt_text: item.logo_alt_text,
+      }
     end
 
     def ordered_featured_documents

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -7,6 +7,8 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       :active,
       name: "Humans going to Mars",
       description: "A topical event description with [a link](http://www.gov.uk)",
+      logo: upload_fixture("images/960x640_jpeg.jpg", "image/jpeg"),
+      logo_alt_text: "Alternative text",
     )
     create(:topical_event_about_page, topical_event: topical_event, read_more_link_text: "Read more about this event")
     public_path = "/government/topical-events/humans-going-to-mars"
@@ -39,6 +41,10 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       details: {
         about_page_link_text: topical_event.about_page.read_more_link_text,
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
+        image: {
+          url: topical_event.logo_url(:s300),
+          alt_text: topical_event.logo_alt_text,
+        },
         start_date: topical_event.start_date.rfc3339,
         end_date: topical_event.end_date.rfc3339,
         ordered_featured_documents: [


### PR DESCRIPTION
This is needed to allow us to include the topical event's logo or image in the content item.

The page is currently rendered by Whitehall, but will be migrated to Collections, which is why this now needs to be included in the content item.

This is dependent on https://github.com/alphagov/govuk-content-schemas/pull/1101 being merged and deployed.

Additionally, all existing topical events will need republishing using the following rake task: `publishing_api:republish:all_topical_events`.

[Trello card](https://trello.com/c/uNbOV24p)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
