### PR TITLE
Move edit translation page to the GOVUK Design System

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition-translations.scss
+++ b/app/assets/stylesheets/admin/views/_edition-translations.scss
@@ -1,0 +1,3 @@
+.edit_edition__english-content {
+  color: $govuk-secondary-text-colour;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 
 @import "./modules/unpublish-display-conditions";
 
+@import "./admin/views/edition-translations";
 @import "./admin/views/whats-new";
 @import "./admin/views/edit-edition";
 

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -7,9 +7,18 @@ class Admin::EditionTranslationsController < Admin::BaseController
     render "legacy_new" unless preview_design_system_user?
   end
 
+  def edit
+    render "edit_legacy" unless preview_design_system_user?
+  end
+
   def update
     @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
-    super
+    if translatable_item.update(translation_params)
+      save_draft_translation if send_downstream?
+      redirect_to update_redirect_path, notice: notice_message("saved")
+    else
+      render action: preview_design_system_user? ? "edit" : "edit_legacy"
+    end
   end
 
 private
@@ -18,7 +27,7 @@ private
     return "admin" unless preview_design_system_user?
 
     case action_name
-    when "new"
+    when "edit", "update", "new"
       "design_system"
     else
       "admin"

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -1,67 +1,70 @@
-<% page_title "Edit translation for: #{@edition.title}" %>
+<% content_for :context, @edition.title %>
+<% content_for :error_summary, render('shared/error_summary', object: @edition, parent_class: "edition", class_name: @edition.format_name) %>
+<% content_for :page_title, "Edit translation for: #{@edition.title}" %>
+<% content_for :title, "#{@translation_locale.native_language_name} (#{@translation_locale.english_language_name}) translation" %>
 
-<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @edition.title %></h1>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition)
+  } %>
+<% end %>
 
-<div class="row">
-  <div class="col-md-8">
-    <section>
-      <%= form_for @translated_edition, as: :edition, url: admin_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
-        <%= form.errors %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @translated_edition, as: :edition, url: admin_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
 
-        <%= form.translated_text_field :title unless @translated_edition.is_a? CorporateInformationPage %>
-        <%= form.translated_text_area :summary, rows: 2, cols: 40 %>
-        <%= form.translated_text_area :body, rows: 20 %>
+      <% unless @edition.is_a?(CorporateInformationPage) %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Translated title (required)",
+          },
+          name: "edition[title]",
+          id: "edition_title",
+          heading_level: 2,
+          heading_size: "l",
+          value: @translated_edition.title,
+          error_items: errors_for(form.object.errors, :title),
+        } %>
 
-        <%= form.save_or_cancel %>
+        <h3 class="govuk-heading-m">English title content:</h2>
+        <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.title %></p>
       <% end %>
-    </section>
-  </div>
-  <div class="col-md-4">
-    <% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
-      <div class="govspeak_help" id="govspeak_help">
-        <%= render partial: "admin/editions/govspeak_help",
-                   locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
-      </div>
-    <% else %>
-      <%= sidebar_tabs edition_tabs(
-        @edition,
-        remarks_count: @document_remarks.total_count,
-        history_count: @document_history.total_count,
-        editing: true,
-      ) do |tabs| %>
 
-        <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
-          <%= render partial: "admin/editions/govspeak_help",
-                     locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
-        <% end %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
+        },
+        name: "edition[summary]",
+        id: "edition_summary",
+        heading_level: 2,
+        heading_size: "l",
+        value: @translated_edition.summary,
+        rows: 2,
+        error_items: errors_for(form.object.errors, :summary),
+      } %>
 
-        <%= tabs.pane class: "audit-trail", id: "notes" do %>
-          <h1>Notes</h1>
-          <p>To add a remark, save your changes.</p>
-          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
-          <%= render_editorial_remarks(@document_remarks, @edition) %>
-          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
-        <% end %>
+      <h3 class="govuk-heading-m">English summary content:</h2>
+      <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.summary %></p>
 
-        <%= tabs.pane class: "audit-trail", id: "history" do %>
-          <div class="audit-trail-page">
-            <h1>Activity</h1>
-            <%= paginate @document_history.query, theme: 'audit_trail' %>
-            <ul class="list-unstyled">
-              <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
-            </ul>
-            <%= paginate @document_history.query, theme: 'audit_trail' %>
-          </div>
-        <% end %>
-          <% if @edition.can_be_fact_checked? %>
-            <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
-              <h1>Fact checking</h1>
-              <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
-              <p>To send a fact check request, save your changes.</p>
-            <% end %>
-          <% end %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Translated body (required)",
+        },
+        name: "edition[body]",
+        id: "edition_body",
+        heading_level: 2,
+        heading_size: "l",
+        value: @translated_edition.body,
+        rows: 20,
+        error_items: errors_for(form.object.errors, :body),
+      } %>
+
+      <h3 class="govuk-heading-m">English body content:</h2>
+        <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.body %></p>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <section class="govuk-grid-column-two-thirds">
     <%= form_for @translated_edition, as: :edition, url: admin_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
 
       <% unless @edition.is_a?(CorporateInformationPage) %>
