### PR TITLE
Update Ministerial Appointment Lists for Truss Government

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -10,6 +10,9 @@ class HistoricAppointmentsController < PublicFacingController
 
   def past_chancellors
     @twentyfirst_century_chancellors = {
+      "Nadhim Zahawi" => {
+        service: "2022",
+      },
       "Rishi Sunak" => {
         service: "2020 to 2022",
       },

--- a/app/controllers/past_foreign_secretaries_controller.rb
+++ b/app/controllers/past_foreign_secretaries_controller.rb
@@ -3,6 +3,9 @@ class PastForeignSecretariesController < PublicFacingController
 
   def index
     @twenty_first_century = {
+      "Elizabeth Truss" => {
+        service: "2021 to 2022",
+      },
       "Dominic Raab" => {
         service: "2019 to 2021",
       },


### PR DESCRIPTION
Makes changes to the historical ministerial appointments section in light of Liz Truss becoming Prime Minister.