### PR TITLE
Tidy routes file (and other routes related things)

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -350,7 +350,7 @@ class HistoricAppointmentsController < PublicFacingController
   end
 
   def show
-    @person = PersonPresenter.new(Person.friendly.find(params[:person_id]), view_context)
+    @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
     @historical_account = @person.historical_accounts.for_role(@role).first
     raise(ActiveRecord::RecordNotFound, "Couldn't find HistoricalAccount for #{@person.inspect}  and #{@role.inspect}") unless @historical_account
   end
@@ -374,11 +374,7 @@ private
   end
 
   def load_role
-    @role = Role.friendly.find(role_id)
-  end
-
-  def role_id
-    Role::HISTORIC_ROLE_PARAM_MAPPINGS[params[:role]]
+    @role = Role.friendly.find("prime-minister")
   end
 
   def previous_appointments

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -192,6 +192,18 @@ module ApplicationHelper
 
   def current_main_navigation_path(parameters)
     case parameters[:controller]
+    when "announcements", "news_articles", "speeches", "fatality_notices", "operational_fields"
+      announcements_path
+    when "consultations", "consultation_responses"
+      publications_path(publication_filter_option: "consultations")
+    when "corporate_information_pages"
+      if parameters.key?(:worldwide_organisation_id)
+        world_locations_path
+      else
+        organisations_path
+      end
+    when "histories", "past_foreign_secretaries", "historic_appointments"
+      how_government_works_path
     when "home"
       case parameters[:action]
       when "home"
@@ -201,14 +213,22 @@ module ApplicationHelper
       else
         how_government_works_path
       end
-    when "histories", "past_foreign_secretaries", "historic_appointments"
-      how_government_works_path
-    when "site"
-      root_path
-    when "announcements", "news_articles", "speeches", "fatality_notices", "operational_fields"
-      announcements_path
-    when "statistics", "statistics_announcements"
-      statistics_path
+    when "latest"
+      if parameters[:departments]
+        organisations_path
+      elsif parameters[:world_locations]
+        world_locations_path
+      else
+        latest_path
+      end
+    when "ministerial_roles"
+      ministerial_roles_path
+    when "organisations", "groups", "email_signup_information"
+      if parameters[:courts_only]
+        courts_path
+      else
+        organisations_path
+      end
     when "publications", "statistical_data_sets"
       if parameters[:publication_filter_option] == "consultations"
         publications_path(publication_filter_option: "consultations")
@@ -219,34 +239,14 @@ module ApplicationHelper
       else
         publications_path
       end
-    when "consultations", "consultation_responses"
-      publications_path(publication_filter_option: "consultations")
-    when "ministerial_roles"
-      ministerial_roles_path
-    when "organisations", "groups", "email_signup_information"
-      if parameters[:courts_only]
-        courts_path
-      else
-        organisations_path
-      end
-    when "corporate_information_pages"
-      if parameters.key?(:worldwide_organisation_id)
-        world_locations_path
-      else
-        organisations_path
-      end
-    when "world_locations", "worldwide_organisations", "worldwide_offices"
-      world_locations_path(locale: :en)
+    when "site"
+      root_path
+    when "statistics", "statistics_announcements"
+      statistics_path
     when "take_part_pages"
       get_involved_path
-    when "latest"
-      if parameters[:departments]
-        organisations_path
-      elsif parameters[:world_locations]
-        world_locations_path
-      else
-        latest_path
-      end
+    when "world_locations", "worldwide_organisations", "worldwide_offices"
+      world_locations_path(locale: :en)
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,30 +37,29 @@ Whitehall::Application.routes.draw do
     resources :worldwide_organisations, path: "worldwide-organisations", only: [:show], defaults: { format: :json }
   end
 
