### PR TITLE
Move Confirm discard page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -210,7 +210,7 @@ private
     return "admin" unless preview_design_system_user?
 
     case action_name
-    when "edit", "update", "new", "create"
+    when "edit", "update", "new", "create", "confirm_destroy"
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -181,7 +181,9 @@ class Admin::EditionsController < Admin::BaseController
     @audit_trail_entry = LocalisedModel.new(audit_trail_entry, audit_trail_entry.primary_locale)
   end
 
-  def confirm_destroy; end
+  def confirm_destroy
+    render :confirm_destroy_legacy unless preview_design_system_user?
+  end
 
   def destroy
     edition_deleter = Whitehall.edition_services.deleter(@edition)

--- a/app/views/admin/editions/confirm_destroy.html.erb
+++ b/app/views/admin/editions/confirm_destroy.html.erb
@@ -1,14 +1,24 @@
-<% page_title "Are you sure you want to discard #{@edition.title}?" %>
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Delete draft" %>
+<% content_for :title, "Delete draft" %>
+<% content_for :title_margin_bottom, 6 %>
 
-<span class="back">
-  <%= link_to 'Back', admin_edition_path(@edition) %>
-</span>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition)
+  } %>
+<% end %>
 
-<div class="row">
-  <div class="col-md-8">
-    <h1 class="add-bottom-margin">Are you sure you want to discard "<%= @edition.title %>"?</h1>
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
     <%= form_tag admin_edition_path(@edition), method: :delete do %>
-      <%= submit_tag 'Discard', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this draft?</p>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Delete",
+        destructive: true,
+        margin_bottom: 8,
+      } %>
     <% end %>
-  </div>
+  </section>
 </div>

--- a/app/views/admin/editions/confirm_destroy_legacy.html.erb
+++ b/app/views/admin/editions/confirm_destroy_legacy.html.erb
@@ -1,0 +1,14 @@
+<% page_title "Are you sure you want to discard #{@edition.title}?" %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<div class="row">
+  <div class="col-md-8">
+    <h1 class="add-bottom-margin">Are you sure you want to discard "<%= @edition.title %>"?</h1>
+    <%= form_tag admin_edition_path(@edition), method: :delete do %>
+      <%= submit_tag 'Discard', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+    <% end %>
+  </div>
+</div>

--- a/features/destroy-draft.feature
+++ b/features/destroy-draft.feature
@@ -1,0 +1,17 @@
+Feature: Discarding a draft of a document
+  As a writer
+  I can discard the draft of a document
+  So that the document will not appear in the list of draft documents
+
+  Scenario: Unwithdrawing a withdrawn document
+    Given I am a writer
+    When I draft a new publication "My Publication"
+    And I discard the draft publication
+    Then the publication is deleted
+
+  Scenario: Unwithdrawing a withdrawn document with design system permission
+    Given I am a writer
+    And I have the "Preview design system" permission
+    When I draft a new publication "My Publication"
+    And I discard the draft publication
+    Then the publication is deleted

--- a/features/step_definitions/destroy_draft_steps.rb
+++ b/features/step_definitions/destroy_draft_steps.rb
@@ -1,0 +1,16 @@
+When("I discard the draft publication") do
+  design_system_layout = @user.can_preview_design_system? || @user.can_preview_second_release?
+
+  @publication = Publication.last
+  visit confirm_destroy_admin_edition_path(@publication)
+  if design_system_layout
+    click_on "Delete"
+  else
+    click_on "Discard"
+  end
+end
+
+Then("the publication is deleted") do
+  @publication = Publication.last
+  expect(@publication).to be_nil
+end

--- a/features/support/publishing_api.rb
+++ b/features/support/publishing_api.rb
@@ -9,6 +9,7 @@ Before do
   )
 
   stub_request(:any, %r{\A#{publishing_api_v1_endpoint}})
+  GdsApi::PublishingApi.any_instance.stubs(:discard_draft)
   GdsApi::PublishingApi.any_instance.stubs(:publish)
   GdsApi::PublishingApi.any_instance.stubs(:put_content)
   GdsApi::PublishingApi.any_instance.stubs(:patch_links)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move the confirm destroy page to the GOVUK design system layout.

## Why

This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

## Screenshots

### After
![whitehall-admin dev gov uk_government_admin_editions_1_confirm_destroy(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/192320802-63a2f5d9-105a-4f3c-b0a7-7bc18e4b398e.png)
![whitehall-admin dev gov uk_government_admin_editions_1_confirm_destroy(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/192320817-7eba65e5-6024-425e-9565-a8d0595cd368.png)

### Before
![whitehall-admin dev gov uk_government_admin_editions_1_confirm_destroy(iPad Pro)](https://user-images.githubusercontent.com/9594455/192320871-7c87b8c2-aba0-4865-8e14-136a184fa198.png)
![whitehall-admin dev gov uk_government_admin_editions_1_confirm_destroy(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/9594455/192320889-976d0dbf-9ef7-4215-a17a-e68473e24bd3.png)
