### PR TITLE
Move new/edit external attachment page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -28,6 +28,10 @@ class Admin::AttachmentsController < Admin::BaseController
     end
   end
 
+  def edit
+    render(preview_design_system_user? ? "edit" : "edit_legacy")
+  end
+
   def update
     attachment.attributes = attachment_params
     if attachment.is_a?(FileAttachment)
@@ -81,7 +85,14 @@ class Admin::AttachmentsController < Admin::BaseController
 private
 
   def get_layout
-    preview_design_system_user? ? "design_system" : "admin"
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "edit", "update", "new", "create"
+      "design_system"
+    else
+      "admin"
+    end
   end
 
   def attachment

--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -2,6 +2,7 @@ class Admin::AttachmentsController < Admin::BaseController
   before_action :limit_attachable_access, if: :attachable_is_an_edition?
   before_action :check_attachable_allows_attachment_type
   before_action :forbid_editing_of_locked_documents, if: :attachable_is_an_edition?
+  layout :get_layout
 
   rescue_from Mysql2::Error, with: :handle_duplicate_key_errors_caused_by_double_create_requests
 
@@ -14,14 +15,16 @@ class Admin::AttachmentsController < Admin::BaseController
     redirect_to attachable_attachments_path(attachable), notice: "Attachments re-ordered"
   end
 
-  def new; end
+  def new
+    render(preview_design_system_user? ? "new" : "new_legacy")
+  end
 
   def create
     if save_attachment
       attachment_updater(attachment.attachment_data)
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
-      render :new
+      render(preview_design_system_user? ? "new" : "new_legacy")
     end
   end
 
@@ -35,7 +38,7 @@ class Admin::AttachmentsController < Admin::BaseController
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
-      render :edit
+      render(preview_design_system_user? ? "edit" : "edit_legacy")
     end
   end
 
@@ -76,6 +79,10 @@ class Admin::AttachmentsController < Admin::BaseController
   helper_method :attachable_attachments_path
 
 private
+
+  def get_layout
+    preview_design_system_user? ? "design_system" : "admin"
+  end
 
   def attachment
     @attachment ||= find_attachment || build_attachment

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,11 +1,21 @@
 <% initialise_script "GOVUK.AdminAttachmentsForm", selector: '.js-attachment-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
 
 <%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "js-attachment-form" } do |form| %>
-  <%= form.errors %>
+  <% content_for :error_summary, render('shared/error_summary', object: attachment.becomes(Attachment), class_name: @attachment.class.name.demodulize.underscore.humanize.downcase) %>
 
-  <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
-    <%= form.text_field :title %>
-  <% end %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Title (required)"
+      },
+      name: "attachment[title]",
+      id: "attachment_title",
+      heading_level: 2,
+      heading_size: "l",
+      value: form.object.title,
+      error_items: errors_for(attachment.errors, :title)
+    } %>
+  </div>
 
   <% if attachable.allows_attachment_references? %>
     <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment %>
@@ -23,7 +33,7 @@
   ### Unnumbered sub-heading
 
   Manually number your headings as appropriate using the above numbering scheme.</pre>
-       </div>
+      </div>
 
       <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
         <%= govspeak_fields.text_area :body, rows: 20, class: "previewable", data: {
@@ -32,12 +42,35 @@
       <% end %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
-    <%= form.text_field :external_url %>
+    <div class="govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "External url (required)"
+        },
+        name: "attachment[external_url]",
+        id: "attachment_external_url",
+        heading_level: 2,
+        heading_size: "l",
+        value: form.object.external_url,
+        error_items: errors_for(attachment.errors, :external_url)
+      } %>
+    </div>
   <% else %>
     <%= render 'attachment_data_fields', form: form %>
   <% end %>
 
   <%= hidden_field_tag :type, params[:type] %>
 
