### PR TITLE
Move history to its own endpoint

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
-  before_action :find_edition, only: %i[show show_locked edit update revise diff destroy update_bypass_id]
+  before_action :find_edition, only: %i[show show_locked edit update revise diff destroy update_bypass_id history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_edition, only: %i[new create]
@@ -20,7 +20,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def enforce_permissions!
     case action_name
-    when "index", "topics"
+    when "index", "topics", "history"
       enforce_permission!(:see, edition_class || Edition)
     when "show", "show_locked"
       enforce_permission!(:see, @edition)
@@ -187,6 +187,10 @@ class Admin::EditionsController < Admin::BaseController
     EditionAuthBypassUpdater.new(edition: @edition, current_user: current_user, updater: updater).call
 
     redirect_to admin_edition_path(@edition), notice: "New document preview link generated"
+  end
+
+  def history
+    @edition_history = Kaminari.paginate_array(@edition.document_version_trail(superseded: false).reverse).page(params[:page]).per(30)
   end
 
 private

--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -21,7 +21,7 @@ module Admin::SidebarHelper
         tabs[:govspeak_help] = "Help"
       end
       tabs[:notes] = ["Notes", options[:remarks_count]] unless current_user.can_view_move_tabs_to_endpoints?
-      tabs[:history] = ["History", options[:history_count]]
+      tabs[:history] = ["History", options[:history_count]] unless current_user.can_view_move_tabs_to_endpoints?
       if edition.can_be_fact_checked?
         tabs[:fact_checking] = ["Fact checking", edition.all_completed_fact_check_requests.count]
       end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -36,17 +36,17 @@
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
           <%= render_editorial_remarks(@edition_remarks, @edition) %>
         <% end %>
-      <% end %>
 
-      <%= tabs.pane class: "audit-trail", id: "history" do %>
-        <div class="audit-trail-page">
-          <h1>Activity</h1>
-          <%= paginate @edition_history, theme: 'audit_trail' %>
-          <ul class="list-unstyled">
-            <%= render partial: "admin/editions/audit_trail_entry", collection: @edition_history %>
-          </ul>
-          <%= paginate @edition_history, theme: 'audit_trail' %>
-        </div>
+        <%= tabs.pane class: "audit-trail", id: "history" do %>
+          <div class="audit-trail-page">
+            <h1>Activity</h1>
+            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <ul class="list-unstyled">
+              <%= render partial: "admin/editions/audit_trail_entry", collection: @edition_history %>
+            </ul>
+            <%= paginate @edition_history, theme: 'audit_trail' %>
+          </div>
+        <% end %>
       <% end %>
 
       <% if @edition.can_be_fact_checked? %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -29,9 +29,12 @@
 <%= render partial: 'alerts', locals: {edition: @edition}  %>
 
 <% if current_user.can_view_move_tabs_to_endpoints? %>
-  <div class= "add-bottom-margin">
-    <%= link_to "Notes", admin_edition_editorial_remarks_path(@edition) %>
-  </div>
+  <nav class= "add-bottom-margin">
+    <ul class="list-unstyled">
+      <li><%= link_to "Notes", admin_edition_editorial_remarks_path(@edition) %></li>
+      <li><%= link_to "History", history_admin_edition_path(@edition) %></li>
+    </ul>
+  </nav>
 <% end %>
 
 <%= render 'edition_view_edit_buttons' %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -58,17 +58,18 @@
             <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
             <%= render_editorial_remarks(@edition_remarks, @edition) %>
           <% end %>
-        <% end %>
 
-        <%= tabs.pane class: "audit-trail", id: "history" do %>
-          <div class="audit-trail-page">
-            <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
-            <ul class="list-unstyled">
-              <%= render partial: "audit_trail_entry", collection: @edition_history %>
-            </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
-          </div>
+
+          <%= tabs.pane class: "audit-trail", id: "history" do %>
+            <div class="audit-trail-page">
+              <h1>Activity</h1>
+              <%= paginate @edition_history, theme: 'audit_trail' %>
+              <ul class="list-unstyled">
+                <%= render partial: "audit_trail_entry", collection: @edition_history %>
+              </ul>
+              <%= paginate @edition_history, theme: 'audit_trail' %>
+            </div>
+          <% end %>
         <% end %>
 
         <% if @edition.can_be_fact_checked? %>

--- a/app/views/admin/editions/history.html.erb
+++ b/app/views/admin/editions/history.html.erb
@@ -1,0 +1,19 @@
+<% page_title "History" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <span class="back">
+      <%= link_to 'Back', admin_edition_path(@edition) %>
+    </span>
+
+    <div class="audit-trail-page">
+      <h1>History</h1>
+
+      <%= paginate @edition_history, theme: 'audit_trail' %>
+      <ul class="list-unstyled">
+        <%= render partial: "admin/editions/audit_trail_entry", collection: @edition_history %>
+      </ul>
+      <%= paginate @edition_history, theme: 'audit_trail' %>
+    </div>
+  </section>
+</div>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -90,17 +90,17 @@
             <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
             <%= render_editorial_remarks(@edition_remarks, @edition) %>
           <% end %>
-        <% end %>
 
-        <%= tabs.pane class: "audit-trail", id: "history" do %>
-          <div class="audit-trail-page">
-            <h1>Activity</h1>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
-            <ul class="list-unstyled">
-              <%= render partial: "audit_trail_entry", collection: @edition_history %>
-            </ul>
-            <%= paginate @edition_history, theme: 'audit_trail' %>
-          </div>
+          <%= tabs.pane class: "audit-trail", id: "history" do %>
+            <div class="audit-trail-page">
+              <h1>Activity</h1>
+              <%= paginate @edition_history, theme: 'audit_trail' %>
+              <ul class="list-unstyled">
+                <%= render partial: "audit_trail_entry", collection: @edition_history %>
+              </ul>
+              <%= paginate @edition_history, theme: 'audit_trail' %>
+            </div>
+          <% end %>
         <% end %>
 
         <% if @edition.can_be_fact_checked? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,6 +301,7 @@ Whitehall::Application.routes.draw do
             get  :audit_trail, to: "edition_audit_trail#index"
             get  :show_locked, to: "editions#show_locked"
             patch :update_bypass_id
+            get :history, to: "editions#history"
           end
           resources :link_check_reports
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]

