### PR TITLE
Allow publishers to reuse previous withdrawal notices

### DIFF
--- a/app/assets/javascripts/admin/views/edition_workflow/confirm_unpublish.js
+++ b/app/assets/javascripts/admin/views/edition_workflow/confirm_unpublish.js
@@ -8,9 +8,11 @@
 
       this.revealCorrectForm()
       this.hideExplanationIfRedirecting()
+      this.revealNewWithdrawalFields()
 
       $("input[name='unpublishing_reason_id']").change(this.revealCorrectForm)
       $('#unpublishing_redirect').change(this.hideExplanationIfRedirecting)
+      $("input[name='previous_withdrawal_id']").change(this.revealNewWithdrawalFields)
     },
 
     revealCorrectForm: function () {
@@ -39,6 +41,14 @@
         $('#published_in_error_explanation').val('').closest('fieldset').hide()
       } else {
         $('#published_in_error_explanation').closest('fieldset').show()
+      }
+    },
+
+    revealNewWithdrawalFields: function () {
+      var withdrawalRadios = $("input[name='previous_withdrawal_id']")
+      if (withdrawalRadios.length > 0) {
+        var selected = withdrawalRadios.filter(':checked').val()
+        $('#new-withdrawal').toggle(selected === 'new')
       }
     }
   }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,6 +42,10 @@ class Document < ApplicationRecord
 
   has_many :edition_versions, through: :editions, source: :versions
 
+  has_many :withdrawals,
+           -> { where(unpublishing_reason_id: UnpublishingReason::Withdrawn).order(unpublished_at: :asc, id: :asc) },
+           through: :editions, source: :unpublishing
+
   before_save { check_if_locked_document(document: self) unless locked_changed? }
 
   validates :content_id, presence: true

--- a/app/services/edition_withdrawer.rb
+++ b/app/services/edition_withdrawer.rb
@@ -4,6 +4,8 @@ class EditionWithdrawer < EditionUnpublisher
   def initialize(edition, options = {})
     super
     @user = options[:user]
+    @previous_withdrawal = options[:previous_withdrawal]
+    use_previous_withdrawal if @previous_withdrawal.present?
   end
 
   def verb
@@ -15,6 +17,11 @@ class EditionWithdrawer < EditionUnpublisher
   end
 
 private
+
+  def use_previous_withdrawal
+    @edition.unpublishing.explanation = @previous_withdrawal.explanation
+    @edition.unpublishing.unpublished_at = @previous_withdrawal.unpublished_at
+  end
 
   def fire_transition!
     edition.authors << user if user

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -46,10 +46,41 @@
 
     <%= hidden_field_tag 'unpublishing[unpublishing_reason_id]', UnpublishingReason::Withdrawn.id %>
     <fieldset>
+      <% if @previous_withdrawals.any? %>
+        <h4>Do you need to reuse a previous withdrawal?</h4>
+        <p>You should only reuse a previous withdrawal date and public explanation if you have:</p>
+        <ul>
+          <li>updated file attachments to mark them ‘withdrawn’</li>
+          <li>made a minor edit, for example fixing a broken link</li>
+          <li>fixed an error or mistake in the content which existed when it was originally withdrawn</li>
+        </ul>
+
+        <% @previous_withdrawals.each do |withdrawal| %>
+          <div class="radio">
+            <%= label_tag "previous_withdrawal_id_#{withdrawal.id}" do %>
+              <% checked = (params["previous_withdrawal_id"] == withdrawal.id.to_s) %>
+              <%= radio_button_tag 'previous_withdrawal_id', withdrawal.id, checked, id: "previous_withdrawal_id_#{withdrawal.id}" %>
+              <strong><%= absolute_date(withdrawal.unpublished_at) %></strong>
+              <p>“<%= withdrawal.explanation %>”</p>
+            <% end %>
+          </div>
+        <% end %>
+
+        <div class="radio">
+          <%= label_tag "previous_withdrawal_id_new" do %>
+            <% checked = (params["previous_withdrawal_id"] == 'new') %>
+            <%= radio_button_tag 'previous_withdrawal_id', "new", checked, id: "previous_withdrawal_id_new" %>
+            <strong>This is a new withdrawal</strong>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div id="new-withdrawal">
         <%= label_tag 'withdrawal_explanation', 'Public explanation (this is shown on the live site) <span>*</span>'.html_safe, class: 'required' %>
         <%= text_area_tag 'unpublishing[explanation]', @unpublishing.explanation, rows: 5, class: "previewable form-control input-md-8", id: 'withdrawal_explanation', data: {
           module: "paste-html-to-govspeak"
         } %>
