### PR TITLE
Revert "Validate that exempt organisations do not have custom logos"

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -153,7 +153,6 @@ class Organisation < ApplicationRecord
   validate :exactly_one_superseding_organisation, if: proc { |organisation| organisation.replaced? || organisation.merged? || organisation.changed_name? }
   validate :at_least_two_superseding_organisations, if: :split?
   validate :exactly_one_devolved_superseding_organisation, if: :devolved?
-  validate :exempt_organisation_does_not_have_custom_logo
 
   delegate :ministerial_department?, to: :type
   delegate :devolved_administration?, to: :type
@@ -247,12 +246,6 @@ class Organisation < ApplicationRecord
   def exactly_one_devolved_superseding_organisation
     if superseding_organisations.size != 1 || !superseding_organisations.first.devolved_administration?
       errors.add(:base, "Please add exactly one devolved superseding organisation for this closed status.")
-    end
-  end
-
-  def exempt_organisation_does_not_have_custom_logo
-    if exempt? && organisation_logo_type == OrganisationLogoType::CustomLogo
-      errors.add(:base, "Organisations which are exempt from GOV.UK cannot have a custom logo.")
     end
   end
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -39,11 +39,6 @@ class OrganisationTest < ActiveSupport::TestCase
     assert new_organisation.valid?
   end
 
-  test "should be invalid if a custom logo is used with an exempt organisation" do
-    assert build(:organisation, govuk_status: "exempt", organisation_logo_type: OrganisationLogoType::NoIdentity).valid?
-    assert_not build(:organisation, govuk_status: "exempt", organisation_logo_type: OrganisationLogoType::CustomLogo).valid?
-  end
-
   test "should be valid if govuk status is transitioning" do
     new_organisation = build(:organisation, govuk_status: "transitioning")
     assert new_organisation.valid?


### PR DESCRIPTION
This PR allows exempt organisations to have a custom logo. It reverts commit 6423776ecfca1232d5b16100551d83a21a1e42a9.

## Changes in Whitehall

Previously a validation rule specifically prevented this:

<img width="630" alt="Error message: Organisations which are exempt from GOV.UK cannot have a custom logo" src="https://user-images.githubusercontent.com/7735945/182426541-41e2549b-75cd-4319-8278-ad64f4fc3dc2.png">

That rule has now been removed so exempt organisations can have a custom logo.

## Changes on GOV.UK frontend

Logos for exempt organisations will now display, the same as they would for any other organisation.

This includes:

- the organisation page ([example](https://www.gov.uk/government/organisations/ofsted))
- corporate information pages ([example](https://www.gov.uk/government/organisations/ofsted/about))
- HTML publication pages ([example](https://www.gov.uk/government/publications/education-recovery-in-early-years-providers-summer-2022/education-recovery-in-early-years-providers-summer-2022))

### A note on HTML publications

The `government-frontend` app currently has [a feature _(not a bug!)_](https://github.com/alphagov/government-frontend/commit/89019a54b8bfd609db617ebf070dce12f4cf23f5) where logos won't display on HTML publications that belong to more than one organisation. A separate change will need to be made to that application if this is no longer the desired behaviour.

---

Trello: https://trello.com/c/emCVBGtM/607-validation-rule-allow-exempt-organisations-to-have-a-custom-logo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
