### PR TITLE
Remove expensive edition queries

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -4,7 +4,7 @@ class Admin::DocumentsController < Admin::BaseController
       Document.find_by(content_id: params[:content_id]) ||
       # If the content_id doesn't match a document, it could be a HTML
       # attachment
-      HtmlAttachment.find_by(content_id: params[:content_id])&.attachable
+      HtmlAttachment.find_by(content_id: params[:content_id])&.attachable&.document
     )
 
     url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -136,7 +136,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def revise
-    if @edition.superseded? && @edition.latest_edition.id == @edition.id
+    if @edition.superseded? && @edition.is_latest_edition?
       # There are a number of documents in Whitehall for which the
       # latest edition is also superseded, something of a
       # contradiction.

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -40,7 +40,7 @@ module PublicDocumentRoutesHelper
     if edition.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       options[:host] = URI(Plek.new.external_url_for("draft-origin")).host
     else
-      options[:preview] = edition.latest_edition.id
+      options[:preview] = edition.document.latest_edition_id
       options[:cachebust] = Time.zone.now.getutc.to_i
     end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -555,10 +555,6 @@ EXISTS (
     end
   end
 
-  def latest_edition
-    document.editions.latest_edition.first
-  end
-
   def latest_published_edition
     document.editions.latest_published_edition.first
   end
@@ -572,7 +568,7 @@ EXISTS (
   end
 
   def is_latest_edition?
-    latest_edition == self
+    document.latest_edition == self
   end
 
   def all_nation_applicability_selected?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -95,6 +95,8 @@ class Edition < ApplicationRecord
 
   scope :future_scheduled_editions,     -> { scheduled.where(Edition.arel_table[:scheduled_publication].gteq(Time.zone.now)) }
 
+  scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
+
   # @!group Callbacks
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
@@ -243,15 +245,6 @@ EXISTS (
   def self.without_locked_documents
     joins(:document)
     .where.not("documents.locked = true")
-  end
-
-  def self.latest_edition
-    where("NOT EXISTS (
-      SELECT 1
-        FROM editions e2
-       WHERE e2.document_id = editions.document_id
-         AND e2.id > editions.id
-         AND e2.state <> 'deleted')")
   end
 
   def self.latest_published_edition

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -6,14 +6,14 @@ class MinisterialRole < Role
 
   def published_speeches(options = {})
     speeches
-      .latest_published_edition
+      .live_edition.published
       .in_reverse_chronological_order
       .limit(options[:limit])
   end
 
   def published_news_articles(options = {})
     news_articles
-      .latest_published_edition
+      .live_edition.published
       .in_reverse_chronological_order
       .limit(options[:limit])
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -51,11 +51,11 @@ class Person < ApplicationRecord
   end
 
   def published_speeches
-    speeches.latest_published_edition.in_reverse_chronological_order
+    speeches.live_edition.published.in_reverse_chronological_order
   end
 
   def published_news_articles
-    news_articles.latest_published_edition.in_reverse_chronological_order
+    news_articles.live_edition.published.in_reverse_chronological_order
   end
 
   def destroyable?

--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -1,5 +1,6 @@
+<% document = edition.document %>
 <% if edition.superseded? %>
-  <% if edition.latest_edition.id == edition.id %>
+  <% if edition.is_latest_edition? %>
     <div class="alert alert-info">
       <p>
         This edition has been superseded, you can still create a
@@ -16,24 +17,24 @@
   <% else %>
     <div class="alert alert-danger">
       <p>This edition has been superseded.</p>
-      <p><%= link_to "Go to most recent edition", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
+      <p><%= link_to "Go to most recent edition", admin_edition_path(document.latest_edition), class: "btn btn-primary" %></p>
     </div>
   <% end %>
-<% elsif edition.pre_publication? && edition.latest_published_edition %>
+<% elsif edition.pre_publication? && document.live_edition.present? %>
   <div class="alert alert-info">
     <p>This is a new draft of a document that has already been published.</p>
     <p>
-      <%= link_to "Go to published edition", admin_edition_path(edition.latest_published_edition), class: "btn btn-primary" %>
-      <% if edition.previous_edition %>
+      <%= link_to "Go to published edition", admin_edition_path(document.live_edition), class: "btn btn-primary" %>
+      <% if edition.previous_edition.present? %>
         <%= link_to "See what’s changed", diff_admin_edition_path(edition, audit_trail_entry_id: edition.previous_edition.id), class: "btn btn-default" %>
       <% end %>
     </p>
   </div>
 <% elsif !edition.is_latest_edition? %>
-  <% if can?(:see, edition.latest_edition) %>
+  <% if can?(:see, document.latest_edition) %>
     <div class="alert alert-info">
       <p>This document has a new draft. You are currently viewing the edition that is published on the website.</p>
-      <p><%= link_to "Go to draft", admin_edition_path(edition.latest_edition), class: "btn btn-primary" %></p>
+      <p><%= link_to "Go to draft", admin_edition_path(document.latest_edition), class: "btn btn-primary" %></p>
     </div>
   <% else %>
     <div class="alert alert-info access-limited-latest-edition">

--- a/db/data_migration/20150514105208_add_eu_logo_url_to_eafrd_editions.rb
+++ b/db/data_migration/20150514105208_add_eu_logo_url_to_eafrd_editions.rb
@@ -11,7 +11,7 @@ logo_url = "https://assets.digital.cabinet-office.gov.uk/media/55547b94ed915d15d
 puts "Adding logos to EAFRD editions"
 slugs.each do |slug|
   document = Document.find_by(slug: slug)
-  latest_published_edition = document.editions.latest_published_edition.first
+  latest_published_edition = document.live_edition
   draft_edition = document.editions.latest_edition.draft.first
 
   puts "Updating logo in #{slug} published version"

--- a/db/data_migration/20150716094419_add_eu_logo_to_regional_development_funding.rb
+++ b/db/data_migration/20150716094419_add_eu_logo_to_regional_development_funding.rb
@@ -12,7 +12,7 @@ logo_url = "https://assets.digital.cabinet-office.gov.uk/government/assets/erdf-
 puts "Adding logos to ERDF editions"
 slugs.each do |slug|
   document = Document.find_by(document_type: "DetailedGuide", slug: slug)
-  latest_published_edition = document.editions.latest_published_edition.first
+  latest_published_edition = document.live_edition
   draft_edition = document.editions.latest_edition.draft.first
 
   puts "Updating logo in #{slug} published version"

--- a/db/data_migration/20150716152627_add_static_eu_logo_to_regional_development_funding.rb
+++ b/db/data_migration/20150716152627_add_static_eu_logo_to_regional_development_funding.rb
@@ -12,7 +12,7 @@ logo_url = "https://assets.digital.cabinet-office.gov.uk/media/55a7cc72ed915d537
 puts "Adding logos to ERDF editions"
 slugs.each do |slug|
   document = Document.find_by(document_type: "DetailedGuide", slug: slug)
-  latest_published_edition = document.editions.latest_published_edition.first
+  latest_published_edition = document.live_edition
   draft_edition = document.editions.latest_edition.draft.first
 
   puts "Updating logo in #{slug} published version"

--- a/features/step_definitions/admin_dashboard_steps.rb
+++ b/features/step_definitions/admin_dashboard_steps.rb
@@ -3,12 +3,12 @@ When(/^I visit the admin dashboard$/) do
 end
 
 Then(/^I should see the draft document "([^"]*)"$/) do |title|
-  edition = Edition.find_by!(title: title).latest_edition
+  edition = Edition.find_by!(title: title).document.latest_edition
   expect(page).to have_selector(".draft-documents #{record_css_selector(edition)}")
 end
 
 Then(/^I should see the force published document "([^"]*)"$/) do |title|
-  edition = Edition.find_by!(title: title).latest_edition
+  edition = Edition.find_by!(title: title).document.latest_edition
   expect(page).to have_selector(".force-published-documents #{record_css_selector(edition)}")
 end
 

--- a/features/step_definitions/most_recent_editions_steps.rb
+++ b/features/step_definitions/most_recent_editions_steps.rb
@@ -1,13 +1,13 @@
 When(/^someone else creates a new edition of the published document "([^"]*)"$/) do |title|
   random_editor = create(:departmental_editor)
