### PR TITLE
Add rake task for world location

### DIFF
--- a/app/workers/world_location_news_worker.rb
+++ b/app/workers/world_location_news_worker.rb
@@ -1,14 +1,16 @@
 class WorldLocationNewsWorker < WorkerBase
   attr_accessor :world_location
 
-  def perform(world_location_id)
+  def perform(world_location_id, send_to_search_api = true)
     self.world_location = WorldLocation.find(world_location_id)
 
     each_locale do
       send_news_page_to_publishing_api
     end
 
-    send_news_page_to_rummager
+    if send_to_search_api
+      send_news_page_to_rummager
+    end
   end
 
 private

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -213,6 +213,18 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
+    desc "Republish all world location news pages"
+    task all_world_location_news: :environment do
+      search_index_delete_worker = SearchIndexDeleteWorker.new
+
+      WorldLocation.all.each do |world_location|
+        search_index_delete_worker.perform(Whitehall.url_maker.world_location_news_index_path(world_location), :government)
+
+        Whitehall::SearchIndex.delete(world_location)
+        WorldLocationNewsWorker.perform_async_in_queue("bulk_republishing", world_location.id)
+      end
+    end
+
     desc "Republish all editions which have attachments to the Publishing API"
     task editions_with_attachments: :environment do
       editions = Edition.publicly_visible.where(

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -213,8 +213,16 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
-    desc "Republish all world location news pages"
+    desc "Republish all world location news pages without re-sending to search"
     task all_world_location_news: :environment do
+      WorldLocation.all.each do |world_location|
+        WorldLocationNewsWorker.perform_async_in_queue("bulk_republishing", world_location.id, false)
+      end
+    end
+
+    # We expect this just to be needed for the initial republishing of world location news pages where we are changing their document type for search
+    desc "Republish all world location news pages with removal and re-adding to search"
+    task all_world_location_news_and_search_pages: :environment do
       search_index_delete_worker = SearchIndexDeleteWorker.new
 
       WorldLocation.all.each do |world_location|

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -418,6 +418,44 @@ class PublishingApiRake < ActiveSupport::TestCase
         Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
       end
 
+      test "When the world location news pages do not have translations, resends the english pages to publishing api but not to search" do
+        french_world_location = create(:world_location, name: "france", slug: "france", news_page_content_id: "id-123", title: "France and the UK")
+        spanish_world_location = create(:world_location, name: "spain", slug: "spain", news_page_content_id: "id-124", title: "Spain and the UK")
+
+        assert_republishes_to_publishing_api(locale: :en, title: french_world_location.title, content_id: french_world_location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: spanish_world_location.title, content_id: spanish_world_location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).never
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+
+      test "When a world location news page has a translation, this is also sent to publishing api" do
+        location = create(:world_location,
+                          slug: "france",
+                          name: "france",
+                          news_page_content_id: "id-123",
+                          title: "France and the UK",
+                          translated_into:
+                            { fr: { name: "La France", title: "Le Royaume Uni et la France" } })
+
+        assert_republishes_to_publishing_api(locale: :fr, title: "Le Royaume Uni et la France", content_id: location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).never
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+    end
+
+    describe "#all_world_location_news_and_search_pages" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:all_world_location_news_and_search_pages"] }
+
+      def assert_republishes_to_publishing_api(locale:, title:, content_id:)
+        Services.publishing_api.expects(:put_content).with(content_id, has_entries(locale: locale.to_s, title: title))
+        Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
+      end
+
       def assert_removes_and_re_adds_to_search_index(world_location)
         SearchIndexDeleteWorker.any_instance.expects(:perform).with("/world/#{world_location.name}/news", :government)
         expected_content_for_rummager = PublishingApi::WorldLocationNewsPresenter.new(world_location).content_for_rummager(world_location.news_page_content_id)

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -410,6 +410,51 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#all_world_location_news" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:all_world_location_news"] }
+
+      def assert_republishes_to_publishing_api(locale:, title:, content_id:)
+        Services.publishing_api.expects(:put_content).with(content_id, has_entries(locale: locale.to_s, title: title))
+        Services.publishing_api.expects(:publish).with(content_id, nil, { locale: locale })
+      end
+
+      def assert_removes_and_re_adds_to_search_index(world_location)
+        SearchIndexDeleteWorker.any_instance.expects(:perform).with("/world/#{world_location.name}/news", :government)
+        expected_content_for_rummager = PublishingApi::WorldLocationNewsPresenter.new(world_location).content_for_rummager(world_location.news_page_content_id)
+        Whitehall::FakeRummageableIndex.any_instance.expects(:add).with(expected_content_for_rummager)
+      end
+
+      test "When the world location news pages do not have translations, removes the page from search and resends the english pages to search and publishing api" do
+        french_world_location = create(:world_location, name: "france", slug: "france", news_page_content_id: "id-123", title: "France and the UK")
+        spanish_world_location = create(:world_location, name: "spain", slug: "spain", news_page_content_id: "id-124", title: "Spain and the UK")
+
+        [french_world_location, spanish_world_location].each do |location|
+          assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+          assert_removes_and_re_adds_to_search_index(location)
+        end
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+
+      test "When a world location news page has a translation, this is also sent to publishing api" do
+        location = create(:world_location,
+                          slug: "france",
+                          name: "france",
+                          news_page_content_id: "id-123",
+                          title: "France and the UK",
+                          translated_into:
+                            { fr: { name: "La France", title: "Le Royaume Uni et la France" } })
+
+        assert_republishes_to_publishing_api(locale: :fr, title: "Le Royaume Uni et la France", content_id: location.news_page_content_id)
+        assert_republishes_to_publishing_api(locale: :en, title: location.title, content_id: location.news_page_content_id)
+        assert_removes_and_re_adds_to_search_index(location)
+
+        task.invoke
+        WorldLocationNewsWorker.drain
+      end
+    end
+
     describe "#all_documents" do
       let(:task) { Rake::Task["publishing_api:bulk_republish:all_documents"] }
 


### PR DESCRIPTION
This PR adds the following two rake tasks:

1) Temporary task to remove all world location news pages from search index, republish them to publishing api, and republish them to search. This is because we are changing the search format type in [this PR](https://github.com/alphagov/whitehall/pull/6747/files) and we want to avoid duplicate search results

2) Slightly less temporary rake task to republish all world location news pages, without touching search. We'll need this in the interim, but it's expected that when we complete the refactoring to world location news pages (see [this](https://trello.com/c/DYfLSOOk/210-introduce-worldlocationnews-model) trello card) we'll no longer require custom republishing logic.

[Trello](https://trello.com/c/5vpV1JUu/194-update-world-news-location-document-type)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
