### PR TITLE
Move fact checking to its own endpoint

### DIFF
--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -20,10 +20,12 @@ module Admin::SidebarHelper
       if options[:editing]
         tabs[:govspeak_help] = "Help"
       end
-      tabs[:notes] = ["Notes", options[:remarks_count]] unless current_user.can_view_move_tabs_to_endpoints?
-      tabs[:history] = ["History", options[:history_count]] unless current_user.can_view_move_tabs_to_endpoints?
-      if edition.can_be_fact_checked?
-        tabs[:fact_checking] = ["Fact checking", edition.all_completed_fact_check_requests.count]
+      unless current_user.can_view_move_tabs_to_endpoints?
+        tabs[:notes] = ["Notes", options[:remarks_count]]
+        tabs[:history] = ["History", options[:history_count]]
+        if edition.can_be_fact_checked?
+          tabs[:fact_checking] = ["Fact checking", edition.all_completed_fact_check_requests.count]
+        end
       end
     end
   end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -47,14 +47,13 @@
             <%= paginate @edition_history, theme: 'audit_trail' %>
           </div>
         <% end %>
-      <% end %>
-
-      <% if @edition.can_be_fact_checked? %>
-        <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
-          <h1>Fact checking</h1>
-          <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
-          <p>To send a fact check request, save your changes.</p>
-        <% end %>
+          <% if @edition.can_be_fact_checked? %>
+            <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
+              <h1>Fact checking</h1>
+              <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
+              <p>To send a fact check request, save your changes.</p>
+            <% end %>
+          <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -17,19 +17,24 @@
     </section>
   </div>
   <div class="col-md-4">
-    <%= sidebar_tabs edition_tabs(
-      @edition,
-      remarks_count: @edition_remarks.length,
-      history_count: @edition_history.total_count,
-      editing: true
-    ) do |tabs| %>
-
-      <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+    <% if current_user.can_view_move_tabs_to_endpoints? %>
+      <div class="govspeak_help" id="govspeak_help">
         <%= render partial: "admin/editions/govspeak_help",
                    locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
-      <% end %>
+      </div>
+    <% else %>
+      <%= sidebar_tabs edition_tabs(
+        @edition,
+        remarks_count: @edition_remarks.length,
+        history_count: @edition_history.total_count,
+        editing: true,
+      ) do |tabs| %>
 
-      <% unless current_user.can_view_move_tabs_to_endpoints? %>
+        <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+          <%= render partial: "admin/editions/govspeak_help",
+                     locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+        <% end %>
+
         <%= tabs.pane class: "audit-trail", id: "notes" do %>
           <h1>Notes</h1>
           <p>To add a remark, save your changes.</p>

--- a/app/views/admin/editions/_fact_check_responses.html.erb
+++ b/app/views/admin/editions/_fact_check_responses.html.erb
@@ -1,6 +1,6 @@
 <section class="responses">
   <% if edition.all_completed_fact_check_requests.any? %>
-  <h1>Responses</h1>
+  <h2>Responses</h2>
   <ul id="completed_fact_check_requests">
     <% edition.all_completed_fact_check_requests.includes(:edition).each do |fact_check_request| %>
       <%= content_tag_for(:li, fact_check_request) do %>
@@ -23,7 +23,7 @@
 </section>
 <section class="pending">
   <% if edition.fact_check_requests.pending.any? %>
-  <h1>Pending requests</h1>
+  <h2>Pending requests</h2>
   <ul id="pending_fact_check_requests">
     <% edition.fact_check_requests.pending.each do |fact_check_request| %>
       <li class="fact_check_request pending">

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -7,7 +7,7 @@
   govspeak_link_errors ||= []
 %>
 
-<h1>Govspeak help</h1>
+<h2>Govspeak help</h2>
 
 <% if govspeak_link_errors.any? %>
   <section id='link-errors' class='alert alert-danger'>
@@ -48,7 +48,7 @@
     </ul>
     <p>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
   </div>
-  
+
   <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>
   <div class="collapse" id="govspeak-headings">
     <pre>## Top level heading – H2

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -33,6 +33,9 @@
     <ul class="list-unstyled">
       <li><%= link_to "Notes", admin_edition_editorial_remarks_path(@edition) %></li>
       <li><%= link_to "History", history_admin_edition_path(@edition) %></li>
