### PR TITLE
Add similar slug warning in the design system

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -205,7 +205,7 @@ private
     return "admin" unless preview_design_system_user?
 
     case action_name
-    when "edit", "update", "new", "create"
+    when "edit", "update"
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -205,7 +205,7 @@ private
     return "admin" unless preview_design_system_user?
 
     case action_name
-    when "edit", "update"
+    when "edit", "update", "new", "create"
       "design_system"
     else
       "admin"

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -27,7 +27,6 @@
       <div class="row">
         <div class="col-md-8">
           <section>
-            <%= render('legacy_similar_slug_warning') if show_similar_slugs_warning?(@edition) %>
             <%= render "legacy_recent_openings", edition: @edition, recent_openings: @recent_openings %>
             <%= render "legacy_form", edition: @edition %>
           </section>

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -20,4 +20,14 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
     put :update, params: { id: edition, edition: { title: "New title" }, save_and_continue: "Save and continue editing" }
     assert_redirected_to edit_admin_edition_tags_path(GenericEdition.last.id)
   end
+
+  view_test "GET :edit shows the similar slug warning as an error which links to the input when user has 'Preview design system' permission" do
+    current_user.permissions << "Preview design system"
+    create(:edition, title: "title")
+    edition_with_same_title = create(:edition, title: "title")
+
+    get :edit, params: { id: edition_with_same_title }
+
+    assert_select ".govuk-error-summary a", text: "Title is already used on GOV.UK. Please create a unique title", href: "#edition_title"
+  end
 end


### PR DESCRIPTION
## Description

If an edition has the same title as another document then we show the user a warning which lets them know that they need to update the title.

After some discussion with the design team, we've decided that presenting this as an error in the error summary  that links to the title input, is preferable to having multiple banners.

## Screenshots

### What it looked like

<img width="598" alt="image" src="https://user-images.githubusercontent.com/42515961/190419455-c066cb6b-edd6-4445-bf88-c1674a1f09fb.png">

### What it looks like now

<img width="767" alt="image" src="https://user-images.githubusercontent.com/42515961/190427558-13893ff9-694e-4f78-88cf-234388e36bbe.png">


## Trello card 

https://trello.com/c/YbYQICAe/684-move-edit-publication-page-to-the-govuk-design-system


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
