### PR TITLE
Increase the size of the custom jobs url field

### DIFF
--- a/db/migrate/20220819125630_lengthen_custom_jobs_url_column.rb
+++ b/db/migrate/20220819125630_lengthen_custom_jobs_url_column.rb
@@ -1,0 +1,9 @@
+class LengthenCustomJobsUrlColumn < ActiveRecord::Migration[7.0]
+  def up
+    change_column(:organisations, :custom_jobs_url, :text)
+  end
+
+  def down
+    change_column(:organisations, :custom_jobs_url, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_12_162047) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_125630) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -709,7 +709,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_162047) do
     t.boolean "foi_exempt", default: false, null: false
     t.string "organisation_chart_url"
     t.string "govuk_closed_status"
-    t.string "custom_jobs_url"
+    t.text "custom_jobs_url"
     t.string "content_id"
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5054145

The user wants to add a link to the civil service jobs site to the custom jobs url that has filters for the organisation.

The link they want to add is: https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=b3duZXJ0eXBlPWZhaXImcGFnZWNsYXNzPVNlYXJjaCZvd25lcj01MDcwMDAwJmNvbnRleHRpZD03MTE1NDI1JnBhZ2VhY3Rpb249c2VhcmNoY29udGV4dCZyZXFzaWc9MTY2MDkwNjUzMC1iNjY0ZjBlMWZiNDkyZmQ4OWRhZTg5YWFmYmI1ZjUxZmEyNWFlM2Jl

When they try to update the field, they get the following error:
`Mysql2::Error: Data too long for column 'custom_jobs_url' at row 1`

This is because the link has 258 characters, whereas the character limit for a string field is 255. This is likely to be a problem for other departments who want to also link to the Civil service jobs site.

Changing the type to "text" ups the character limit to 65,535.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
