### PR TITLE
[Part4] Remove attachment tabs from editions edit page

### DIFF
--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -3,9 +3,15 @@
 
 <div class="row">
   <section class="col-md-8">
+    <% if current_user.can_remove_edit_tabs? %>
+      <span class="back">
+        <%= link_to 'Back', admin_edition_path(attachment.attachable) %>
+      </span>
+    <% end %>
+
     <h1>Attachments for <%= attachment.attachable_model_name %></h1>
 
-    <%= attachable_editing_tabs(attachable) do %>
+    <% if current_user.can_remove_edit_tabs? %>
       <p class="qa-helper-copy">
         <strong>Note:</strong>
         <%= attachment_note(attachment.attachable_model_name) %>
@@ -41,6 +47,44 @@
       </div>
 
       <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
+    <% else %>
+      <%= attachable_editing_tabs(attachable) do %>
+        <p class="qa-helper-copy">
+          <strong>Note:</strong>
+          <%= attachment_note(attachment.attachable_model_name) %>
+        </p>
+        <ul class="actions list-unstyled">
+          <li>
+            <%= link_to 'Upload new file attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment]) %>
+          </li>
+          <% if attachable.is_a?(Edition) %>
+            <li>
+              <%= link_to 'Bulk upload from Zip file'.html_safe, new_admin_edition_bulk_upload_path(attachable) %>
+            </li>
+          <% end %>
+          <% if attachable.allows_html_attachments? %>
+            <li>
+              <%= link_to 'Add new HTML attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment], type: "html") %>
+            </li>
+          <% end %>
+          <% if attachable.allows_external_attachments? %>
+            <li>
+              <%= link_to 'Add new external attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment], type: "external") %>
+            </li>
+          <% end %>
+        </ul>
+
+        <div class="alert alert-warning">
+          <p>
+            You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.<br/>
+          </p>
+          <p>
+            For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.
+          </p>
+        </div>
+
+        <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
+      <% end %>
     <% end %>
   </section>
 </div>

--- a/app/views/admin/responses/show.html.erb
+++ b/app/views/admin/responses/show.html.erb
@@ -1,6 +1,7 @@
 <% page_title "#{@response.friendly_name.capitalize} for: #{@edition.title}" %>
 <% page_class "response" %>
 
+
 <div class="row">
   <section class="col-md-8">
     <% if current_user.can_remove_edit_tabs? %>

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -28,7 +28,6 @@ Feature: Managing attachments on editions
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
-    When I visit the attachments page
     Then I can see the attachment title "Beard Length Graphs 2012"
     And I can see the preview link to the attachment "HTML attachment"
 


### PR DESCRIPTION
## Description 

This follows on from https://github.com/alphagov/whitehall/pull/6740 and removes the tabs from the attachments index page

## Screenshots

### Attachment index page 

#### Before 

<img width="721" alt="image" src="https://user-images.githubusercontent.com/42515961/184919092-71f9416c-a859-4a40-b02e-e4a49fac598f.png">


#### After

<img width="723" alt="image" src="https://user-images.githubusercontent.com/42515961/184919048-361454f7-0229-4868-8d0e-982beb9784c3.png">


## Trello card

https://trello.com/c/X0ZL0ouj/625-remove-attachment-tab-from-edit-edition-page-and-document-tab-from-attachments-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