-  current = Edition.find_by(title: title).latest_edition
+  current = Edition.find_by(title: title).document.latest_edition
   current.create_draft(random_editor)
 end
 
 When(/^someone else creates a new edition of the published document "([^"]*)" and limits access to members of "([^"]+)"$/) do |title, organisation_name|
   org = Organisation.find_by(name: organisation_name) || create(:organisation, name: organisation_name)
   random_editor = create(:departmental_editor)
-  current = Edition.find_by(title: title).latest_edition
+  current = Edition.find_by(title: title).document.latest_edition
   new_draft = current.create_draft(random_editor)
   new_draft.organisations << org
   new_draft.access_limited = true
@@ -16,14 +16,13 @@ When(/^someone else creates a new edition of the published document "([^"]*)" an
 end
 
 When(/^I view the old edition of document "([^"]*)"$/) do |title|
-  newest = Edition.find_by(title: title).latest_edition
-  oldest = newest.document.editions.order(:id).first
+  oldest = Edition.find_by(title: title).document.editions.first
   visit admin_edition_path(oldest)
 end
 
 Then(/^I can click through to the most recent version of document "([^"]*)"$/) do |title|
   click_on "Go to draft"
-  expect(page).to have_current_path(admin_edition_path(Edition.find_by(title: title).latest_edition))
+  expect(page).to have_current_path(admin_edition_path(Edition.find_by(title: title).document.latest_edition))
 end
 
 Then(/^I cannot click through to the most recent version of document "([^"]*)"$/) do |_title|

