### PR TITLE
Add additional routes for Topical Event presentation

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "topical_event",
       )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item, additional_routes: %w[atom]))
     end
 
     def links

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -40,6 +40,10 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
           path: public_path,
           type: "exact",
         },
+        {
+          path: "#{public_path}.atom",
+          type: "exact",
+        },
       ],
       update_type: "major",
       redirects: [],
@@ -106,6 +110,10 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
       routes: [
         {
           path: public_path,
+          type: "exact",
+        },
+        {
+          path: "#{public_path}.atom",
           type: "exact",
         },
       ],


### PR DESCRIPTION
The atom feed for topical events is currently being rendered by Whitehall, despite the code for this being migrated to Collections.

The reason being is router was not aware of the atom feed routes, so used the default behaviour of sending all unregistered `/government` requests to Whitehall.

Adding the additional route to the content that is presented to Publishing API to resolve this issue.

After deployment, all topical events will need to be republished using the following rake task: `publishing_api:republish:all_topical_events`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
