### PR TITLE
Implement Analytics tracking on the 'Topic taxonomy tags' page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,6 @@
 //= require modules/paste-html-to-govspeak
 //= require modules/unpublish-display-conditions
 //= require modules/unpublish-tracking
+//= require modules/track-selected-taxons
 
 window.GOVUK.navBarHelper.init()

--- a/app/assets/javascripts/modules/track-selected-taxons.js
+++ b/app/assets/javascripts/modules/track-selected-taxons.js
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         taxonPath.push(taxons[i].innerText.trim())
       }
 
-      GOVUK.analytics.trackEvent('taxonSelection', taxonPath.join(' > '), { label: window.location.pathname })
+      GOVUK.analytics.trackEvent('taxonSelection', taxonPath.join(' > '), { label: this.getCurrentPath() })
     }
   }
 
@@ -43,6 +43,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         )
       })
     }
+  }
+
+  TrackSelectedTaxons.prototype.getCurrentPath = function () {
+    return window.location.pathname
   }
 
   Modules.TrackSelectedTaxons = TrackSelectedTaxons

--- a/app/assets/javascripts/modules/track-selected-taxons.js
+++ b/app/assets/javascripts/modules/track-selected-taxons.js
@@ -1,0 +1,29 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function TrackSelectedTaxons (module) {
+    this.form = module
+  }
+
+  TrackSelectedTaxons.prototype.init = function () {
+    this.form.addEventListener('submit', this.onSubmitListener.bind(this))
+  }
+
+  TrackSelectedTaxons.prototype.onSubmitListener = function (e) {
+    var selectedItems = this.form.querySelectorAll('.miller-columns-selected__list .miller-columns-selected__list-item')
+
+    for (var index = 0; index < selectedItems.length; index++) {
+      var taxonPath = []
+      var taxons = selectedItems[index].querySelectorAll('.govuk-breadcrumbs__list-item')
+
+      for (var i = 0; i < taxons.length; i++) {
+        taxonPath.push(taxons[i].innerText.trim())
+      }
+
+      GOVUK.analytics.trackEvent('taxonSelection', taxonPath.join(' > '), { label: window.location.pathname })
+    }
+  }
+
+  Modules.TrackSelectedTaxons = TrackSelectedTaxons
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-selected-taxons.js
+++ b/app/assets/javascripts/modules/track-selected-taxons.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   TrackSelectedTaxons.prototype.init = function () {
     this.form.addEventListener('submit', this.onSubmitListener.bind(this))
+    this.addTaxonSelectionEvent()
   }
 
   TrackSelectedTaxons.prototype.onSubmitListener = function (e) {
@@ -22,6 +23,25 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       GOVUK.analytics.trackEvent('taxonSelection', taxonPath.join(' > '), { label: window.location.pathname })
+    }
+  }
+
+  TrackSelectedTaxons.prototype.addTaxonSelectionEvent = function () {
+    var taxonCheckboxes = this.form.querySelectorAll('.miller-columns__item .govuk-checkboxes__input')
+
+    for (var index = 0; index < taxonCheckboxes.length; index++) {
+      var checkbox = taxonCheckboxes[index]
+
+      checkbox.addEventListener('click', function (e) {
+        var target = e.currentTarget
+        var label = this.form.querySelector('label[for="' + target.id + '"]').innerText.trim()
+
+        GOVUK.analytics.trackEvent(
+          'pageElementInteraction',
+          target.checked ? 'checkboxClickedOn' : 'checkboxClickedOff',
+          { label: label }
+        )
+      })
     }
   }
 

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -30,7 +30,9 @@
       margin_bottom: 2,
     } %>
 
-    <%= form_for @tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
+    <%= form_for @tag_form, url: admin_edition_tags_path(@edition), method: :put, data: {
+      module: "track-selected-taxons"
+    } do |form| %>
       <%= form.hidden_field :previous_version %>
 
       <% if @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons).count() %>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -50,15 +50,16 @@
         If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
       <% end %>
 
