### PR TITLE
Add new translation page in bootstrap and design system

### DIFF
--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -3,7 +3,7 @@ module TranslationControllerConcern
 
   included do
     before_action :load_translatable_item
-    before_action :load_translated_models, except: [:index]
+    before_action :load_translated_models, except: %i[index new]
     helper_method :translation_locale
   end
 

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -3,6 +3,8 @@ class Admin::EditionTranslationsController < Admin::BaseController
 
   before_action :forbid_editing_of_locked_documents
 
+  def new; end
+
   def update
     @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
     super

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -1,9 +1,11 @@
 class Admin::EditionTranslationsController < Admin::BaseController
   include TranslationControllerConcern
-
+  layout :get_layout
   before_action :forbid_editing_of_locked_documents
 
-  def new; end
+  def new
+    render "legacy_new" unless preview_design_system_user?
+  end
 
   def update
     @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
@@ -11,6 +13,17 @@ class Admin::EditionTranslationsController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "new"
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def create_redirect_path
     edit_admin_edition_translation_path(@edition, id: translation_locale)

--- a/app/views/admin/edition_translations/legacy_new.html.erb
+++ b/app/views/admin/edition_translations/legacy_new.html.erb
@@ -1,0 +1,16 @@
+<% page_title "Add translation" %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<h1>Add translation</h1>
+
+<%= form_tag(admin_edition_translations_path(@edition.id)) do %>
+    <div class="form-group">
+      <%= label_tag :translation_locale, 'Locale' %>
+      <%= select_locale :translation_locale, @edition.missing_translations, class: 'form-control input-md-4' %>
+    </div>
+
+    <%= submit_tag "Add translation", class: "btn btn-success" %>
+<% end %>

--- a/app/views/admin/edition_translations/new.html.erb
+++ b/app/views/admin/edition_translations/new.html.erb
@@ -1,0 +1,16 @@
+<% page_title "Add translation" %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<h1>Add translation</h1>
+
+<%= form_tag(admin_edition_translations_path(@edition.id)) do %>
+    <div class="form-group">
+      <%= label_tag :translation_locale, 'Locale' %>
+      <%= select_locale :translation_locale, @edition.missing_translations, class: 'form-control input-md-4' %>
+    </div>
+
+    <%= submit_tag "Add translation", class: "btn btn-success" %>
+<% end %>

--- a/app/views/admin/edition_translations/new.html.erb
+++ b/app/views/admin/edition_translations/new.html.erb
@@ -1,16 +1,32 @@
-<% page_title "Add translation" %>
+<% content_for :page_title, "Add translation" %>
 
-<span class="back">
-  <%= link_to 'Back', admin_edition_path(@edition) %>
-</span>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: admin_edition_path(@edition)
+} %>
 
-<h1>Add translation</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      context: @edition.title,
+      title: "Add translation"
+    } %>
 
-<%= form_tag(admin_edition_translations_path(@edition.id)) do %>
-    <div class="form-group">
-      <%= label_tag :translation_locale, 'Locale' %>
-      <%= select_locale :translation_locale, @edition.missing_translations, class: 'form-control input-md-4' %>
-    </div>
+    <%= form_with url: admin_edition_translations_path(@edition.id) do |form| %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "translation_locale",
+        label: "Choose language",
+        full_width: true,
+        options: options_for_locales(@edition.missing_translations).map do |language, value|
+          {
+            text: language,
+            value: value,
+          }
+        end
+      } %>
 
-    <%= submit_tag "Add translation", class: "btn btn-success" %>
-<% end %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Next"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -83,14 +83,12 @@
     <h2>
       Translations
       <% if @edition.editable? and @edition.missing_translations.any? %>
-        <a href="#add-translation-modal" id="open-add-translation-modal" class="btn btn-default pull-right" data-toggle="modal">
+        <%= link_to new_admin_edition_translation_path(@edition.id), class: "btn btn-default pull-right" do %>
           <i class="glyphicon glyphicon-plus-sign"></i> Add translation
-        </a>
+        <% end %>
       <% end %>
     </h2>
-    <% if @edition.editable? and @edition.missing_translations.any? %>
-      <%= render partial: 'admin/shared/translation_modal', locals: { id: "add-translation-modal", form_path: admin_edition_translations_path(@edition), locales: @edition.missing_translations } %>
-    <% end %>
+
     <% if @edition.non_english_translations.any? %>
       <table class="table">
         <thead>

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -43,8 +43,15 @@ When(/^I translate the "([^"]*)" corporate information page for the worldwide or
   click_link "Corporate information pages"
   click_link corp_page
   click_link "Add translation"
-  select "Français", from: "Locale"
-  click_button "Add translation"
+
+  if @user.can_preview_design_system?
+    select "Français", from: "Choose language"
+    click_button "Next"
+  else
+    select "Français", from: "Locale"
+    click_button "Add translation"
+  end
+
   fill_in "Summary", with: "Le summary"
   fill_in "Body", with: "Le body"
   click_on "Save"

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -42,7 +42,7 @@ When(/^I translate the "([^"]*)" corporate information page for the worldwide or
   visit admin_worldwide_organisation_path(worldwide_organisation)
   click_link "Corporate information pages"
   click_link corp_page
-  click_link "open-add-translation-modal"
+  click_link "Add translation"
   select "Français", from: "Locale"
   click_button "Add translation"
   fill_in "Summary", with: "Le summary"

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -16,8 +16,14 @@ end
 When(/^I add a french translation$/) do
   visit admin_edition_path(@edition)
   click_link "Add translation"
