### PR TITLE
Have Sidekiq log to stdout by default.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,8 @@
 :verbose: true
 :concurrency: 8
-:logfile: ./log/sidekiq.json.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :queues:
   - scheduled_publishing
   - default


### PR DESCRIPTION
All of our logs need to go to stdout/stderr when running on k8s.

As of Sidekiq 6.0, the `logfile` directive and `-L` option are being
removed and logs will always go to stdout anyway:
https://github.com/mperham/sidekiq/wiki/Logging#log-redirection

This is essentially the same change as alphagov/publisher@5547a1a.

https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
