### PR TITLE
Switch Topical Event rendering to use Collections

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "topical_event",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -29,7 +29,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     expected_hash = {
       base_path: public_path,
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       schema_name: "topical_event",
       document_type: "topical_event",
       title: "Humans going to Mars",
@@ -97,7 +97,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     expected_hash = {
       base_path: public_path,
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       schema_name: "topical_event",
       document_type: "topical_event",
       title: "Humans going to Mars",


### PR DESCRIPTION
The rendering of Topical Events has been built into the Collections app, as part of the work to remove frontend rendering from Whitehall.

This will allow us to republish the content items for all topical events to switch the rendering to a different application, by running the following rake task: `publishing_api:republish:all_topical_events`.

**Not to be merged until we have confirmed the Collections rendered page is complete.**

[Trello card](https://trello.com/c/KcNZgjIA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
