### PR TITLE
Persist latest_edition_id and published_edition_id on document

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -118,7 +118,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   def unwithdraw
     edition_unwithdrawer = Whitehall.edition_services.unwithdrawer(@edition, user: current_user)
     if edition_unwithdrawer.perform!
-      new_edition = @edition.document.published_edition
+      new_edition = @edition.document.live_edition
       redirect_to admin_edition_path(new_edition), notice: "This document has been unwithdrawn"
     else
       flash.now[:alert] = edition_unwithdrawer.failure_reason

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -134,7 +134,7 @@ private
 
   # Returns the published edition of any detailed guide documents that this edition is related to.
   def published_outbound_related_detailed_guides
-    related_documents.published.where(document_type: "DetailedGuide").map(&:published_edition).compact
+    related_documents.published.where(document_type: "DetailedGuide").map(&:live_edition).compact
   end
 
   # Returns the published editions that are related to this edition's document.

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,7 +14,7 @@ class Document < ApplicationRecord
   has_many :edition_relations, dependent: :destroy, inverse_of: :document
 
   has_one  :published_edition,
-           -> { where(state: Edition::PUBLICLY_VISIBLE_STATES) },
+           -> { joins(:document).where("editions.id = documents.live_edition_id") },
            class_name: "Edition",
            inverse_of: :document
   has_one  :pre_publication_edition,
@@ -23,14 +23,7 @@ class Document < ApplicationRecord
            inverse_of: :document
 
   has_one  :latest_edition,
