### PR TITLE
[PROTOTYPE] Spike: merging History & Notes pages

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -199,7 +199,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def history
-    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    @timeline = Document::PaginatedTimeline.new(document: @edition.document, page: params.fetch(:page, 1))
   end
 
 private

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -154,4 +154,19 @@ Please tell us:
 
     link_to native_language_name_for(locale), options, lang: locale, class: "govuk-link"
   end
+
+  def render_timeline(timeline)
+    list_items = timeline.entries.map do |entry|
+      case entry
+      when EditorialRemark
+        render partial: "admin/editions/remark_entry", locals: { remark: entry }
+      when Document::PaginatedHistory::AuditTrailEntry
+        render partial: "admin/editions/audit_trail_entry", locals: { audit_trail_entry: entry }
+      end
+    end
+
+    tag.ul(class: "list-unstyled") do
+      list_items.join.html_safe
+    end
+  end
 end

--- a/app/models/document/paginated_timeline.rb
+++ b/app/models/document/paginated_timeline.rb
@@ -1,0 +1,97 @@
+class Document::PaginatedTimeline
+  PER_PAGE = 30
+
+  def initialize(document:, page:)
+    @document = document
+    @page = page.to_i
+  end
+
+  def entries
+    paginated_query.rows.map do |row|
+      model_name, id = row
+
+      case model_name
+      when "Version"
+        version = versions.find(id)
+        Document::PaginatedHistory::AuditTrailEntry.new(
+          version,
+          is_first_edition: false,
+          previous_version: nil,
+        )
+      when "EditorialRemark"
+        remarks.find(id)
+      end
+    end
+  end
+
+  def total_count
+    @total_count ||= begin
+      sql = "SELECT COUNT(*) FROM (#{union_query}) x"
+      ApplicationRecord.connection.exec_query(sql).rows[0][0]
+    end
+  end
+
+  def total_pages
+    (total_count / PER_PAGE.to_f).ceil
+  end
+
+  def current_page
+    @page
+  end
+
+  def limit_value
+    PER_PAGE
+  end
+
+  def next_page
+    if current_page < total_pages
+      current_page + 1
+    else
+      false
+    end
+  end
+
+  def prev_page
+    if current_page > 1
+      current_page - 1
+    else
+      false
+    end
+  end
+
+private
+
+  def versions
+    @document.edition_versions
+  end
+
+  def remarks
+    @document.editorial_remarks
+  end
+
+  def union_query
+    common_fields = %i[id created_at]
+    versions_query = versions.select("'#{versions.class_name}' AS model_name", *common_fields)
+    remarks_query = remarks.select("'#{remarks.class_name}' AS model_name", *common_fields)
+
+    "(#{versions_query.to_sql}) UNION (#{remarks_query.to_sql})"
+  end
+
+  def paginated_query
+    sql = <<~SQL
+      #{union_query}
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    SQL
+
+    limit = PER_PAGE
+    offset = (@page - 1) * PER_PAGE
+
+    bind_params = [
+      ActiveRecord::Relation::QueryAttribute.new("", limit, ActiveRecord::Type::Integer.new),
+      ActiveRecord::Relation::QueryAttribute.new("", offset, ActiveRecord::Type::Integer.new),
+    ]
+
+    ApplicationRecord.connection.exec_query(sql, "SQL", bind_params)
+  end
+end

--- a/app/views/admin/editions/history.html.erb
+++ b/app/views/admin/editions/history.html.erb
@@ -9,11 +9,9 @@
     <div class="audit-trail-page">
       <h1>History</h1>
 
-      <%= paginate @document_history.query, theme: 'audit_trail' %>
-      <ul class="list-unstyled">
-        <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
-      </ul>
-      <%= paginate @document_history.query, theme: 'audit_trail' %>
+      <%= paginate @timeline, theme: 'audit_trail' %>
+      <%= render_timeline @timeline %>
+      <%= paginate @timeline, theme: 'audit_trail' %>
     </div>
   </section>
 </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 default: &default
   encoding: utf8
   adapter: mysql2
