### PR TITLE
Move subtype fields and locales to design system

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,7 +4,6 @@ class Admin::EditionsController < Admin::BaseController
 
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
-  before_action :infer_blank_checkbox_params, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
   before_action :find_edition, only: %i[show show_locked edit update revise diff confirm_destroy destroy update_bypass_id history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
@@ -425,12 +424,6 @@ private
 
   def remove_blank_parameters
     params.reject! { |_, value| value.blank? }
-  end
-
-  def infer_blank_checkbox_params
-    return if edition_params.empty? || !preview_design_system_user?
-
-    edition_params[:political] = "0" if edition_params[:political].blank?
   end
 
   def clean_edition_parameters

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -260,6 +260,7 @@ private
       :location,
       :person_override,
       :primary_locale,
+      :create_foreign_language_only,
       :related_mainstream_content_url,
       :additional_related_mainstream_content_url,
       :primary_specialist_sector_tag,
@@ -429,7 +430,8 @@ private
     return if edition_params.empty?
 
     edition_params[:title].strip! if edition_params[:title]
-    edition_params.delete(:primary_locale) if edition_params[:primary_locale].blank?
+    edition_params.delete(:primary_locale) if edition_params[:primary_locale].blank? || (preview_design_system_user? && edition_params[:create_foreign_language_only].blank?)
+    edition_params.delete(:create_foreign_language_only)
   end
 
   def clear_scheduled_publication_if_not_activated

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,6 +4,7 @@ class Admin::EditionsController < Admin::BaseController
 
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
+  before_action :infer_blank_checkbox_params, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
   before_action :find_edition, only: %i[show show_locked edit update revise diff confirm_destroy destroy update_bypass_id history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
@@ -424,6 +425,12 @@ private
 
   def remove_blank_parameters
     params.reject! { |_, value| value.blank? }
+  end
+
+  def infer_blank_checkbox_params
+    return if edition_params.empty? || !preview_design_system_user?
+
+    edition_params[:political] = "0" if edition_params[:political].blank?
   end
 
   def clean_edition_parameters

--- a/app/views/admin/editions/_additional_significant_fields.html.erb
+++ b/app/views/admin/editions/_additional_significant_fields.html.erb
@@ -1,0 +1,4 @@
+<% # This file is intentionally empty. It acts as a 'base' partial that
+# specific Edition types (e.g. Speech) can override to include extra
+# fields in the edit form.
+%>

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,0 +1,35 @@
+<% if edition.locale_can_be_changed? %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "edition[create_foreign_language_only]",
+    id: "edition_create_foreign_language_only",
+    heading: "Foreign language only #{edition.model_name.human.downcase}",
+    no_hint_text: true,
+    error_items: errors_for_input(edition.errors, :create_foreign_language_only),
+    items: [
+      {
+        label: "Create a foreign language only #{edition.model_name.human.downcase}",
+        value: "1",
+        checked: form.object.primary_locale != "en",
+        conditional: (render "govuk_publishing_components/components/select", {
+          id: "edition_primary_locale",
+          name: "edition[primary_locale]",
+          label: "Document language",
+          full_width: true,
+          allow_blank: true,
+          errors: errors_for(edition.errors, :primary_locale),
+          options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
+            {
+              text: language,
+              value: value,
+              selected: edition.primary_locale == value
+            }
+          end
+        })
+      }
+    ]
+  } %>
+
+  <% if edition.is_a?(NewsArticle) %>
+    <p class="govuk-body govuk-!-font-weight-bold">Warning: News stories without an English version cannot have other translations.</p>
+  <% end %>
+<% end %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -49,6 +49,8 @@
 
   <%= render partial: "legacy_additional_significant_fields", locals: { form: form, edition: form.object } %>
   <% if edition.document && edition.document.live? && can?(:mark_political, edition) %>
+    <%= form.hidden_field :political, value: "0" %>
+
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: "edition[political]",
       id: "edition_political",

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -1,5 +1,5 @@
 <div class=<%= "right-to-left" if edition.rtl? %>>
-  <%= render "legacy_subtype_fields", form: form, edition: form.object %>
+  <%= render "subtype_fields", form: form, edition: form.object %>
   <%= render "legacy_locale_fields", form: form, edition: edition %>
   <%= form.hidden_field :lock_version %>
 

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -1,6 +1,6 @@
 <div class=<%= "right-to-left" if edition.rtl? %>>
   <%= render "subtype_fields", form: form, edition: form.object %>
-  <%= render "legacy_locale_fields", form: form, edition: edition %>
+  <%= render "locale_fields", form: form, edition: edition %>
   <%= form.hidden_field :lock_version %>
 
   <% if form.object.document %>

--- a/app/views/admin/editions/_subtype_fields.html.erb
+++ b/app/views/admin/editions/_subtype_fields.html.erb
@@ -1,0 +1,4 @@
+<% # This file is intentionally empty. It acts as a 'base' partial that
+# specific Edition types (e.g. Speech) can override to include extra
+# fields in the edit form.
+%>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -1,0 +1,16 @@
+<%= render "govuk_publishing_components/components/select", {
+  name: "edition[news_article_type_id]",
+  id: "edition_news_article_type_id",
+  label: "News article type",
+  heading_size: "s",
+  full_width: true,
+  value: edition.news_article_type_id,
+  error_message: errors_for(edition.errors, :news_article_type_id),
+  options: NewsArticleType.all.map do |type|
+    {
+      text: type.singular_name,
+      value: type.id,
+      selected: edition.news_article_type_id == type.id
+    }
+  end
+} %>

--- a/app/views/admin/news_articles/_subtype_fields.html.erb
+++ b/app/views/admin/news_articles/_subtype_fields.html.erb
@@ -1,0 +1,1 @@
+<%= render "news_article_type_fields", form: form, edition: edition %>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-form-group">
+  <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
+    Publication type
+  </label>
+  <% if errors_for_input(edition.errors, :publication_type_id).present? %>
+    <p class="gem-c-error-message govuk-error-message">
+      <span class="govuk-visually-hidden">Error: <%= errors_for_input(edition.errors, :publication_type_id) %></span>
+    </p>
+  <% end %>
+
+  <select class="govuk-select govuk-select gem-c-select__select--full-width" id="edition_publication_type_id" name="edition[publication_type_id]" >
+    <optgroup label="Common types">
+      <% PublicationType.primary.each do |publication_type| %>
+        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+      <% end %>
+    <optgroup/>
+    <optgroup label="Less common types">
+      <% PublicationType.less_common.each do |publication_type| %>
+        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+      <% end %>
+    <optgroup/>
+    <optgroup label="Use discouraged">
+      <% PublicationType.use_discouraged.each do |publication_type| %>
+        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+      <% end %>
+    <optgroup/>
+  </select>
+</div>

--- a/app/views/admin/publications/_subtype_fields.html.erb
+++ b/app/views/admin/publications/_subtype_fields.html.erb
@@ -1,0 +1,1 @@
+<%= render 'publication_type_fields', form: form, edition: edition %>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -1,0 +1,16 @@
+<%= render "govuk_publishing_components/components/select", {
+  name: "edition[speech_type_id]",
+  id: "edition_speech_type_id",
+  label: "Speech type",
+  heading_size: "s",
+  full_width: true,
+  value: edition.speech_type_id,
+  error_message: errors_for(edition.errors, :speech_type_id),
+  options: SpeechType.primary.map do |type|
+    {
+      text: type.singular_name,
+      value: type.id,
+      selected: edition.speech_type_id == type.id
+    }
+  end
+} %>

--- a/app/views/admin/speeches/_subtype_fields.html.erb
+++ b/app/views/admin/speeches/_subtype_fields.html.erb
@@ -1,0 +1,1 @@
+<%= render 'speech_type_fields', form: form, edition: edition %>


### PR DESCRIPTION
## Description

This builds upon https://github.com/alphagov/whitehall/pull/6840 and adds subtype and locale fields.

## Screenshots

### Publications

<img width="805" alt="image" src="https://user-images.githubusercontent.com/42515961/191485632-5286e0d5-ed03-4dba-b8a7-d574ca8d0883.png">

### News stories

<img width="884" alt="image" src="https://user-images.githubusercontent.com/42515961/191486002-5285398a-094a-465a-88df-451fc7ac8923.png">

### Speeches

<img width="792" alt="image" src="https://user-images.githubusercontent.com/42515961/191486130-9c274c89-779e-46ee-8806-10c13558c7a1.png">

### Locales 

<img width="851" alt="image" src="https://user-images.githubusercontent.com/42515961/191486710-f0eb5602-1906-41d8-bb0a-c24004bf0b64.png">

## Trello card 

https://trello.com/c/YbYQICAe/684-move-edit-edition-page-to-the-govuk-design-system


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
