### PR TITLE
Update Whitehall CSV Rendering to handle draft CSVs

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -134,6 +134,11 @@ class AttachmentData < ApplicationRecord
     visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
   end
 
+  def draft_edition_for(user)
+    draft_attachable = draft_attachment_for(user)&.attachable
+    draft_attachable.is_a?(Edition) ? draft_attachable : nil
+  end
+
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -130,6 +130,10 @@ class AttachmentData < ApplicationRecord
     visible_attachable.is_a?(Edition) ? visible_attachable : nil
   end
 
+  def draft_attachment_for(user)
+    visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
+  end
+
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/views/layouts/draft_html_attachments.html.erb
+++ b/app/views/layouts/draft_html_attachments.html.erb
@@ -1,0 +1,5 @@
+<%= render :layout => 'layouts/frontend_base', locals: {extra_body_class: "html-publication draft", stylesheet: 'html-publication'} do %>
+  <div class="govuk-width-container html-publications-show">
+    <%= yield %>
+  </div>
+<% end %>

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -15,7 +15,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     @organisation1 = create(:organisation)
     @organisation2 = create(:organisation)
-    @edition = create(:publication, organisations: [organisation1, organisation2])
+    @edition = create(:publication, :published, organisations: [organisation1, organisation2])
     @attachment = build(:file_attachment)
 
     controller.stubs(:attachment_data).returns(attachment_data)
@@ -456,6 +456,22 @@ class CsvPreviewControllerTest < ActionController::TestCase
     get :show, params: params
 
     assert_select ".govuk-body:last-child", text: /This file could not be previewed/
+  end
+
+  # draft asset
+
+  test "responds with 200, assigns the correct variables and renders the draft_html_attachments template" do
+    draft_edition = create(:publication, organisations: [organisation1, organisation2])
+    draft_attachment = create(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    setup_stubs(accessible?: true)
+    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
+
+    get :show, params: params
+
+    assert_response :ok
+    assert_equal draft_edition, assigns(:edition)
+    assert_equal draft_attachment, assigns(:attachment)
+    assert_template "show", layout: "draft_html_attachments"
   end
 
 private

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -474,6 +474,17 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_template "show", layout: "draft_html_attachments"
   end
 
+  test "responds with 404 if no draft edition is present" do
+    response = build(:consultation_outcome)
+    create(:file_attachment, attachment_data: attachment_data, attachable: response)
+    setup_stubs(accessible?: true, visible_edition: nil)
+    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
+
+    get :show, params: params
+
+    assert_response :not_found
+  end
+
 private
 
   def setup_stubs(attributes = {})

--- a/test/integration/page_title_test.rb
+++ b/test/integration/page_title_test.rb
@@ -11,6 +11,7 @@ class PageTitleTest < ActiveSupport::TestCase
     layouts/frontend.html.erb
     layouts/home.html.erb
     layouts/html_attachments.html.erb
+    layouts/draft_html_attachments.html.erb
   ].map do |f|
     File.expand_path(Rails.root.join("app/views/#{f}"))
   end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -353,4 +353,17 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     assert_not attachment_data.deleted?
   end
+
+  test "#draft_edition_for(user) returns the attachment with a draft edition" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    published_edition = build(:edition, :published)
+    draft_edition = build(:edition)
+    published_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: published_edition)
+    draft_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    attachment_data.stubs(:attachments).returns([published_attachment, draft_attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_attachment_for(user), draft_attachment
+  end
 end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -354,7 +354,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_not attachment_data.deleted?
   end
 
-  test "#draft_edition_for(user) returns the attachment with a draft edition" do
+  test "#draft_attachment_for(user) returns the attachment with a draft edition" do
     user = build(:user)
     attachment_data = build(:attachment_data)
     published_edition = build(:edition, :published)
@@ -365,5 +365,27 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data.stubs(:visible_to?).returns(true)
 
     assert_equal attachment_data.draft_attachment_for(user), draft_attachment
+  end
+
+  test "#draft_edition_for(user) returns a draft edition when is associated with an attachment" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    draft_edition = build(:edition)
+    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    attachment_data.stubs(:attachments).returns([attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_edition_for(user), draft_edition
+  end
+
+  test "#draft_edition_for(user) returns nil when the attachable is not an `Edition`" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    response = build(:consultation_outcome)
+    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: response)
+    attachment_data.stubs(:attachments).returns([attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_edition_for(user), nil
   end
 end


### PR DESCRIPTION
## Description 

At the moment, this endpoint is passed the attachment_data id. As attachment data has many attachments for the same file, it is currently not possible to distinguish which file has been requested.

At the moment, the CSV preview endpoint defaults to rendering the attachment belonging to the latest published edition for the attachment data passed in. 

We need to ensure that when a draft CSV is previewed it has the correct styling and uses the draft editions details on the page.

This PR adds this functionality in by using the url to determine whether a draft asset has been requested.

## Screenshots

### Draft CSV 

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/42515961/177988704-017ce407-8f8c-4422-8afe-ce369566d752.png">

### Publised CSV 

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/42515961/177988624-2a156ac3-069c-4e9b-a044-59e652faaa64.png">

## Trello card

https://trello.com/c/ktlUy34f/511-csv-previews-for-shareable-preview-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
