### PR TITLE
Move notes tab to have its own endpoints

### DIFF
--- a/app/controllers/admin/editorial_remarks_controller.rb
+++ b/app/controllers/admin/editorial_remarks_controller.rb
@@ -8,6 +8,10 @@ class Admin::EditorialRemarksController < Admin::BaseController
     enforce_permission!(:make_editorial_remark, @edition)
   end
 
+  def index
+    @edition_remarks = @edition.document_remarks_trail.reverse
+  end
+
   def new
     @editorial_remark = @edition.editorial_remarks.build
   end
@@ -15,7 +19,11 @@ class Admin::EditorialRemarksController < Admin::BaseController
   def create
     @editorial_remark = @edition.editorial_remarks.build(editorial_remark_params)
     if @editorial_remark.save
-      redirect_to admin_edition_path(@edition)
+      if current_user.can_view_move_tabs_to_endpoints?
+        redirect_to admin_edition_editorial_remarks_path(@edition)
+      else
+        redirect_to admin_edition_path(@edition)
+      end
     else
       render "new"
     end

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -26,7 +26,7 @@ module Admin::AuditTrailHelper
     )
   end
 
-  def render_editorial_remarks_in_sidebar(remarks, edition)
+  def render_editorial_remarks(remarks, edition)
     this_edition_remarks, other_edition_remarks = remarks.partition { |r| r.edition == edition }
     out = ""
     if this_edition_remarks.any?

--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -20,7 +20,7 @@ module Admin::SidebarHelper
       if options[:editing]
         tabs[:govspeak_help] = "Help"
       end
-      tabs[:notes] = ["Notes", options[:remarks_count]]
+      tabs[:notes] = ["Notes", options[:remarks_count]] unless current_user.can_view_move_tabs_to_endpoints?
       tabs[:history] = ["History", options[:history_count]]
       if edition.can_be_fact_checked?
         tabs[:fact_checking] = ["Fact checking", edition.all_completed_fact_check_requests.count]

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -17,17 +17,25 @@
     </section>
   </div>
   <div class="col-md-4">
-    <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @edition_history.total_count, editing: true) do |tabs| %>
+    <%= sidebar_tabs edition_tabs(
+      @edition,
+      remarks_count: @edition_remarks.length,
+      history_count: @edition_history.total_count,
+      editing: true
+    ) do |tabs| %>
+
       <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
         <%= render partial: "admin/editions/govspeak_help",
                    locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
       <% end %>
 
-      <%= tabs.pane class: "audit-trail", id: "notes" do %>
-        <h1>Notes</h1>
-        <p>To add a remark, save your changes.</p>
-        <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-        <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+      <% unless current_user.can_view_move_tabs_to_endpoints? %>
+        <%= tabs.pane class: "audit-trail", id: "notes" do %>
+          <h1>Notes</h1>
+          <p>To add a remark, save your changes.</p>
+          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+        <% end %>
       <% end %>
 
       <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -34,7 +34,7 @@
           <h1>Notes</h1>
           <p>To add a remark, save your changes.</p>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+          <%= render_editorial_remarks(@edition_remarks, @edition) %>
         <% end %>
       <% end %>
 

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -28,6 +28,12 @@
 <%= render partial: "rejected_by", locals: { edition: @edition } %>
 <%= render partial: 'alerts', locals: {edition: @edition}  %>
 
+<% if current_user.can_view_move_tabs_to_endpoints? %>
+  <div class= "add-bottom-margin">
+    <%= link_to "Notes", admin_edition_editorial_remarks_path(@edition) %>
+  </div>
+<% end %>
+
 <%= render 'edition_view_edit_buttons' %>
 
 <% if @edition.change_note_required? %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -56,7 +56,7 @@
             <h1>Notes</h1>
             <p>To add a remark, save your changes.</p>
             <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-            <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+            <%= render_editorial_remarks(@edition_remarks, @edition) %>
           <% end %>
         <% end %>
 

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -33,7 +33,13 @@
     </div>
 
     <div class="col-md-4">
-      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @edition_history.total_count, editing: true) do |tabs| %>
+      <%= sidebar_tabs edition_tabs(
+        @edition,
+        remarks_count: @edition_remarks.length,
+        history_count: @edition_history.total_count,
+        editing: true
+      ) do |tabs| %>
+
         <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
           <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
                                       show_attachments_tab_help: true,
