### PR TITLE
Add confirm delete page for attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -65,6 +65,8 @@ class Admin::AttachmentsController < Admin::BaseController
     end
   end
 
+  def confirm_destroy; end
+
   def destroy
     attachment_data = attachment.attachment_data
     attachment.destroy!
@@ -88,7 +90,7 @@ private
     return "admin" unless preview_design_system_user?
 
     case action_name
-    when "edit", "update", "new", "create"
+    when "edit", "update", "new", "create", "confirm_destroy"
       "design_system"
     else
       "admin"

--- a/app/views/admin/attachments/confirm_destroy.html.erb
+++ b/app/views/admin/attachments/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :context, attachment.title %>
+<% content_for :page_title, "Delete attachment" %>
+<% content_for :title, "Delete attachment" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: attachable_attachments_path(attachable)
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this attachment?</p>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Delete attachment",
+        destructive: true,
+        margin_bottom: 8,
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,6 +313,7 @@ Whitehall::Application.routes.draw do
           resources :attachments, except: [:show] do
             put :order, on: :collection
             put :update_many, on: :collection, constraints: { format: "json" }
+            get :confirm_destroy, on: :member
           end
           resources :bulk_uploads, except: %i[show edit update] do
             post :upload_zip, on: :collection


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Introduce confirm delete page for attachments using the new design system.](https://trello.com/c/gCDiXR7n/636-add-confirm-delete-page-for-attachments)
The PR does not use the confirm delete page or introduce a bootstrap version of the page - the old attachment index page can continue to use a modal.

## Why

The new design system does not use modals. Currently confirmation that an attachment should be deleted is performed using a modal. This PR introduces a new page to be linked to in the new list of attachments.

## Screenshots

![whitehall-admin dev gov uk_government_admin_editions_1_attachments_2_confirm_destroy(iPad Pro)](https://user-images.githubusercontent.com/9594455/192792106-9911f0a0-08b9-436f-ac93-17be1fdaa782.png)
![whitehall-admin dev gov uk_government_admin_editions_1_attachments_2_confirm_destroy(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/192792112-a3026288-b8ce-43d9-a0ef-bca3329b3dc6.png)
