### PR TITLE
Fix typo in what's new phase banner

### DIFF
--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -5,7 +5,7 @@
     message: sanitize("6 October: topic taxonomy tags page moves to the GOV.UK Design System -
       #{
         link_to(
-          "find more about the change",
+          "find out more about the change",
           admin_whats_new_path,
           {
             class: "govuk-link",


### PR DESCRIPTION
This PR adds in a missing word in the phase banner, particularly the link text.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
