### PR TITLE
Add rake task for bulk republishing missed html attachments

### DIFF
--- a/lib/tasks/republish_draft_html_attachments_associated_with_reponses.rake
+++ b/lib/tasks/republish_draft_html_attachments_associated_with_reponses.rake
@@ -1,0 +1,20 @@
+desc "Republish all documents with draft html attachments whose parent is a `Response`"
+task republish_draft_html_attachments_associated_with_responses: :environment do
+  consultation_ids = HtmlAttachment
+                      .includes(:attachable)
+                      .where(attachable_type: "Response")
+                      .map { |html_attachment| html_attachment.attachable.edition_id }
+
+  document_ids = Consultation
+                  .in_pre_publication_state
+                  .where(id: consultation_ids)
+                  .pluck(:document_id)
+
+  puts "Enqueueing #{document_ids.count} documents with `Responses` for republishing"
+
+  document_ids.each do |document_id|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+  end
+
+  puts "Finished enqueueing documents with `Responses` for republishing"
+end

--- a/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
+++ b/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "rake"
+
+class RepublishDraftHtmlAttachmentsWithAssoicatedResponsesRake < ActiveSupport::TestCase
+  test "it republishes documents with an associated draft response which has an html attachment" do
+    draft_consultation_with_outcome = create(:draft_consultation)
+    draft_outcome = create(:consultation_outcome, consultation: draft_consultation_with_outcome)
+    create(:html_attachment, attachable: draft_outcome)
+
+    published_consultation_with_outcome = create(:published_consultation)
+    published_outcome = create(:consultation_outcome, consultation: published_consultation_with_outcome)
+    create(:html_attachment, attachable: published_outcome)
+
+    draft_consultation_with_public_feedback = create(:draft_consultation)
+    draft_feedback = create(:consultation_public_feedback, consultation: draft_consultation_with_public_feedback)
+    create(:html_attachment, attachable: draft_feedback)
+
+    published_consultation_with_public_feedback = create(:published_consultation)
+    published_feedback = create(:consultation_public_feedback, consultation: published_consultation_with_public_feedback)
+    create(:html_attachment, attachable: published_feedback)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      draft_consultation_with_outcome.document_id,
+      true,
+    )
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      draft_consultation_with_public_feedback.document_id,
+      true,
+    )
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      published_consultation_with_outcome.document_id,
+      true,
+    ).never
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      published_consultation_with_public_feedback.document_id,
+      true,
+    ).never
+
+    Rake.application.invoke_task "republish_draft_html_attachments_associated_with_responses"
+  end
+end


### PR DESCRIPTION
## Description

HTML Attachments can be associated with Editions or Responses. As part of the work to add `auth_bypass_id`s for HTML Attachments we backfilled them for all HTML Attachments which belong to an Edition.

However the backfill for HTML Attachments which are associated with Responses were missed. These come in two shapes, both of which belong to consultations.

1. `ConsultationOutcome`
2. `ConsultationPublicFeedback`

This commit adds a rake task which republishes documents which have a draft HTML Attachment which belongs to an outcome or public feedback. These always belong to a Consultation.

## Trello card

https://trello.com/c/Biydhhag/506-investigate-why-consultations-are-not-working-for-sharable-previews

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
