### PR TITLE
Update phase banner with release group 2 changes

### DIFF
--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -2,10 +2,10 @@
 
 <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "What's new",
-    message: sanitize("6 October: topic taxonomy and unpublishing and withdrawing pages move to the GOV.UK Design System -
+    message: sanitize("6 October: topic taxonomy tags page moves to the GOV.UK Design System -
       #{
         link_to(
-          "find more about the changes",
+          "find more about the change",
           admin_whats_new_path,
           {
             class: "govuk-link",

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -1,11 +1,11 @@
 <% tracking_module ||= "gem-track-click" %>
 
 <%= render "govuk_publishing_components/components/phase_banner", {
-    phase: "Update",
-    message: sanitize("Whitehall Publisher is changing -
+    phase: "What's new",
+    message: sanitize("6 October: topic taxonomy and unpublishing and withdrawing pages move to the GOV.UK Design System -
       #{
         link_to(
-          "find more about upcoming changes and what's new",
+          "find more about the changes",
           admin_whats_new_path,
           {
             class: "govuk-link",

--- a/test/integration/whats_new_test.rb
+++ b/test/integration/whats_new_test.rb
@@ -25,7 +25,7 @@ class WhatsNewTest < ActionDispatch::IntegrationTest
     get admin_whats_new_path
 
     assert_select ".gem-c-phase-banner"
-    assert_select ".gem-c-phase-banner .govuk-phase-banner__content__tag", text: "Update"
+    assert_select ".gem-c-phase-banner .govuk-phase-banner__content__tag"
     assert_select ".gem-c-phase-banner .govuk-phase-banner__text"
   end
 end


### PR DESCRIPTION
This pull request updates the phase banner content in Whitehall Publisher for release group two of moving to the GOV.UK Design System.

This should be merged after https://github.com/alphagov/whitehall/pull/6877 (adding release group 2 content to the what's new page).

https://trello.com/c/Ks2wKgwD/789-update-phase-banner-content-for-release-group-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
