### PR TITLE
Generate new link for shareable preview

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
-  before_action :find_edition, only: %i[show show_locked edit update revise diff destroy]
+  before_action :find_edition, only: %i[show show_locked edit update revise diff destroy update_bypass_id]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_edition, only: %i[new create]
@@ -28,7 +28,7 @@ class Admin::EditionsController < Admin::BaseController
       enforce_permission!(:create, edition_class || Edition)
     when "create"
       enforce_permission!(:create, @edition)
-    when "edit", "update", "revise", "diff"
+    when "edit", "update", "revise", "diff", "update_bypass_id"
       enforce_permission!(:update, @edition)
     when "destroy"
       enforce_permission!(:delete, @edition)
@@ -181,6 +181,14 @@ class Admin::EditionsController < Admin::BaseController
     else
       redirect_to admin_edition_path(@edition), alert: edition_deleter.failure_reason
     end
+  end
+
+  def update_bypass_id
+    @edition.set_auth_bypass_id
+    @edition.save_as(current_user)
+    updater.perform!
+
+    redirect_to admin_edition_path(@edition)
   end
 
 private

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -184,9 +184,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update_bypass_id
-    @edition.set_auth_bypass_id
-    @edition.save_as(current_user)
-    updater.perform!
+    EditionAuthBypassUpdater.new(edition: @edition, current_user: current_user, updater: updater).call
 
     redirect_to admin_edition_path(@edition), notice: "Sharable preview link has been updated"
   end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -188,7 +188,7 @@ class Admin::EditionsController < Admin::BaseController
     @edition.save_as(current_user)
     updater.perform!
 
-    redirect_to admin_edition_path(@edition)
+    redirect_to admin_edition_path(@edition), notice: "Sharable preview link has been updated"
   end
 
 private

--- a/app/services/edition_auth_bypass_updater.rb
+++ b/app/services/edition_auth_bypass_updater.rb
@@ -1,0 +1,15 @@
+class EditionAuthBypassUpdater
+  attr_reader :edition, :current_user, :updater
+
+  def initialize(edition:, current_user:, updater:)
+    @edition = edition
+    @current_user = current_user
+    @updater = updater
+  end
+
+  def call
+    @edition.set_auth_bypass_id
+    @edition.save_as(@current_user)
+    @updater.perform!
+  end
+end

--- a/app/services/edition_auth_bypass_updater.rb
+++ b/app/services/edition_auth_bypass_updater.rb
@@ -11,5 +11,58 @@ class EditionAuthBypassUpdater
     @edition.set_auth_bypass_id
     @edition.save_as(@current_user)
     @updater.perform!
+
+    update_file_attachments(@edition)
+    update_image_attachments(@edition)
+    update_consultation_attachments(@edition)
+  end
+
+private
+
+  def update_file_attachments(edition)
+    return unless edition.respond_to?(:attachments) && edition.attachments.files.present?
+
+    new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+    edition.attachments.files.each do |file_attachment|
+      attachment_data_id = file_attachment.attachment_data.to_global_id
+      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+    end
+  end
+
+  def update_image_attachments(edition)
+    edition.images.each do |image|
+      image_data_id = image.image_data.to_global_id
+      new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", image_data_id, new_attributes)
+    end
+  end
+
+  def update_consultation_attachments(edition)
+    return unless edition.is_a?(Consultation)
+
+    if edition.consultation_participation&.consultation_response_form.present?
+      response_form = edition.consultation_participation.consultation_response_form
+      response_form_data_id = response_form.consultation_response_form_data.to_global_id
+      new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+
+      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", response_form_data_id, new_attributes)
+    end
+
+    if edition.outcome.present?
+      edition.outcome.attachments.files.each do |file_attachment|
+        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        attachment_data_id = file_attachment.attachment_data.to_global_id
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+      end
+    end
+
+    if edition.public_feedback.present?
+      edition.public_feedback.attachments.files.each do |file_attachment|
+        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        attachment_data_id = file_attachment.attachment_data.to_global_id
+        AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", attachment_data_id, new_attributes)
+      end
+    end
   end
 end

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -41,7 +41,13 @@
             <p>No password is needed and anyone with the preview link can view it. You're responsible for who you share draft documents with. </p>
             <p>The preview link will expire on <%= Date.today.next_month.strftime('%-d %B %Y') %> or when the document is published.</p>
             <input class="form-control form-group-lg" type="text" readonly="readonly" value="<%= utm_uri %>" /><br>
