### PR TITLE
Move withdrawal explanation page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -1,6 +1,11 @@
 class Admin::EditionUnpublishingController < Admin::BaseController
+  layout :get_layout
   before_action :load_unpublishing
   before_action :enforce_permissions!
+
+  def edit
+    render "edit_legacy" unless preview_design_system_user?
+  end
 
   def update
     services = Whitehall.edition_services
@@ -13,11 +18,22 @@ class Admin::EditionUnpublishingController < Admin::BaseController
       redirect_to admin_edition_path(@unpublishing.edition), notice: "The public explanation was updated"
     else
       flash.now[:alert] = "The public explanation could not be updated"
-      render :edit
+      render action: preview_design_system_user? ? "edit" : "edit_legacy"
     end
   end
 
 private
+
+  def get_layout
+    return "admin" unless preview_design_system_user?
+
+    case action_name
+    when "edit", "update", "new"
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def load_unpublishing
     @unpublishing = Edition.find(params[:edition_id]).unpublishing

--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -16,9 +16,11 @@ class Admin::EditionUnpublishingController < Admin::BaseController
         services.unpublisher(@unpublishing.edition).perform!
       end
       redirect_to admin_edition_path(@unpublishing.edition), notice: "The public explanation was updated"
+    elsif preview_design_system_user?
+      render "edit"
     else
       flash.now[:alert] = "The public explanation could not be updated"
-      render action: preview_design_system_user? ? "edit" : "edit_legacy"
+      render "edit_legacy"
     end
   end
 

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -1,31 +1,38 @@
-<% edition = @unpublishing.edition
-   withdrawal_or_unpublishing = withdrawal_or_unpublishing(@unpublishing.edition)
-%>
+<% content_for :context, @unpublishing.edition.title %>
+<% content_for :page_title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
+<% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@unpublishing.edition)
+  } %>
+<% end %>
 
-<% page_title "Edit public explanation for #{withdrawal_or_unpublishing}"  %>
-
-<h1><%= edition.title %></h1>
-<div class="well edit-unpublishing-form add-top-margin">
-  <section>
-    <h2 class="remove-top-margin">Edit public explanation for <%= withdrawal_or_unpublishing %></h2>
-    <p>
-      <strong>Reason for <%= withdrawal_or_unpublishing %></strong><br />
-      <%= @unpublishing.unpublishing_reason.as_sentence.capitalize %>
-    </p>
-
-    <%= form_for @unpublishing, url: admin_edition_unpublishing_path(edition) do |f| %>
-      <fieldset>
-        <%= f.text_area :explanation, rows: 5, class: "previewable input-md-8", required: true,
-          label_text: %{Public explanation (this is shown on the live site)}.html_safe,
-          data: {
-            module: "paste-html-to-govspeak"
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_for @unpublishing, url: admin_edition_unpublishing_path(@unpublishing.edition) do |f| %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "l",
+          text: "Public explanation",
+        },
+        hint: "This is shown on the live site",
+        name: "unpublishing[explanation]",
+        value: @unpublishing.explanation,
+        data: {
+          module: "paste-html-to-govspeak"
+        },
+        error_items: (@unpublishing.errors.as_json(full_messages: true)[:explanation].map do |error|
+          {
+            "text": error,
           }
-        %>
-      </fieldset>
-      <fieldset>
-        <%= f.submit "Update #{withdrawal_or_unpublishing} explanation", class: "btn btn-primary" %>
-        <%= link_to 'Cancel', [:admin, edition], class: 'btn btn-default add-left-margin' %>
-      </fieldset>
+        end if @unpublishing.errors[:explanation].present?)
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: 8
+      } %>
     <% end %>
   </section>
 </div>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :context, @unpublishing.edition.title %>
-<% content_for :page_title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
-<% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
+<% content_for :page_title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
+<% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
 <% content_for :title_margin_bottom, 6 %>
-<% content_for :error_summary, render('shared/error_summary', object: @unpublishing, class_name: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explaination") %>
+<% content_for :error_summary, render('shared/error_summary', object: @unpublishing, class_name: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explanation") %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: admin_edition_path(@unpublishing.edition)
@@ -35,7 +35,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination",
+        text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation",
         margin_bottom: 8
       } %>
     <% end %>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
 <% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render('shared/error_summary', object: @unpublishing, class_name: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explaination") %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: admin_edition_path(@unpublishing.edition)
@@ -10,6 +11,13 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Reason for #{withdrawal_or_unpublishing(@unpublishing.edition)}",
+        font_size: "l",
+        margin_bottom: 3
+    } %>
+    <p class="govuk-body govuk-!-margin-bottom-6"><%= @unpublishing.unpublishing_reason.as_sentence.capitalize %></p>
+
     <%= form_for @unpublishing, url: admin_edition_unpublishing_path(@unpublishing.edition) do |f| %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
@@ -18,19 +26,16 @@
         },
         hint: "This is shown on the live site",
         name: "unpublishing[explanation]",
