### PR TITLE
Improve paginated history performance

### DIFF
--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -3,6 +3,6 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
 
   def index
     @edition = Edition.find(params[:id])
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 end

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -32,7 +32,7 @@ private
 
   def load_translated_models
     @edition_remarks = @edition.document_remarks_trail.reverse
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
     @translated_edition = LocalisedModel.new(@edition, translation_locale.code)
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -190,7 +190,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def history
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 
 private
@@ -201,7 +201,7 @@ private
 
   def fetch_version_and_remark_trails
     @edition_remarks = @edition.document_remarks_trail.reverse
-    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 
   def edition_class

--- a/app/models/document/paginated_history.rb
+++ b/app/models/document/paginated_history.rb
@@ -1,0 +1,64 @@
+class Document::PaginatedHistory
+  PER_PAGE = 30
+
+  attr_reader :document, :query
+
+  delegate :total_count, to: :query
+
+  def initialize(document, page)
+    @document = document
+    @query = document.edition_versions
+                     .includes(:user)
+                     .where.not(state: :superseded)
+                     .reorder(created_at: :desc, id: :desc)
+                     .page(page)
+                     .per(PER_PAGE)
+  end
+
+  def audit_trail
+    first_edition_id = document.editions.first&.id
+    query.map.with_index do |version, index|
+      AuditTrailEntry.new(version,
+                          is_first_edition: version.item_id == first_edition_id,
+                          previous_version: query[index + 1])
+    end
+  end
+
+  class AuditTrailEntry
+    extend ActiveModel::Naming
+
+    def self.model_name
+      ActiveModel::Name.new(Version, nil)
+    end
+
+    attr_reader :version
+
+    delegate :created_at, :to_key, to: :version
+
+    def initialize(version, is_first_edition:, previous_version: nil)
+      @version = version
+      @is_first_edition = is_first_edition
+      @preloaded_previous_version = previous_version
+    end
+
+    def actor
+      version.user
+    end
+
+    def action
+      case version.event
+      when "create"
+        @is_first_edition ? "created" : "editioned"
+      else
+        previous_version&.state != version.state ? version.state : "updated"
+      end
+    end
+
+  private
+
+    def previous_version
+      # we can avoid n+1 queries by using our preloaded_prev_version
+      @previous_version ||= @preloaded_previous_version || version.previous
+    end
+  end
+end

--- a/app/views/admin/edition_audit_trail/index.html.erb
+++ b/app/views/admin/edition_audit_trail/index.html.erb
@@ -1,8 +1,8 @@
 <div class="audit-trail-page">
   <h1>Activity</h1>
-  <%= paginate @edition_history, theme: 'audit_trail' %>
+  <%= paginate @document_history.query, theme: 'audit_trail' %>
   <ul class="list-unstyled">
-    <%= render partial: "audit_trail_entry", collection: @edition_history %>
+    <%= render partial: "audit_trail_entry", collection: @document_history.audit_trail %>
   </ul>
-  <%= paginate @edition_history, theme: 'audit_trail' %>
+  <%= paginate @document_history.query, theme: 'audit_trail' %>
 </div>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -26,7 +26,7 @@
       <%= sidebar_tabs edition_tabs(
         @edition,
         remarks_count: @edition_remarks.length,
-        history_count: @edition_history.total_count,
+        history_count: @document_history.total_count,
         editing: true,
       ) do |tabs| %>
 
@@ -45,11 +45,11 @@
         <%= tabs.pane class: "audit-trail", id: "history" do %>
           <div class="audit-trail-page">
             <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
             <ul class="list-unstyled">
-              <%= render partial: "admin/editions/audit_trail_entry", collection: @edition_history %>
+              <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
             </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
           </div>
         <% end %>
           <% if @edition.can_be_fact_checked? %>

--- a/app/views/admin/editions/_audit_trail_entry.html.erb
+++ b/app/views/admin/editions/_audit_trail_entry.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag_for(:li, audit_trail_entry) do %>
-  <% if audit_trail_entry.is_a?(Edition::AuditTrail::VersionAuditEntry) && audit_trail_entry.action == "published" %>
+  <% if audit_trail_entry.is_a?(Document::PaginatedHistory::AuditTrailEntry) && audit_trail_entry.action == "published" %>
     <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: audit_trail_entry.version.item_id) %>
   <% end %>
 

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -48,7 +48,7 @@
         <%= sidebar_tabs edition_tabs(
           @edition,
           remarks_count: @edition_remarks.length,
-          history_count: @edition_history.total_count,
+          history_count: @document_history.total_count,
           editing: true,
         ) do |tabs| %>
 
