### PR TITLE
Add 'Preview design system' permission

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
     VIEW_MOVE_TABS_TO_ENDPOINTS = "View move tabs to endpoints".freeze
+    PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
   end
 
   def role
@@ -94,6 +95,10 @@ class User < ApplicationRecord
 
   def can_view_move_tabs_to_endpoints?
     has_permission?(Permissions::VIEW_MOVE_TABS_TO_ENDPOINTS)
+  end
+
+  def can_preview_design_system?
+    has_permission?(Permissions::PREVIEW_DESIGN_SYSTEM)
   end
 
   def organisation_name

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -149,6 +149,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_view_move_tabs_to_endpoints?
   end
 
+  test "cannot preview the design system by default" do
+    user = build(:user)
+    assert_not user.can_preview_design_system?
+  end
+
+  test "can preview the design system if given permission" do
+    user = build(:user, permissions: [User::Permissions::PREVIEW_DESIGN_SYSTEM])
+    assert user.can_preview_design_system?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
This adds the 'Preview design system' permission. This will be used as a feature flag for porting over pages to the GOV.UK Design System.

Allowing us to test and incrementally release updates.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
