### PR TITLE
Add rake tasks for amending a change note

### DIFF
--- a/lib/tasks/change_note.rake
+++ b/lib/tasks/change_note.rake
@@ -1,0 +1,48 @@
+namespace :change_note do
+  desc "List change notes for a content ID"
+  task :list, %i[content_id] => :environment do |_, args|
+    change_history = Document
+      .find_by(content_id: args[:content_id])
+      .editions
+      .where
+      .not(major_change_published_at: nil)
+      .pluck(:id, :major_change_published_at, :change_note)
+
+    if change_history.empty?
+      puts "No change notes found"
+      next
+    end
+
+    change_history.each do |change|
+      puts change.join("\t")
+    end
+  end
+
+  desc "Amend a change note for an edition"
+  task :amend, %i[edition_id new_change_note email] => :environment do |_, args|
+    edition = Edition.find(args[:edition_id])
+    old_change_note = edition.change_note
+
+    user = User.find_by(email: args[:email])
+    unless user
+      puts "User with email #{args[:email]} not found"
+      next
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    edition.update_attribute(:change_note, args[:new_change_note])
+    # rubocop:enable Rails/SkipsModelValidations
+
+    EditorialRemark.create!(
+      edition: edition,
+      body: "Updated change note from #{old_change_note} to #{args[:new_change_note]}",
+      author: user,
+      created_at: Time.zone.now,
+      updated_at: Time.zone.now,
+    )
+
+    PublishingApiDocumentRepublishingWorker.perform_async(edition.document.id)
+
+    puts "Updated change note from #{old_change_note} to #{args[:new_change_note]}"
+  end
+end

--- a/test/unit/tasks/change_note_test.rb
+++ b/test/unit/tasks/change_note_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ChangeNoteRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  describe "#list" do
+    let(:task) { Rake::Task["change_note:list"] }
+
+    test "Lists major change history" do
+      edition = create(:edition, :published, :with_document)
+
+      expected_output = "#{edition.id}\t#{edition.major_change_published_at}\t#{edition.change_note}\n"
+
+      assert_output(expected_output) { task.invoke(edition.content_id) }
+    end
+
+    test "Returns an appropriate message if no history found" do
+      edition = create(:edition, :draft, :with_document)
+
+      assert_output("No change notes found\n") { task.invoke(edition.content_id) }
+    end
+  end
+
+  describe "#amend" do
+    let(:task) { Rake::Task["change_note:amend"] }
+
+    test "Changes a change note" do
+      edition = create(:edition, :published, :with_document)
+      user = create(:user)
+
+      PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document.id)
+
+      task.invoke(edition.id, "New change note", user.email)
+
+      edition.reload
+      assert_equal(edition.change_note, "New change note")
+      assert_equal(edition.editorial_remarks.pluck(:body), ["Updated change note from change-note to New change note"])
+    end
+
+    test "aborts early if user not found" do
+      edition = create(:edition, :published, :with_document)
+
+      assert_output("User with email not-a-user@gov.uk not found\n") { task.invoke(edition.id, "New change note", "not-a-user@gov.uk") }
+
+      edition.reload
+      assert_equal(edition.change_note, "change-note")
+    end
+  end
+end


### PR DESCRIPTION
The [documentation](https://docs.publishing.service.gov.uk/manual/howto-modify-change-note.html#whitehall) currently expects developers to log into a production Rails console, perform a fuzzy match then update the attribute within the console 😬.

This is _very_ bad practice. There is also no audit trail of who made the change or what was changed.

Adding a rake task will allow us to avoid using the console for this task, until a user interface is built for this regular task.

Usage:
1. Get a list of change notes for the given document:
```
rake change_note:list[content_id]
```

2. From the output, get the edition ID for the edition whose change note
needs amending, then amend the change note:
```
rake change_note:amend[edition_id, "New change note", email]
```

The email of the person running the rake task is required. This creates an editorial remark in Whitehall, so there is an audit log of the change that was made and who made it.

We need to skip validations in updating the change note as Whitehall does not permit changes to published editions.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
