### PR TITLE
Update to use govuk schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :test do
   gem "database_cleaner-active_record"
   gem "equivalent-xml"
   gem "factory_bot"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "i18n-coverage"
   gem "maxitest"
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,8 +253,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_ab_testing (2.4.2)
     govuk_admin_template (6.9.2)
       bootstrap-sass (~> 3.4)
@@ -282,6 +280,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.4.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -771,12 +771,12 @@ DEPENDENCIES
   gds-sso
   globalize
   govspeak
-  govuk-content-schema-test-helpers
   govuk_ab_testing
   govuk_admin_template
   govuk_app_config
   govuk_frontend_toolkit
   govuk_publishing_components
+  govuk_schemas
   govuk_sidekiq
   govuk_test
   graphviz_transitions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require "webmock/minitest"
 require "whitehall/not_quite_as_fake_search"
 require "whitehall/search_index"
 require "sidekiq/testing"
-require "govuk-content-schema-test-helpers/test_unit"
+require "govuk_schemas/assert_matchers"
 
 if ENV["USE_I18N_COVERAGE"]
   require "i18n/coverage"
@@ -35,11 +35,6 @@ Mocha.configure do |c|
   c.stubbing_non_existent_method = :prevent
 end
 
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
 class ActiveSupport::TestCase
   include AssetManagerTestHelpers
   include FactoryBot::Syntax::Methods
@@ -48,7 +43,7 @@ class ActiveSupport::TestCase
   include HtmlAssertions
   include I18nHelpers
   include PublishingApiTestHelpers
-  include GovukContentSchemaTestHelpers::TestUnit
+  include GovukSchemas::AssertMatchers
   include UrlHelpers
   extend GovspeakValidationTestHelper
 

--- a/test/unit/finder_schema_validation_test.rb
+++ b/test/unit/finder_schema_validation_test.rb
@@ -9,7 +9,7 @@ class FinderSchemaValidationTest < ActiveSupport::TestCase
     test "the #{name} finder is a valid finder" do
       finder = JSON.parse(File.read(file_path))
 
-      assert_valid_against_schema(finder, "finder")
+      assert_valid_against_publisher_schema(finder, "finder")
     end
   end
 end

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -59,7 +59,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
     presented_item = present(case_study)
 
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     assert_valid_against_links_schema({ links: presented_item.links }, "case_study")
     assert_equal expected_content.except(:details), presented_item.content.except(:details)
     # We test for HTML equivalance rather than string equality to get around
@@ -84,7 +84,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
     presented_item = present(case_study)
 
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     assert_equal expected_hash, presented_item.content[:details][:image]
   end
 
@@ -99,7 +99,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
     presented_item = present(case_study)
 
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     assert_equal expected_hash, presented_item.content[:details][:image]
   end
 
@@ -116,7 +116,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
     presented_item = present(case_study)
 
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     assert_equal expected_hash, presented_item.content[:details][:image]
   end
 
@@ -132,7 +132,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
     presented_item = present(case_study)
 
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     assert_equal expected_hash, presented_item.content[:details][:image]
   end
 
@@ -175,7 +175,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     new_timestamp = Time.zone.now
     new_edition = create(:published_case_study, document: original.document, published_major_version: 2, change_note: "More changes", major_change_published_at: new_timestamp)
     presented_item = present(new_edition)
-    assert_valid_against_schema(presented_item.content, "case_study")
+    assert_valid_against_publisher_schema(presented_item.content, "case_study")
     presented_history = presented_item.content[:details][:change_history]
     expected_history = [
       { public_timestamp: new_timestamp, note: "More changes" },

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -183,7 +183,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
 
     test "it presents the base_path if locale is :en" do
@@ -239,7 +239,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -298,7 +298,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -312,7 +312,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -388,7 +388,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -451,7 +451,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -496,7 +496,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -516,7 +516,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -536,7 +536,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -555,7 +555,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -595,7 +595,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 
@@ -616,7 +616,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "consultation"
+      assert_valid_against_publisher_schema presented_content, "consultation"
     end
   end
 

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -78,7 +78,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
     }
 
     assert_equal expected_content, @presented.content
-    assert_valid_against_schema(@presented.content, "contact")
+    assert_valid_against_publisher_schema(@presented.content, "contact")
   end
 
   test "links hash includes organisations" do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -195,7 +195,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 
@@ -331,7 +331,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 
@@ -346,7 +346,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 
@@ -423,7 +423,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 
@@ -443,7 +443,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 
@@ -462,7 +462,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "corporate_information_page"
+      assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
   end
 end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -20,7 +20,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
 
     presented_item = present(detailed_guide)
 
