### PR TITLE
Fix world location news translations

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -23,7 +23,7 @@ class WorldLocation < ApplicationRecord
   accepts_nested_attributes_for :edition_world_locations
   accepts_nested_attributes_for :offsite_links
 
-  after_update :send_news_page_to_publishing_api_and_rummager
+  after_commit :send_news_page_to_publishing_api_and_rummager, on: %i[create update]
 
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = "WL"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,7 @@ if Government.where(name: "Test Government").blank?
 end
 
 if WorldLocation.where(name: "Test World Location").blank?
+  WorldLocation.skip_callback(:commit, :after, :send_news_page_to_publishing_api_and_rummager, raise: false)
   WorldLocation.create!(
     name: "Test World Location",
     world_location_type_id: 1,
@@ -51,6 +52,7 @@ if WorldLocation.where(name: "Test World Location").blank?
 end
 
 if WorldLocation.where(name: "Test International Delegation").blank?
+  WorldLocation.skip_callback(:commit, :after, :send_news_page_to_publishing_api_and_rummager, raise: false)
   WorldLocation.create!(
     name: "Test International Delegation",
     world_location_type_id: 3,

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -41,6 +41,9 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "a world location exists" do
     set_up do
       DatabaseCleaner.clean_with :truncation
+      stub_request(:any, %r{#{Regexp.escape(Plek.find('publishing-api'))}/v2/content})
+      stub_request(:any, %r{#{Regexp.escape(Plek.find('publishing-api'))}/v2/links/})
+
       create(:world_location, name: "France", slug: "france")
     end
   end

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :world_location, traits: [:translated] do
     name { "British Antarctic Territory" }
     world_location_type { WorldLocationType::WorldLocation }
+    title { "British Antarctic Territory and the UK" }
 
     trait(:with_worldwide_organisations) do
       after :create do |world_location, _evaluator|

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { "British Antarctic Territory" }
     world_location_type { WorldLocationType::WorldLocation }
     title { "British Antarctic Territory and the UK" }
+    news_page_content_id { SecureRandom.uuid }
 
     trait(:with_worldwide_organisations) do
       after :create do |world_location, _evaluator|

--- a/test/integration/world_location_integration_test.rb
+++ b/test/integration/world_location_integration_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api"
+require "capybara/rails"
+
+class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+  include TaxonomyHelper
+
+  before do
+    organisation = create(:organisation)
+    managing_editor = create(:managing_editor, organisation: organisation, uid: "user-uid")
+
+    login_as managing_editor
+  end
+
+  setup do
+    @original_french_mission_statement = "Enseigner aux gens comment infuser le thé"
+    @original_english_title = "France and the UK"
+    @original_english_mission_statement = "a mission statement"
+    @original_french_title = "Le Royaume-Uni et la France"
+    @world_location = create(:world_location,
+                             slug: "france",
+                             mission_statement: @original_english_mission_statement,
+                             news_page_content_id: "id-123",
+                             title: @original_english_title,
+                             translated_into:
+                               { fr: {
+                                 name: "La France",
+                                 title: @original_french_title,
+                                 mission_statement: @original_french_mission_statement,
+                               } })
+  end
+
+  def put_content_hash_containing(locale, title, mission_statement)
+    has_entries(locale: locale, title: title, details: has_entries(mission_statement: mission_statement))
+  end
+
+  test "when updating the english news page, other translations retains their original values" do
+    Sidekiq::Testing.inline! do
+      visit edit_admin_world_location_path(@world_location)
+      new_mission_statement = "a different mission"
+      fill_in "world_location_mission_statement", with: new_mission_statement
+      new_title = "a new title"
+      fill_in "Title", with: new_title
+
+      Services.publishing_api.expects(:put_content).once.with("id-123", put_content_hash_containing("en", new_title, new_mission_statement))
+      Services.publishing_api.expects(:put_content).once.with("id-123", put_content_hash_containing("fr", @original_french_title, @original_french_mission_statement))
+      Services.publishing_api.expects(:put_content).once.with(@world_location.content_id, has_entries(document_type: "world_location"))
+      Services.publishing_api.expects(:publish).at_least_once
+
+      click_on "Save"
+    end
+  end
+
+  test "when updating a non-english news page, the english version retains its original values" do
+    Sidekiq::Testing.inline! do
+      visit admin_world_location_path(@world_location)
+      click_link "Translations"
+      click_link "Français"
+      new_mission_statement = "un mission différent"
+      fill_in "world_location_mission_statement", with: new_mission_statement
+      new_title = "un titre différent"
+      fill_in "Title", with: new_title
+
+      Services.publishing_api.expects(:put_content).once.with("id-123", put_content_hash_containing("en", @original_english_title, @original_english_mission_statement))
+      Services.publishing_api.expects(:put_content).once.with("id-123", put_content_hash_containing("fr", new_title, new_mission_statement))
+      Services.publishing_api.expects(:put_content).at_least_once.with(@world_location.content_id, has_entries(document_type: "world_location"))
+      Services.publishing_api.expects(:publish).at_least_once
+
+      click_on "Save"
+    end
+  end
+end

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -33,6 +33,7 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
     world_location = FactoryBot.create(
       :world_location,
       name: "France",
+      title: "UK and France",
       news_page_content_id: "id-123",
       translated_into: [:fr],
     )
@@ -42,8 +43,12 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
     end
 
     I18n.with_locale(:fr) do
+      world_location.update!(title: "Le Royaume-Uni et la France")
       @french = PublishingApi::WorldLocationNewsPresenter.new(world_location).content
     end
+
+    assert_equal("UK and France", @english[:title])
+    assert_equal("Le Royaume-Uni et la France", @french[:title])
 
     Services.publishing_api.expects(:put_content).with("id-123", @english)
     Services.publishing_api.expects(:publish).with("id-123", nil, locale: :en)


### PR DESCRIPTION
This fixes a bug with the content items sent for world location news pages, whereby editing a translatable field, such as the mission statement, sent that field through in the content item for all locales. So this means that editing the French content for a world location news item would have resulted in French content appearing on the English page. The same would happen for editing the English content, with English content then appearing on the French page.

The fix in this commit is to switch the after_update hook to an after_commit hook for world location news pages. This addresses a known issue - see https://github.com/globalize/globalize/issues/659 - with the Globalize gem, whereby in an after_update or after_save hook does not respect the I18n locale that it is acting in the context of. After_commit does not have the same issue.

To note that we are adding the publishing to publishing api behaviour now when the world location page is saved, as well as when it is updated. Previously, this behaviour only happened on update. We have decided to introduce this behaviour now since when we switch to using the `PublishesToPublishingApi` trait, we will introduce this behaviour anyway. If this results in undesired behaviour (at worst, some empty world location / world location news pages published to the website), the fix for this should be to make these pages properly editionable and creatable via the UI, rather than continuing to hack around world location news pages.

[Trello](https://trello.com/c/BcmT8Ley/205-fix-presentation-of-translated-world-location-news-pages-to-publishing-api)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
