### PR TITLE
Enable shareable previews for all users

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -733,8 +733,8 @@ EXISTS (
   end
 
   # conditions for document types will be removed after enabling shareable preview for them
-  def has_enabled_shareable_preview?(user)
-    state == "draft" && user.can_share_previews? && type != "DocumentCollection"
+  def has_enabled_shareable_preview?
+    state == "draft" && type != "DocumentCollection"
   end
 
   delegate :locked?, to: :document

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,6 @@ class User < ApplicationRecord
     FORCE_PUBLISH_ANYTHING = "Force publish anything".freeze
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
-    CAN_SHARE_PREVIEWS = "can share previews".freeze
   end
 
   def role
@@ -90,10 +89,6 @@ class User < ApplicationRecord
 
   def can_force_publish_anything?
     has_permission?(Permissions::FORCE_PUBLISH_ANYTHING)
-  end
-
-  def can_share_previews?
-    has_permission?(Permissions::CAN_SHARE_PREVIEWS)
   end
 
   def organisation_name

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 </section>
 
-<% if @edition.has_enabled_shareable_preview?(current_user) %>
+<% if @edition.has_enabled_shareable_preview? %>
   <section>
     <%
     utm_uri = preview_document_url_with_auth_bypass_token(@edition)

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -46,7 +46,7 @@
             <% if !@edition.publicly_visible? %>
               <br>
               <p>Reset and generate a new preview link if you've shared the preview with the wrong person or if the link has expired. This will disable the previous preview link.</p>
-              <%= link_to "Generate new link", update_bypass_id_admin_edition_path(@edition), class: 'btn btn-lg btn-default public_version', method: :patch %>
+              <%= link_to "Generate new link", update_bypass_id_admin_edition_path(@edition), class: 'btn btn-lg btn-default', method: :patch %>
             <% end %>
           </div>
         </div>

--- a/test/integration/shareable_preview_generate_new_link_test.rb
+++ b/test/integration/shareable_preview_generate_new_link_test.rb
@@ -54,7 +54,6 @@ class ShareablePreviewGenerateNewLinkIntegrationTest < ActionDispatch::Integrati
 
     def create_setup(edition)
       @user = create(:gds_editor)
-      @user.permissions << "can share previews"
       login_as @user
       topic_taxon = build(:taxon_hash)
       stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])

--- a/test/integration/shareable_preview_test.rb
+++ b/test/integration/shareable_preview_test.rb
@@ -35,21 +35,6 @@ class ShareablePreviewIntegrationTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "for draft documents when the user does not have a permission" do
-      let(:edition) { create(:draft_case_study) }
-
-      before do
-        create_setup(edition)
-        @user.permissions = []
-        visit admin_case_study_path(edition)
-      end
-
-      test "it shows shareable preview feature" do
-        get admin_case_study_path(edition)
-        assert_no_selector "section", text: "Share document preview"
-      end
-    end
-
     #  test below will be removed after enabling shareable preview for those doccument types
     context "for excluded type of documents - document collection" do
       let(:edition) { create(:draft_document_collection) }
@@ -67,7 +52,6 @@ class ShareablePreviewIntegrationTest < ActionDispatch::IntegrationTest
 
     def create_setup(edition)
       @user = create(:gds_editor)
-      @user.permissions << "can share previews"
       login_as @user
       topic_taxon = build(:taxon_hash)
       stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -36,33 +36,20 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal payload["exp"], 1.month.from_now.to_i
   end
 
-  test "edition has shareable preview enabled if it is in the draft state, user has the permission and the type is not excluded" do
+  test "edition has shareable preview enabled if it is in the draft state and the type is not excluded" do
     edition = create(:draft_case_study)
-    user = create(:gds_editor)
-    user.permissions << "can share previews"
-    assert_equal edition.has_enabled_shareable_preview?(user), true
+    assert_equal edition.has_enabled_shareable_preview?, true
   end
 
   test "edition has shareable preview disabled if it is in the published state" do
     edition = create(:published_case_study)
-    user = create(:gds_editor)
-    user.permissions << "can share previews"
-    assert_equal edition.has_enabled_shareable_preview?(user), false
+    assert_equal edition.has_enabled_shareable_preview?, false
   end
 
-  test "edition has shareable preview disabled if the user does not have a permission" do
-    edition = create(:draft_consultation)
-    user = create(:gds_editor)
-    user.permissions = []
-    assert_equal edition.has_enabled_shareable_preview?(user), false
-  end
-
-  # test below will be removed after enabling shareable preview for this doccument type
+  # test below will be removed after enabling shareable preview for this document type
   test "edition has shareable preview disabled if it has document collection type" do
     edition = create(:draft_document_collection)
-    user = create(:gds_editor)
-    user.permissions << "can share previews"
-    assert_equal edition.has_enabled_shareable_preview?(user), false
+    assert_equal edition.has_enabled_shareable_preview?, false
   end
 
   test "uses provided document if available" do


### PR DESCRIPTION
This PR removes the feature flag which was used to limit access to the shareable previews functionality while it was in development.

Users no longer need the "can share previews" permission to share previews.

---

### Merge to launch shareable previews

Only merge this PR in when we're ready to launch shareable previews for all users.

---

Trello: https://trello.com/c/dwUmcobQ/425-test-and-release-phase-one-of-shareable-preview

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
