### PR TITLE
Repurpose rake task - republish all attachment doc

### DIFF
--- a/lib/tasks/republish_docs_with_attachments.rake
+++ b/lib/tasks/republish_docs_with_attachments.rake
@@ -1,8 +1,6 @@
-desc "Republish all documents with attachments for organisations in accessible format request pilot"
-task repubish_docs_with_attachments_for_accessible_format_request_pilot: :environment do
-  pilot_emails = %w[alternative.formats@education.gov.uk].freeze
-
-  organisations = Organisation.where(alternative_format_contact_email: [pilot_emails])
+desc "Republish all documents with attachments for organisations"
+task repubish_docs_with_attachments: :environment do
+  organisations = Organisation.all
 
   organisations.each do |org|
     published_editions_for_org = Edition.latest_published_edition.in_organisation(org)


### PR DESCRIPTION
We need to republish all documents with attachments to ensure they
include the updated accessible format element [1]. As we don't need 
the old task anymore, we can repurpose it for this one-off task.

Successful run: https://deploy.blue.staging.govuk.digital/job/run-rake-task/218297/console

[1]: https://github.com/alphagov/whitehall/pull/5804

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
