### PR TITLE
Move bulk upload attachments page to design system

### DIFF
--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -31,21 +31,14 @@ class Admin::BulkUploadsController < Admin::BaseController
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)
     else
-      render :set_titles
+      render(preview_design_system_user? ? "set_titles" : "set_titles_legacy")
     end
   end
 
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "new", "upload_zip"
-      "design_system"
-    else
-      "admin"
-    end
+    preview_design_system_user? ? "design_system" : "admin"
   end
 
   def find_edition

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -3,9 +3,11 @@ class Admin::BulkUploadsController < Admin::BaseController
   before_action :limit_edition_access!
   before_action :enforce_permissions!
   before_action :prevent_modification_of_unmodifiable_edition
+  layout :get_layout
 
   def new
     @zip_file = BulkUpload::ZipFile.new
+    render(preview_design_system_user? ? "new" : "new_legacy")
   end
 
   def upload_zip
@@ -14,9 +16,9 @@ class Admin::BulkUploadsController < Admin::BaseController
     if @zip_file.valid?
       @bulk_upload = BulkUpload.from_files(@edition, @zip_file.extracted_file_paths)
       @zip_file.cleanup_extracted_files
-      render :set_titles
+      render(preview_design_system_user? ? "set_titles" : "set_titles_legacy")
     else
-      render :new
+      render(preview_design_system_user? ? "new" : "new_legacy")
     end
   end
 
@@ -34,6 +36,17 @@ class Admin::BulkUploadsController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "new", "upload_zip"
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def find_edition
     @edition = Edition.find(params[:edition_id])

--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -1,20 +1,32 @@
 <%= form.fields_for(:attachment_data, include_id: false) do |attachment_data_fields| %>
   <% if attachment_data_fields.object.filename %>
     <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id || attachment_data_fields.object.id) %>
-    <p>Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url %></p>
+    <p class="govuk-body">Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url %></p>
   <% end %>
 
-  <%= attachment_data_fields.label :file, (attachment_data_fields.object.filename ? 'Replace file' : nil), required: false %>
+  <%= render "govuk_publishing_components/components/file_upload", {
+    label: {
+      text: attachment_data_fields.object.filename ? 'Replace file' : 'File',
+      heading_level: 2,
+      heading_size: "l",
+    },
+    name: "attachment[attachment_data_attributes][file]",
+    hint: raw("You must upload attachments in an <a href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>.")
+  } %>
 
-  <p>
-    You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.
-  </p>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "attachment[accessible]",
+    items: [
+      {
+        label: "Attachment is accessible",
+        value: "1"
+      }
+    ]
+  } %>
 
-  <%= attachment_data_fields.file_field :file %>
-
-  <%= form.check_box :accessible, label_text: "Attachment is accessible" %>
   <% if attachment_data_fields.object.file_cache.present? %>
-    <span class="already_uploaded"><%= File.basename(attachment_data_fields.object.file_cache) %> already uploaded</span>
+    <p class="govuk-body already_uploaded"><%= File.basename(attachment_data_fields.object.file_cache) %> already uploaded</p>
   <% end %>
+
   <%= attachment_data_fields.hidden_field :file_cache %>
 <% end %>

--- a/app/views/admin/attachments/_attachment_data_fields_legacy.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields_legacy.html.erb
@@ -1,0 +1,20 @@
+<%= form.fields_for(:attachment_data, include_id: false) do |attachment_data_fields| %>
+  <% if attachment_data_fields.object.filename %>
+    <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id || attachment_data_fields.object.id) %>
+    <p>Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url %></p>
+  <% end %>
+
+  <%= attachment_data_fields.label :file, (attachment_data_fields.object.filename ? 'Replace file' : nil), required: false %>
+
+  <p class="here">
+    You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.
+  </p>
+
+  <%= attachment_data_fields.file_field :file %>
+
+  <%= form.check_box :accessible, label_text: "Attachment is accessible" %>
+  <% if attachment_data_fields.object.file_cache.present? %>
+    <span class="already_uploaded"><%= File.basename(attachment_data_fields.object.file_cache) %> already uploaded</span>
+  <% end %>
+  <%= attachment_data_fields.hidden_field :file_cache %>
+<% end %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,6 +1,6 @@
 <% initialise_script "GOVUK.AdminAttachmentsForm", selector: '.js-attachment-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
 
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "js-attachment-form" } do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "js-attachment-form" }, multipart: true do |form| %>
   <% content_for :error_summary, render('shared/error_summary', object: attachment, parent_class: "attachment", class_name: @attachment.class.name.demodulize.underscore.humanize.downcase) %>
 
   <div class="govuk-!-margin-bottom-8">
