### PR TITLE
Add support for upcoming changes section

### DIFF
--- a/app/views/admin/whats_new/_type.html.erb
+++ b/app/views/admin/whats_new/_type.html.erb
@@ -1,9 +1,9 @@
 <%
   type_class = case type.downcase
                 when "new" then "govuk-tag--green"
-                when "improved" then "govuk-tag--blue"
-                when "changed" then "govuk-tag--red"
-                when "fixed" then "govuk-tag--yellow"
+                when "improvement" then "govuk-tag--blue"
+                when "change" then "govuk-tag--red"
+                when "fix" then "govuk-tag--yellow"
                end
 %>
 

--- a/app/views/admin/whats_new/index.html.erb
+++ b/app/views/admin/whats_new/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, t('admin.whats_new.title') %>
 <% content_for :title, t('admin.whats_new.title') %>
 <% content_for :title_margin_bottom, 0 %>
+<% upcoming_changes = t('admin.whats_new.upcoming_changes') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -15,6 +16,10 @@
             href: "##{t('admin.whats_new.introduction.heading').parameterize(separator: '-')}",
             text: t('admin.whats_new.introduction.heading'),
           },
+          *([
+            href: "##{t('admin.whats_new.upcoming_changes.heading').parameterize(separator: '-')}",
+            text: t('admin.whats_new.upcoming_changes.heading'),
+          ] if upcoming_changes[:updates].present?),
           {
             href: "##{t('admin.whats_new.recent_changes.heading').parameterize(separator: '-')}",
             text: t('admin.whats_new.recent_changes.heading'),
@@ -23,7 +28,7 @@
             href: "##{t('admin.whats_new.guidance.heading').parameterize(separator: '-')}",
             text: t('admin.whats_new.guidance.heading'),
           }
-        ]
+        ].compact
       } %>
     </div>
 
@@ -37,6 +42,19 @@
       <%= render_govspeak(t('admin.whats_new.introduction.body_govspeak')) %>
       <%= render partial: "admin/whats_new/back_to_top" %>
     </section>
+
+    <% if upcoming_changes[:updates].present? %>
+      <section class="app-view-whats-new__section" id="<%= t('admin.whats_new.upcoming_changes.heading').parameterize(separator: '-')%>">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: upcoming_changes[:heading],
+          font_size: "m",
+          margin_bottom: 3,
+        } %>
+
+        <%= render(partial: "admin/whats_new/updates", locals: { updates: upcoming_changes[:updates] }) %>
+        <%= render partial: "admin/whats_new/back_to_top" %>
+      </section>
+    <% end %>
 
     <section class="app-view-whats-new__section" id="<%= t('admin.whats_new.recent_changes.heading').parameterize(separator: '-')%>">
       <%= render "govuk_publishing_components/components/heading", {

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -17,7 +17,7 @@ en:
         updates:
           - heading: Topic taxonomy tags page moves to the Design System
             area: Creating and updating documents
-            type: improved
+            type: improvement
             date: 5 October 2022
             body_govspeak: |
               The topic taxonomy tags page will move to the GOV.UK Design System.
@@ -28,7 +28,7 @@ en:
         updates:
           - heading: Reusing previous withdrawal dates and public explanations
             area: Creating and updating documents
-            type: improved
+            type: improvement
             date: 26 September 2022
             body_govspeak: |
               When re-withdrawing content, you can choose to reuse a previous withdrawal date and public explanation in certain circumstances.

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -15,15 +15,12 @@ en:
       upcoming_changes:
         heading: Upcoming changes
         updates:
-          - heading: Topic taxonomy tagging and unpublishing and withdrawing pages move to the Design System
+          - heading: Topic taxonomy tags page moves to the Design System
             area: Creating and updating documents
             type: improved
             date: 5 October 2022
             body_govspeak: |
-              The following pages will move to the GOV.UK Design System:
-              
-              * topic taxonomy tagging
-              * unpublishing, withdrawing and unwithdrawing
+              The topic taxonomy tags page will move to the GOV.UK Design System.
 
               Topics that are tagged to a document will be listed under the ‘Selected topics’ header on the ‘Topic taxonomy tags’ page. You can also remove tags in this section.
       recent_changes:

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -18,7 +18,7 @@ en:
           - heading: Topic taxonomy tags page moves to the Design System
             area: Creating and updating documents
             type: improvement
-            date: 5 October 2022
+            date: 6 October 2022
             body_govspeak: |
               The topic taxonomy tags page will move to the GOV.UK Design System.
 

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -15,14 +15,17 @@ en:
       upcoming_changes:
         heading: Upcoming changes
         updates:
-          - heading: Reusing previous withdrawal dates and public explanations
+          - heading: Topic taxonomy tagging and unpublishing and withdrawing pages move to the Design System
             area: Creating and updating documents
             type: improved
-            date: 26 September 2022
+            date: 5 October 2022
             body_govspeak: |
-              When re-withdrawing content, you can choose to reuse a previous withdrawal date and public explanation in certain circumstances.
+              The following pages will move to the GOV.UK Design System:
+              
+              * topic taxonomy tagging
+              * unpublishing, withdrawing and unwithdrawing
 
-              [Read the guidance about when you can reuse previous withdrawal dates and explanations](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving).
+              Topics that are tagged to a document will be listed under the ‘Selected topics’ header on the ‘Topic taxonomy tags’ page. You can also remove tags in this section.
       recent_changes:
         heading: Recent changes
         updates:

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -12,6 +12,17 @@ en:
           This will make Whitehall Publisher more accessible, more user friendly and give you a consistent user experience throughout your publishing journey on GOV.UK.
 
           [Read more about the changes on the content community Basecamp](https://3.basecamp.com/4322319/buckets/15005645/messages/5287245970).
+      upcoming_changes:
+        heading: Upcoming changes
+        updates:
+          - heading: Reusing previous withdrawal dates and public explanations
+            area: Creating and updating documents
+            type: improved
+            date: 26 September 2022
+            body_govspeak: |
+              When re-withdrawing content, you can choose to reuse a previous withdrawal date and public explanation in certain circumstances.
+
+              [Read the guidance about when you can reuse previous withdrawal dates and explanations](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving).
       recent_changes:
         heading: Recent changes
         updates:

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -4,7 +4,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 5 September 2022
+      last_updated: Last updated 3 October 2022
       introduction:
         heading: Moving to the Design System
         body_govspeak: |


### PR DESCRIPTION
## What
We need to add an 'Upcoming changes' section to the 'What's new' page in Whitehall Publisher.

This section would be between the introduction section and the 'recent changes' section.

The section and entries follow the same format as the 'recent changes' section.

The section shouldn't show in the contents list or on the page if there's no entries/content in the YAML file.

## Why
We're using the page to communicate with publishers upcoming changes to Whitehall Publisher.

## Additional Information
https://github.com/alphagov/whitehall/blob/main/config/locales/en/admin/whats_new.yml

https://github.com/alphagov/whitehall/tree/main/app/views/admin/whats_new

![whitehall-admin dev gov uk_government_admin_whats-new(iPad Pro) (10)](https://user-images.githubusercontent.com/4599889/193545518-cab28170-5ca6-4d5f-b2db-8c799b50a0a1.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/Cf4p7Ied/785-add-upcoming-changes-section-to-whats-new-page
