### PR TITLE
Republish world location news when a feature changes

### DIFF
--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -13,7 +13,7 @@ class Admin::FeaturesController < Admin::BaseController
     end
 
     if @feature.save
-      @feature.republish_organisation_to_publishing_api
+      @feature.republish_featurable_to_publishing_api
       PublishingApiDocumentRepublishingWorker.perform_async(@feature.document_id) if @feature.document_id.present?
       redirect_to admin_feature_list_path(@feature_list), notice: "The document has been saved"
     else
@@ -26,7 +26,7 @@ class Admin::FeaturesController < Admin::BaseController
     @feature = @feature_list.features.find(params[:id])
 
     if @feature.end!
-      @feature.republish_organisation_to_publishing_api
+      @feature.republish_featurable_to_publishing_api
       message = { notice: "'#{@feature}' unfeatured" }
     else
       message = { alert: "Unable to unfeature '#{@feature}' because #{@feature.errors.full_messages.to_sentence}" }

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -17,7 +17,7 @@ class Feature < ApplicationRecord
 
   before_validation :set_started_at!, on: :create
 
-  delegate :republish_organisation_to_publishing_api, to: :feature_list
+  delegate :republish_featurable_to_publishing_api, to: :feature_list
 
   def to_s
     if document && document.live_edition

--- a/app/models/feature_list.rb
+++ b/app/models/feature_list.rb
@@ -20,7 +20,7 @@ class FeatureList < ApplicationRecord
         feature.save!
       end
     end
-    republish_organisation_to_publishing_api
+    republish_featurable_to_publishing_api
     true
   rescue ActiveRecord::RecordNotFound => e
     errors.add(:base, message: "Can't reorder because '#{e}'")
@@ -44,8 +44,8 @@ class FeatureList < ApplicationRecord
 
   delegate :empty?, to: :current
 
-  def republish_organisation_to_publishing_api
-    if featurable.is_a?(Organisation) && featurable.persisted?
+  def republish_featurable_to_publishing_api
+    if (featurable.is_a?(Organisation) || featurable.is_a?(WorldLocationNews)) && featurable.persisted?
       Whitehall::PublishingApi.republish_async(featurable)
     end
   end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -197,7 +197,7 @@ private
   alias_method :features?, :any?
 
   def republish_feature_organisations_to_publishing_api
-    features.map(&:republish_organisation_to_publishing_api)
+    features.map(&:republish_featurable_to_publishing_api)
   end
 
   def start_and_end_dates

--- a/app/services/service_listeners/featurable_organisation_republisher.rb
+++ b/app/services/service_listeners/featurable_organisation_republisher.rb
@@ -4,6 +4,6 @@ class ServiceListeners::FeaturableOrganisationRepublisher
   end
 
   def call
-    @edition.document.features.map(&:republish_organisation_to_publishing_api)
+    @edition.document.features.map(&:republish_featurable_to_publishing_api)
   end
 end

--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -28,7 +28,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
     assert_equal Time.zone.now, feature.ended_at
   end
 
-  test "post :unfeature republishes the organisation" do
+  test "post :unfeature republishes the organisation when the featurable is an organisation" do
     organisation = create(:organisation)
     feature_list = create(:feature_list, featurable: organisation, locale: :en)
     edition = create(:published_speech)
@@ -39,7 +39,19 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
     post :unfeature, params: { feature_list_id: feature_list, id: feature }
   end
 
-  test "post :feature creates a feature and republishes the document & organisation" do
+  test "post :unfeature republishes the world location news when the featurable is a world location news" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, world_location_news: world_location_news)
+    feature_list = create(:feature_list, featurable: world_location_news, locale: :en)
+    edition = create(:published_speech)
+    feature = create(:feature, document: edition.document, feature_list: feature_list)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(world_location_news).once
+
+    post :unfeature, params: { feature_list_id: feature_list, id: feature }
+  end
+
+  test "post :feature creates a feature and republishes the document & organisation when the featurable is an organisation" do
     organisation = create(:organisation)
     feature_list = create(:feature_list, featurable: organisation, locale: :en)
     edition = create(:published_speech)
@@ -52,6 +64,26 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
     PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id)
     Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
+
+    post :create, params: { feature_list_id: feature_list.id, feature: params }
+
+    assert_equal edition.document_id, Feature.last.document_id
+  end
+
+  test "post :feature creates a feature and republishes the document & world location news when the featurable is an world location news" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, world_location_news: world_location_news)
+    feature_list = create(:feature_list, featurable: world_location_news, locale: :en)
+    edition = create(:published_speech)
+
+    params = {
+      document_id: edition.document_id,
+      image: upload_fixture("images/960x640_gif.gif"),
+      alt_text: "some text",
+    }
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id)
+    Whitehall::PublishingApi.expects(:republish_async).with(world_location_news).once
 
     post :create, params: { feature_list_id: feature_list.id, feature: params }
 

--- a/test/unit/feature_list_test.rb
+++ b/test/unit/feature_list_test.rb
@@ -44,12 +44,22 @@ class FeatureListTest < ActiveSupport::TestCase
     assert_equal [feature2, feature1], feature_list.features
   end
 
-  test "republishes the organisation after reordering features" do
+  test "republishes the organisation after reordering features when featurable is an organisation" do
     organisation = create(:organisation)
     feature_list = create(:feature_list, featurable: organisation, features: build_list(:feature, 6))
 
     # the organisation should only be republished once
     Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
+
+    feature_list.reorder! feature_list.features.pluck(:id).reverse
+  end
+
+  test "republishes the world location news after reordering features when featurable is a world location news" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, world_location_news: world_location_news)
+    feature_list = create(:feature_list, featurable: world_location_news, features: build_list(:feature, 6))
+
+    Whitehall::PublishingApi.expects(:republish_async).with(world_location_news).once
 
     feature_list.reorder! feature_list.features.pluck(:id).reverse
   end


### PR DESCRIPTION
When a featured document changes, we need to republish the `WorldLocationNews` content to make this change live on the website.

As these pages were previously rendered by Whitehall, it did not matter that this didn't happen.  But now we render these pages in Collections using the content item, this update is essential.

[Trello card](https://trello.com/c/9FzBvL38/282-bug-featuring-a-document-on-world-location-news-doesnt-update-on-the-live-site)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️