### PR TITLE
Implement simpler redirect flow for edition tagging

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -40,7 +40,7 @@ class Admin::EditionTagsController < Admin::BaseController
 private
 
   def redirect_path
-    if params[:save]
+    if params[:save] || current_user.can_redirect_to_summary_page?
       admin_edition_path(@edition)
     else
       edit_admin_edition_legacy_associations_path(@edition, return: :tags)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -293,8 +293,8 @@ private
   end
 
   def show_or_edit_path
-    if params[:save].present?
-      [:edit, :admin, @edition]
+    if current_user.can_redirect_to_summary_page? || params[:save].present?
+      [:admin, @edition]
     else
       edit_admin_edition_tags_path(@edition.id)
     end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -220,8 +220,11 @@ module Admin::EditionsHelper
           locals: { form: form, edition: edition },
         )
       end
-
-      concat form.save_or_continue_or_cancel
+      if current_user.can_redirect_to_summary_page?
+        concat form.save_or_cancel
+      else
+        concat form.save_or_continue_or_cancel
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
     EXPORT_DATA = "Export data".freeze
     VIEW_MOVE_TABS_TO_ENDPOINTS = "View move tabs to endpoints".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
+    REDIRECT_TO_SUMMARY_PAGE = "Redirect to summary page".freeze
   end
 
   def role
@@ -99,6 +100,10 @@ class User < ApplicationRecord
 
   def can_preview_design_system?
     has_permission?(Permissions::PREVIEW_DESIGN_SYSTEM)
+  end
+
+  def can_redirect_to_summary_page?
+    has_permission?(Permissions::REDIRECT_TO_SUMMARY_PAGE)
   end
 
   def organisation_name

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -58,12 +58,14 @@
                   track_category: 'taxonSelection',
                   track_label: request.path
               }) %>
-          <%= form.submit('Save and review specialist topic tagging', name: "legacy_tags", class: "btn btn-lg btn-primary",
-              data: {
-                  module: 'track-selected-taxons',
-                  track_category: 'taxonSelection',
-                  track_label: request.path
-              }) %>
+          <% unless current_user.can_redirect_to_summary_page? %>
+            <%= form.submit('Save and review specialist topic tagging', name: "legacy_tags", class: "btn btn-lg btn-primary",
+                data: {
+                    module: 'track-selected-taxons',
+                    track_category: 'taxonSelection',
+                    track_label: request.path
+                }) %>
+          <% end %>
           <span class="or_cancel">
             or
             <%= link_to('cancel', admin_edition_path(@edition)) %>

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -14,7 +14,6 @@ Feature: New Tagging Workflow
 Scenario: Publication that does not support the new taxonomy
   Given I am a writer
   When I start editing a draft document which cannot be tagged to the new taxonomy
-  And I continue to the tagging page
   And I continue to the legacy tagging page
   Then I should be on the legacy tagging page
   And I should be able to update the legacy tags

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -7,6 +7,5 @@ Feature: Tagging content with specialist sectors
     Given I am a writer
     And there are some specialist sectors
     When I start editing a draft document
-    And I continue to the tagging page
     And I continue to the legacy tagging page
     Then I can tag it to some specialist sectors

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -6,8 +6,7 @@ When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/
       fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
     end
   end
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -1,8 +1,7 @@
 When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/) do |title, location_name|
   begin_drafting_publication(title)
   select location_name, from: "Select the world locations this publication is about"
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -1,6 +1,6 @@
 Given(/^a document that has gone through many changes$/) do
   begin_drafting_publication("An frequently changed publication")
-  click_on "Save and continue"
+  click_button "Save"
   expect(page).to have_content("An frequently changed publication")
   @the_publication = Publication.find_by(title: "An frequently changed publication")
   # fake it

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -56,8 +56,7 @@ When(/^I save and publish the amended consultation$/) do
   ensure_path edit_admin_consultation_path(consultation)
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   publish force: true
 end
 

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -25,8 +25,7 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   publish(force: true)
 end
 

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -160,8 +160,7 @@ When("I force publish {edition}") do |edition|
   click_link "Edit draft"
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   publish(force: true)
 end
 

