### PR TITLE
Tidy up stylesheet and JavaScript imports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,6 +6,8 @@
 //
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/govspeak
 //
 //= require jquery/dist/jquery

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,6 @@
 // the compiled file.
 //
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/govspeak

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -9,18 +9,11 @@ $govuk-new-link-styles: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/big-number";
-@import "govuk_publishing_components/components/button";
-@import "govuk_publishing_components/components/breadcrumbs";
 @import "govuk_publishing_components/components/contents-list";
 @import "govuk_publishing_components/components/document-list";
-@import "govuk_publishing_components/components/error-message";
-@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/details";
 @import "govuk_publishing_components/components/govspeak";
-@import "govuk_publishing_components/components/heading";
-@import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/image-card";
-@import "govuk_publishing_components/components/input";
-@import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";
 @import "govuk_publishing_components/components/notice";
@@ -30,7 +23,6 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/share-links";
 @import "govuk_publishing_components/components/previous-and-next-navigation";
 @import "govuk_publishing_components/components/subscription-links";
-@import "govuk_publishing_components/components/title";
 
 // STYLEGUIDE
 // Mixins to be shared across gov.uk sites. Anything set in these

--- a/app/assets/stylesheets/frontend/print.scss
+++ b/app/assets/stylesheets/frontend/print.scss
@@ -17,6 +17,8 @@ $gutter-one-sixth: $gutter-one-third * .5; // equivalent to 8px
 $is-print: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/print/contents-list";
+@import "govuk_publishing_components/components/print/organisation-logo";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/title";
 

--- a/app/assets/stylesheets/frontend/print.scss
+++ b/app/assets/stylesheets/frontend/print.scss
@@ -17,7 +17,6 @@ $gutter-one-sixth: $gutter-one-third * .5; // equivalent to 8px
 $is-print: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/print/button";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/title";
 


### PR DESCRIPTION
## What

- Remove stylesheets already included in Static
- Add missing component stylesheets and JavaScript

Note - this is only for the base CSS file. The CSS file for HTML publications has been left alone for this pull request to avoid extra complication as the rendering of the HTML publications appears to be shared between `whitehall` and `government-frontend` - [for example](https://www.gov.uk/goernment/publications/coronavirus-covid-19-antibody-tests/coronavirus-covid-19-antibody-tests).

## Why

Removing the stylesheets means there should be no duplication of CSS between the stylesheet served by `whitehall` and the stylesheet served by `static`.

There were a couple of uses of components without the required stylesheet and JavaScript - this would lead to a broken component. Adding them back in should fix things.

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
