### PR TITLE
Update Plek to 4.1.0.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    plek (4.0.0)
+    plek (4.1.0)
     prometheus_exporter (2.0.3)
       webrick
     pry (0.14.1)

--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -10,6 +10,6 @@ module Admin::ContentDataRoutesHelper
 private
 
   def content_data_base_url
-    Plek.current.external_url_for("content-data")
+    Plek.new.external_url_for("content-data")
   end
 end

--- a/app/helpers/admin/content_publisher_routes_helper.rb
+++ b/app/helpers/admin/content_publisher_routes_helper.rb
@@ -9,6 +9,6 @@ module Admin::ContentPublisherRoutesHelper
 private
 
   def content_publisher_base_url
-    Plek.current.external_url_for("content-publisher")
+    Plek.new.external_url_for("content-publisher")
   end
 end

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -41,7 +41,7 @@ class RummagerDocumentPresenter < ActionView::Base
   end
 
   def url
-    Plek.current.website_root + link
+    Plek.new.website_root + link
   end
 
   def publication_collections
@@ -103,7 +103,7 @@ private
   def format_link(title, link)
     return unless title.present? && link.present?
 
-    link_to(title, Plek.current.website_root + link, class: "govuk-link")
+    link_to(title, Plek.new.website_root + link, class: "govuk-link")
   end
 
   def operational_field_link(operational_field)

--- a/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
+++ b/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
@@ -1,5 +1,5 @@
 require "gds_api/router"
-router_api = GdsApi::Router.new(Plek.current.find("router-api"))
+router_api = GdsApi::Router.new(Plek.new.find("router-api"))
 
 REDIRECT_TO = "/government/organisations/hm-revenue-customs".freeze
 

--- a/db/data_migration/20150423152138_redirect_policies.rb
+++ b/db/data_migration/20150423152138_redirect_policies.rb
@@ -1,6 +1,6 @@
 require "csv"
 require "gds_api/router"
-router_api = GdsApi::Router.new(Plek.current.find("router-api"))
+router_api = GdsApi::Router.new(Plek.new.find("router-api"))
 
 csv_file = File.join(File.dirname(__FILE__), "20150423152138_redirect_policies.csv")
 

--- a/features/step_definitions/admin_locked_documents_steps.rb
+++ b/features/step_definitions/admin_locked_documents_steps.rb
@@ -22,7 +22,7 @@ Then(/^I can see that the document cannot be edited$/) do
 end
 
 And(/^I can see that the document can be edited in Content Publisher$/) do
-  content_publisher_base_url = Plek.current.external_url_for("content-publisher")
+  content_publisher_base_url = Plek.new.external_url_for("content-publisher")
   content_publisher_link = "#{content_publisher_base_url}/documents/#{@edition.content_id}:#{@edition.primary_locale}"
   expect(page).to have_link("Edit in Content Publisher", href: content_publisher_link)
 end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -6,7 +6,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   # To avoid clashes between v1 and v2 helpers, we've reimplemented them here,
   # as `publish_intents` only exist in v1 and there's no plan to reimplement them
   # as their functionality will ultimately be included in `publishing-api`.
-  PUBLISHING_API_V1_ENDPOINT = Plek.current.find("publishing-api")
+  PUBLISHING_API_V1_ENDPOINT = Plek.new.find("publishing-api")
 
   def assert_publishing_api_put_intent(base_path, attributes = {}, times = 1)
     intent_url = "#{PUBLISHING_API_V1_ENDPOINT}/publish-intent#{base_path}"

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -4,7 +4,7 @@ module PublishingApiTestHelpers
   include GdsApi::TestHelpers::PublishingApi
 
   def stub_publishing_api_publish_intent
-    stub_request(:any, %r{\A#{Plek.current.find('publishing-api')}/publish-intent/.+})
+    stub_request(:any, %r{\A#{Plek.new.find('publishing-api')}/publish-intent/.+})
   end
 
   def stub_publishing_api_registration_for(editions)


### PR DESCRIPTION
Generated by running `bundle update plek` followed by `git grep -l Plek.current |xargs -n1 gsed -i 's/Plek\.current/Plek.new/g'` to fix the deprecation warnings.