### PR TITLE
Move Legacy redirect URLs pages to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/document_sources_controller.rb
+++ b/app/controllers/admin/document_sources_controller.rb
@@ -2,8 +2,11 @@ class Admin::DocumentSourcesController < Admin::BaseController
   before_action :require_import_permission!
   before_action :find_edition
   before_action :forbid_editing_of_locked_documents
+  layout :get_layout
 
-  def edit; end
+  def edit
+    render :edit_legacy unless preview_design_system_user?
+  end
 
   def update
     @document_sources = params[:document_sources]
@@ -19,5 +22,16 @@ private
 
   def find_edition
     @edition = Edition.find(params[:edition_id])
+  end
+
+  def get_layout
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "edit"
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/views/admin/document_sources/edit.html.erb
+++ b/app/views/admin/document_sources/edit.html.erb
@@ -1,4 +1,3 @@
-<% content_for :context, @edition.title %>
 <% content_for :page_title, "Edit legacy URL redirects" %>
 
 <% content_for :back_link do %>
@@ -9,6 +8,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @edition.title %></span>
     <%= form_tag admin_edition_document_sources_path(@edition), method: :patch do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {

--- a/app/views/admin/document_sources/edit.html.erb
+++ b/app/views/admin/document_sources/edit.html.erb
@@ -1,19 +1,31 @@
-<% page_title 'Edit legacy URL redirects' %>
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Edit legacy URL redirects" %>
 
-<span class="back">
-  <%= link_to 'Back', admin_edition_path(@edition) %>
-</span>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition)
+  } %>
+<% end %>
 
-<h1>Edit legacy URL redirects</h1>
-
-<div class="row">
-  <div class="col-md-8">
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
     <%= form_tag admin_edition_document_sources_path(@edition), method: :patch do %>
-      <p>Enter one URL per line.</p>
-      <div class="form-group">
-        <%= text_area_tag :document_sources, @edition.document.document_sources.map(&:url).join("\n"), rows: 20, class: 'form-control add-bottom-margin' %>
-        <%= submit_tag "Save", class: "btn btn-success" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
-      </div>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          is_page_heading: true,
+          heading_size: "xl",
+          text: "Edit legacy URL redirects"
+        },
+        hint: "Enter one URL per line.",
+        name: "document_sources",
+        id: "document_sources",
+        value: @edition.document.document_sources.map(&:url).join("\n"),
+        rows: 20
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: 8
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/document_sources/edit_legacy.html.erb
+++ b/app/views/admin/document_sources/edit_legacy.html.erb
@@ -1,0 +1,19 @@
+<% page_title 'Edit legacy URL redirects' %>
+
+<span class="back">
+  <%= link_to 'Back', admin_edition_path(@edition) %>
+</span>
+
+<h1>Edit legacy URL redirects</h1>
+
+<div class="row">
+  <div class="col-md-8">
+    <%= form_tag admin_edition_document_sources_path(@edition), method: :patch do %>
+      <p>Enter one URL per line.</p>
+      <div class="form-group">
+        <%= text_area_tag :document_sources, @edition.document.document_sources.map(&:url).join("\n"), rows: 20, class: 'form-control add-bottom-margin' %>
+        <%= submit_tag "Save", class: "btn btn-success" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/features/document-sources.feature
+++ b/features/document-sources.feature
@@ -19,6 +19,14 @@ Feature: Managing Document Sources
     And I view the publication "One must have many urls"
     Then I should see the legacy url "http://im-old.com"
 
+  Scenario: Creating a legacy URL with design system permission
+    Given a draft publication "One must have many urls" exists
+    And I have the "Preview design system" permission
+    When I add "http://im-old.com" as a legacy url to the "One must have many urls" publication
+    And I visit the list of draft documents
+    And I view the publication "One must have many urls"
+    Then I should see the legacy url "http://im-old.com"
+
   Scenario: Editing a legacy URL
     Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
     When I change the legacy url "http://im-old.com" to "http://im-really-old.com" on the "One must have many urls" publication
@@ -26,8 +34,24 @@ Feature: Managing Document Sources
     And I view the publication "One must have many urls"
     Then I should see the legacy url "http://im-really-old.com"
 
+  Scenario: Editing a legacy URL with design system permission
+    Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
+    And I have the "Preview design system" permission
+    When I change the legacy url "http://im-old.com" to "http://im-really-old.com" on the "One must have many urls" publication
+    And I visit the list of draft documents
+    And I view the publication "One must have many urls"
+    Then I should see the legacy url "http://im-really-old.com"
+
   Scenario: Removing a legacy URL
     Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
+    When I remove the legacy url "http://im-old.com" on the "One must have many urls" publication
+    And I visit the list of draft documents
+    And I view the publication "One must have many urls"
+    Then I should see that "http://im-old.com" has been removed
+
+  Scenario: Removing a legacy URL with design system permission
+    Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
+    And I have the "Preview design system" permission
     When I remove the legacy url "http://im-old.com" on the "One must have many urls" publication
     And I visit the list of draft documents
     And I view the publication "One must have many urls"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Move the legacy urls page to the GOVUK design system layout.

## Why

This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

## Screenshots

### After
![whitehall-admin dev gov uk_government_admin_editions_1_document-sources_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/192541663-0a93c836-d998-4e39-a389-804569a4bb11.png)
![whitehall-admin dev gov uk_government_admin_editions_1_document-sources_edit(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/192541678-48266104-3ab5-4778-81dc-2cf16f0b0295.png)

### Before
![whitehall-admin dev gov uk_government_admin_editions_1_document-sources_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/192538011-bac376f4-8757-4b9e-950a-280132e1728d.png)
![whitehall-admin dev gov uk_government_admin_editions_1_document-sources_edit(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/9594455/192538027-b4bffa40-4e4a-4873-97f9-b734b3c7eb88.png)
