### PR TITLE
Show attachment changes in change note box

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -26,14 +26,7 @@
       var $changeNotesSection = $('.js-change-notes-section', $fieldset)
 
       $radioButtons.change(showOrHideChangeNotes)
-      appendHintToFormLabel()
       showOrHideChangeNotes()
-
-      function appendHintToFormLabel () {
-        var $label = $($changeNotesSection).find('label')
-        var exampleText = 'For example, "Edited chapter 6 - centres in Cardiff and Aberystwyth have closed."'
-        $label.append('<p class="hint"; style="font-weight: normal">' + exampleText + '</p>')
-      }
 
       function showOrHideChangeNotes () {
         if ($minorChangeRadioButton.prop('checked')) {

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -171,6 +171,11 @@ fieldset.fatality-notice-casualties {
       &.hint {
         margin-top: .2em;
         color: #626a6e;
+
+        &.change-note-hint {
+          margin-bottom: 20px;
+          font-weight: normal;
+        }
       }
     }
 

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -1,6 +1,6 @@
 module Attachable
   extend ActiveSupport::Concern
-  EDITION_CREATE_GRACE_PERIOD = 30.seconds
+  EDITION_CREATE_GRACE_PERIOD = 20.seconds
 
   included do
     has_many :attachments,
@@ -77,7 +77,7 @@ module Attachable
     # Using a 30 second grace period because GovspeakContent#render_govspeak! historically used to change the updated_at timestamp
     # when running in an async worker to convert body to HTML. This meant that all HTML attachments ended up with
     # (updated_at > created_at) so would show as 'changed'.
-    updated_html_attachments = html_attachments.joins(:govspeak_content).where("govspeak_contents.updated_at > DATE_ADD(govspeak_contents.created_at,  INTERVAL 30 SECOND)")
+    updated_html_attachments = html_attachments.joins(:govspeak_content).where("govspeak_contents.updated_at > DATE_ADD(govspeak_contents.created_at,  INTERVAL 20 SECOND)")
     updated = (updated_attachments + updated_html_attachments) - created
 
     created.map { |a| ChangedAttachment.new(a, :created) } +

--- a/app/models/govspeak_content.rb
+++ b/app/models/govspeak_content.rb
@@ -18,7 +18,7 @@ class GovspeakContent < ApplicationRecord
   def render_govspeak!
     self.computed_body_html = generate_govspeak
     self.computed_headers_html = generate_headers
-    save!
+    save!(touch: false)
   end
 
 private

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -1,24 +1,41 @@
 <fieldset class="js-change-notes">
-  <h3 class="remove-top-margin">What sort of change are you making?</h3>
-  
-  <div class="radio">
-    <%= form.label :minor_change_true do %>
-      <%= form.radio_button(:minor_change, true) %>
-      <strong>Fixing a typo or broken link, a style change or similar</strong>
-      <p class="hint">Users signed up to email alerts won't be notified</p>
-    <% end %>
-  </div>
+  <h3 class="remove-top-margin">Do users need to know the content has changed?</h3>
+  <p class="hint change-note-hint"> Telling users when published information changes is important for transparency.</p>
+
+  <% if edition.allows_attachments? && edition.changed_attachments.any? %>
+    <div class="alert alert-info">
+      <h4> Attachments you've added, changed or deleted </h4>
+      <ul class="govuk-list">
+        <% label_classes = {created: "label-success", updated: "label-warning", deleted: "label-danger"} %>
+        <% edition.changed_attachments.each do |attachment| %>
+          <li>
+            <%= "#{attachment.attachment.title} - #{attachment.attachment.readable_type} attachment" %>
+            <%= tag.span attachment.status, class: ["label", label_classes[attachment.status]] %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="radio">
     <%= form.label :minor_change_false do %>
       <%= form.radio_button(:minor_change, false) %>
-      <strong>A significant edit that affects what users need to do or know</strong>
-      <p class="hint">A change note will be published on the page and emailed to users signed up to alerts</p>
+      <strong>Yes - information has been added, updated or removed</strong>
+      <p class="hint">A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.</p>
     <% end %>
   </div>
   <div class="js-change-notes-section">
-    <div class="form-group">
-      <%= form.text_area(:change_note, rows: 4, label_text: "Public change note", class: 'form-control') %>
+    <%= form.label :change_note do %>
+      Describe the change for users
+      <p class="hint change-note-hint">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended." <br>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes (opens in a new tab)</a>.</p>
+      <%= form.text_area(:change_note, label: false, rows: 4) %>
+    <% end %>
     </div>
+  <div class="radio">
+    <%= form.label :minor_change_true do %>
+      <%= form.radio_button(:minor_change, true) %>
+      <strong>No – it’s a minor edit that does not change the meaning</strong>
+      <p class="hint">This includes fixing a typo or broken link, a style change or similar. Users signed up to email alerts will not get notified and the ‘last updated’ date will not change.</p>
+    <% end %>
   </div>
-  <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>
 </fieldset>

--- a/lib/whitehall/form_builder.rb
+++ b/lib/whitehall/form_builder.rb
@@ -85,12 +85,20 @@ module Whitehall
 
     def text_area(method, *args)
       options = (args.last || {})
+      label = options.delete(:label)
       add_class_to_options(options, "form-control")
-      label_options = { required: options.delete(:required) }
-      label_text = options.delete(:label_text)
 
-      @template.tag.div(class: "form-group") do
-        label(method, label_text, label_options) + super
+      if label == false
+        @template.tag.div(class: "form-group") do
+          super
+        end
+      else
+        label_options = { required: options.delete(:required) }
+        label_text = options.delete(:label_text)
+
+        @template.tag.div(class: "form-group") do
+          label(method, label_text, label_options) + super
+        end
       end
     end
 

--- a/test/unit/govspeak_content_test.rb
+++ b/test/unit/govspeak_content_test.rb
@@ -60,7 +60,7 @@ class GovspeakContentTest < ActiveSupport::TestCase
     assert_equal govspeak_content.id, job["args"].first
   end
 
-  test "#render_govspeak sets computed_headers_html correctly" do
+  test "#render_govspeak! sets computed_headers_html correctly" do
     govspeak_content = create(
       :html_attachment,
       manually_numbered_headings: false,
@@ -77,7 +77,7 @@ class GovspeakContentTest < ActiveSupport::TestCase
     assert_equivalent_html expected_headers_html, govspeak_content.computed_headers_html
   end
 
-  test "#render_govspeak sets computed_headers_html correctly when manually
+  test "#render_govspeak! sets computed_headers_html correctly when manually
     numbered headings is true" do
     govspeak_content = create(
       :html_attachment,
@@ -98,7 +98,7 @@ class GovspeakContentTest < ActiveSupport::TestCase
     assert_equivalent_html expected_headers_html, govspeak_content.computed_headers_html
   end
 
-  test "#render_govspeak sets computed_body_html correctly" do
+  test "#render_govspeak! sets computed_body_html correctly" do
     govspeak_content = create(
       :html_attachment,
       manually_numbered_headings: false,
@@ -117,7 +117,7 @@ class GovspeakContentTest < ActiveSupport::TestCase
     assert_equivalent_html expected_body_html, govspeak_content.computed_body_html
   end
 
-  test "#render_govspeak adds images from consultations to HTML attachments on the consultation's responses" do
+  test "#render_govspeak! adds images from consultations to HTML attachments on the consultation's responses" do
     consultation = FactoryBot.create(:consultation_with_outcome, images: [FactoryBot.create(:image)])
     consultation_outcome = consultation.outcome
 
@@ -127,6 +127,20 @@ class GovspeakContentTest < ActiveSupport::TestCase
     govspeak_content.render_govspeak!
 
     assert_includes govspeak_content.computed_body_html, "image"
+  end
+
+  test "#render_govspeak! doesn't change the updated_at timestamp" do
+    govspeak_content = create(:html_attachment).govspeak_content
+
+    pre_updated_at = govspeak_content.updated_at
+
+    # When #render_govspeak! is called from govspeak_content it waits 10 seconds to call the job
+    Timecop.travel 10.seconds.from_now
+
+    govspeak_content.render_govspeak!
+    post_updated_at = govspeak_content.reload.updated_at
+
+    assert_equal pre_updated_at, post_updated_at
   end
 
 private

--- a/test/unit/whitehall/form_builder_test.rb
+++ b/test/unit/whitehall/form_builder_test.rb
@@ -71,4 +71,12 @@ class FormBuilderTest < ActionView::TestCase
 
     assert_dom_equal expected_html, @builder.upload(:image, label_text: "Image upload")
   end
+
+  test "Whitehall::FormBuilder#text_area can produce no label" do
+    expected_html = '<div class="form-group">' \
+                      '<textarea class="form-control" name="promotional_feature_item[summary]" id="promotional_feature_item_summary">
+</textarea></div>'
+
+    assert_dom_equal expected_html, @builder.text_area(:summary, label: false)
+  end
 end


### PR DESCRIPTION
Update the change note box:
- Improve content around choosing major or minor changes
- Include a list of attachments that have been changed

Before: 
<img width="792" alt="Screenshot 2022-07-12 at 17 42 16" src="https://user-images.githubusercontent.com/17481621/184346278-f85ae075-c24d-4231-ae67-f550d45c208d.png">


After :
<img width="628" alt="image" src="https://user-images.githubusercontent.com/17481621/183110738-1a67c1ca-1e3b-4e66-9ab5-acf36aafc30f.png">


Trello card: https://trello.com/c/isH3BtNG/419-display-attachment-changes-in-edition-change-note