### PR TITLE
Add recent openings partial in the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -9,7 +9,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_edition, only: %i[new create]
-  before_action :detect_other_active_editors, only: [:edit]
+  before_action :detect_other_active_editors, only: %i[edit update]
   before_action :set_edition_defaults, only: :new
   before_action :build_edition_dependencies, only: %i[new edit]
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update destroy revise]

--- a/app/views/admin/editions/_recent_openings.html.erb
+++ b/app/views/admin/editions/_recent_openings.html.erb
@@ -1,0 +1,20 @@
+<% if recent_openings.count > 1  %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "Multiple people have started editing this #{edition.format_name}:",
+    description_govspeak:  (render "govuk_publishing_components/components/list", {
+      visible_counters: true,
+      items: recent_openings.map do |opening|
+               tag.p("#{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work.", class: "govuk-!-margin-bottom-2") +
+               "Contact " + mail_to(opening.editor.email) + " if you think they are still working on it."
+             end
+      }
+    ),
+    show_banner_title: true,
+  } %>
+<% elsif recent_openings.present? %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "#{recent_openings.first.editor.name} started editing this #{edition.format_name} #{time_ago_in_words recent_openings.first.created_at} ago and hasn’t yet saved their work.",
+    description_govspeak: sanitize("Contact #{mail_to(recent_openings.first.editor.email)} if you think they are still working on it."),
+    show_banner_title: true,
+  } %>
+<% end %>

--- a/app/views/admin/editions/_recent_openings.html.erb
+++ b/app/views/admin/editions/_recent_openings.html.erb
@@ -1,20 +1,23 @@
-<% if recent_openings.count > 1  %>
-  <%= render "govuk_publishing_components/components/notice", {
-    title: "Multiple people have started editing this #{edition.format_name}:",
-    description_govspeak:  (render "govuk_publishing_components/components/list", {
+<%
+  return unless recent_openings.present?
+  if recent_openings.count > 1
+    title = "Multiple people have started editing this #{edition.format_name}:"
+    description_govspeak = render("govuk_publishing_components/components/list", {
       visible_counters: true,
       items: recent_openings.map do |opening|
-               tag.p("#{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work.", class: "govuk-!-margin-bottom-2") +
-               "Contact " + mail_to(opening.editor.email) + " if you think they are still working on it."
+              render_govspeak("
+                #{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work.
+                Contact #{mail_to(opening.editor.email)} if you think they are still working on it.
+              ")
              end
-      }
-    ),
-    show_banner_title: true,
-  } %>
-<% elsif recent_openings.present? %>
-  <%= render "govuk_publishing_components/components/notice", {
-    title: "#{recent_openings.first.editor.name} started editing this #{edition.format_name} #{time_ago_in_words recent_openings.first.created_at} ago and hasn’t yet saved their work.",
-    description_govspeak: sanitize("Contact #{mail_to(recent_openings.first.editor.email)} if you think they are still working on it."),
-    show_banner_title: true,
-  } %>
-<% end %>
+    })
+  else
+    title = "#{recent_openings.first.editor.name} started editing this #{edition.format_name} #{time_ago_in_words recent_openings.first.created_at} ago and hasn’t yet saved their work."
+    description_govspeak = sanitize("Contact #{mail_to(recent_openings.first.editor.email)} if you think they are still working on it.")
+  end
+%>
+<%= render "govuk_publishing_components/components/notice", {
+  title: title,
+  description_govspeak: description_govspeak,
+  show_banner_title: true,
+} %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -4,6 +4,7 @@
   })
 %>
 <% content_for :error_summary, render('shared/error_summary', object: @edition.becomes(Edition), class_name: @edition.class.name.demodulize.underscore.humanize.downcase) %>
+<% content_for :banner, render("recent_openings", edition: @edition, recent_openings: @recent_openings) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -27,7 +28,6 @@
       <div class="row">
         <div class="col-md-8">
           <section>
-            <%= render "recent_openings", edition: @edition, recent_openings: @recent_openings %>
             <%= render "legacy_form", edition: @edition %>
           </section>
         </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -27,7 +27,7 @@
       <div class="row">
         <div class="col-md-8">
           <section>
-            <%= render "legacy_recent_openings", edition: @edition, recent_openings: @recent_openings %>
+            <%= render "recent_openings", edition: @edition, recent_openings: @recent_openings %>
             <%= render "legacy_form", edition: @edition %>
           </section>
         </div>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -32,6 +32,15 @@
 
       <%= yield(:error_summary) %>
 
