### PR TITLE
Add info to world location news presenter

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,6 +5,7 @@ class Organisation < ApplicationRecord
   include Organisation::OrganisationTypeConcern
 
   DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
+  FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
   belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
 

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -149,7 +149,7 @@ class WorldLocation < ApplicationRecord
   friendly_id
 
   def send_news_page_to_publishing_api_and_rummager
-    WorldLocationNewsPageWorker.new.perform(id)
+    WorldLocationNewsWorker.new.perform(id)
   end
 
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 5

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -151,4 +151,6 @@ class WorldLocation < ApplicationRecord
   def send_news_page_to_publishing_api_and_rummager
     WorldLocationNewsPageWorker.new.perform(id)
   end
+
+  FEATURED_DOCUMENTS_DISPLAY_LIMIT = 5
 end

--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -1,6 +1,6 @@
 module PublishingApi
   module FeaturedDocumentsPresenter
-    def featured_documents(featurable_item, document_limit = 6)
+    def featured_documents(featurable_item, document_limit)
       featurable_item.feature_list_for_locale(I18n.locale).current.limit(document_limit).map do |feature|
         if feature.document
           featured_documents_editioned(feature)

--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -1,0 +1,65 @@
+module PublishingApi
+  module FeaturedDocumentsPresenter
+    def featured_documents(featurable_item, document_limit = 6)
+      featurable_item.feature_list_for_locale(I18n.locale).current.limit(document_limit).map do |feature|
+        if feature.document
+          featured_documents_editioned(feature)
+        elsif feature.topical_event
+          featured_documents_topical_event(feature)
+        elsif feature.offsite_link
+          featured_documents_offsite_link(feature)
+        end
+      end
+    end
+
+  private
+
+    def featured_documents_editioned(feature)
+      # Editioned formats (like news) that have been featured
+      edition = feature.document.published_edition
+      {
+        title: edition.title,
+        href: Whitehall.url_maker.public_document_path(edition),
+        image: {
+          url: feature.image.url,
+          alt_text: feature.alt_text,
+        },
+        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(edition.summary),
+        public_updated_at: edition.public_timestamp,
+        document_type: edition.display_type,
+      }
+    end
+
+    def featured_documents_topical_event(feature)
+      # Topical events that have been featured
+      topical_event = feature.topical_event
+      {
+        title: topical_event.name,
+        href: Whitehall.url_maker.polymorphic_path(topical_event),
+        image: {
+          url: feature.image.url,
+          alt_text: feature.alt_text,
+        },
+        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
+        public_updated_at: topical_event.start_date,
+        document_type: nil, # We don't want a type for topical events
+      }
+    end
+
+    def featured_documents_offsite_link(feature)
+      # Offsite links that have been featured
+      offsite_link = feature.offsite_link
+      {
+        title: offsite_link.title,
+        href: offsite_link.url,
+        image: {
+          url: feature.image.url,
+          alt_text: feature.alt_text,
+        },
+        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(offsite_link.summary),
+        public_updated_at: offsite_link.date,
+        document_type: offsite_link.display_type,
+      }
+    end
+  end
+end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -7,6 +7,7 @@ module PublishingApi
     include OrganisationHelper
     # This is a hack to get the OrganisationHelper to work in this context
     include ActionView::Helpers::UrlHelper
+    include FeaturedDocumentsPresenter
 
     attr_accessor :item, :update_type
 
@@ -83,7 +84,7 @@ module PublishingApi
         ordered_corporate_information_pages: corporate_information_pages,
         secondary_corporate_information_pages: secondary_corporate_information_pages,
         ordered_featured_links: featured_links,
-        ordered_featured_documents: featured_documents,
+        ordered_featured_documents: featured_documents(item),
         ordered_promotional_features: promotional_features,
         important_board_members: important_board_members,
         organisation_featuring_priority: organisation_featuring_priority,
@@ -271,66 +272,6 @@ module PublishingApi
           href: link.url,
         }
       end
