### PR TITLE
[Part2] Remove attachment tabs from editions edit page

### DIFF
--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -6,7 +6,7 @@
 
 <h1><%= @collection.title %></h1>
 
-<%= edition_editing_tabs(@collection) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= render partial: 'collection_size_warning' %>
   <%= form_tag admin_document_collection_new_whitehall_member_path(@collection) do %>
     <h2>Add document to a group</h2>
@@ -103,4 +103,103 @@
       <i class="glyphicon glyphicon-plus"></i> Add a new group
     <% end %>
   </p>
+<% else %>
+  <%= edition_editing_tabs(@collection) do %>
+    <%= render partial: 'collection_size_warning' %>
+    <%= form_tag admin_document_collection_new_whitehall_member_path(@collection) do %>
+      <h2>Add document to a group</h2>
+      <div id="document-finder" class="document-finder form-inline well remove-top-margin">
+        <label for="title">Add</label>
+        <div class="document-finder-fields">
+          <%= search_field_tag :title, '', placeholder: 'Title or slug&hellip;'.html_safe, results: 5, autosave: 'unique', autofocus: true, class: 'form-control input-sm' %>
+          <%= button_tag 'Find', type: 'button', id: 'find-documents', class: 'btn btn-default btn-sm add-right-margin' %>
+          <%= image_tag 'loading-666666.gif', class: 'js-loader' %>
+          <p class="tip">
+            Only the first 10 results are returned – be as specific as you can
+          </p>
+        </div>
+        to the
+        <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :heading, session[:document_collection_selected_group_id]), class: 'form-control input-sm' %>
+        group
+        <%= submit_tag 'Add', class: 'btn btn-sm btn-info' %>
+        <%= hidden_field_tag :document_id %>
+      </div>
+    <% end %>
+
+    <details class="non-whitehall-disclosure"<% if flash[:open_non_whitehall] %> open<% end %>>
+      <summary>
+        Add GOV.UK content created outside of Whitehall to a group
+      </summary>
+      <%= form_tag admin_document_collection_new_non_whitehall_member_path(@collection), class: 'document-finder' do %>
+        <div class="document-finder form-inline well remove-top-margin">
+          <label for="url">Add</label>
+          <%= text_field_tag :url, flash[:url], placeholder: 'GOV.UK URL', class: 'form-control input-sm' %>
+          to the
+          <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :heading, session[:document_collection_selected_group_id]), class: 'form-control input-sm' %>
+          group
+          <%= submit_tag 'Add', class: 'btn btn-sm btn-info' %>
+        </div>
+      <% end %>
+    </details>
+
+    <div class="js-group-container">
+      <div class="reorder-buttons">
+        <%= button_tag 'Reorder groups', class: 'btn btn-sm btn-info js-reorder' %><%= button_tag 'Finish reordering', class: 'btn btn-sm btn-success js-finish-reorder' %>
+      </div>
+      <% @groups.each do |group| %>
+        <section class="group">
+          <header class="js-group-header">
+            <h2>
+              <span class="small">Group</span><br/>
+              <%= group.heading %>
+            </h2>
+            <ul class="actions">
+              <li>
+                <%= link_to 'Edit group heading and body', edit_admin_document_collection_group_path(@collection, group) %>
+              </li>
+              <li>
+                <%= link_to 'Delete group', delete_admin_document_collection_group_path(@collection, group) %>
+              </li>
+            </ul>
+          </header>
+          <div class="js-group-body">
+            <% if group.editable_members.empty? %>
+              <p class="no-content no-content-bordered js-document-group" data-group-id="<%= group.id %>">
+                No documents in this group<br />
+                Add documents by searching or dragging them from another group.
+              </p>
+            <% else %>
+              <%= form_tag admin_document_collection_group_members_path(@collection, group), method: 'delete' do %>
+                <ul class="controls list-unstyled">
+                  <li>
+                    <%= check_box_tag :select_all, group.id, false, id: nil, class: 'checkbox' %>
+                  </li>
+                  <li class="remove">
+                    <%= submit_tag 'Remove', class: 'btn btn-sm btn-default' %>
+                  </li>
+                  <% other_groups = @groups - [group] %>
+                  <% if other_groups.size > 0 %>
+                    <li class="move form-inline">
+                      Move selected to
+                      <%= select_tag :new_group_id, options_from_collection_for_select(other_groups, :id, :heading), class: 'form-control input-sm' %>
+                      <%= submit_tag 'Move', class: 'btn btn-sm btn-default' %>
+                    </li>
+                  <% end %>
+                </ul>
+                <ol class="document-list js-document-group list-unstyled" data-group-id="<%= group.id %>">
+                  <%= render partial: 'collection_document', collection: group.editable_members, as: :membership, locals: { document_collection: @collection } %>
+                </ol>
+              <% end %>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+    </div>
+
+    <p class="add-group">
+      <%= link_to new_admin_document_collection_group_path(@collection), class: 'btn btn-default' do %>
+        <i class="glyphicon glyphicon-plus"></i> Add a new group
+      <% end %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -4,6 +4,12 @@
 <% initialise_script 'GOVUK.documentFinder' %>
 <% initialise_script 'GOVUK.documentCollectionCheckboxSelector' %>
 