+  prepared_statements: true
   variables:
     sql_mode: TRADITIONAL
 


### PR DESCRIPTION
This spike follows the 'wrapper' pattern established by [Document::PaginatedHistory] and [Document::PaginatedHistory]. This approach allows us to encapsulate a regular ActiveRecord query object, while providing custom objects as the result set for rendering to the view.

How to view it
==============

You need the "Preview design system" permission enabled so you can view the standalone 'History' page.

Example URL path: `/government/admin/editions/1350491/history`

<details>
<summary><strong>Screenshot (click to expand)</strong></summary>

![whitehall-admin dev gov uk_government_admin_editions_1350491_history_page=16 (2)](https://user-images.githubusercontent.com/7735945/192811165-167c1748-c257-4038-b5b4-bf1c7ab7bae7.png)

</details>

New concept: Document Timeline
==============================

This spike introduces a new concept called a Document ‘Timeline’ – this is a representation of the History (Versions) and Notes (Editorial Remarks) of a Document, combined into one chronological list.

How does the data get combined?
===============================

I've used a [union query] to merge the queries for `Document#edition_versions` and `Document#editorial_remarks` into one result set, sorted by creation date. This provides a single chronological timeline of ‘history’ and ‘note’ entries.

Union queries aren't natively supported by Active Record. While it's possible to [extend Active Record to support union queries][activerecord-union], that starts to make things more complicated than they really need to be. We have a very specific use case for union queries, so it seems simpler to perform the query manually rather than bending Active Record to support it.

Both queries need to return the same columns so they can be merged. So we return three fields that exist in both tables: id, created_at, and model_name (so we know which table the record came from). We include created_at so the list can be sorted chronologically.

Rendering in the view
=====================

When rendering these items to the view, we need more than just the three fields returned by the union query.

The `Document::Timeline#entries` method returns a list of 'proper' ActiveRecord objects for the current page of the timeline. These entries will either be `AuditTrailEntry` (History) objects or `EditorialRemark` (Note) objects. The view then uses existing partials to render each type of timeline entry.

Other things to note
====================

- The `render_timeline` helper is part of the Documents Helper, even though the Controller action exists in Editions. Should we settle on one place for this? Ideally it’d be modelled so that it belongs to either the Document or the Edition.
- `Document::PaginatedTimeline#entries` currently creates N+1 queries, one for each timeline item (version or remark) rendered on the page. This could (and should) be avoided with some extra work.
- I've enabled ‘prepared queries’ in the MySQL database adapter config. This allows us to safely escape parameters in SQL queries (avoiding SQL injection attacks). They’re currently disabled in Whitehall (which is the Rails default), but will be [enabled by default in Rails 7.2] so should be a non-controversial change.
- For now, I've hardcoded the `is_first_edition:, previous_version:` params on the `AuditTrailEntry` object. The `Document::PaginatedTimeline` will need to replicate some of the functionality of `Document::PaginatedHistory` so that these values are set correctly. These need to be provided so that `AuditTrailEntry#action` is determined correctly.
- I've not written any tests in this spike.

[Document::PaginatedHistory]: https://github.com/alphagov/whitehall/blob/1581ed3e28df111022cd22d57bc09c92fc0aefdb/app/models/document/paginated_history.rb
[Document::PaginatedRemarks]: https://github.com/alphagov/whitehall/blob/1581ed3e28df111022cd22d57bc09c92fc0aefdb/app/models/document/paginated_remarks.rb
[union query]: https://dev.mysql.com/doc/refman/8.0/en/union.html
[activerecord-union]: https://joshfrankel.me/blog/a-journey-into-writing-union-queries-with-active-record/
[enabled by default in Rails 7.2]: https://github.com/rails/rails/blob/c41e2f1bca65b51bccda7dd465d525071c66264f/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L172

---

Trello: https://trello.com/c/CccmjGTQ/750-techspike-into-combining-notes-history

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