-            <%= link_to "Copy link", "#", id: "copy_preview_link", title: "Copy preview link", class: "btn btn-default btn-lg add-left-margin copy-to-clipboard" %><br>
+            <%= link_to "Copy link", "#", id: "copy_preview_link", title: "Copy preview link", class: "btn btn-default btn-lg copy-to-clipboard" %><br>
+
+            <% if !@edition.publicly_visible? %>
+              <br>
+              <p>Reset and generate a new preview link if you've shared the preview with the wrong person or if the link has expired. This will disable the previous preview link.</p>
+              <%= link_to "Generate new link", update_bypass_id_admin_edition_path(@edition), class: 'btn btn-lg btn-default public_version', method: :patch %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,7 @@ Whitehall::Application.routes.draw do
             post :convert_to_draft, to: "edition_workflow#convert_to_draft"
             get  :audit_trail, to: "edition_audit_trail#index"
             get  :show_locked, to: "editions#show_locked"
+            patch :update_bypass_id
           end
           resources :link_check_reports
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]

--- a/test/integration/shareable_preview_generate_new_link_test.rb
+++ b/test/integration/shareable_preview_generate_new_link_test.rb
@@ -33,6 +33,7 @@ class ShareablePreviewGenerateNewLinkIntegrationTest < ActionDispatch::Integrati
         new_query_string = Rack::Utils.parse_query URI(new_preview_url).query
         new_token = new_query_string["token"]
 
+        assert_selector ".flash.notice", text: "Sharable preview link has been updated"
         assert_not_equal current_token, new_token
       end
     end

--- a/test/integration/shareable_preview_generate_new_link_test.rb
+++ b/test/integration/shareable_preview_generate_new_link_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+require "capybara/rails"
+
+class ShareablePreviewGenerateNewLinkIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include TaxonomyHelper
+
+  describe "shareable preview generate new link feature" do
+    context "for draft documents" do
+      let(:edition) { create(:draft_case_study) }
+
+      before do
+        create_setup(edition)
+        visit admin_case_study_path(edition)
+      end
+
+      test "it shows the generate new link feature" do
+        get admin_case_study_path(edition)
+        assert_selector "section", text: "Generate new link"
+      end
+
+      test "it revokes the previous links and generates a new one" do
+        get admin_case_study_path(edition)
+
+        current_preview_url = all("input").first.value
+        current_query_string = Rack::Utils.parse_query URI(current_preview_url).query
+        current_token = current_query_string["token"]
+
+        click_link "Generate new link"
+
+        new_preview_url = all("input").first.value
+        new_query_string = Rack::Utils.parse_query URI(new_preview_url).query
+        new_token = new_query_string["token"]
+
+        assert_not_equal current_token, new_token
+      end
+    end
+
+    context "for published documents" do
+      let(:edition) { create(:published_case_study) }
+
+      before do
+        create_setup(edition)
+        visit admin_case_study_path(edition)
+      end
+
+      test "it does not show the generate new link feature" do
+        get admin_case_study_path(edition)
+        assert_no_selector "section", text: "Generate new link"
+      end
+    end
+
+    def create_setup(edition)
+      @user = create(:gds_editor)
+      @user.permissions << "can share previews"
+      login_as @user
+      topic_taxon = build(:taxon_hash)
+      stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+    end
+  end
+end

--- a/test/unit/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/services/editon_auth_bypass_updater_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
+  test "#call" do
+    edition = create(:draft_edition)
+    user = create(:user)
+    updater = MiniTest::Mock.new
+    service = EditionAuthBypassUpdater.new(
+      edition: edition,
+      current_user: user,
+      updater: updater,
+    )
+
+    uid = SecureRandom.uuid
+    SecureRandom.stubs(uuid: uid)
+
+    updater.expect :perform!, true
+
+    service.call
+
+    assert_equal edition.auth_bypass_id, uid
+    assert_equal edition.edition_authors.last.user, user
+  end
+end

--- a/test/unit/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/services/editon_auth_bypass_updater_test.rb
@@ -1,24 +1,152 @@
 require "test_helper"
 
 class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
