### PR TITLE
Add Copy preview link button for shareable preview

### DIFF
--- a/app/assets/javascripts/admin/edition_publishing.js
+++ b/app/assets/javascripts/admin/edition_publishing.js
@@ -34,6 +34,25 @@ jQuery(function ($) {
 });
 
 (function ($) {
+  var _copyToClipboard = function () {
+    $(this).click(function (e) {
+      e.preventDefault()
+      var input = $(this).siblings('input')[0]
+      input.select()
+      document.execCommand('copy')
+    })
+  }
+
+  $.fn.extend({
+    copyToClipboard: _copyToClipboard
+  })
+})(jQuery)
+
+jQuery(function ($) {
+  $('.copy-to-clipboard').copyToClipboard()
+});
+
+(function ($) {
   var hidePersonOverride = function () {
     if ($('input#person_override_active').prop('checked')) {
       $('.edition_person_override').show()

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -36,12 +36,12 @@
           </h4>
         </div>
         <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-          <div class="panel-body">
+          <div class="panel-body" data-module="track-button-click" data-track-category="pageElementInteraction" data-track-action="CopyDocumentPreview">
             <p>Send this preview link to someone so they can see the content and how the document will appear on GOV.UK.</p>
             <p>No password is needed and anyone with the preview link can view it. You're responsible for who you share draft documents with. </p>
             <p>The preview link will expire on <%= Date.today.next_month.strftime('%-d %B %Y') %> or when the document is published.</p>
-            <input class="form-control form-group-lg" type="text" readonly="readonly" value="<%= utm_uri %>" /></br>
-            <%= link_to "Copy link", "#", id: "copy_preview_link", title: "Copy preview link", class: "btn btn-default btn-lg add-left-margin copy-to-clipboard" %></br>
+            <input class="form-control form-group-lg" type="text" readonly="readonly" value="<%= utm_uri %>" /><br>
+            <%= link_to "Copy link", "#", id: "copy_preview_link", title: "Copy preview link", class: "btn btn-default btn-lg add-left-margin copy-to-clipboard" %><br>
           </div>
         </div>
       </div>

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -40,8 +40,8 @@
             <p>Send this preview link to someone so they can see the content and how the document will appear on GOV.UK.</p>
             <p>No password is needed and anyone with the preview link can view it. You're responsible for who you share draft documents with. </p>
             <p>The preview link will expire on <%= Date.today.next_month.strftime('%-d %B %Y') %> or when the document is published.</p>
-            <p><strong>Highlight or 'select all' and copy the link</strong></p>
-            <textarea class="form-control" rows="3"><%= utm_uri %></textarea>
+            <input class="form-control form-group-lg" type="text" readonly="readonly" value="<%= utm_uri %>" /></br>
+            <%= link_to "Copy link", "#", id: "copy_preview_link", title: "Copy preview link", class: "btn btn-default btn-lg add-left-margin copy-to-clipboard" %></br>
           </div>
         </div>
       </div>

--- a/spec/javascripts/admin/edition_publishing.spec.js
+++ b/spec/javascripts/admin/edition_publishing.spec.js
@@ -66,3 +66,26 @@ describe('enableChangeNoteHighlighting', function () {
     })
   })
 })
+
+describe('copyToClipboard', function () {
+  var previewLinkElement, container
+
+  beforeEach(function () {
+    previewLinkElement = $(
+      '<input class="form-control form-group-lg" type="text" readonly="readonly" value="http://draft-origin.dev.gov.uk/government/news/test-share-view-1705?token=eyJh4bFE&amp;utm_campaign=govuk_publishing&amp;utm_medium=preview&amp;utm_source=share" />' +
+      '<a id="copy_preview_link" title="Copy preview link" class="btn btn-default btn-lg add-left-margin copy-to-clipboard" href="#">Copy link</a>'
+    )
+
+    container = $('<div>').append(previewLinkElement)
+    $(document.body).append(container)
+  })
+
+  it('copy the links to the clipboard', function () {
+    spyOn(document, 'execCommand')
+
+    $('.copy-to-clipboard').copyToClipboard()
+    $('#copy_preview_link').trigger('click')
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+})


### PR DESCRIPTION
This includes copy to clipboard implementation.

[Trello link](https://trello.com/c/XMFrREv8/447-add-copy-link-button-for-shareable-preview-with-event-tracking)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
