### PR TITLE
Create route helpers for Get Involved and Topical Events

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -1,6 +1,10 @@
 module FeedHelper
   def atom_feed_url_for(resource)
-    Whitehall.atom_feed_maker.url_for(resource)
+    if resource.instance_of?(TopicalEvent)
+      Whitehall.url_maker.topical_event_url(resource, format: "atom")
+    else
+      Whitehall.atom_feed_maker.url_for(resource)
+    end
   end
 
   def documents_as_feed_entries(documents, builder, feed_updated_timestamp = Time.zone.now)

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -112,6 +112,38 @@ module PublicDocumentRoutesHelper
     Plek.new.website_root + take_part_page_path(object, options)
   end
 
+  def topical_event_path(object, options = {})
+    slug = case object
+           when String
+             object
+           when TopicalEvent
+             object.slug
+           else
+             raise ArgumentError, "Must provide a slug or TopicalEvent"
+           end
+
+    append_url_options("/government/topical-events/#{slug}", options)
+  end
+
+  def topical_event_url(object, options = {})
+    Plek.new.website_root + topical_event_path(object, options)
+  end
+
+  def topical_event_about_pages_path(object, options = {})
+    slug = case object
+           when String
+             object
+           when TopicalEvent
+             object.slug
+           when TopicalEventAboutPage
+             object.topical_event.slug
+           else
+             raise ArgumentError, "Must provide a slug, TopicalEvent or TopicalEventAboutPage"
+           end
+
+    append_url_options("/government/topical-events/#{slug}/about", options)
+  end
+
 private
 
   def build_url_for_corporate_information_page(edition, options)

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -87,6 +87,31 @@ module PublicDocumentRoutesHelper
     polymorphic_url(organisation, options.merge(host: URI(Plek.new.external_url_for("draft-origin")).host))
   end
 
+  def get_involved_path(options = {})
+    append_url_options("/government/get-involved", options)
+  end
+
+  def get_involved_url(options = {})
+    Plek.new.website_root + get_involved_path(options)
+  end
+
+  def take_part_page_path(object, options = {})
+    slug = case object
+           when String
+             object
+           when TakePartPage
+             object.slug
+           else
+             raise ArgumentError, "Must provide a slug or TakePartPage"
+           end
+
+    append_url_options("/government/get-involved/take-part/#{slug}", options)
+  end
+
+  def take_part_page_url(object, options = {})
+    Plek.new.website_root + take_part_page_path(object, options)
+  end
+
 private
 
   def build_url_for_corporate_information_page(edition, options)

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -126,4 +126,23 @@ private
       self
     end
   end
+
+  def append_url_options(path, options = {})
+    if options[:format] && options[:locale]
+      path = "#{path}.#{options[:locale]}.#{options[:format]}"
+    elsif options[:locale]
+      path = "#{path}.#{options[:locale]}"
+    elsif options[:format]
+      path = "#{path}.#{options[:format]}"
+    end
+
+    if options[:cachebust]
+      query_params = {
+        cachebust: options[:cachebust],
+      }
+      path = "#{path}?#{query_params.to_query}"
+    end
+
+    path
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,9 +137,6 @@ Whitehall::Application.routes.draw do
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
     get "/statistics/:id(.:locale)", as: "statistic", to: "_#_", constraints: { locale: valid_locales_regex }
     get "/statistics/:statistics_id/:id" => "_#_", as: "statistic_html_attachment"
-    resources :topical_events, path: "topical-events", only: [:show] do
-      resource :about_pages, path: "about", only: [:show]
-    end
     # End of routes no longer rendered by Whitehall
 
     constraints(AdminRequest) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,10 +119,6 @@ Whitehall::Application.routes.draw do
         get :upcoming
       end
     end
-    scope "/get-involved" do
-      root to: "home#get_involved", as: :get_involved, via: :get
-      get "take-part/:id", to: "take_part_pages#show", as: "take_part_page"
-    end
     get "/latest" => "latest#index", as: "latest"
     get "/organisations/:id(.:locale)", as: "organisation", to: "organisations#show", constraints: { locale: valid_locales_regex }
     resources :organisations, only: [:index]

--- a/test/functional/admin/get_involved_controller_test.rb
+++ b/test/functional/admin/get_involved_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Admin::GetInvolvedControllerTest < ActionController::TestCase
+  setup do
+    login_as :gds_editor
+  end
+
+  should_be_an_admin_controller
+
+  test "GET :index returns ok" do
+    get :index
+
+    assert_response :success
+    assert_template "index"
+  end
+end

--- a/test/functional/admin/topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/topical_event_about_pages_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
+  include PublicDocumentRoutesHelper
+
   def setup
     login_as :user
     @topical_event = create(:topical_event)

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RoutingLocaleTest < ActionDispatch::IntegrationTest
+  include PublicDocumentRoutesHelper
+
   test "#index in default locale" do
     assert_equal "/government/ministers", ministerial_roles_path
   end

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -191,4 +191,56 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
   test "append_url_options adds cachebust string, format and locale when all present" do
     assert_equal "/government/foo.cy.atom?cachebust=123", append_url_options("/government/foo", cachebust: "123", format: "atom", locale: "cy")
   end
