### PR TITLE
Add temporary out of date banner for ministerial page

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -12,6 +12,10 @@
         text: sanitize("Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.")
       } %>
     <% end %>
+
+    <%= render "govuk_publishing_components/components/notice" do %>
+      <p class="govuk-body">This page is currently being updated and some ministerial appointments might not be accurate. Check all <a class="govuk-link" href="/government/news/ministerial-appointments-july-2022">the latest Cabinet appointments</a>.</p>
+    <% end %>
   </div>
 </header>
 


### PR DESCRIPTION
This is to alert to users that the page may not be up to date because of recent numerous and quick changes in government

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
