### PR TITLE
Add permission for viewing the second release

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -56,6 +56,10 @@ class Admin::BaseController < ApplicationController
     current_user.can_preview_design_system?
   end
 
+  def user_can_preview_second_release?
+    current_user.can_preview_second_release?
+  end
+
 private
 
   def forbidden!

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -9,7 +9,7 @@ class Admin::EditionTagsController < Admin::BaseController
     @topic_taxonomy = Taxonomy::TopicTaxonomy.new
     @tag_form = TaxonomyTagForm.load(@edition.content_id)
 
-    render(preview_design_system_user? ? "edit" : "edit_legacy")
+    render(preview_design_system_user? || user_can_preview_second_release? ? "edit" : "edit_legacy")
   end
 
   def update
@@ -29,7 +29,7 @@ class Admin::EditionTagsController < Admin::BaseController
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
+    return "admin" unless preview_design_system_user? || user_can_preview_second_release?
 
     case action_name
     when "edit"

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -103,7 +103,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   def confirm_unpublish
     @unpublishing = @edition.build_unpublishing
 
-    render preview_design_system_user? ? :confirm_unpublish : :confirm_unpublish_legacy
+    render(preview_design_system_user? || user_can_preview_second_release? ? :confirm_unpublish : :confirm_unpublish_legacy)
   end
 
   def unpublish
@@ -114,12 +114,12 @@ class Admin::EditionWorkflowController < Admin::BaseController
     else
       @unpublishing = @edition.unpublishing || @edition.build_unpublishing(unpublishing_params)
       flash.now[:alert] = message
-      render preview_design_system_user? ? :confirm_unpublish : :confirm_unpublish_legacy
+      render(preview_design_system_user? || user_can_preview_second_release? ? :confirm_unpublish : :confirm_unpublish_legacy)
     end
   end
 
   def confirm_unwithdraw
-    render preview_design_system_user? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy
+    render(preview_design_system_user? || user_can_preview_second_release? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy)
   end
 
   def unwithdraw
@@ -129,7 +129,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
       redirect_to admin_edition_path(new_edition), notice: "This document has been unwithdrawn"
     else
       flash.now[:alert] = edition_unwithdrawer.failure_reason
-      render preview_design_system_user? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy
+      render(preview_design_system_user? || user_can_preview_second_release? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy)
     end
   end
 
@@ -179,7 +179,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
+    return "admin" unless preview_design_system_user? || user_can_preview_second_release?
 
     case action_name
     when "confirm_unpublish"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     REDIRECT_TO_SUMMARY_PAGE = "Redirect to summary page".freeze
     REMOVE_EDIT_TABS = "Remove edit tabs".freeze
+    PREVIEW_SECOND_RELEASE = "Preview second release".freeze
   end
 
   def role
@@ -109,6 +110,10 @@ class User < ApplicationRecord
 
   def can_remove_edit_tabs?
     has_permission?(Permissions::REMOVE_EDIT_TABS)
+  end
+
+  def can_preview_second_release?
+    has_permission?(Permissions::PREVIEW_SECOND_RELEASE)
   end
 
   def organisation_name

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -32,3 +32,11 @@ Scenario: Publication that supports the new taxonomy with the Preview design sys
   And I continue to the tagging page
   Then I should be on the taxonomy tagging page
   And I should be able to update the taxonomy and click the "Update tags" button
+
+Scenario: Publication that supports the new taxonomy with the Preview design system permission
+  Given I am a writer
+  And I have the "Preview second release" permission
+  When I start editing a draft document which can be tagged to the new taxonomy
+  And I continue to the tagging page
+  Then I should be on the taxonomy tagging page
+  And I should be able to update the taxonomy and click the "Update tags" button

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -11,7 +11,7 @@ Given(/^there is a published document that is a duplicate of another page$/) do
 end
 
 When(/^I unpublish the duplicate, marking it as consolidated into the other page$/) do
-  design_system_layout = @user.has_permission? "Preview design system"
+  design_system_layout = @user.can_preview_design_system? || @user.can_preview_second_release?
 
   visit admin_edition_path(@duplicate_edition)
   click_on "Withdraw or unpublish"