-  # World locations and Worldwide organisations
-  get "/world/organisations/:organisation_id/office" => redirect("/world/organisations/%{organisation_id}", prefix: "")
-  get "/world/organisations/:organisation_id/about" => redirect("/world/organisations/%{organisation_id}", prefix: "")
-  get "/world/organisations/:id(.:locale)", as: "worldwide_organisation", to: "worldwide_organisations#show", constraints: { locale: valid_locales_regex }
-
-  resources :worldwide_organisations, path: "world/organisations", only: [] do
-    get "/about/:id(.:locale)", as: "corporate_information_page", to: "corporate_information_pages#show", constraints: { locale: valid_locales_regex }
-    # Dummy path for the sake of polymorphic_path: will always be directed above.
-    get "/about(.:locale)", as: "about", to: "_#_", constraints: { locale: valid_locales_regex }
-
-    get "/office/:id(.:locale)", to: "worldwide_offices#show", as: :worldwide_office, constraints: { locale: valid_locales_regex }
-  end
-
-  resources :embassies, path: "world/embassies", only: [:index]
-
-  get "/world(.:locale)", as: "world_locations", to: "world_locations#index", constraints: { locale: valid_locales_regex }
-  get "/world/:id(.:locale)", as: "world_location", to: "world_locations#show", constraints: { locale: valid_locales_regex }
-  get "/world/:world_location_id/news(.:locale)", as: "world_location_news_index", to: "world_location_news#index", constraints: { locale: valid_locales_regex }
-
   # Override the /auth/failure route in gds-sso, as Slimmer gets
   # involved and causes the page to fail to render
   #
   # This can be removed once Slimmer is removed from Whitehall.
   get "/auth/failure", to: "admin/base#auth_failure", as: "auth_failure_fixed"
+
+  # Routes rendered by Whitehall to the public under the /world scope
+  scope "/world" do
+    get "(.:locale)", as: "world_locations", to: "world_locations#index", constraints: { locale: valid_locales_regex }
+    get "/:id(.:locale)", as: "world_location", to: "world_locations#show", constraints: { locale: valid_locales_regex }
+    get "/:world_location_id/news(.:locale)", as: "world_location_news_index", to: "world_location_news#index", constraints: { locale: valid_locales_regex }
+
+    resources :embassies, path: "embassies", only: [:index]
+
+    get "/organisations/:id(.:locale)", as: "worldwide_organisation", to: "worldwide_organisations#show", constraints: { locale: valid_locales_regex }
+    resources :worldwide_organisations, path: "organisations", only: [] do
+      get "/:organisation_id/about" => redirect("/world/organisations/%{organisation_id}", prefix: "")
+      get "/:organisation_id/office" => redirect("/world/organisations/%{organisation_id}", prefix: "")
+      get "/:organisation_id/about(.:locale)", as: "about", to: "_#_", constraints: { locale: valid_locales_regex }
+      get "/about/:id(.:locale)", as: "corporate_information_page", to: "corporate_information_pages#show", constraints: { locale: valid_locales_regex }
+      get "/office/:id(.:locale)", as: "worldwide_office", to: "worldwide_offices#show", constraints: { locale: valid_locales_regex }
+    end
+  end
 
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
     root to: redirect("/", prefix: ""), via: :get, as: :main_root

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,13 +82,9 @@ Whitehall::Application.routes.draw do
     resource :email_signups, path: "email-signup", only: %i[create new]
     get "/email-signup", to: redirect("/")
 
-    get "/announcements(.:locale)", as: "announcements", to: "announcements#index", constraints: { locale: valid_locales_regex }
-    get "/news/:id(.:locale)", as: "news_article", to: "news_articles#show", constraints: { locale: valid_locales_regex }
     resources :fatality_notices, path: "fatalities", only: [:show]
     get "/news" => redirect("/announcements"), as: "news_articles"
     get "/fatalities" => redirect("/announcements"), as: "fatality_notices"
-
-    get "/publications(.:locale)", as: "publications", to: "publications#index", constraints: { locale: valid_locales_regex }
 
     get "/speeches" => redirect("/announcements")
 
@@ -96,6 +92,12 @@ Whitehall::Application.routes.draw do
     get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
 
     resources :operational_fields, path: "fields-of-operation", only: %i[index show]
