### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/features/support/admin_taxonomy_helper.rb
+++ b/features/support/admin_taxonomy_helper.rb
@@ -24,11 +24,3 @@ module AdminTaxonomyHelper
   end
 end
 World(AdminTaxonomyHelper)
-
-Around do |_, block|
-  redis = Redis.new
-  Redis.new = nil
-  block.call
-ensure
-  Redis.new = redis
-end

--- a/features/support/admin_taxonomy_helper.rb
+++ b/features/support/admin_taxonomy_helper.rb
@@ -26,9 +26,9 @@ end
 World(AdminTaxonomyHelper)
 
 Around do |_, block|
-  redis = Redis.current
-  Redis.current = nil
+  redis = Redis.new
+  Redis.new = nil
   block.call
 ensure
-  Redis.current = redis
+  Redis.new = redis
 end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -3,7 +3,7 @@ require "redis-lock"
 namespace :taxonomy do
   desc "Rebuild the taxonomy cache"
   task rebuild_cache: [:environment] do
-    Redis.current.lock("rebuild_taxonomy_cache_worker_lock", life: 10.minutes, acquire: 1) do
+    Redis.new.lock("rebuild_taxonomy_cache_worker_lock", life: 10.minutes, acquire: 1) do
       Rails.logger.info "Scheduling taxonomy cache rebuild"
       RebuildTaxonomyCacheWorker.perform_async
     end

--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -3,7 +3,7 @@ module Taxonomy
     TAXONS_CACHE_KEY = "topic_taxonomy_taxons".freeze
     WORLD_TAXONS_CACHE_KEY = "world_taxonomy_taxons".freeze
 
-    def initialize(redis_client: Redis.current, adapter: PublishingApiAdapter.new)
+    def initialize(redis_client: Redis.new, adapter: PublishingApiAdapter.new)
       @redis_client = redis_client
       @adapter = adapter
     end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -58,6 +58,7 @@ module TaxonomyHelper
       .stubs(:get)
       .with(Taxonomy::RedisCacheAdapter::TAXONS_CACHE_KEY)
       .returns(JSON.dump(taxons))
+    Redis.stubs(:new).returns(redis_client)
   end
 
   def redis_cache_has_world_taxons(world_taxons)
@@ -65,6 +66,7 @@ module TaxonomyHelper
       .stubs(:get)
       .with(Taxonomy::RedisCacheAdapter::WORLD_TAXONS_CACHE_KEY)
       .returns(JSON.dump(world_taxons))
+    Redis.stubs(:new).returns(redis_client)
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)
@@ -106,7 +108,7 @@ module TaxonomyHelper
 private
 
   def redis_client
-    @redis_client ||= Redis.current = stub
+    @redis_client ||= stub
   end
 
   def child_taxon


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)\\

Test Updates: 
- Because taxonomy helper tests need a shared Redis instance (for stubbing), we also Stub Redis.new to return the stubbed client.
- Because we're always getting a new Redis instance, remove the block in the feature tests that previously forced a new Redis instance.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
