### PR TITLE
Add royal.uk to the list of permitted offsite links

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -98,6 +98,7 @@ private
       "tse-lab-net.eu",
       "beisgovuk.citizenspace.com",
       "nhs.uk",
+      "royal.uk",
     ]
 
     whitelisted_hosts.any? { |whitelisted_host| host =~ /(?:^|\.)#{whitelisted_host}$/ }


### PR DESCRIPTION
We want to be able to link to the Book of Condolence on the Her Majesty Queen Elizabeth II's topical event page.

Currently users are getting a validation error:

<kbd><img width="513" alt="Screenshot 2022-09-14 at 11 56 32" src="https://user-images.githubusercontent.com/38078064/190136252-99ae6e41-137a-4e35-987e-161c4fa6d5c0.png"></kbd>


### Depends on:

- [ ] Publishing platform team product decision

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
