### PR TITLE
Update world location news document type

### DIFF
--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -43,7 +43,7 @@ module PublishingApi
         {
           content_id: content_id,
           link: path_for_news_page,
-          format: "world_location_news_page", # Used for the rummager document type
+          format: "world_location_news",
           title: title,
           description: description,
           indexable_content: description,

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
           ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
           world_location_news_type: world_location.world_location_type.key,
         },
-        document_type: "placeholder_world_location_news_page",
+        document_type: "world_location_news",
         public_updated_at: world_location.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "world_location_news",

--- a/app/workers/world_location_news_worker.rb
+++ b/app/workers/world_location_news_worker.rb
@@ -1,14 +1,16 @@
 class WorldLocationNewsWorker < WorkerBase
   attr_accessor :world_location
 
-  def perform(world_location_id)
+  def perform(world_location_id, send_to_search_api = true)
     self.world_location = WorldLocation.find(world_location_id)
 
     each_locale do
       send_news_page_to_publishing_api
     end
 
-    send_news_page_to_rummager
+    if send_to_search_api
+      send_news_page_to_rummager
+    end
   end
 
 private

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -213,8 +213,20 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
-    desc "Republish all world location news pages"
+    desc "Republish all world location news pages without re-sending to search"
     task all_world_location_news: :environment do
+      world_locations = WorldLocation.all
+
+      puts "Republishing #{world_locations.size} world locations"
+
+      world_locations.each do |world_location|
+        WorldLocationNewsWorker.perform_async_in_queue("bulk_republishing", world_location.id, false)
+      end
+    end
+
+    # We expect this just to be needed for the initial republishing of world location news pages where we are changing their document type for search
+    desc "Republish all world location news pages with removal and re-adding to search"
+    task all_world_location_news_and_search_pages: :environment do
       search_index_delete_worker = SearchIndexDeleteWorker.new
 
       world_locations = WorldLocation.all

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -95,7 +95,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
     expected = {
       content_id: "id-123",
       link: "/world/aardistan/news",
-      format: "world_location_news_page",
+      format: "world_location_news",
       title: "Aardistan and the Uk",
       description: "Updates, news and events from the UK government in Aardistan",
       indexable_content: "Updates, news and events from the UK government in Aardistan",

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -47,7 +47,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
         ordered_featured_documents: featured_documents(world_location, WorldLocation::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
         world_location_news_type: "world_location",
       },
-      document_type: "placeholder_world_location_news_page",
+      document_type: "world_location_news",
       public_updated_at: world_location.updated_at,
       rendering_app: "whitehall-frontend",
       schema_name: "world_location_news",

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -418,6 +418,44 @@ class PublishingApiRake < ActiveSupport::TestCase
         Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
       end
 
+      test "When the world location news pages do not have translations, resends the english pages to publishing api but not to search" do
+        french_world_location = create(:world_location, name: "france", slug: "france", news_page_content_id: "id-123", title: "France and the UK")
+        spanish_world_location = create(:world_location, name: "spain", slug: "spain", news_page_content_id: "id-124", title: "Spain and the UK")
+
+        assert_republishes_to_publishing_api(locale: :en, title: french_world_location.title, content_id: french_world_location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: spanish_world_location.title, content_id: spanish_world_location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).never
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+
+      test "When a world location news page has a translation, this is also sent to publishing api" do
+        location = create(:world_location,
+                          slug: "france",
+                          name: "france",
+                          news_page_content_id: "id-123",
+                          title: "France and the UK",
+                          translated_into:
+                            { fr: { name: "La France", title: "Le Royaume Uni et la France" } })
+
+        assert_republishes_to_publishing_api(locale: :fr, title: "Le Royaume Uni et la France", content_id: location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).never
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+    end
+
+    describe "#all_world_location_news_and_search_pages" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:all_world_location_news_and_search_pages"] }
+
+      def assert_republishes_to_publishing_api(locale:, title:, content_id:)
+        Services.publishing_api.expects(:put_content).with(content_id, has_entries(locale: locale.to_s, title: title))
+        Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
+      end
+
       def assert_removes_and_re_adds_to_search_index(world_location)
         SearchIndexDeleteWorker.any_instance.expects(:perform).with("/world/#{world_location.name}/news", :government)
         expected_content_for_rummager = PublishingApi::WorldLocationNewsPresenter.new(world_location).content_for_rummager(world_location.news_page_content_id)

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -410,6 +410,51 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#all_world_location_news" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:all_world_location_news"] }
+
+      def assert_republishes_to_publishing_api(locale:, title:, content_id:)
+        Services.publishing_api.expects(:put_content).with(content_id, has_entries(locale: locale.to_s, title: title))
+        Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
+      end
+
+      def assert_removes_and_re_adds_to_search_index(world_location)
+        SearchIndexDeleteWorker.any_instance.expects(:perform).with("/world/#{world_location.name}/news", :government)
+        expected_content_for_rummager = PublishingApi::WorldLocationNewsPresenter.new(world_location).content_for_rummager(world_location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).with(expected_content_for_rummager)
+      end
+
+      test "When the world location news pages do not have translations, removes the page from search and resends the english pages to search and publishing api" do
+        french_world_location = create(:world_location, name: "france", slug: "france", news_page_content_id: "id-123", title: "France and the UK")
+        spanish_world_location = create(:world_location, name: "spain", slug: "spain", news_page_content_id: "id-124", title: "Spain and the UK")
+
+        [french_world_location, spanish_world_location].each do |location|
+          assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+          assert_removes_and_re_adds_to_search_index(location)
+        end
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+
+      test "When a world location news page has a translation, this is also sent to publishing api" do
+        location = create(:world_location,
+                          slug: "france",
+                          name: "france",
+                          news_page_content_id: "id-123",
+                          title: "France and the UK",
+                          translated_into:
+                            { fr: { name: "La France", title: "Le Royaume Uni et la France" } })
+
+        assert_republishes_to_publishing_api(locale: :fr, title: "Le Royaume Uni et la France", content_id: location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+        assert_removes_and_re_adds_to_search_index(location)
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+    end
+
     describe "#all_documents" do
       let(:task) { Rake::Task["publishing_api:bulk_republish:all_documents"] }
 

--- a/test/unit/workers/world_location_news_worker_test.rb
+++ b/test/unit/workers/world_location_news_worker_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
+class WorldLocationNewsWorkerTest < ActiveSupport::TestCase
   test "sends to the publishing api" do
     world_location = FactoryBot.create(
       :world_location,


### PR DESCRIPTION
This switches from using a placeholder document type to the newly created world_location_news doc type, as part of preparatory work ahead of migrating rendering for this content type away from whitehall.

This document type is added in [this PR](https://github.com/alphagov/govuk-content-schemas/pull/1116) in content schemas, and should not be merged until that is.

This also renames the document format we send to search api, from "world_location_news_page" to "world_location_news", in order to standardise what we call this content type and remove any existing confusion from different names used for it across the stack.

Also in this PR is a renaming of a test that was missed from when the worker it's testing was renamed.

Merged into this PR: the PR (approved) to add the rake tasks for republishing world location news.

[Trello](https://trello.com/c/5vpV1JUu/194-update-world-news-location-document-type)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
