### PR TITLE
Allow any offsite link on HM Queen Elizabeth II's page

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -55,7 +55,7 @@ class OffsiteLink < ApplicationRecord
       host = uri.host
     end
 
-    unless government_or_whitelisted_url?(host)
+    unless government_or_whitelisted_url?(host) || allow_non_government_url?
       errors.add(:base, "Please enter a valid government URL, such as https://www.gov.uk/jobsearch")
     end
   rescue URI::InvalidURIError
@@ -75,6 +75,11 @@ class OffsiteLink < ApplicationRecord
   end
 
 private
+
+  def allow_non_government_url?
+    # This is a special exception
+    parent.content_id == TopicalEvent::HM_THE_QUEEN_CONTENT_ID
+  end
 
   def government_or_whitelisted_url?(host)
     url_is_gov_uk?(host) || url_is_gov_wales?(host) || url_is_gov_scot?(host) || url_is_whitelisted?(host)
@@ -98,7 +103,6 @@ private
       "tse-lab-net.eu",
       "beisgovuk.citizenspace.com",
       "nhs.uk",
-      "royal.uk",
     ]
 
     whitelisted_hosts.any? { |whitelisted_host| host =~ /(?:^|\.)#{whitelisted_host}$/ }

--- a/test/factories/offsite_links.rb
+++ b/test/factories/offsite_links.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :offsite_link do
+    association :parent, factory: :organisation
     title { "Summary text" }
     link_type { "alert" }
     summary { "Summary text" }

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -47,10 +47,21 @@ class OffsiteLinkTest < ActiveSupport::TestCase
       "http://www.tse-lab-net.eu",
       "http://beisgovuk.citizenspace.com",
       "http://www.nhs.uk",
-      "http://www.royal.uk",
     ]
     whitelisted_urls.each do |url|
       assert build(:offsite_link, url: url).valid?, "#{url} not valid"
+    end
+  end
+
+  test "should always be valid on Her Majesty Queen Elizabeth II's page" do
+    topical_event = create(:topical_event, content_id: "7feaef73-a6a8-484a-8915-6efbbe4a8269")
+    example_urls = [
+      "https://www.royal.uk",
+      "https://youtube.com",
+      "http://example.com",
+    ]
+    example_urls.each do |url|
+      assert build(:offsite_link, url: url, parent: topical_event).valid?, "#{url} not valid"
     end
   end
 


### PR DESCRIPTION
This has been requested as part of London Bridge work so that the Topical Event page for [HM Queen Elizabeth II][1] can link to relevant offsite non-government URLs.

This is expected to be a short-term need which should be reverted afterwards.

[1]: https://www.gov.uk/government/topical-events/her-majesty-queen-elizabeth-ii

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