-  <%= form.save_or_cancel cancel: attachable_attachments_path(attachable) %>
+  <% if attachment.is_a?(ExternalAttachment) %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Next"
+    } %>
+  <% else %>
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
+      <a class="govuk-link" href="attachable_attachments_path(attachable)">Cancel</a>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/admin/attachments/_form_legacy.html.erb
+++ b/app/views/admin/attachments/_form_legacy.html.erb
@@ -1,0 +1,43 @@
+<% initialise_script "GOVUK.AdminAttachmentsForm", selector: '.js-attachment-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
+
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "js-attachment-form" } do |form| %>
+  <%= form.errors %>
+
+  <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
+    <%= form.text_field :title %>
+  <% end %>
+
+  <% if attachable.allows_attachment_references? %>
+    <%= render 'reference_fields_legacy', attachable: attachable, form: form, attachment: attachment %>
+  <% end %>
+
+  <% if attachment.is_a?(HtmlAttachment) %>
+    <%= form.fields_for :govspeak_content do |govspeak_fields| %>
+
+      <%= govspeak_fields.check_box :manually_numbered_headings %>
+      <div class="js-manual-numbering-help<%= ' js-hidden' unless attachment.manually_numbered_headings? %>">
+        <pre>
+  ## 1. First heading
+  ### 1.1 First sub-heading
+  ### 1.2 Second sub-heading
+  ### Unnumbered sub-heading
+
+  Manually number your headings as appropriate using the above numbering scheme.</pre>
+       </div>
+
+      <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
+        <%= govspeak_fields.text_area :body, rows: 20, class: "previewable", data: {
+          module: "paste-html-to-govspeak"
+        } %>
+      <% end %>
+    <% end %>
+  <% elsif attachment.is_a?(ExternalAttachment) %>
+    <%= form.text_field :external_url %>
+  <% else %>
+    <%= render 'attachment_data_fields', form: form %>
+  <% end %>
+
+  <%= hidden_field_tag :type, params[:type] %>
+
+  <%= form.save_or_cancel cancel: attachable_attachments_path(attachable) %>
+<% end %>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,24 +1,53 @@
-<div class="paper-number clearfix">
-  <%= form.text_field :hoc_paper_number,
-                      label_text: "House of Commons paper number",
-                      class: 'input-md-3' %>
-
-  <%= form.check_box :unnumbered_hoc_paper,
-                     label_text: "Unnumbered act paper" %>
-
-  <p class="help-block">
-    Fill in the command and House of Commons boxes to publish an official
-    document which will appear in the list of official documents.
-  </p>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: "House of Commons paper number",
+    heading_level: 2,
+    heading_size: "l",
+    name: "attachment[unnumbered_hoc_paper]",
+    id_prefix: "hoc_paper_number_conditional",
+    items: [
+      {
+        value: "0",
+        text: "Numbered",
+        checked: form.object.unnumbered_hoc_paper.eql?(false),
+        conditional: render("govuk_publishing_components/components/input", {
+          label: {
+            text: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
+          },
+          name: "attachment[hoc_paper_number]",
+          id: "attachment_hoc_paper_number",
+          value: form.object.hoc_paper_number,
+          error_items: errors_for(attachment.errors, :command_paper_number)
+        })
+      },
+      {
+        value: "1",
+        text: "Unnumbered",
+        checked: form.object.unnumbered_hoc_paper
+      }
+    ]
+  } %>
 </div>
 
-<div class="form-group">
-  <%= form.label :parliamentary_session %>
+<%
+  options = [{text: "Choose the right Parliamentary session", value: ""}]
+  options.concat(Attachment.parliamentary_sessions.map do |session|
+    {
+      text: session,
+      value: session,
+      selected: form.object.parliamentary_session == session
+    }
+  end)
+%>
 
-  <%= form.select :parliamentary_session,
-                  Attachment.parliamentary_sessions,
-                  { include_blank: true },
-                  { class: "form-control input-md-3" } %>
-
-  <p class="help-block">Choose the right Parliamentary session.</p>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/select", {
+    label: "Parliamentary session",
+    name: "attachment[parliamentary_session]",
+    id: "attachment_parliamentary_session",
+    heading_level: 2,
+    heading_size: "l",
+    options: options,
+    error_message: errors_for_input(attachment.errors, :parliamentary_session)
+  } %>
 </div>

--- a/app/views/admin/attachments/_hoc_reference_fields_legacy.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields_legacy.html.erb
@@ -1,0 +1,24 @@
+<div class="paper-number clearfix">
+  <%= form.text_field :hoc_paper_number,
+                      label_text: "House of Commons paper number",
+                      class: 'input-md-3' %>
+
+  <%= form.check_box :unnumbered_hoc_paper,
+                     label_text: "Unnumbered act paper" %>
+
+  <p class="help-block">
+    Fill in the command and House of Commons boxes to publish an official
+    document which will appear in the list of official documents.
+  </p>
+</div>
+
+<div class="form-group">
+  <%= form.label :parliamentary_session %>
+
+  <%= form.select :parliamentary_session,
+                  Attachment.parliamentary_sessions,
+                  { include_blank: true },
+                  { class: "form-control input-md-3" } %>
+
+  <p class="help-block">Choose the right Parliamentary session.</p>
+</div>

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -1,17 +1,84 @@
+<%
+  options = [{text: "All languages", value: ""}]
+  options.concat(attachable.translated_locales.map do |locale|
+    {
+      text: native_language_name_for(locale),
+      value: locale
+    }
+  end)
+%>
+
 <% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
