### PR TITLE
Add `VIEW_MOVE_TABS_TO_ENDPOINTS` permission

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
     FORCE_PUBLISH_ANYTHING = "Force publish anything".freeze
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
+    VIEW_MOVE_TABS_TO_ENDPOINTS = "View move tabs to endpoints".freeze
   end
 
   def role
@@ -89,6 +90,10 @@ class User < ApplicationRecord
 
   def can_force_publish_anything?
     has_permission?(Permissions::FORCE_PUBLISH_ANYTHING)
+  end
+
+  def can_view_move_tabs_to_endpoints?
+    has_permission?(Permissions::VIEW_MOVE_TABS_TO_ENDPOINTS)
   end
 
   def organisation_name

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -139,6 +139,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_force_publish_anything?
   end
 
+  test "cannot view migration of tabs to endpoints by default" do
+    user = build(:user)
+    assert_not user.can_view_move_tabs_to_endpoints?
+  end
+
+  test "can view migration of tabs to endpoints if given permission" do
+    user = build(:user, permissions: [User::Permissions::VIEW_MOVE_TABS_TO_ENDPOINTS])
+    assert user.can_view_move_tabs_to_endpoints?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description

This permission will be used to feature flag the work we're going to do to move notes, history and fact checking from tabs to their own endpoints.

## Trello card 

https://trello.com/c/i10jV4uX/786-move-adding-a-note-to-a-separate-endpoint

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
