### PR TITLE
Include location type when presenting World Location News

### DIFF
--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -22,6 +22,7 @@ module PublishingApi
           ordered_featured_links: featured_links,
           mission_statement: world_location.mission_statement || "",
           ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
+          world_location_news_type: world_location.world_location_type.key,
         },
         document_type: "placeholder_world_location_news_page",
         public_updated_at: world_location.updated_at,

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -45,6 +45,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
         ],
         mission_statement: "This is a great mission",
         ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
+        world_location_news_type: "world_location",
       },
       document_type: "placeholder_world_location_news_page",
       public_updated_at: world_location.updated_at,


### PR DESCRIPTION
This is required so we can add a label to the World Location News page telling users whether the news relates to a World Location or International Delegation.

This is dependent on https://github.com/alphagov/govuk-content-schemas/pull/1114 being merged and deployed.

[Trello card](https://trello.com/c/zxDhAkI3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