-           lambda {
-             where(%(
-               NOT EXISTS (
-               SELECT 1 FROM editions e2
-               WHERE e2.document_id = editions.document_id
-               AND e2.id > editions.id
-               AND e2.state <> 'deleted')))
-           },
+           -> { joins(:document).where("editions.id = documents.latest_edition_id") },
            class_name: "Edition",
            inverse_of: :document
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -247,8 +247,8 @@ EXISTS (
     joins(:document).where("editions.id = documents.latest_edition_id")
   end
 
-  def self.latest_published_edition
-    joins(:document).where("editions.id = documents.live_edition_id AND state = 'published'")
+  def self.latest_live_edition
+    joins(:document).where("editions.id = documents.live_edition_id")
   end
 
   def self.search_format_type
@@ -551,13 +551,13 @@ EXISTS (
     end
   end
 
-  def latest_published_edition
-    document.published_edition
+  def latest_live_edition
+    document.live_edition
   end
 
   def previous_edition
     if pre_publication?
-      latest_published_edition
+      latest_live_edition
     else
       document.ever_published_editions.reverse.second
     end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -244,21 +244,11 @@ EXISTS (
   end
 
   def self.latest_edition
-    where("NOT EXISTS (
-      SELECT 1
-        FROM editions e2
-       WHERE e2.document_id = editions.document_id
-         AND e2.id > editions.id
-         AND e2.state <> 'deleted')")
+    joins(:document).where("editions.id = documents.latest_edition_id")
   end
 
   def self.latest_published_edition
-    published.where("NOT EXISTS (
-      SELECT 1
-        FROM editions e2
-       WHERE e2.document_id = editions.document_id
-         AND e2.id > editions.id
-         AND e2.state = 'published')")
+    joins(:document).where("editions.id = documents.live_edition_id AND state = 'published'")
   end
 
   def self.search_format_type
@@ -560,12 +550,8 @@ EXISTS (
     end
   end
 
-  def latest_edition
-    document.editions.latest_edition.first
-  end
-
   def latest_published_edition
-    document.editions.latest_published_edition.first
+    document.published_edition
   end
 
   def previous_edition
@@ -737,6 +723,7 @@ EXISTS (
   end
 
   delegate :locked?, to: :document
+  delegate :latest_edition, to: :document
 
   # TODO: this can be removed once rails/rails#44770 is released.
   def attribute_names

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -487,6 +487,7 @@ EXISTS (
       self.class.new(draft_attributes).tap do |draft|
         traits.each { |t| t.process_associations_before_save(draft) }
         if (draft.valid? || !draft.errors.key?(:base)) && draft.save(validate: false)
+          document.update!(latest_edition_id: draft.id)
           traits.each { |t| t.process_associations_after_save(draft) }
         end
       end

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -38,8 +38,8 @@ module Edition::Identifiable
     def published_as(slug, locale = I18n.default_locale)
       document = Document.at_slug(document_type, slug)
       if document.present?
-        published_edition = document.published_edition
-        return published_edition if published_edition.present? && published_edition.available_in_locale?(locale)
+        live_edition = document.live_edition
+        return live_edition if live_edition.present? && live_edition.available_in_locale?(locale)
       end
       nil
     end

--- a/app/models/edition/statistical_data_sets.rb
+++ b/app/models/edition/statistical_data_sets.rb
@@ -11,7 +11,7 @@ module Edition::StatisticalDataSets
     has_many :edition_statistical_data_sets, foreign_key: :edition_id, dependent: :destroy
     has_many :statistical_data_set_documents, through: :edition_statistical_data_sets, source: :document
     has_many :statistical_data_sets, through: :statistical_data_set_documents, source: :latest_edition
-    has_many :published_statistical_data_sets, through: :statistical_data_set_documents, source: :published_edition, class_name: "StatisticalDataSet"
+    has_many :published_statistical_data_sets, through: :statistical_data_set_documents, source: :live_edition, class_name: "StatisticalDataSet"
 
     add_trait Trait
   end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -28,8 +28,8 @@ class Feature < ApplicationRecord
   end
 
   def to_s
-    if document && document.published_edition
-      LocalisedModel.new(document.published_edition, locale).title
+    if document && document.live_edition
+      LocalisedModel.new(document.live_edition, locale).title
     elsif topical_event
       topical_event.name
     elsif offsite_link
@@ -43,8 +43,8 @@ class Feature < ApplicationRecord
     where(ended_at: nil)
   end
 
-  def self.with_published_edition
-    joins(document: :published_edition)
+  def self.with_live_edition
+    joins(document: :live_edition)
   end
 
   def self.with_topical_events

--- a/app/models/feature_list.rb
+++ b/app/models/feature_list.rb
@@ -30,11 +30,11 @@ class FeatureList < ApplicationRecord
   end
 
   def current
-    features.current.includes([:topical_event, { document: :published_edition }])
+    features.current.includes([:topical_event, { document: :live_edition }])
   end
 
   def published_features
-    features.current.with_published_edition
+    features.current.with_live_edition
   end
 
   def topical_events

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -6,14 +6,14 @@ class MinisterialRole < Role
 
   def published_speeches(options = {})
     speeches
-      .latest_published_edition
+      .latest_live_edition
       .in_reverse_chronological_order
       .limit(options[:limit])
   end
 
   def published_news_articles(options = {})
     news_articles
-      .latest_published_edition
+      .latest_live_edition
       .in_reverse_chronological_order
       .limit(options[:limit])
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -51,11 +51,11 @@ class Person < ApplicationRecord
   end
 
   def published_speeches
-    speeches.latest_published_edition.in_reverse_chronological_order
+    speeches.latest_live_edition.in_reverse_chronological_order
   end
 
   def published_news_articles
-    news_articles.latest_published_edition.in_reverse_chronological_order
+    news_articles.latest_live_edition.in_reverse_chronological_order
   end
 
   def destroyable?

--- a/app/presenters/feature_presenter.rb
+++ b/app/presenters/feature_presenter.rb
@@ -14,7 +14,7 @@ FeaturePresenter = Struct.new(:feature) do
   delegate :document, to: :feature
 
   def edition
-    document.published_edition
+    document.live_edition
   end
 
   delegate :topical_event, to: :feature

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -287,7 +287,7 @@ module PublishingApi
 
     def featured_documents_editioned(feature)
       # Editioned formats (like news) that have been featured
-      edition = feature.document.published_edition
+      edition = feature.document.live_edition
       {
         title: edition.title,
         href: Whitehall.url_maker.public_document_path(edition),

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -3,6 +3,7 @@ class DraftEditionUpdater < EditionService
     if can_perform?
       update_publishing_api!
       notify!
+      update_latest_edition
       true
     end
   end
@@ -17,5 +18,9 @@ class DraftEditionUpdater < EditionService
 
   def verb
     "update_draft"
+  end
+
+  def update_latest_edition
+    edition.document.update!(latest_edition_id: edition.id)
   end
 end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -3,7 +3,7 @@ class DraftEditionUpdater < EditionService
     if can_perform?
       update_publishing_api!
       notify!
-      update_latest_edition
+      update_live_edition_id_and_latest_edition_id
       true
     end
   end
@@ -18,9 +18,5 @@ class DraftEditionUpdater < EditionService
 
   def verb
     "update_draft"
-  end
-
-  def update_latest_edition
-    edition.document.update!(latest_edition_id: edition.id)
   end
 end

--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -27,5 +27,10 @@ private
     edition.save!(validate: false)
     edition.clear_slug
     edition.delete_all_attachments if edition.respond_to?(:delete_all_attachments)
+    update_latest_edition_id
+  end
+
+  def update_latest_edition_id
+    edition.document.update!(latest_edition_id: edition.document.live_edition_id)
   end
 end

--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -27,10 +27,5 @@ private
     edition.save!(validate: false)
     edition.clear_slug
     edition.delete_all_attachments if edition.respond_to?(:delete_all_attachments)
-    update_latest_edition_id
-  end
-
-  def update_latest_edition_id
-    edition.document.update!(latest_edition_id: edition.document.live_edition_id)
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -39,7 +39,6 @@ private
     super
     supersede_previous_editions!
     delete_unpublishing!
-    update_live_edition_id
   end
 
   def previous_editions
@@ -70,9 +69,5 @@ private
     return if edition.document.published?
 
     edition.political = PoliticalContentIdentifier.political?(edition)
-  end
-
-  def update_live_edition_id
-    edition.document.update!(live_edition_id: edition.id)
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -39,6 +39,7 @@ private
     super
     supersede_previous_editions!
     delete_unpublishing!
+    update_live_edition_id
   end
 
   def previous_editions
@@ -69,5 +70,9 @@ private
     return if edition.document.published?
 
     edition.political = PoliticalContentIdentifier.political?(edition)
+  end
+
+  def update_live_edition_id
+    edition.document.update!(live_edition_id: edition.id)
   end
 end

--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -14,6 +14,7 @@ class EditionService
         prepare_edition
         fire_transition!
         update_publishing_api!
+        update_live_edition_id_and_latest_edition_id
       end
       notify!
       true
@@ -69,5 +70,9 @@ private
 
   def fire_transition!
     edition.public_send("#{verb}!")
+  end
+
+  def update_live_edition_id_and_latest_edition_id
+    UpdateLiveAndLatestEditionId.new(edition.document).call
   end
 end

--- a/app/services/update_live_and_latest_edition_id.rb
+++ b/app/services/update_live_and_latest_edition_id.rb
@@ -1,0 +1,31 @@
+class UpdateLiveAndLatestEditionId
+  attr_accessor :edition, :document
+
+  def initialize(edition)
+    @edition = edition
+    @document = edition.document
+  end
+
+  def call
+    update_live_edition_id
+    update_latest_edition_id
+  end
+
+private
+
+  def update_live_edition_id
+    document.update!(live_edition_id: edition.id) if edition.state.in?(Edition::PUBLICLY_VISIBLE_STATES)
+  end
+
+  def update_latest_edition_id
+    document.update!(latest_edition_id: edition.id) if !edition.deleted? && (latest_edition_id_is_blank? || edition_is_most_recent_pre_publication_edition?)
+  end
+
+  def latest_edition_id_is_blank?
+    document.latest_edition_id.blank?
+  end
+
+  def edition_is_most_recent_pre_publication_edition?
+    edition.id == document.editions.where(state: [Edition::PRE_PUBLICATION_STATES]).order(id: :desc).first&.id
+  end
+end

--- a/app/services/update_live_and_latest_edition_id.rb
+++ b/app/services/update_live_and_latest_edition_id.rb
@@ -1,9 +1,8 @@
 class UpdateLiveAndLatestEditionId
-  attr_accessor :edition, :document
+  attr_accessor :document
 
-  def initialize(edition)
-    @edition = edition
-    @document = edition.document
+  def initialize(document)
+    @document = document
   end
 
   def call
@@ -14,18 +13,12 @@ class UpdateLiveAndLatestEditionId
 private
 
   def update_live_edition_id
-    document.update!(live_edition_id: edition.id) if edition.state.in?(Edition::PUBLICLY_VISIBLE_STATES)
+    live_edition_id = document.editions.where(state: Edition::PUBLICLY_VISIBLE_STATES).order(id: :desc).limit(1).first&.id
+    document.update!(live_edition_id: live_edition_id)
   end
 
   def update_latest_edition_id
-    document.update!(latest_edition_id: edition.id) if !edition.deleted? && (latest_edition_id_is_blank? || edition_is_most_recent_pre_publication_edition?)
-  end
-
-  def latest_edition_id_is_blank?
-    document.latest_edition_id.blank?
-  end
-
-  def edition_is_most_recent_pre_publication_edition?
-    edition.id == document.editions.where(state: [Edition::PRE_PUBLICATION_STATES]).order(id: :desc).first&.id
+    latest_edition_id = document.editions.where.not(state: "deleted").order(id: :desc).limit(1).first&.id
+    document.update!(latest_edition_id: latest_edition_id)
   end
 end

--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -19,11 +19,11 @@
       <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
     </div>
   <% end %>
-<% elsif edition.pre_publication? && edition.latest_published_edition %>
+<% elsif edition.pre_publication? && edition.latest_live_edition %>
   <div class="alert alert-info">
     <p>This is a new draft of a document that has already been published.</p>
     <p>
-      <%= link_to "Go to published edition", admin_edition_path(edition.latest_published_edition), class: "btn btn-primary" %>
+      <%= link_to "Go to published edition", admin_edition_path(edition.latest_live_edition), class: "btn btn-primary" %>
       <% if edition.previous_edition %>
         <%= link_to "See what’s changed", diff_admin_edition_path(edition, audit_trail_entry_id: edition.previous_edition.id), class: "btn btn-default" %>
       <% end %>

--- a/app/views/admin/feature_lists/_current_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_current_feature_list.html.erb
@@ -15,14 +15,14 @@
         <div class="well feature-list">
           <%= label_tag "ordering-#{feature.id}" do %>
             <div class="row">
-              <% if feature.document && feature.document.published_edition %>
+              <% if feature.document && feature.document.live_edition %>
                 <div class="title col-md-6">
                   <i class="glyphicon glyphicon-align-justify add-right-margin"></i>
-                  <%= link_to(feature, admin_edition_path(feature.document.published_edition)) %>
+                  <%= link_to(feature, admin_edition_path(feature.document.live_edition)) %>
                 </div>
-                <div class="type col-md-2"><%= feature.document.published_edition.type.titleize %> (document)</div>
-                <div class="date col-md-2"><%=localize feature.document.published_edition.major_change_published_at.to_date %></div>
-                <%= content_tag_for :div, feature.document.published_edition, class: "button text-right col-md-2" do %>
+                <div class="type col-md-2"><%= feature.document.live_edition.type.titleize %> (document)</div>
+                <div class="date col-md-2"><%=localize feature.document.live_edition.major_change_published_at.to_date %></div>
+                <%= content_tag_for :div, feature.document.live_edition, class: "button text-right col-md-2" do %>
                   <%= link_to('Unfeature',
                         unfeature_admin_feature_list_feature_path(feature_list, feature),
                         data: { confirm: "Unfeature '#{feature}'?" },

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -24,7 +24,7 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
     check_if_locked_document(document: document)
 
     # this the latest edition in a visible state ie: withdrawn, published
-    @published_edition = document.published_edition
+    @published_edition = document.live_edition
     # this is the latest edition in a non visible state - draft, scheduled
     # unpublished editions (other than withdrawn) will be in draft state with
     # an associated unpublishing

--- a/db/migrate/20220718210147_add_latest_edition_and_published_edition_to_document.rb
+++ b/db/migrate/20220718210147_add_latest_edition_and_published_edition_to_document.rb
@@ -1,0 +1,47 @@
+class AddLatestEditionAndPublishedEditionToDocument < ActiveRecord::Migration[7.0]
+  def up
+    change_table :documents, bulk: true do |t|
+      t.column :latest_edition_id, :integer
+      t.column :live_edition_id, :integer
+      t.index %i[latest_edition_id]
+      t.index %i[live_edition_id]
+    end
+
+    add_foreign_key :documents, :editions, column: :latest_edition_id
+    add_foreign_key :documents, :editions, column: :live_edition_id
+
+    # Backfill live_edition_id
+    execute <<-SQL
+      UPDATE documents
+      SET live_edition_id = (
+        SELECT MAX(id)
+        FROM editions
+        WHERE documents.id = editions.document_id
+        AND editions.state IN ('published', 'withdrawn')
+      )
+    SQL
+
+    # Backfill latest_edition_id
+    execute <<-SQL
+      UPDATE documents
+      SET latest_edition_id = (
+        SELECT MAX(id)
+        FROM editions
+        WHERE documents.id = editions.document_id
+        AND editions.state != 'deleted'
+      )
+    SQL
+  end
+
+  def down
+    remove_foreign_key :documents, :editions, column: :latest_edition_id
+    remove_foreign_key :documents, :editions, column: :live_edition_id
+
+    change_table :documents, bulk: true do |t|
+      t.remove :latest_edition_id
+      t.remove :live_edition_id
+      t.remove_index :latest_edition_id
+      t.remove_index :live_edition_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_18_073429) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_18_210147) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -268,7 +268,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_073429) do
     t.string "document_type"
     t.string "content_id", null: false
     t.boolean "locked", default: false, null: false
+    t.integer "latest_edition_id"
+    t.integer "live_edition_id"
     t.index ["document_type"], name: "index_documents_on_document_type"
+    t.index ["latest_edition_id"], name: "index_documents_on_latest_edition_id"
+    t.index ["live_edition_id"], name: "index_documents_on_live_edition_id"
     t.index ["slug", "document_type"], name: "index_documents_on_slug_and_document_type", unique: true
   end
 
@@ -1205,6 +1209,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_073429) do
     t.datetime "updated_at", precision: nil
   end
 
+  add_foreign_key "documents", "editions", column: "latest_edition_id"
+  add_foreign_key "documents", "editions", column: "live_edition_id"
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
 end

--- a/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
+++ b/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
@@ -5,12 +5,12 @@ When(/^I unwithdraw the publication$/) do
   click_link "Unwithdraw"
   click_button "Unwithdraw"
 
-  @latest_published_edition = publication.document.published_edition
+  @latest_live_edition = publication.document.live_edition
 
   expect(:superseded).to eq(publication.reload.current_state)
-  expect(:published).to eq(@latest_published_edition.current_state)
+  expect(:published).to eq(@latest_live_edition.current_state)
 end
 
 Then(/^I should be redirected to the latest edition of the publication$/) do
-  expect(page).to have_current_path(admin_edition_path(@latest_published_edition))
+  expect(page).to have_current_path(admin_edition_path(@latest_live_edition))
 end

--- a/lib/content_publisher/document_collection_group_membership_migrator.rb
+++ b/lib/content_publisher/document_collection_group_membership_migrator.rb
@@ -7,7 +7,7 @@ module ContentPublisher
     end
 
     def call
-      edition = document.published_edition || document.latest_edition
+      edition = document.live_edition || document.latest_edition
 
       return unless DocumentCollectionGroupMembership.exists?(document_id: document.id)
 

--- a/lib/content_publisher/featured_document_migrator.rb
+++ b/lib/content_publisher/featured_document_migrator.rb
@@ -7,7 +7,7 @@ module ContentPublisher
     end
 
     def call
-      edition = document.published_edition.presence || document.latest_edition
+      edition = document.live_edition.presence || document.latest_edition
 
       public_url = Whitehall.url_maker.public_document_url(edition)
       public_updated_at = (edition.public_timestamp || edition.updated_at)

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -41,6 +41,11 @@ FactoryBot.define do
           manually_numbered_headings: evaluator.manually_numbered_headings,
         )
     end
+
+    after :create do |attachment|
+      attachment.attachable.save!
+      attachment.attachable.document.update!(latest_edition_id: attachment.attachable_id) if attachment.attachable_type == "Edition"
+    end
   end
 
   factory :external_attachment, traits: [:abstract_attachment] do

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     auth_bypass_id { SecureRandom.uuid }
 
     after :create do |edition|
-      UpdateLiveAndLatestEditionId.new(edition).call
+      UpdateLiveAndLatestEditionId.new(edition.document).call
     end
 
     trait(:with_organisations) do
@@ -109,8 +109,7 @@ FactoryBot.define do
       state { "superseded" }
 
       after(:create) do |edition|
-        published_edition = create(:published_edition, document: edition.document)
-        edition.document.update!(latest_edition_id: published_edition.id)
+        create(:published_edition, document: edition.document)
       end
     end
 

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -11,9 +11,7 @@ FactoryBot.define do
     auth_bypass_id { SecureRandom.uuid }
 
     after :create do |edition|
-      document = edition.document
-      document.update!(live_edition_id: edition.id) if edition.state.in?(Edition::PUBLICLY_VISIBLE_STATES)
-      document.update!(latest_edition_id: edition.id) if !edition.deleted? && (document.latest_edition_id.blank? || edition.id == document.editions.where(state: [Edition::PRE_PUBLICATION_STATES]).order(id: :desc).first&.id)
+      UpdateLiveAndLatestEditionId.new(edition).call
     end
 
     trait(:with_organisations) do

--- a/test/functional/admin/generic_editions_controller_tests/translation_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/translation_test.rb
@@ -86,6 +86,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
       edition.attributes = { title: "french-title", summary: "french-summary", body: "french-body" }
     end
     edition.save!
+    edition.document.update!(latest_edition_id: edition.id, live_edition_id: edition.id)
 
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -488,6 +488,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
   test "responds with 404 if no attachable is present" do
     draft_edition = create(:publication, organisations: [organisation1, organisation2])
     create(:file_attachment, attachment_data: attachment_data, attachable: draft_edition)
+    draft_edition.document.update!(latest_edition_id: nil)
     draft_edition.destroy!
     setup_stubs(accessible?: true, visible_edition: nil)
     ActionController::TestRequest.any_instance.stubs(:hostname).returns("draft-assets.integration.publishing.service.gov.uk")

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -199,6 +199,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "should destroy associated consultation participation when destroyed" do
     consultation_participation = create(:consultation_participation, link_url: "http://example.com")
     consultation = create(:consultation, consultation_participation: consultation_participation)
+    consultation.document.update!(latest_edition_id: nil, live_edition_id: nil)
     consultation.destroy!
     assert_not ConsultationParticipation.exists?(consultation_participation.id)
   end
@@ -206,6 +207,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "should destroy the consultation outcome when the consultation is destroyed" do
     consultation = create(:consultation)
     outcome = create(:consultation_outcome, consultation: consultation)
+    consultation.document.update!(latest_edition_id: nil, live_edition_id: nil)
 
     consultation.destroy!
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -58,14 +58,6 @@ class DocumentTest < ActiveSupport::TestCase
     assert_not published_publication.document.published?
   end
 
-  test "should ignore deleted editions when finding latest edition" do
-    document = create(:document)
-    original_edition = create(:published_edition, document: document)
-    _deleted_edition = create(:deleted_edition, document: document)
-
-    assert_equal original_edition, document.latest_edition
-  end
-
   test "#pre_publication_edition returns the edition in a pre-publication state" do
     document = create(:document)
     create(:deleted_edition, document: document)

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -24,7 +24,7 @@ class DocumentTest < ActiveSupport::TestCase
     published_publication = draft_publication
     _new_draft_publication = published_publication.create_draft(user)
 
-    assert_equal published_publication, document.reload.published_edition
+    assert_equal published_publication, document.reload.live_edition
   end
 
   test "should be able to retrieve documents of a certain type at a particular slug" do
@@ -47,15 +47,6 @@ class DocumentTest < ActiveSupport::TestCase
   test "should not be published if no published edition exists" do
     draft_publication = create(:draft_publication)
     assert_not draft_publication.document.published?
-  end
-
-  test "should no longer be published when it's edition is unpublished" do
-    published_publication = create(:published_publication)
-    assert published_publication.document.published?
-
-    published_publication.unpublish!
-
-    assert_not published_publication.document.published?
   end
 
   test "#pre_publication_edition returns the edition in a pre-publication state" do

--- a/test/unit/edition/fact_checkable_test.rb
+++ b/test/unit/edition/fact_checkable_test.rb
@@ -4,6 +4,7 @@ class Edition::FactCheckableTest < ActiveSupport::TestCase
   test "#destroy should also remove the fact check requests" do
     edition = create(:draft_publication)
     fact_check_request = create(:fact_check_request, edition: edition)
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not FactCheckRequest.find_by(id: fact_check_request.id)
   end

--- a/test/unit/edition/nation_inapplicability_test.rb
+++ b/test/unit/edition/nation_inapplicability_test.rb
@@ -8,6 +8,7 @@ class Edition::NationInapplicabilityTest < ActiveSupport::TestCase
 
   test "#destroy should also remove the relationship" do
     relation = @edition.nation_inapplicabilities.first
+    @edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     @edition.destroy!
 
     assert_not NationInapplicability.find_by(id: relation.id)

--- a/test/unit/edition/organisations_test.rb
+++ b/test/unit/edition/organisations_test.rb
@@ -4,6 +4,7 @@ class Edition::OrganisationsTest < ActiveSupport::TestCase
   test "#destroy removes relationship with organisation" do
     edition = create(:draft_publication, organisations: [create(:organisation)])
     relation = edition.edition_organisations.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not EditionOrganisation.exists?(relation.id)
   end

--- a/test/unit/edition/topical_events_test.rb
+++ b/test/unit/edition/topical_events_test.rb
@@ -10,6 +10,7 @@ class Edition::TopicalEventsTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     edition = create(:published_news_article, topical_events: [topical_event])
     relation = edition.classification_memberships.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not ClassificationMembership.find_by(id: relation.id)
   end
@@ -30,6 +31,7 @@ class Edition::TopicalEventsTest < ActiveSupport::TestCase
     edition = create(:published_news_article)
     _rel = topical_event.feature(edition_id: edition.id, alt_text: "Woooo", image: create(:classification_featuring_image_data))
     relation = edition.classification_featurings.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not ClassificationFeaturing.find_by(id: relation.id)
   end

--- a/test/unit/edition/world_locations_test.rb
+++ b/test/unit/edition/world_locations_test.rb
@@ -4,6 +4,7 @@ class Edition::WorldLocationsTest < ActiveSupport::TestCase
   test "#destroy should also remove the relationship" do
     edition = create(:draft_publication, world_locations: [create(:world_location)])
     relation = edition.edition_world_locations.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not EditionWorldLocation.find_by(id: relation.id)
   end

--- a/test/unit/edition/worldwide_organisations_test.rb
+++ b/test/unit/edition/worldwide_organisations_test.rb
@@ -8,6 +8,7 @@ class Edition::WorldwideOrganisationsTest < ActiveSupport::TestCase
   test "#destroy removes association with organisations" do
     organisation = create(:worldwide_organisation)
     edition = create(:draft_case_study, worldwide_organisations: [organisation])
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not edition.edition_worldwide_organisations.any?
     assert WorldwideOrganisation.exists?(organisation.id)

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -107,13 +107,13 @@ class EditionTest < ActiveSupport::TestCase
     assert_not Edition.latest_edition.include?(deleted_edition)
   end
 
-  test ".latest_published_edition includes only published editions" do
+  test ".latest_live_edition includes only published editions" do
     document = create(:document)
     original_edition = create(:published_edition, document: document)
     draft_edition = create(:draft_edition, document: document)
 
-    assert Edition.latest_published_edition.include?(original_edition)
-    assert_not Edition.latest_published_edition.include?(draft_edition)
+    assert Edition.latest_live_edition.include?(original_edition)
+    assert_not Edition.latest_live_edition.include?(draft_edition)
   end
 
   test ".most_recent_change_note returns the most recent change note" do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -499,6 +499,7 @@ class EditionTest < ActiveSupport::TestCase
   test "#destroy should also remove the relationship to any authors" do
     edition = create(:draft_edition, creator: create(:writer))
     relation = edition.edition_authors.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not EditionAuthor.find_by(id: relation.id)
   end
@@ -506,6 +507,7 @@ class EditionTest < ActiveSupport::TestCase
   test "#destroy should also remove the relationship to any editorial remarks" do
     edition = create(:draft_edition, editorial_remarks: [create(:editorial_remark)])
     relation = edition.editorial_remarks.first
+    edition.document.update!(latest_edition_id: nil, live_edition_id: nil)
     edition.destroy!
     assert_not EditorialRemark.find_by(id: relation.id)
   end

--- a/test/unit/feature_list_test.rb
+++ b/test/unit/feature_list_test.rb
@@ -89,7 +89,7 @@ class FeatureListTest < ActiveSupport::TestCase
     assert_equal [new_draft.document], feature_list.features.map(&:document)
   end
 
-  test "#published_features only returns features where there is a published edition" do
+  test "#published_features only returns features where there is a live edition" do
     published = create(:published_news_article)
     draft = create(:draft_news_article)
 

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -12,6 +12,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
     corporate_information_page.external = true
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    corporate_information_page.document.update!(latest_edition_id: nil, live_edition_id: nil)
     corporate_information_page.save!
   end
 
@@ -19,6 +20,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    corporate_information_page.document.update!(latest_edition_id: nil, live_edition_id: nil)
     corporate_information_page.destroy!
   end
 

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -21,7 +21,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path generates a localized link to the edition" do
     d = stub_record(:document)
     cs = stub_record(:case_study, document: d, create_default_organisation: false)
-    d.stubs(:published_edition).returns(cs)
+    d.stubs(:live_edition).returns(cs)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -32,7 +32,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path generates an unlocalized link to the edition if it's not a localizable type" do
     d = stub_record(:document)
     p = stub_record(:consultation, document: d, create_default_organisation: false, alternative_format_provider: nil)
-    d.stubs(:published_edition).returns(p)
+    d.stubs(:live_edition).returns(p)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -43,7 +43,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path respects the locale of the feature when generating localized edition links" do
     d = stub_record(:document)
     cs = stub_record(:case_study, document: d, create_default_organisation: false)
-    d.stubs(:published_edition).returns(cs)
+    d.stubs(:live_edition).returns(cs)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -56,7 +56,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path forces the global locale to english when generating edition links for a non localizable types" do
     d = stub_record(:document)
     p = stub_record(:consultation, document: d, create_default_organisation: false, alternative_format_provider: nil)
-    d.stubs(:published_edition).returns(p)
+    d.stubs(:live_edition).returns(p)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -64,6 +64,6 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
     edition ||= @edition
     @unwithdrawer = EditionUnwithdrawer.new(edition, user: @user)
     @unwithdrawer.perform!
-    edition.document.published_edition
+    edition.document.live_edition
   end
 end

--- a/test/unit/services/updated_published_and_latest_edition_id_test.rb
+++ b/test/unit/services/updated_published_and_latest_edition_id_test.rb
@@ -9,7 +9,7 @@ class UpdateLiveAndLatestEditionIdTest < ActiveSupport::TestCase
     @document.update!(live_edition_id: nil, latest_edition_id: nil)
   end
 
-  test "updates published_edition_id to the most recent publicly_visible editions id" do
+  test "updates live_edition_id to the most recent publicly_visible editions id" do
     UpdateLiveAndLatestEditionId.new(@document).call
     assert_equal @document.live_edition_id, @withdrawn_edition.id
   end

--- a/test/unit/services/updated_published_and_latest_edition_id_test.rb
+++ b/test/unit/services/updated_published_and_latest_edition_id_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class UpdateLiveAndLatestEditionIdTest < ActiveSupport::TestCase
+  setup do
+    @document = create(:document)
+    @published_edition = create(:edition, :published, document: @document)
+    @withdrawn_edition = create(:edition, :withdrawn, document: @document)
+    @deleted_edition = create(:edition, :deleted, document: @document)
+    @document.update!(live_edition_id: nil, latest_edition_id: nil)
+  end
+
+  test "updates published_edition_id to the most recent publicly_visible editions id" do
+    UpdateLiveAndLatestEditionId.new(@document).call
+    assert_equal @document.live_edition_id, @withdrawn_edition.id
+  end
+
+  test "updates latest_edition_id to the most recent non-deleted edition" do
+    UpdateLiveAndLatestEditionId.new(@document).call
+    assert_equal @document.latest_edition_id, @withdrawn_edition.id
+  end
+end

--- a/test/unit/tasks/asset_manager_test.rb
+++ b/test/unit/tasks/asset_manager_test.rb
@@ -53,12 +53,11 @@ class AssetManagerRake < ActiveSupport::TestCase
 
     test "does not update attachments where the latest edition isn't draft" do
       document = create(:document)
-      scheduled_edition = create(:scheduled_detailed_guide, document: document)
       published_edition = create(:published_detailed_guide, document: document)
 
       assert_equal published_edition, document.latest_edition
 
-      create(:file_attachment, attachable: scheduled_edition)
+      create(:file_attachment, attachable: published_edition)
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
 
@@ -115,9 +114,8 @@ class AssetManagerRake < ActiveSupport::TestCase
 
     test "does not update attachments where the latest edition isn't draft" do
       document = create(:document)
-      scheduled_edition = create(:scheduled_consultation, document: document)
       published_edition = create(:published_consultation, document: document)
-      participation = create(:consultation_participation, consultation: scheduled_edition)
+      participation = create(:consultation_participation, consultation: published_edition)
       create(:consultation_response_form, consultation_participation: participation)
 
       assert_equal published_edition, document.latest_edition
@@ -224,12 +222,11 @@ class AssetManagerRake < ActiveSupport::TestCase
 
     test "does not update image where the latest edition isn't draft" do
       document = create(:document)
-      scheduled_edition = create(:scheduled_case_study, document: document)
       published_edition = create(:published_case_study, document: document)
 
       assert_equal published_edition, document.latest_edition
 
-      create(:image, edition: scheduled_edition)
+      create(:image, edition: published_edition)
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).never
 

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -70,6 +70,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     edition = build(:published_edition, title: "Published edition", document: document)
     with_locale(:es) { edition.title = "spanish-title" }
     edition.save!
+    edition.document.update!(latest_edition_id: edition.id, live_edition_id: edition.id)
 
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: "republish")
     requests = [

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -6,7 +6,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
   test "it pushes the published and the draft editions of a document if there is a later draft" do
     document = stub(
-      published_edition: published_edition = build(:edition, id: 1),
+      live_edition: published_edition = build(:edition, id: 1),
       id: 1,
       pre_publication_edition: draft_edition = build(:edition, id: 2),
       locked?: false,
@@ -47,7 +47,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   class DraftException < StandardError; end
   test "it pushes the published version first if there is a more recent draft" do
     document = stub(
-      published_edition: build(:edition),
+      live_edition: build(:edition),
       id: 1,
       pre_publication_edition: build(:edition),
       locked?: false,
@@ -104,7 +104,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   test "it publishes and then unpublishes if the published edition is withdrawn" do
     unpublishing = build(:withdrawn_unpublishing, id: 10)
     document = stub(
-      published_edition: published_edition = create(:withdrawn_edition, unpublishing: unpublishing),
+      live_edition: published_edition = create(:withdrawn_edition, unpublishing: unpublishing),
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
@@ -137,7 +137,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
   test "it raises if an unknown combination is encountered" do
     document = stub(
-      published_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
+      live_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
@@ -155,7 +155,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     # we want to ignore these and not have to try and avoid passing them in
     # when doing bulk republishing
     document = stub(
-      published_edition: nil,
+      live_edition: nil,
       id: 1,
       pre_publication_edition: nil,
       locked?: false,


### PR DESCRIPTION
## Document 

https://docs.google.com/document/d/1WQ5u0JmFHYu1Hv0TX9YGEfPLWyhMZblVvHkSlObxMJM/edit

## Trello card 

https://trello.com/c/iWcORsD5/549-investigate-if-we-can-get-the-latest-edition-of-a-document-more-efficiently

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