+      </div>
     </fieldset>
     <fieldset>
       <%= form.submit 'Withdraw', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>

--- a/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
+++ b/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
@@ -1,14 +1,24 @@
-When(/^I unwithdraw the publication$/) do
-  publication = Publication.last
-  visit admin_edition_path(publication)
+def unwithdraw_publication
+  visit admin_edition_path(@publication)
 
   click_link "Unwithdraw"
   click_button "Unwithdraw"
 
-  @latest_published_edition = publication.document.published_edition
+  @latest_published_edition = @publication.document.published_edition
 
-  expect(:superseded).to eq(publication.reload.current_state)
+  expect(:superseded).to eq(@publication.reload.current_state)
   expect(:published).to eq(@latest_published_edition.current_state)
+end
+
+When(/^I unwithdraw the publication$/) do
+  @publication = Publication.last
+  unwithdraw_publication
+end
+
+Given("it was subsequently unwithdrawn") do
+  last_withdrawal = Unpublishing.where(unpublishing_reason_id: UnpublishingReason::Withdrawn.id).last
+  @publication = last_withdrawal.edition
+  unwithdraw_publication
 end
 
 Then(/^I should be redirected to the latest edition of the publication$/) do

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -32,9 +32,19 @@ Feature: Unpublishing published documents
     Given a published publication "Shaving kits for all" exists
     When I withdraw the publication with the explanation "Policy change"
     Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
+    And the withdrawal date should be today
 
   Scenario: Change the public explanation for a withdrawn document
     Given a published publication "Shaving kits for all" exists
     When I withdraw the publication with the explanation "Policy change"
     When I edit the public explanation for withdrawal to "The policy has changed"
     Then there should be an unpublishing explanation of "The policy has changed" and a reason of "No longer current government policy/activity"
+
+  Scenario: Withdraw a document using a previous withdrawal date & explanation
+    Given a published publication "Free ice creams" exists
+    And the publication was withdrawn on 01/12/2020 with the explanation "It's too cold for ice cream"
+    And it was subsequently unwithdrawn
+    When I go to withdraw the publication again
+    And I choose to reuse the withdrawal from 01/12/2020
+    Then there should be an unpublishing explanation of "It's too cold for ice cream" and a reason of "No longer current government policy/activity"
+    And the withdrawal date should be 01/12/2020

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -1,43 +1,40 @@
 Feature: Unpublishing published documents
-  As a GDS Editor
+  As a managing editor
   I want to be able to revert published documents back to the draft state
   So that I can remove documents from the site that were published in error
 
+  Background:
+    Given I am a managing editor
+
   @not-quite-as-fake-search
   Scenario: Unpublishing a published document
-    Given I am a managing editor
-    And a published document "Published by accident" exists
+    Given a published document "Published by accident" exists
     When I unpublish the document because it was published in error
     Then there should be an editorial remark recording the fact that the document was unpublished
     And there should be an unpublishing explanation of "This page should never have existed" and a reason of "Published in error"
 
   Scenario: Draft resulting from an unpublishing should not be deletable
-    Given I am a managing editor
-    And a published document exists with a slug that does not match the title
+    Given a published document exists with a slug that does not match the title
     When I unpublish the document because it was published in error
     Then I should not be able to discard the draft resulting from the unpublishing
 
   Scenario: Unpublishing a document and redirecting
