### PR TITLE
Move editing legacy urls to an endpoint and remove modal

### DIFF
--- a/app/controllers/admin/document_sources_controller.rb
+++ b/app/controllers/admin/document_sources_controller.rb
@@ -3,6 +3,8 @@ class Admin::DocumentSourcesController < Admin::BaseController
   before_action :find_edition
   before_action :forbid_editing_of_locked_documents
 
+  def edit; end
+
   def update
     @document_sources = params[:document_sources]
     @edition.document.document_sources.destroy_all

--- a/app/views/admin/document_sources/edit.html.erb
+++ b/app/views/admin/document_sources/edit.html.erb
@@ -1,0 +1,19 @@
+<% page_title 'Edit legacy URL redirects' %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<h1>Edit legacy URL redirects</h1>
+
+<div class="row">
+  <div class="col-md-8">
+    <%= form_tag admin_edition_document_sources_path(@edition), method: :patch do %>
+      <p>Enter one URL per line.</p>
+      <div class="form-group">
+        <%= text_area_tag :document_sources, @edition.document.document_sources.map(&:url).join("\n"), rows: 20, class: 'form-control add-bottom-margin' %>
+        <%= submit_tag "Save", class: "btn btn-success" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -177,29 +177,7 @@
       <% end %>
     </ul>
     <% if current_user.can_import? %>
-      <p><a href="#document-sources-modal" class="btn btn-default" data-toggle="modal">Edit URL redirects</a></p>
-      <div id="document-sources-modal" class="modal">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-              <h3 class="modal-title">Edit legacy URL redirects</h3>
-            </div>
-            <%= form_tag admin_edition_document_sources_path(@edition), method: :put do %>
-              <div class="modal-body">
-                <div class="form-group">
-                  <p>Enter one URL per line.</p>
-                  <%= text_area_tag :document_sources, @edition.document.document_sources.map(&:url).join("\n"), rows: 20, class: 'form-control' %>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button class="btn btn-default add-right-margin" data-dismiss="modal" aria-hidden="true">Cancel</button>
-                <%= submit_tag "Save", class: "btn btn-success" %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
+      <%= link_to "Edit URL redirects", edit_admin_edition_document_sources_path(@edition), class: "btn btn-default" %>
     <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,7 +308,7 @@ Whitehall::Application.routes.draw do
           resources :translations, controller: "edition_translations", except: %i[index show]
           resources :editorial_remarks, only: %i[new create index], shallow: true
           resources :fact_check_requests, only: %i[show index new create edit update], shallow: true
-          resource :document_sources, path: "document-sources", except: [:show]
+          resource :document_sources, path: "document-sources", except: %i[show new]
           resources :attachments, except: [:show] do
             put :order, on: :collection
             put :update_many, on: :collection, constraints: { format: "json" }

--- a/features/document-sources.feature
+++ b/features/document-sources.feature
@@ -31,4 +31,4 @@ Feature: Managing Document Sources
     When I remove the legacy url "http://im-old.com" on the "One must have many urls" publication
     And I visit the list of draft documents
     And I view the publication "One must have many urls"
-    Then I should see that it has no legacy urls
+    Then I should see that "http://im-old.com" has been removed

--- a/features/step_definitions/document_sources_steps.rb
+++ b/features/step_definitions/document_sources_steps.rb
@@ -26,6 +26,10 @@ end
 When(/^I change the legacy url "([^"]*)" to "([^"]*)" on the "([^"]*)" publication$/) do |old_old_url, new_old_url, title|
   publication = Publication.find_by!(title: title)
   visit admin_edition_path(publication)
+  within "#document-sources-section" do
+    expect(page).to have_content old_old_url
+  end
+  click_link "Edit URL redirects"
   expect(page).to have_field("document_sources", with: old_old_url)
   fill_in "document_sources", with: new_old_url
   click_button "Save"
@@ -34,12 +38,13 @@ end
 When(/^I remove the legacy url "([^"]*)" on the "([^"]*)" publication$/) do |_old_url, title|
   publication = Publication.find_by!(title: title)
   visit admin_edition_path(publication)
+  click_link "Edit URL redirects"
   fill_in "document_sources", with: ""
   click_button "Save"
 end
 
-Then(/^I should see that it has no legacy urls$/) do
+Then(/^I should see that "([^"]*)" has been removed$/) do |old_url|
   within "#document-sources-section" do
-    expect(page).to have_field("document_sources", with: "")
+    expect(page).not_to have_content old_url
   end
 end


### PR DESCRIPTION
## Description

As we're transitioning to the GOV.UK Design System soon we're removing Bootstrap modals.

This moves the edit legacy url functionality to its own endpoint, removes the modal and updates the feature specs.

## Screenshots 

### Before

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/42515961/185150479-5c2b68da-fd52-48eb-8b72-2201a2441116.png">


### After

<img width="706" alt="image" src="https://user-images.githubusercontent.com/42515961/185150232-7bee3f10-5295-422c-8920-f437c5fd5714.png">

<img width="797" alt="image" src="https://user-images.githubusercontent.com/42515961/185150300-fad539c7-1155-440d-a0e4-f26ea38b6bdf.png">

## Trello card

https://trello.com/c/gHKKYIgb/616-add-endpoint-for-legacy-url-redirects


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