+      <% if @edition.can_be_fact_checked? %>
+        <li><%= link_to "Fact checking", admin_edition_fact_check_requests_path(@edition) %></li>
+      <% end %>
     </ul>
   </nav>
 <% end %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -59,7 +59,6 @@
             <%= render_editorial_remarks(@edition_remarks, @edition) %>
           <% end %>
 
-
           <%= tabs.pane class: "audit-trail", id: "history" do %>
             <div class="audit-trail-page">
               <h1>Activity</h1>
@@ -70,14 +69,13 @@
               <%= paginate @edition_history, theme: 'audit_trail' %>
             </div>
           <% end %>
-        <% end %>
-
-        <% if @edition.can_be_fact_checked? %>
-          <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
-            <h1>Fact checking</h1>
-            <%= render partial: 'fact_check_responses', locals: {edition: @edition}  %>
-            <p>To send a fact check request, save your changes.</p>
-          <% end %>
+            <% if @edition.can_be_fact_checked? %>
+              <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
+                <h1>Fact checking</h1>
+                <%= render partial: 'fact_check_responses', locals: {edition: @edition}  %>
+                <p>To send a fact check request, save your changes.</p>
+              <% end %>
+            <% end %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -33,14 +33,8 @@
     </div>
 
     <div class="col-md-4">
-      <%= sidebar_tabs edition_tabs(
-        @edition,
-        remarks_count: @edition_remarks.length,
-        history_count: @edition_history.total_count,
-        editing: true
-      ) do |tabs| %>
-
-        <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+      <% if current_user.can_view_move_tabs_to_endpoints? %>
+        <div class="govspeak_help" id="govspeak_help">
           <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
                                       show_attachments_tab_help: true,
                                       govspeak_link_errors: force_publisher.govspeak_link_errors,
@@ -49,9 +43,26 @@
           <%= render "words_to_avoid_guidance" %>
           <h3 class="style-title">Style</h3>
           <p>For style, see the <a href="https://www.gov.uk/guidance/style-guide">style guide</a></p>
-        <% end %>
+        </div>
+      <% else %>
+        <%= sidebar_tabs edition_tabs(
+          @edition,
+          remarks_count: @edition_remarks.length,
+          history_count: @edition_history.total_count,
+          editing: true,
+        ) do |tabs| %>
 
-        <% unless current_user.can_view_move_tabs_to_endpoints? %>
+          <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+            <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
+                                        show_attachments_tab_help: true,
+                                        govspeak_link_errors: force_publisher.govspeak_link_errors,
+                                        link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_reports.last : nil %>
+
+            <%= render "words_to_avoid_guidance" %>
+            <h3 class="style-title">Style</h3>
+            <p>For style, see the <a href="https://www.gov.uk/guidance/style-guide">style guide</a></p>
+          <% end %>
+
           <%= tabs.pane class: "audit-trail", id: "notes" do %>
             <h1>Notes</h1>
             <p>To add a remark, save your changes.</p>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -76,7 +76,7 @@
     <%= render partial: "history_state", locals: { edition: @edition } %>
     <% if @edition.imported? %>
       <%= render partial: 'speed_tagging' %>
-    <% else %>
+    <% elsif !current_user.can_view_move_tabs_to_endpoints?  %>
       <%= sidebar_tabs edition_tabs(
         @edition,
         remarks_count: @edition_remarks.length,
@@ -84,23 +84,21 @@
         ),
         class: 'remarks-history' do |tabs| %>
 
-        <% unless current_user.can_view_move_tabs_to_endpoints? %>
-          <%= tabs.pane class: "audit-trail", id: "notes" do %>
-            <h1>Notes</h1>
-            <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-            <%= render_editorial_remarks(@edition_remarks, @edition) %>
-          <% end %>
+        <%= tabs.pane class: "audit-trail", id: "notes" do %>
+          <h1>Notes</h1>
+          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+          <%= render_editorial_remarks(@edition_remarks, @edition) %>
+        <% end %>
 
