### PR TITLE
Limit audit trail on documents with large history

### DIFF
--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -89,12 +89,10 @@ private
   def document_trail(superseded: true, versions: false, remarks: false)
     scope = document.editions
 
-    # Temporary fix to limit history on document:
-    # /government/publications/royal-courts-of-justice-cause-list
-    # which is known to cause timeouts due to the size of its history
-    if document.content_id == "c7346901-13fe-47df-a1f0-b583b78bf6e7"
-      scope = scope.order("first_published_at ASC").limit(3)
-    end
+    # Temporary fix to limit history on documents with more than 5000 versions.
+    # Large change histories are known to cause `504 Gateway Timeout` errors.
+    # A longer term fix is being worked on here: https://trello.com/c/SKFiAakd
+    scope = scope.limit(50) if document.edition_versions.count > 5000
 
     scope = scope.includes(versions: [:user]) if versions
     scope = scope.includes(editorial_remarks: [:author]) if remarks


### PR DESCRIPTION
This commit builds upon a 'quick fix' which was implemented in d06a2b41deca09b6d46e51e1b3ae80df788fd703 to avoid timeouts when publishers need to edit documents that have a large change history.

There is ongoing work to [make Whitehall better at handling large document histories][1] – but in the meantime, this is being put in place as a precautionary measure to avoid the potential for future incidents.

### Why is 5000 versions the limit?

- The document we've observed breaking Whitehall has more than 10,000 versions.
- At the time of writing, there are 7 documents with more than 5000 versions.
- The average number of versions per document is 16.

It therefore seems reasonable to set the threshold at 5000. This should ensure that even the heaviest Whitehall pages continue to work, with some leeway to cover when the server is under heavier than usual load.

[1]: https://trello.com/c/SKFiAakd/493-handle-large-change-histories-more-efficiently-in-whitehall

Trello: https://trello.com/c/JTaGC5v0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