--- a/features/admin-viewing-history.feature
+++ b/features/admin-viewing-history.feature
@@ -1,0 +1,13 @@
+Feature: Viewing a document's history
+
+Scenario: Viewing history with the View move tabs to endpoints permission
+  Given I am a writer
+  And I have the "View move tabs to endpoints" permission
+  When I visit the edition show page
+  Then the "History" tab is not visible
+  When I visit the edit edition page
+  Then the "History" tab is not visible
+  When I add a french translation
+  Then the "History" tab is not visible
+  When I visit the history page
+  Then I should be able to see the document's history

--- a/features/step_definitions/view_history.rb
+++ b/features/step_definitions/view_history.rb
@@ -1,0 +1,10 @@
+When(/^I visit the history page$/) do
+  visit admin_edition_path(@edition)
+  click_link "History"
+end
+
+Then(/^I should be able to see the document's history$/) do
+  ensure_path history_admin_edition_path(@edition)
+  expect(find("h1").text).to eq "History"
+  expect(all(".action")[0].text).to eq "Created"
+end


### PR DESCRIPTION
## Description

This follows on from https://github.com/alphagov/whitehall/pull/6710 which adds an endpoint for `Notes`. 

This PR does a few things:
1. Adds some integration tests which check the `History` tab does not render for users who have the `View move tabs to endpoints` permission
2. Remove the `History` tab from the edit edition, edition summary (show) and edit translation pages.
3. Adds a Edition#history endpoint
4. Adds a link to the edition summary page which links to the new endpoint

## Screenshots

### Edition summary page 

|Before|After|
|---------------|---------------|
|<img width="862" alt="image" src="https://user-images.githubusercontent.com/42515961/182407425-f7d3a44d-d300-4098-9927-3b4d1c953e8b.png">|<img width="1314" alt="image" src="https://user-images.githubusercontent.com/42515961/182621545-5bb64353-f39b-4930-ad2e-00ad3beca618.png">|

### Edit edition page

|Before|After|
|---------------|---------------|
|<img width="1157" alt="image" src="https://user-images.githubusercontent.com/42515961/182408219-4114aec9-531b-45f4-ac1d-fa9ecc27426e.png">|<img width="1305" alt="image" src="https://user-images.githubusercontent.com/42515961/182621685-95c367d2-59d5-45cb-90a3-adc13c762486.png">|

### Edit translation page

|Before|After|
---------------|---------------|
|<img width="1154" alt="image" src="https://user-images.githubusercontent.com/42515961/182408368-060da15d-db96-44d8-8f2f-bb3258a12cfb.png">|<img width="1283" alt="image" src="https://user-images.githubusercontent.com/42515961/182621814-a53f280a-4eae-4528-bc26-539e8ba18032.png">|

### History index page 

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/42515961/182619834-aa85c8a4-54ec-41e2-9bee-2fa02ec3da0f.png">

## Trello card

https://trello.com/c/4jfxp2WJ/604-move-viewing-history-to-a-separate-endpoint


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