-    end
-
-    def featured_documents
-      item.feature_list_for_locale(I18n.locale).current.limit(6).map do |feature|
-        if feature.document
-          featured_documents_editioned(feature)
-        elsif feature.topical_event
-          featured_documents_topical_event(feature)
-        elsif feature.offsite_link
-          featured_documents_offsite_link(feature)
-        end
-      end
-    end
-
-    def featured_documents_editioned(feature)
-      # Editioned formats (like news) that have been featured
-      edition = feature.document.published_edition
-      {
-        title: edition.title,
-        href: Whitehall.url_maker.public_document_path(edition),
-        image: {
-          url: feature.image.url,
-          alt_text: feature.alt_text,
-        },
-        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(edition.summary),
-        public_updated_at: edition.public_timestamp,
-        document_type: edition.display_type,
-      }
-    end
-
-    def featured_documents_topical_event(feature)
-      # Topical events that have been featured
-      topical_event = feature.topical_event
-      {
-        title: topical_event.name,
-        href: Whitehall.url_maker.polymorphic_path(topical_event),
-        image: {
-          url: feature.image.url,
-          alt_text: feature.alt_text,
-        },
-        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
-        public_updated_at: topical_event.start_date,
-        document_type: nil, # We don't want a type for topical events
-      }
-    end
-
-    def featured_documents_offsite_link(feature)
-      # Offsite links that have been featured
-      offsite_link = feature.offsite_link
-      {
-        title: offsite_link.title,
-        href: offsite_link.url,
-        image: {
-          url: feature.image.url,
-          alt_text: feature.alt_text,
-        },
-        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(offsite_link.summary),
-        public_updated_at: offsite_link.date,
-        document_type: offsite_link.display_type,
-      }
     end
 
     def promotional_features

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -84,7 +84,7 @@ module PublishingApi
         ordered_corporate_information_pages: corporate_information_pages,
         secondary_corporate_information_pages: secondary_corporate_information_pages,
         ordered_featured_links: featured_links,
