### PR TITLE
Add Rishi Sunak to Past Chancellors List

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -10,6 +10,9 @@ class HistoricAppointmentsController < PublicFacingController
 
   def past_chancellors
     @twentyfirst_century_chancellors = {
+      "Rishi Sunak" => {
+        service: "2020 to 2022",
+      },
       "Sajid Javid" => {
         service: "2019 to 2020",
       },


### PR DESCRIPTION
Rishi Sunak has resigned from the government, so should be added to this list: https://www.gov.uk/government/history/past-chancellors