### PR TITLE
Fix display_type for languages which don't have singular nouns

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -577,7 +577,7 @@ EXISTS (
   end
 
   def display_type
-    I18n.t("document.type.#{display_type_key}.one")
+    I18n.t("document.type.#{display_type_key}", count: 1)
   end
 
   def display_type_key

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -34,11 +34,11 @@ class OffsiteLink < ApplicationRecord
     def self.display_type(link_type)
       case link_type
       when "content_publisher_news_story"
-        I18n.t("document.type.news_story.one")
+        I18n.t("document.type.news_story", count: 1)
       when "content_publisher_press_release"
-        I18n.t("document.type.press_release.one")
+        I18n.t("document.type.press_release", count: 1)
       else
-        I18n.t("document.type.#{link_type}.one")
+        I18n.t("document.type.#{link_type}", count: 1)
       end
     end
   end

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -41,9 +41,9 @@ class Speech < Announcement
 
   def display_type
     if speech_type.statement_to_parliament?
-      I18n.t("document.type.statement_to_parliament.one")
+      I18n.t("document.type.statement_to_parliament", count: 1)
     else
-      I18n.t("document.type.speech.one")
+      I18n.t("document.type.speech", count: 1)
     end
   end
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -131,7 +131,7 @@ class StatisticsAnnouncement < ApplicationRecord
   end
 
   def display_type
-    I18n.t("document.type.#{display_type_key}.one")
+    I18n.t("document.type.#{display_type_key}", count: 1)
   end
 
   def display_type_key

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -928,6 +928,19 @@ class EditionTest < ActiveSupport::TestCase
     edition.update!(title: "some updated title")
   end
 
+  test "display type translates correctly for languages which do and don't use singular nouns" do
+    locales_and_expected_translations = {
+      de: "document.type.generic_edition.one",
+      zh: "document.type.generic_edition.other",
+    }
+    locales_and_expected_translations.each do |locale, expected_translation_path|
+      with_locale(locale) do
+        speech = create(:edition)
+        assert_equal I18n.t(expected_translation_path), speech.display_type
+      end
+    end
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -140,4 +140,22 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     feature_list.reload
     assert_equal 0, feature_list.features.size
   end
+
+  test "display type translates correctly for different document types and different languages" do
+    locales_and_expected_translations = [
+      [:de, "content_publisher_news_story", "document.type.news_story.one"],
+      [:zh, "content_publisher_news_story", "document.type.news_story.other"],
+      [:de, "content_publisher_press_release", "document.type.press_release.one"],
+      [:zh, "content_publisher_press_release", "document.type.press_release.other"],
+      [:de, "campaign", "document.type.campaign.one"],
+      [:zh, "campaign", "document.type.campaign.other"],
+    ]
+
+    locales_and_expected_translations.each do |locale, link_type, expected_translation_path|
+      with_locale(locale) do
+        offsite_link = create(:offsite_link, link_type:)
+        assert_equal I18n.t(expected_translation_path), offsite_link.display_type
+      end
+    end
+  end
 end

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -79,6 +79,19 @@ class SpeechTest < ActiveSupport::TestCase
     end
   end
 
+  test "display type translates correctly for languages which do and don't use singular nouns" do
+    locales_and_expected_translations = {
+      de: "document.type.speech.one",
+      zh: "document.type.speech.other",
+    }
+    locales_and_expected_translations.each do |locale, expected_translation_path|
+      with_locale(locale) do
+        speech = create(:speech)
+        assert_equal I18n.t(expected_translation_path), speech.display_type
+      end
+    end
+  end
+
   test "creating a new draft should not associate speech with duplicate organisations" do
     organisation = create(:organisation)
     ministerial_role = create(:ministerial_role, organisations: [organisation])

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -266,6 +266,19 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     end
   end
 
+  test "display type translates correctly for languages which do and don't use singular nouns" do
+    locales_and_expected_translations = {
+      de: "document.type.official_statistics.one",
+      zh: "document.type.official_statistics.other",
+    }
+    locales_and_expected_translations.each do |locale, expected_translation_path|
+      with_locale(locale) do
+        speech = create(:statistics_announcement)
+        assert_equal I18n.t(expected_translation_path), speech.display_type
+      end
+    end
+  end
+
 private
 
   def create_announcement_with_changes


### PR DESCRIPTION
We were previously losing translations and defaulting to English for the edition display type for languages which don't tend to have singular nouns, e.g. Mandarin, since we were specifically looking for the translation for 'one', whereas for some languages only a translation for 'other' exists. This change uses I18n's internal logic for deciding which translation (/) to look for, depending on the locale, so we shouldn't be losing translations for display types now.

We know this was causing issues with world location news page translations, but the logic exists for a multitude of document types, so this fixes for all these cases.

[Trello:](https://trello.com/c/DSL6gfzK/288-fix-issue-with-mandarin-document-types-not-being-pulled-through-in-correct-language)

We will also need to republish affected documents after this in order to see this come into effect.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