-        ordered_featured_documents: featured_documents(item),
+        ordered_featured_documents: featured_documents(item, item.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
         ordered_promotional_features: promotional_features,
         important_board_members: important_board_members,
         organisation_featuring_priority: organisation_featuring_priority,

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -18,6 +18,7 @@ module PublishingApi
         description: description,
         details: {
           ordered_featured_links: featured_links,
+          mission_statement: world_location.mission_statement || "",
         },
         document_type: "placeholder_world_location_news_page",
         public_updated_at: world_location.updated_at,

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -16,7 +16,9 @@ module PublishingApi
 
       content.merge!(
         description: description,
-        details: {},
+        details: {
+          ordered_featured_links: featured_links,
+        },
         document_type: "placeholder_world_location_news_page",
         public_updated_at: world_location.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
@@ -45,6 +47,15 @@ module PublishingApi
     end
 
   private
+
+    def featured_links
+      world_location.featured_links.map do |link|
+        {
+          title: link.title,
+          href: link.url,
+        }
+      end
+    end
 
     def path_for_news_page
       Whitehall.url_maker.world_location_news_index_path(world_location)

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class WorldLocationNewsPagePresenter
+    include FeaturedDocumentsPresenter
+
     attr_accessor :world_location, :update_type
 
     def initialize(world_location, update_type: nil)
@@ -19,6 +21,7 @@ module PublishingApi
         details: {
           ordered_featured_links: featured_links,
           mission_statement: world_location.mission_statement || "",
+          ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
         },
         document_type: "placeholder_world_location_news_page",
         public_updated_at: world_location.updated_at,

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
         document_type: "placeholder_world_location_news_page",
         public_updated_at: world_location.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
+        schema_name: "world_location_news",
         base_path: path_for_news_page,
       )
       content.merge!(PayloadBuilder::Routes.for(path_for_news_page))

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -1,5 +1,5 @@
 module PublishingApi
-  class WorldLocationNewsPagePresenter
+  class WorldLocationNewsPresenter
     include FeaturedDocumentsPresenter
 
     attr_accessor :world_location, :update_type

--- a/app/views/admin/feature_lists/_current_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_current_feature_list.html.erb
@@ -2,7 +2,9 @@
 <p class="warning">
   Warning: changes to features appear instantly on the live site.
 </p>
-
+<p>
+    Please note that you can only feature a maximum of <%= maximum_featured_documents %> documents. Any featured documents beyond this limit will not appear on the live site.
+</p>
 <% if feature_list.features.current.any? %>
   <% if feature_list.features.current.many? %>
     <p>

--- a/app/views/admin/feature_lists/_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_feature_list.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'admin/feature_lists/current_feature_list', locals: {feature_list: feature_list} %>
+<%= render partial: 'admin/feature_lists/current_feature_list', locals: {feature_list: feature_list, maximum_featured_documents: maximum_featured_documents } %>
 
 <hr />
 <h2 class="add-bottom-margin feature-title">Feature new documents</h2>

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -5,6 +5,6 @@
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>
-    <%= render @feature_list, filter_by: [:title, :type, :author, :organisation], maximum_featured_documents: @organisation.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT %>
+    <%= render partial: 'admin/feature_lists/feature_list', locals: {feature_list: @feature_list, filter_by: [:title, :type, :author, :organisation], maximum_featured_documents: @organisation.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT} %>
   <% end %>
 </section>

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -5,6 +5,6 @@
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>
-    <%= render @feature_list, filter_by: [:title, :type, :author, :organisation] %>
+    <%= render @feature_list, filter_by: [:title, :type, :author, :organisation], maximum_featured_documents: @organisation.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT %>
   <% end %>
 </section>

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -9,6 +9,6 @@
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>
-    <%= render @feature_list, filter_by: [:title, :type, :world_location] %>
+    <%= render @feature_list, filter_by: [:title, :type, :world_location], maximum_featured_documents: @world_location.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT %>
   </section>
 <% end %>

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -9,6 +9,6 @@
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>
-    <%= render @feature_list, filter_by: [:title, :type, :world_location], maximum_featured_documents: @world_location.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT %>
+    <%= render partial: 'admin/feature_lists/feature_list', locals: {feature_list: @feature_list, filter_by: [:title, :type, :world_location], maximum_featured_documents: @world_location.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT} %>
   </section>
 <% end %>

--- a/app/workers/world_location_news_worker.rb
+++ b/app/workers/world_location_news_worker.rb
@@ -1,4 +1,4 @@
-class WorldLocationNewsPageWorker < WorkerBase
+class WorldLocationNewsWorker < WorkerBase
   attr_accessor :world_location
 
   def perform(world_location_id)
@@ -25,7 +25,7 @@ private
   end
 
   def presenter
-    PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
+    PublishingApi::WorldLocationNewsPresenter.new(world_location)
   end
 
   def send_news_page_to_rummager

--- a/db/data_migration/20170814083356_republish_world_location_news_pages.rb
+++ b/db/data_migration/20170814083356_republish_world_location_news_pages.rb
@@ -1,4 +1,4 @@
 WorldLocation.where(world_location_type_id: 1).each do |world_location|
   puts "Republishing news page for #{world_location.name}"
-  WorldLocationNewsPageWorker.new.perform(world_location.id)
+  WorldLocationNewsWorker.new.perform(world_location.id)
 end

--- a/db/data_migration/20171003143628_republish_world_location_news_pages.rb
+++ b/db/data_migration/20171003143628_republish_world_location_news_pages.rb
@@ -1,4 +1,4 @@
 WorldLocation.pluck(:id).each do |id|
   print "."
-  WorldLocationNewsPageWorker.perform_async_in_queue("bulk_republishing", id)
+  WorldLocationNewsWorker.perform_async_in_queue("bulk_republishing", id)
 end

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -12,23 +12,23 @@ def add_translation_to_world_location(location, translation)
 end
 
 Given(/^an? (world location|international delegation) "([^"]*)" exists$/) do |world_location_type, name|