@@ -24,7 +24,7 @@ When(/^I unpublish the duplicate, marking it as consolidated into the other page
 end
 
 def withdraw_publication(explanation)
-  design_system_layout = @user.has_permission? "Preview design system"
+  design_system_layout = @user.can_preview_design_system? || @user.can_preview_second_release?
 
   @publication = Publication.last
   visit admin_edition_path(@publication)

--- a/features/support/unpublishing_helpers.rb
+++ b/features/support/unpublishing_helpers.rb
@@ -1,6 +1,6 @@
 module UnpublishingHelpers
   def unpublish_edition(edition)
-    design_system_layout = @user.has_permission? "Preview design system"
+    design_system_layout = @user.can_preview_design_system? || @user.can_preview_second_release?
 
     visit admin_edition_path(edition)
     click_on "Withdraw or unpublish"

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -20,6 +20,13 @@ Feature: Unpublishing published documents
     Then there should be an editorial remark recording the fact that the document was unpublished
     And there should be an unpublishing explanation of "This page should never have existed" and a reason of "Published in error"
 
+  Scenario: Unpublishing a published document with preview second release permission
+    Given a published document "Published by accident" exists
+    And I have the "Preview second release" permission
+    When I unpublish the document because it was published in error
+    Then there should be an editorial remark recording the fact that the document was unpublished
+    And there should be an unpublishing explanation of "This page should never have existed" and a reason of "Published in error"
+
   Scenario: Draft resulting from an unpublishing should not be deletable
     Given a published document exists with a slug that does not match the title
     When I unpublish the document because it was published in error
@@ -41,6 +48,12 @@ Feature: Unpublishing published documents
     When I unpublish the duplicate, marking it as consolidated into the other page
     Then the unpublishing should redirect to the existing edition
 
+  Scenario: Consolidating a document into another GOV.UK page with preview second release permission
+    Given there is a published document that is a duplicate of another page
+    And I have the "Preview second release" permission
+    When I unpublish the duplicate, marking it as consolidated into the other page
+    Then the unpublishing should redirect to the existing edition
+
   Scenario: Withdraw a document that is no longer current
     Given a published publication "Shaving kits for all" exists
     When I withdraw the publication with the explanation "Policy change"
@@ -50,6 +63,13 @@ Feature: Unpublishing published documents
   Scenario: Withdraw a document that is no longer current with design system permission
     Given a published publication "Shaving kits for all" exists
     And I have the "Preview design system" permission
+    When I withdraw the publication with the explanation "Policy change"
+    Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
+    And the withdrawal date should be today
+
+  Scenario: Withdraw a document that is no longer current with preview second release permission
+    Given a published publication "Shaving kits for all" exists
+    And I have the "Preview second release" permission
     When I withdraw the publication with the explanation "Policy change"
     Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
     And the withdrawal date should be today
@@ -72,6 +92,16 @@ Feature: Unpublishing published documents
   Scenario: Withdraw a document using a previous withdrawal date & explanation with design system permission
     Given a published publication "Free ice creams" exists
     And I have the "Preview design system" permission
+    And the publication was withdrawn on 01/12/2020 with the explanation "It's too cold for ice cream"
+    And it was subsequently unwithdrawn
+    When I go to withdraw the publication again
+    And I choose to reuse the withdrawal from 01/12/2020
+    Then there should be an unpublishing explanation of "It's too cold for ice cream" and a reason of "No longer current government policy/activity"
+    And the withdrawal date should be 01/12/2020
+
+  Scenario: Withdraw a document using a previous withdrawal date & explanation with preview second release permission
+    Given a published publication "Free ice creams" exists
+    And I have the "Preview second release" permission
     And the publication was withdrawn on 01/12/2020 with the explanation "It's too cold for ice cream"
     And it was subsequently unwithdrawn
     When I go to withdraw the publication again

--- a/features/unwithdrawing-withdrawn-documents.feature
+++ b/features/unwithdrawing-withdrawn-documents.feature
@@ -17,3 +17,11 @@ Feature: Unpublishing published documents
     When I withdraw the publication with the explanation "Policy change"
     And I unwithdraw the publication
     Then I should be redirected to the latest edition of the publication
+
+  Scenario: Unwithdrawing a withdrawn document with second release permission
+    Given I am a managing editor
+    And I have the "Preview second release" permission
+    And a published publication "Shaving kits for all" exists
+    When I withdraw the publication with the explanation "Policy change"
+    And I unwithdraw the publication
+    Then I should be redirected to the latest edition of the publication

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -179,6 +179,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_remove_edit_tabs?
   end
 
+  test "cannot preview second release by default" do
+    user = build(:user)
+    assert_not user.can_preview_second_release?
+  end
+
+  test "can preview second release if given permission" do
+    user = build(:user, permissions: [User::Permissions::PREVIEW_SECOND_RELEASE])
+    assert user.can_preview_second_release?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description

There's a need on content to be able to view changes that are going out in the second release so that the guidance can be kept up to date.

This PR adds in a "Preview second release" permission and ensures that users can see the taxonomy and unpublish/withdraw flow if they have it, but no other Design System changes.

If you want to test it the branch is live on Int and i've created the permission.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
