### PR TITLE
Configure Pact to use the test database

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,3 +1,5 @@
+ENV["RAILS_ENV"] = "test"
+
 require "pact/provider/rspec"
 require "webmock/rspec"
 require "factory_bot"

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] = "test"
+ENV["PACT_DO_NOT_TRACK"] = "true"
 
 require "pact/provider/rspec"
 require "webmock/rspec"


### PR DESCRIPTION
Prior to this, Pact tests would run against the development database by default. This had the unfortunate side effect of truncating tables and populating them with test data.

Whilst that wasn't noticable in the CI environment, it did mean that development databases were cleared when running Pact tests on local development environments (e.g. govuk-docker). This behaviour resulted in confusion as test suites are usually expected to run against the test database.

It seems pretty common for `ENV['RAILS_ENV'] = "test"` to be at the beginning of test helper files – for example, that's what `test/test_helper.rb` does. So I've taken the same approach here.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