-  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   create(world_location_type.tr(" ", "_").to_sym, name: name, active: true)
 end
 
 Given(/^an? (world location|international delegation) "([^"]*)" exists with the mission statement "([^"]*)"$/) do |world_location_type, name, mission_statement|
-  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   create(world_location_type.tr(" ", "_").to_sym, name: name, active: true, mission_statement: mission_statement)
 end
 
 Given(/^the (world location|international delegation) "([^"]*)" is inactive/) do |world_location_type, name|
-  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   world_location = WorldLocation.find_by(name: name) || create(world_location_type.tr(" ", "_").to_sym, name: name, active: true)
   world_location.update_column(:active, false)
 end
 
 Given(/^an? (world location|international delegation) "([^"]*)" exists with a translation for the locale "([^"]*)"$/) do |world_location_type, name, locale|
-  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   location = create(world_location_type.tr(" ", "_").to_sym, name: name, active: true)
   locale = Locale.find_by_language_name(locale)
 

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -472,4 +472,13 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     get :edit, params: { id: organisation }
     assert_select ".political-status"
   end
+
+  view_test "the featurables tab should display information regarding max documents" do
+    first_feature = build(:feature, document: create(:published_case_study).document, ordering: 1)
+    organisation = create(:organisation)
+    create(:feature_list, locale: :en, featurable: organisation, features: [first_feature])
+    get :features, params: { id: organisation }
+
+    assert_match(/Please note that you can only feature a maximum of 6 documents.*/, response.body)
+  end
 end

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
       Locale.new(:fr), Locale.new(:es)
     ])
 
-    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+    WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Admin::WorldLocationsControllerTest < ActionController::TestCase
   setup do
     login_as :writer
-    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+    WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -113,4 +113,13 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
       assert_match(/#{Regexp.escape("https://www.test.gov.uk/world/france/news.fr")}/, view_links.first["href"])
     end
   end
+
+  view_test "the featurables tab should display information regarding the maximum number of featurable documents" do
+    first_feature = build(:feature, document: create(:published_case_study).document, ordering: 1)
+    world_location = create(:world_location, slug: "france")
+    create(:feature_list, locale: :en, featurable: world_location, features: [first_feature])
+    get :features, params: { id: world_location }
+
+    assert_match(/Please note that you can only feature a maximum of [\d+] documents.*/, response.body)
+  end
 end

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -137,7 +137,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
 
   test "shows featured items in defined order for locale" do
     with_stubbed_rummager(@rummager) do
-      WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+      WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
       LocalisedModel.new(@world_location, :fr).update!(name: "Territoire antarctique britannique")
 
       less_recent_news_article = create(:published_news_article, first_published_at: 2.days.ago)

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -7,7 +7,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
   def setup
-    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+    WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
     @rummager = stub
   end
 

--- a/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
@@ -8,6 +8,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
     first_feature = build(:feature, document: case_study.document, ordering: 1)
     news_article = create(:published_news_article)
     second_feature = build(:feature, document: news_article.document, ordering: 2)
+    featured_documents_display_limit = 5
 
     world_location = create(:world_location)
 
@@ -34,7 +35,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
             document_type: I18n.t("document.type.press_release.one") },
         ]
 
-        assert_equal expected_ordered_featured_documents, featured_documents(world_location)
+        assert_equal expected_ordered_featured_documents, featured_documents(world_location, featured_documents_display_limit)
       end
     end
   end
@@ -42,6 +43,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
   test("determines ordered featured documents in different locales for topical events") do
     topical_event = create(:topical_event, name: "topical_event_1", start_date: 1.year.ago.to_date)
     feature = build(:feature, document: nil, topical_event: topical_event, ordering: 1)
+    featured_documents_display_limit = 5
 
     organisation = create(:organisation)
 
@@ -61,7 +63,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
             document_type: nil },
         ]
 
-        assert_equal expected_ordered_featured_documents, featured_documents(organisation)
+        assert_equal expected_ordered_featured_documents, featured_documents(organisation, featured_documents_display_limit)
       end
     end
   end