+
+    # Routes that exist solely for the purpose of non-English finders
+    get "/announcements(.:locale)", as: "announcements", to: "announcements#index", constraints: { locale: valid_locales_regex }
+    get "/news/:id(.:locale)", as: "news_article", to: "news_articles#show", constraints: { locale: valid_locales_regex }
+    get "/publications(.:locale)", as: "publications", to: "publications#index", constraints: { locale: valid_locales_regex }
+    # End of routes solely for non-English finders
 
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
     get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,8 @@ Whitehall::Application.routes.draw do
     # End of redirects rendered by Whitehall
 
     # Public facing routes still rendered by Whitehall
+    resource :email_signups, path: "email-signup", only: %i[create new]
+    resources :fatality_notices, path: "fatalities", only: [:show]
     scope "/history" do
       get "/past-chancellors", to: "historic_appointments#past_chancellors"
 
@@ -90,18 +92,11 @@ Whitehall::Application.routes.draw do
       get "/past-prime-ministers", to: "historic_appointments#index"
       get "/past-prime-ministers/:id", to: "historic_appointments#show", as: :historic_appointment
     end
-    # End of public facing routes still rendered by Whitehall
-
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
-
-    resource :email_signups, path: "email-signup", only: %i[create new]
-
-    resources :fatality_notices, path: "fatalities", only: [:show]
-
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
     get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
-
     resources :operational_fields, path: "fields-of-operation", only: %i[index show]
+    # End of public facing routes still rendered by Whitehall
 
     # Routes that exist solely for the purpose of non-English finders
     get "/announcements(.:locale)", as: "announcements", to: "announcements#index", constraints: { locale: valid_locales_regex }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,18 +79,8 @@ Whitehall::Application.routes.draw do
 
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
 
-    scope "/get-involved" do
-      # Controller removed. Whitehall frontend no longer serves these
-      # pages however the route is needed to generate path and url
-      # helper methods.
-      root to: "home#get_involved", as: :get_involved, via: :get
-      get "take-part/:id", to: "take_part_pages#show", as: "take_part_page"
-    end
-
     resource :email_signups, path: "email-signup", only: %i[create new]
     get "/email-signup", to: redirect("/")
-
-    get "/tour" => redirect("/tour", prefix: "")
 
     get "/announcements(.:locale)", as: "announcements", to: "announcements#index", constraints: { locale: valid_locales_regex }
     get "/news/:id(.:locale)", as: "news_article", to: "news_articles#show", constraints: { locale: valid_locales_regex }
@@ -98,28 +88,22 @@ Whitehall::Application.routes.draw do
     get "/news" => redirect("/announcements"), as: "news_articles"
     get "/fatalities" => redirect("/announcements"), as: "fatality_notices"
 
-    get "/latest" => "latest#index", as: "latest"
-
     get "/publications(.:locale)", as: "publications", to: "publications#index", constraints: { locale: valid_locales_regex }
-    get "/publications/:id(.:locale)", as: "publication", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/publications/:publication_id/:id" => "_#_", as: "publication_html_attachment"
-
-    # TODO: Remove when paths can be generated without a routes entry
-    get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }
-    get "/speeches/:id(.:locale)", as: "speech", to: "speeches#show", constraints: { locale: valid_locales_regex }
-    resources :statistical_data_sets, path: "statistical-data-sets", only: [:show]
 
     get "/speeches" => redirect("/announcements")
 
-    # Controller removed for stats announce show. Whitehall frontend no longer serves these
-    # pages however the route is needed to generate path and url
-    # helper methods.
-    # TODO: Remove `:show` when stats announcement paths can be otherwise generated
-    resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
-    get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
-    get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: valid_locales_regex }
-    get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
+    get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
+    get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
 
