### PR TITLE
Fix 'FakeRummagableIndex' error in development

### DIFF
--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -50,37 +50,39 @@ module Whitehall
     end
   end
 
-  class FakeRummageableIndex < Rummageable::Index
-    class << self
-      attr_accessor :store
-    end
-    @store = nil
+  unless defined?(FakeRummageableIndex)
+    class FakeRummageableIndex < Rummageable::Index
+      class << self
+        attr_accessor :store
+      end
+      @store = nil
 
-    def initialize(url, name, options = {})
-      super
-      @index_name = name
-    end
+      def initialize(url, name, options = {})
+        super
+        @index_name = name
+      end
 
-    def add(entry)
-      add_batch([entry])
-    end
+      def add(entry)
+        add_batch([entry])
+      end
 
-    def add_batch(entries)
-      store.add(entries, @index_name) if store.present?
-    end
+      def add_batch(entries)
+        store.add(entries, @index_name) if store.present?
+      end
 
-    def delete(link)
-      store.delete(link, @index_name) if store.present?
-    end
+      def delete(link)
+        store.delete(link, @index_name) if store.present?
+      end
 
-    def make_request(_method, *_args)
-      raise "Use the in memory index (rather than rummager) in tests"
-    end
+      def make_request(_method, *_args)
+        raise "Use the in memory index (rather than rummager) in tests"
+      end
 
-  private
+    private
 
-    def store
-      self.class.store
+      def store
+        self.class.store
+      end
     end
   end
 end


### PR DESCRIPTION
A 'constant `Whitehall::FakeRummagableIndex` is already defined' error message would frequently appear when working in a development environment.

The error would appear when changing files in the project while the Rails server is already running. On the first page reload after making code changes, this error would appear. It'd usually disappear again on a second reload.

The error message suggested that the `FakeRummagableIndex` class was being redefined. Presumably this was happening because Rails reloads source code when changes are made.

It seems that this change fixes the issue by only defining the `Whitehall::FakeRummagableIndex` class if it hasn't already been defined.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
