### PR TITLE
Add confirm delete endpoint for editions

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
-  before_action :find_edition, only: %i[show show_locked edit update revise diff destroy update_bypass_id history]
+  before_action :find_edition, only: %i[show show_locked edit update revise diff confirm_destroy destroy update_bypass_id history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_edition, only: %i[new create]
@@ -30,7 +30,7 @@ class Admin::EditionsController < Admin::BaseController
       enforce_permission!(:create, @edition)
     when "edit", "update", "revise", "diff", "update_bypass_id"
       enforce_permission!(:update, @edition)
-    when "destroy"
+    when "destroy", "confirm_destroy"
       enforce_permission!(:delete, @edition)
     when "export", "confirm_export"
       enforce_permission!(:export, edition_class || Edition)
@@ -173,6 +173,8 @@ class Admin::EditionsController < Admin::BaseController
     audit_trail_entry = edition_class.find(params[:audit_trail_entry_id])
     @audit_trail_entry = LocalisedModel.new(audit_trail_entry, audit_trail_entry.primary_locale)
   end
+
+  def confirm_destroy; end
 
   def destroy
     edition_deleter = Whitehall.edition_services.deleter(@edition)

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -119,7 +119,7 @@ module Admin::EditionActionsHelper
   end
 
   def delete_edition_button(edition)
-    button_to "Discard draft", admin_edition_path(edition), method: :delete, title: "Delete", data: { confirm: "Are you sure you want to discard this draft?" }, class: "btn btn-danger"
+    link_to "Discard draft", confirm_destroy_admin_edition_path(edition), method: :get, class: "btn btn-danger"
   end
 
   # If adding new models also update filter_options_for_edition

--- a/app/views/admin/editions/confirm_destroy.html.erb
+++ b/app/views/admin/editions/confirm_destroy.html.erb
@@ -1,0 +1,14 @@
+<% page_title "Are you sure you want to discard #{@edition.title}?" %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<div class="row">
+  <div class="col-md-8">
+    <h1 class="add-bottom-margin">Are you sure you want to discard "<%= @edition.title %>"?</h1>
+    <%= form_tag admin_edition_path(@edition), method: :delete do %>
+      <%= submit_tag 'Discard', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,6 +302,7 @@ Whitehall::Application.routes.draw do
             get  :show_locked, to: "editions#show_locked"
             patch :update_bypass_id
             get :history, to: "editions#history"
+            get :confirm_destroy
           end
           resources :link_check_reports
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]

--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -17,9 +17,8 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: draft_edition }
 
-    assert_select "form[action='#{admin_generic_edition_path(draft_edition)}']" do
-      assert_select "input[name='_method'][type='hidden'][value='delete']"
-      assert_select "input[type='submit']"
+    assert_select ".edition-sidebar" do
+      assert_select "a[href=?]", confirm_destroy_admin_edition_path(draft_edition), text: "Discard draft"
     end
   end
 
@@ -29,9 +28,8 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: submitted_edition }
 
-    assert_select "form[action='#{admin_generic_edition_path(submitted_edition)}']" do
-      assert_select "input[name='_method'][type='hidden'][value='delete']"
-      assert_select "input[type='submit']"
+    assert_select ".edition-sidebar" do
+      assert_select "a[href=?]", confirm_destroy_admin_edition_path(submitted_edition), text: "Discard draft"
     end
   end
 

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -65,7 +65,8 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       context "when draft document is discarded" do
         before do
           visit admin_news_article_path(edition)
-          click_button "Discard draft"
+          click_link "Discard draft"
+          click_button "Discard"
         end
 
         it "deletes all corresponding assets in Asset Manager" do


### PR DESCRIPTION
## Description

As we're transitioning to the GOV.UK Design System soon we're adding confirm delete endpoints in favour of JS.

This adds a confirm delete endpoint for editions and updates the tests.

## Screenshot

<img width="816" alt="image" src="https://user-images.githubusercontent.com/42515961/185170817-4be59696-6b61-4c21-9d7b-dfe98471ff44.png">

## Trello card 

https://trello.com/c/NkxQgCym/635-add-confirm-discard-draft-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
