### PR TITLE
Add nations fields in the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -8,6 +8,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :find_edition, only: %i[show show_locked edit update revise diff confirm_destroy destroy update_bypass_id history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
+  before_action :build_national_exclusion_params, only: %i[create update]
   before_action :build_edition, only: %i[new create]
   before_action :detect_other_active_editors, only: %i[edit update]
   before_action :set_edition_defaults, only: :new
@@ -272,6 +273,7 @@ private
       :all_nation_applicability,
       :image_display_option,
       {
+        all_nation_applicability: [],
         secondary_specialist_sector_tags: [],
         lead_organisation_ids: [],
         supporting_organisation_ids: [],
@@ -345,6 +347,25 @@ private
   def find_edition
     edition = edition_class.find(params[:id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def build_national_exclusion_params
+    return unless %w[consultations detailed_guides publications].include?(controller_name) && preview_design_system_user?
+
+    exclusion_params = edition_params["all_nation_applicability"]
+    return if exclusion_params.blank? || edition_params["nation_inapplicabilities_attributes"].blank?
+
+    edition_params["all_nation_applicability"] = exclusion_params.include?("all_nations") ? "1" : "0"
+
+    build_nation_params(nation_id: 1, checked: exclusion_params.include?("england"))
+    build_nation_params(nation_id: 2, checked: exclusion_params.include?("scotland"))
+    build_nation_params(nation_id: 3, checked: exclusion_params.include?("wales"))
+    build_nation_params(nation_id: 4, checked: exclusion_params.include?("northern_ireland"))
+  end
+
+  def build_nation_params(nation_id:, checked:)
+    edition_params["nation_inapplicabilities_attributes"][(nation_id - 1).to_s]["excluded"] = checked ? "1" : "0"
+    edition_params["nation_inapplicabilities_attributes"][(nation_id - 1).to_s]["alternative_url"] = nil unless checked
   end
 
   def build_edition_dependencies

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -165,7 +165,7 @@
     </div>
 
     <%= render 'topical_event_fields', form: form, edition: edition %>
-    <%= render 'legacy_nation_fields', form: form, edition: edition %>
+    <%= render 'nation_fields', form: form, edition: edition %>
     <%= render 'organisation_fields', form: form, edition: edition %>
   <% end %>
   <%= render "govuk_publishing_components/components/fieldset", {

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -62,5 +62,5 @@
     } %>
   <% end %>
 
-  <%= render 'legacy_nation_fields', form: form, edition: edition %>
+  <%= render 'nation_fields', form: form, edition: edition %>
 <% end %>

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -1,0 +1,75 @@
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][0][id]", edition.nation_inapplicabilities.find_by(nation_id: 1)&.id %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][1][id]", edition.nation_inapplicabilities.find_by(nation_id: 2)&.id %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][2][id]", edition.nation_inapplicabilities.find_by(nation_id: 3)&.id %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][3][id]", edition.nation_inapplicabilities.find_by(nation_id: 4)&.id %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][0][nation_id]", 1 %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][1][nation_id]", 2 %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][2][nation_id]", 3 %>
+<%= hidden_field_tag "edition[nation_inapplicabilities_attributes][3][nation_id]", 4 %>
+
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "edition[all_nation_applicability][]",
+  id: "edition_nation_inapplicabilities",
+  heading: "Excluded nations",
+  error: errors_for_input(edition.errors, :nation_inapplicabilities),
+  no_hint_text: true,
+  items: [
+    {
+      label: "Applies to all UK nations",
+      value: "all_nations",
+      checked: edition.all_nation_applicability_selected?
+    },
+    {
+      label: "Does not apply to England",
+      value: "england",
+      checked: edition.nation_inapplicabilities.map(&:nation_id).include?(1),
+      conditional: (render "govuk_publishing_components/components/input", {
+         label: {
+           text: "URL of corresponding content"
+         },
+         name: "edition[nation_inapplicabilities_attributes][0][alternative_url]",
+         id: "edition_nation_inapplicabilities_attributes_0_alternative_url",
+         value: @edition.nation_inapplicabilities.select { |inapplicability| inapplicability.nation_id == 1 }.first&.alternative_url,
+      })
+    },
+    {
+      label: "Does not apply to Scotland",
+      value: "scotland",
+      checked: edition.nation_inapplicabilities.map(&:nation_id).include?(2),
+      conditional: (render "govuk_publishing_components/components/input", {
+         label: {
+           text: "URL of corresponding content"
+         },
+         name: "edition[nation_inapplicabilities_attributes][1][alternative_url]",
+         id: "edition_nation_inapplicabilities_attributes_1_alternative_url",
+         value: @edition.nation_inapplicabilities.select { |inapplicability| inapplicability.nation_id == 2 }.first&.alternative_url,
+      })
+    },
+    {
+      label: "Does not apply to Wales",
+      value: "wales",
+      checked: edition.nation_inapplicabilities.map(&:nation_id).include?(3).present?,
+      conditional: (render "govuk_publishing_components/components/input", {
+         label: {
+           text: "URL of corresponding content"
+         },
+         name: "edition[nation_inapplicabilities_attributes][2][alternative_url]",
+         id: "edition_nation_inapplicabilities_attributes_2_alternative_url",
+         value: @edition.nation_inapplicabilities.select { |inapplicability| inapplicability.nation_id == 3 }.first&.alternative_url,
+      })
+    },
+    {
+      label: "Does not apply to  Northern Ireland",
+      value: "northern_ireland",
+      checked: edition.nation_inapplicabilities.map(&:nation_id).include?(4),
+      conditional: (render "govuk_publishing_components/components/input", {
+         label: {
+           text: "URL of corresponding content"
+         },
+         name: "edition[nation_inapplicabilities_attributes][3][alternative_url]",
+         id: "edition_nation_inapplicabilities_attributes_3_alternative_url",
+         value: @edition.nation_inapplicabilities.select { |inapplicability| inapplicability.nation_id == 4 }.first&.alternative_url,
+      })
+    }
+  ]
+} %>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -19,6 +19,6 @@
     <%= render 'topical_event_fields', form: form, edition: edition %>
     <%= render 'world_location_fields', form: form, edition: edition %>
     <%= render 'organisation_fields', form: form, edition: edition %>
-    <%= render 'legacy_nation_fields', form: form, edition: edition %>
+    <%= render 'nation_fields', form: form, edition: edition %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Description

This adds in the nation_fields partial in the GOV.UK Design System.

The Bootstrap implementation was pretty weird in that it had a checkbox for all nations that passes a value to the controller via the `all_nation_applicability` attribute, then all 4 nations are passed as part of the nested `nation_inapplicabilities_attributes`

(see the highlighted code)

<img width="663" alt="image" src="https://user-images.githubusercontent.com/42515961/192907709-96c20189-0dd9-42a4-8696-e8c447e3bd49.png">

I've had to do a decent amount of controller munging to get this work with the publishing component checkbox component and keep it accessible.

One issue i encountered was we only need to build the nation params for publications, consultations and detailed guides. This needs to be done before the build_edition before action, which builds the edition based on the params. 

However, as we only want to build the nation params for certain types and there isn't a persisted object yet, i've used the controller_name to infer which edition object will be built.

There may well be a better way of doing it, but it's late and sleepy! Please feel free to change this if anyone can think of anything better!

## Screenshot

<img width="629" alt="image" src="https://user-images.githubusercontent.com/42515961/192907304-88592137-96b2-4f6c-b6a7-86f1e1caa80f.png">

## Trello card

https://trello.com/c/YbYQICAe/684-move-edit-edition-page-to-the-govuk-design-system
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
