### PR TITLE
Remove unused policy area tables

### DIFF
--- a/db/migrate/20220916091333_drop_classification_relations_table.rb
+++ b/db/migrate/20220916091333_drop_classification_relations_table.rb
@@ -1,0 +1,5 @@
+class DropClassificationRelationsTable < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :classification_relations
+  end
+end

--- a/db/migrate/20220916111449_drop_classification_policies_table.rb
+++ b/db/migrate/20220916111449_drop_classification_policies_table.rb
@@ -1,0 +1,5 @@
+class DropClassificationPoliciesTable < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :classification_policies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_093553) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_16_091333) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -75,15 +75,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093553) do
     t.datetime "updated_at", precision: nil
     t.index ["classification_id"], name: "index_classification_policies_on_classification_id"
     t.index ["policy_content_id"], name: "index_classification_policies_on_policy_content_id"
-  end
-
-  create_table "classification_relations", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
-    t.integer "classification_id", null: false
-    t.integer "related_classification_id", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.index ["classification_id"], name: "index_classification_relations_on_classification_id"
-    t.index ["related_classification_id"], name: "index_classification_relations_on_related_classification_id"
   end
 
   create_table "consultation_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_091333) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_16_111449) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -66,15 +66,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_16_091333) do
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"
     t.index ["ordering"], name: "index_attachments_on_ordering"
-  end
-
-  create_table "classification_policies", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "classification_id"
-    t.string "policy_content_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.index ["classification_id"], name: "index_classification_policies_on_classification_id"
-    t.index ["policy_content_id"], name: "index_classification_policies_on_policy_content_id"
   end
 
   create_table "consultation_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/factories/classification_policy.rb
+++ b/test/factories/classification_policy.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :classification_policy do
-    association :classification, factory: :topical_event
-  end
-end

--- a/test/factories/classification_relations.rb
+++ b/test/factories/classification_relations.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :classification_relation do
-    association :classification, factory: :topic
-    association :related_classification, factory: :topic
-  end
-end


### PR DESCRIPTION
This drops two database tables that were identified in https://github.com/alphagov/whitehall/pull/5666, but never done.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