-    assert_valid_against_schema(presented_item.content, "detailed_guide")
+    assert_valid_against_publisher_schema(presented_item.content, "detailed_guide")
     assert_valid_against_links_schema({ links: presented_item.links }, "detailed_guide")
   end
 
@@ -228,7 +228,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       },
     }
 
-    assert_valid_against_schema(presented_item.content, "detailed_guide")
+    assert_valid_against_publisher_schema(presented_item.content, "detailed_guide")
     assert_equal expected_national_applicability, details[:national_applicability]
   end
 
@@ -249,7 +249,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     detailed_guide = create(:published_detailed_guide, :with_file_attachment)
 
     presented_item = present(detailed_guide)
-    assert_valid_against_schema(presented_item.content, "detailed_guide")
+    assert_valid_against_publisher_schema(presented_item.content, "detailed_guide")
     assert_equal presented_item.content.dig(:details, :attachments, 0, :id),
                  detailed_guide.attachments.first.id.to_s
   end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -16,7 +16,7 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid document_collection content item" do
-    assert_valid_against_schema @presented_content, "document_collection"
+    assert_valid_against_publisher_schema @presented_content, "document_collection"
   end
 
   test "it delegates the content id" do
@@ -431,6 +431,6 @@ class PublishingApi::DocumentCollectionAccessLimitedTest < ActiveSupport::TestCa
   end
 
   test "is valid against content schemas" do
-    assert_valid_against_schema @presented_document_collection.content, "document_collection"
+    assert_valid_against_publisher_schema @presented_document_collection.content, "document_collection"
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -16,7 +16,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid fatality_notice content item" do
-    assert_valid_against_schema @presented_content, "fatality_notice"
+    assert_valid_against_publisher_schema @presented_content, "fatality_notice"
   end
 
   test "it delegates the content id" do

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module PublishingApi
   class GenericEditionPresenterTest < ActiveSupport::TestCase
-    include GovukContentSchemaTestHelpers::TestUnit
+    include GovukSchemas::AssertMatchers
 
     def present(edition, update_type: nil)
       edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
@@ -46,7 +46,7 @@ module PublishingApi
 
       presented_item = present(edition)
       assert_equal expected_hash, presented_item.content
-      assert_valid_against_schema(presented_item.content, "placeholder")
+      assert_valid_against_publisher_schema(presented_item.content, "placeholder")
     end
 
     test "links hash includes topics and parent if set" do

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -50,7 +50,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     }
     presented_item = present(html_attachment)
 
-    assert_valid_against_schema(presented_item.content, "html_publication")
+    assert_valid_against_publisher_schema(presented_item.content, "html_publication")
     assert_valid_against_links_schema({ links: presented_item.links }, "html_publication")
 
     # We test for HTML equivalance rather than string equality to get around
@@ -165,7 +165,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       },
     }
 
-    assert_valid_against_schema(presenter.content, "html_publication")
+    assert_valid_against_publisher_schema(presenter.content, "html_publication")
     assert_equal expected_national_applicability, details[:national_applicability]
   end
 end

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -9,7 +9,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
     I18n.with_locale(:en) do
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
 
-      assert_valid_against_schema(presented_item.content, "ministers_index")
+      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
     end
   end
 

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -174,7 +174,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
 
     test "auth bypass id" do
@@ -192,7 +192,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -206,7 +206,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -220,7 +220,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -284,7 +284,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -304,7 +304,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -324,7 +324,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -345,7 +345,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 
@@ -391,7 +391,7 @@ module PublishingApi::NewsArticlePresenterTest
     end
 
     test "validity" do
-      assert_valid_against_schema presented_content, "news_article"
+      assert_valid_against_publisher_schema presented_content, "news_article"
     end
   end
 end

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid placeholder content item" do
-    assert_valid_against_schema @presented_content, "placeholder"
+    assert_valid_against_publisher_schema @presented_content, "placeholder"
   end
 
   test "it delegates the content id" do

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -111,7 +111,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal organisation.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "organisation")
+    assert_valid_against_publisher_schema(presented_item.content, "organisation")
   end
 
   test "presents an organisation’s custom logo" do

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -57,7 +57,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "person")
+    assert_valid_against_publisher_schema(presented_item.content, "person")
   end
 
   test "accepts people without an image" do
@@ -72,6 +72,6 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
 
     presented_item = present(person)
 
-    assert_valid_against_schema(presented_item.content, "person")
+    assert_valid_against_publisher_schema(presented_item.content, "person")
   end
 end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -74,7 +74,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
 
     presented_item = present(publication)
 