-    Given I am a managing editor
-    And a published document "Published by accident" exists
+    Given a published document "Published by accident" exists
     When I unpublish the document and ask for a redirect to "https://www.test.gov.uk/example"
     Then the unpublishing should redirect to "https://www.test.gov.uk/example"
 
   Scenario: Consolidating a document into another GOV.UK page
-    Given I am a managing editor
-    And there is a published document that is a duplicate of another page
+    Given there is a published document that is a duplicate of another page
     When I unpublish the duplicate, marking it as consolidated into the other page
     Then the unpublishing should redirect to the existing edition
 
   Scenario: Withdraw a document that is no longer current
-    Given I am a managing editor
-    And a published publication "Shaving kits for all" exists
+    Given a published publication "Shaving kits for all" exists
     When I withdraw the publication with the explanation "Policy change"
     Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
 
-  Scenario: Change the public explanation for archiving a document
-    Given I am a managing editor
-    And a published publication "Shaving kits for all" exists
+  Scenario: Change the public explanation for a withdrawn document
+    Given a published publication "Shaving kits for all" exists
     When I withdraw the publication with the explanation "Policy change"
     When I edit the public explanation for withdrawal to "The policy has changed"
     Then there should be an unpublishing explanation of "The policy has changed" and a reason of "No longer current government policy/activity"


### PR DESCRIPTION
This PR adds functionality for users who need to reuse a previous document withdrawal.

## User interface changes

### First withdrawal of a document

The first time a document is withdrawn, publishers will be asked to provide a public explanation for the withdrawal. This preserves the existing UI, where the 'public explanation' field appears once the user has selected the 'Withdraw' radio.

<img width="1210" alt="First withdrawal of a document" src="https://user-images.githubusercontent.com/7735945/180225019-8869c91b-5e3f-411c-93b7-f43d8e80ab32.png">

### Subsequent withdrawals

If a document has been withdrawn, and subsequently un-withdrawn, this is when the UI changes. The next time a publisher chooses to withdraw the document, they will be presented with the dates and public explanations of previous withdrawals on the document.

The publisher must choose to either re-use a previous withdrawal date or withdraw using today's date. If they choose a previous date, the withdrawal notice will be backdated to show the previous date and public explanation. Alternatively, choosing today's date will make the 'public explanation' field appear for user input.

#### Using a previous withdrawal date

<img width="1210" alt="Withdraw using a previous withdrawal date" src="https://user-images.githubusercontent.com/7735945/180992792-9fb9d883-cde2-4876-851c-5b2fe83c39d8.png">

#### Using today's date

<img width="1210" alt="Withdrawing using today's date" src="https://user-images.githubusercontent.com/7735945/180992866-afb722d4-1fa4-4f92-9525-dabdef40eba7.png">

## Effect on frontend

This affects the date and explanation shown to end users on the GOV.UK frontend.

<img width="591" alt="Withdrawal notice on GOV.UK" src="https://user-images.githubusercontent.com/7735945/180226722-047fac54-99d4-47df-a95d-4b09ba42c158.png">

## Code changes

Code changes for this feature are relatively self contained.

### Edition Workflow controller

Handles form input – including the new radios which are used to select between creating a new withdrawal vs re-using a previous withdrawal. A validation error will be shown if no radio is selected.

The controller sets `@previous_withdrawals` for use by the view. This is a list of previous withdrawals that have been performed on the document, but with an arbitrary limit of 50. This limit is purely there to ensure it's not a limitless query which could cause page load performance issues on documents with extreme numbers of withdrawals.

### Edition Withdrawer service

I've adapted the `EditionWithdrawer` service to accept an additional parameter `previous_withdrawal`. This parameter is **optional**. When provided, it should be the previous `Unpublishing` object that is to be re-used.

### Document model

I've added `Document#withdrawals` as a new association on the Document model.

This makes it possible to retrieve previous withdrawals on Editions associated with the current Document.

---

Trello: https://trello.com/c/lQVUQh0s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
