### PR TITLE
Make line height normal

### DIFF
--- a/app/assets/stylesheets/admin/_layout.scss
+++ b/app/assets/stylesheets/admin/_layout.scss
@@ -72,6 +72,7 @@ $collapse-tabs-width: 710px;
   width: 16.4%;
   float: left;
   background: #6d6d6d;
+  line-height: normal;
 
   &.active {
     color: $black;


### PR DESCRIPTION
There is a line height added globally (1.4em) which causes this to break in the design system. This is part of some legacy code.

This change fixes this issue and makes it consistent across all views and layout modes.

https://trello.com/c/SLgo9xS4/795-make-line-height-normal-on-header-items

## Before

![whitehall-admin dev gov uk_government_admin_whats-new(iPad Pro) (12)](https://user-images.githubusercontent.com/4599889/193628148-54495cd0-e58b-4ea4-b0a9-8cad2d299292.png)

## After

![whitehall-admin dev gov uk_government_admin_whats-new(iPad Pro) (11)](https://user-images.githubusercontent.com/4599889/193628139-613a78cb-ea18-4e0b-a7a6-469028d11385.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
