### PR TITLE
Add .protectuk.police.uk to redirect allow list

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,6 +1,6 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
-  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk].freeze
+  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk .protectuk.police.uk].freeze
 
   def validate_each(record, attribute, value)
     unless self.class.matches_gov_uk?(value) || matches_allow_list?(value)


### PR DESCRIPTION
This domain has been approved to host content off of GOV.UK. Content designers need to redirect existing content to this external domain.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
