### PR TITLE
Change info banner to detail

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -25,14 +25,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/notice", {
-      title: "Topic taxonomy tags are applied to all editions of a document",
-      description_govspeak: sanitize("<p>This means changes will be reflected on the live site if there's a published edition.</p>"),
-      show_banner_title: true,
-      banner_title: "Information"
-    } %>
-
-
     <%= render "govuk_publishing_components/components/heading", {
       text: "Selected topics",
       margin_bottom: 2,
@@ -51,6 +43,12 @@
       <% end %>
 
       <%= form.hidden_field "invisible_taxons", value: @tag_form.invisible_taxons.join(",") %>
+
+      <%= render "govuk_publishing_components/components/details", {
+        title: "Changes are applied to a live page as soon as you update the tags"
+      } do %>
+        If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
+      <% end %>
 
       <div class="form-actions govuk-button-group govuk-!-margin-top-7" data-module="track-button-click" data-track-category="form-button" data-track-action="taxonomy-tag-form-button">
         <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
The info banner introduced in PR #6726 seems very "loud" and in your face, distracting the user from their task.

This changes it to a details component that delivers the same results but with a more minimalistic style.

## Before

<img width="1230" alt="Screenshot 2022-08-22 at 4 38 44 pm" src="https://user-images.githubusercontent.com/4599889/185961662-68a1bacb-cdfe-4cae-ac4a-03cc62372d69.png">

## After

<img width="1181" alt="Screenshot 2022-08-22 at 4 58 52 pm" src="https://user-images.githubusercontent.com/4599889/185965925-634a3c7e-e771-48b8-a0da-d9f25c754be9.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