--- a/features/step_definitions/new_tagging_workflow_steps.rb
+++ b/features/step_definitions/new_tagging_workflow_steps.rb
@@ -32,7 +32,7 @@ Then(/^I should be on the legacy tagging page$/) do
   @publication = Publication.last
 
   expect(page).to have_current_path(
-    edit_admin_edition_legacy_associations_path(@publication, return: "tags"),
+    edit_admin_edition_legacy_associations_path(@publication),
   )
 end
 

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -28,8 +28,7 @@ When(/^I draft a French-only "World news story" news article associated with "([
   select location_name, from: "Select the world locations this news article is about"
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
   select "", from: "edition_lead_organisation_ids_1"
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   @news_article = find_news_article_in_locale!(:fr, "French-only news article")
 end
 
@@ -79,8 +78,7 @@ Then("I subsequently change the primary locale") do
   click_button "Create new edition to edit"
   select "Deutsch (German)", from: "edition[primary_locale]"
   choose "edition_minor_change_true"
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
 end
 
 Then("there should exist only one translation") do

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -15,14 +15,12 @@ end
 
 When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
 end
 
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   add_external_attachment
 end
 
@@ -30,16 +28,14 @@ Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   user = User.find_by(name: user_name)
   as_user(user) do
     begin_drafting_publication(title)
-    click_button "Save and continue"
-    click_button "Save tagging changes"
+    click_button "Save"
   end
 end
 
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
   select data_set_name, from: "Related statistical data sets"
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -18,8 +18,8 @@ Then(/^I can tag it to some specialist sectors$/) do
 
   click_on "Edit draft"
   check "Applies to all UK nations"
-  click_on "Save and continue"
-  click_on "Save and review specialist topic tagging"
+  click_on "Save"
+  click_on "Change specialist topic tags"
 
   expect("WELLS").to eq(find_field("Primary specialist topic tag").value)
   expect(%w[OFFSHORE FIELDS DISTILL].to_set)

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -7,8 +7,7 @@ Given(/^"([^"]*)" submitted a speech "([^"]*)" with body "([^"]*)"$/) do |author
   step %(I am a writer called "#{author}")
   visit new_admin_speech_path
   begin_drafting_speech title: title, body: body
-  click_button "Save and continue"
-  click_button "Save tagging changes"
+  click_button "Save"
   click_button "Submit"
 end
 

--- a/features/step_definitions/statistical_data_set_steps.rb
+++ b/features/step_definitions/statistical_data_set_steps.rb
@@ -1,7 +1,5 @@
 When(/^I draft a new statistical data set "([^"]*)" for organisation "([^"]*)"$/) do |title, organisation_name|
   begin_drafting_statistical_data_set(title: title)
   set_lead_organisation_on_document(Organisation.find_by(name: organisation_name))
-  click_button "Save and continue"
-  click_button "Save and review specialist topic tagging"
   click_button "Save"
 end

--- a/features/step_definitions/tagging_steps.rb
+++ b/features/step_definitions/tagging_steps.rb
@@ -1,7 +1,9 @@
 When(/^I continue to the tagging page$/) do
-  click_button "Save and continue"
+  click_button "Save"
+  click_link "Add tag"
 end
 
 When(/^I continue to the legacy tagging page$/) do
-  click_button "Save and review specialist topic tagging"
+  click_button "Save"
+  click_link "Add specialist topic tags"
 end

--- a/features/support/corporate_information_page_helper.rb
+++ b/features/support/corporate_information_page_helper.rb
@@ -14,8 +14,7 @@ module CorporateInformationPageHelper
     click_link "Edit draft"
     markdown = find_markdown_snippet_to_insert_attachment(attachment)
     fill_in "Body", with: "#{page.body}\n\n#{markdown}"
-    click_button "Save and continue"
-    click_button "Save topic changes"
+    click_button "Save"
   end
 
   def check_attachment_appears_on_corporate_information_page(attachment, page)

--- a/features/support/fatalities_helper.rb
+++ b/features/support/fatalities_helper.rb
@@ -4,8 +4,6 @@ module FatalitiesHelper
     begin_drafting_document type: "fatality_notice", title: title, summary: "fatality notice summary", previously_published: false
     fill_in "Introduction", with: "fatality notice roll call introduction"
     select field, from: "Field of operation"
-    click_button "Save and continue"
-    click_button "Save and review specialist topic tagging"
     click_button "Save"
   end
 end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -79,6 +79,14 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     assert_redirected_to edit_admin_edition_legacy_associations_path(@edition, return: :tags)
   end
 
+  view_test "should not render the `Save and review specialist topic tagging` button when the user has the `Redirect to summary page` permission" do
+    @user.permissions << "Redirect to summary page"
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select ".btn-primary", count: 0
+  end
+
   test "should post empty array to publishing api if no taxons are selected" do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -159,6 +159,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_preview_design_system?
   end
 
+  test "cannot redirect to the summary page by default" do
+    user = build(:user)
+    assert_not user.can_redirect_to_summary_page?
+  end
+
+  test "can redirect to the summary page if given permission" do
+    user = build(:user, permissions: [User::Permissions::REDIRECT_TO_SUMMARY_PAGE])
+    assert user.can_redirect_to_summary_page?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description

At the moment, there's a `wizard` like flow that a user goes through when they create a new edition when you click save and continue on each page. 

This starts with the edit page, then goes to tagging, specialist tagging. Nikin's designs laid out in this Figma https://www.figma.com/file/P7FiX7C1w0SoanGPwPJB5q/Whitehall-Transition?node-id=946%3A61905

This PR does the work to remove the `Save and continue` and  `Save and review specialist topic tagging ` buttons and ensure that the user is always redirected to the Edition summary page between updating each section

This will allow us to add validations each for each page later down he line and generally creates a simpler more linear flow for users

## Trello card

https://trello.com/c/r7y52au8/619-redirect-to-edition-summary-page-after-completing-section

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
