### PR TITLE
Remove exclusion of Document Collection for shareable previews

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -732,9 +732,8 @@ EXISTS (
     )
   end
 
-  # conditions for document types will be removed after enabling shareable preview for them
   def has_enabled_shareable_preview?
-    PRE_PUBLICATION_STATES.include?(state) && type != "DocumentCollection"
+    PRE_PUBLICATION_STATES.include?(state)
   end
 
   delegate :locked?, to: :document

--- a/test/integration/shareable_preview_test.rb
+++ b/test/integration/shareable_preview_test.rb
@@ -35,21 +35,6 @@ class ShareablePreviewIntegrationTest < ActionDispatch::IntegrationTest
       end
     end
 
-    #  test below will be removed after enabling shareable preview for those doccument types
-    context "for excluded type of documents - document collection" do
-      let(:edition) { create(:draft_document_collection) }
-
-      before do
-        create_setup(edition)
-        visit admin_document_collection_path(edition)
-      end
-
-      test "it does not show shareable preview feature" do
-        get admin_document_collection_path(edition)
-        assert_no_selector "section", text: "Share document preview"
-      end
-    end
-
     def create_setup(edition)
       @user = create(:gds_editor)
       login_as @user

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -55,10 +55,9 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal edition.has_enabled_shareable_preview?, false
   end
 
-  # test below will be removed after enabling shareable preview for this document type
-  test "edition has shareable preview disabled if it has document collection type" do
+  test "edition has shareable preview enabled if it has document collection type" do
     edition = create(:draft_document_collection)
-    assert_equal edition.has_enabled_shareable_preview?, false
+    assert_equal edition.has_enabled_shareable_preview?, true
   end
 
   test "uses provided document if available" do


### PR DESCRIPTION
This is to enable shareable previews functionality for all type of documents.

[Trello card](https://trello.com/c/q6mdu7Or/518-make-document-collections-accessible-by-shareable-previews)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
