### PR TITLE
Switch rendering of World Location news pages to Collections

### DIFF
--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -26,7 +26,7 @@ module PublishingApi
         },
         document_type: "world_location_news",
         public_updated_at: world_location.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: rendering_app,
         schema_name: "world_location_news",
         base_path: path_for_news_page,
       )
@@ -60,6 +60,10 @@ module PublishingApi
           href: link.url,
         }
       end
+    end
+
+    def rendering_app
+      I18n.locale == :en ? Whitehall::RenderingApp::COLLECTIONS_FRONTEND : Whitehall::RenderingApp::WHITEHALL_FRONTEND
     end
 
     def path_for_news_page

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -49,7 +49,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
       },
       document_type: "world_location_news",
       public_updated_at: world_location.updated_at,
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       schema_name: "world_location_news",
       base_path: "/world/aardistan/news",
       routes: [{ path: "/world/aardistan/news", type: "exact" }],
@@ -110,6 +110,15 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
       base_path = presented_item.content[:base_path]
 
       assert_equal "/world/aardistan/news.fr", base_path
+    end
+  end
+
+  test "it uses whitehall as the rendering app for non-english locales" do
+    I18n.with_locale(:fr) do
+      presented_item = present(world_location)
+      rendering_app = presented_item.content[:rendering_app]
+
+      assert_equal "whitehall-frontend", rendering_app
     end
   end
 


### PR DESCRIPTION
Switch rendering of World Location news pages to Collections

Done as the last part of the work to migrate rendering of these pages
out of Whitehall

Trello: https://trello.com/c/19zawXo9/228-switch-world-location-news-rendering-to-collections

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
