### PR TITLE
Allow document withdrawals to be backdated

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -12,6 +12,8 @@ class Unpublishing < ApplicationRecord
 
   after_initialize :ensure_presence_of_content_id
 
+  before_save :set_unpublished_at
+
   before_validation :strip_alternative_url
 
   def strip_alternative_url
@@ -88,5 +90,9 @@ private
 
   def ensure_presence_of_content_id
     self.content_id ||= SecureRandom.uuid
+  end
+
+  def set_unpublished_at
+    self.unpublished_at = Time.zone.now if unpublished_at.blank?
   end
 end

--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -61,7 +61,7 @@ module ServiceListeners
           edition.unpublishing.explanation,
           edition.primary_locale,
           false,
-          edition.unpublishing.created_at,
+          edition.unpublishing.unpublished_at,
         )
       end
     end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -32,7 +32,7 @@ module ServiceListeners
           api.publish_withdrawal_async(
             edition.content_id,
             edition.unpublishing.explanation,
-            edition.unpublishing.created_at,
+            edition.unpublishing.unpublished_at,
             translation.locale.to_s,
           )
         end

--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -44,7 +44,7 @@ class PublishingApiUnpublishingWorker < WorkerBase
           unpublishing.explanation,
           locale,
           allow_draft,
-          unpublishing.created_at,
+          unpublishing.unpublished_at,
         )
       end
     end

--- a/db/migrate/20220711144922_add_unpublished_at_to_unpublishings.rb
+++ b/db/migrate/20220711144922_add_unpublished_at_to_unpublishings.rb
@@ -1,0 +1,18 @@
+class AddUnpublishedAtToUnpublishings < ActiveRecord::Migration[7.0]
+  def up
+    add_column :unpublishings, :unpublished_at, :datetime, null: true
+
+    # Backfill unpublished_at with created_at values
+    execute <<-SQL
+      UPDATE unpublishings
+      SET unpublished_at = created_at
+      WHERE unpublished_at IS NULL;
+    SQL
+
+    change_column_null :unpublishings, :unpublished_at, false
+  end
+
+  def down
+    remove_column :unpublishings, :unpublished_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_11_144922) do
   create_table "about_pages", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"
@@ -416,7 +416,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
     t.boolean "political", default: false
     t.string "logo_url"
     t.boolean "read_consultation_principles", default: false
-    t.boolean "all_nation_applicability"
+    t.boolean "all_nation_applicability", default: true
     t.string "image_display_option"
     t.string "auth_bypass_id", null: false
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
@@ -483,8 +483,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
     t.text "title"
     t.string "locale", null: false
     t.integer "featured_link_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["featured_link_id"], name: "index_on_featured_link"
     t.index ["locale"], name: "index_on_locale"
   end
@@ -817,8 +817,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
     t.bigint "policy_group_id"
     t.string "dependable_type"
     t.bigint "dependable_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["dependable_id", "dependable_type", "policy_group_id"], name: "index_policy_group_dependencies_on_dependable_and_policy_group", unique: true
     t.index ["dependable_type", "dependable_id"], name: "index_policy_group_dependencies_on_dependable"
     t.index ["policy_group_id"], name: "index_policy_group_dependencies_on_policy_group_id"
@@ -952,8 +952,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
     t.text "title"
     t.string "locale", null: false
     t.integer "social_media_account_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["locale"], name: "index_on_locale"
     t.index ["social_media_account_id"], name: "index_on_social_media_account"
   end
@@ -1074,6 +1074,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_090755) do
     t.string "slug"
     t.boolean "redirect", default: false
     t.string "content_id", null: false
+    t.datetime "unpublished_at", null: false
     t.index ["edition_id"], name: "index_unpublishings_on_edition_id"
     t.index ["unpublishing_reason_id"], name: "index_unpublishings_on_unpublishing_reason_id"
   end

--- a/test/unit/models/unpublishing_test.rb
+++ b/test/unit/models/unpublishing_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class UnpublishingTest < ActiveSupport::TestCase
+  test "#unpublished_at is automatically populated if left blank" do
+    unpublishing = create(:unpublishing)
+    assert_equal Time.zone.now, unpublishing.unpublished_at
+  end
+
+  test "#unpublished_at can be set manually" do
+    unpublished_at = 3.weeks.ago
+    unpublishing = create(:unpublishing, unpublished_at: unpublished_at)
+    assert_equal unpublished_at, unpublishing.unpublished_at
+  end
+end

