### PR TITLE
Add RepublishCsvAttachments rake task

### DIFF
--- a/lib/tasks/republish_csv_attachments.rake
+++ b/lib/tasks/republish_csv_attachments.rake
@@ -1,0 +1,16 @@
+desc "Republish all documents with non-pdf attachments"
+task republish_csv_attachments: :environment do
+  document_ids = Attachment.joins(:attachment_data)
+                           .joins("JOIN editions ON editions.id = attachments.attachable_id AND attachments.attachable_type = 'Edition'")
+                           .where.not(deleted: true)
+                           .where(attachment_data: { content_type: "text/csv" })
+                           .where.not(attachable: nil)
+                           .distinct
+                           .pluck(:document_id)
+
+  puts "#{document_ids.length} items to republish"
+
+  document_ids.each do |document_id|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+  end
+end

--- a/test/unit/tasks/republish_csv_attachments_test.rb
+++ b/test/unit/tasks/republish_csv_attachments_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "rake"
+
+class RepublishCsvAttachmentsRake < ActiveSupport::TestCase
+  test "it republishes documents with an associated CSV attachment" do
+    edition_with_csv_attachment = create(:edition)
+    create(:csv_attachment, attachable: edition_with_csv_attachment)
+
+    edition_with_deleted_csv_attachment = create(:edition)
+    create(:csv_attachment, attachable: edition_with_csv_attachment, deleted: true)
+
+    edition_with_pdf_attachment = create(:edition)
+    create(:file_attachment, attachable: edition_with_pdf_attachment)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      edition_with_csv_attachment.document_id,
+      true,
+    )
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      edition_with_deleted_csv_attachment.document_id,
+      true,
+    ).never
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      edition_with_pdf_attachment.document_id,
+      true,
+    ).never
+
+    Rake.application.invoke_task "republish_csv_attachments"
+  end
+end


### PR DESCRIPTION
## Description 

Recently we've done some work to fix draft CSV rendering. As a result the link to view the CSV attachment which is passed down for the Frontend to render needs to be updated to contain the File's ID rather then the AttachmenData ID.

See this PR https://github.com/alphagov/whitehall/pull/6651

Resultantly, we need to republish all documents with an associated CSV. This commit adds a rake task to do this.

## Trello card

https://trello.com/c/ktlUy34f/511-csv-previews-for-shareable-preview-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
