### PR TITLE
Change the page title to use the page title component

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -33,8 +33,11 @@
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l"><%= yield(:context) %></span>
-            <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+            <%= render "govuk_publishing_components/components/title", {
+              context: yield(:context),
+              title: yield(:title),
+              margin_top: 0,
+            } %>
           </div>
           <div class="govuk-grid-column-one-third app-grid-column--align-right">
             <%= yield(:title_side) %>

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -236,7 +236,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: @edition }
 
-    assert_select ".govuk-caption-l", @edition[:title]
+    assert_select ".govuk-caption-xl", @edition[:title]
     assert_select "h1", "Topic taxonomy tags"
   end
 


### PR DESCRIPTION
This makes it consistent with font sizes  and spacing expected for a page title.

Previously we have hard coded html which was incorrectly sized

https://trello.com/c/NqhMR3Gp/711-use-page-title-component-for-page-titles-in-design-system-layout

## Before

<img width="806" alt="Screenshot 2022-09-02 at 2 41 11 pm" src="https://user-images.githubusercontent.com/4599889/188158847-fdd39bd2-4017-4b05-b8d2-6a0948e69ced.png">

## After

<img width="798" alt="Screenshot 2022-09-02 at 2 40 54 pm" src="https://user-images.githubusercontent.com/4599889/188158880-61749950-d372-4428-a933-184eb623f20e.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
