### PR TITLE
Ensure draft csvs can be rendered

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -131,7 +131,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def draft_attachment_for(user)
-    visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
+    visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable&.draft? } : nil
   end
 
   def draft_edition_for(user)

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -134,6 +134,11 @@ class AttachmentData < ApplicationRecord
     visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
   end
 
+  def draft_edition_for(user)
+    draft_attachable = draft_attachment_for(user)&.attachable
+    draft_attachable.is_a?(Edition) ? draft_attachable : nil
+  end
+
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -130,6 +130,10 @@ class AttachmentData < ApplicationRecord
     visible_attachable.is_a?(Edition) ? visible_attachable : nil
   end
 
+  def draft_attachment_for(user)
+    visible_to?(user) ? attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable.draft? } : nil
+  end
+
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/views/layouts/draft_html_attachments.html.erb
+++ b/app/views/layouts/draft_html_attachments.html.erb
@@ -1,0 +1,5 @@
+<%= render :layout => 'layouts/frontend_base', locals: {extra_body_class: "html-publication draft", stylesheet: 'html-publication'} do %>
+  <div class="govuk-width-container html-publications-show">
+    <%= yield %>
+  </div>
+<% end %>

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -15,7 +15,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     @organisation1 = create(:organisation)
     @organisation2 = create(:organisation)
-    @edition = create(:publication, organisations: [organisation1, organisation2])
+    @edition = create(:publication, :published, organisations: [organisation1, organisation2])
     @attachment = build(:file_attachment)
 
     controller.stubs(:attachment_data).returns(attachment_data)
@@ -456,6 +456,22 @@ class CsvPreviewControllerTest < ActionController::TestCase
     get :show, params: params
 
     assert_select ".govuk-body:last-child", text: /This file could not be previewed/
+  end
+
+  # draft asset
+
+  test "responds with 200, assigns the correct variables and renders the draft_html_attachments template" do
+    draft_edition = create(:publication, organisations: [organisation1, organisation2])
+    draft_attachment = create(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    setup_stubs(accessible?: true)
+    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
+
+    get :show, params: params
+
+    assert_response :ok
+    assert_equal draft_edition, assigns(:edition)
+    assert_equal draft_attachment, assigns(:attachment)
+    assert_template "show", layout: "draft_html_attachments"
   end
 
 private

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -485,6 +485,18 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "responds with 404 if no attachable is present" do
+    draft_edition = create(:publication, organisations: [organisation1, organisation2])
+    create(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    draft_edition.destroy!
+    setup_stubs(accessible?: true, visible_edition: nil)
+    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
+
+    get :show, params: params
+
+    assert_response :not_found
+  end
+
 private
 
   def setup_stubs(attributes = {})

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -474,6 +474,17 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_template "show", layout: "draft_html_attachments"
   end
 
+  test "responds with 404 if no draft edition is present" do
+    response = build(:consultation_outcome)
+    create(:file_attachment, attachment_data: attachment_data, attachable: response)
+    setup_stubs(accessible?: true, visible_edition: nil)
+    ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")
+
+    get :show, params: params
+
+    assert_response :not_found
+  end
+
 private
 
   def setup_stubs(attributes = {})

--- a/test/integration/page_title_test.rb
+++ b/test/integration/page_title_test.rb
@@ -11,6 +11,7 @@ class PageTitleTest < ActiveSupport::TestCase
     layouts/frontend.html.erb
     layouts/home.html.erb
     layouts/html_attachments.html.erb
+    layouts/draft_html_attachments.html.erb
   ].map do |f|
     File.expand_path(Rails.root.join("app/views/#{f}"))
   end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -386,6 +386,16 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data.stubs(:attachments).returns([attachment])
     attachment_data.stubs(:visible_to?).returns(true)
 
-    assert_equal attachment_data.draft_edition_for(user), nil
+    assert_nil attachment_data.draft_edition_for(user)
+  end
+
+  test "#draft_edition_for(user) returns nil when the attachable is not present" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: nil)
+    attachment_data.stubs(:attachments).returns([attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_nil attachment_data.draft_edition_for(user)
   end
 end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -353,4 +353,17 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     assert_not attachment_data.deleted?
   end
+
+  test "#draft_edition_for(user) returns the attachment with a draft edition" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    published_edition = build(:edition, :published)
+    draft_edition = build(:edition)
+    published_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: published_edition)
+    draft_attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    attachment_data.stubs(:attachments).returns([published_attachment, draft_attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_attachment_for(user), draft_attachment
+  end
 end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -354,7 +354,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_not attachment_data.deleted?
   end
 
-  test "#draft_edition_for(user) returns the attachment with a draft edition" do
+  test "#draft_attachment_for(user) returns the attachment with a draft edition" do
     user = build(:user)
     attachment_data = build(:attachment_data)
     published_edition = build(:edition, :published)
@@ -365,5 +365,27 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data.stubs(:visible_to?).returns(true)
 
     assert_equal attachment_data.draft_attachment_for(user), draft_attachment
+  end
+
+  test "#draft_edition_for(user) returns a draft edition when is associated with an attachment" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    draft_edition = build(:edition)
+    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    attachment_data.stubs(:attachments).returns([attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_edition_for(user), draft_edition
+  end
+
+  test "#draft_edition_for(user) returns nil when the attachable is not an `Edition`" do
+    user = build(:user)
+    attachment_data = build(:attachment_data)
+    response = build(:consultation_outcome)
+    attachment = build(:file_attachment, attachment_data: attachment_data, attachable: response)
+    attachment_data.stubs(:attachments).returns([attachment])
+    attachment_data.stubs(:visible_to?).returns(true)
+
+    assert_equal attachment_data.draft_edition_for(user), nil
   end
 end


### PR DESCRIPTION
## Description 

This reimplements https://github.com/alphagov/whitehall/pull/6651 which was reverted here https://github.com/alphagov/whitehall/pull/6672

The reason for the PR needed to be reverted was due to this issue https://sentry.io/organizations/govuk/issues/3420276773/?project=202259&query=is%3Aunresolved+csv&statsPeriod=14d

where the `draft?` method was called on an attachments attachable. In some cases an attachments attachable can be nil.

When `draft?` is called on nil it blows up.

This PR adds an additional commit which adds a save navigator and tests to ensure the fix works.

## Trello card 

https://trello.com/c/ktlUy34f/511-csv-previews-for-shareable-preview-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
