### PR TITLE
Revert "Update Whitehall CSV Rendering to handle draft CSVs"

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -5,21 +5,13 @@ class CsvPreviewController < ApplicationController
     respond_to do |format|
       format.html do
         @csv_response = CsvFileFromPublicHost.csv_response(attachment_data.file.asset_manager_path)
-
-        if attachment_data.csv? && attachment_visible? && visible_or_draft_edition_present?
+        if attachment_data.csv? && attachment_visible? && visible_edition
           expires_headers
+          @edition = visible_edition
+          @attachment = attachment_data.visible_attachment_for(current_user)
           @csv_preview = CsvFileFromPublicHost.csv_preview_from(@csv_response)
           @page_base_href = Plek.new.website_root
-
-          if draft_assets_request_and_draft_edition_present?
-            @attachment = attachment_data.draft_attachment_for(current_user)
-            @edition = draft_edition
-            render layout: "draft_html_attachments"
-          else
-            @attachment = attachment_data.visible_attachment_for(current_user)
-            @edition = visible_edition
-            render layout: "html_attachments"
-          end
+          render layout: "html_attachments"
         else
           fail
         end
@@ -80,25 +72,5 @@ private
     # cached by CDNs.
     expires_in(1.minute, public: true)
     redirect_to placeholder_path
-  end
-
-  def visible_or_draft_edition_present?
-    draft_assets_request_and_draft_edition_present? || assets_request_and_visible_edition_present?
-  end
-
-  def draft_assets_request_and_draft_edition_present?
-    draft_edition.present? && hostname_starts_with_draft_assets?
-  end
-
-  def assets_request_and_visible_edition_present?
-    visible_edition.present? && !hostname_starts_with_draft_assets?
-  end
-
-  def draft_edition
-    @draft_edition ||= attachment_data.draft_edition_for(current_user)
-  end
-
-  def hostname_starts_with_draft_assets?
-    request.hostname.start_with? "draft-assets"
   end
 end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -130,15 +130,6 @@ class AttachmentData < ApplicationRecord
     visible_attachable.is_a?(Edition) ? visible_attachable : nil
   end
 
-  def draft_attachment_for(user)
-    visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
-  end
-
-  def draft_edition_for(user)
-    draft_attachable = draft_attachment_for(user)&.attachable
-    draft_attachable.is_a?(Edition) ? draft_attachable : nil
-  end
-
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/views/layouts/draft_html_attachments.html.erb
+++ b/app/views/layouts/draft_html_attachments.html.erb
@@ -1,5 +1,0 @@
-<%= render :layout => 'layouts/frontend_base', locals: {extra_body_class: "html-publication draft", stylesheet: 'html-publication'} do %>
-  <div class="govuk-width-container html-publications-show">
-    <%= yield %>
-  </div>
-<% end %>

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -15,7 +15,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     @organisation1 = create(:organisation)
     @organisation2 = create(:organisation)
-    @edition = create(:publication, :published, organisations: [organisation1, organisation2])
+    @edition = create(:publication, organisations: [organisation1, organisation2])
     @attachment = build(:file_attachment)
 
     controller.stubs(:attachment_data).returns(attachment_data)
@@ -456,33 +456,6 @@ class CsvPreviewControllerTest < ActionController::TestCase
     get :show, params: params
 
     assert_select ".govuk-body:last-child", text: /This file could not be previewed/
-  end
-
-  # draft asset
-
-  test "responds with 200, assigns the correct variables and renders the draft_html_attachments template" do
-    draft_edition = create(:publication, organisations: [organisation1, organisation2])
-    draft_attachment = create(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
-    setup_stubs(accessible?: true)
-    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
-
-    get :show, params: params
-
-    assert_response :ok
-    assert_equal draft_edition, assigns(:edition)
-    assert_equal draft_attachment, assigns(:attachment)
-    assert_template "show", layout: "draft_html_attachments"
-  end
-
-  test "responds with 404 if no draft edition is present" do
-    response = build(:consultation_outcome)
-    create(:file_attachment, attachment_data: attachment_data, attachable: response)
-    setup_stubs(accessible?: true, visible_edition: nil)
-    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
-
-    get :show, params: params
-
-    assert_response :not_found
   end
 
 private

--- a/test/integration/page_title_test.rb
+++ b/test/integration/page_title_test.rb
@@ -11,7 +11,6 @@ class PageTitleTest < ActiveSupport::TestCase
     layouts/frontend.html.erb
     layouts/home.html.erb
     layouts/html_attachments.html.erb
-    layouts/draft_html_attachments.html.erb
   ].map do |f|
     File.expand_path(Rails.root.join("app/views/#{f}"))
   end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -353,39 +353,4 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     assert_not attachment_data.deleted?
   end
-
-  test "#draft_attachment_for(user) returns the attachment with a draft edition" do
-    user = build(:user)
-    attachment_data = build(:attachment_data)
-    published_edition = build(:edition, :published)
-    draft_edition = build(:edition)
-    published_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: published_edition)
-    draft_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
-    attachment_data.stubs(:attachments).returns([published_attachment, draft_attachment])
-    attachment_data.stubs(:visible_to?).returns(true)
-
-    assert_equal attachment_data.draft_attachment_for(user), draft_attachment
-  end
-
-  test "#draft_edition_for(user) returns a draft edition when is associated with an attachment" do
-    user = build(:user)
-    attachment_data = build(:attachment_data)
-    draft_edition = build(:edition)
-    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
-    attachment_data.stubs(:attachments).returns([attachment])
-    attachment_data.stubs(:visible_to?).returns(true)
-
-    assert_equal attachment_data.draft_edition_for(user), draft_edition
-  end
-
-  test "#draft_edition_for(user) returns nil when the attachable is not an `Edition`" do
-    user = build(:user)
-    attachment_data = build(:attachment_data)
-    response = build(:consultation_outcome)
-    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: response)
-    attachment_data.stubs(:attachments).returns([attachment])
-    attachment_data.stubs(:visible_to?).returns(true)
-
-    assert_equal attachment_data.draft_edition_for(user), nil
-  end
 end


### PR DESCRIPTION
Temporarily reverting #6651 until we can figure out what caused these Sentry errors:

https://sentry.io/organizations/govuk/issues/3420276773/?project=202259

More context in Slack:

https://gds.slack.com/archives/C02L13S214K/p1657643321667789

Trello: https://trello.com/c/ktlUy34f/511-csv-previews-for-shareable-preview-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
