### PR TITLE
Move taxonomy update from upcoming to recent changes

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -4,7 +4,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 3 October 2022
+      last_updated: Last updated 6 October 2022
       introduction:
         heading: Moving to the Design System
         body_govspeak: |
@@ -14,22 +14,23 @@ en:
           [Read more about the changes on the content community Basecamp](https://3.basecamp.com/4322319/buckets/15005645/messages/5287245970).
       upcoming_changes:
         heading: Upcoming changes
+      recent_changes:     
+        heading: Recent changes
         updates:
           - heading: Topic taxonomy tags page moves to the Design System
             area: Creating and updating documents
             type: improvement
             date: 6 October 2022
             body_govspeak: |
-              The topic taxonomy tags page will move to the GOV.UK Design System.
-
-              Topics that are tagged to a document will be listed under the ‘Selected topics’ header on the ‘Topic taxonomy tags’ page. You can also remove tags in this section.
-      recent_changes:
-        heading: Recent changes
-        updates:
+              The topic taxonomy tags page has moved to the GOV.UK Design System.
+              
+              Topics that are tagged to a document are now listed under the ‘Selected topics’ header on the ‘Topic taxonomy tags’ page. You can also remove tags in this section.
+              
+              You can use the ‘back’ button on these pages to return to a previous page. 
           - heading: Reusing previous withdrawal dates and public explanations
             area: Creating and updating documents
             type: improvement
-            date: 26 September 2022
+            date: 2 August 2022
             body_govspeak: |
               When re-withdrawing content, you can choose to reuse a previous withdrawal date and public explanation in certain circumstances.
 
@@ -55,5 +56,5 @@ en:
 
           - [How to publish content on GOV.UK guidance](https://www.gov.uk/guidance/how-to-publish-on-gov-uk)
           - [Planning, writing and managing content guidance](https://www.gov.uk/guidance/content-design)
-          - [Inside GOV.UK blog](https://insidegovuk.blog.gov.uk/)
           - [Style guide](https://www.gov.uk/guidance/style-guide)
+          - [Inside GOV.UK blog](https://insidegovuk.blog.gov.uk/)


### PR DESCRIPTION
This PR is based off changes in https://github.com/alphagov/whitehall/pull/6890, which includes:

- moving the taxonomy update from upcoming to recent changes
- updates the last updated date
- fixes an incorrect date on a previous entry
- re-orders the guidance links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
