### PR TITLE
Fix topical event ordering

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -133,7 +133,7 @@ class Classification < ApplicationRecord
 
   def next_ordering
     last = classification_featurings.order("ordering desc").limit(1).last
-    last ? last.ordering + 1 : 1
+    last ? last.ordering + 1 : 0
   end
 
   def to_s

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -132,8 +132,8 @@ class Classification < ApplicationRecord
   end
 
   def next_ordering
-    last = classification_featurings.order("ordering desc").limit(1).last
-    last ? last.ordering + 1 : 0
+    last = classification_featurings.maximum(:ordering)
+    last ? last + 1 : 0
   end
 
   def to_s

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -114,5 +114,39 @@ class ClassificationTest < ActiveSupport::TestCase
     assert_equal topical_event.importance_ordered_organisations, [first_lead_org, second_lead_org, supporting_org]
   end
 
+  test "#next_ordering gives a value of 1 when there are no existing features" do
+    topical_event = create(:topical_event)
+
+    assert_equal 1, topical_event.next_ordering
+  end
+
+  test "#next_ordering gives the next value when there are existing features" do
+    topical_event = create(:topical_event)
+
+    news_article_1 = create(:published_news_article)
+    image_1 = create(:classification_featuring_image_data)
+    topical_event.feature(edition_id: news_article_1.id, alt_text: "A thing", image: image_1)
+
+    news_article_2 = create(:published_news_article)
+    image_2 = create(:classification_featuring_image_data)
+    topical_event.feature(edition_id: news_article_2.id, alt_text: "A thing", image: image_2)
+
+    assert_equal 2, topical_event.next_ordering
+  end
+
+  test "#next_ordering gives the next value when there are existing features that have been reordered" do
+    topical_event = create(:topical_event)
+
+    news_article_1 = create(:published_news_article)
+    image_1 = create(:classification_featuring_image_data)
+    topical_event.feature(edition_id: news_article_1.id, alt_text: "A thing", image: image_1, ordering: 1)
+
+    news_article_2 = create(:published_news_article)
+    image_2 = create(:classification_featuring_image_data)
+    topical_event.feature(edition_id: news_article_2.id, alt_text: "A thing", image: image_2, ordering: 0)
+
+    assert_equal 2, topical_event.next_ordering
+  end
+
   should_not_accept_footnotes_in :description
 end

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -63,7 +63,7 @@ class ClassificationTest < ActiveSupport::TestCase
     topical_event.feature(edition_id: news_article.id, alt_text: "A thing", image: image)
     featuring = topical_event.featuring_of(news_article)
     assert featuring
-    assert_equal 1, featuring.ordering
+    assert_equal 0, featuring.ordering
     assert topical_event.featured?(news_article)
   end
 
@@ -114,10 +114,10 @@ class ClassificationTest < ActiveSupport::TestCase
     assert_equal topical_event.importance_ordered_organisations, [first_lead_org, second_lead_org, supporting_org]
   end
 
-  test "#next_ordering gives a value of 1 when there are no existing features" do
+  test "#next_ordering gives a value of 0 when there are no existing features" do
     topical_event = create(:topical_event)
 
-    assert_equal 1, topical_event.next_ordering
+    assert_equal 0, topical_event.next_ordering
   end
 
   test "#next_ordering gives the next value when there are existing features" do


### PR DESCRIPTION
There was a bug where new topical event (aka classification) features get incorrectly numbered when the list has previously been sorted. The new feature always gets numbered as `1`, meaning it is in the same position as another feature. The rendered ordering then varies (maybe somewhat randomly).

The problem was caused as the `order` method did not override the default scope, which orders the features in ascending order. Because of this, the last item was actually the first and was ordered 0.

Changing to the `maximum` method means Rails will ignore the default scope.

Additionally, there was an anomaly in ordering of topical event features.

If you add a new feature to a new topical event, the ordering starts from 1 and continues upwards. But if you reorder existing features on a topical event, the ordering starts from 0 and continues upwards.

Updating the behaviour so both situations start from 0.

The tests have been added in a separate commit so they deliberately fail and it would be possible to see why the ordering was incorrect.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
