### PR TITLE
Add link tracking module to What's new link on dashboard

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -27,6 +27,7 @@
       <li><%= link_to("What's new",
                       admin_whats_new_path,
                       data: {
+                          module: "track-link-click",
                           track_category: 'dashboardLink',
                           track_action: "What's new",
                           track_label: 'whats-new-click'


### PR DESCRIPTION
The tracking was not being triggered as the module was not included.

This change resolves the issue

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
