### PR TITLE
Fix past prime minister href

### DIFF
--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
   <% if role_appointment.has_historical_account? %>
     <%= render "govuk_publishing_components/components/image_card", {
-      href: historic_appointment_path(role.historic_param, role_appointment.person),
+      href: historic_appointment_path(role_appointment.person),
       image_src: role_appointment.person.image_url(:s216),
       image_loading: "lazy",
       heading_text: role_appointment.person.name,


### PR DESCRIPTION
This fixes a bug introduced by an earlier routes refactor.

Past prime ministers links are currently broken - e.g. the link for Gordon Brown on [this page](https://www.integration.publishing.service.gov.uk/government/history/past-prime-ministers) goes to https://www.gov.uk/government/history/past-prime-ministers/past-prime-ministers.gordon-brown rather than 
https://www.gov.uk/government/history/past-prime-ministers/gordon-brown


| Current href on live | Href after this change: |
| -------| ------ |
|<img width="654" alt="Screenshot 2022-10-07 at 13 26 28" src="https://user-images.githubusercontent.com/25515510/194553105-e652a288-ab84-4c45-8732-f368b8f4972f.png">|<img width="656" alt="Screenshot 2022-10-07 at 13 24 42" src="https://user-images.githubusercontent.com/25515510/194552797-de7dce46-b18c-4d99-bed4-963cd541b936.png">|

We should introduce a test for this but currently prioritising getting a fix into production.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