@@ -45,11 +51,13 @@
           <p>For style, see the <a href="https://www.gov.uk/guidance/style-guide">style guide</a></p>
         <% end %>
 
-        <%= tabs.pane class: "audit-trail", id: "notes" do %>
-          <h1>Notes</h1>
-          <p>To add a remark, save your changes.</p>
-          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+        <% unless current_user.can_view_move_tabs_to_endpoints? %>
+          <%= tabs.pane class: "audit-trail", id: "notes" do %>
+            <h1>Notes</h1>
+            <p>To add a remark, save your changes.</p>
+            <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+            <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+          <% end %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -77,11 +77,19 @@
     <% if @edition.imported? %>
       <%= render partial: 'speed_tagging' %>
     <% else %>
-      <%= sidebar_tabs edition_tabs(@edition, remarks_count: @edition_remarks.length, history_count: @edition_history.total_count), class: 'remarks-history' do |tabs| %>
-        <%= tabs.pane class: "audit-trail", id: "notes" do %>
-          <h1>Notes</h1>
-          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+      <%= sidebar_tabs edition_tabs(
+        @edition,
+        remarks_count: @edition_remarks.length,
+        history_count: @edition_history.total_count
+        ),
+        class: 'remarks-history' do |tabs| %>
+
+        <% unless current_user.can_view_move_tabs_to_endpoints? %>
+          <%= tabs.pane class: "audit-trail", id: "notes" do %>
+            <h1>Notes</h1>
+            <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+            <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+          <% end %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -88,7 +88,7 @@
           <%= tabs.pane class: "audit-trail", id: "notes" do %>
             <h1>Notes</h1>
             <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-            <%= render_editorial_remarks_in_sidebar(@edition_remarks, @edition) %>
+            <%= render_editorial_remarks(@edition_remarks, @edition) %>
           <% end %>
         <% end %>
 

--- a/app/views/admin/editorial_remarks/index.html.erb
+++ b/app/views/admin/editorial_remarks/index.html.erb
@@ -1,0 +1,15 @@
+<% page_title "Notes" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <span class="back">
+      <%= link_to 'Back', admin_edition_path(@edition) %>
+    </span>
+
+    <h1>Notes</h1>
+
+    <%= render_editorial_remarks(@edition_remarks, @edition) %>
+
+    <%= link_to "Add note", new_admin_edition_editorial_remark_path(@edition) %>
+  </section>
+</div>

--- a/app/views/admin/editorial_remarks/new.html.erb
+++ b/app/views/admin/editorial_remarks/new.html.erb
@@ -15,7 +15,7 @@
     <%= form_for [:admin, @edition, @editorial_remark], url: admin_edition_editorial_remarks_path(@edition) do |feedback_form| %>
       <%= feedback_form.errors %>
       <%= feedback_form.text_area :body, rows: 20, label_text: "Remark" %>
-      <%= feedback_form.submit "Submit remark", class: "btn btn-default" %>
+      <%= feedback_form.submit current_user.can_view_move_tabs_to_endpoints? ? "Add note" : "Submit remark", class: "btn btn-default" %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,7 +305,7 @@ Whitehall::Application.routes.draw do
           resources :link_check_reports
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]
           resources :translations, controller: "edition_translations", except: %i[index show]
-          resources :editorial_remarks, only: %i[new create], shallow: true
+          resources :editorial_remarks, only: %i[new create index], shallow: true
           resources :fact_check_requests, only: %i[show create edit update], shallow: true
           resource :document_sources, path: "document-sources", except: [:show]
           resources :attachments, except: [:show] do

--- a/features/admin-editorial-remarks.feature
+++ b/features/admin-editorial-remarks.feature
@@ -1,6 +1,19 @@
 Feature: Creating and viewing editorial remarks
 
-Scenario: Adding an editorial remark
+Background:
   Given I am a writer
+
+Scenario: Adding an editorial remark
   When I add an editorial remark "Try using a spellchecker" to the document "Badddly Rittin"
   Then my editorial remark should be visible with the document
