### PR TITLE
Fix rubocop errors following Ruby 3.1.2 upgrade

### DIFF
--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -41,10 +41,10 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
   test "post :unfeature republishes the world location news when the featurable is a world location news" do
     world_location_news = build(:world_location_news)
-    create(:world_location, world_location_news: world_location_news)
+    create(:world_location, world_location_news:)
     feature_list = create(:feature_list, featurable: world_location_news, locale: :en)
     edition = create(:published_speech)
-    feature = create(:feature, document: edition.document, feature_list: feature_list)
+    feature = create(:feature, document: edition.document, feature_list:)
 
     Whitehall::PublishingApi.expects(:republish_async).with(world_location_news).once
 
@@ -72,7 +72,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
   test "post :feature creates a feature and republishes the document & world location news when the featurable is an world location news" do
     world_location_news = build(:world_location_news)
-    create(:world_location, world_location_news: world_location_news)
+    create(:world_location, world_location_news:)
     feature_list = create(:feature_list, featurable: world_location_news, locale: :en)
     edition = create(:published_speech)
 

--- a/test/unit/feature_list_test.rb
+++ b/test/unit/feature_list_test.rb
@@ -56,7 +56,7 @@ class FeatureListTest < ActiveSupport::TestCase
 
   test "republishes the world location news after reordering features when featurable is a world location news" do
     world_location_news = build(:world_location_news)
-    create(:world_location, world_location_news: world_location_news)
+    create(:world_location, world_location_news:)
     feature_list = create(:feature_list, featurable: world_location_news, features: build_list(:feature, 6))
 
     Whitehall::PublishingApi.expects(:republish_async).with(world_location_news).once


### PR DESCRIPTION
The code in https://github.com/alphagov/whitehall/pull/6826 was authored before Whitehall's Ruby version was updated to 3.1.2 in https://github.com/alphagov/whitehall/pull/6820.

A rubocop rule changed behaviour for this ruby version, therefore the merged code contains failures that cause the main branch is not build.

This fixes those failures.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
