### PR TITLE
[Part3] Remove attachment tabs from editions edit page

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -4,7 +4,7 @@
   <p>Check you have read the current <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>.</p>
 </div>
 
-<%= consultation_editing_tabs(edition) do %>
+<% if current_user.can_remove_edit_tabs? %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Held on another website</legend>
@@ -59,5 +59,63 @@
       <legend>Consultation principles</legend>
       <%= form.check_box :read_consultation_principles, label_text: 'We have considered the <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>'.html_safe %>
     </fieldset>
+  <% end %>
+<% else %>
+  <%= consultation_editing_tabs(edition) do %>
+    <%= standard_edition_form(edition, @information) do |form| %>
+      <fieldset>
+        <legend>Held on another website</legend>
+        <%= form.check_box :external, label_text: "This #{edition.class.name.humanize.downcase} is held on another website" %>
+        <div class="js-external-url">
+          <%= form.text_field :external_url, label_text: "External link URL" %>
+        </div>
+      </fieldset>
+
+      <div class="js-external-url-set">
+        <fieldset>
+          <legend>Ways to respond</legend>
+          <%= form.fields_for :consultation_participation, edition.consultation_participation || edition.build_consultation_participation do |participation_fields| %>
+            <%= participation_fields.text_field :link_url, label_text: 'Link URL' %>
+            <%= participation_fields.text_field :email %>
+            <%= participation_fields.text_area :postal_address, rows: "4", style: "width: auto" %>
+            <%= participation_fields.fields_for :consultation_response_form, participation_fields.object.consultation_response_form || participation_fields.object.build_consultation_response_form do |response_form_fields| %>
+              <%= response_form_fields.text_field :title, label_text: "Downloadable response form title", required: false %>
+              <% if response_form_fields.object.persisted? %>
+                <div class="attachment">
+                  <p>Current data: <%= link_to File.basename(response_form_fields.object.consultation_response_form_data.file.path), response_form_fields.object.consultation_response_form_data.file.url %></p>
+                  <p>Actions: <%= attachment_action_fields(response_form_fields, :consultation_response_form_data) %></p>
+                  <%= consultation_response_form_data_fields(response_form_fields) %>
+                </div>
+              <% else %>
+                <%= consultation_response_form_data_fields(response_form_fields) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </fieldset>
+      </div>
+
+      <div class="js-external-url-set">
+        <%= render 'html_version_fields', form: form, edition: edition %>
+        <%= render 'inline_attachments_info', form: form, edition: edition %>
+      </div>
+
+      <fieldset>
+        <legend>Associations</legend>
+        <div class="js-external-url-set">
+          <%= render 'appointment_fields', form: form, edition: edition %>
+        </div>
+
+        <%= render 'topical_event_fields', form: form, edition: edition %>
+
+        <%= render 'nation_fields', form: form, edition: edition %>
+
+        <%= render 'organisation_fields', form: form, edition: edition %>
+      </fieldset>
+
+      <fieldset>
+        <legend>Consultation principles</legend>
+        <%= form.check_box :read_consultation_principles, label_text: 'We have considered the <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>'.html_safe %>
+      </fieldset>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -168,6 +168,32 @@
   </section>
 <% end %>
 
+<% if @edition.is_a?(Consultation) && current_user.can_remove_edit_tabs? %>
+  <section>
+    <h2>Public feedback</h2>
+      <% if @edition.editable? %>
+        <span>
+          <%= link_to admin_consultation_public_feedback_path(@edition), title: "Modify public feedback for #{@edition.title}", class: "btn btn-default" do %>
+            <i class="glyphicon glyphicon-edit"></i> Modify public feedback
+          <% end %>
+        </span>
+      <% end %>
+  </section>
+<% end %>
+
+<% if @edition.is_a?(Consultation) && current_user.can_remove_edit_tabs? %>
+  <section>
+    <h2>Final outcome</h2>
+      <% if @edition.editable? %>
+        <span>
+          <%= link_to admin_consultation_outcome_path(@edition), title: "Modify final outcome of #{@edition.title}", class: "btn btn-default" do %>
+            <i class="glyphicon glyphicon-edit"></i> Modify final outcome
+          <% end %>
+        </span>
+      <% end %>
+  </section>
+<% end %>
+
 <% if @edition.document.document_sources.any? or current_user.can_import? %>
   <section id="document-sources-section">
     <h2>Legacy URL redirects</h2>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -1,3 +1,9 @@
