### PR TITLE
Revert "Work around a MySQL 8.0.27 bug that broke sorting"

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,11 +3,6 @@ default: &default
   adapter: mysql2
   variables:
     sql_mode: TRADITIONAL
-    # We need to set `sort_buffer_size` to work around a bug in MySQL 8.0.27 [1]
-    # This quadruples the default sort buffer size, which seems to provide enough headroom to allow sorting to work correctly with our dataset.
-    # The bug is fixed in MySQL 8.0.28 (currently unreleased), so we should be able to remove this fix once we're on that version.
-    # [1]: https://bugs.mysql.com/bug.php?id=105304
-    sort_buffer_size: 1048576
 
 development:
   <<: *default


### PR DESCRIPTION
This reverts commit 19712a2a2e5f2bf691132d4625d582b709d123bc.

Now that MySQL 8.0.28 has been rolled out, this workaround is no longer needed.

I've tested this on integration and can confirm that the route which previously triggered the MySQL bug now works as expected.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