@@ -66,11 +66,8 @@
       text: "Next"
     } %>
   <% else %>
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save"
-      } %>
-      <a class="govuk-link" href="attachable_attachments_path(attachable)">Cancel</a>
-    </div>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save"
+    } %>
   <% end %>
 <% end %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <% if attachable.allows_attachment_references? %>
-    <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment %>
+    <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: heading_size %>
   <% end %>
 
   <% if attachment.is_a?(HtmlAttachment) %>

--- a/app/views/admin/attachments/_form_legacy.html.erb
+++ b/app/views/admin/attachments/_form_legacy.html.erb
@@ -34,7 +34,7 @@
   <% elsif attachment.is_a?(ExternalAttachment) %>
     <%= form.text_field :external_url %>
   <% else %>
-    <%= render 'attachment_data_fields', form: form %>
+    <%= render 'attachment_data_fields_legacy', form: form %>
   <% end %>
 
   <%= hidden_field_tag :type, params[:type] %>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -2,7 +2,7 @@
   <%= render "govuk_publishing_components/components/radio", {
     heading: "House of Commons paper number",
     heading_level: 2,
-    heading_size: "l",
+    heading_size: heading_size,
     name: "attachment[unnumbered_hoc_paper]",
     id_prefix: "hoc_paper_number_conditional",
     items: [
@@ -46,7 +46,7 @@
     name: "attachment[parliamentary_session]",
     id: "attachment_parliamentary_session",
     heading_level: 2,
-    heading_size: "l",
+    heading_size: heading_size,
     options: options,
     error_message: errors_for_input(attachment.errors, :parliamentary_session)
   } %>

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -15,7 +15,7 @@
       label: "Display language",
       name: "attachment[locale]",
       heading_level: 2,
-      heading_size: "l",
+      heading_size: heading_size,
       options: options,
       hint: "This determines the translations of the publication that the attachment will appear in."
     } %>
@@ -30,7 +30,7 @@
     name: "attachment[isbn]",
     id: "attachment_isbn",
     heading_level: 2,
-    heading_size: "l",
+    heading_size: heading_size,
     value: form.object.isbn,
     error_items: errors_for(attachment.errors, :isbn)
   } %>
@@ -43,7 +43,7 @@
     },
     name: "attachment[unique_reference]",
     heading_level: 2,
-    heading_size: "l",
+    heading_size: heading_size,
     value: form.object.unique_reference
   } %>
 </div>
