### PR TITLE
Add error summary component and error helper

### DIFF
--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,23 @@
+module ErrorsHelper
+  def errors_for_input(errors, attribute)
+    return nil if errors.blank?
+
+    errors.filter_map { |error|
+      if error.attribute == attribute
+        error.full_message
+      end
+    }.join("\n")
+  end
+
+  def errors_for(errors, attribute)
+    return nil if errors.blank?
+
+    errors.filter_map do |error|
+      if error.attribute == attribute
+        {
+          text: error.full_message,
+        }
+      end
+    end
+  end
+end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -30,6 +30,8 @@
         } %>
       <% end %>
 
+      <%= yield(:error_summary) %>
+
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.present? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: "To save the #{object.class.name.demodulize.underscore.humanize.downcase} please fix the following issues:",
+    items: object.errors.errors.map do |error|
+        {
+          href:"##{object.class.to_s.underscore}_#{error.attribute.to_s}",
+          text: error.full_message,
+        }
+      end
+  } %>
+<% end %>

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,7 +1,9 @@
+<% class_name = class_name.presence || object.class.name.demodulize.underscore.humanize.downcase %>
+
 <% if object.errors.present? %>
   <%= render "govuk_publishing_components/components/error_summary", {
     id: "error-summary",
-    title: "To save the #{object.class.name.demodulize.underscore.humanize.downcase} please fix the following issues:",
+    title: "To save the #{class_name} please fix the following issues:",
     items: object.errors.errors.map do |error|
         {
           href:"##{object.class.to_s.underscore}_#{error.attribute.to_s}",

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,14 +1,28 @@
 <% class_name = class_name.presence || object.class.name.demodulize.underscore.humanize.downcase %>
 
 <% if object.errors.present? %>
-  <%= render "govuk_publishing_components/components/error_summary", {
-    id: "error-summary",
-    title: "To save the #{class_name} please fix the following issues:",
-    items: object.errors.errors.map do |error|
-        {
-          href:"##{object.class.to_s.underscore}_#{error.attribute.to_s}",
-          text: error.full_message,
-        }
-      end
-  } %>
+  <div class="gem-c-error-summary govuk-error-summary" data-module="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" id="error-summary" data-govuk-error-summary-module-started="true">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      To save the <%= class_name %> please fix the following issues:
+    </h2>
+
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% object.errors.errors.map do |error| %>
+          <% analytics_action = "#{class_name}-error" %>
+          <% error_message = error.full_message %>
+
+          <%= tag.li(
+            tag.a(
+              error_message,
+              href: "##{object.class.to_s.underscore}_#{error.attribute.to_s}",
+              class: "govuk-link"
+            ),
+            data: track_analytics_data("form-error", analytics_action, error_message),
+            class: "gem-c-error-summary__list-item"
+          ) %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
 <% end %>

--- a/test/unit/helpers/errors_helper_test.rb
+++ b/test/unit/helpers/errors_helper_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ErrorsHelperTest < ActionView::TestCase
+  setup do
+    @object_with_no_errors = ErrorTestObject.new("title", Time.zone.today)
+    @object_with_errors = ErrorTestObject.new(nil, nil)
+    @object_with_errors.validate
+  end
+
+  test "#error_for_input returns nil when there are no error messages" do
+    assert_nil errors_for_input(@object_with_no_errors.errors, :title)
+  end
+
+  test "#error_for_input returns errors for the attribute passed in" do
+    assert_equal errors_for_input(@object_with_errors.errors, :title), "Title can't be blank"
+  end
+
+  test "#error_for_input formats the error message when there are multiple errors on a field" do
+    assert_equal errors_for_input(@object_with_errors.errors, :date), "Date can't be blank\nDate is invalid"
+  end
+
+  test "#error_for returns nil when there are no error messages" do
+    assert_nil errors_for(@object_with_no_errors.errors, :title)
+  end
+
+  test "#error_for returns errors for the attribute passed in" do
+    assert_equal errors_for(@object_with_errors.errors, :title), [{ text: "Title can't be blank" }]
+  end
+
+  test "#error_for formats the error message when there are multiple errors on a field" do
+    assert_equal errors_for(@object_with_errors.errors, :date), [{ text: "Date can't be blank" }, { text: "Date is invalid" }]
+  end
+
+  class ErrorTestObject
+    include ActiveModel::Model
+    attr_accessor :title, :date
+
+    validates :title, :date, presence: true
+    validate :date_is_a_date
+
+    def initialize(title, date)
+      @title = title
+      @date = date
+    end
+
+    def date_is_a_date
+      errors.add(:date, :invalid) unless date.is_a?(Date)
+    end
+  end
+end


### PR DESCRIPTION
## Description

We need to be able render an error summary component which renders above the title and link the errors to the relevant input. We also need to be able to easily render errors for fields in views. 

This PR addresses this by doing two things. Adding an error summary partial which can be used by passing in an object and an optional class name. 

These are used to render the errors and title in the component respectively.

I've also added an ErrorsHelper which can be used to render errors for fields on a form

This has two methods #errors_for_input and #errors_for.Publishing components handles errors differently for inputs and all
other components.

For inputs you pass it the object and it outputs a string

```

For all other fields it outputs an array of hashes such as:
[
  {
    text: "error message"
  },
  {
    text: "second error message"
  },
]
```

## Screenshot

<img width="941" alt="image" src="https://user-images.githubusercontent.com/42515961/189098003-27dcb913-2829-4b26-b6f4-56f7ddbcb2af.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