+
+      <% if yield(:error_summary).blank? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= yield(:banner) %>
+          </div>
+        </div>
+      <% end %>
+
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1200,10 +1200,27 @@ module AdminEditionControllerTestHelpers
         request.env["HTTPS"] = "on"
         get :edit, params: { id: edition }
 
-        assert_select ".editing_conflict", /Joe Bloggs/ do
-          assert_select "img[src^='https']"
-        end
-        assert_select ".editing_conflict", /1 hour ago/
+        assert_select ".govuk-notification-banner__heading", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work."
+        assert_select ".govuk-notification-banner__content .govuk-govspeak", "Contact joe@example.com if you think they are still working on it."
+        assert_select ".govuk-notification-banner__content a", text: "joe@example.com", href: "mailto:joe@example.com"
+      end
+
+      view_test "should see a warning when editing an edition has been recently edited by multiple people" do
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        other_user = create(:author, name: "Joe Bloggs", email: "joe@example.com")
+        third_user = create(:author, name: "Josie Bloggs", email: "josie@example.com")
+        edition.open_for_editing_as(other_user)
+        edition.open_for_editing_as(third_user)
+        Timecop.travel 1.hour.from_now
+
+        request.env["HTTPS"] = "on"
+        get :edit, params: { id: edition }
+
+        assert_select ".govuk-notification-banner__heading", "Multiple people have started editing this #{edition.format_name}:"
+        assert_select ".govuk-notification-banner__content li", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.Contact joe@example.com if you think they are still working on it."
+        assert_select ".govuk-notification-banner__content a", text: "joe@example.com", href: "mailto:joe@example.com"
+        assert_equal assert_select(".govuk-notification-banner__content li")[1].text, "Josie Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.Contact josie@example.com if you think they are still working on it."
+        assert_select ".govuk-notification-banner__content a", text: "josie@example.com", href: "mailto:josie@example.com"
       end
 
       test "saving a #{edition_type} should remove any RecentEditionOpening records for the current user" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1202,7 +1202,6 @@ module AdminEditionControllerTestHelpers
 
         assert_select ".govuk-notification-banner__heading", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work."
         assert_select ".govuk-notification-banner__content .govuk-govspeak", "Contact joe@example.com if you think they are still working on it."
-        assert_select ".govuk-notification-banner__content a", text: "joe@example.com", href: "mailto:joe@example.com"
       end
 
       view_test "should see a warning when editing an edition has been recently edited by multiple people" do
@@ -1217,10 +1216,10 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select ".govuk-notification-banner__heading", "Multiple people have started editing this #{edition.format_name}:"
-        assert_select ".govuk-notification-banner__content li", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.Contact joe@example.com if you think they are still working on it."
-        assert_select ".govuk-notification-banner__content a", text: "joe@example.com", href: "mailto:joe@example.com"
-        assert_equal assert_select(".govuk-notification-banner__content li")[1].text, "Josie Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.Contact josie@example.com if you think they are still working on it."
-        assert_select ".govuk-notification-banner__content a", text: "josie@example.com", href: "mailto:josie@example.com"
+        assert_select ".govuk-notification-banner__content li", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.
+            Contact <a href=\"mailto:joe@example.com\">joe@example.com</a> if you think they are still working on it."
+        assert_equal assert_select(".govuk-notification-banner__content li")[1].text.strip,  "Josie Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.
+            Contact <a href=\"mailto:josie@example.com\">josie@example.com</a> if you think they are still working on it."
       end
 
       test "saving a #{edition_type} should remove any RecentEditionOpening records for the current user" do


### PR DESCRIPTION
## Description

This PR ports over the recent opening partial to the GOV.UK Design System following the design in this figma https://www.figma.com/file/gG3zErQmsOvKeaYHHIrlMi/Phase-1a-of-Whitehall-Transition?node-id=998%3A46389

## Screenshots

### Single recent opening

<img width="742" alt="image" src="https://user-images.githubusercontent.com/42515961/190623957-5754ea46-0200-4130-b7da-9ff34070bd56.png">

### Multiple recent openings

<img width="755" alt="image" src="https://user-images.githubusercontent.com/42515961/190623839-ca080b8f-9b63-4333-b004-96461f2a02f5.png">

## Trello card

https://trello.com/c/YbYQICAe/684-move-edit-publication-page-to-the-govuk-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
