### PR TITLE
Change link on world locations admin panel to point to live site

### DIFF
--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -6,7 +6,7 @@
     <h1>
       <span class="name"><%= @world_location.name %></span>
     </h1>
-    <p><%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %></p>
+    <p><%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location, cachebust_url_options) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>
@@ -23,7 +23,7 @@
           <% @world_location.non_english_translated_locales.each do |locale| %>
             <tr>
               <td class="locale">
-                <%= link_to locale.native_language_name, edit_admin_world_location_translation_path(@world_location, locale.code) %> (<%= link_to "view", world_location_news_index_path(@world_location, locale: locale) %>)
+                <%= link_to locale.native_language_name, edit_admin_world_location_translation_path(@world_location, locale.code) %> (<%= link_to "view", Whitehall.url_maker.world_location_news_index_url(@world_location, locale: locale) %>)
               </td>
               <td class="actions">
                 <%= button_to 'Delete',

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -5,7 +5,7 @@
     <h1>
       <span class="name"><%= @world_location.name %></span>
     </h1>
-    <p><%= link_to "View on website", world_location_news_index_path(@world_location, {locale: params[:locale]}.merge(cachebust_url_options)) %></p>
+    <p><%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location, {locale: params[:locale]}.merge(cachebust_url_options)) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_locations/show.html.erb
+++ b/app/views/admin/world_locations/show.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
     </h1>
     <p>
-    <%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %>
+    <%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location, cachebust_url_options) %>
   </div>
 
   <section class="world-location-details">

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -76,6 +76,26 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
     end
   end
 
+  view_test "the 'View on website' link on the show page goes to the news page" do
+    location = create(:world_location, translated_into: [:fr], name: "France")
+    get :index, params: { world_location_id: location }
+
+    assert_select "a" do |links|
+      view_links = links.select { |link| link.text =~ /View on website/ }
+      assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/france/news")}/, view_links.first["href"])
+    end
+  end
+
+  view_test "the view buttons for translations link to the new page on the live site" do
+    location = create(:world_location, translated_into: [:fr], name: "France")
+    get :index, params: { world_location_id: location }
+
+    assert_select "a" do |links|
+      view_links = links.select { |link| link.text =~ /view/ }
+      assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/france/news.fr")}/, view_links.first["href"])
+    end
+  end
+
   view_test "update updates translation and redirects back to the index" do
     put :update,
         params: { world_location_id: @location,

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
     get :show, params: { id: world_location }
     assert_select "a" do |links|
       view_links = links.select { |link| link.text =~ /View on website/ }
-      assert_match(/\/world\/germany\/news/, view_links.first["href"])
+      assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/germany/news")}/, view_links.first["href"])
     end
   end
 
@@ -100,7 +100,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select "a" do |links|
       view_links = links.select { |link| link.text =~ /View on website/ }
-      assert_match(/\/world\/france\/news/, view_links.first["href"])
+      assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/france/news")}/, view_links.first["href"])
     end
   end
 
@@ -110,7 +110,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select "a" do |links|
       view_links = links.select { |link| link.text =~ /View on website/ }
-      assert_match(/\/world\/france\/news\.fr/, view_links.first["href"])
+      assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/france/news.fr")}/, view_links.first["href"])
     end
   end
 end


### PR DESCRIPTION
Currently, the 'view on website' link on the world locations admin panel, features and translation tabs point to the whitehall admin link for the content (e.g. https://whitehall-admin.integration.publishing.service.gov.uk/world/some-news-url/news instead of https://www.integration.publishing.service.gov.uk/world/some-news-url/news). This will no longer work when we remove rendering of world location news from Whitehall, so this link is updated to point to the live site.

[This](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/world_locations/france) is an example page where you can currently see the link to whitehall admin (including on the features and translations tab)
[Trello](https://trello.com/c/Qet0mRxb/167-fix-link-from-whitehall-to-world-location-news-on-live-site) 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
