### PR TITLE
Improve mustache templates compilation config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 /yarn-error.log
 
 spec/reports/pacts
+
+/app/assets/javascripts/templates.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
   GOVUK_WEBSITE_ROOT=www.gov.uk \
   GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk \
   JWT_AUTH_SECRET=secret \
-  bundle exec rake shared_mustache:compile assets:precompile
+  bundle exec rake assets:precompile
 
 FROM $base_image
 ENV RAILS_ENV=production GOVUK_APP_NAME=whitehall

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,6 @@ node {
           govuk.runRakeTask("test:publishing_schemas --trace")
         } else {
           govuk.runRakeTask("ci:setup:minitest test --trace")
-          govuk.runRakeTask("shared_mustache:compile")
           sh("bundle exec cucumber")
           govuk.runRakeTask("jasmine")
         }

--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,4 @@ end
 Whitehall::Application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test shared_mustache:compile cucumber jasmine pact:verify]
+task default: %i[lint test assets:precompile cucumber jasmine pact:verify]

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,2 +1,5 @@
 # Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
 Rake::Task["assets:precompile"].enhance(["yarn:install"])
+
+# Compiles shared Mustache templates when running assets:precompile
+Rake::Task["assets:precompile"].enhance(["shared_mustache:compile"])

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "yarn run lint:js && yarn run lint:scss",
     "lint:js": "standardx 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
     "lint:scss": "stylelint app/assets/stylesheets/",
-    "jasmine:prepare": "RAILS_ENV=test bundle exec rails assets:clobber shared_mustache:compile assets:precompile",
+    "jasmine:prepare": "RAILS_ENV=test bundle exec rails assets:clobber assets:precompile",
     "jasmine:ci": "yarn run jasmine:prepare && yarn run jasmine-browser-runner runSpecs",
     "jasmine:browser": "yarn run jasmine:prepare && yarn run jasmine-browser-runner"
   },


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/ISXwzUZE/475-make-shared-mustache-templates-less-annoying)

- [Commit 1:](https://github.com/alphagov/whitehall/commit/659a517423171db7c79e07cc8c2f094c8c4c414e) Adds app/assets/javascripts/templates.js to .gitignore
- [Commit 2:](https://github.com/alphagov/whitehall/commit/8662edbb4a9bc0b086ba09975e23acac300762fd) Extends the asset:precompile rake task to also run the shared_mustache:compile rake task and adds a test file to check shared_mustache:compile is invoked when asset:precompile is invoked.
- [Commit 3:](https://github.com/alphagov/whitehall/commit/d0db0c58df4264963062c851ebfb4875d5193e88) Removes all direct use of shared_mustache:compile

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