-    assert_valid_against_schema(presented_item.content, "publication")
+    assert_valid_against_publisher_schema(presented_item.content, "publication")
     assert_valid_against_links_schema({ links: presented_item.links }, "publication")
 
     assert_equal expected_content.except(:details),
@@ -133,7 +133,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     create(:government)
     new_edition = create(:published_publication, document: original.document, published_major_version: 2, change_note: "More changes", major_change_published_at: new_timestamp)
     presented_item = present(new_edition)
-    assert_valid_against_schema(presented_item.content, "publication")
+    assert_valid_against_publisher_schema(presented_item.content, "publication")
     presented_history = presented_item.content[:details][:change_history]
     expected_history = [
       { public_timestamp: new_timestamp, note: "More changes" },

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -9,7 +9,7 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
     role_appointment = create(:role_appointment)
 
     presented_item = present(role_appointment)
-    assert_valid_against_schema(presented_item.content, "role_appointment")
+    assert_valid_against_publisher_schema(presented_item.content, "role_appointment")
   end
 
   test "presents a role appointment ready for adding to the Publishing API" do

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -57,7 +57,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal role.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "role")
+    assert_valid_against_publisher_schema(presented_item.content, "role")
   end
 
   test "presents a Ministerial Whip Role ready for adding to the Publishing API" do
@@ -116,7 +116,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal role.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "role")
+    assert_valid_against_publisher_schema(presented_item.content, "role")
   end
 
   test "presents a Board Member Role ready for adding to the Publishing API" do

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -40,6 +40,6 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
     assert_hash_includes presented_item.links, expected_links
     assert_equal expected_update_type, presented_item.update_type
 
-    assert_valid_against_schema(presented_item.content, "generic")
+    assert_valid_against_publisher_schema(presented_item.content, "generic")
   end
 end

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
     describe "validating against content schemas" do
       it "is valid against the details schema" do
-        assert_valid_against_schema(presented.content, "speech")
+        assert_valid_against_publisher_schema(presented.content, "speech")
       end
 
       it "is valid against the links schema" do

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -15,7 +15,7 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid statistical_data_set content item" do
-    assert_valid_against_schema @presented_content, "statistical_data_set"
+    assert_valid_against_publisher_schema @presented_content, "statistical_data_set"
   end
 
   test "it delegates the content id" do
@@ -196,7 +196,7 @@ class PublishingApi::StatisticalDataSetPresenterAttachmentTest < ActiveSupport::
   end
 
   test "its attachments are valid against the schema" do
-    assert_valid_against_schema @presented_statistical_data_set.content, "statistical_data_set"
+    assert_valid_against_publisher_schema @presented_statistical_data_set.content, "statistical_data_set"
   end
 end
 
@@ -295,6 +295,6 @@ class PublishingApi::StatisticalDataSetAccessLimitedTest < ActiveSupport::TestCa
   end
 
   test "is valid against content schemas" do
-    assert_valid_against_schema @presented_statistical_data_set.content, "statistical_data_set"
+    assert_valid_against_publisher_schema @presented_statistical_data_set.content, "statistical_data_set"
   end
 end

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -39,7 +39,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
     presented_item = present(statistics_announcement)
     presented_content = presented_item.content
 
-    assert_valid_against_schema(presented_content, "statistics_announcement")
+    assert_valid_against_publisher_schema(presented_content, "statistics_announcement")
     assert_valid_against_links_schema({ links: presented_item.links }, "statistics_announcement")
 
     assert_equivalent_html expected_content[:details].delete(:body),
@@ -85,7 +85,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
     presented_item = present(statistics_announcement)
     presented_content = presented_item.content
 
-    assert_valid_against_schema(presented_content, "statistics_announcement")
+    assert_valid_against_publisher_schema(presented_content, "statistics_announcement")
     assert_valid_against_links_schema({ links: presented_item.links }, "statistics_announcement")
 
     assert_equivalent_html expected_content[:details].delete(:body),
@@ -135,7 +135,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
     presented_item = present(statistics_announcement)
     presented_content = presented_item.content
 
-    assert_valid_against_schema(presented_content, "statistics_announcement")
+    assert_valid_against_publisher_schema(presented_content, "statistics_announcement")
     assert_valid_against_links_schema({ links: presented_item.links }, "statistics_announcement")
 
     assert_equivalent_html expected_content[:details].delete(:body),

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -38,7 +38,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
     presented_item = present(take_part_page)
     presented_content = presented_item.content
 
-    assert_valid_against_schema(presented_content, "take_part")
+    assert_valid_against_publisher_schema(presented_content, "take_part")
     assert_valid_against_links_schema({ links: presented_item.links }, "take_part")
 
     # We test for HTML equivalance rather than string equality to get around

