### PR TITLE
Fix 'Republish all documents with attachments' rake task

### DIFF
--- a/lib/tasks/republish_docs_with_attachments.rake
+++ b/lib/tasks/republish_docs_with_attachments.rake
@@ -6,7 +6,7 @@ task repubish_docs_with_attachments: :environment do
     published_editions_for_org = Edition.latest_published_edition.in_organisation(org)
     puts "Total editions for #{org.slug}: #{published_editions_for_org.count}"
     editions_with_attachments = published_editions_for_org.publicly_visible.where(
-      id: Attachment.where(accessible: false, attachable_type: "Edition").select("attachable_id"),
+      id: Attachment.where(accessible: [false, nil], attachable_type: "Edition").select("attachable_id"),
     )
     puts "Enqueueing #{editions_with_attachments.count} editions with attachments for #{org.slug}"
     editions_with_attachments.joins(:document).distinct.pluck("documents.id").each do |document_id|


### PR DESCRIPTION
We've had a [report] that a particular publication was showing a
"Request an accessible format link" that doesn't do anything. This
is evidently a known issue and has been fixed already; what's
needed is to republish all affected documents.

The `repubish_docs_with_attachments` rake task was run, but did
not fix the publication specified in the report. On further
investigation, the publication has attachments which have a
`accessible` value of `nil`, not `false`. We therefore need to
widen the query to include documents containing attachments that
are both `accessible: false` and `accessible: nil`.

[report]: https://govuk.zendesk.com/agent/tickets/5017289

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