-      <div class="form-actions govuk-button-group govuk-!-margin-top-7" data-module="track-button-click" data-track-category="form-button" data-track-action="taxonomy-tag-form-button">
+      <div class="govuk-button-group govuk-!-margin-top-7">
         <%= render "govuk_publishing_components/components/button", {
           text: "Update tags",
           name: "save",
           value: "save",
           data_attributes: {
-              module: 'track-selected-taxons',
-              track_category: 'taxonSelection',
-              track_label: request.path,
+              module: 'gem-track-click',
+              track_category: 'form-button',
+              track_label: "Save tagging changes",
+              track_action: "taxonomy-tag-form-button",
           }
         } %>
 
@@ -69,9 +70,10 @@
             value: "legacy_tags",
             secondary_solid: true,
             data_attributes: {
-              module: 'track-selected-taxons',
-              track_category: 'taxonSelection',
-              track_label: request.path,
+              module: 'gem-track-click',
+              track_category: 'form-button',
+              track_label: "Save and review specialist topic tagging",
+              track_action: "taxonomy-tag-form-button",
             }
           } %>
         <% end %>

--- a/spec/javascripts/modules/track-selected-taxon.spec.js
+++ b/spec/javascripts/modules/track-selected-taxon.spec.js
@@ -1,0 +1,145 @@
+describe('GOVUK.Modules.TrackSelectedTaxons', function () {
+  var form
+
+  beforeEach(function () {
+    form = document.createElement('form')
+    form.setAttribute('data-module', 'track-selected-taxons')
+    form.innerHTML = `
+      <div class="app-c-miller-columns">
+        <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">
+          Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.
+        </p>
+
+        <miller-columns-selected id="selected-items" for="miller-columns-04c58f82" class="miller-columns-selected">
+          <ol class="miller-columns-selected__list">
+            <li class="miller-columns-selected__list-item">
+              <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                  <li class="govuk-breadcrumbs__list-item">Parenting, childcare and children's services</li>
+                  <li class="govuk-breadcrumbs__list-item">Divorce, separation and legal issues</li>
+                </ol>
+              </div>
+              <button class="miller-columns-selected__remove-topic" type="button">Remove topic<span class="miller-columns-selected__remove-topic-name">: Divorce, separation and legal issues</span></button>
+            </li>
+            <li class="miller-columns-selected__list-item">
+              <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                  <li class="govuk-breadcrumbs__list-item">Parenting, childcare and children's services</li>
+                  <li class="govuk-breadcrumbs__list-item">Childcare and early years</li>
+                </ol>
+              </div>
+              <button class="miller-columns-selected__remove-topic" type="button">Remove topic<span class="miller-columns-selected__remove-topic-name">: Childcare and early years</span></button>
+            </li>
+          </ol>
+        </miller-columns-selected>
+
+        <miller-columns class="miller-columns" for="miller-columns-04c58f82-list" selected="selected-items" id="miller-columns-04c58f82" aria-describedby="navigation-instructions" style="display: block;">
+          <div class="miller-columns__column" data-root="true">
+            <ul class="miller-columns__column-list">
+              <li class="miller-columns__item govuk-checkboxes--small miller-columns__item--parent miller-columns__item--selected miller-columns__item--active" aria-describedby="navigation-instructions" tabindex="0">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" type="checkbox" name="miller-columns-04c58f82[]" value="parenting-childcare-and-children-s-services" id="miller-columns-04c58f82-0" tabindex="-1">
+                  <label class="govuk-label govuk-checkboxes__label" for="miller-columns-04c58f82-0">
+                    Parenting, childcare and children's services
+                  </label>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="miller-columns__column">
+            <button class="govuk-back-link" type="button">Back</button>
+            <h3 class="miller-columns__column-heading">Parenting, childcare and children's services</h3>
+            <ul class="miller-columns__column-list">
+              <li class="miller-columns__item govuk-checkboxes--small miller-columns__item--selected" aria-describedby="navigation-instructions" tabindex="0">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" type="checkbox" name="miller-columns-04c58f82[]" value="divorce-separation-and-legal-issues" id="miller-columns-04c58f82-0-0" tabindex="-1">
+                  <label class="govuk-label govuk-checkboxes__label" for="miller-columns-04c58f82-0-0">
+                    Divorce, separation and legal issues
+                  </label>
+                </div>
+              </li>
+              <li class="miller-columns__item govuk-checkboxes--small miller-columns__item--parent miller-columns__item--selected miller-columns__item--active" aria-describedby="navigation-instructions" tabindex="0">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" type="checkbox" name="miller-columns-04c58f82[]" value="childcare-and-early-years" id="miller-columns-04c58f82-0-1" tabindex="-1">
+                  <label class="govuk-label govuk-checkboxes__label" for="miller-columns-04c58f82-0-1">
+                    Childcare and early years
+                  </label>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="miller-columns__column miller-columns__column--active">
+            <button class="govuk-back-link" type="button">Back</button>
+            <h3 class="miller-columns__column-heading">Childcare and early years</h3>
+            <ul class="miller-columns__column-list">
+              <li class="miller-columns__item govuk-checkboxes--small" aria-describedby="navigation-instructions" tabindex="0">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" type="checkbox" name="miller-columns-04c58f82[]" value="childcare-vouchers" id="miller-columns-04c58f82-0-1-0" tabindex="-1">
+                  <label class="govuk-label govuk-checkboxes__label" for="miller-columns-04c58f82-0-1-0">
+                    Childcare vouchers
+                  </label>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </miller-columns>
+      </div>
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        <button
+          class="gem-c-button govuk-button" type="submit"
+          name="save" value="save">
+          Update tags
+        </button>
+        <button
+          class="gem-c-button govuk-button govuk-button--secondary" type="submit"
+          name="legacy_tags" value="legacy_tags">
+          Update and review specialist topic tags
+        </button>
+      </div>
+    `
+
+    var trackSelectedTaxons = new GOVUK.Modules.TrackSelectedTaxons(form)
+    trackSelectedTaxons.init()
+  })
+
+  it('should send tracking events for each selected taxon when form is submitted', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(window.location, 'pathname').andReturn('/government/admin/editions/1/tags/edit')
+    form.dispatchEvent(new Event('submit'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'taxonSelection',
+      'Parenting, childcare and children\'s services > Divorce, separation and legal issues',
+      { label: '/government/admin/editions/1/tags/edit' }
+    )
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'taxonSelection',
+      'Parenting, childcare and children\'s services > Childcare and early years',
+      { label: '/government/admin/editions/1/tags/edit' }
+    )
+  })
+
+  it('should send tracking event when you select and unselect a taxon', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    var checkbox = form.querySelector('#miller-columns-04c58f82-0-1')
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'pageElementInteraction',
+      'checkboxClickedOn',
+      { label: 'Childcare and early years' }
+    )
+
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'pageElementInteraction',
+      'checkboxClickedOff',
+      { label: 'Childcare and early years' }
+    )
+  })
+})

