### PR TITLE
Republish Topical Event when features are reordered

### DIFF
--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -45,6 +45,9 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
     params[:ordering].each do |topical_event_featuring_id, ordering|
       @topical_event.topical_event_featurings.find(topical_event_featuring_id).update_column(:ordering, ordering)
     end
+
+    Whitehall::PublishingApi.republish_async(@topical_event)
+
     redirect_to polymorphic_path([:admin, @topical_event, :topical_event_featurings]), notice: "Featured items re-ordered"
   end
 

--- a/test/functional/admin/topical_event_featurings_controller_test.rb
+++ b/test/functional/admin/topical_event_featurings_controller_test.rb
@@ -81,6 +81,8 @@ class Admin::TopicalEventFeaturingsControllerTest < ActionController::TestCase
     feature2 = create(:topical_event_featuring, topical_event: @topical_event)
     feature3 = create(:topical_event_featuring, topical_event: @topical_event)
 
+    Whitehall::PublishingApi.expects(:republish_async).with(@topical_event).once
+
     put :order,
         params: { topical_event_id: @topical_event,
                   ordering: {


### PR DESCRIPTION
When a topical event's features are reordered, we need the topical event to be republished so the content item includes the updated order of features.

Whilst there is a callback on the `TopicalEventFeaturing` model to republish the associated topical event, this was not being called as the `order` method uses `update_column` which skips callbacks.

Changing this to `update` would not be desirable, as the topical event will get republished once for each featured item (which could be multiple items).  Therefore adding a single republish request so we get the desired behaviour of the topical event only being republished once.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