@@ -26,45 +26,90 @@
           error_items: errors_for(form.object.errors, :title),
         } %>
 
-        <h3 class="govuk-heading-m">English title content:</h2>
-        <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.title %></p>
+        <h3 class="edit_edition__english-content govuk-heading-m govuk-!-margin-bottom-2">English title content:</h3>
+        <p class="edit_edition__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.title %></p>
       <% end %>
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
+          heading_size: "l",
           text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
         },
         name: "edition[summary]",
         id: "edition_summary",
-        heading_level: 2,
-        heading_size: "l",
         value: @translated_edition.summary,
         rows: 2,
         error_items: errors_for(form.object.errors, :summary),
       } %>
 
-      <h3 class="govuk-heading-m">English summary content:</h2>
-      <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.summary %></p>
+      <h3 class="edit_edition__english-content govuk-heading-m govuk-!-margin-bottom-2">English summary content:</h3>
+      <p class="edit_edition__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.summary %></p>
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
+          heading_size: "l",
           text: "Translated body (required)",
         },
         name: "edition[body]",
         id: "edition_body",
-        heading_level: 2,
-        heading_size: "l",
         value: @translated_edition.body,
         rows: 20,
         error_items: errors_for(form.object.errors, :body),
       } %>
 
-      <h3 class="govuk-heading-m">English body content:</h2>
-        <p class="govuk-body govuk-!-margin-bottom-8"><%= @edition.body %></p>
+      <h3 class="edit_edition__english-content govuk-heading-m govuk-!-margin-bottom-2">English body content:</h3>
+      <p class="edit_edition__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.body %></p>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Save"
       } %>
     <% end %>
-  </div>
+  </section>
+
+  <% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
+    <div class="govspeak_help" id="govspeak_help">
+      <%= render partial: "admin/editions/govspeak_help",
+                 locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+    </div>
+  <% else %>
+    <%= sidebar_tabs edition_tabs(
+      @edition,
+      remarks_count: @document_remarks.total_count,
+      history_count: @document_history.total_count,
+      editing: true,
+    ) do |tabs| %>
+
+      <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+        <%= render partial: "admin/editions/govspeak_help",
+                   locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+      <% end %>
+
+      <%= tabs.pane class: "audit-trail", id: "notes" do %>
+        <h1>Notes</h1>
+        <p>To add a remark, save your changes.</p>
+        <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+        <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+        <%= render_editorial_remarks(@document_remarks, @edition) %>
+        <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+      <% end %>
+
+      <%= tabs.pane class: "audit-trail", id: "history" do %>
+        <div class="audit-trail-page">
+          <h1>Activity</h1>
+          <%= paginate @document_history.query, theme: 'audit_trail' %>
+          <ul class="list-unstyled">
+            <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
+          </ul>
+          <%= paginate @document_history.query, theme: 'audit_trail' %>
+        </div>
+      <% end %>
+        <% if @edition.can_be_fact_checked? %>
+          <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
+            <h1>Fact checking</h1>
+            <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
+            <p>To send a fact check request, save your changes.</p>
+          <% end %>
+        <% end %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/admin/edition_translations/edit_legacy.html.erb
+++ b/app/views/admin/edition_translations/edit_legacy.html.erb
@@ -1,0 +1,67 @@
+<% page_title "Edit translation for: #{@edition.title}" %>
+
+<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @edition.title %></h1>
+
+<div class="row">
+  <div class="col-md-8">
+    <section>
+      <%= form_for @translated_edition, as: :edition, url: admin_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
+        <%= form.errors %>
+
+        <%= form.translated_text_field :title unless @translated_edition.is_a? CorporateInformationPage %>
+        <%= form.translated_text_area :summary, rows: 2, cols: 40 %>
+        <%= form.translated_text_area :body, rows: 20 %>
+
+        <%= form.save_or_cancel %>
+      <% end %>
+    </section>
+  </div>
+  <div class="col-md-4">
+    <% if current_user.can_view_move_tabs_to_endpoints? && !@edition.is_a?(CorporateInformationPage) %>
+      <div class="govspeak_help" id="govspeak_help">
+        <%= render partial: "admin/editions/govspeak_help",
+                   locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+      </div>
+    <% else %>
+      <%= sidebar_tabs edition_tabs(
+        @edition,
+        remarks_count: @document_remarks.total_count,
+        history_count: @document_history.total_count,
+        editing: true,
+      ) do |tabs| %>
+
+        <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+          <%= render partial: "admin/editions/govspeak_help",
+                     locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+        <% end %>
+
+        <%= tabs.pane class: "audit-trail", id: "notes" do %>
+          <h1>Notes</h1>
+          <p>To add a remark, save your changes.</p>
+          <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+          <%= render_editorial_remarks(@document_remarks, @edition) %>
+          <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
+        <% end %>
+
+        <%= tabs.pane class: "audit-trail", id: "history" do %>
+          <div class="audit-trail-page">
+            <h1>Activity</h1>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
+            <ul class="list-unstyled">
+              <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
+            </ul>
+            <%= paginate @document_history.query, theme: 'audit_trail' %>
+          </div>
+        <% end %>
+          <% if @edition.can_be_fact_checked? %>
+            <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
+              <h1>Fact checking</h1>
+              <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
+              <p>To send a fact check request, save your changes.</p>
+            <% end %>
+          <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -47,13 +47,15 @@ When(/^I translate the "([^"]*)" corporate information page for the worldwide or
   if @user.can_preview_design_system?
     select "Français", from: "Choose language"
     click_button "Next"
