### PR TITLE
Query-based pagination for editorial remarks

### DIFF
--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -31,7 +31,7 @@ private
   end
 
   def load_translated_models
-    @edition_remarks = @edition.document_remarks_trail.reverse
+    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
     @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
     @translated_edition = LocalisedModel.new(@edition, translation_locale.code)
   end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -202,7 +202,7 @@ private
   end
 
   def fetch_version_and_remark_trails
-    @edition_remarks = @edition.document_remarks_trail.reverse
+    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
     @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 

--- a/app/controllers/admin/editorial_remarks_controller.rb
+++ b/app/controllers/admin/editorial_remarks_controller.rb
@@ -9,7 +9,7 @@ class Admin::EditorialRemarksController < Admin::BaseController
   end
 
   def index
-    @edition_remarks = @edition.document_remarks_trail.reverse
+    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:page])
   end
 
   def new

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,6 +37,7 @@ class Document < ApplicationRecord
   has_many :features, inverse_of: :document, dependent: :destroy
 
   has_many :edition_versions, through: :editions, source: :versions
+  has_many :editorial_remarks, through: :editions
 
   has_many :withdrawals,
            -> { where(unpublishing_reason_id: UnpublishingReason::Withdrawn).order(unpublished_at: :asc, id: :asc) },

--- a/app/models/document/paginated_remarks.rb
+++ b/app/models/document/paginated_remarks.rb
@@ -1,0 +1,16 @@
+class Document::PaginatedRemarks
+  PER_PAGE = 30
+
+  attr_reader :query
+
+  delegate :total_count, to: :query
+
+  def initialize(document, page)
+    @document = document
+    @query = document.editorial_remarks
+                     .includes(:author)
+                     .reorder(created_at: :desc, id: :desc)
+                     .page(page)
+                     .per(PER_PAGE)
+  end
+end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -25,7 +25,7 @@
     <% else %>
       <%= sidebar_tabs edition_tabs(
         @edition,
-        remarks_count: @edition_remarks.length,
+        remarks_count: @document_remarks.total_count,
         history_count: @document_history.total_count,
         editing: true,
       ) do |tabs| %>
@@ -39,7 +39,9 @@
           <h1>Notes</h1>
           <p>To add a remark, save your changes.</p>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks(@edition_remarks, @edition) %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+          <%= render_editorial_remarks(@document_remarks, @edition) %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editions/_remark_entry.html.erb
+++ b/app/views/admin/editions/_remark_entry.html.erb
@@ -1,0 +1,12 @@
+<%= content_tag(:li, class: "editorial_remark") do %>
+  <div class="image">
+    <%= gravatar_image(remark.author, ssl: request.ssl?) %>
+  </div>
+  <span class="body"><%= remark.body %></span>
+  <% if remark.author %>
+    <span class="actor"><%= linked_author(remark.author) %></span>
+  <% else %>
+    User (removed)
+  <% end %>
+  <%= absolute_time(remark.created_at, class: "created_at") %>
+<% end %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -53,7 +53,7 @@
       <% else %>
         <%= sidebar_tabs edition_tabs(
           @edition,
-          remarks_count: @edition_remarks.length,
+          remarks_count: @document_remarks.total_count,
           history_count: @document_history.total_count,
           editing: true,
         ) do |tabs| %>
@@ -73,7 +73,9 @@
             <h1>Notes</h1>
             <p>To add a remark, save your changes.</p>
             <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-            <%= render_editorial_remarks(@edition_remarks, @edition) %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+            <%= render_editorial_remarks(@document_remarks, @edition) %>
+            <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
           <% end %>
 
           <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -78,7 +78,7 @@
     <% elsif !current_user.can_view_move_tabs_to_endpoints? || @edition.is_a?(CorporateInformationPage) %>
       <%= sidebar_tabs edition_tabs(
         @edition,
-        remarks_count: @edition_remarks.length,
+        remarks_count: @document_remarks.total_count,
         history_count: @document_history.total_count
         ),
         class: 'remarks-history' do |tabs| %>
@@ -86,7 +86,9 @@
         <%= tabs.pane class: "audit-trail", id: "notes" do %>
           <h1>Notes</h1>
           <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= render_editorial_remarks(@edition_remarks, @edition) %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+          <%= render_editorial_remarks(@document_remarks, @edition) %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
         <% end %>
 
         <%= tabs.pane class: "audit-trail", id: "history" do %>

--- a/app/views/admin/editorial_remarks/index.html.erb
+++ b/app/views/admin/editorial_remarks/index.html.erb
@@ -8,7 +8,9 @@
 
     <h1>Notes</h1>
 
-    <%= render_editorial_remarks(@edition_remarks, @edition) %>
+    <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+    <%= render_editorial_remarks(@document_remarks, @edition) %>
+    <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
 
     <%= link_to "Add note", new_admin_edition_editorial_remark_path(@edition) %>
   </section>

--- a/app/views/kaminari/remarks/_next_page.html.erb
+++ b/app/views/kaminari/remarks/_next_page.html.erb
@@ -1,0 +1,1 @@
+<li class="next"><%= link_to_unless current_page.last?, "Older >>", url, data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1) } %></li>

