### PR TITLE
Expand featured section to 9 items on HM Queen Elizabeth II's page

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -92,6 +92,8 @@ class TopicalEvent < ApplicationRecord
   extend FriendlyId
   friendly_id
 
+  HM_THE_QUEEN_CONTENT_ID = "7feaef73-a6a8-484a-8915-6efbbe4a8269".freeze
+
   alias_method :display_name, :to_s
 
   def archived?

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -61,7 +61,7 @@ module PublishingApi
       item
         .topical_event_featurings
         .includes(:image, edition: :document)
-        .limit(FeaturedLink::DEFAULT_SET_SIZE)
+        .limit(featured_documents_display_limit)
         .map do |feature|
           {
             title: feature.title,
@@ -83,6 +83,10 @@ module PublishingApi
           title: social_media_account.display_name,
         }
       end
+    end
+
+    def featured_documents_display_limit
+      item.content_id == TopicalEvent::HM_THE_QUEEN_CONTENT_ID ? 9 : FeaturedLink::DEFAULT_SET_SIZE
     end
   end
 end

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -149,12 +149,21 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(presenter.content, "topical_event")
   end
 
-  test "it limits the number of featured items" do
+  test "it limits the number of featured items to 5 by default" do
     topical_event = create(:topical_event, start_date: Time.zone.today)
     create_list(:topical_event_featuring, FeaturedLink::DEFAULT_SET_SIZE + 1, topical_event: topical_event)
 
     presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
 
     assert_equal FeaturedLink::DEFAULT_SET_SIZE, presenter.content.dig(:details, :ordered_featured_documents).length
+  end
+
+  test "it limits the number of featured items to 9 on the Her Majesty Queen Elizabeth II's page" do
+    topical_event = create(:topical_event, content_id: "7feaef73-a6a8-484a-8915-6efbbe4a8269", start_date: Time.zone.today)
+    create_list(:topical_event_featuring, 9, topical_event: topical_event)
+
+    presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
+
+    assert_equal 9, presenter.content.dig(:details, :ordered_featured_documents).length
   end
 end


### PR DESCRIPTION
We want to be able to feature more than the default 5 items on https://www.gov.uk/government/topical-events/her-majesty-queen-elizabeth-ii

There is no limit in the frontend: https://github.com/alphagov/collections/blob/779aabf/app/views/topical_events/show.html.erb#L84

[Tech debt tracked](https://trello.com/c/iLCjJrtu/739-expand-featured-section-to-9-items)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