+    resources :operational_fields, path: "fields-of-operation", only: %i[index show]
+
+    # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
+    get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }
+    get "/collections/:id(.:locale)", as: "document_collection", to: "document_collections#show", constraints: { locale: valid_locales_regex }
+    get "/collections" => redirect("/publications")
+    get "/consultations/:consultation_id/:id" => "_#_", as: "consultation_html_attachment"
+    get "/consultations/:consultation_id/outcome/:id" => "_#_", as: "consultation_outcome_html_attachment"
+    get "/consultations/:consultation_id/public-feedback/:id" => "_#_", as: "consultation_public_feedback_html_attachment"
     get "/consultations/:id(.:locale)", as: "consultation", to: "consultations#show", constraints: { locale: valid_locales_regex }
     resources :consultations, only: %i[index] do
       collection do
@@ -128,25 +112,13 @@ Whitehall::Application.routes.draw do
         get :upcoming
       end
     end
-    get "/consultations/:consultation_id/:id" => "_#_", as: "consultation_html_attachment"
-    get "/consultations/:consultation_id/outcome/:id" => "_#_", as: "consultation_outcome_html_attachment"
-    get "/consultations/:consultation_id/public-feedback/:id" => "_#_", as: "consultation_public_feedback_html_attachment"
-
-    # Controller removed. Whitehall frontend no longer serves these
-    # pages however the route is needed to generate path and urlgenerate path and url
-    # helper methods.
-    resources :topical_events, path: "topical-events", only: [:show] do
-      # TODO: Remove when about page paths can be otherwise generated
-      resource :about_pages, path: "about", only: [:show]
+    scope "/get-involved" do
+      root to: "home#get_involved", as: :get_involved, via: :get
+      get "take-part/:id", to: "take_part_pages#show", as: "take_part_page"
     end
-
-    # TODO: Remove when paths can be generated without a routes entry
-    get "/collections/:id(.:locale)", as: "document_collection", to: "document_collections#show", constraints: { locale: valid_locales_regex }
-    get "/collections" => redirect("/publications")
-
+    get "/latest" => "latest#index", as: "latest"
     get "/organisations/:id(.:locale)", as: "organisation", to: "organisations#show", constraints: { locale: valid_locales_regex }
     resources :organisations, only: [:index]
-
     resources :organisations, only: [] do
       # No need to forward the locale as collections aren't localised.
       get "/series/:slug(.:locale)" => redirect("/collections/%{slug}"), constraints: { locale: valid_locales_regex }
@@ -159,14 +131,21 @@ Whitehall::Application.routes.draw do
     get "/organisations/:organisation_id/consultations" => redirect("/organisations/%{organisation_id}")
     get "/organisations/:organisation_id/chiefs-of-staff" => redirect("/organisations/%{organisation_id}")
     get "/organisations/:organisation_slug/email-signup", to: "mhra_email_signup#show", as: :mhra_email_signup
-
-    get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
-    get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
     get "/people/:id(.:locale)", as: "person", to: "people#show", constraints: { locale: valid_locales_regex }
-
-    # TODO: Remove `:show` when policy group paths can be otherwise generated
     resources :policy_groups, path: "groups", only: [:show]
-    resources :operational_fields, path: "fields-of-operation", only: %i[index show]
+    get "/publications/:id(.:locale)", as: "publication", to: "_#_", constraints: { locale: valid_locales_regex }
+    get "/publications/:publication_id/:id" => "_#_", as: "publication_html_attachment"
+    get "/speeches/:id(.:locale)", as: "speech", to: "speeches#show", constraints: { locale: valid_locales_regex }
+    resources :statistical_data_sets, path: "statistical-data-sets", only: [:show]
+    resources :statistics_announcements, path: "statistics/announcements", only: %i[index show]
+    get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
+    get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: valid_locales_regex }
+    get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
+    resources :topical_events, path: "topical-events", only: [:show] do
+      resource :about_pages, path: "about", only: [:show]
+    end
+    get "/tour" => redirect("/tour", prefix: "")
+    # End of routes no longer rendered by Whitehall
 
     constraints(AdminRequest) do
       namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,30 +61,31 @@ Whitehall::Application.routes.draw do
     end
   end
 
+  # Routes rendered by Whitehall to the public under the /government scope (specified in lib/whitehall.rb under the `router_prefix` method)
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
     root to: redirect("/", prefix: ""), via: :get, as: :main_root