@@ -69,6 +71,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
   test("determines ordered featured documents in different locales for offsite links") do
     offsite_link = create(:offsite_link, date: 1.year.ago.to_date)
     feature = build(:feature, document: nil, offsite_link: offsite_link, ordering: 1)
+    featured_documents_display_limit = 5
 
     organisation = create(:organisation)
 
@@ -88,12 +91,12 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
             document_type: offsite_link.display_type },
         ]
 
-        assert_equal expected_ordered_featured_documents, featured_documents(organisation)
+        assert_equal expected_ordered_featured_documents, featured_documents(organisation, featured_documents_display_limit)
       end
     end
   end
 
-  test("caps number of documents when limit provided") do
+  test("caps number of documents at limit when it exceeds this") do
     first_feature = build(:feature, document: create(:published_case_study).document, ordering: 1)
     second_feature = build(:feature, document: create(:published_news_article).document, ordering: 2)
 

--- a/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
@@ -1,0 +1,109 @@
+require "test_helper"
+
+class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
+  include PublishingApi::FeaturedDocumentsPresenter
+
+  test("determines ordered featured documents in different locales for editions") do
+    case_study = create(:published_case_study)
+    first_feature = build(:feature, document: case_study.document, ordering: 1)
+    news_article = create(:published_news_article)
+    second_feature = build(:feature, document: news_article.document, ordering: 2)
+
+    world_location = create(:world_location)
+
+    locales = %i[en fr]
+
+    locales.each do |locale|
+      I18n.with_locale(locale) do
+        create(:feature_list, locale: locale, featurable: world_location, features: [second_feature, first_feature])
+
+        expected_ordered_featured_documents = [
+          { title: case_study.title,
+            href: "/government/case-studies/case-study-title",
+            image: { url: first_feature.image.url,
+                     alt_text: first_feature.alt_text },
+            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(case_study.summary),
+            public_updated_at: case_study.public_timestamp,
+            document_type: I18n.t("document.type.case_study.one") },
+          { title: news_article.title,
+            href: "/government/news/news-title",
+            image: { url: second_feature.image.url,
+                     alt_text: second_feature.alt_text },
+            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(news_article.summary),
+            public_updated_at: news_article.public_timestamp,
+            document_type: I18n.t("document.type.press_release.one") },
+        ]
+
+        assert_equal expected_ordered_featured_documents, featured_documents(world_location)
+      end
+    end
+  end
+
+  test("determines ordered featured documents in different locales for topical events") do
+    topical_event = create(:topical_event, name: "topical_event_1", start_date: 1.year.ago.to_date)
+    feature = build(:feature, document: nil, topical_event: topical_event, ordering: 1)
+
+    organisation = create(:organisation)
+
+    locales = %i[en fr]
+
+    locales.each do |locale|
+      I18n.with_locale(locale) do
+        create(:feature_list, locale: locale, featurable: organisation, features: [feature])
+
+        expected_ordered_featured_documents = [
+          { title: topical_event.name,
+            href: "/government/topical-events/topical_event_1",
+            image: { url: feature.image.url,
+                     alt_text: feature.alt_text },
+            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
+            public_updated_at: topical_event.start_date,
+            document_type: nil },
+        ]
+
+        assert_equal expected_ordered_featured_documents, featured_documents(organisation)
+      end
+    end
+  end
+
+  test("determines ordered featured documents in different locales for offsite links") do
+    offsite_link = create(:offsite_link, date: 1.year.ago.to_date)
+    feature = build(:feature, document: nil, offsite_link: offsite_link, ordering: 1)
+
+    organisation = create(:organisation)
+
+    locales = %i[en fr]
+
+    locales.each do |locale|
+      I18n.with_locale(locale) do
+        create(:feature_list, locale: locale, featurable: organisation, features: [feature])
+
+        expected_ordered_featured_documents = [
+          { title: offsite_link.title,
+            href: offsite_link.url,
+            image: { url: feature.image.url,
+                     alt_text: feature.alt_text },
+            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(offsite_link.summary),
+            public_updated_at: offsite_link.date,
+            document_type: offsite_link.display_type },
+        ]
+
+        assert_equal expected_ordered_featured_documents, featured_documents(organisation)
+      end
+    end
+  end
+
+  test("caps number of documents when limit provided") do
+    first_feature = build(:feature, document: create(:published_case_study).document, ordering: 1)
+    second_feature = build(:feature, document: create(:published_news_article).document, ordering: 2)
+
+    world_location = create(:world_location)
+
+    create(:feature_list, locale: :en, featurable: world_location, features: [second_feature, first_feature])
+
+    document_limit = 1
+    presented_locations = featured_documents(world_location, document_limit)
+
+    assert_equal [create(:published_case_study).title], (presented_locations.map { |presented_location| presented_location[:title] })
+  end
+end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -114,6 +114,18 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_valid_against_publisher_schema(presented_item.content, "organisation")
   end
 