-  select "Français", from: "Locale"
-  click_button "Add translation"
+
+  if @user.can_preview_design_system?
+    select "Français", from: "Choose language"
+    click_button "Next"
+  else
+    select "Français", from: "Locale"
+    click_button "Add translation"
+  end
 end
 
 When(/^I add an editorial remark "([^"]*)" to the document$/) do |remark_text|

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -15,7 +15,7 @@ end
 
 When(/^I add a french translation$/) do
   visit admin_edition_path(@edition)
-  click_link "open-add-translation-modal"
+  click_link "Add translation"
   select "Français", from: "Locale"
   click_button "Add translation"
 end

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -31,8 +31,15 @@ end
 When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |french_title, english_title|
   visit admin_edition_path(Edition.find_by!(title: english_title))
   click_link "Add translation"
-  select "Français", from: "Locale"
-  click_button "Add translation"
+
+  if @user.can_preview_design_system?
+    select "Français", from: "Choose language"
+    click_button "Next"
+  else
+    select "Français", from: "Locale"
+    click_button "Add translation"
+  end
+
   fill_in "Title", with: french_title
   fill_in "Summary", with: "French summary"
   fill_in "Body", with: "French body"

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -30,7 +30,7 @@ end
 
 When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |french_title, english_title|
   visit admin_edition_path(Edition.find_by!(title: english_title))
-  click_link "open-add-translation-modal"
+  click_link "Add translation"
   select "Français", from: "Locale"
   click_button "Add translation"
   fill_in "Title", with: french_title

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -7,6 +7,30 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
+  view_test "new displays a form to create missing translations" do
+    edition = create(:draft_edition)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :new, params: { edition_id: edition }
+
+    assert_select "form[action=?]", admin_edition_translations_path(edition) do
+      assert_select "select[name=translation_locale]"
+      assert_select "input[type=submit]"
+    end
+  end
+
+  view_test "new omits existing edition translations from create select" do
+    edition = create(:draft_edition)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+    with_locale(:es) { edition.update!(attributes_for("draft_edition")) }
+
+    get :new, params: { edition_id: edition }
+
+    assert_select "select[name=translation_locale]" do
+      assert_select "option[value=es]", count: 0
+    end
+  end
+
   test "create redirects to edit for the chosen language" do
     edition = create(:edition)
     post :create, params: { edition_id: edition, translation_locale: "fr" }

--- a/test/functional/admin/generic_editions_controller_tests/translation_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/translation_test.rb
@@ -13,49 +13,23 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     GenericEdition.translatable = false
   end
 
-  view_test "show displays a form to create missing translations" do
-    edition = create(:draft_edition)
+  view_test "show links to new translation page when the edition is editable" do
+    edition = create(:draft_edition, title: "english-title", summary: "english-summary", body: "english-body")
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
 
-    assert_select "form[action=?]", admin_edition_translations_path(edition) do
-      assert_select "select[name=translation_locale]"
-      assert_select "input[type=submit]"
-    end
+    assert_select "a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation"
   end
 
-  view_test "show omits existing edition translations from create select" do
-    edition = create(:draft_edition)
-    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-    with_locale(:es) { edition.update!(attributes_for("draft_edition")) }
-
-    get :show, params: { id: edition }
-
-    assert_select "select[name=translation_locale]" do
-      assert_select "option[value=es]", count: 0
-    end
-  end
-
-  view_test "show omits create form if no missing translations" do
-    edition = create(:draft_edition)
-    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-    with_locale(:es) { edition.update!(attributes_for("draft_edition")) }
-    Locale.stubs(:non_english).returns([Locale.new(:es)])
-
-    get :show, params: { id: edition }
-
-    assert_select "select[name=translation_locale]", count: 0
-  end
-
-  view_test "show omits create form unless the edition is editable" do
+  view_test "show omits new translation link unless the edition is editable" do
     edition = create(:published_edition)
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
     assert_not edition.editable?
 
     get :show, params: { id: edition }
 
-    assert_select "select[name=translation_locale]", count: 0
+    assert_select "a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation", count: 0
   end
 
   view_test "show displays a link to edit an existing translation" do


### PR DESCRIPTION
## Description

Currently, when a user wants to add a translation they are greeted with a bootstrap modal. They then select a language before seeing the edit page.

We want to get rid of this behaviour and replace the modal with a new translation endpoint.

Eventually we want to render this new view in the GOV.UK Design System. But for now it should render in Bootstrap.

This PR adds the new endpoint, adds views in Bootstrap and the GOV.UK Design System, and conditionally renders the view based on the "Preview design system permission".

## Sreenshots

### Before

<img width="960" alt="image" src="https://user-images.githubusercontent.com/42515961/189171504-a969a86c-b607-427a-815d-fc09696c3a66.png">


### After

#### Bootstrap

<img width="658" alt="image" src="https://user-images.githubusercontent.com/42515961/189171802-ed715551-c8f8-40fe-84ea-7a4fa209e8c6.png">

#### GOV.UK Design System

<img width="836" alt="image" src="https://user-images.githubusercontent.com/42515961/189171559-77f5e183-14c4-4a45-93d1-b3c02516820e.png">

## Trello card 

https://trello.com/c/oiTIQR1G/637-add-new-translation-page
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