+<% if current_user.can_remove_edit_tabs? %>
+  <span class="back">
+    <%= link_to 'Back', admin_edition_path(@edition) %>
+  </span>
+<% end %>
+
 <% page_title "Editing: #{@edition.title}"  %>
 <% if @conflicting_edition %>
   <section>

--- a/app/views/admin/responses/show.html.erb
+++ b/app/views/admin/responses/show.html.erb
@@ -3,10 +3,15 @@
 
 <div class="row">
   <section class="col-md-8">
+    <% if current_user.can_remove_edit_tabs? %>
+      <span class="back">
+        <%= link_to 'Back', admin_edition_path(@edition) %>
+      </span>
+    <% end %>
+
     <h1><%= @response.friendly_name.capitalize %> for consultation</h1>
 
-    <%= consultation_editing_tabs(@edition) do %>
-
+    <% if current_user.can_remove_edit_tabs? %>
       <% if @response.persisted? %>
         <div class="summary">
           <h3><%= @response.friendly_name.capitalize %> summary</h3>
@@ -31,6 +36,34 @@
         </p>
 
         <%= render partial: 'form', locals: { consultation: @edition, consultation_response: @response } %>
+      <% end %>
+    <% else %>
+      <%= consultation_editing_tabs(@edition) do %>
+        <% if @response.persisted? %>
+          <div class="summary">
+            <h3><%= @response.friendly_name.capitalize %> summary</h3>
+            <%= govspeak_to_html @response.summary %>
+            <p>Published on <%= @response.published_on.to_fs(:long_ordinal) %></p>
+          </div>
+
+          <ul class="actions">
+            <li><%= link_to "Edit #{@response.friendly_name}", [:edit, :admin, @edition, @response.singular_routing_symbol] %></li>
+          </ul>
+
+          <h3>Attachments (optional)</h3>
+          <ul class="actions">
+            <li><%= link_to 'Upload new file attachment', new_admin_response_attachment_path(@response) %></li>
+            <li><%= link_to 'Add new HTML attachment', new_admin_response_attachment_path(@response, type: "html") %></li>
+          </ul>
+          <%= render('admin/attachments/attachments', attachable: @response) if @response.attachments.any? %>
+
+        <% else %>
+          <p class="alert alert-info">
+            <%= consulation_response_help_text(@response) %>
+          </p>
+
+          <%= render partial: 'form', locals: { consultation: @edition, consultation_response: @response } %>
+        <% end %>
       <% end %>
     <% end %>
   </section>

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -31,8 +31,15 @@ end
 When(/^I add an outcome to the consultation$/) do
   visit edit_admin_consultation_path(Consultation.last)
   click_button "Create new edition"
+  if @user.can_remove_edit_tabs?
+    fill_in_change_note_if_required
+    apply_to_all_nations_if_required
+    click_button "Save"
+    click_link "Modify final outcome"
+  else
+    click_link "Final outcome"
+  end
 
-  click_link "Final outcome"
   fill_in "Detail/Summary", with: "Outcome summary"
   click_button "Save"
 
@@ -42,8 +49,15 @@ end
 When(/^I add public feedback to the consultation$/) do
   visit edit_admin_consultation_path(Consultation.last)
   click_button "Create new edition"
+  if @user.can_remove_edit_tabs?
+    fill_in_change_note_if_required
+    apply_to_all_nations_if_required
+    click_button "Save"
+    click_link "Modify public feedback"
+  else
+    click_link "Public feedback"
+  end
 
-  click_link "Public feedback"
   fill_in "Summary", with: "Feedback summary"
   click_button "Save"
 

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -41,8 +41,12 @@ end
 
 When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
 
   base_path = URI.parse(url).path
   content_id = SecureRandom.uuid