@@ -52,7 +52,7 @@
   <%= render "govuk_publishing_components/components/radio", {
     heading: "Command paper number",
     heading_level: 2,
-    heading_size: "l",
+    heading_size: heading_size,
     name: "attachment[unnumbered_command_paper]",
     id_prefix: "command_paper_number_conditional",
     items: [
@@ -80,5 +80,5 @@
 </div>
 
 <% if attachable.can_have_attached_house_of_commons_papers? %>
-  <%= render 'admin/attachments/hoc_reference_fields', attachable: attachable, form: form, attachment: attachment %>
+  <%= render 'admin/attachments/hoc_reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: heading_size %>
 <% end %>

--- a/app/views/admin/attachments/edit.html.erb
+++ b/app/views/admin/attachments/edit.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <%= render partial: 'form', locals: { attachable: attachable, attachment: attachment } %>
+    <%= render partial: 'form', locals: { attachable: attachable, attachment: attachment, heading_size: "l" } %>
   </section>
 
   <% if attachment.html? %>

--- a/app/views/admin/attachments/new.html.erb
+++ b/app/views/admin/attachments/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <%= render 'form', attachable: attachable %>
+    <%= render 'form', attachable: attachable, heading_size: "l" %>
   </section>
 
   <% if attachment.html? %>

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -1,17 +1,29 @@
-<% page_title "Bulk upload for: #{@edition.title}" %>
+<% content_for :page_title, "Bulk upload for: #{@edition.title}" %>
+<% content_for :title, "Bulk upload" %>
+<% content_for :context, "Attachments for #{@edition.format_name}" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_attachments_path(@edition)
+  } %>
+<% end %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Bulk upload for: <%= @edition.title %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @zip_file, url: upload_zip_admin_edition_bulk_uploads_path(@edition), multipart: true do |form| %>
+      <% content_for :error_summary, render('shared/error_summary', object: @zip_file, parent_class: "zip_file", class_name: @zip_file.class.name.demodulize.underscore.humanize.downcase) %>
 
-    <%= form_for @zip_file, url: upload_zip_admin_edition_bulk_uploads_path(@edition) do |form| %>
-      <%= form.errors %>
-      <div class="form-group">
-        <%= form.label :zip_file %>
-        <%= form.file_field :zip_file %>
-      </div>
-      <%= form.form_actions(buttons: { commit: 'Upload zip'}, cancel: admin_edition_attachments_path(@edition)) %>
+      <%= render "govuk_publishing_components/components/file_upload", {
+        label: {
+          text: "Upload a zip file"
+        },
+        name: "bulk_upload_zip_file[zip_file]",
+        id: "zip_file_zip_file",
+        error_items: errors_for(@zip_file.errors, :zip_file)
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Next",
+      } %>
     <% end %>
-
-  </section>
+  </div>
 </div>

--- a/app/views/admin/bulk_uploads/new_legacy.html.erb
+++ b/app/views/admin/bulk_uploads/new_legacy.html.erb
@@ -1,0 +1,17 @@
+<% page_title "Bulk upload for: #{@edition.title}" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Bulk upload for: <%= @edition.title %></h1>
+
+    <%= form_for @zip_file, url: upload_zip_admin_edition_bulk_uploads_path(@edition) do |form| %>
+      <%= form.errors %>
+      <div class="form-group">
+        <%= form.label :zip_file %>
+        <%= form.file_field :zip_file %>
+      </div>
+      <%= form.form_actions(buttons: { commit: 'Upload zip'}, cancel: admin_edition_attachments_path(@edition)) %>
+    <% end %>
+
+  </section>
+</div>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -1,34 +1,65 @@
-<% page_title "Bulk upload for: #{@edition.title}" %>
+<% content_for :page_title, "Bulk upload for: #{@edition.title}" %>
+<% content_for :title, "Edit file attachments" %>
+<% content_for :context, "Attachments for publication" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_attachments_path(@edition)
+  } %>
+<% end %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Set titles for your attachments</h1>
-    <%= form_for @bulk_upload, url: admin_edition_bulk_uploads_path(@edition) do |form| %>
-      <%= form.errors %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-8">
+      <%= form_for @bulk_upload, url: admin_edition_bulk_uploads_path(@edition) do |form| %>
+        <% content_for :error_summary, render('shared/error_summary', object: @bulk_upload, parent_class: "bulk_upload", class_name: @bulk_upload.class.name.demodulize.underscore.humanize.downcase) %>
 
-      <ol class="uploaded-attachments">
-        <% @bulk_upload.attachments.each do |attachment| %>
+        <% @bulk_upload.attachments.each.with_index do |attachment, i| %>
           <%= form.fields_for :attachments, attachment do |attachment_fields| %>
-            <li class="well">
-              <span class="file">File: <%= attachment_fields.object.filename %></span>
-              <%= attachment_fields.text_field :title %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "File: " + attachment_fields.object.filename,
+              font_size: "l",
+              padding: true
+            } %>
 
-              <% if @edition.allows_attachment_references? %>
-                <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields, attachment: attachment %>
-              <% end %>
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Title (required)"
+              },
+              name: "bulk_upload[attachments_attributes][#{i}][title]",
+              autofocus: true,
+              margin_top: 10,
+              heading_level: 2,
+              heading_size: "m",
+              value: attachment_fields.object.title
+            } %>
 
-              <%= attachment_fields.fields_for :attachment_data, attachment_fields.object.attachment_data, include_id: false do |attachment_data_fields| %>
-                <%= attachment_data_fields.hidden_field :file_cache %>
-                <% if attachment_data_fields.object.to_replace_id %>
-                  <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id) %>
-                <% end %>
+            <% if @edition.allows_attachment_references? %>
+              <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields, attachment: attachment, heading_size: "m" %>
+            <% end %>
+
+            <%= render "govuk_publishing_components/components/checkboxes", {
+              name: "Attachment is accessible",
+              items: [
+                {
+                  label: "Attachment is accessible",
+                  value: true
+                }
+              ]
+            } %>
+
+            <%= attachment_fields.fields_for :attachment_data, attachment_fields.object.attachment_data, include_id: false do |attachment_data_fields| %>
+              <%= attachment_data_fields.hidden_field :file_cache %>
+              <% if attachment_data_fields.object.to_replace_id %>
+                <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id) %>
               <% end %>