+  test "caps number of featured documents at 6" do
+    features = (1..7).to_a.map do |i|
+      created_case_study = create(:published_case_study, title: "case-study-#{i}")
+      build(:feature, document: created_case_study.document, ordering: i)
+    end
+    organisation = create(:organisation)
+
+    create(:feature_list, featurable: organisation, features: features)
+
+    assert_equal 6, present(organisation).content.dig(:details, :ordered_featured_documents).size
+  end
+
   test "presents an organisation’s custom logo" do
     organisation = create(
       :organisation,

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -10,13 +10,27 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
   end
 
   test "presents an item for publishing api" do
+    newer_link = create(:featured_link, linkable: world_location, title: "2 days ago", created_at: 2.days.ago)
+    older_link = create(:featured_link, linkable: world_location, title: "12 days ago", created_at: 12.days.ago)
+
     expected = {
       title: "Aardistan and the Uk",
       locale: "en",
       publishing_app: "whitehall",
       redirects: [],
       description: "Updates, news and events from the UK government in Aardistan",
-      details: {},
+      details: {
+        ordered_featured_links: [
+          {
+            title: older_link.title,
+            href: older_link.url,
+          },
+          {
+            title: newer_link.title,
+            href: newer_link.url,
+          },
+        ],
+      },
       document_type: "placeholder_world_location_news_page",
       public_updated_at: world_location.updated_at,
       rendering_app: "whitehall-frontend",

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -6,7 +6,7 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
   end
 
   def world_location
-    @world_location ||= create(:world_location, name: "Aardistan", "title": "Aardistan and the Uk")
+    @world_location ||= create(:world_location, name: "Aardistan", "title": "Aardistan and the Uk", mission_statement: "This is a great mission")
   end
 
   test "presents an item for publishing api" do
@@ -30,6 +30,7 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
             href: newer_link.url,
           },
         ],
+        mission_statement: "This is a great mission",
       },
       document_type: "placeholder_world_location_news_page",
       public_updated_at: world_location.updated_at,
@@ -46,6 +47,14 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
     assert_equal expected, presented_content
 
     assert_valid_against_publisher_schema(presented_content, "world_location_news")
+  end
+
+  test "presents mission statement as an empty string when it is nil" do
+    world_location_without_mission_statement = create(:world_location)
+
+    presented_content = present(world_location_without_mission_statement).content
+
+    assert_equal "", presented_content.dig(:details, :mission_statement)
   end
 
   test "presents an item for rummager" do

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -20,14 +20,18 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
       document_type: "placeholder_world_location_news_page",
       public_updated_at: world_location.updated_at,
       rendering_app: "whitehall-frontend",
-      schema_name: "placeholder",
+      schema_name: "world_location_news",
       base_path: "/world/aardistan/news",
       routes: [{ path: "/world/aardistan/news", type: "exact" }],
       analytics_identifier: "WL#{world_location.id}",
       update_type: "major",
     }
 
-    assert_equal expected, present(world_location).content
+    presented_content = present(world_location).content
+
+    assert_equal expected, presented_content
+
+    assert_valid_against_publisher_schema(presented_content, "world_location_news")
   end
 
   test "presents an item for rummager" do

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -44,7 +44,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
           },
         ],
         mission_statement: "This is a great mission",