+<% if current_user.can_remove_edit_tabs? %>
+  <span class="back">
+    <%= link_to 'Back', admin_edition_path(@collection) %>
+  </span>
+<% end %>
+
 <h1><%= @collection.title %></h1>
 
 <% if current_user.can_remove_edit_tabs? %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Continuously curated, permanent lists of closely related documents for a specific audience – not just by subject.</p>
 </div>
 
-<%= edition_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <fieldset>
@@ -10,5 +10,16 @@
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= edition_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
+        <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -155,6 +155,19 @@
   </section>
 <% end %>
 
+<% if @edition.is_a?(DocumentCollection) && current_user.can_remove_edit_tabs? %>
+  <section>
+    <h2>Collection documents</h2>
+      <% if @edition.editable? %>
+        <span>
+          <%= link_to admin_document_collection_groups_path(@edition), title: "Modify collection documents of #{@edition.title}", class: "btn btn-default" do %>
+            <i class="glyphicon glyphicon-edit"></i> Modify collection documents
+          <% end %>
+        </span>
+      <% end %>
+  </section>
+<% end %>
+
 <% if @edition.document.document_sources.any? or current_user.can_import? %>
   <section id="document-sources-section">
     <h2>Legacy URL redirects</h2>

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -14,6 +14,14 @@ Feature: Grouping documents into a collection
     Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
 
   @javascript
+  Scenario: Admin creates a document collection with the `Remove edit tabs` permission
+    Given a published document "Wombats of Wimbledon" exists
+    And I have the "Remove edit tabs" permission
+    When I draft a new document collection called "Wildlife of Wimbledon Common"
+    And I add the document "Wombats of Wimbledon" to the document collection
+    Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
+
+  @javascript
   Scenario: Admin creates a document collection in another language
     Given a published publication "Wombats of Wimbledon" with locale "cy" exists
     When I draft a new "Cymraeg" language document collection called "Wildlife of Wimbledon Common"

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -71,8 +71,13 @@ When(/^I add the document "(.*?)" to the document collection$/) do |document_tit
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
 
   fill_in "title", with: document_title
   click_on "Find"
@@ -138,8 +143,12 @@ end
 
 Then(/^I can see in the admin that "(.*?)" is part of the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
 
   assert_document_is_part_of_document_collection(document_title)
 end

--- a/features/support/document_collection_helper.rb
+++ b/features/support/document_collection_helper.rb
@@ -1,7 +1,13 @@
 module DocumentCollectionStepHelpers
   def assert_document_is_part_of_document_collection(document_title)
-    within ".tab-content" do
-      expect(page).to have_content(document_title)
+    if @user.can_remove_edit_tabs?
+      within ".document-row" do
+        expect(page).to have_content(document_title)
+      end
+    else
+      within ".tab-content" do
+        expect(page).to have_content(document_title)
+      end
     end
   end
 


### PR DESCRIPTION
## Description 

This follows on from https://github.com/alphagov/whitehall/pull/6734

It does the following:

1. Removes the tabs from the edition edit page for DocumentCollections
2. Moves the link to the `Collection documents` page to the edition summary page
3. Adds a test for the new flow

## Screenshots

### Edition summary page 

<img width="762" alt="image" src="https://user-images.githubusercontent.com/42515961/184861505-7aababd5-e743-438e-962e-cd9991f356ec.png">

### Edition edit page 

#### Before 

<img width="852" alt="image" src="https://user-images.githubusercontent.com/42515961/184861790-00834c11-761a-437d-9e86-1fc46ce854ab.png">

#### After

<img width="930" alt="image" src="https://user-images.githubusercontent.com/42515961/184861704-8d165c6f-5105-4cae-bf30-c203a324d969.png">

### Edit collections page

#### Before

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/42515961/184861618-a70b7463-314b-480a-9347-9077954104cf.png">

#### After 

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/42515961/184863235-cbafcffe-b5ff-4e21-b248-c10d86fd6cb3.png">

## Guidance for review

The design on the section on the Edition Summary page will need some discussion with Nikin when he gets back. For now i'm just linking to the section. It's behind a flag though so it shouldn't stop us merging and iterating

## Trello card

https://trello.com/c/X0ZL0ouj/625-remove-attachment-tab-from-edit-edition-page-and-document-tab-from-attachments-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
