### PR TITLE
Bump paste html to govspeak v0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "jquery": "1.12.4",
-    "paste-html-to-govspeak": "^0.2.6"
+    "paste-html-to-govspeak": "^0.3.0"
   },
   "devDependencies": {
     "jasmine-browser-runner": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,10 +1817,10 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-paste-html-to-govspeak@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.6.tgz#a7bbb5e2b7ce4b38a0fec68febf67001d4764163"
-  integrity sha512-vRF4DbxgVqaI5bCFWrNAxRHSPY1NYNAwKR9M1v0YB928kvrh0TOvPGY9R67nzRm44L8Fn/+TdILA/NldeN2RjQ==
+paste-html-to-govspeak@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.3.0.tgz#9c4717690f3d6cd290c972c9bf106ead14adb177"
+  integrity sha512-K4jcJkZLQpvpukkiSzXZcXPbV80CDSKTI3zEs0/gVG+jx5H7v2XsdIOEuCZ56cRCCuuIH3rsrJcyoleGqPj6xw==
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What
Currently, the Paste to Govspeak converter (paste-html-to-govspeak) in the publishing applications automatically converts any H4s, H5s and H6s to a H3 - see https://github.com/alphagov/paste-html-to-govspeak/blob/main/src/html-to-govspeak.js#L88:L89.

We want to remove this functionality and allow H4s, H5s and H6s without them being converted to H3s.

## Why
Although GOV.UK doesn't style H4s and below (in non-HTML attachments), it's important for users using assistive technology get the correct heading structure.

https://trello.com/c/aWGmHS2s/573-allow-h4s-to-h6s-with-paste-to-govspeak-converter

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
