### PR TITLE
[Part1] Remove attachment tabs from editions edit page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
     VIEW_MOVE_TABS_TO_ENDPOINTS = "View move tabs to endpoints".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     REDIRECT_TO_SUMMARY_PAGE = "Redirect to summary page".freeze
+    REMOVE_EDIT_TABS = "Remove edit tabs".freeze
   end
 
   def role
@@ -104,6 +105,10 @@ class User < ApplicationRecord
 
   def can_redirect_to_summary_page?
     has_permission?(Permissions::REDIRECT_TO_SUMMARY_PAGE)
+  end
+
+  def can_remove_edit_tabs?
+    has_permission?(Permissions::REMOVE_EDIT_TABS)
   end
 
   def organisation_name

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Case studies that show someone’s experience of a process covered on GOV.UK or a policy problem the government is trying to solve.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Associations</legend>
@@ -10,5 +10,16 @@
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
+        <%= render 'world_location_fields', form: form, edition: edition %>
+        <%= render 'organisation_fields', form: form, edition: edition %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/corporate_information_pages/_form.html.erb
+++ b/app/views/admin/corporate_information_pages/_form.html.erb
@@ -1,8 +1,17 @@
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <div class="js-external-url-set">
       <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
     </div>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+
+      <div class="js-external-url-set">
+        <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -2,7 +2,7 @@
   <p>Detailed guides tell users the steps they need to take to complete a specific task. They are usually aimed at specialist or professional audiences.</p><p>Read the <a href="https://www.gov.uk/guidance/content-design/content-types#detailed-guide" target="_blank">detailed guides guidance</a> in full.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <fieldset>
@@ -29,5 +29,35 @@
     </fieldset>
 
     <%= render partial: 'nation_fields', locals: { form: form, edition: edition } %>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