-  <%= form.label :locale, 'Display language' %>
-  <p class="help-block">This determines the translations of the publication that the attachment will appear in.</p>
-  <%= form.select :locale, options_for_locales(attachable.translated_locales), include_blank: 'All languages' %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/select", {
+      id: "attachment_parliamentary_session",
+      label: "Display language",
+      name: "attachment[locale]",
+      heading_level: 2,
+      heading_size: "l",
+      options: options,
+      hint: "This determines the translations of the publication that the attachment will appear in."
+    } %>
+  </div>
 <% end %>
 
-<%= form.text_field :isbn, label_text: "ISBN" %>
-
-<%= form.text_field :unique_reference %>
-<div class="paper-number">
-  <%= form.text_field :command_paper_number, class: 'input-md-3' %>
-  <%= form.check_box :unnumbered_command_paper, label_text: 'Unnumbered' %>
-  <p class="help-block">The number must start with one of <%= Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') %>, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV</p>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "ISBN"
+    },
+    name: "attachment[isbn]",
+    id: "attachment_isbn",
+    heading_level: 2,
+    heading_size: "l",
+    value: form.object.isbn,
+    error_items: errors_for(attachment.errors, :isbn)
+  } %>
 </div>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Unique reference"
+    },
+    name: "attachment[unique_reference]",
+    heading_level: 2,
+    heading_size: "l",
+    value: form.object.unique_reference
+  } %>
+</div>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: "Command paper number",
+    heading_level: 2,
+    heading_size: "l",
+    name: "attachment[unnumbered_command_paper]",
+    id_prefix: "command_paper_number_conditional",
+    items: [
+      {
+        value: "0",
+        text: "Numbered",
+        checked: form.object.unnumbered_command_paper.eql?(false),
+        conditional: render("govuk_publishing_components/components/input", {
+          label: {
+            text: "The number must start with one of " + Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') + ", followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
+          },
+          name: "attachment[command_paper_number]",
+          id: "attachment_command_paper_number",
+          value: form.object.command_paper_number,
+          error_items: errors_for(attachment.errors, :command_paper_number)
+        })
+      },
+      {
+        value: "1",
+        text: "Unnumbered",
+        checked: form.object.unnumbered_command_paper
+      }
+    ]
+  } %>
+</div>
+
 <% if attachable.can_have_attached_house_of_commons_papers? %>
-  <%= render 'admin/attachments/hoc_reference_fields', form: form %>
+  <%= render 'admin/attachments/hoc_reference_fields', attachable: attachable, form: form, attachment: attachment %>
 <% end %>

--- a/app/views/admin/attachments/_reference_fields_legacy.html.erb
+++ b/app/views/admin/attachments/_reference_fields_legacy.html.erb
@@ -1,0 +1,17 @@
+<% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
+  <%= form.label :locale, 'Display language' %>
+  <p class="help-block">This determines the translations of the publication that the attachment will appear in.</p>
+  <%= form.select :locale, options_for_locales(attachable.translated_locales), include_blank: 'All languages' %>
+<% end %>
+
+<%= form.text_field :isbn, label_text: "ISBN" %>
+
+<%= form.text_field :unique_reference %>
+<div class="paper-number">
+  <%= form.text_field :command_paper_number, class: 'input-md-3' %>
+  <%= form.check_box :unnumbered_command_paper, label_text: 'Unnumbered' %>
+  <p class="help-block">The number must start with one of <%= Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') %>, followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV</p>
+</div>
+<% if attachable.can_have_attached_house_of_commons_papers? %>
+  <%= render 'admin/attachments/hoc_reference_fields_legacy', form: form %>
+<% end %>

--- a/app/views/admin/attachments/edit.html.erb
+++ b/app/views/admin/attachments/edit.html.erb
@@ -1,11 +1,15 @@
-<% page_title "Editing #{attachment.attachable_model_name} #{attachment.readable_type} attachment" %>
+<% content_for :page_title, "Editing #{attachment.attachable_model_name} #{attachment.readable_type} attachment" %>
+<% content_for :title, "Edit #{attachment.readable_type} attachment" %>
+<% content_for :context, "Attachments for #{attachment.attachable_model_name}" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", href: attachable_attachments_path(attachable) %>
+<% end %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Editing <%= attachment.attachable_model_name %> <%= attachment.readable_type %> attachment</h1>
-
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
     <%= render partial: 'form', locals: { attachable: attachable, attachment: attachment } %>
   </section>
+
   <% if attachment.html? %>
     <div class="col-md-4">
       <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>

