### PR TITLE
Add new role payment types

### DIFF
--- a/app/models/role_payment_type.rb
+++ b/app/models/role_payment_type.rb
@@ -3,8 +3,8 @@ class RolePaymentType
 
   attr_accessor :id, :name
 
-  Unpaied = create!(id: 1, name: "Unpaid")
+  Consultant = create!(id: 4, name: "Paid as a consultant")
   ParliamentarySecretary = create!(id: 2, name: "Paid as a Parliamentary Secretary")
   Whip = create!(id: 3, name: "Paid as a whip")
-  Consultant = create!(id: 4, name: "Paid as a consultant")
+  Unpaied = create!(id: 1, name: "Unpaid")
 end

--- a/app/models/role_payment_type.rb
+++ b/app/models/role_payment_type.rb
@@ -5,4 +5,6 @@ class RolePaymentType
 
   Unpaied = create!(id: 1, name: "Unpaid")
   ParliamentarySecretary = create!(id: 2, name: "Paid as a Parliamentary Secretary")
+  Whip = create!(id: 3, name: "Paid as a whip")
+  Consultant = create!(id: 4, name: "Paid as a consultant")
 end

--- a/app/models/role_payment_type.rb
+++ b/app/models/role_payment_type.rb
@@ -6,5 +6,5 @@ class RolePaymentType
   Consultant = create!(id: 4, name: "Paid as a consultant")
   ParliamentarySecretary = create!(id: 2, name: "Paid as a Parliamentary Secretary")
   Whip = create!(id: 3, name: "Paid as a whip")
-  Unpaied = create!(id: 1, name: "Unpaid")
+  Unpaid = create!(id: 1, name: "Unpaid")
 end


### PR DESCRIPTION
This PR adds two new options to the 'Payment options' select box on Roles in Whitehall. It also sorts the options in the list alphabetically to make them easier to scan.

This was requested by a publisher so they can more accurately represent the way some roles are paid in their organisation.

## Options added

- Paid as a consultant
- Paid as a whip

<img width="301" alt="Screenshot 2022-09-13 at 16 02 38" src="https://user-images.githubusercontent.com/7735945/189938205-3b6a99de-95a8-41eb-bf8b-bce00370c26d.png">

## Location on page

<img width="1053" alt="New_role_-_Admin_-_GOV_UK" src="https://user-images.githubusercontent.com/7735945/189939424-401bcb08-c6cf-490e-81f7-ef15a92e9e76.png">

---

Trello: https://trello.com/c/kR8a5bja/732-new-paid-type-for-roles-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