-            </li>
+            <% end %>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
           <% end %>
         <% end %>
-      </ol>
-
-      <%= form.save_or_cancel cancel: admin_edition_attachments_path(@edition) %>
-    <% end %>
-  </section>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/bulk_uploads/set_titles_legacy.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles_legacy.html.erb
@@ -1,0 +1,34 @@
+<% page_title "Bulk upload for: #{@edition.title}" %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Set titles for your attachments</h1>
+    <%= form_for @bulk_upload, url: admin_edition_bulk_uploads_path(@edition) do |form| %>
+      <%= form.errors %>
+
+      <ol class="uploaded-attachments">
+        <% @bulk_upload.attachments.each do |attachment| %>
+          <%= form.fields_for :attachments, attachment do |attachment_fields| %>
+            <li class="well">
+              <span class="file">File: <%= attachment_fields.object.filename %></span>
+              <%= attachment_fields.text_field :title %>
+
+              <% if @edition.allows_attachment_references? %>
+                <%= render 'admin/attachments/reference_fields_legacy', attachable: @edition, form: attachment_fields, attachment: attachment %>
+              <% end %>
+
+              <%= attachment_fields.fields_for :attachment_data, attachment_fields.object.attachment_data, include_id: false do |attachment_data_fields| %>
+                <%= attachment_data_fields.hidden_field :file_cache %>
+                <% if attachment_data_fields.object.to_replace_id %>
+                  <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id) %>
+                <% end %>
+              <% end %>
+            </li>
+          <% end %>
+        <% end %>
+      </ol>
+
+      <%= form.save_or_cancel cancel: admin_edition_attachments_path(@edition) %>
+    <% end %>
+  </section>
+</div>

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -105,6 +105,13 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
     assert_equal @titles[1], @edition.attachments[1].title
   end
 
+  view_test "POST :create with invalid attachments re-renders the bulk upload form" do
+    post :create, params: { edition_id: @edition, bulk_upload: invalid_create_params }
+
+    assert_response :success
+    assert_select ".form-errors", text: /enter missing fields/
+  end
+
   view_test "POST :create with invalid attachments re-renders the bulk upload form with design system permission" do
     @current_user.permissions << "Preview design system"
 

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -105,11 +105,13 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
     assert_equal @titles[1], @edition.attachments[1].title
   end
 
-  view_test "POST :create with invalid attachments re-renders the bulk upload form" do
+  view_test "POST :create with invalid attachments re-renders the bulk upload form with design system permission" do
+    @current_user.permissions << "Preview design system"
+
     post :create, params: { edition_id: @edition, bulk_upload: invalid_create_params }
 
     assert_response :success
-    assert_select ".form-errors", text: /enter missing fields/
+    assert_select ".govuk-error-summary", text: /enter missing fields/
   end
 
   test "POST :create associates the attachment's attachment_data object with the edition" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/UCQ6nWML/613-move-bulk-upload-attachments-page-to-the-govuk-design-system)

These changes port the "Bulk upload from Zip file" pages to the Design System. 

There are two views, steps one and two below. 

Also shown is the second step submitted with the form inputs left blank. Only the titles are verified and a single generic error message is displayed at the top of the page. This is the current behaviour, which doesn't match other areas where a more strict verification is carried out.

### Step One 

![Screenshot 2022-09-29 at 14 44 01](https://user-images.githubusercontent.com/6080548/193048387-684ecf35-7765-4ca2-aa29-c71eb84906e4.png)

---

### Step Two

![Screenshot 2022-09-29 at 14 47 13](https://user-images.githubusercontent.com/6080548/193050649-394f71e5-7aef-406b-9291-e118e4e09ced.png)

---

### Submitted with blank fields

![Screenshot 2022-09-29 at 14 58 19](https://user-images.githubusercontent.com/6080548/193051789-21235b66-2dd6-4eba-a97e-fd4e192c6bef.png)