-  test "#call" do
-    edition = create(:draft_edition)
-    user = create(:user)
-    updater = MiniTest::Mock.new
-    service = EditionAuthBypassUpdater.new(
-      edition: edition,
-      current_user: user,
-      updater: updater,
-    )
+  extend Minitest::Spec::DSL
 
-    uid = SecureRandom.uuid
-    SecureRandom.stubs(uuid: uid)
+  describe "#call" do
+    let(:user) { create(:user) }
+    let(:updater) { MiniTest::Mock.new }
+    let(:uid) { SecureRandom.uuid }
 
-    updater.expect :perform!, true
+    before do
+      updater.expect :perform!, true
+      SecureRandom.stubs(uuid: uid)
+    end
 
-    service.call
+    test "updates the editions auth_bypass_id, saves it with the current user and calls 'perform!' on the updater" do
+      edition = create(:draft_edition)
 
-    assert_equal edition.auth_bypass_id, uid
-    assert_equal edition.edition_authors.last.user, user
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      service.call
+
+      assert_equal edition.auth_bypass_id, uid
+      assert_equal edition.edition_authors.last.user, user
+    end
+
+    test "updates attachments with auth_bypass_ids" do
+      edition = create(:draft_edition)
+      file_attachment = create(:file_attachment, attachable: edition)
+      expected_attributes = { auth_bypass_ids: [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      service.call
+    end
+
+    test "updates an image with auth_bypass_id" do
+      edition = create(:draft_case_study)
+      image = create(:image, edition: edition)
+      expected_attributes = { auth_bypass_ids: [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        image.image_data.to_global_id,
+        expected_attributes,
+      )
+
+      service.call
+    end
+
+    test "does not attempt to update html attachments via the update whitehall asset worker" do
+      edition = create(:draft_edition)
+      create(:html_attachment, attachable: edition)
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
+
+      service.call
+    end
+
+    test "updates a consultation response form asset with auth_bypass_id" do
+      edition = create(:consultation)
+      participation = create(:consultation_participation, consultation: edition)
+      consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
+
+      expected_attributes = { auth_bypass_ids: [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        consultation_response_form.consultation_response_form_data.to_global_id,
+        expected_attributes,
+      )
+
+      service.call
+    end
+
+    test "updates a consultation outcome's attachments with auth_bypass_id" do
+      edition = create(:draft_consultation)
+      outcome = create(:consultation_outcome, consultation: edition)
+      file_attachment = create(:file_attachment, attachable: outcome)
+
+      expected_attributes = { auth_bypass_ids: [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      service.call
+    end
+
+    test "updates a consultation's public feedback attachments with auth_bypass_id" do
+      edition = create(:draft_consultation)
+      feedback = create(:consultation_public_feedback, consultation: edition)
+      file_attachment = create(:file_attachment, attachable: feedback)
+
+      expected_attributes = { auth_bypass_ids: [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition: edition,
+        current_user: user,
+        updater: updater,
+      )
+
+      AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        file_attachment.attachment_data.to_global_id,
+        expected_attributes,
+      )
+
+      service.call
+    end
   end
 end


### PR DESCRIPTION
## Description 

As part of [Shareable Previews: Phase 2](https://docs.google.com/document/d/1E2jUtyez-ZJgt0KP6IvlUruTCqgIx6NB1AGyciZvR9M/edit#heading=h.21479u8hfu84), we need to add the ability for users to 'revoke' or 'rotate' a shareable preview link using a "Generate new link" button in the UI.

Clicking the button should change the `auth_bypass_id` associated with a draft Edition. This will have the effect of invalidating any previously shared preview links that contain the old `auth_bypass_id`.

### Changes

- Add button and copy to the shareable previews details tab

<img width="842" alt="image" src="https://user-images.githubusercontent.com/42515961/174552003-cb28fd18-5415-4e32-bbfc-356d951b2a56.png">

- Update the auth_bypass_id and push changes downstream
- Update auth_bypass_id for assets (see https://github.com/alphagov/whitehall/blob/main/lib/tasks/asset_manager.rake for the logic for which assets should be updated)

## Trello card

https://trello.com/c/8UhIXU9T/497-add-generate-new-link-feature

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