+
+    # Public facing routes still rendered by Whitehall
+    scope "/history" do
+      get "/past-chancellors", to: "historic_appointments#past_chancellors"
+
+      get "/past-foreign-secretaries", to: "past_foreign_secretaries#index"
+      get "/past-foreign-secretaries/:id", to: "past_foreign_secretaries#show"
+
+      get "/past-prime-ministers", to: "historic_appointments#index"
+      get "/past-prime-ministers/:id", to: "historic_appointments#show", as: :historic_appointment
+    end
+    # End of public facing routes still rendered by Whitehall
+
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
+
     scope "/get-involved" do
       # Controller removed. Whitehall frontend no longer serves these
       # pages however the route is needed to generate path and url
       # helper methods.
       root to: "home#get_involved", as: :get_involved, via: :get
-
       get "take-part/:id", to: "take_part_pages#show", as: "take_part_page"
     end
-
-    # Past foreign secretaries are currently hard-coded, so this
-    # resource falls straight through to views.
-    resources :past_foreign_secretaries, path: "/history/past-foreign-secretaries", only: %i[index show]
-    # Past chancellors is also hard-coded
-    get "history/past-chancellors" => "historic_appointments#past_chancellors"
-
-    # Past foreign secretaries and past chancellors are here for the
-    # purposes of reversing URLs in a consistent way from other views.
-
-    # TODO: make these dynamic, they're hard-coded above.
-    get "/history/:role" => "historic_appointments#index", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointments"
-    get "/history/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointment"
 
     resource :email_signups, path: "email-signup", only: %i[create new]
     get "/email-signup", to: redirect("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Whitehall::Application.routes.draw do
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
     get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
     resources :operational_fields, path: "fields-of-operation", only: %i[index show]
+    get "/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview" => "csv_preview#show", as: :csv_preview
     # End of public facing routes still rendered by Whitehall
 
     # Routes that exist solely for the purpose of non-English finders
@@ -403,8 +404,6 @@ Whitehall::Application.routes.draw do
 
   # TODO: Remove when paths for new content can be generated without a route helper
   get "/guidance/:id(.:locale)", as: "detailed_guide", to: "detailed_guides#show", constraints: { id: /[A-z0-9\-]+/, locale: valid_locales_regex }
-
-  get "/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview" => "csv_preview#show", as: :csv_preview
 
   resources :broken_links_export_request, path: "/export/broken_link_reports", param: :export_id, only: [:show]
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,21 @@ Whitehall::Application.routes.draw do
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
     root to: redirect("/", prefix: ""), via: :get, as: :main_root
 
+    # Redirects rendered by Whitehall
+    get "/collections" => redirect("/publications")
+    get "/email-signup", to: redirect("/")
+    get "/fatalities" => redirect("/announcements"), as: "fatality_notices"
+    get "/news" => redirect("/announcements"), as: "news_articles"
+    get "/organisations/:organisation_id/chiefs-of-staff" => redirect("/organisations/%{organisation_id}")
+    get "/organisations/:organisation_id/consultations" => redirect("/organisations/%{organisation_id}")
+    get "/organisations/:organisation_id/groups" => redirect("/organisations/%{organisation_id}")
+    get "/organisations/:organisation_id/groups/:id" => redirect("/organisations/%{organisation_id}")
+    get "/organisations/:organsation_id/series(.:locale)" => redirect("/publications"), constraints: { locale: valid_locales_regex }
+    get "/organisations/:organsation_id/series/:slug(.:locale)" => redirect("/collections/%{slug}"), constraints: { locale: valid_locales_regex }
+    get "/speeches" => redirect("/announcements")
+    get "/tour" => redirect("/tour", prefix: "")
+    # End of redirects rendered by Whitehall
+
     # Public facing routes still rendered by Whitehall
     scope "/history" do
       get "/past-chancellors", to: "historic_appointments#past_chancellors"
@@ -80,13 +95,8 @@ Whitehall::Application.routes.draw do
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
 
     resource :email_signups, path: "email-signup", only: %i[create new]
-    get "/email-signup", to: redirect("/")
 
     resources :fatality_notices, path: "fatalities", only: [:show]
-    get "/news" => redirect("/announcements"), as: "news_articles"
-    get "/fatalities" => redirect("/announcements"), as: "fatality_notices"
-
-    get "/speeches" => redirect("/announcements")
 
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
     get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
@@ -102,7 +112,6 @@ Whitehall::Application.routes.draw do
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
     get "/case-studies/:id(.:locale)", as: "case_study", to: "case_studies#show", constraints: { locale: valid_locales_regex }
     get "/collections/:id(.:locale)", as: "document_collection", to: "document_collections#show", constraints: { locale: valid_locales_regex }
-    get "/collections" => redirect("/publications")
     get "/consultations/:consultation_id/:id" => "_#_", as: "consultation_html_attachment"
     get "/consultations/:consultation_id/outcome/:id" => "_#_", as: "consultation_outcome_html_attachment"
     get "/consultations/:consultation_id/public-feedback/:id" => "_#_", as: "consultation_public_feedback_html_attachment"
@@ -122,16 +131,9 @@ Whitehall::Application.routes.draw do
     get "/organisations/:id(.:locale)", as: "organisation", to: "organisations#show", constraints: { locale: valid_locales_regex }
     resources :organisations, only: [:index]
     resources :organisations, only: [] do
-      # No need to forward the locale as collections aren't localised.
-      get "/series/:slug(.:locale)" => redirect("/collections/%{slug}"), constraints: { locale: valid_locales_regex }
-      get "/series(.:locale)" => redirect("/publications"), constraints: { locale: valid_locales_regex }
       get "/about(.:locale)", as: "corporate_information_pages", to: "corporate_information_pages#index", constraints: { locale: valid_locales_regex }
       get "/about/:id(.:locale)", as: "corporate_information_page", to: "corporate_information_pages#show", constraints: { locale: valid_locales_regex }
     end
-    get "/organisations/:organisation_id/groups" => redirect("/organisations/%{organisation_id}")
-    get "/organisations/:organisation_id/groups/:id" => redirect("/organisations/%{organisation_id}")
-    get "/organisations/:organisation_id/consultations" => redirect("/organisations/%{organisation_id}")
-    get "/organisations/:organisation_id/chiefs-of-staff" => redirect("/organisations/%{organisation_id}")
     get "/organisations/:organisation_slug/email-signup", to: "mhra_email_signup#show", as: :mhra_email_signup
     get "/people/:id(.:locale)", as: "person", to: "people#show", constraints: { locale: valid_locales_regex }
     resources :policy_groups, path: "groups", only: [:show]
@@ -146,7 +148,6 @@ Whitehall::Application.routes.draw do
     resources :topical_events, path: "topical-events", only: [:show] do
       resource :about_pages, path: "about", only: [:show]
     end
-    get "/tour" => redirect("/tour", prefix: "")
     # End of routes no longer rendered by Whitehall
 
     constraints(AdminRequest) do

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -16,8 +16,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
       { path: "government/history/past-prime-ministers/barry", method: :get },
       controller: "historic_appointments",
       action: "show",
-      role: "past-prime-ministers",
-      person_id: "barry",
+      id: "barry",
     )
   end
 