--- a/spec/javascripts/modules/track-selected-taxon.spec.js
+++ b/spec/javascripts/modules/track-selected-taxon.spec.js
@@ -1,5 +1,5 @@
 describe('GOVUK.Modules.TrackSelectedTaxons', function () {
-  var form
+  var form, trackSelectedTaxons
 
   beforeEach(function () {
     form = document.createElement('form')
@@ -98,13 +98,14 @@ describe('GOVUK.Modules.TrackSelectedTaxons', function () {
       </div>
     `
 
-    var trackSelectedTaxons = new GOVUK.Modules.TrackSelectedTaxons(form)
+    trackSelectedTaxons = new GOVUK.Modules.TrackSelectedTaxons(form)
     trackSelectedTaxons.init()
   })
 
   it('should send tracking events for each selected taxon when form is submitted', function () {
     spyOn(GOVUK.analytics, 'trackEvent')
-    spyOn(window.location, 'pathname').andReturn('/government/admin/editions/1/tags/edit')
+    spyOn(trackSelectedTaxons, 'getCurrentPath').and.returnValue('/government/admin/editions/1/tags/edit')
+
     form.dispatchEvent(new Event('submit'))
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(


### PR DESCRIPTION
## What

Implement tracking on the Design System version of the 'Topic taxonomy tags' page.

## Why

So that we can continue tracking how publishers use this page.

https://trello.com/c/EyKlvBnz/793-implement-analytics-tracking-on-the-topic-taxonomy-tags-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
