### PR TITLE
Move add/edit user needs page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -1,8 +1,11 @@
 class Admin::NeedsController < Admin::BaseController
   before_action :find_latest_edition
   before_action :forbid_editing_of_locked_documents
+  layout :get_layout
 
-  def edit; end
+  def edit
+    render(preview_design_system_user? ? "edit" : "edit_legacy")
+  end
 
   def update
     @document.need_ids = params[:need_ids] || []
@@ -12,6 +15,17 @@ class Admin::NeedsController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "edit"
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def find_latest_edition
     @document = Document.find_by(content_id: params[:content_id])

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -1,17 +1,32 @@
-<% page_title @edition.title, @edition.format_name %>
-<% page_class "edition-show" %>
-<% initialise_script "GOVUK.adminEditionShow" %>
+<% content_for :page_title, @edition.title %>
+<% content_for :title, "Associated user needs" %>
+<% content_for :context, @edition.title %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", href: admin_edition_path(@edition) %>
+<% end %>
 
-<div class="row">
-  <div class="<%= @edition.imported? ? "col-md-6" : "col-md-8" %> edition-metadata">
-    <h2>Associated user needs</h2>
-    <fieldset class="document-user-needs">
-      <%= form_tag admin_update_needs_path(content_id: @document.content_id), method: :patch do %>
-          <%= label_tag :need_ids, 'Select/deselect needs', required: true %>
-          <%= select_tag :need_ids, options_for_select(taggable_needs_container, @document.need_ids), multiple: true, class: 'chzn-select form-control', data: { placeholder: "Search Maslow user needs by title"} %>
-          <br/>
-          <%= submit_tag "Save needs", class: "btn btn-primary" %>
-      <% end %>
-    </fieldset>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">      
+    <%= form_tag admin_update_needs_path(content_id: @document.content_id), method: :patch do %>
+      <%= render "components/autocomplete", {
+          id: "need_ids",
+          name: "need_ids[]",
+          label: {
+            text: "Select associated user needs",
+            bold: true,
+            required: true,
+          },
+          heading_size: "l",
+          select: {
+            options: [""] + taggable_needs_container,
+            multiple: true,
+            selected: @document.need_ids,
+          },
+      } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save"
+        } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/needs/edit_legacy.html.erb
+++ b/app/views/admin/needs/edit_legacy.html.erb
@@ -1,0 +1,17 @@
+<% page_title @edition.title, @edition.format_name %>
+<% page_class "edition-show" %>
+<% initialise_script "GOVUK.adminEditionShow" %>
+
+<div class="row">
+  <div class="<%= @edition.imported? ? "col-md-6" : "col-md-8" %> edition-metadata">
+    <h2>Associated user needs</h2>
+    <fieldset class="document-user-needs">
+      <%= form_tag admin_update_needs_path(content_id: @document.content_id), method: :patch do %>
+          <%= label_tag :need_ids, 'Select/deselect needs', required: true %>
+          <%= select_tag :need_ids, options_for_select(taggable_needs_container, @document.need_ids), multiple: true, class: 'chzn-select form-control', data: { placeholder: "Search Maslow user needs by title"} %>
+          <br/>
+          <%= submit_tag "Save needs", class: "btn btn-primary" %>
+      <% end %>
+    </fieldset>
+  </div>
+</div>

--- a/features/edition-needs.feature
+++ b/features/edition-needs.feature
@@ -3,8 +3,20 @@ Feature: Managing needs on editions
   An editor
   Should be able to go to the Edit needs page
 
+  Background:
+    Given I am an editor
+
   Scenario: Adding and removing needs
     Given a submitted publication "Extended goatee for the modern man" with a PDF attachment
+    When I visit the list of documents awaiting review
+    And I view the publication "Extended goatee for the modern man"
+    And I start editing the needs from the publication page
+    And I choose the first need in the dropdown
+    Then I should see the first need in the list of associated needs
+
+  Scenario: Adding and removing needs with design system permission
+    Given I have the "Preview design system" permission
+    And a submitted publication "Extended goatee for the modern man" with a PDF attachment
     When I visit the list of documents awaiting review
     And I view the publication "Extended goatee for the modern man"
     And I start editing the needs from the publication page

--- a/features/step_definitions/needs_steps.rb
+++ b/features/step_definitions/needs_steps.rb
@@ -5,7 +5,7 @@ end
 When(/^I choose the first need in the dropdown$/) do
   option = first("#need_ids option").text
   select option, from: "need_ids"
-  click_button "Save needs"
+  click_button @user.can_preview_design_system? ? "Save" : "Save needs"
 end
 
 Then(/^I should see the first need in the list of associated needs$/) do


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/QcPxBlPV/615-move-add-edit-user-needs-page-to-the-govuk-design-system)
# What
This PR moves the add/edit user needs page over to the GOV.UK Design System. 

# Why
This is part of a Whitehall transition work to move from bootstrap to GOV.UK Design System.

# Screenshots
## Before
![whitehall-admin integration publishing service gov uk_government_admin_28c6532e-04ce-417a-8fe8-3033da90732c_needs(iPhone 12 Pro)](https://user-images.githubusercontent.com/94846816/192834239-2a4f63b3-18fc-4c18-871e-0ca558e1f2eb.png)
![whitehall-admin integration publishing service gov uk_government_admin_28c6532e-04ce-417a-8fe8-3033da90732c_needs(iPad Pro)](https://user-images.githubusercontent.com/94846816/192834259-b88e0646-a0fa-4710-92b0-449bee50be93.png)
## After
![whitehall-admin integration publishing service gov uk_government_admin_28c6532e-04ce-417a-8fe8-3033da90732c_needs(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/94846816/193559480-55e65215-9dc9-4649-b641-ddd90f7b35b0.png)
![whitehall-admin integration publishing service gov uk_government_admin_28c6532e-04ce-417a-8fe8-3033da90732c_needs(iPad Pro) (1)](https://user-images.githubusercontent.com/94846816/193559489-24f8a2d4-b8c2-4707-9dd2-522073f07873.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
