### PR TITLE
Fix historical route generation

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -350,7 +350,7 @@ class HistoricAppointmentsController < PublicFacingController
   end
 
   def show
-    @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
+    @person = PersonPresenter.new(Person.friendly.find(params[:person_id]), view_context)
     @historical_account = @person.historical_accounts.for_role(@role).first
     raise(ActiveRecord::RecordNotFound, "Couldn't find HistoricalAccount for #{@person.inspect}  and #{@role.inspect}") unless @historical_account
   end
@@ -374,7 +374,11 @@ private
   end
 
   def load_role
-    @role = Role.friendly.find("prime-minister")
+    @role = Role.friendly.find(role_id)
+  end
+
+  def role_id
+    Role::HISTORIC_ROLE_PARAM_MAPPINGS[params[:role]]
   end
 
   def previous_appointments

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
   <% if role_appointment.has_historical_account? %>
     <%= render "govuk_publishing_components/components/image_card", {
-      href: historic_appointment_path(role_appointment.person),
+      href: historic_appointment_path(role.historic_param, role_appointment.person),
       image_src: role_appointment.person.image_url(:s216),
       image_loading: "lazy",
       heading_text: role_appointment.person.name,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,13 +84,18 @@ Whitehall::Application.routes.draw do
     resource :email_signups, path: "email-signup", only: %i[create new]
     resources :fatality_notices, path: "fatalities", only: [:show]
     scope "/history" do
-      get "/past-chancellors", to: "historic_appointments#past_chancellors"
+      # Past foreign secretaries are currently hard-coded, so this
+      # resource falls straight through to views.
+      resources :past_foreign_secretaries, path: "/past-foreign-secretaries", only: %i[index show]
+      # Past chancellors is also hard-coded
+      get "/past-chancellors" => "historic_appointments#past_chancellors"
 
-      get "/past-foreign-secretaries", to: "past_foreign_secretaries#index"
-      get "/past-foreign-secretaries/:id", to: "past_foreign_secretaries#show"
+      # Past foreign secretaries and past chancellors are here for the
+      # purposes of reversing URLs in a consistent way from other views.
 
-      get "/past-prime-ministers", to: "historic_appointments#index"
-      get "/past-prime-ministers/:id", to: "historic_appointments#show", as: :historic_appointment
+      # TODO: make these dynamic, they're hard-coded above.
+      get "/:role" => "historic_appointments#index", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointments"
+      get "/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointment"
     end
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -16,7 +16,8 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
       { path: "government/history/past-prime-ministers/barry", method: :get },
       controller: "historic_appointments",
       action: "show",
-      id: "barry",
+      role: "past-prime-ministers",
+      person_id: "barry",
     )
   end
 
@@ -48,7 +49,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Prime Ministers" do
     pm_account = create(:historical_account, roles: [pm_role])
     create(:role_appointment, person: pm_account.person, role: pm_role)
-    get :show, params: { role: "past-prime-ministers", id: pm_account.person.slug }
+    get :show, params: { role: "past-prime-ministers", person_id: pm_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -61,7 +62,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     chancellor_account = create(:historical_account, roles: [chancellor_role])
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :show, params: { role: "past-prime-ministers", id: chancellor_account.person.slug }
+      get :show, params: { role: "past-prime-ministers", person_id: chancellor_account.person.slug }
     end
   end
 


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/6888 made some changes to how routes work for historical appointments. These were slightly more complicated than initially thought and the implementation broke some route generation. This PR reverts these changes to make sure that routes are generated properly again.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
