### PR TITLE
Remove extra parameter in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,6 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      workflowTrigger: ${{ github.event_name }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
This removes the workflowTrigger parameter from the deploy workflow, which is no longer used. This should fix the call to the reusable workflow.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