--- a/lib/tasks/republish_docs_with_attachments.rake
+++ b/lib/tasks/republish_docs_with_attachments.rake
@@ -3,9 +3,9 @@ task repubish_docs_with_attachments: :environment do
   organisations = Organisation.all
 
   organisations.each do |org|
-    published_editions_for_org = Edition.latest_published_edition.in_organisation(org)
-    puts "Total editions for #{org.slug}: #{published_editions_for_org.count}"
-    editions_with_attachments = published_editions_for_org.publicly_visible.where(
+    editions = org.editions.publicly_visible
+    puts "Total editions for #{org.slug}: #{editions.count}"
+    editions_with_attachments = editions.where(
       id: Attachment.where(accessible: [false, nil], attachable_type: "Edition").select("attachable_id"),
     )
     puts "Enqueueing #{editions_with_attachments.count} editions with attachments for #{org.slug}"

--- a/test/functional/admin/documents_controller_test.rb
+++ b/test/functional/admin/documents_controller_test.rb
@@ -17,9 +17,10 @@ class Admin::DocumentsControllerTest < ActionController::TestCase
 
   view_test "GET by-content-id supports HTML Attachments" do
     attachment = create(:html_attachment)
+    document = attachment.attachable.document
 
     get :by_content_id, params: { content_id: attachment.content_id }
-    assert_redirected_to @url_maker.admin_edition_path(attachment.attachable.latest_edition)
+    assert_redirected_to @url_maker.admin_edition_path(document.latest_edition)
   end
 
   view_test "GET by-content-id redirects to a search if content_id is not found" do

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -353,4 +353,16 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal edition.id, document.latest_edition_id
     assert_equal edition.id, document.live_edition_id
   end
+
+  test '#live_edition is a "published" or "withdrawn" edition' do
+    published = create(:published_edition)
+    withdrawn = create(:withdrawn_edition)
+    unpublished = create(:unpublished_edition)
+    draft = create(:draft_edition)
+
+    assert_equal published, published.document.live_edition
+    assert_equal withdrawn, withdrawn.document.live_edition
+    assert_nil unpublished.document.live_edition
+    assert_nil draft.document.live_edition
+  end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -105,7 +105,7 @@ class EditionTest < ActiveSupport::TestCase
     assert Edition.latest_edition.include?(edition)
   end
 
-  test ".latest_edition includes only latest edition of a edition" do
+  test ".latest_edition includes only latest edition of a document" do
     original_edition = create(:published_edition)
     new_draft = original_edition.create_draft(create(:writer))
     assert_not Edition.latest_edition.include?(original_edition)
@@ -121,13 +121,13 @@ class EditionTest < ActiveSupport::TestCase
     assert_not Edition.latest_edition.include?(deleted_edition)
   end
 
-  test ".latest_published_edition includes only published editions" do
+  test ".live_edition includes only currently live edition of a document" do
     document = create(:document)
-    original_edition = create(:published_edition, document: document)
-    draft_edition = create(:draft_edition, document: document)
+    create(:superseded_edition, document: document)
+    published = create(:published_edition, document: document)
+    create(:draft_edition, document: document)
 
-    assert Edition.latest_published_edition.include?(original_edition)
-    assert_not Edition.latest_published_edition.include?(draft_edition)
+    assert [published], Edition.live_edition
   end
 
   test ".most_recent_change_note returns the most recent change note" do

--- a/test/unit/ministerial_role_test.rb
+++ b/test/unit/ministerial_role_test.rb
@@ -20,7 +20,7 @@ class MinisterialRoleTest < ActiveSupport::TestCase
   end
 
   test "should be able to get published news_articles associated with the role" do
-    editions = [create(:draft_news_article), create(:published_news_article)]
+    editions = [create(:draft_news_article), create(:published_news_article), create(:news_article, :withdrawn)]
     ministerial_role = create(:ministerial_role)
     create(:role_appointment, role: ministerial_role, editions: editions)
     assert_equal editions[1..1], ministerial_role.published_news_articles
@@ -41,6 +41,7 @@ class MinisterialRoleTest < ActiveSupport::TestCase
       ended_at: nil,
     )
     create(:published_speech, role_appointment: appointment)
