### PR TITLE
Add GA tracking to unpublish/withdraw journey

### DIFF
--- a/app/assets/javascripts/admin/views/edition_workflow/confirm_unpublish.js
+++ b/app/assets/javascripts/admin/views/edition_workflow/confirm_unpublish.js
@@ -13,6 +13,7 @@
       $("input[name='unpublishing_reason_id']").change(this.revealCorrectForm)
       $('#unpublishing_redirect').change(this.hideExplanationIfRedirecting)
       $("input[name='previous_withdrawal_id']").change(this.revealNewWithdrawalFields)
+      $('main form').on('submit', this.trackFormSubmission)
     },
 
     revealCorrectForm: function () {
@@ -49,6 +50,16 @@
       if (withdrawalRadios.length > 0) {
         var selected = withdrawalRadios.filter(':checked').val()
         $('#new-withdrawal').toggle(selected === 'new')
+      }
+    },
+
+    trackFormSubmission: function () {
+      var unpublishType = $("input[name='unpublishing_reason_id']:checked").parent().text().trim()
+      GOVUKAdmin.trackEvent('WithdrawUnpublishSelection', 'WithdrawUnpublish-selection', { label: unpublishType })
+
+      var withdrawalDate = $('input[name=previous_withdrawal_id]:checked').parent().find('strong').text().trim()
+      if (withdrawalDate) {
+        GOVUKAdmin.trackEvent('WithdrawUnpublishSelection', 'Withdraw-selection', { label: withdrawalDate })
       }
     }
   }


### PR DESCRIPTION
This commit adds Google Analytics event tracking to the edition unpublish/withdraw journey.

When the user submits the form to unpublish a document, the following events will be recorded:

1. The type of unpublishing selected.

   EventCategory: "WithdrawUnpublishSelection"
   EventAction: "WithdrawUnpublish-selection"
   EventLabel:
     - "Withdraw: no longer current government policy/activity"
     - "Unpublish: published in error"
     - "Unpublish: consolidated into another GOV.UK page"

2. If withdrawing, the withdrawal date that was selected.

   EventCategory: "WithdrawUnpublishSelection"
   EventAction: "Withdraw-selection"
   EventLabel:
     - the date of a previous withdrawal to use, e.g. "8 November 2020"
     - or "This is a new withdrawal"

Trello: https://trello.com/c/RYIv3oZb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