@@ -73,11 +73,11 @@
           <%= tabs.pane class: "audit-trail", id: "history" do %>
             <div class="audit-trail-page">
               <h1>Activity</h1>
-              <%= paginate @edition_history, theme: 'audit_trail' %>
+              <%= paginate @document_history.query, theme: 'audit_trail' %>
               <ul class="list-unstyled">
-                <%= render partial: "audit_trail_entry", collection: @edition_history %>
+                <%= render partial: "audit_trail_entry", collection: @document_history.audit_trail %>
               </ul>
-              <%= paginate @edition_history, theme: 'audit_trail' %>
+              <%= paginate @document_history.query, theme: 'audit_trail' %>
             </div>
           <% end %>
             <% if @edition.can_be_fact_checked? %>

--- a/app/views/admin/editions/history.html.erb
+++ b/app/views/admin/editions/history.html.erb
@@ -9,11 +9,11 @@
     <div class="audit-trail-page">
       <h1>History</h1>
 
-      <%= paginate @edition_history, theme: 'audit_trail' %>
+      <%= paginate @document_history.query, theme: 'audit_trail' %>
       <ul class="list-unstyled">
-        <%= render partial: "admin/editions/audit_trail_entry", collection: @edition_history %>
+        <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
       </ul>
-      <%= paginate @edition_history, theme: 'audit_trail' %>
+      <%= paginate @document_history.query, theme: 'audit_trail' %>
     </div>
   </section>
 </div>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -80,7 +80,7 @@
       <%= sidebar_tabs edition_tabs(
         @edition,
         remarks_count: @edition_remarks.length,
-        history_count: @edition_history.total_count
+        history_count: @document_history.total_count
         ),
         class: 'remarks-history' do |tabs| %>
 
@@ -93,11 +93,11 @@
         <%= tabs.pane class: "audit-trail", id: "history" do %>
           <div class="audit-trail-page">
             <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
             <ul class="list-unstyled">
-              <%= render partial: "audit_trail_entry", collection: @edition_history %>
+              <%= render partial: "audit_trail_entry", collection: @document_history.audit_trail %>
             </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
           </div>
         <% end %>
 

--- a/test/unit/models/document/paginated_history_test.rb
+++ b/test/unit/models/document/paginated_history_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class PaginatedHistoryTest < ActiveSupport::TestCase
+  setup do
+    @per_page = 3
+
+    @document = create(:document)
+    @first_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+    Timecop.travel 1.day.from_now
+    @first_edition.submit!
+    Timecop.travel 1.day.from_now
+    @first_edition.versions.create!(event: "updated", state: "submitted")
+    Timecop.travel 1.day.from_now
+    @first_edition.schedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.unschedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.schedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.unschedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.schedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.unschedule!
+    Timecop.travel 1.day.from_now
+    @first_edition.force_publish!
+
+    @newest_edition = create(:draft_edition, document: @document)
+  end
+
+  test "#initialize query contains most recent versions first" do
+    history = Document::PaginatedHistory.new(@document, 1)
+
+    assert_equal history.query.first.item_id, @newest_edition.id
+  end
+
+  test "#initialize performs queries with pagination" do
+    mock_pagination do
+      expected_pages = 4
+      (1..expected_pages).each do |page|
+        history = Document::PaginatedHistory.new(@document, page)
+        assert history.query.count <= @per_page
+      end
+    end
+  end
+
+  test "#audit_trail correctly determines action" do
+    history = Document::PaginatedHistory.new(@document, 1)
+    audit_trail = history.audit_trail
+
+    actual_actions = audit_trail.map(&:action)
+    expected_actions = %w[editioned
+                          published
+                          submitted
+                          scheduled
+                          submitted
+                          scheduled
+                          submitted
+                          scheduled
+                          updated
+                          submitted
+                          created]
+
+    assert_equal expected_actions, actual_actions
+  end
+
+  def mock_pagination(&block)
+    Document::PaginatedHistory.stub_const(:PER_PAGE, @per_page, &block)
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/UUAOsryV/537-use-query-based-pagination-for-the-document-history-tab)

This PR changes the approach to loading document history when rendering the show page of an Edition.

The previous approach was to load all document history from the database when displaying the page. For a page with a long history this would add a significant performance overhead (for example: https://www.gov.uk/government/publications/royal-courts-of-justice-cause-list has 1000's of updates). 

Co-authored-by: Johnny Young <jonathan.young@digital.cabinet-office.gov.uk>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
