### PR TITLE
Remove accidental debug output

### DIFF
--- a/app/views/historic_appointments/_past_chancellors_person.html.erb
+++ b/app/views/historic_appointments/_past_chancellors_person.html.erb
@@ -1,5 +1,5 @@
 <div role="list">
-  <%= past_chancellors_person.each_slice(4) do |row| %>
+  <% past_chancellors_person.each_slice(4) do |row| %>
   <div class="govuk-grid-row historic-people-index__section-row">
     <% row.each do | name, info| %>    
     <div class="govuk-grid-column-one-quarter" role="listitem">

--- a/app/views/historic_appointments/_past_chancellors_person.html.erb
+++ b/app/views/historic_appointments/_past_chancellors_person.html.erb
@@ -19,4 +19,4 @@
     <%end%>
   </div> 
   <% end %> 
-<div>
+</div>

--- a/app/views/past_foreign_secretaries/_past_foreign_secretaries_image.html.erb
+++ b/app/views/past_foreign_secretaries/_past_foreign_secretaries_image.html.erb
@@ -1,5 +1,5 @@
 <div class="historic-people-index__section-row-header" role="list">
-  <%= past_foreign_secretaries_image.each_slice(4) do |row| %>
+  <% past_foreign_secretaries_image.each_slice(4) do |row| %>
   <div class="govuk-grid-row">
     <% row.each do | name, info| %>
       <div role="listitem" class="govuk-grid-column-one-quarter">

--- a/app/views/past_foreign_secretaries/_past_foreign_secretaries_person.html.erb
+++ b/app/views/past_foreign_secretaries/_past_foreign_secretaries_person.html.erb
@@ -25,5 +25,4 @@
       <% end %> 
   </div> 
   <% end %> 
-<div>
-
+</div>

--- a/app/views/past_foreign_secretaries/_past_foreign_secretaries_person.html.erb
+++ b/app/views/past_foreign_secretaries/_past_foreign_secretaries_person.html.erb
@@ -1,5 +1,5 @@
 <div class="historic-people-index__section-row" role="list">
-  <%= past_foreign_secretary_person.each_slice(4) do |row| %>
+  <% past_foreign_secretary_person.each_slice(4) do |row| %>
   <div class="govuk-grid-row">
     <% row.each do |name, link| %> 
       <div role="listitem" class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
A Hash object was being dumped to the page, causing unwanted output.

I'm not sure what's triggered this to suddenly start happening, since these files haven't been touched in ages. My working theory is that the recent [Ruby 3.1.2 upgrade][1] could have introduced this new behaviour.

[1]: https://github.com/alphagov/whitehall/pull/6820

## Affected pages

- https://www.gov.uk/government/history/past-foreign-secretaries
- https://www.gov.uk/government/history/past-chancellors

| Before | After |
| --- | --- |
| <img width="975" alt="Screenshot 2022-09-20 at 15 54 38" src="https://user-images.githubusercontent.com/7735945/191292115-d9131323-3500-4c81-ba9f-a8b0216700f4.png"> | <img width="972" alt="Screenshot 2022-09-20 at 15 54 48" src="https://user-images.githubusercontent.com/7735945/191292177-f72314aa-519f-422b-b574-0613926c3f9b.png"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