--- a/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
@@ -32,7 +32,7 @@ class PublishingApi::TopicalEventAboutPagePresenterTest < ActiveSupport::TestCas
     presented_item = present(topical_event_about_page)
     presented_content = presented_item.content
 
-    assert_valid_against_schema(presented_item.content, "topical_event_about_page")
+    assert_valid_against_publisher_schema(presented_item.content, "topical_event_about_page")
     assert_valid_against_links_schema({ links: presented_item.links }, "topical_event_about_page")
     assert_equal topical_event_about_page.topical_event.content_id, presented_item.links[:parent][0]
 

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -87,7 +87,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
 
     assert_equal expected_hash, presenter.content
-    assert_valid_against_schema(presenter.content, "topical_event")
+    assert_valid_against_publisher_schema(presenter.content, "topical_event")
   end
 
   test "handles topical events without dates" do
@@ -123,7 +123,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
 
     assert_equal expected_hash, presenter.content
-    assert_valid_against_schema(presenter.content, "topical_event")
+    assert_valid_against_publisher_schema(presenter.content, "topical_event")
   end
 
   test "handles topical events without an end_date" do
@@ -138,7 +138,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       ordered_featured_documents: [],
       social_media_links: [],
     }, presenter.content[:details])
-    assert_valid_against_schema(presenter.content, "topical_event")
+    assert_valid_against_publisher_schema(presenter.content, "topical_event")
   end
 
   test "it limits the number of featured items" do

--- a/test/unit/presenters/publishing_api/working_group_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/working_group_presenter_test.rb
@@ -40,7 +40,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::WorkingGroupPresenter.new(group)
 
     assert_equal expected_hash, presenter.content
-    assert_valid_against_schema(presenter.content, "working_group")
+    assert_valid_against_publisher_schema(presenter.content, "working_group")
   end
 
   test "renders attachments in the body" do

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -31,6 +31,6 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal world_location.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "world_location")
+    assert_valid_against_publisher_schema(presented_item.content, "world_location")
   end
 end

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -34,6 +34,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     assert_equal "major", presented_item.update_type
     assert_equal worldwide_org.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, "placeholder")
+    assert_valid_against_publisher_schema(presented_item.content, "placeholder")
   end
 end

--- a/test/unit/publish_organisations_index_page_test.rb
+++ b/test/unit/publish_organisations_index_page_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "govuk-content-schema-test-helpers"
+require "govuk_schemas"
 
 class PublishOrganisationsIndexPageTest < ActiveSupport::TestCase
   test "sends the page to publishing api" do
@@ -33,11 +33,11 @@ class PublishOrganisationsIndexPageTest < ActiveSupport::TestCase
   end
 
   def expect_valid_for_schema(presented_page)
-    validator = GovukContentSchemaTestHelpers::Validator.new(
+    validator = GovukSchemas::Validator.new(
       presented_page[:schema_name],
-      "schema",
+      "publisher",
       presented_page,
     )
-    assert validator.valid?, validator.errors.join("\n")
+    assert validator.valid?, validator.error_message
   end
 end

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "govuk-content-schema-test-helpers"
+require "govuk_schemas"
 
 class PublishStaticPagesTest < ActiveSupport::TestCase
   test "sends static pages to rummager and publishing api" do
@@ -38,11 +38,11 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
   end
 
   def expect_valid_for_schema(presented_page)
-    validator = GovukContentSchemaTestHelpers::Validator.new(
+    validator = GovukSchemas::Validator.new(
       presented_page[:schema_name],
-      "schema",
+      "publisher",
       presented_page,
     )
-    assert validator.valid?, validator.errors.join("\n")
+    assert validator.valid?, validator.error_message
   end
 end

--- a/test/unit/whitehall/publishing_api/redirect_test.rb
+++ b/test/unit/whitehall/publishing_api/redirect_test.rb
@@ -11,7 +11,7 @@ class Whitehall::PublishingApi::RedirectTest < ActiveSupport::TestCase
   end
 
   test "generates a valid redirect content item" do
-    assert_valid_against_schema(@output_hash, "redirect")
+    assert_valid_against_publisher_schema(@output_hash, "redirect")
   end
 
   test "#base_path returns the base_path" do


### PR DESCRIPTION
## Description

The [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) gem has been deprecated. Applications should now use the `govuk_schemas` gem instead. 

We recently, did some work to add support for Minitest applications in this PR https://github.com/alphagov/govuk_schemas/pull/66

This PR removes `govuk-content-schema-test-helpers`, adds `govuk_schemas` and updates the tests to use the new syntax.

## Trelllo card

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
