### PR TITLE
Rename published edition to live edition

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -119,7 +119,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   def unwithdraw
     edition_unwithdrawer = Whitehall.edition_services.unwithdrawer(@edition, user: current_user)
     if edition_unwithdrawer.perform!
-      new_edition = @edition.document.published_edition
+      new_edition = @edition.document.live_edition
       redirect_to admin_edition_path(new_edition), notice: "This document has been unwithdrawn"
     else
       flash.now[:alert] = edition_unwithdrawer.failure_reason

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -290,7 +290,7 @@ module Admin::EditionsHelper
   end
 
   def show_similar_slugs_warning?(edition)
-    !edition.document.published? && edition.document.similar_slug_exists?
+    !edition.document.live? && edition.document.similar_slug_exists?
   end
 
   def edition_is_a_novel?(edition)

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -132,9 +132,9 @@ private
     published_edition_date || draft_edition_date
   end
 
-  # Returns the published edition of any detailed guide documents that this edition is related to.
+  # Returns the live edition of any detailed guide documents that this edition is related to.
   def published_outbound_related_detailed_guides
-    related_documents.published.where(document_type: "DetailedGuide").map(&:live_edition).compact
+    related_documents.live.where(document_type: "DetailedGuide").map(&:live_edition).compact
   end
 
   # Returns the published editions that are related to this edition's document.

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -134,7 +134,7 @@ private
 
   # Returns the published edition of any detailed guide documents that this edition is related to.
   def published_outbound_related_detailed_guides
-    related_documents.published.where(document_type: "DetailedGuide").map(&:published_edition).compact
+    related_documents.published.where(document_type: "DetailedGuide").map(&:live_edition).compact
   end
 
   # Returns the published editions that are related to this edition's document.

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -86,7 +86,7 @@ class Document < ApplicationRecord
   end
 
   def update_slug_if_possible(new_title)
-    return if published?
+    return if live?
 
     candidate_slug = normalize_friendly_id(new_title)
     unless candidate_slug == slug
@@ -94,7 +94,7 @@ class Document < ApplicationRecord
     end
   end
 
