### PR TITLE
Add a sort to Document#editions so they're in order of creation

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,7 +10,9 @@ class Document < ApplicationRecord
 
   after_destroy :destroy_all_editions
 
-  has_many :editions, inverse_of: :document
+  has_many :editions,
+           -> { order(created_at: :asc, id: :asc) },
+           inverse_of: :document
   has_many :edition_relations, dependent: :destroy, inverse_of: :document
 
   has_one  :published_edition,

--- a/app/models/document_history.rb
+++ b/app/models/document_history.rb
@@ -65,6 +65,6 @@ private
   end
 
   def all_published_editions_in_creation_order
-    document.ever_published_editions.order("created_at")
+    document.ever_published_editions
   end
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -163,6 +163,18 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal publication_date, new_edition.document.first_published_on_govuk
   end
 
+  test "has_many #editions in order of creation" do
+    document = create(:document)
+    [
+      # Create editions in a random order to prove we don't rely on insertion order (i.e. MySQL's auto-incremented IDs)
+      one_hour_ago = build(:published_edition, document: document, created_at: 1.hour.ago),
+      one_day_ago = build(:superseded_edition, document: document, created_at: 1.day.ago),
+      one_week_ago = build(:superseded_edition, document: document, created_at: 1.week.ago),
+    ].shuffle.map(&:save!)
+
+    assert_equal [one_week_ago, one_day_ago, one_hour_ago], document.editions
+  end
+
   test "#ever_published_editions returns all editions that have ever been published or withdrawn" do
     document = create(:document)
     superseded = create(:superseded_edition, document: document)

--- a/test/unit/tasks/data_hygiene/change_note_remover_test.rb
+++ b/test/unit/tasks/data_hygiene/change_note_remover_test.rb
@@ -5,9 +5,9 @@ class ChangeNoteRemoverTest < ActiveSupport::TestCase
 
   describe DataHygiene::ChangeNoteRemover do
     let(:document)                { create(:document) }
-    let!(:superseded_edition)     { create(:superseded_edition, document: document, change_note: "First change note.", first_published_at: Time.zone.now - 2.days, major_change_published_at: Time.zone.now - 2.days) }
-    let!(:previous_major_edition) { create(:superseded_edition, document: document, change_note: "Second change note.", first_published_at: Time.zone.now - 1.day, major_change_published_at: Time.zone.now - 1.day) }
-    let!(:live_edition)           { create(:published_edition, document: document, change_note: "Third change note.", first_published_at: Time.zone.now, major_change_published_at: Time.zone.now) }
+    let!(:superseded_edition)     { create(:superseded_edition, document: document, change_note: "First change note.", first_published_at: 2.days.ago, created_at: 2.days.ago, major_change_published_at: 2.days.ago) }
+    let!(:previous_major_edition) { create(:superseded_edition, document: document, change_note: "Second change note.", created_at: 1.day.ago, major_change_published_at: 1.day.ago) }
+    let!(:live_edition)           { create(:published_edition, document: document, change_note: "Third change note.", created_at: Time.zone.now, major_change_published_at: Time.zone.now) }
 
     let(:query) { nil }
 


### PR DESCRIPTION
Added an ascending sort order on `created_at` and `id`. This needs to be investigated a bit more to see why the test `test/unit/tasks/data_hygiene/change_note_remover_test.rb:67` is failing.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
