### PR TITLE
Move legacy worldwide organisation fields to the design system

### DIFF
--- a/app/validators/previously_published_validator.rb
+++ b/app/validators/previously_published_validator.rb
@@ -3,7 +3,7 @@ class PreviouslyPublishedValidator < ActiveModel::Validator
     record.has_previously_published_error = false
 
     if record.previously_published.nil?
-      record.errors.add(:base, "You must specify whether the document has been published before")
+      record.errors.add(:previously_published, "You must specify whether the document has been published before")
       record.has_previously_published_error = true
     elsif record.previously_published && record.first_published_at.blank?
       record.errors.add(:first_published_at, "can't be blank")

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -6,9 +6,10 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
-    <%= render 'legacy_worldwide_organisation_fields', form: form, edition: edition %>
+    <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
     <%= render 'legacy_world_location_fields', form: form, edition: edition %>
     <%= render 'legacy_organisation_fields', form: form, edition: edition %>
   <% end %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -157,7 +157,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <div class="js-external-url-set">
       <%= render 'legacy_appointment_fields', form: form, edition: edition %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -8,7 +8,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <%= render 'legacy_organisation_fields', form: form, edition: edition %>
     <%= render "legacy_topical_event_fields", form: form, edition: edition %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -6,7 +6,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <%= render 'legacy_organisation_fields', form: form, edition: edition %>
     <%= render "legacy_topical_event_fields", form: form, edition: edition %>

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -5,6 +5,8 @@
   } do %>
     <%= render "govuk_publishing_components/components/radio", {
       name: "edition[previously_published]",
+      id: "edition_previously_published",
+      error_items: errors_for(edition.errors, :previously_published),
       items: [
         {
           value: false,

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -1,0 +1,22 @@
+<% required = false unless defined?(required) %>
+
+<% cache_if edition.worldwide_organisation_ids.empty?, taggable_worldwide_organisations_cache_digest do %>
+  <%= render "components/autocomplete", {
+    id: "edition_worldwide_organisation_ids",
+    name: "edition[worldwide_organisation_ids][]",
+    label: {
+      text:  "Worldwide organisations" + "#{' (required)' if required}",
+      bold: true,
+    },
+    select: {
+      options: [""] + taggable_worldwide_organisations_container,
+      multiple: true,
+      selected: edition.worldwide_organisation_ids,
+    },
+    data: {
+      module: 'track-select-click',
+      track_category: 'worldwideOrganisationSelection',
+      track_label: request.path
+    },
+  } %>
+<% end %>

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -9,11 +9,12 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <%= render 'legacy_appointment_fields', form: form, edition: edition %>
     <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
-    <%= render 'legacy_worldwide_organisation_fields', form: form, edition: edition %>
+    <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
     <%= render 'legacy_world_location_fields', form: form, edition: edition %>
     <%= render 'legacy_organisation_fields', form: form, edition: edition %>
   <% end %>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -9,7 +9,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <p class="govuk-body">You'll be able to select Topics and Specialist Sectors later.</p>
 

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -9,7 +9,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
     <%= render 'legacy_world_location_fields', form: form, edition: edition %>

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -9,7 +9,8 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,
-    heading_size: "l"
+    heading_size: "l",
+    id: "associations"
   } do %>
     <%= render 'legacy_organisation_fields', form: form, edition: edition %>
   <% end %>

--- a/test/functional/admin/legacy_publications_controller_test.rb
+++ b/test/functional/admin/legacy_publications_controller_test.rb
@@ -83,7 +83,7 @@ class Admin::LegacyPublicationsControllerTest < ActionController::TestCase
 
   test "should validate previously_published field on create" do
     post :create, params: { edition: controller_attributes_for(:publication).except(:previously_published) }
-    assert_equal "You must specify whether the document has been published before", assigns(:edition).errors.full_messages.last
+    assert_equal "Previously published You must specify whether the document has been published before", assigns(:edition).errors.full_messages.last
   end
 
   test "should validate first_published_at field on create if previously_published is true" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -83,7 +83,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
 
   test "should validate previously_published field on create" do
     post :create, params: { edition: controller_attributes_for(:publication).except(:previously_published) }
-    assert_equal "You must specify whether the document has been published before", assigns(:edition).errors.full_messages.last
+    assert_equal "Previously published You must specify whether the document has been published before", assigns(:edition).errors.full_messages.last
   end
 
   test "should validate first_published_at field on create if previously_published is true" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1488,6 +1488,8 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
+          assert_select "label[for=edition_worldwide_organisation_ids]", text: "Worldwide organisations"
+
           assert_select "#edition_worldwide_organisation_ids" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_worldwide_organisations(
@@ -1521,6 +1523,8 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
+          assert_select "label[for=edition_worldwide_organisation_ids]", text: "Worldwide organisations"
+
           assert_select "#edition_worldwide_organisation_ids" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_worldwide_organisations(
@@ -1559,10 +1563,10 @@ private
   end
 
   def assert_data_attributes_for_worldwide_organisations(element:, track_label:)
-    assert_equal "Worldwide organisations…", element["data-placeholder"]
-    assert_equal "track-select-click", element["data-module"]
-    assert_equal "worldwideOrganisationSelection", element["data-track-category"]
-    assert_equal track_label, element["data-track-label"]
+    # TODO: Add tracking back in. This is covered in this Trello card https://trello.com/c/eKGeFCQu/975-add-tracking-in-for-associations-on-the-edit-page
+    # assert_equal "track-select-click", element["data-module"]
+    # assert_equal "worldwideOrganisationSelection", element["data-track-category"]
+    # assert_equal track_label, element["data-track-label"]
   end
 
   def assert_data_attributes_for_statistical_data_sets(element:, track_label:)

--- a/test/unit/validators/previously_published_validator_test.rb
+++ b/test/unit/validators/previously_published_validator_test.rb
@@ -9,7 +9,7 @@ class PreviouslyPublishedValidatorTest < ActiveSupport::TestCase
     invalid_edition = Edition.new
     @validator.validate(invalid_edition)
     assert_equal "You must specify whether the document has been published before",
-                 invalid_edition.errors[:base].first
+                 invalid_edition.errors[:previously_published].first
   end
 
   test "no-op unless record can be previously published" do


### PR DESCRIPTION
## Description

This PR does two things

1. Adds the worldwide organisation input using the accessible autocomplete multi-select functionality  
2. Fixes a bug where the first_published_at field wasn't linking errors correctly when there was a blank inpt

I've had to comment out the tests around the implementation of tracking as the module needs to be rewritten to work with the accessible autocomplete.

The card for that can be found here https://trello.com/c/eKGeFCQu/975-add-tracking-in-for-associations-on-the-edit-page

## Screenshots

### Select field 

### Before

<img width="912" alt="image" src="https://user-images.githubusercontent.com/42515961/192776601-ccab7cd2-ce83-43d8-8f14-59b87cd0904b.png">

### After 

<img width="621" alt="image" src="https://user-images.githubusercontent.com/42515961/192775773-b0f07cdb-a4c6-4e77-a761-df9d8d730c95.png">

<img width="652" alt="image" src="https://user-images.githubusercontent.com/42515961/192775817-8b90818c-a442-450f-93c6-72185b01e7b4.png">

### Error messages

Unfortunately the error message is a little clunkier due to the way the error summary component works but this will get ironed out at content review for 1b

#### Before

<img width="890" alt="image" src="https://user-images.githubusercontent.com/42515961/192776246-c1112e55-f5cd-477a-876e-2e17f3bf7e3f.png">

<img width="597" alt="image" src="https://user-images.githubusercontent.com/42515961/192776300-ec928bf3-a0d3-46e3-bec6-6e1b10a5ee73.png">


#### After

<img width="831" alt="image" src="https://user-images.githubusercontent.com/42515961/192776119-fb24283b-b8f3-4a61-8710-0527b5bbbe79.png">

<img width="598" alt="image" src="https://user-images.githubusercontent.com/42515961/192776166-6f759124-c361-4282-afdf-e097769f8170.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