+    create(:speech, :withdrawn, role_appointment: appointment)
     create(:draft_speech, role_appointment: appointment)
 
     assert appointment.role.published_speeches.all?(&:published?)

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -61,6 +61,15 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal [speech1, speech2], person.speeches
   end
 
+  test "published_speeches only returns published speeches" do
+    person = create(:person)
+    published_speech = create(:published_speech, role_appointment: create(:role_appointment, person: person))
+    create(:draft_speech, role_appointment: create(:role_appointment, person: person))
+    create(:speech, :withdrawn, role_appointment: create(:role_appointment, person: person))
+
+    assert_equal [published_speech], person.published_speeches
+  end
+
   test "can access news_articles associated with ministerial roles of a person" do
     person = create(:person)
     news_articles = 2.times.map { create(:news_article) }
@@ -84,10 +93,11 @@ class PersonTest < ActiveSupport::TestCase
 
   test "published_news_articles only returns published news articles" do
     person = create(:person)
-    news_articles = [create(:published_news_article), create(:draft_news_article)]
+    news_articles = [create(:published_news_article), create(:draft_news_article), create(:news_article, :withdrawn)]
+    news_articles.each do |edition|
+      create(:ministerial_role_appointment, person: person).editions << edition
+    end
 
-    create(:ministerial_role_appointment, person: person).editions << news_articles[0]
-    create(:ministerial_role_appointment, person: person).editions << news_articles[1]
     assert_equal news_articles[0..0], person.published_news_articles
   end
 


### PR DESCRIPTION
This PR is a follow-up to #6733. It implements step 4 of the Data Migration outlined in that PR:

> 4. Deploy code changes to use the new columns

I've removed the expensive database queries which were used to dynamically find the latest Edition of a Document, replacing them with the newly created and populated (in #6733) fields `latest_edition_id` and `live_edition_id`. I've also taken the opportunity to tidy up the various `latest_*` methods belonging to the Edition model, which were either duplicate implementations or have otherwise been made redundant.

It's probably easiest to review this PR one commit at a time. I've tried to keep each commit relatively focussed on implementing one particular change across the codebase.

## Summary of high level changes

| Method | Change made |
| --- | --- |
| `Document#latest_edition` | refactored to use new database column |
| `Document#live_edition` | refactored to use new database column |
| `Edition.latest_edition` | refactored to use new database column |
| `Edition#latest_edition` | removed in favour of `Document#latest_edition` |
| `Edition.latest_published_edition` | replaced by `Edition.live_edition` |
| `Edition#latest_published_edition` | removed |

Note: `#` signifies an instance method, where `.` represents a class method.

## Other learnings

### `Edition#previous_edition` is a bit weird

I've noticed that the method `Edition#previous_edition` could do with some love. Its name is slightly misleading because it will only ever return the most recently live Edition of a Document (i.e. an edition that was published/withdrawn) **excluding the current Edition**. When dealing with the latest Edition, this method name makes sense. But when working with an older Edition, the method will actually return a _more recent_ Edition which seems counterintuitive.

Unfortunately `Edition#previous_edition` is not covered by Unit Tests, despite being used in several places throughout the codebase. So while its behaviour doesn't strictly match its name, it seems that various things depend on it working the way it currently does.

I'm open to suggestions about what to do about this. I guess options include:

- Do nothing (feels a bit rubbish)
- Rename the method to make its purpose more obvious (maybe even relocate it to the Document model?)
- Retrospectively add Unit Tests to make sure the current behaviour is maintained, even if it has a counterintuitive name

Or a combination of the above.

---

Trello: https://trello.com/c/iWcORsD5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
