### PR TITLE
Clean up old "temporary" code

### DIFF
--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -3,7 +3,7 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
   # performing a database query here to look up the `unpublishing` linked to the most
   # recent edition, we pass it in directly because the `unpublishing` isn't always
   # saved in the database yet when this worker runs.
-  def perform(content_id, explanation, locale, allow_draft = false, unpublished_at = nil)
+  def perform(content_id, explanation, locale, allow_draft, unpublished_at)
     check_if_locked_document(content_id: content_id)
 
     Services.publishing_api.unpublish(
@@ -12,28 +12,10 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
       locale: locale,
       explanation: Whitehall::GovspeakRenderer.new.govspeak_to_html(explanation),
       allow_draft: allow_draft,
-      unpublished_at: find_unpublished_at(content_id, unpublished_at),
+      unpublished_at: Time.zone.parse(unpublished_at.to_s),
     )
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
-  end
-
-private
-
-  def find_unpublished_at(content_id, given_unpublished_at)
-    if given_unpublished_at
-      # We call this job both directly and via Sidekiq. When called by Sidekiq, the date gets turned
-      # into a string (because jobs must be JSON serialisable) and `Services.publishing_api.unpublish`
-      # rejects it.
-      Time.zone.parse(given_unpublished_at.to_s)
-    else
-      # Temporary code to handle old workers that are still in the queue without an `unpublished_at`
-      Edition
-        .joins(:document)
-        .where(documents: { content_id: content_id })
-        .where(state: "withdrawn")
-        .pick(:updated_at)
-    end
   end
 end

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -7,26 +7,6 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
   test "publishes a 'withdrawal' item for the supplied 'content_id'" do
     publication = create(:withdrawn_publication)
 
-    request = stub_publishing_api_unpublish(
-      publication.document.content_id,
-      body: {
-        type: "withdrawal",
-        locale: "en",
-        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
-        unpublished_at: publication.updated_at.utc.iso8601,
-      },
-    )
-
-    PublishingApiWithdrawalWorker.new.perform(
-      publication.document.content_id, "*why?*", "en"
-    )
-
-    assert_requested request
-  end
-
-  test "publishes a 'withdrawal' item for the supplied 'content_id' and 'unpublished_at'" do
-    publication = create(:withdrawn_publication)
-
     unpublished_at = Time.zone.parse("2020-01-01 12:00")
 
     request = stub_publishing_api_unpublish(
@@ -49,9 +29,11 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
   test "raises an error if the document is locked" do
     document = create(:document, locked: true)
 
+    unpublished_at = Time.zone.now
+
     assert_raises LockedDocumentConcern::LockedDocumentError, "Cannot perform this operation on a locked document" do
       PublishingApiWithdrawalWorker.new.perform(
-        document.content_id, "*why?*", "en"
+        document.content_id, "*why?*", "en", false, unpublished_at
       )
     end
   end


### PR DESCRIPTION
This commit cleans up some code which is no longer needed. It was added following a change to the `PublishingApiWithdrawalWorker` signature so that existing in-flight Sidekiq jobs didn't break. It's safe to assume that all old jobs have been processed now since it was introduced 2 years ago.

Related PR: #5476 - commit 28d5ec07b43d300d76be599ad49002aef9df4bb4

Trello: https://trello.com/c/lQVUQh0s/507-spike-reverting-withdrawn-date-when-a-document-if-its-not-the-first-withdrawal

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
