### PR TITLE
Reverse show notice flag to be false by default

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% content_for :navbar do %>
-  <%= render "shared/header" %>
+  <%= render "shared/header", show_legacy_notices: true %>
   <div class="govuk-design-system-styling">
     <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
       <%= render "shared/whats_new_banner", tracking_module: "track-link-click" %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -9,7 +9,7 @@
 
   <div class="legacy-whitehall">
     <div class="environment-<%= environment %>">
-      <%= render "shared/header", show_notices: false %>
+      <%= render partial: "shared/header" %>
     </div>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <% environment_style = GovukAdminTemplate.environment_style %>
 <% environment_label = GovukAdminTemplate.environment_label %>
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
-<% show_notices ||= true %>
+<% show_legacy_notices ||= false %>
 
 <header class="
   masthead
@@ -79,7 +79,7 @@
       </li>
     </ul>
   </div>
-  <% if show_notices %>
+  <% if show_legacy_notices %>
     <section class="notices">
       <%= render partial: "shared/notices" %>
     </section>


### PR DESCRIPTION
The logic OR assignment was treating the `false` flag we passed in as always to be [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) (which is correct).

This changes it to make sure that it only shows if you pass in a value of `true`.

https://trello.com/c/rHlLiraK/788-fix-double-notices-showing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Before

![Screenshot 2022-10-03 at 10 17 49 am](https://user-images.githubusercontent.com/4599889/193542736-59bce15e-6a3b-45d3-a3b3-d7d383ef664f.png)

## After

![Screenshot 2022-10-03 at 10 12 07 am](https://user-images.githubusercontent.com/4599889/193542782-7c284755-eb2a-40de-a832-8d984412c7f2.png)
![Screenshot 2022-10-03 at 10 12 42 am](https://user-images.githubusercontent.com/4599889/193542786-e95b9d7f-4e15-4abb-84b4-132ecdda5e87.png)