+
+        <%= render "topical_event_fields", form: form, edition: edition %>
+
+        <% cache_if edition.related_detailed_guide_ids.empty?, taggable_detailed_guides_cache_digest do %>
+          <%= form.label :related_detailed_guide_ids, 'Related guides' %>
+          <%= form.select :related_detailed_guide_ids, options_for_select(taggable_detailed_guides_container, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related detailed guides…"} %>
+        <% end %>
+      </fieldset>
+
+      <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
+
+      <fieldset>
+        <legend>Related mainstream content</legend>
+        <p>
+          Link to the top-level URL for mainstream content - not a specific chapter.
+        </p>
+        <%= form.text_field :related_mainstream_content_url %>
+        <%= form.text_field :additional_related_mainstream_content_url %>
+      </fieldset>
+
+      <%= render partial: 'nation_fields', locals: { form: form, edition: edition } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -2,16 +2,14 @@
   <p><strong>Use this format for:</strong> Initial fatality notices and subsequent obituaries of forces and MOD personnel. Don’t publish a news story which duplicates this announcement.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
-
     <fieldset>
       <legend>Associations</legend>
       <p>You'll be able to specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'appointment_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'operational_field_fields', locals: { form: form, edition: edition } %>
-
     </fieldset>
 
     <fieldset class="named fatality-notice-casualties js-duplicate-fields">
@@ -24,5 +22,28 @@
         </div>
       <% end %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <fieldset>
+        <legend>Associations</legend>
+        <p>You'll be able to specialist sectors later.</p>
+        <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
+        <%= render partial: 'appointment_fields', locals: { form: form, edition: edition } %>
+        <%= render partial: 'operational_field_fields', locals: { form: form, edition: edition } %>
+      </fieldset>
+
+      <fieldset class="named fatality-notice-casualties js-duplicate-fields">
+        <legend>Roll call info (displays on the field of operation)</legend>
+        <%= form.text_area :roll_call_introduction, rows: 2, label_text: 'Introduction' %>
+        <h3>Casualties</h3>
+        <%= form.fields_for :fatality_notice_casualties do |casualty_form| %>
+          <div class="js-duplicate-fields-set well">
+            <%= casualty_form.text_area :personal_details, rows: 2 %>
+          </div>
+        <% end %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -4,7 +4,7 @@
   <p>Do <em>not</em> use for: promoting the publication of other content (eg statistics).</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <%= render 'inline_attachments_info', form: form, edition: edition %>
 
@@ -16,5 +16,20 @@
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <%= render 'inline_attachments_info', form: form, edition: edition %>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render 'appointment_fields', form: form, edition: edition %>
+        <%= render 'topical_event_fields', form: form, edition: edition %>
+        <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
+        <%= render 'world_location_fields', form: form, edition: edition %>
+        <%= render 'organisation_fields', form: form, edition: edition %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Stand-alone government documents, issued on a specified date through GOV.UK for distribution.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <%= form.hidden_field :statistics_announcement_id %>
 
@@ -19,5 +19,25 @@
       <%= render 'organisation_fields', form: form, edition: edition %>
       <%= render 'nation_fields', form: form, edition: edition %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <%= form.hidden_field :statistics_announcement_id %>
+
+      <%= render 'inline_attachments_info', form: form, edition: edition %>
+      <%= render 'html_version_fields', form: form, edition: edition %>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <p>You'll be able to select Topics and Specialist Sectors later.</p>
+        <%= render 'appointment_fields', form: form, edition: edition %>
+        <%= render 'statistical_data_set_fields', form: form, edition: edition %>
+        <%= render 'topical_event_fields', form: form, edition: edition %>
+        <%= render 'world_location_fields', form: form, edition: edition %>
+        <%= render 'organisation_fields', form: form, edition: edition %>
+        <%= render 'nation_fields', form: form, edition: edition %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -5,7 +5,7 @@
   <p>Do <em>not</em> use for: statements <em>not</em> made to Parliament (use the “news article” format for those).</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Associations</legend>
@@ -13,5 +13,16 @@
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render 'topical_event_fields', form: form, edition: edition %>
+        <%= render 'world_location_fields', form: form, edition: edition %>
+        <%= render 'organisation_fields', form: form, edition: edition %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -4,7 +4,8 @@
   <p>Do <em>not</em> use for: less frequently updated (eg quarterly) data. Use a publication (subtype: statistics) instead.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
@@ -13,5 +14,17 @@
       <legend>Associations</legend>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+
+      <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/supporting_pages/_form.html.erb
+++ b/app/views/admin/supporting_pages/_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Detailed background or information about an action government is taking in relation to a policy.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <div class="js-external-url-set">
@@ -13,5 +13,19 @@
       <legend>Associations</legend>
       <%= render partial: 'specialist_sector_fields', locals: { form: form, edition: edition } %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+
+      <div class="js-external-url-set">
+        <%= render 'inline_attachments_info', form: form, edition: edition %>
+      </div>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render partial: 'specialist_sector_fields', locals: { form: form, edition: edition } %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
@@ -9,6 +9,10 @@ class AttachableEditionTest < ActionController::TestCase
     assert_select "ul.nav-tabs li a[href*=?]", path, link_text
   end
 
+  def assert_not_tab(link_text)
+    assert_select "ul.nav-tabs li", text: link_text, count: 0
+  end
+
   view_test 'GET :new displays a "Document" tab' do
     get :new
     assert_tab "Document", new_admin_news_article_path
@@ -19,6 +23,14 @@ class AttachableEditionTest < ActionController::TestCase
     get :edit, params: { id: edition }
     assert_tab "Document", edit_admin_news_article_path(edition)
     assert_tab "Attachments", admin_edition_attachments_path(edition)
+  end
+
+  view_test 'GET :edit does not display "Document" and "Attachments" tabs when user has the `Remove edit tabs` permission' do
+    @current_user.permissions << "Remove edit tabs"
+    edition = create(:news_article)
+    get :edit, params: { id: edition }
+    assert_not_tab "Document"
+    assert_not_tab "Attachments"
   end
 end
 

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -66,7 +66,9 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
           stub_publishing_api_has_linkables([], document_type: "topic")
           visit admin_news_article_path(edition)
           click_button "Create new edition to edit"
-          click_link "Attachments 1"
+          fill_in "edition_change_note", with: "changes"
+          click_button "Save"
+          click_link "Modify attachments"
           within ".existing-attachments" do
             click_link "Edit"
           end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -169,6 +169,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_redirect_to_summary_page?
   end
 
+  test "cannot remove edit tabs by default" do
+    user = build(:user)
+    assert_not user.can_remove_edit_tabs?
+  end
+
+  test "can remove edit tabs if given permission" do
+    user = build(:user, permissions: [User::Permissions::REMOVE_EDIT_TABS])
+    assert user.can_remove_edit_tabs?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description 

This is the first of 4 pull requests. All of this work sits behind the `REMOVE_EDIT_TABS ` permission https://github.com/alphagov/whitehall/blob/main/app/models/user.rb#L32

The pull requests will do the following 

1. This PR will remove tabs from the Edition edit page for all Edition types except `DocumentCollections` and `Consultations` 
2. Remove tabs for `DocumentCollections` and add them to the Edition Summary page (otherwise there would be no way to navigate to them)
3.  Ditto for `Consultations`
4.  Remove all tabs from the Attachments index page (Document etc.)


## Trello card

https://trello.com/c/X0ZL0ouj/625-remove-attachment-tab-from-edit-edition-page-and-document-tab-from-attachments-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