+
+Scenario: Adding an editorial remark with the View move tabs to endpoints permission
+  Given I have the "View move tabs to endpoints" permission
+  When I visit the edition show page
+  Then the "Notes" tab is not visible
+  When I visit the edit edition page
+  Then the "Notes" tab is not visible
+  When I add a french translation
+  Then the "Notes" tab is not visible
+  When I add an editorial remark "Try using a spellchecker" to the document
+  Then my editorial remark should be visible on the notes index page

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -1,3 +1,42 @@
+When(/^I visit the edition show page$/) do
+  begin_drafting_document type: "case_study", title: "New edition", previously_published: false
+  click_button "Save"
+  @edition = Edition.find_by!(title: "New edition")
+  visit admin_edition_path(@edition)
+end
+
+Then(/^the "([^"]*)" tab is not visible$/) do |tab_name|
+  expect(all(".nav-tabs").map(&:text)).not_to have_content tab_name
+end
+
+When(/^I visit the edit edition page$/) do
+  visit edit_admin_edition_path(@edition)
+end
+
+When(/^I add a french translation$/) do
+  visit admin_edition_path(@edition)
+  click_link "open-add-translation-modal"
+  select "Français", from: "Locale"
+  click_button "Add translation"
+end
+
+When(/^I add an editorial remark "([^"]*)" to the document$/) do |remark_text|
+  @remark_text = remark_text
+
+  visit admin_edition_path(@edition)
+  click_link "Notes"
+  ensure_path admin_edition_editorial_remarks_path(@edition)
+  click_link "Add note"
+  ensure_path new_admin_edition_editorial_remark_path(@edition)
+  fill_in "Remark", with: @remark_text
+  click_button "Add note"
+end
+
+Then(/^my editorial remark should be visible on the notes index page$/) do
+  ensure_path admin_edition_editorial_remarks_path(@edition)
+  expect(page).to have_content(@remark_text)
+end
+
 When(/^I add an editorial remark "([^"]*)" to the document "([^"]*)"$/) do |remark_text, document_title|
   @edition = create(:draft_publication, title: document_title)
   @remark_text = remark_text


### PR DESCRIPTION
## Description 

This PR moves the `Notes` tab to its own endpoint. This work is behind the `View move tabs to endpoints` permission. Users without this permission should see be unaffected.

It does a few things:

1. Adds a new cucmber spec for adding a note for users who have the `View move tabs to endpoints` permission
2. Remove the `Notes` tab from the edit edition, edition summary (show) and edit translation pages.
3. Adds a `EditionRemark#index` endpoint
4. Adds a link to the edition summary page which links to the new endpoint
5. Adds controller tests for the index endpoint

## Sceenshots

### Edition summary page 

|Before|After|
|---------------|---------------|
|<img width="1217" alt="image" src="https://user-images.githubusercontent.com/42515961/182408640-3eee74c5-dfb5-4c33-8f34-b0a7c1679aa7.png">|<img width="862" alt="image" src="https://user-images.githubusercontent.com/42515961/182407425-f7d3a44d-d300-4098-9927-3b4d1c953e8b.png">|

### Edit edition page

|Before|After|
|---------------|---------------|
|<img width="1183" alt="image" src="https://user-images.githubusercontent.com/42515961/182408840-dd99406f-2570-4136-93de-466ae0d5b720.png">|<img width="1157" alt="image" src="https://user-images.githubusercontent.com/42515961/182408219-4114aec9-531b-45f4-ac1d-fa9ecc27426e.png">|

### Edit translation page

|Before|After|
---------------|---------------|
|<img width="1223" alt="image" src="https://user-images.githubusercontent.com/42515961/182408540-fae02016-5979-4e0d-be40-71799da01f25.png">|<img width="1154" alt="image" src="https://user-images.githubusercontent.com/42515961/182408368-060da15d-db96-44d8-8f2f-bb3258a12cfb.png">|

### Notes index page 

<img width="1577" alt="image" src="https://user-images.githubusercontent.com/42515961/182411561-510cd33e-f423-4299-9041-19b57db56894.png">

## Guidance for review

Per commit will be easiest

I'm wondering if the link to the Notes section should be larger. It's not super visible at the moment. Wdyt?

## Trello card

https://trello.com/c/i10jV4uX/602-move-adding-a-note-to-a-separate-endpoint


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