-  def published?
+  def live?
     Edition.exists?(
       state: Edition::PUBLICLY_VISIBLE_STATES,
       document_id: id,
@@ -111,7 +111,7 @@ class Document < ApplicationRecord
   end
 
   def first_published_date
-    live_edition.first_public_at if published?
+    live_edition.first_public_at if live?
   end
 
   def first_published_on_govuk

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -56,7 +56,7 @@ class Document < ApplicationRecord
 
   attr_accessor :sluggable_string
 
-  def self.published
+  def self.live
     joins(:live_edition)
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -15,7 +15,7 @@ class Document < ApplicationRecord
            inverse_of: :document
   has_many :edition_relations, dependent: :destroy, inverse_of: :document
 
-  has_one  :published_edition,
+  has_one  :live_edition,
            -> { where(state: Edition::PUBLICLY_VISIBLE_STATES) },
            class_name: "Edition",
            inverse_of: :document
@@ -57,7 +57,7 @@ class Document < ApplicationRecord
   attr_accessor :sluggable_string
 
   def self.published
-    joins(:published_edition)
+    joins(:live_edition)
   end
 
   def self.at_slug(document_types, slug)
@@ -111,7 +111,7 @@ class Document < ApplicationRecord
   end
 
   def first_published_date
-    published_edition.first_public_at if published?
+    live_edition.first_public_at if published?
   end
 
   def first_published_on_govuk

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -12,7 +12,7 @@ module Edition::Identifiable
   delegate :slug, :change_history, :content_id, to: :document
 
   def linkable?
-    document.published? || document.published_very_soon?
+    document.live? || document.published_very_soon?
   end
 
   def ensure_presence_of_document

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -38,8 +38,8 @@ module Edition::Identifiable
     def published_as(slug, locale = I18n.default_locale)
       document = Document.at_slug(document_type, slug)
       if document.present?
-        published_edition = document.published_edition
-        return published_edition if published_edition.present? && published_edition.available_in_locale?(locale)
+        live_edition = document.live_edition
+        return live_edition if live_edition.present? && live_edition.available_in_locale?(locale)
       end
       nil
     end

--- a/app/models/edition/statistical_data_sets.rb
+++ b/app/models/edition/statistical_data_sets.rb
@@ -11,7 +11,7 @@ module Edition::StatisticalDataSets
     has_many :edition_statistical_data_sets, foreign_key: :edition_id, dependent: :destroy
     has_many :statistical_data_set_documents, through: :edition_statistical_data_sets, source: :document
     has_many :statistical_data_sets, through: :statistical_data_set_documents, source: :latest_edition
-    has_many :published_statistical_data_sets, through: :statistical_data_set_documents, source: :published_edition, class_name: "StatisticalDataSet"
+    has_many :published_statistical_data_sets, through: :statistical_data_set_documents, source: :live_edition, class_name: "StatisticalDataSet"
 
     add_trait Trait
   end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -28,8 +28,8 @@ class Feature < ApplicationRecord
   end
 
   def to_s
-    if document && document.published_edition
-      LocalisedModel.new(document.published_edition, locale).title
+    if document && document.live_edition
+      LocalisedModel.new(document.live_edition, locale).title
     elsif topical_event
       topical_event.name
     elsif offsite_link
@@ -44,7 +44,7 @@ class Feature < ApplicationRecord
   end
 
   def self.with_published_edition
-    joins(document: :published_edition)
+    joins(document: :live_edition)
   end
 
   def self.with_topical_events

--- a/app/models/feature_list.rb
+++ b/app/models/feature_list.rb
@@ -30,7 +30,7 @@ class FeatureList < ApplicationRecord
   end
 
   def current
-    features.current.includes([:topical_event, { document: :published_edition }])
+    features.current.includes([:topical_event, { document: :live_edition }])
   end
 
   def published_features

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -216,10 +216,10 @@ class Organisation < ApplicationRecord
       documents.each { |d| Whitehall::PublishingApi.republish_document_async(d) }
     end
 
-    # If the alternative format contact rmail is changed, we need to republish
+    # If the alternative format contact email is changed, we need to republish
     # all attachments belonging to the organisation
     if saved_change_to_alternative_format_contact_email?
-      documents = Document.published.where(editions: { alternative_format_provider_id: self })
+      documents = Document.live.where(editions: { alternative_format_provider_id: self })
       documents.find_each { |d| Whitehall::PublishingApi.republish_document_async(d, bulk: true) }
     end
   end

--- a/app/presenters/feature_presenter.rb
+++ b/app/presenters/feature_presenter.rb
@@ -14,7 +14,7 @@ FeaturePresenter = Struct.new(:feature) do
   delegate :document, to: :feature
 
   def edition
-    document.published_edition
+    document.live_edition
   end
 
   delegate :topical_event, to: :feature

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -63,7 +63,7 @@ module PublishingApi
     end
 
     def first_public_at
-      return item.first_public_at if item.document.published?
+      return item.first_public_at if item.document.live?
 
       item.document.created_at.iso8601
     end

--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -16,7 +16,7 @@ module PublishingApi
 
     def featured_documents_editioned(feature)
       # Editioned formats (like news) that have been featured
-      edition = feature.document.published_edition
+      edition = feature.document.live_edition
       {
         title: edition.title,
         href: Whitehall.url_maker.public_document_path(edition),

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -66,7 +66,7 @@ private
   end
 
   def flag_if_political_content!
-    return if edition.document.published?
+    return if edition.document.live?
 
     edition.political = PoliticalContentIdentifier.political?(edition)
   end

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -18,7 +18,7 @@
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 
-  <% if (edition.document and edition.document.published?) and can?(:mark_political, edition) %>
+  <% if (edition.document and edition.document.live?) and can?(:mark_political, edition) %>
     <%= form.check_box :political, label_text: "Associate with government of the time (currently set to #{edition.government&.name}).", class: 'political-status' %>
     <p><a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode'>Read the history mode guidance</a> for more information as to what this means.</p>
   <% end %>

--- a/app/views/admin/feature_lists/_current_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_current_feature_list.html.erb
@@ -17,14 +17,14 @@
         <div class="well feature-list">
           <%= label_tag "ordering-#{feature.id}" do %>
             <div class="row">
-              <% if feature.document && feature.document.published_edition %>
+              <% if feature.document && feature.document.live_edition %>
                 <div class="title col-md-6">
                   <i class="glyphicon glyphicon-align-justify add-right-margin"></i>
-                  <%= link_to(feature, admin_edition_path(feature.document.published_edition)) %>
+                  <%= link_to(feature, admin_edition_path(feature.document.live_edition)) %>
                 </div>
-                <div class="type col-md-2"><%= feature.document.published_edition.type.titleize %> (document)</div>
-                <div class="date col-md-2"><%=localize feature.document.published_edition.major_change_published_at.to_date %></div>
-                <%= content_tag_for :div, feature.document.published_edition, class: "button text-right col-md-2" do %>
+                <div class="type col-md-2"><%= feature.document.live_edition.type.titleize %> (document)</div>
+                <div class="date col-md-2"><%=localize feature.document.live_edition.major_change_published_at.to_date %></div>
+                <%= content_tag_for :div, feature.document.live_edition, class: "button text-right col-md-2" do %>
                   <%= link_to('Unfeature',
                         unfeature_admin_feature_list_feature_path(feature_list, feature),
                         data: { confirm: "Unfeature '#{feature}'?" },

--- a/db/data_migration/20140724134114_change_slugs_on_detailed_guides.rb
+++ b/db/data_migration/20140724134114_change_slugs_on_detailed_guides.rb
@@ -8,9 +8,9 @@ slug_changes.each do |old_slug, new_slug|
 
   if document
     puts "Changing detailed guide slug #{old_slug} to #{new_slug}"
-    Whitehall::SearchIndex.delete(document.published_edition)
+    Whitehall::SearchIndex.delete(document.live_edition)
     document.update!(slug: new_slug)
-    Whitehall::SearchIndex.add(document.published_edition)
+    Whitehall::SearchIndex.add(document.live_edition)
   else
     puts "Warning: DetailedGuide with slug '#{old_slug}' not found"
   end

--- a/db/data_migration/20140811124333_fix_too_long_slugs.rb
+++ b/db/data_migration/20140811124333_fix_too_long_slugs.rb
@@ -5,7 +5,7 @@ router = GdsApi::Router.new(Plek.find("router-api"))
 updated = false
 
 Document.find_by_sql("SELECT *, LENGTH(slug) AS slug_length FROM documents HAVING `slug_length` > 250;").each do |document|
-  next unless (published = document.published_edition)
+  next unless (published = document.live_edition)
 
   old_slug = document.slug
   old_path = Whitehall.url_maker.document_path(published)

--- a/db/data_migration/20141204142323_publish_all_unpublished_editions_to_content_api.rb
+++ b/db/data_migration/20141204142323_publish_all_unpublished_editions_to_content_api.rb
@@ -6,7 +6,7 @@ non_published_editions_with_unpublishings = Edition.unscoped
 
 # reject any editions that have subsequently been re-published
 unpublished_editions = non_published_editions_with_unpublishings.reject do |edition|
-  edition.document.published_edition.present?
+  edition.document.live_edition.present?
 end
 
 # DataHygiene::PublishingApiRepublisher expects a scope.

--- a/db/data_migration/20150325130413_retitle_policies.rb
+++ b/db/data_migration/20150325130413_retitle_policies.rb
@@ -15,7 +15,7 @@ csv.each do |row|
 
     if (policy_document = Document.at_slug("Policy", slug))
 
-      [policy_document.latest_edition, policy_document.published_edition].compact.uniq.each do |policy|
+      [policy_document.latest_edition, policy_document.live_edition].compact.uniq.each do |policy|
         old_title = policy.title
         puts %(Updating policy: #{old_title} -> #{new_title})
 

--- a/db/data_migration/20150422112600_merge_old_policies.rb
+++ b/db/data_migration/20150422112600_merge_old_policies.rb
@@ -7,6 +7,6 @@ SLUG_TO_CONTENT_ID_MAPPING = {
 SLUG_TO_CONTENT_ID_MAPPING.each do |slug, content_id|
   document = Document.at_slug(Policy, slug)
   other_document = Document.find_by(content_id: content_id)
-  puts "\tmerging '#{document.published_edition.title}' into '#{other_document.published_edition.title}'  (setting content_id to '#{content_id}')"
+  puts "\tmerging '#{document.live_edition.title}' into '#{other_document.live_edition.title}'  (setting content_id to '#{content_id}')"
   document.update_column(:content_id, content_id)
 end

--- a/db/data_migration/20150424094040_republish_coming_soon.rb
+++ b/db/data_migration/20150424094040_republish_coming_soon.rb
@@ -1,5 +1,5 @@
 Edition.scheduled.each do |edition|
-  next if edition.document.published?
+  next if edition.document.live?
 
   edition.translated_locales.each do |locale|
     PublishingApiComingSoonWorker.perform_async(edition.id, locale)

--- a/db/data_migration/20160108173056_republish_docs_with_no_content_item.rb
+++ b/db/data_migration/20160108173056_republish_docs_with_no_content_item.rb
@@ -12,5 +12,5 @@ dodgy_slugs = %w[
 
 dodgy_slugs.each do |slug|
   puts "Republishing #{slug}"
-  Whitehall::PublishingApi.republish_async(Document.where(slug: slug).first.published_edition)
+  Whitehall::PublishingApi.republish_async(Document.where(slug: slug).first.live_edition)
 end

--- a/db/data_migration/20160504145225_republish_all_editions.rb
+++ b/db/data_migration/20160504145225_republish_all_editions.rb
@@ -1,3 +1,3 @@
 Document
-  .includes(:published_edition, :pre_publication_edition)
+  .includes(:live_edition, :pre_publication_edition)
   .find_each { |d| Whitehall::PublishingApi.republish_document_async(d, bulk: true) }

--- a/db/data_migration/20160623092908_correct_document_content_ids.rb
+++ b/db/data_migration/20160623092908_correct_document_content_ids.rb
@@ -39,7 +39,7 @@ end
 # correct IDs from the content store and set them accordingly:
 slugs_to_fix.each do |slug|
   document = Document.find_by(slug: slug)
-  base_path = Whitehall.url_maker.public_document_path(document.published_edition)
+  base_path = Whitehall.url_maker.public_document_path(document.live_edition)
   correct_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
   if correct_content_id.blank?
     raise ArgumentError, "no content id found for #{base_path}"

--- a/db/data_migration/20170109152833_remove_non_existent_stats_datasets.rb
+++ b/db/data_migration/20170109152833_remove_non_existent_stats_datasets.rb
@@ -4,7 +4,7 @@ non_existent_data_sets = Document.where(id: [71_831, 71_833])
 
 doc_ids.each do |doc_id|
   d = Document.find(doc_id)
-  e = d.published_edition
+  e = d.live_edition
   e.statistical_data_sets = (e.statistical_data_sets - non_existent_data_sets)
   e.save!
 end

--- a/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
+++ b/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
@@ -2,9 +2,9 @@
 document_id = 272_247
 detailed_guide = Document.find(document_id)
 
-if detailed_guide.published_edition
+if detailed_guide.live_edition
   unpublisher = EditionUnpublisher.new(
-    detailed_guide.published_edition,
+    detailed_guide.live_edition,
     unpublishing: {
       unpublishing_reason_id: UnpublishingReason::Consolidated.id,
       explanation: "Unpublished as consolidated into another GOV.UK page. Editorial Board approval received. Redirected.",

--- a/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
+++ b/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
@@ -1,7 +1,7 @@
 Document.where(
   id: Edition.where(state: :scheduled).select(:document_id),
 ).all.each do |document|
-  next unless document.published_edition.nil?
+  next unless document.live_edition.nil?
 
   puts "Saving draft for #{document.id} (content_id: #{document.content_id})"
   Whitehall::PublishingApi.save_draft(document.pre_publication_edition)

--- a/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
+++ b/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
@@ -1,7 +1,7 @@
 Document.where(
   id: Edition.where(state: :scheduled).select(:document_id),
 ).all.each do |document|
-  next unless document.published_edition.nil?
+  next unless document.live_edition.nil?
 
   puts "Saving draft for #{document.id} (content_id: #{document.content_id})"
   Whitehall::PublishingApi.save_draft(document.pre_publication_edition)

--- a/db/data_migration/20181102131225_republish_additional_documents.rb
+++ b/db/data_migration/20181102131225_republish_additional_documents.rb
@@ -71,7 +71,7 @@ content_ids = %w[
 documents = Document.where(content_id: content_ids)
 
 documents.find_each do |document|
-  edition = document.published_edition
+  edition = document.live_edition
 
   if edition.respond_to?(:attachments)
     edition.attachments.each do |attachment|

--- a/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
+++ b/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
@@ -4,10 +4,10 @@ def unwithdraw_publication
   click_link "Unwithdraw"
   click_button "Unwithdraw"
 
-  @latest_published_edition = @publication.document.published_edition
+  @latest_live_edition = @publication.document.live_edition
 
   expect(:superseded).to eq(@publication.reload.current_state)
-  expect(:published).to eq(@latest_published_edition.current_state)
+  expect(:published).to eq(@latest_live_edition.current_state)
 end
 
 When(/^I unwithdraw the publication$/) do
@@ -22,5 +22,5 @@ Given("it was subsequently unwithdrawn") do
 end
 
 Then(/^I should be redirected to the latest edition of the publication$/) do
-  expect(page).to have_current_path(admin_edition_path(@latest_published_edition))
+  expect(page).to have_current_path(admin_edition_path(@latest_live_edition))
 end

--- a/lib/content_publisher/document_collection_group_membership_migrator.rb
+++ b/lib/content_publisher/document_collection_group_membership_migrator.rb
@@ -7,7 +7,7 @@ module ContentPublisher
     end
 
     def call
-      edition = document.published_edition || document.latest_edition
+      edition = document.live_edition || document.latest_edition
 
       return unless DocumentCollectionGroupMembership.exists?(document_id: document.id)
 

--- a/lib/content_publisher/featured_document_migrator.rb
+++ b/lib/content_publisher/featured_document_migrator.rb
@@ -7,7 +7,7 @@ module ContentPublisher
     end
 
     def call
-      edition = document.published_edition.presence || document.latest_edition
+      edition = document.live_edition.presence || document.latest_edition
 
       public_url = Whitehall.url_maker.public_document_url(edition)
       public_updated_at = (edition.public_timestamp || edition.updated_at)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -110,7 +110,7 @@ namespace :export do
 
   desc "Exports HTML attachments for a particular publication as JSON"
   task :html_attachments, [:slug] => :environment do |_t, args|
-    edition = Document.find_by(slug: args[:slug]).published_edition
+    edition = Document.find_by(slug: args[:slug]).live_edition
 
     result = edition.html_attachments.map do |a|
       {

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -26,7 +26,7 @@ namespace :export do
             document.slug,
             document.display_type,
             document.latest_edition.state,
-            document.published? ? Whitehall.url_maker.public_document_url(edition) : nil,
+            document.live? ? Whitehall.url_maker.public_document_url(edition) : nil,
             edition.id,
             edition.title,
             edition.state,

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,7 +1,7 @@
 namespace :search do
   desc "Re-index one Document. Takes a `content_id` as argument."
   task :resend_document, [:content_id] => [:environment] do |_, args|
-    Document.find_by(content_id: args[:content_id]).published_edition.update_in_search_index
+    Document.find_by(content_id: args[:content_id]).live_edition.update_in_search_index
   end
 
   desc "Re-index a collection of Documents with specified world location. Takes a `world_location_slug` as argument."
@@ -12,7 +12,7 @@ namespace :search do
       content_ids = Edition.in_world_location(world_location.id).map(&:content_id)
 
       Document.where(content_id: content_ids).each do |document|
-        document.published_edition.try(:update_in_search_index)
+        document.live_edition.try(:update_in_search_index)
       end
     else
       puts "World location for #{args[:world_location_slug]} not found"
@@ -98,9 +98,9 @@ namespace :search do
     desc "indexes all documents which were last updated in the given date range, the time defaults to midnight if only a date is given"
     task :published_between, %i[start_date end_date] => :environment do |_t, args|
       Document
-        .joins(:published_edition)
+        .joins(:live_edition)
         .where(editions: { updated_at: args[:start_date]..args[:end_date] })
-        .find_each { |doc| doc.published_edition&.update_in_search_index }
+        .find_each { |doc| doc.live_edition&.update_in_search_index }
     end
   end
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -11,7 +11,7 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal [published_publication.document], Document.published
   end
 
-  test "should return the published edition" do
+  test "should return the live edition" do
     user = create(:departmental_editor)
     document = create(:document)
     original_publication = create(:draft_publication, document: document)
@@ -24,7 +24,7 @@ class DocumentTest < ActiveSupport::TestCase
     published_publication = draft_publication
     _new_draft_publication = published_publication.create_draft(user)
 
-    assert_equal published_publication, document.reload.published_edition
+    assert_equal published_publication, document.reload.live_edition
   end
 
   test "should be able to retrieve documents of a certain type at a particular slug" do

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -39,23 +39,28 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal speech.document, Document.at_slug([news.type, speech.type], speech.document.slug)
   end
 
-  test "should be published if a published edition exists" do
+  test "should be live if a published edition exists" do
     published_publication = create(:published_publication)
-    assert published_publication.document.published?
+    assert published_publication.document.live?
   end
 
-  test "should not be published if no published edition exists" do
+  test "should be live if a withdrawn edition exists" do
+    published_publication = create(:withdrawn_publication)
+    assert published_publication.document.live?
+  end
+
+  test "should not be live if no published or withdrawn edition exists" do
     draft_publication = create(:draft_publication)
-    assert_not draft_publication.document.published?
+    assert_not draft_publication.document.live?
   end
 
-  test "should no longer be published when it's edition is unpublished" do
+  test "should no longer be live when it's edition is unpublished" do
     published_publication = create(:published_publication)
-    assert published_publication.document.published?
+    assert published_publication.document.live?
 
     published_publication.unpublish!
 
-    assert_not published_publication.document.published?
+    assert_not published_publication.document.live?
   end
 
   test "should ignore deleted editions when finding latest edition" do

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -3,12 +3,13 @@ require "test_helper"
 class DocumentTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
-  test "should return documents that have published editions" do
+  test "should return documents that have live editions" do
     create(:superseded_publication)
     create(:draft_publication)
     published_publication = create(:published_publication)
+    withdrawn_publication = create(:withdrawn_publication)
 
-    assert_equal [published_publication.document], Document.published
+    assert_equal [published_publication.document, withdrawn_publication.document], Document.live
   end
 
   test "should return the live edition" do

--- a/test/unit/presenters/feature_list_presenter_test.rb
+++ b/test/unit/presenters/feature_list_presenter_test.rb
@@ -19,7 +19,7 @@ class FeatureListPresenterTest < PresenterTestCase
 
   def feature
     @feature ||= stub("feature").tap do |feature|
-      document = stub("document", published_edition: stub("published_edition"))
+      document = stub("document", live_edition: stub("live_edition"))
       feature.stubs(:document).returns(document)
     end
   end

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -21,7 +21,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path generates a localized link to the edition" do
     d = stub_record(:document)
     cs = stub_record(:case_study, document: d, create_default_organisation: false)
-    d.stubs(:published_edition).returns(cs)
+    d.stubs(:live_edition).returns(cs)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -32,7 +32,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path generates an unlocalized link to the edition if it's not a localizable type" do
     d = stub_record(:document)
     p = stub_record(:consultation, document: d, create_default_organisation: false, alternative_format_provider: nil)
-    d.stubs(:published_edition).returns(p)
+    d.stubs(:live_edition).returns(p)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -43,7 +43,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path respects the locale of the feature when generating localized edition links" do
     d = stub_record(:document)
     cs = stub_record(:case_study, document: d, create_default_organisation: false)
-    d.stubs(:published_edition).returns(cs)
+    d.stubs(:live_edition).returns(cs)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
@@ -56,7 +56,7 @@ class FeaturePresenterTest < PresenterTestCase
   test "#public_path forces the global locale to english when generating edition links for a non localizable types" do
     d = stub_record(:document)
     p = stub_record(:consultation, document: d, create_default_organisation: false, alternative_format_provider: nil)
-    d.stubs(:published_edition).returns(p)
+    d.stubs(:live_edition).returns(p)
     f = stub_record(:feature, topical_event: nil, document: d)
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -64,6 +64,6 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
     edition ||= @edition
     @unwithdrawer = EditionUnwithdrawer.new(edition, user: @user)
     @unwithdrawer.perform!
-    edition.document.published_edition
+    edition.document.live_edition
   end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -6,7 +6,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
   test "it pushes the published and the draft editions of a document if there is a later draft" do
     document = stub(
-      published_edition: published_edition = build(:edition, id: 1),
+      live_edition: live_edition = build(:edition, id: 1),
       id: 1,
       pre_publication_edition: draft_edition = build(:edition, id: 2),
       locked?: false,
@@ -16,14 +16,14 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     Document.stubs(:find).returns(document)
 
     Whitehall::PublishingApi.expects(:publish).with(
-      published_edition,
+      live_edition,
       "republish",
       bulk_publishing: false,
     )
 
     Whitehall::PublishingApi
       .expects(:patch_links)
-      .with(published_edition, bulk_publishing: false)
+      .with(live_edition, bulk_publishing: false)
 
     Whitehall::PublishingApi
       .expects(:save_draft)
@@ -32,7 +32,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     invocation_order = sequence("invocation_order")
     ServiceListeners::PublishingApiHtmlAttachments
       .expects(:process)
-      .with(published_edition, "republish")
+      .with(live_edition, "republish")
       .in_sequence(invocation_order)
     ServiceListeners::PublishingApiHtmlAttachments
       .expects(:process)
@@ -47,7 +47,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   class DraftException < StandardError; end
   test "it pushes the published version first if there is a more recent draft" do
     document = stub(
-      published_edition: build(:edition),
+      live_edition: build(:edition),
       id: 1,
       pre_publication_edition: build(:edition),
       locked?: false,
@@ -103,7 +103,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   test "it publishes and then unpublishes if the published edition is withdrawn" do
     unpublishing = build(:withdrawn_unpublishing, id: 10)
     document = stub(
-      published_edition: published_edition = create(:withdrawn_edition, unpublishing: unpublishing),
+      live_edition: live_edition = create(:withdrawn_edition, unpublishing: unpublishing),
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
@@ -113,22 +113,22 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     Document.stubs(:find).returns(document)
 
     Whitehall::PublishingApi.expects(:publish).with(
-      published_edition,
+      live_edition,
       "republish",
       bulk_publishing: false,
     )
 
     PublishingApiUnpublishingWorker.expects(:new).returns(unpublishing_worker = mock)
-    unpublishing_worker.expects(:perform).with(published_edition.unpublishing.id, false)
+    unpublishing_worker.expects(:perform).with(live_edition.unpublishing.id, false)
 
     invocation_order = sequence("invocation_order")
     ServiceListeners::PublishingApiHtmlAttachments
       .expects(:process)
-      .with(published_edition, "republish")
+      .with(live_edition, "republish")
       .in_sequence(invocation_order)
     ServiceListeners::PublishingApiHtmlAttachments
       .expects(:process)
-      .with(published_edition, "republish")
+      .with(live_edition, "republish")
       .in_sequence(invocation_order)
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
@@ -136,7 +136,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
   test "it raises if an unknown combination is encountered" do
     document = stub(
-      published_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
+      live_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
       id: 1,
       pre_publication_edition: nil,
       locked?: false,
@@ -149,12 +149,12 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test "it completes silently if there are no published or pre_pub editions" do
+  test "it completes silently if there are no live or pre_publication editions" do
     # whitehall has a lot of old documents that only have superseded editions
     # we want to ignore these and not have to try and avoid passing them in
     # when doing bulk republishing
     document = stub(
-      published_edition: nil,
+      live_edition: nil,
       id: 1,
       pre_publication_edition: nil,
       locked?: false,


### PR DESCRIPTION
This PR attempts to pull out the work done in c2903dfd67f7d7cb801e64a76624cb15e4ebb287 as part of the #6696 spike into resolving performance issues on `Document#latest_edition`.

It's a [preparatory refactor](https://martinfowler.com/articles/preparatory-refactoring-example.html) for improving the performance of `Document#latest_edition` ([Trello card](https://trello.com/c/iWcORsD5/549-replace-slow-query-for-finding-latest-edition-of-a-document)).

It aims to clarify the concept of a Document being "live", which means it's either "published" or "withdrawn" and is therefore publicly visible on the GOV.UK website.

Previously the term "published" was used to describe Documents in this state. This ended up becoming an overloaded name in the codebase because it muddled the difference between a "published" (a.k.a. "live") Document and an Edition which is in the "published" state.

### Changes made

- [Rename `Document#published_edition` to `Document#live_edition`](https://github.com/alphagov/whitehall/pull/6729/commits/cd250a30addd490bff26455050ea4f807ad81614)
- [Rename `Document#published?` to `Document#live?`](https://github.com/alphagov/whitehall/pull/6729/commits/309aa2c56ad32417c59fb2d8c1084f851834b6e5)
- [Rename `Document#published` to `Document#live`](https://github.com/alphagov/whitehall/pull/6729/commits/a5cc3510d4c62aab87952f0650072de038689f64)

### Changes NOT made

I haven't changed `Edition#latest_published_edition` to `Edition#latest_live_edition` – which was done in the original spike (c2903dfd67f7d7cb801e64a76624cb15e4ebb287).

The existing `latest_published_edition` only includes "published" Editions – **not** "withdrawn" editions. This was also [acknowledged in the original spike](https://github.com/alphagov/whitehall/pull/6696#pullrequestreview-1054663907). So rather than rename it and change the behaviour, I've left it as is – that way its name describes its behaviour.

https://github.com/alphagov/whitehall/blob/28befd709676754b31f5c4b0f73cc88da6829dee/app/models/edition.rb#L255-L262

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
