### PR TITLE
Add View Components gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,7 @@ Rails/LexicallyScopedActionFilter:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'app/workers/*.rb'
+
+Lint/MissingSuper:
+  Exclude:
+    - 'app/components/*/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "sprockets-rails"
 gem "transitions", require: ["transitions", "active_record/transitions"]
 gem "uglifier"
 gem "validates_email_format_of"
+gem "view_component"
 gem "whenever", require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,6 +714,10 @@ GEM
     validates_email_format_of (1.7.2)
       i18n
     version_gem (1.1.1)
+    view_component (2.71.0)
+      activesupport (>= 5.0.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
@@ -825,6 +829,7 @@ DEPENDENCIES
   transitions
   uglifier
   validates_email_format_of
+  view_component
   webmock
   whenever
 


### PR DESCRIPTION
## Description

We now have an ADR https://github.com/alphagov/whitehall/blob/main/adr/0001-add-view-components.md and documentation for View Components https://github.com/alphagov/whitehall/blob/main/docs/view_components.md

This adds the gem so that we can use it going forward.

## Trello card 

https://trello.com/c/KXx0qxRl/824-spike-and-write-up-document-on-view-components

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
