### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -7,6 +7,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/big-number";
 @import "govuk_publishing_components/components/contents-list";


### PR DESCRIPTION
## What

Prevent the font from being included in `whitehall`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `whitehall`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `whitehall`.

Before (the font paths contains `whitehall`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/181037319-666ab623-31a4-4e1d-85e5-3d1654876c26.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/181037342-34cc0ec4-e976-4eb6-b860-53ab6e4f625e.png">

---

## Search page examples to sanity check:

- TBC