-          <%= tabs.pane class: "audit-trail", id: "history" do %>
-            <div class="audit-trail-page">
-              <h1>Activity</h1>
-              <%= paginate @edition_history, theme: 'audit_trail' %>
-              <ul class="list-unstyled">
-                <%= render partial: "audit_trail_entry", collection: @edition_history %>
-              </ul>
-              <%= paginate @edition_history, theme: 'audit_trail' %>
-            </div>
-          <% end %>
+        <%= tabs.pane class: "audit-trail", id: "history" do %>
+          <div class="audit-trail-page">
+            <h1>Activity</h1>
+            <%= paginate @edition_history, theme: 'audit_trail' %>
+            <ul class="list-unstyled">
+              <%= render partial: "audit_trail_entry", collection: @edition_history %>
+            </ul>
+            <%= paginate @edition_history, theme: 'audit_trail' %>
+          </div>
         <% end %>
 
         <% if @edition.can_be_fact_checked? %>

--- a/app/views/admin/fact_check_requests/index.html.erb
+++ b/app/views/admin/fact_check_requests/index.html.erb
@@ -1,0 +1,15 @@
+<% page_title "Fact checking" %>
+
+<div class="row">
+  <div class="col-md-8">
+    <span class="back">
+      <%= link_to 'Back', admin_edition_path(@edition) %>
+    </span>
+
+    <h1>Fact checking</h1>
+
+    <%= render partial: 'admin/editions/fact_check_responses', locals: { edition: @edition }  %>
+
+    <%= link_to "Request fact check", new_admin_edition_fact_check_request_path(@edition) %>
+  </div>
+</div>

--- a/app/views/admin/fact_check_requests/new.html.erb
+++ b/app/views/admin/fact_check_requests/new.html.erb
@@ -1,0 +1,17 @@
+<% page_title "Request fact check" %>
+
+<div class="row">
+  <div class="col-md-8">
+    <span class="back">
+      <%= link_to 'Back', admin_edition_fact_check_requests_path(@edition) %>
+    </span>
+
+    <h1>Request fact check</h1>
+
+    <%= form_for [:admin, @edition, FactCheckRequest.new] do |f| %>
+      <%= f.text_field :email_address %>
+      <%= f.text_area :instructions, cols: nil, rows: nil, label_text: "Extra instructions" %>
+      <%= f.submit 'Send request', class: "btn btn-default" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -307,7 +307,7 @@ Whitehall::Application.routes.draw do
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]
           resources :translations, controller: "edition_translations", except: %i[index show]
           resources :editorial_remarks, only: %i[new create index], shallow: true
-          resources :fact_check_requests, only: %i[show create edit update], shallow: true
+          resources :fact_check_requests, only: %i[show index new create edit update], shallow: true
           resource :document_sources, path: "document-sources", except: [:show]
           resources :attachments, except: [:show] do
             put :order, on: :collection

--- a/features/fact-checking-edition.feature
+++ b/features/fact-checking-edition.feature
@@ -1,0 +1,13 @@
+Feature: Fact checking an edition
+
+Scenario: Requesting a fact check
+  Given I am a writer
+  And I have the "View move tabs to endpoints" permission
+  When I visit the edition show page
+  Then the "Fact checking" tab is not visible
+  When I visit the edit edition page
+  Then the "Fact checking" tab is not visible
+  When I add a french translation
+  Then the "Fact checking" tab is not visible
+  When I request a review from "not-a-real-email-address@email.com" with the instructions "please fact check when you can" for the document "Badddly Rittin"
+  Then I should see I have a pending fact check request

--- a/features/step_definitions/fact_checking_edition_steps.rb
+++ b/features/step_definitions/fact_checking_edition_steps.rb
@@ -1,0 +1,17 @@
+When(/^I request a review from "([^"]*)" with the instructions "([^"]*)" for the document "([^"]*)"$/) do |email_address, extra_instructions, document_title|
+  @edition = create(:draft_publication, title: document_title)
+  @email_address = email_address
+  @extra_instructions = extra_instructions
+
+  visit admin_edition_path(@edition)
+  click_link "Fact checking"
+  click_link "Request fact check"
+  fill_in "Email address", with: @email_address
+  fill_in "Extra instructions", with: @extra_instructions
+  click_button "Send request"
+end
+
+Then(/^I should see I have a pending fact check request$/) do
+  ensure_path admin_edition_fact_check_requests_path(@edition)
+  expect(page).to have_selector(".pending", text: @email_address)
+end

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -7,6 +7,17 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     login_as_admin
   end
 
