### PR TITLE
Add "What's new" phase banner

### DIFF
--- a/app/assets/javascripts/admin/modules/track_link_click.js
+++ b/app/assets/javascripts/admin/modules/track_link_click.js
@@ -1,0 +1,19 @@
+/* global GOVUKAdmin */
+
+(function (Modules) {
+  'use strict'
+
+  Modules.TrackLinkClick = function () {
+    this.start = function (link) {
+      var trackClick = function () {
+        var category = link.data('track-category')
+        var action = link.data('track-action') || 'link-clicked'
+        var label = link.data('track-label') || $(this).text()
+
+        GOVUKAdmin.trackEvent(category, action, { label: label })
+      }
+
+      link.on('click', trackClick)
+    }
+  }
+})(window.GOVUKAdmin.Modules)

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -22,3 +22,5 @@
 @import "vendor/jquery.highlighttextarea";
 @import "shared/helpers/magna-charta";
 @import "admin/base";
+
+@import "admin/govuk-design-system-overrides";

--- a/app/assets/stylesheets/admin/_govuk-design-system-overrides.scss
+++ b/app/assets/stylesheets/admin/_govuk-design-system-overrides.scss
@@ -1,0 +1,16 @@
+.govuk-design-system-styling {
+  @import "govuk_publishing_components/all_components";
+
+  .app-width-container--full-width {
+    margin: 0 govuk-spacing(3);
+  }
+
+  .govuk-phase-banner__content,
+  .govuk-tag {
+    font-size: 16px;
+  }
+
+  .govuk-phase-banner {
+    margin-bottom: 10px;
+  }
+}

--- a/app/assets/stylesheets/admin/_layout.scss
+++ b/app/assets/stylesheets/admin/_layout.scss
@@ -51,6 +51,7 @@ $collapse-tabs-width: 710px;
 .masthead {
   border-top-width: 5px;
   border-bottom-width: 0;
+  margin-bottom: 0;
 }
 
 .masthead .container-fluid .navbar-brand {

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -15,6 +15,11 @@
 
 <% content_for :navbar do %>
   <%= render "shared/header" %>
+  <div class="govuk-design-system-styling">
+    <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
+      <%= render "shared/whats_new_banner", tracking_module: "track-link-click" %>
+    </div>
+  </div>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -14,6 +14,8 @@
   </div>
 
   <div class="govuk-width-container">
+    <%= render "shared/whats_new_banner" %>
+
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,8 +9,7 @@
   navbar-default
   navbar-inverse
   navbar-static-top
-  <% if environment_style %>environment-indicator<% end %>
-  add-bottom-margin" role="banner">
+  <% if environment_style %>environment-indicator<% end %>" role="banner">
   <div class="navbar-container container-fluid">
     <div class="navbar-header">
       <%# Bootstrap toggle for collapsed navbar content, used at smaller widths %>

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -1,0 +1,21 @@
+<% tracking_module ||= "gem-track-click" %>
+
+<%= render "govuk_publishing_components/components/phase_banner", {
+    phase: "Update",
+    message: sanitize("Whitehall Publisher is changing -
+      #{
+        link_to(
+          "find more about upcoming changes and what's new",
+          admin_whats_new_path,
+          {
+            class: "govuk-link",
+            data: {
+              module: tracking_module,
+              track_category: 'phaseBanner',
+              track_action: 'whats-new-banner-click',
+              track_label: 'Whats new'
+            }
+          }
+        )
+      }.", attributes: %w(class href data-module data-track-category data-track-action data-track-label))
+  } %>

--- a/spec/javascripts/admin/modules/track_link_click.spec.js
+++ b/spec/javascripts/admin/modules/track_link_click.spec.js
@@ -1,0 +1,23 @@
+describe('GOVUKAdmin.Modules.TrackLinkClick', function () {
+  var link, trackLinkClick
+
+  beforeEach(function () {
+    link = $('<a href="/blah" data-module="track-link-click" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label">blahhh</a>')
+    $(document.body).append(link)
+
+    trackLinkClick = new GOVUKAdmin.Modules.TrackLinkClick()
+  })
+
+  afterEach(function () {
+    link.remove()
+  })
+
+  it('should send a tracking event when link is clicked', function () {
+    spyOn(GOVUKAdmin, 'trackEvent')
+
+    trackLinkClick.start(link)
+    link.click()
+
+    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { label: 'track-label' })
+  })
+})

--- a/test/integration/whats_new_test.rb
+++ b/test/integration/whats_new_test.rb
@@ -2,23 +2,30 @@ require "test_helper"
 
 class WhatsNewTest < ActionDispatch::IntegrationTest
   test "it shows whats new page" do
-    @user = create(:gds_editor)
-    login_as @user
-
+    login_as create(:gds_editor)
     get admin_whats_new_path
+
     assert_select "h1", text: "What’s new in Whitehall Publisher"
   end
 
   test "each section has h2 and a back to top link" do
-    @user = create(:gds_editor)
-    login_as @user
-
+    login_as create(:gds_editor)
     get admin_whats_new_path
+
     assert_select ".app-view-whats-new__section" do |sections|
       sections.each do |section|
         assert_select section, "h2", count: 1
         assert_select section, ".app-view-whats-new__back-to-top-link", count: 1
       end
     end
+  end
+
+  test "shows whats new banner page" do
+    login_as create(:gds_editor)
+    get admin_whats_new_path
+
+    assert_select ".gem-c-phase-banner"
+    assert_select ".gem-c-phase-banner .govuk-phase-banner__content__tag", text: "Update"
+    assert_select ".gem-c-phase-banner .govuk-phase-banner__text"
   end
 end


### PR DESCRIPTION
Add a what's new phase banner to Whitehall

This will allow users to see when things are being updated and quickly jump to the "What's new" page

https://trello.com/c/WtPp7qE5/713-add-whats-new-phase-banner

## Screenshots

### Design system page

![whitehall-admin dev gov uk_government_admin_whats-new(iPad Pro) (9)](https://user-images.githubusercontent.com/4599889/191219651-e3f3be2a-59cf-433b-9fbd-d10d1bf2910a.png)


### Bootstrap page with container

![whitehall-admin dev gov uk_government_admin(iPad Pro) (1)](https://user-images.githubusercontent.com/4599889/191219726-9020d6cc-1a0b-4558-8788-cc7761858035.png)


### Bootstrap page with full width

![whitehall-admin dev gov uk_government_admin_editions_organisation=2 state=active(iPad Pro) (1)](https://user-images.githubusercontent.com/4599889/191219758-1eed94bb-7a90-44a6-a7f7-e7a52df2982d.png)




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