+
+  test "get_involved_path returns the path" do
+    assert_equal "/government/get-involved", get_involved_path
+  end
+
+  test "get_involved_url returns the url" do
+    assert_equal "https://www.test.gov.uk/government/get-involved", get_involved_url
+  end
+
+  test "get_involved_path returns the path and appends options" do
+    assert_equal "/government/get-involved?cachebust=123", get_involved_path(cachebust: "123")
+  end
+
+  test "get_involved_url returns the url and appends options" do
+    assert_equal "https://www.test.gov.uk/government/get-involved?cachebust=123", get_involved_url(cachebust: "123")
+  end
+
+  test "take_part_page_path returns the correct path for a slug" do
+    assert_equal "/government/get-involved/take-part/foo", take_part_page_path("foo")
+  end
+
+  test "take_part_page_path returns the correct path for a slug with options" do
+    assert_equal "/government/get-involved/take-part/foo?cachebust=123", take_part_page_path("foo", cachebust: "123")
+  end
+
+  test "take_part_page_path returns the correct path for a TakePart object" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "/government/get-involved/take-part/foo", take_part_page_path(object)
+  end
+
+  test "take_part_page_path returns the correct path for a TakePart object with options" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "/government/get-involved/take-part/foo?cachebust=123", take_part_page_path(object, cachebust: "123")
+  end
+
+  test "take_part_page_url returns the correct path for a slug" do
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", take_part_page_url("foo")
+  end
+
+  test "take_part_page_url returns the correct path for a slug with options" do
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", take_part_page_url("foo", cachebust: "123")
+  end
+
+  test "take_part_page_url returns the correct path for a TakePart object" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", take_part_page_url(object)
+  end
+
+  test "take_part_page_url returns the correct path for a TakePart object with options" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", take_part_page_url(object, cachebust: "123")
+  end
 end

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -243,4 +243,52 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
     object = create(:take_part_page, slug: "foo")
     assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", take_part_page_url(object, cachebust: "123")
   end
+
+  test "topical_event_path returns the correct path for a TopicalEvent object" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo", topical_event_path(object)
+  end
+
+  test "topical_event_path returns the correct path for a TopicalEvent object with options" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo?cachebust=123", topical_event_path(object, cachebust: "123")
+  end
+
+  test "topical_event_url returns the correct path for a slug" do
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo", topical_event_url("foo")
+  end
+
+  test "topical_event_url returns the correct path for a slug with options" do
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", topical_event_url("foo", cachebust: "123")
+  end
+
+  test "topical_event_url returns the correct path for a TopicalEvent object" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo", topical_event_url(object)
+  end
+
+  test "topical_event_url returns the correct path for a TopicalEvent object with options" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", topical_event_url(object, cachebust: "123")
+  end
+
+  test "topical_event_about_pages_path returns the correct path for a TopicalEvent object" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo/about", topical_event_about_pages_path(object)
+  end
+
+  test "topical_event_about_pages_path returns the correct path for a TopicalEventAboutPage object" do
+    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
+    assert_equal "/government/topical-events/foo/about", topical_event_about_pages_path(object.topical_event_about_page)
+  end
+
+  test "topical_event_about_pages_path returns the correct path for a TopicalEvent object with options" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo/about?cachebust=123", topical_event_about_pages_path(object, cachebust: "123")
+  end
+
+  test "topical_event_about_pages_path returns the correct path for a TopicalEventAboutPage object with options" do
+    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
+    assert_equal "/government/topical-events/foo/about?cachebust=123", topical_event_about_pages_path(object.topical_event_about_page, cachebust: "123")
+  end
 end

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -171,4 +171,24 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
     assert_equal "/government/organisations/foobar", organisation_path("foobar")
     assert_equal "http://test.host/government/organisations/foobar", organisation_url("foobar")
   end
+
+  test "append_url_options adds locale" do
+    assert_equal "/government/foo.cy", append_url_options("/government/foo", locale: "cy")
+  end
+
+  test "append_url_options adds format" do
+    assert_equal "/government/foo.atom", append_url_options("/government/foo", format: "atom")
+  end
+
+  test "append_url_options adds locale and format when both present" do
+    assert_equal "/government/foo.cy.atom", append_url_options("/government/foo", format: "atom", locale: "cy")
+  end
+
+  test "append_url_options adds cachebust string when present" do
+    assert_equal "/government/foo?cachebust=123", append_url_options("/government/foo", cachebust: "123")
+  end
+
+  test "append_url_options adds cachebust string, format and locale when all present" do
+    assert_equal "/government/foo.cy.atom?cachebust=123", append_url_options("/government/foo", cachebust: "123", format: "atom", locale: "cy")
+  end
 end

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class FeaturePresenterTest < PresenterTestCase
+  include PublicDocumentRoutesHelper
+
   test "#public_path generates a link to a topical event if that is what has been featured" do
     te = stub_record(:topical_event)
     f = stub_record(:feature, topical_event: te, document: nil)


### PR DESCRIPTION
The controllers for these routes were removed some time ago, however the routes (and the non-existent controller names) remained in the routes file solely so we could utilise the route helpers automatically created by Rails.

This removes those routes and creates our own custom route helper methods.

I did investigate using [`direct` routes](https://guides.rubyonrails.org/routing.html#direct-routes) as an alternative.  This would be fine to use if we only wanted fairly static URLs, e.g. `/government/get-involved` or `/government/get-involves/take-part/#{slug}`.  It appears the returned string gets passed into `url_for`, which doesn't apply any of the options (e.g. appending a cachebust string, locale or format) if you pass in a string (it does if you use a model or controller name).  Therefore we'll need to create our own helpers in order to add in these options which are quite extensively baked into Whitehall.

This PR includes a commit that fixes a test (forming atom feed URLs) that will be removed when https://github.com/alphagov/whitehall/pull/6900 is merged, as Whitehall no longer needs to create these URLs for formats that it no longer renders.

[Trello card](https://trello.com/c/EfhUs8ak/33-tidy-whitehalls-routes-file)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
