### PR TITLE
Remove duplicate error messages from the Edit Edition page

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -98,7 +98,7 @@ class Admin::EditionsController < Admin::BaseController
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
       flash.now[:alert] = "There are some problems with the document" unless preview_design_system_user?
-      @information = updater.failure_reason
+      @information = updater.failure_reason unless preview_design_system_user?
       build_edition_dependencies
       render(preview_design_system_user? ? :new : :new_legacy)
     end
@@ -127,7 +127,7 @@ class Admin::EditionsController < Admin::BaseController
       if speed_tagging?
         render :show
       else
-        @information = updater.failure_reason
+        @information = updater.failure_reason unless preview_design_system_user?
         build_edition_dependencies
         fetch_version_and_remark_trails
         construct_similar_slug_warning_error

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -129,7 +129,6 @@ module Admin::EditionsHelper
     initialise_script "GOVUK.adminEditionsForm", selector: ".js-edition-form", right_to_left_locales: Locale.right_to_left.collect(&:to_param)
     if preview_design_system
       form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition) } do |form|
-        concat edition_information(information) if information
         concat render("standard_fields", form:, edition:)
         yield(form)
         concat render("legacy_access_limiting_fields", form:, edition:)

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -341,56 +341,6 @@ module AdminEditionControllerTestHelpers
               },
             }
       end
-
-      view_test "reports an error if the updater has an error on create" do
-        draft_updater = stub(
-          "draft updater",
-          can_perform?: false,
-          perform!: false,
-          failure_reason: "Unable to perform draft update",
-        )
-
-        Whitehall.edition_services.stubs(:draft_updater).returns(draft_updater)
-
-        attributes = controller_attributes_for(edition_type)
-
-        assert_difference "Edition.count", 0 do
-          post :create,
-               params: {
-                 edition: attributes.merge(
-                   summary: "my summary",
-                 ),
-               }
-        end
-
-        assert_template "editions/new"
-        assert_select ".alert", text: /Unable to perform draft update/
-      end
-
-      view_test "reports an error if the updater has an error on update" do
-        edition = create("draft_#{edition_type}", title: "Original title")
-
-        draft_updater = stub(
-          "draft updater",
-          can_perform?: false,
-          perform!: false,
-          failure_reason: "Unable to perform draft update",
-        )
-
-        Whitehall.edition_services.stubs(:draft_updater).returns(draft_updater)
-
-        put :update,
-            params: {
-              id: edition,
-              edition: {
-                title: "updated title",
-              },
-            }
-
-        assert_equal "Original title", edition.reload.title
-        assert_template "editions/edit"
-        assert_select ".alert", text: /Unable to perform draft update/
-      end
     end
 
     def should_allow_speed_tagging_of(edition_type)


### PR DESCRIPTION
## Description 

At the moment, when an object is passed to the draft updater to see if it can be passed downstream, it checks to see if the edition is in a draft state and if so, whether the object is valid.

```
def failure_reason
  if !edition.pre_publication?
    "A #{edition.state} edition may not be updated."
  elsif !edition.valid?
    "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
  end
end
```

This is then set as a variable in the controller

```
@information = updater.failure_reason
```

and then passed into the `standard_edition_form` method and concatonated into the template

```
concat edition_information(information) if information
```

As we now handle errors in via the summary component, we no longer need this functionality.

Originally i thought that there might be an issue with the "A #{edition.state} edition may not be updated." not showing, but this before_action handles it anyway and redirects to the summary page.

```
before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
```

```
def prevent_modification_of_unmodifiable_edition
  if @edition.unmodifiable?
    notice = "You cannot modify a #{@edition.state} #{@edition.type.titleize}"
    redirect_to admin_edition_path(@edition), notice:
  end
end
```

This means we can just remove the @information functionality all together in the GOV.UK Design System implementation

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/42515961/192753878-7e2a9fef-941b-465e-84a9-f75d0a9b0890.png)

### After 

<img width="857" alt="image" src="https://user-images.githubusercontent.com/42515961/192754363-226a399a-cf66-49ce-a7d5-1e57e7fd6a70.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
