### PR TITLE
Add limit to topical events displayed featured documents

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -58,17 +58,21 @@ module PublishingApi
     end
 
     def ordered_featured_documents
-      item.classification_featurings.includes(:image, edition: :document).map do |feature|
-        {
-          title: feature.title,
-          href: feature.url,
-          image: {
-            url: feature.image.file.url(:s465),
-            alt_text: feature.alt_text,
-          },
-          summary: feature.summary,
-        }
-      end
+      item
+        .classification_featurings
+        .includes(:image, edition: :document)
+        .limit(FeaturedLink::DEFAULT_SET_SIZE)
+        .map do |feature|
+          {
+            title: feature.title,
+            href: feature.url,
+            image: {
+              url: feature.image.file.url(:s465),
+              alt_text: feature.alt_text,
+            },
+            summary: feature.summary,
+          }
+        end
     end
 
     def social_media_links

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -140,4 +140,13 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     }, presenter.content[:details])
     assert_valid_against_schema(presenter.content, "topical_event")
   end
+
+  test "it limits the number of featured items" do
+    topical_event = create(:topical_event, start_date: Time.zone.today)
+    create_list(:classification_featuring, FeaturedLink::DEFAULT_SET_SIZE + 1, classification: topical_event)
+
+    presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
+
+    assert_equal FeaturedLink::DEFAULT_SET_SIZE, presenter.content.dig(:details, :ordered_featured_documents).length
+  end
 end


### PR DESCRIPTION
This limit was originally chosen (as far as I'm aware) fairly arbitrarily several years ago. This commit basically mirrors the functionality that's currently implemented on the frontend in the backend. This will ensure that the limit is now set on publication so no more than 5 featured documents will show up once we fully migrate topical events to collections. It has the added side efect of reducing the size of the content item as the limit's being applied earlier.

Trello: https://trello.com/c/gBGGw6T3/147-front-end-tweaks-to-documents-section

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
