### PR TITLE
Scope nav sidebar changes to the editions interface/tab

### DIFF
--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -20,7 +20,7 @@ module Admin::SidebarHelper
       if options[:editing]
         tabs[:govspeak_help] = "Help"
       end
-      unless current_user.can_view_move_tabs_to_endpoints?
+      unless current_user.can_view_move_tabs_to_endpoints? && !edition.is_a?(CorporateInformationPage)
         tabs[:notes] = ["Notes", options[:remarks_count]]
         tabs[:history] = ["History", options[:history_count]]
         if edition.can_be_fact_checked?

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -17,7 +17,7 @@
     </section>
   </div>
   <div class="col-md-4">
-    <% if current_user.can_view_move_tabs_to_endpoints? %>
+    <% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
       <div class="govspeak_help" id="govspeak_help">
         <%= render partial: "admin/editions/govspeak_help",
                    locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -28,7 +28,7 @@
 <%= render partial: "rejected_by", locals: { edition: @edition } %>
 <%= render partial: 'alerts', locals: {edition: @edition}  %>
 
-<% if current_user.can_view_move_tabs_to_endpoints? %>
+<% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
   <nav class= "add-bottom-margin">
     <ul class="list-unstyled">
       <li><%= link_to "Notes", admin_edition_editorial_remarks_path(@edition) %></li>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -33,7 +33,7 @@
     </div>
 
     <div class="col-md-4">
-      <% if current_user.can_view_move_tabs_to_endpoints? %>
+      <% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
         <div class="govspeak_help" id="govspeak_help">
           <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
                                       show_attachments_tab_help: true,

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -74,9 +74,10 @@
     <% end %>
 
     <%= render partial: "history_state", locals: { edition: @edition } %>
+
     <% if @edition.imported? %>
       <%= render partial: 'speed_tagging' %>
-    <% elsif !current_user.can_view_move_tabs_to_endpoints?  %>
+    <% elsif !current_user.can_view_move_tabs_to_endpoints? || @edition.is_a?(CorporateInformationPage) %>
       <%= sidebar_tabs edition_tabs(
         @edition,
         remarks_count: @edition_remarks.length,

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -30,4 +30,36 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
       assert_select "input[name='edition[images_attributes][0][image_data_attributes][file]'][type='file']"
     end
   end
+
+  view_test "GET :show renders a side nav bar with notes, history and fact checking" do
+    edition = create(:draft_case_study)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".nav-tabs a", text: "Notes 0"
+    assert_select ".nav-tabs a", text: "History 1"
+  end
+
+  view_test "GET :show editions renders links to history, notes and fact checking endpoints and no sidebar when user has `View move tabs to endpoints` permission" do
+    @current_user.permissions << "View move tabs to endpoints"
+    edition = create(:draft_case_study)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select "a", text: "Notes", count: 1
+    assert_select "a", text: "History", count: 1
+    assert_select ".nav-tabs a", text: "Notes 0", count: 0
+    assert_select ".nav-tabs a", text: "History 1", count: 0
+  end
+
+  view_test "GET :edit renders a side nav bar with notes, history and fact checking" do
+    edition = create(:draft_case_study)
+
+    get :edit, params: { id: edition }
+
+    assert_select ".nav-tabs a", text: "Notes 0"
+    assert_select ".nav-tabs a", text: "History 1"
+  end
 end

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -113,6 +113,19 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     assert_redirected_to [:admin, @organisation, CorporateInformationPage]
   end
 
+  view_test "GET :show corporate information pages continues to render side nav bar with notes, history and fact checking when user has `Redirect to summary page` permission" do
+    @current_user.permissions << "Redirect to summary page"
+    corporate_information_page = create(:corporate_information_page, :published, organisation: @organisation)
+    stub_publishing_api_expanded_links_with_taxons(corporate_information_page.content_id, [])
+
+    get :show, params: { organisation_id: @organisation, id: corporate_information_page }
+
+    assert_select "a", text: "Notes", count: 0
+    assert_select "a", text: "History", count: 0
+    assert_select ".nav-tabs a", text: "Notes 0"
+    assert_select ".nav-tabs a", text: "History 1"
+  end
+
 private
 
   def corporate_information_page_attributes(overrides = {})

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -73,6 +73,16 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     assert_select "#notes"
   end
 
+  view_test "edit shows editorial remarks for corporate_information_pages when the `View move tabs to endpoints` permission is present" do
+    @writer.permissions << "View move tabs to endpoints"
+    edition = create(:corporate_information_page)
+    create(:editorial_remark, edition: edition)
+
+    get :edit, params: { edition_id: edition, id: "fr" }
+
+    assert_select "#notes"
+  end
+
   view_test "edit when translating corporate information pages does not allow title to be edited" do
     edition = create(:corporate_information_page)
 


### PR DESCRIPTION
Recently, we (i) made some changes to move History, Notes, and Fact checking functionality from the sidebar to separate endpoints. However, we (I) overlooked that there is a separate tab in Whitehall for `Corporate information` which essentially reuses all the views from the `Editions` tab.

This means that any changes we apply there are mirrored, which currently is undesirable behaviour. We will apply them there as well later, but for now it should retain the same behaviour.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