--- a/app/views/kaminari/remarks/_paginator.html.erb
+++ b/app/views/kaminari/remarks/_paginator.html.erb
@@ -1,0 +1,8 @@
+<%= paginator.render do -%>
+  <nav class="remarks-nav" role="navigation">
+    <ul class="pager">
+      <%= prev_page_tag unless current_page.first? %>
+      <%= next_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/remarks/_prev_page.html.erb
+++ b/app/views/kaminari/remarks/_prev_page.html.erb
@@ -1,0 +1,1 @@
+<li class="previous"><%= link_to_unless current_page.first?, "<< Newer", url, data: {'remote-pagination' => paginated_audit_trail_url(current_page - 1) } %></li>

--- a/test/unit/helpers/admin/audit_trail_helper_test.rb
+++ b/test/unit/helpers/admin/audit_trail_helper_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class Admin::AuditTrailHelperTest < ActionView::TestCase
+  setup do
+    document = create(:document)
+    first_edition = create(:published_edition, document: document)
+    create(:editorial_remark, body: "First edition remark", edition: first_edition)
+    second_edition = create(:published_edition, document: document)
+    create(:editorial_remark, body: "Second edition remark", edition: second_edition)
+    newest_edition = create(:published_edition, document: document)
+    create(:editorial_remark, body: "Newest edition remark", edition: newest_edition)
+
+    document_remarks = Document::PaginatedRemarks.new(newest_edition.document, 1)
+
+    @render_newest = Nokogiri::HTML(render_editorial_remarks(document_remarks, newest_edition))
+    @render_second = Nokogiri::HTML(render_editorial_remarks(document_remarks, second_edition))
+    @render_first = Nokogiri::HTML(render_editorial_remarks(document_remarks, first_edition))
+  end
+
+  def groups_from_html(html_node)
+    # HTML structure should be a <h2> followed by a <ul> of remarks
+    html_node.css("h2").map do |h2|
+      ul = h2.next
+      {
+        heading: h2.text,
+        remarks: ul.css("li .body").map(&:text),
+      }
+    end
+  end
+
+  test "#render_editorial_remarks for the newest edition of a document" do
+    expected_groups = [
+      {
+        heading: "On this edition",
+        remarks: [
+          "Newest edition remark",
+        ],
+      },
+      {
+        heading: "On previous editions",
+        remarks: [
+          "Second edition remark",
+          "First edition remark",
+        ],
+      },
+    ]
+
+    assert_equal expected_groups, groups_from_html(@render_newest)
+  end
+
+  test "#render_editorial_remarks for an older edition of a document" do
+    expected_groups = [
+      {
+        heading: "On newer editions",
+        remarks: [
+          "Newest edition remark",
+        ],
+      },
+      {
+        heading: "On this edition",
+        remarks: [
+          "Second edition remark",
+        ],
+      },
+      {
+        heading: "On previous editions",
+        remarks: [
+          "First edition remark",
+        ],
+      },
+    ]
+
+    assert_equal expected_groups, groups_from_html(@render_second)
+  end
+
+  test "#render_editorial_remarks for the oldest edition of a document" do
+    expected_groups = [
+      {
+        heading: "On newer editions",
+        remarks: [
+          "Newest edition remark",
+          "Second edition remark",
+        ],
+      },
+      {
+        heading: "On this edition",
+        remarks: [
+          "First edition remark",
+        ],
+      },
+    ]
+
+    assert_equal expected_groups, groups_from_html(@render_first)
+  end
+end

--- a/test/unit/models/document/paginated_remarks_test.rb
+++ b/test/unit/models/document/paginated_remarks_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class PaginatedRemarksTest < ActiveSupport::TestCase
+  setup do
+    @per_page = 3
+
+    @document = create(:document)
+    edition = create(:published_edition, document: @document)
+    3.times do
+      create(:editorial_remark, edition: edition)
+      Timecop.travel 1.day.from_now
+    end
+    @newest_remark = create(:editorial_remark, edition: edition)
+  end
+
+  test "#query contains remarks ordered by most recent versions first" do
+    remarks = Document::PaginatedRemarks.new(@document, 1)
+    assert_equal remarks.query.first, @newest_remark
+    assert_equal remarks.query, remarks.query.sort_by(&:created_at).reverse
+  end
+
+  test "#query contains the results of a single page" do
+    mock_pagination do
+      expected_pages = 2
+      (1..expected_pages).each do |page|
+        remarks = Document::PaginatedRemarks.new(@document, page)
+        assert remarks.query.count <= @per_page
+      end
+    end
+  end
+
+  def mock_pagination(&block)
+    Document::PaginatedRemarks.stub_const(:PER_PAGE, @per_page, &block)
+  end
+end


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/UUAOsryV/537-use-query-based-pagination-for-the-document-history-tab)

This PR builds on previous work done to improve page load performance by implementing query-based pagination for editorial remarks. 

[Commit 1:](https://github.com/alphagov/whitehall/commit/c8bfaa9e4f6e29aadfef154d942c14d650ca99ec) Adds a PaginatedRemarks class, with query-based pagination of editorial remarks, and associated test file.
[Commit 2:](https://github.com/alphagov/whitehall/commit/57e70c945f033c553190867567355c7834ca9f69) Adds/updates the relevant views and controllers to utilise the new PaginatedRemarks class. This commit also updates the headers in the editorial remarks column to show when editorial remarks are on a newer edition, which is new functionality.

The redundant code has been left in for this PR, and will be removed in a separate PR.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