+    fill_in "Translated summary", with: "Le summary"
+    fill_in "Translated body (required)", with: "Le body"
   else
     select "Français", from: "Locale"
     click_button "Add translation"
+    fill_in "Summary", with: "Le summary"
+    fill_in "Body", with: "Le body"
   end
 
-  fill_in "Summary", with: "Le summary"
-  fill_in "Body", with: "Le body"
   click_on "Save"
 end
 

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -40,9 +40,15 @@ When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |fre
     click_button "Add translation"
   end
 
-  fill_in "Title", with: french_title
-  fill_in "Summary", with: "French summary"
-  fill_in "Body", with: "French body"
+  if @user.can_preview_design_system?
+    fill_in "Translated title (required)", with: french_title
+    fill_in "Translated summary (required)", with: "French summary"
+    fill_in "Translated body (required)", with: "French body"
+  else
+    fill_in "Title", with: french_title
+    fill_in "Summary", with: "French summary"
+    fill_in "Body", with: "French body"
+  end
   click_button "Save"
 end
 

--- a/features/translated-content.feature
+++ b/features/translated-content.feature
@@ -14,6 +14,13 @@ Feature: Providing translated content from gov.uk/government
     When I add a french translation "Échange officier de l'armée" to the "Military officer exchange" document
     Then I should see on the admin edition page that "Military officer exchange" has a french translation "Échange officier de l'armée"
 
+  Scenario: Adding a translation to a draft translatable document with design system permission
+    Given I am a GDS editor
+    And I have drafted a translatable document "Military officer exchange"
+    And I have the "Preview design system" permission
+    When I add a french translation "Échange officier de l'armée" to the "Military officer exchange" document
+    Then I should see on the admin edition page that "Military officer exchange" has a french translation "Échange officier de l'armée"
+
   Scenario: Adding a translation for contact details
     Given I am a GDS editor
     And the organisation "Wales Office" is translated into Welsh and has a contact "Wales Office, Cardiff"

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -107,3 +107,11 @@ Feature: Administering worldwide organisation
     When I translate the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     Then I should be able to read the translated "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France" on the site
+
+  Scenario: Translating a corporate information page for a worldwide organisation with design system permission
+    Given a worldwide organisation "Department of Beards in France"
+    And I have the "Preview design system" permission
+    And I add a "Terms of reference" corporate information page to the worldwide organisation
+    When I translate the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
+    And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
+    Then I should be able to read the translated "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France" on the site


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

### What
[Move the unwithdraw page to the GOVUK design system layout.
](https://trello.com/c/2hK1jDBA/714-move-edit-translation-page-to-the-govuk-design-system)
### Why
This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

### Screenshots
![Screenshot 2022-09-23 at 16 45 02](https://user-images.githubusercontent.com/9594455/192003372-cf6589f8-fb7e-4cab-9505-cdd0cb65d7ad.png)
![Screenshot 2022-09-23 at 16 45 08](https://user-images.githubusercontent.com/9594455/192003381-075a0e23-00dd-43df-b2e1-64f356bdf9e2.png)
![Screenshot 2022-09-23 at 16 45 10](https://user-images.githubusercontent.com/9594455/192003389-0b5726c8-f90e-4499-9bef-48f13e75067b.png)
![whitehall-admin dev gov uk_government_admin_editions_1_translations_de_edit(iPhone 12 Pro) (2)](https://user-images.githubusercontent.com/9594455/192003458-78e99fc0-2b3a-46a2-b15c-2679661a4abb.png)

### Before
![Screenshot 2022-09-23 at 16 45 52](https://user-images.githubusercontent.com/9594455/192003531-ed2586e1-3a74-4ef5-a1f3-5a191c59bf18.png)
![Screenshot 2022-09-23 at 16 45 55](https://user-images.githubusercontent.com/9594455/192003540-635c5d25-b94c-4f6b-b4b4-6c654f9bc8b4.png)
![Screenshot 2022-09-23 at 16 45 56](https://user-images.githubusercontent.com/9594455/192003551-cd9e2270-3e95-48b6-a7b0-b9beb7e955b2.png)
![whitehall-admin dev gov uk_government_admin_editions_1_translations_de_edit(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/9594455/192003575-9ec82b4d-9f49-4cad-b127-96edd3c6d0c2.png)
