### PR TITLE
Only show notices for legacy layout

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -9,7 +9,7 @@
 
   <div class="legacy-whitehall">
     <div class="environment-<%= environment %>">
-      <%= render "shared/header" %>
+      <%= render "shared/header", show_notices: false %>
     </div>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,7 @@
 <% environment_style = GovukAdminTemplate.environment_style %>
 <% environment_label = GovukAdminTemplate.environment_label %>
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
+<% show_notices ||= true %>
 
 <header class="
   masthead
@@ -79,7 +80,9 @@
       </li>
     </ul>
   </div>
-  <section class="notices">
-    <%= render partial: "shared/notices" %>
-  </section>
+  <% if show_notices %>
+    <section class="notices">
+      <%= render partial: "shared/notices" %>
+    </section>
+  <% end %>
 </header>


### PR DESCRIPTION
This adds an option to the header component that stops the notices section from showing.

This is needed as the design system layout uses the header component but the design system layout has it's own error message notification system.

This change hides it for the design system layout.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