@@ -49,7 +48,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Prime Ministers" do
     pm_account = create(:historical_account, roles: [pm_role])
     create(:role_appointment, person: pm_account.person, role: pm_role)
-    get :show, params: { role: "past-prime-ministers", person_id: pm_account.person.slug }
+    get :show, params: { role: "past-prime-ministers", id: pm_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -61,7 +60,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Chanellors" do
     chancellor_account = create(:historical_account, roles: [chancellor_role])
     create(:role_appointment, person: chancellor_account.person, role: chancellor_role)
-    get :show, params: { role: "past-chancellors", person_id: chancellor_account.person.slug }
+    get :show, params: { role: "past-chancellors", id: chancellor_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -74,7 +73,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     chancellor_account = create(:historical_account, roles: [chancellor_role])
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :show, params: { role: "past-prime-ministers", person_id: chancellor_account.person.slug }
+      get :show, params: { role: "past-prime-ministers", id: chancellor_account.person.slug }
     end
   end
 

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -57,18 +57,6 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     assert_equal PersonPresenter.new(pm_account.person, @controller.view_context), assigns(:person)
   end
 
-  test "GET on :show loads the person, appointment and historical account for previous Chanellors" do
-    chancellor_account = create(:historical_account, roles: [chancellor_role])
-    create(:role_appointment, person: chancellor_account.person, role: chancellor_role)
-    get :show, params: { role: "past-chancellors", id: chancellor_account.person.slug }
-
-    assert_response :success
-    assert_template :show
-    assert_equal chancellor_role, assigns(:role)
-    assert_equal chancellor_account, assigns(:historical_account)
-    assert_equal PersonPresenter.new(chancellor_account.person, @controller.view_context), assigns(:person)
-  end
-
   test "GET on :show raises a 404 if a person does not exist with a historical account in the specified role" do
     chancellor_account = create(:historical_account, roles: [chancellor_role])
 

--- a/test/unit/whitehall/url_maker_test.rb
+++ b/test/unit/whitehall/url_maker_test.rb
@@ -24,12 +24,5 @@ module Whitehall
 
       assert_equal "http://gov.uk/world/organisations/#{worldwide_organisation.slug}.atom", maker.url_for(worldwide_organisation)
     end
-
-    test "the default format can be overridden for a non-localised resource" do
-      maker = Whitehall::UrlMaker.new(host: "gov.uk", format: "atom")
-      topical_event = create(:topical_event)
-
-      assert_equal "http://gov.uk/government/topical-events/#{topical_event.slug}.atom", maker.url_for(topical_event)
-    end
   end
 end

--- a/test/unit/whitehall/url_maker_test.rb
+++ b/test/unit/whitehall/url_maker_test.rb
@@ -4,18 +4,18 @@ module Whitehall
   class UrlMakerTest < ActiveSupport::TestCase
     test "default url options can be set at create time" do
       maker = Whitehall::UrlMaker.new(host: "yahoo.com", protocol: "ftp")
-      assert_equal "ftp://yahoo.com/government/get-involved/take-part/woo", maker.take_part_page_url("woo")
+      assert_equal "ftp://yahoo.com/government/how-government-works", maker.how_government_works_url
     end
 
     test "default url options set on an instance do not interfere with other instances" do
       with_defaults = Whitehall::UrlMaker.new(host: "yahoo.com", protocol: "ftp")
       without_defaults = Whitehall::UrlMaker.new(host: "meh.com", protocol: "gopher")
-      assert_not_equal with_defaults.get_involved_url, without_defaults.get_involved_url
+      assert_not_equal with_defaults.how_government_works_url, without_defaults.how_government_works_url
     end
 
     test "host can be set when using _url helpers" do
       maker = Whitehall::UrlMaker.new
-      assert_equal "http://gov.uk/government/get-involved/take-part/woo", maker.take_part_page_url("woo", host: "gov.uk")
+      assert_equal "http://gov.uk/government/how-government-works", maker.how_government_works_url(host: "gov.uk")
     end
 
     test "the default format can be overridden for a localised resource" do


### PR DESCRIPTION
The public-facing routes part of the `config/routes.rb` file had become somewhat disorganised with no logical ordering and inconsistent syntax for different routes.

This breaks that part of the file into the following sections:
- routes rendered by Whitehall to the public under the `/world` scope
- routes rendered by Whitehall to the public under the `/government` scope
- routes that exist solely for the purpose of non-English finders
- redirects rendered by Whitehall (ideally these would be moved out so they are handled at the router level)
- routes no longer rendered by Whitehall, but retained to maintain the route helpers (we will look into resolving these in a later PR)

Additionally each section has been sorted into alphabetical order.  Furthermore some other related code and tests have been updated so we don't need to maintain so many redundant routes.

[Trello card](https://trello.com/c/EfhUs8ak)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
