### PR TITLE
Adds conditional reveal to "another website" checkbox

### DIFF
--- a/app/assets/javascripts/admin/edition_publishing.js
+++ b/app/assets/javascripts/admin/edition_publishing.js
@@ -74,6 +74,8 @@ jQuery(function ($) {
 })(jQuery);
 
 (function ($) {
+  var govukDesignSystemCheckbox = $('input#edition_external-0')
+
   var externalEdition = function () {
     if ($('input#edition_external').prop('checked')) {
       $('.js-external-url').show()
@@ -85,8 +87,10 @@ jQuery(function ($) {
     }
   }
 
-  $('input#edition_external').change(externalEdition)
-  externalEdition()
+  if (govukDesignSystemCheckbox.length < 1) {
+    $('input#edition_external').change(externalEdition)
+    externalEdition()
+  }
 })(jQuery);
 
 (function ($) {

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -432,6 +432,7 @@ private
     edition_params[:title].strip! if edition_params[:title]
     edition_params.delete(:primary_locale) if edition_params[:primary_locale].blank? || (preview_design_system_user? && edition_params[:create_foreign_language_only].blank?)
     edition_params.delete(:create_foreign_language_only)
+    edition_params[:external_url] = nil if edition_params[:external] == "0"
   end
 
   def clear_scheduled_publication_if_not_activated

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -15,6 +15,7 @@
       heading: "Held on another website",
       heading_level: 3,
       heading_size: "l",
+      no_hint_text: true,
       error_items: errors_for(edition.errors, :external),
       items: [
         {

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -16,7 +16,6 @@
       heading: "Held on another website",
       heading_level: 3,
       heading_size: "l",
-      hint_text: "",
       error_items: errors_for(edition.errors, :external),
       items: [
         {

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -6,13 +6,12 @@
 
 <%= standard_edition_form(edition, @information, preview_design_system: true) do |form| %>
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "",
+    legend_text: ""
   } do %>
     <%= form.hidden_field :external, value: "0" %>
 
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: "edition[external]",
-      id: "edition_external",
       heading: "Held on another website",
       heading_level: 3,
       heading_size: "l",

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -8,6 +8,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "",
   } do %>
+    <%= form.hidden_field :external, value: "0" %>
+
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: "edition[external]",
       id: "edition_external",

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -6,13 +6,15 @@
 
 <%= standard_edition_form(edition, @information, preview_design_system: true) do |form| %>
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Held on another website",
-    heading_level: 3,
-    heading_size: "l"
+    legend_text: "",
   } do %>
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: "edition[external]",
       id: "edition_external",
+      heading: "Held on another website",
+      heading_level: 3,
+      heading_size: "l",
+      hint_text: "",
       error_items: errors_for(edition.errors, :external),
       items: [
         {
@@ -20,22 +22,19 @@
           value: 1,
           checked: edition.external,
           bold: true,
+          conditional: render("govuk_publishing_components/components/input", {
+            label: {
+              text: "External link URL",
+              bold: true,
+            },
+            name: "edition[external_url]",
+            id: "edition_external_url",
+            value: edition.external_url,
+            error_items: errors_for(edition.errors, :external_url)
+          })
         }
       ]
     } %>
-
-    <div class="js-external-url">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "External link URL",
-          bold: true,
-        },
-        name: "edition[external_url]",
-        id: "edition_external_url",
-        value: edition.external_url,
-        error_items: errors_for(edition.errors, :external_url),
-      } %>
-    </div>
   <% end %>
 
   <div class="js-external-url-set">

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -64,6 +64,29 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     assert response_form.consultation_response_form_data.file.present?
   end
 
+  test "create should not persist external_url if the external checkbox is not checked" do
+    attributes = controller_attributes_for(
+      :consultation,
+      external: "0",
+      external_url: "http://participation.com",
+      consultation_participation_attributes: {
+        link_url: "http://participation.com",
+        email: "countmein@participation.com",
+        consultation_response_form_attributes: {
+          title: "the title of the response form",
+          consultation_response_form_data_attributes: {
+            file: upload_fixture("two-pages.pdf"),
+          },
+        },
+      },
+    )
+
+    post :create, params: { edition: attributes }
+
+    consultation = Consultation.last
+    assert consultation.external_url.blank?
+  end
+
   test "create should create a new consultation without consultation participation if participation fields are all blank" do
     attributes = controller_attributes_for(
       :consultation,


### PR DESCRIPTION
[Trello card](https://trello.com/c/OoA1ipPB/773-bug-missing-conditional-external-url-input-on-held-on-another-website-field)

This change restores a conditional input on the "Edit consultation" page which permanently hidden after porting to the Design System. This led to the user receiving an error message ("External URL can't be blank") if they checked the checkbox but they had no option to provide a value for the URL.

| Before | After |
| --- | --- |
| ![Screenshot 2022-09-27 at 15 45 43](https://user-images.githubusercontent.com/6080548/192558816-c7cd5be7-8831-4977-90ce-ecd464c3453d.png) | ![Screenshot 2022-09-27 at 15 44 36](https://user-images.githubusercontent.com/6080548/192558481-53ca5411-1213-40a1-8072-a4c4399f6b50.png) |