--- a/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
@@ -341,7 +341,7 @@ module ServiceListeners
             "content was withdrawn",
             "en",
             false,
-            publication.unpublishing.created_at,
+            publication.unpublishing.unpublished_at,
           )
           call(publication)
         end
@@ -432,7 +432,7 @@ module ServiceListeners
           "content was withdrawn",
           "en",
           false,
-          publication.unpublishing.created_at,
+          publication.unpublishing.unpublished_at,
         )
         call(publication)
       end

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -67,11 +67,11 @@ module ServiceListeners
       )
 
       Whitehall::PublishingApi.expects(:publish_withdrawal_async)
-        .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.created_at, edition.primary_locale)
+        .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.unpublished_at, edition.primary_locale)
 
       translations.each do |translation|
         Whitehall::PublishingApi.expects(:publish_withdrawal_async)
-          .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.created_at, translation.to_s)
+          .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.unpublished_at, translation.to_s)
       end
 
       stub_html_attachment_pusher(edition, "withdraw")

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -79,7 +79,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
       unpublishing.explanation,
       :en,
       false,
-      unpublishing.created_at,
+      unpublishing.unpublished_at,
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -117,7 +117,7 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
       unpublishing.explanation,
       :en,
       true,
-      unpublishing.created_at,
+      unpublishing.unpublished_at,
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id, true)


### PR DESCRIPTION
### Context

This PR changes the way withdrawal dates are populated on the GOV.UK website:

[<img width="478" alt="Example of a document withdrawal notice" src="https://user-images.githubusercontent.com/7735945/178524146-b86c2f56-9332-43ad-a04c-62a0ba1e31f2.png">](https://www.gov.uk/government/news/wear-and-tear-repairs-for-m53-link-road)

This is [represented in the Content Item](https://www.gov.uk/api/content/government/news/wear-and-tear-repairs-for-m53-link-road) as:

```
"withdrawn_notice": {
  "explanation": "<div class=\"govspeak\"><p>This document is no longer current</p>\n</div>",
  "withdrawn_at": "2017-10-12T20:52:31Z"
}
```

### How it works currently (before this PR)

When an Edition is withdrawn in Whitehall, the details are kept in an `Unpublishing` record.

The `"withdrawn_notice"` JSON object is populated by:

| JSON key | Ruby value |
| --- | --- |
| `"explanation"` | `Unpublishing#explanation` |
| `"withdrawn_at"` | `Unpublishing#created_at` |

However, we now have a need to backdate the withdrawal date under particular circumstances. This means that the `"withdrawn_at"` field might need to be populated with a value which is different to the `Unpublishing#created_at` date.

### What this PR changes

This PR adds a new field to the `Unpublishing` model called `unpublished_at`.

This new field is now used to populate the `"withdrawn_notice"` JSON object:

| JSON key | Ruby value |
| --- | --- |
| `"explanation"` | `Unpublishing#explanation` |
| `"withdrawn_at"` | ~`Unpublishing#created_at`~ <br> **`Unpublishing#unpublished_at`** |

A [database migration](https://github.com/alphagov/whitehall/blob/add-unpublished-at-timestamp/db/migrate/20220711144922_add_unpublished_at_to_unpublishings.rb) adds this new field to the `unpublishings` table. Since all previous withdrawals used the `created_at` date, the migration backfills all `unpublished_at` fields to be the same as `created_at`.

For new `Unpublishing` records, the `unpublished_at` field is [automatically populated with the current time](https://github.com/alphagov/whitehall/blob/add-unpublished-at-timestamp/test/unit/models/unpublishing_test.rb#L4-L7) – which means it's functionally the same as the previous `created_at` timestamp. This change is therefore backwards compatible with the previous implementation.

However, it's now possible to [manually set the `unpublished_at` value](https://github.com/alphagov/whitehall/blob/add-unpublished-at-timestamp/test/unit/models/unpublishing_test.rb#L9-L13) if you want it to be something different. This can be used to backdate the withdrawal date that gets published on GOV.UK.

For now, nothing will be manually setting this new field. However, some proposed upcoming changes to the UI will make it possible for users to re-use an old withdrawal date if the document is being re-withdrawn (i.e. it was withdrawn, unwithdrawn, and is now being withdrawn again.)

---

Trello ticket: https://trello.com/c/lQVUQh0s/507-spike-reverting-withdrawn-date-when-a-document-if-its-not-the-first-withdrawal

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