@@ -93,8 +97,12 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
 
   # Simulate drag-droping document.
   execute_script %{
@@ -118,8 +126,13 @@ Then(/^I (?:can )?view the document collection in the admin$/) do
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
+
   expect(page).to have_selector("h1", text: @document_collection.title)
 end
 
@@ -167,7 +180,15 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
 
   visit admin_document_collection_path(@document_collection)
   click_on "Create new edition to edit"
-  click_on "Collection documents"
+  fill_in_change_note_if_required
+  click_on "Save"
+
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
 
   check document_title
   click_on "Remove"
@@ -184,8 +205,14 @@ end
 
 And(/^I search for "(.*?)" to add it to the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
-  click_on "Edit draft"
-  click_on "Collection documents"
+
+  if @user.can_remove_edit_tabs?
+    click_on "Modify collection documents"
+  else
+    click_on "Edit draft"
+    click_on "Collection documents"
+  end
+
   fill_in "title", with: document_title
   click_on "Find"
 end

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -61,7 +61,15 @@ When(/^I replace the data file of the attachment in a new draft of the publicati
   visit edit_admin_publication_path(@old_edition)
   click_button "Create new edition"
   @new_edition = Publication.last
-  click_on "Attachments"
+
+  if @user.can_remove_edit_tabs?
+    fill_in_change_note_if_required
+    apply_to_all_nations_if_required
+    click_button "Save"
+    click_link "Modify attachments"
+  else
+    click_on "Attachments"
+  end
 
   within record_css_selector(@new_edition.attachments.first.becomes(Attachment)) do
     click_on "Edit"

--- a/features/support/document_collection_helper.rb
+++ b/features/support/document_collection_helper.rb
@@ -12,8 +12,12 @@ module DocumentCollectionStepHelpers
   end
 
   def refute_document_is_part_of_document_collection(document_title)
-    within ".tab-content" do
+    if @user.can_remove_edit_tabs?
       expect(page).to_not have_content(document_title)
+    else
+      within ".tab-content" do
+        expect(page).to_not have_content(document_title)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description 

This follows on from https://github.com/alphagov/whitehall/pull/6737

It does the following:

1. Removes the tabs from the edition edit page for edit Consultation page
2. Removes tabs from the public feedback page 
3. Removes tabs from the final outcome page
4. Moves the link to the `Public feedback` page to the edition summary page
5. Moves the link to the `Final outcome` page to the edition summary page

## Screenshots

### Edition summary page 

<img width="781" alt="image" src="https://user-images.githubusercontent.com/42515961/184895684-61099992-e38c-445a-9dda-8efb2d191767.png">

### Edition edit page 

#### Before 

<img width="725" alt="image" src="https://user-images.githubusercontent.com/42515961/184896506-b1d9d421-b764-410a-9636-edee1be0d9ba.png">

#### After

<img width="880" alt="image" src="https://user-images.githubusercontent.com/42515961/184895806-0b7a3b19-6390-4f26-8c11-bc1a94f2aeec.png">


### Public feedback page

#### Before

<img width="753" alt="image" src="https://user-images.githubusercontent.com/42515961/184897004-ec491ec3-1f2d-4bb5-a446-7b594f163183.png">


#### After 

<img width="773" alt="image" src="https://user-images.githubusercontent.com/42515961/184897306-c9fecb2c-8ee8-4435-8c80-5cea32785769.png">

### Final outcome page

#### Before

<img width="734" alt="image" src="https://user-images.githubusercontent.com/42515961/184897076-5276ee65-ad94-4c72-8df6-7c1e41514837.png">


#### After 

<img width="725" alt="image" src="https://user-images.githubusercontent.com/42515961/184897153-eb9c47b1-3b08-4eb9-be62-0de090c05ab7.png">

## Trello card

https://trello.com/c/X0ZL0ouj/625-remove-attachment-tab-from-edit-edition-page-and-document-tab-from-attachments-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