-        ordered_featured_documents: featured_documents(world_location),
+        ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
       },
       document_type: "placeholder_world_location_news_page",
       public_updated_at: world_location.updated_at,

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -1,10 +1,10 @@
 require "test_helper"
 
-class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCase
+class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
   include PublishingApi::FeaturedDocumentsPresenter
 
   def present(...)
-    PublishingApi::WorldLocationNewsPagePresenter.new(...)
+    PublishingApi::WorldLocationNewsPresenter.new(...)
   end
 
   def world_location

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -7,12 +7,12 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
       name: "France",
       news_page_content_id: "id-123",
     )
-    presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
+    presenter = PublishingApi::WorldLocationNewsPresenter.new(world_location)
 
     Services.publishing_api.expects(:put_content).with("id-123", presenter.content)
     Services.publishing_api.expects(:publish).with("id-123", nil, locale: :en)
 
-    WorldLocationNewsPageWorker.new.perform(world_location.id)
+    WorldLocationNewsWorker.new.perform(world_location.id)
   end
 
   test "sends to rummager" do
@@ -21,12 +21,12 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
       name: "France",
       news_page_content_id: "id-123",
     )
-    presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
+    presenter = PublishingApi::WorldLocationNewsPresenter.new(world_location)
 
     Whitehall::FakeRummageableIndex.any_instance.expects(:add)
       .with(presenter.content_for_rummager("id-123"))
 
-    WorldLocationNewsPageWorker.new.perform(world_location.id)
+    WorldLocationNewsWorker.new.perform(world_location.id)
   end
 
   test "sends translations to the publishing api under the same content_id" do
@@ -38,11 +38,11 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
     )
 
     I18n.with_locale(:en) do
-      @english = PublishingApi::WorldLocationNewsPagePresenter.new(world_location).content
+      @english = PublishingApi::WorldLocationNewsPresenter.new(world_location).content
     end
 
     I18n.with_locale(:fr) do
-      @french = PublishingApi::WorldLocationNewsPagePresenter.new(world_location).content
+      @french = PublishingApi::WorldLocationNewsPresenter.new(world_location).content
     end
 
     Services.publishing_api.expects(:put_content).with("id-123", @english)
@@ -51,6 +51,6 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
     Services.publishing_api.expects(:put_content).with("id-123", @french)
     Services.publishing_api.expects(:publish).with("id-123", nil, locale: :fr)
 
-    WorldLocationNewsPageWorker.new.perform(world_location.id)
+    WorldLocationNewsWorker.new.perform(world_location.id)
   end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -4,7 +4,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   should_protect_against_xss_and_content_attacks_on :name, :mission_statement
 
   def setup
-    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+    WorldLocationNewsWorker.any_instance.stubs(:perform).returns(true)
   end
 
   test "should be invalid without a name" do
@@ -297,7 +297,7 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   test "should call perform on World Location News Page Worker when saving a World Location" do
     world_location = create(:world_location, slug: "india")
-    WorldLocationNewsPageWorker.any_instance.expects(:perform).at_least_once.with(world_location.id)
+    WorldLocationNewsWorker.any_instance.expects(:perform).at_least_once.with(world_location.id)
     world_location.save!
   end
 


### PR DESCRIPTION
This PR adds the following fields to the details presented to publishing-api for world location news items:

* featured links
* featured documents
* mission statement

and switches to using the newly created schema for world location news, since world location news was previously using a placeholder schema. 

Other changes include:

* Renaming the world location news presenter for consistency
* Moving some organisations presenter code into a shared helper since there is similar functionality across the organisations and world_location_news content types.

Depends on [the sister content schemas change](https://github.com/alphagov/govuk-content-schemas/pull/1110) - CI reported below as passing has been run against that branch. 

[Trello](https://trello.com/c/FUNRgTWI/168-get-world-news-content-into-content-item)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️