### PR TITLE
Limit world location featured documents at 5

### DIFF
--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -53,7 +53,7 @@ module PublishingApi
   private
 
     def featured_links
-      world_location.featured_links.map do |link|
+      world_location.featured_links.limit(FeaturedLink::DEFAULT_SET_SIZE).map do |link|
         {
           title: link.title,
           href: link.url,

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -63,6 +63,14 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(presented_content, "world_location_news")
   end
 
+  test "caps number of featured links at 5" do
+    6.times do
+      create(:featured_link, linkable: world_location)
+    end
+
+    assert_equal 5, present(world_location).content.dig(:details, :ordered_featured_links).size
+  end
+
   test "caps number of featured documents at 5" do
     features = (1..6).to_a.map do |i|
       created_case_study = create(:published_case_study, title: "case-study-#{i}")


### PR DESCRIPTION
When World Location News pages are rendered by Whitehall, we limit the number of featured links at 5, regardless of the number entered into the UI.

This is consistent with the message displayed to publishers (even though we don't actually limit the number they can enter).

Updating the behaviour here so the content item also only contains thefirst 5 featured links, so we present the same content through Collections when rendering is switched over.

[Trello card](https://trello.com/c/i577upcN)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