+        id: "unpublishing_explanation",
         value: @unpublishing.explanation,
         data: {
           module: "paste-html-to-govspeak"
         },
-        error_items: (@unpublishing.errors.as_json(full_messages: true)[:explanation].map do |error|
-          {
-            "text": error,
-          }
-        end if @unpublishing.errors[:explanation].present?)
+        error_items: errors_for(@unpublishing.errors, :explanation)
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
+        text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explaination",
         margin_bottom: 8
       } %>
     <% end %>

--- a/app/views/admin/edition_unpublishing/edit_legacy.html.erb
+++ b/app/views/admin/edition_unpublishing/edit_legacy.html.erb
@@ -1,0 +1,31 @@
+<% edition = @unpublishing.edition
+   withdrawal_or_unpublishing = withdrawal_or_unpublishing(@unpublishing.edition)
+%>
+
+<% page_title "Edit public explanation for #{withdrawal_or_unpublishing}"  %>
+
+<h1><%= edition.title %></h1>
+<div class="well edit-unpublishing-form add-top-margin">
+  <section>
+    <h2 class="remove-top-margin">Edit public explanation for <%= withdrawal_or_unpublishing %></h2>
+    <p>
+      <strong>Reason for <%= withdrawal_or_unpublishing %></strong><br />
+      <%= @unpublishing.unpublishing_reason.as_sentence.capitalize %>
+    </p>
+
+    <%= form_for @unpublishing, url: admin_edition_unpublishing_path(edition) do |f| %>
+      <fieldset>
+        <%= f.text_area :explanation, rows: 5, class: "previewable input-md-8", required: true,
+          label_text: %{Public explanation (this is shown on the live site)}.html_safe,
+          data: {
+            module: "paste-html-to-govspeak"
+          }
+        %>
+      </fieldset>
+      <fieldset>
+        <%= f.submit "Update #{withdrawal_or_unpublishing} explanation", class: "btn btn-primary" %>
+        <%= link_to 'Cancel', [:admin, edition], class: 'btn btn-default add-left-margin' %>
+      </fieldset>
+    <% end %>
+  </section>
+</div>

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -10,7 +10,17 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     @edition = create(:withdrawn_edition)
   end
 
-  test "#edit loads the unpublishing and renders the unpublish edit template" do
+  test "#edit loads the unpublishing and renders the unpublish legacy edit template" do
+    unpublishing = @edition.unpublishing
+    get :edit, params: { edition_id: @edition.id }
+
+    assert_response :success
+    assert_template :edit_legacy
+    assert_equal unpublishing, assigns(:unpublishing)
+  end
+
+  test "#edit loads the unpublishing and renders the unpublish edit template when the user has the 'Preview design system' permission" do
+    @current_user.permissions << "Preview design system"
     unpublishing = @edition.unpublishing
     get :edit, params: { edition_id: @edition.id }
 
@@ -51,13 +61,23 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_equal "this used to say unpublished", @unpublished_edition.unpublishing.reload.explanation
   end
 
-  test "#update shows form with error if the update was not possible" do
+  test "#update shows legacy form with error if the update was not possible" do
+    unpublishing = @edition.unpublishing
+    original_explanation = unpublishing.explanation
+    put :update, params: { edition_id: @edition, unpublishing: { explanation: nil } }
+
+    assert_template :edit_legacy
+    assert_equal "The public explanation could not be updated", flash[:alert]
+    assert_equal original_explanation, unpublishing.reload.explanation
+  end
+
+  test "#update shows form with error if the update was not possible when the user has the 'Preview design system' permission" do
+    @current_user.permissions << "Preview design system"
     unpublishing = @edition.unpublishing
     original_explanation = unpublishing.explanation
     put :update, params: { edition_id: @edition, unpublishing: { explanation: nil } }
 
     assert_template :edit
-    assert_equal "The public explanation could not be updated", flash[:alert]
     assert_equal original_explanation, unpublishing.reload.explanation
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

### What
[Move the withdrawal explaination page to the GOVUK design system layout.
](https://trello.com/c/LhicV17K/776-move-withdrawal-explanation-page-to-the-govuk-design-system)
### Why
This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

### Screenshots
![whitehall-admin dev gov uk_government_admin_editions_5_unpublishing_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/193609900-3d93dd04-9743-4af3-944a-b6bff73d5772.png)
![whitehall-admin dev gov uk_government_admin_editions_5_unpublishing(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/193609916-cae98446-3036-4806-bb64-771c48deeeda.png)
![whitehall-admin dev gov uk_government_admin_editions_5_unpublishing_edit(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/193609925-276b310a-dcc7-409a-9b24-87eab374c3fd.png)


#### Before
![whitehall-admin dev gov uk_government_admin_editions_1_unpublishing_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/193281238-4ca70a66-4d70-4c8e-92d2-827ce062693a.png)
![whitehall-admin dev gov uk_government_admin_editions_1_unpublishing_edit(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/193281245-07628361-9167-489e-b010-edf7bc22e1f5.png)