+  view_test "#index should render previous fact checking requests in the correct order" do
+    edition = create(:publication)
+    completed_fact_check = create(:fact_check_request, edition: edition, comments: "comment")
+    pending_fact_check = create(:fact_check_request, edition: edition, comments: nil)
+
+    get :index, params: { edition_id: edition }
+
+    assert_select ".responses .from", text: completed_fact_check.email_address
+    assert_select ".pending .from", text: pending_fact_check.email_address
+  end
+
   view_test "should render the content using govspeak markup" do
     edition = create(:edition, body: "body-in-govspeak")
     fact_check_request = create(:fact_check_request, edition: edition, comments: "comment")
@@ -234,6 +245,13 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     assert_redirected_to admin_publication_path(@edition)
   end
 
+  test "redirect back to the fact check index page a fact check has been requested and the user has the `View move tabs to endpoints` permission" do
+    @requestor.permissions << "View move tabs to endpoints"
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
+
+    assert_redirected_to admin_edition_fact_check_requests_path(@edition)
+  end
+
   test "should not send an email if the fact checker's email address is missing" do
     @attributes[:email_address] = ""
     post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
@@ -253,6 +271,14 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_redirected_to admin_publication_path(@edition)
+  end
+
+  test "redirect back to the fact checking new view if the fact checker's email address is missing and the user has the `View move tabs to endpoints` permission" do
+    @requestor.permissions << "View move tabs to endpoints"
+    @attributes[:email_address] = ""
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
+
+    assert_redirected_to new_admin_edition_fact_check_request_path(@edition)
   end
 
   test "should reject invalid email addresses" do


### PR DESCRIPTION
## Description

This follows on from https://github.com/alphagov/whitehall/pull/6710 which adds an endpoint for `Notes` and https://github.com/alphagov/whitehall/pull/6714 which adds an endpoint for `History`.

This PR does a few things:
1.  Adds a feature spec to check the `Fact checking` tab does not render for users who have the `View move tabs to endpoints` permission
2. Remove the `Fact checking` tab from the edit edition, edition summary (show) and edit translation pages.
3. Adds a `FactCheckRequestsController#index` and `FactCheckRequestsController#new` endpoint
4. Adds a link to the edition summary page which links to the `FactCheckRequestsController#index`` endpoint

## Screenshots

### Edition summary page 

|Before|After|
|---------------|---------------|
|<img width="1314" alt="image" src="https://user-images.githubusercontent.com/42515961/182621545-5bb64353-f39b-4930-ad2e-00ad3beca618.png">|<img width="1220" alt="image" src="https://user-images.githubusercontent.com/42515961/183081509-7274e684-1297-4697-a40b-6d480008c042.png">|

### Edit edition page

|Before|After|
|---------------|---------------|
|<img width="1305" alt="image" src="https://user-images.githubusercontent.com/42515961/182621685-95c367d2-59d5-45cb-90a3-adc13c762486.png">|<img width="1255" alt="image" src="https://user-images.githubusercontent.com/42515961/183081592-04e0256d-92bd-4a7a-a9e0-38876ae5b6f9.png">|

### Edit translation page

|Before|After|
---------------|---------------|
|<img width="1283" alt="image" src="https://user-images.githubusercontent.com/42515961/182621814-a53f280a-4eae-4528-bc26-539e8ba18032.png">|<img width="1224" alt="image" src="https://user-images.githubusercontent.com/42515961/183081697-c5fb0c32-a03a-4f99-9be5-54df48465d75.png">|

### Fact check index page 

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/42515961/183080947-108c990c-7b24-4354-b3ae-b7447546e4a7.png">


### Fact check new page

<img width="915" alt="image" src="https://user-images.githubusercontent.com/42515961/183081416-a0290bfb-3873-4994-9465-77a3812e5d25.png">

## Trello card

https://trello.com/c/yLK9t9yI/605-move-fact-checking-request-to-a-separate-endpoint

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
