### PR TITLE
Remove support for request accessible format form pilot

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -13,13 +13,6 @@ module AttachmentsHelper
     csv_preview_path(id: attachment.attachment_data.id, file: attachment.filename_without_extension, extension: attachment.file_extension)
   end
 
-  def participating_in_accessible_format_request_pilot?(contact_email)
-    # A small number of organisations are taking part in a pilot scheme for accessible
-    # format requests to be submitted by a form rather than a direct email
-    pilot_addresses = GovukPublishingComponents::Presenters::AttachmentHelper::EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT
-    pilot_addresses.include?(contact_email)
-  end
-
   def block_attachments(attachments = [],
                         alternative_format_contact_email = nil,
                         published_on = nil)

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -60,10 +60,6 @@ class PolicyGroup < ApplicationRecord
     true
   end
 
-  def alternative_format_provider
-    nil
-  end
-
   extend FriendlyId
   friendly_id
 

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -19,8 +19,6 @@ class Response < ApplicationRecord
 
   delegate :alternative_format_contact_email, to: :consultation
 
-  delegate :alternative_format_provider, to: :consultation
-
   delegate :publicly_visible?, to: :parent_attachable
 
   delegate :accessible_to?, to: :parent_attachable

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -69,27 +69,23 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <% if attachment.attachable.alternative_format_provider.present? && participating_in_accessible_format_request_pilot?(alternative_format_contact_email) %>
-        <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.attachable.content_id}&attachment_id=#{attachment.id}", class: "govuk-link govuk-!-font-size-19" %>
-      <% else %>
-        <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
-          <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
-          <%= render "govuk_publishing_components/components/details", {
-            title: t('attachment.accessibility.request_a_different_format'),
-            data_attributes: {
-              track_category: "Accessible Format Request",
-              track_action: "FormatRequestClicked",
-              track_label: attachment.title,
-              module: "govuk-details"
-            }
-          } do %>
-            <%= t('attachment.accessibility.full_help_html',
-            email: alternative_format_order_link(attachment, alternative_format_contact_email),
-            title: attachment.title,
-            references: attachment_references(attachment)) %>
-          <% end %>
-        </div>
-      <% end %>
+      <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
+        <p class="govuk-body"><%= t('attachment.accessibility.intro') %></p>
+        <%= render "govuk_publishing_components/components/details", {
+          title: t('attachment.accessibility.request_a_different_format'),
+          data_attributes: {
+            track_category: "Accessible Format Request",
+            track_action: "FormatRequestClicked",
+            track_label: attachment.title,
+            module: "govuk-details"
+          }
+        } do %>
+          <%= t('attachment.accessibility.full_help_html',
+          email: alternative_format_order_link(attachment, alternative_format_contact_email),
+          title: attachment.title,
+          references: attachment_references(attachment)) %>
+        <% end %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/test/unit/helpers/attachments_helper_test.rb
+++ b/test/unit/helpers/attachments_helper_test.rb
@@ -15,16 +15,4 @@ class AttachmentsHelperTest < ActionView::TestCase
     csv_on_policy_group = create(:csv_attachment, attachable: create(:policy_group))
     assert_not previewable?(csv_on_policy_group)
   end
-
-  test "Attachments belonging to organisations taking part in the accessible format request pilot can be identified" do
-    GovukPublishingComponents::Presenters::AttachmentHelper.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, ["in_pilot@example.com"]) do
-      assert participating_in_accessible_format_request_pilot?("in_pilot@example.com")
-    end
-  end
-
-  test "Attachments belonging to organisations not taking part in the accessible format request pilot can be identified" do
-    GovukPublishingComponents::Presenters::AttachmentHelper.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, []) do
-      assert_not participating_in_accessible_format_request_pilot?("not_in_pilot@example.com")
-    end
-  end
 end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -154,25 +154,12 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     assert_equal [location.content_id], presented_item.content[:links][:world_locations]
   end
 
-  test "documents include the alternative format contact email with a direct email link" do
+  test "documents include the alternative format contact email" do
     publication = create(:publication, :with_command_paper)
-    GovukPublishingComponents::Presenters::AttachmentHelper.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, []) do
-      presented_item = present(publication)
-      document = presented_item.content[:details][:documents].first
-      assert document.include?("This file may not be suitable for users of assistive technology.")
-      assert document.include?("mailto:#{publication.alternative_format_provider.alternative_format_contact_email}")
-    end
-  end
-
-  test "documents belonging to organisations in the accessible format request pilot include the form link" do
-    publication = create(:publication, :with_command_paper)
-    email_address = publication.alternative_format_provider.alternative_format_contact_email
-    GovukPublishingComponents::Presenters::AttachmentHelper.stub_const(:EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT, [email_address]) do
-      presented_item = present(publication)
-      document = presented_item.content[:details][:documents].first
-      assert document.include?("Request an accessible format of this document")
-      assert document.include?("/contact/govuk/request-accessible-format?content_id=#{publication.content_id}&amp;attachment_id=#{publication.attachments.first.id}")
-    end
+    presented_item = present(publication)
+    document = presented_item.content[:details][:documents].first
+    assert document.include?("This file may not be suitable for users of assistive technology.")
+    assert document.include?("mailto:#{publication.alternative_format_provider.alternative_format_contact_email}")
   end
 
   test "it uses the PayloadBuilder::FirstPublishedAt helper" do


### PR DESCRIPTION
Now that there are no longer any departments taking part, remove code 
while we rethink.

https://trello.com/c/iZEzpeFy/1340-remove-dfe-from-the-accessible-format-pilot

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