--- a/app/views/admin/attachments/edit_legacy.html.erb
+++ b/app/views/admin/attachments/edit_legacy.html.erb
@@ -1,0 +1,14 @@
+<% page_title "Editing #{attachment.attachable_model_name} #{attachment.readable_type} attachment" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Editing <%= attachment.attachable_model_name %> <%= attachment.readable_type %> attachment</h1>
+
+    <%= render partial: 'form_legacy', locals: { attachable: attachable, attachment: attachment } %>
+  </section>
+  <% if attachment.html? %>
+    <div class="col-md-4">
+      <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/attachments/new.html.erb
+++ b/app/views/admin/attachments/new.html.erb
@@ -1,13 +1,17 @@
-<% page_title "Add #{attachment.readable_type} attachment to: #{attachment.attachable_model_name}" %>
+<% content_for :page_title, "Adding #{attachment.attachable_model_name} #{attachment.readable_type} attachment" %>
+<% content_for :title, "Add #{attachment.readable_type} attachment" %>
+<% content_for :context, "Attachments for #{attachment.attachable_model_name}" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", href: attachable_attachments_path(attachable) %>
+<% end %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Add <%= attachment.readable_type %>  attachment to <%= attachment.attachable_model_name %></h1>
-
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
     <%= render 'form', attachable: attachable %>
   </section>
+
   <% if attachment.html? %>
-    <div class="col-md-4">
+    <div>
       <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>
     </div>
   <% end %>

--- a/app/views/admin/attachments/new_legacy.html.erb
+++ b/app/views/admin/attachments/new_legacy.html.erb
@@ -1,0 +1,14 @@
+<% page_title "Add #{attachment.readable_type} attachment to: #{attachment.attachable_model_name}" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Add <%= attachment.readable_type %> attachment to <%= attachment.attachable_model_name %></h1>
+
+    <%= render 'form_legacy', attachable: attachable %>
+  </section>
+  <% if attachment.html? %>
+    <div class="col-md-4">
+      <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>
+    </div>
+  <% end %>
+</div>

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -23,6 +23,26 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
+  Scenario: Adding and reordering attachments with design system permission
+    Given I am an writer
+    And I have the "Preview design system" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I start editing the attachments from the publication page
+    And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
+    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
+    And I add an external attachment with the title "Beard Length Illustrations" and the URL "http://www.beardlengths.gov.uk"
+    Then the publication "Standard Beard Lengths" should have 3 attachments
+    When I set the order of attachments to:
+      |         title                | order |
+      | Beard Length Graphs 2012     |   0   |
+      | Beard Length Statistics 2014 |   1   |
+      | Beard Length Illustrations   |   2   |
+    Then the attachments should be in the following order:
+      |         title                |
+      | Beard Length Graphs 2012     |
+      | Beard Length Statistics 2014 |
+      | Beard Length Illustrations   |
+
   Scenario: Previewing HTML attachment
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"

--- a/features/support/attachment_helper.rb
+++ b/features/support/attachment_helper.rb
@@ -24,10 +24,12 @@ module AttachmentHelper
   end
 
   def create_external_attachment(url, attachment_title)
+    design_system = @user.has_permission? "Preview design system"
+
     click_on "Add new external attachment"
     fill_in "Title", with: attachment_title
     fill_in "External url", with: url
-    click_on "Save"
+    click_on design_system ? "Next" : "Save"
     Attachment.find_by(title: attachment_title)
   end
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -303,6 +303,13 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
+    assert_template :new_legacy
+    assert_equal 0, @edition.reload.attachments.size
+  end
+
+  test "POST :create with bad data does not save the attachment and re-renders the new template when the user has the 'Preview design system' permission" do
+    @current_user.permissions << "Preview design system"
+    post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new
     assert_equal 0, @edition.reload.attachments.size
   end


### PR DESCRIPTION
The work in this PR moves the add/edit external attachment pages to the design system layout. See the [Trello card](https://trello.com/c/UUh0Bjp9/612-move-new-edit-attachment-page-to-the-govuk-design-system) for this work. 

| Current layout | Design System layout |
|---|---|
| ![Screenshot 2022-08-31 at 08 36 52](https://user-images.githubusercontent.com/6080548/187620557-474af5f6-bcd3-4225-98c5-a3b75b315f1a.png) | ![Screenshot 2022-09-01 at 15 02 40](https://user-images.githubusercontent.com/6080548/187934393-8ad589bf-d9da-46c8-8ce3-e367823d3c37.png) |
|  | ![Screenshot 2022-09-01 at 15 08 37](https://user-images.githubusercontent.com/6080548/187934804-4fb1d005-9eec-466d-a1a5-d6b63dcff50c.png) |