### PR TITLE
Remove no-op mustache compile task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,13 +20,5 @@ end
 
 Whitehall::Application.load_tasks
 
-# no-op task to ease removal of shared mustache, to be removed once dependents are amended.
-namespace :shared_mustache do
-  desc "[Temporary] A task that does nothing for any denpendent tools that call this"
-  task compile: :environment do
-    puts "This application no longer depends on shared_mustache and there is no further need to call this task"
-  end
-end
-
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 task default: %i[lint test cucumber jasmine pact:verify]


### PR DESCRIPTION
Once https://github.com/alphagov/govuk-app-deployment/pull/448 is merged this task can be safely removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
