### PR TITLE
Remove edit tabs permission

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,6 @@ class User < ApplicationRecord
     VIEW_MOVE_TABS_TO_ENDPOINTS = "View move tabs to endpoints".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     REDIRECT_TO_SUMMARY_PAGE = "Redirect to summary page".freeze
-    REMOVE_EDIT_TABS = "Remove edit tabs".freeze
   end
 
   def role
@@ -105,10 +104,6 @@ class User < ApplicationRecord
 
   def can_redirect_to_summary_page?
     has_permission?(Permissions::REDIRECT_TO_SUMMARY_PAGE)
-  end
-
-  def can_remove_edit_tabs?
-    has_permission?(Permissions::REMOVE_EDIT_TABS)
   end
 
   def organisation_name

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -3,15 +3,9 @@
 
 <div class="row">
   <section class="col-md-8">
-    <% if current_user.can_remove_edit_tabs? %>
-      <span class="back">
-        <%= link_to 'Back', admin_edition_path(attachment.attachable) %>
-      </span>
-    <% end %>
-
     <h1>Attachments for <%= attachment.attachable_model_name %></h1>
 
-    <% if current_user.can_remove_edit_tabs? %>
+    <%= attachable_editing_tabs(attachable) do %>
       <p class="qa-helper-copy">
         <strong>Note:</strong>
         <%= attachment_note(attachment.attachable_model_name) %>
@@ -47,44 +41,6 @@
       </div>
 
       <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
-    <% else %>
-      <%= attachable_editing_tabs(attachable) do %>
-        <p class="qa-helper-copy">
-          <strong>Note:</strong>
-          <%= attachment_note(attachment.attachable_model_name) %>
-        </p>
-        <ul class="actions list-unstyled">
-          <li>
-            <%= link_to 'Upload new file attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment]) %>
-          </li>
-          <% if attachable.is_a?(Edition) %>
-            <li>
-              <%= link_to 'Bulk upload from Zip file'.html_safe, new_admin_edition_bulk_upload_path(attachable) %>
-            </li>
-          <% end %>
-          <% if attachable.allows_html_attachments? %>
-            <li>
-              <%= link_to 'Add new HTML attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment], type: "html") %>
-            </li>
-          <% end %>
-          <% if attachable.allows_external_attachments? %>
-            <li>
-              <%= link_to 'Add new external attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment], type: "external") %>
-            </li>
-          <% end %>
-        </ul>
-
-        <div class="alert alert-warning">
-          <p>
-            You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.<br/>
-          </p>
-          <p>
-            For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.
-          </p>
-        </div>
-
-        <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
       <% end %>
-    <% end %>
   </section>
 </div>

--- a/app/views/admin/case_studies/_legacy_form.html.erb
+++ b/app/views/admin/case_studies/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Case studies that show someone’s experience of a process covered on GOV.UK or a policy problem the government is trying to solve.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Associations</legend>
@@ -10,16 +10,5 @@
       <%= render 'legacy_world_location_fields', form: form, edition: edition %>
       <%= render 'legacy_organisation_fields', form: form, edition: edition %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render 'legacy_worldwide_organisation_fields', form: form, edition: edition %>
-        <%= render 'legacy_world_location_fields', form: form, edition: edition %>
-        <%= render 'legacy_organisation_fields', form: form, edition: edition %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/consultations/_legacy_form.html.erb
+++ b/app/views/admin/consultations/_legacy_form.html.erb
@@ -4,7 +4,7 @@
   <p>Check you have read the current <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= consultation_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Held on another website</legend>
@@ -59,63 +59,5 @@
       <legend>Consultation principles</legend>
       <%= form.check_box :read_consultation_principles, label_text: 'We have considered the <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>'.html_safe %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= consultation_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <fieldset>
-        <legend>Held on another website</legend>
-        <%= form.check_box :external, label_text: "This #{edition.class.name.humanize.downcase} is held on another website" %>
-        <div class="js-external-url">
-          <%= form.text_field :external_url, label_text: "External link URL" %>
-        </div>
-      </fieldset>
-
-      <div class="js-external-url-set">
-        <fieldset>
-          <legend>Ways to respond</legend>
-          <%= form.fields_for :consultation_participation, edition.consultation_participation || edition.build_consultation_participation do |participation_fields| %>
-            <%= participation_fields.text_field :link_url, label_text: 'Link URL' %>
-            <%= participation_fields.text_field :email %>
-            <%= participation_fields.text_area :postal_address, rows: "4", style: "width: auto" %>
-            <%= participation_fields.fields_for :consultation_response_form, participation_fields.object.consultation_response_form || participation_fields.object.build_consultation_response_form do |response_form_fields| %>
-              <%= response_form_fields.text_field :title, label_text: "Downloadable response form title", required: false %>
-              <% if response_form_fields.object.persisted? %>
-                <div class="attachment">
-                  <p>Current data: <%= link_to File.basename(response_form_fields.object.consultation_response_form_data.file.path), response_form_fields.object.consultation_response_form_data.file.url %></p>
-                  <p>Actions: <%= attachment_action_fields(response_form_fields, :consultation_response_form_data) %></p>
-                  <%= consultation_response_form_data_fields(response_form_fields) %>
-                </div>
-              <% else %>
-                <%= consultation_response_form_data_fields(response_form_fields) %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </fieldset>
-      </div>
-
-      <div class="js-external-url-set">
-        <%= render 'legacy_html_version_fields', form: form, edition: edition %>
-        <%= render 'legacy_inline_attachments_info', form: form, edition: edition %>
-      </div>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <div class="js-external-url-set">
-          <%= render 'legacy_appointment_fields', form: form, edition: edition %>
-        </div>
-
-        <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
-
-        <%= render 'legacy_nation_fields', form: form, edition: edition %>
-
-        <%= render 'legacy_organisation_fields', form: form, edition: edition %>
-      </fieldset>
-
-      <fieldset>
-        <legend>Consultation principles</legend>
-        <%= form.check_box :read_consultation_principles, label_text: 'We have considered the <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>'.html_safe %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/corporate_information_pages/_legacy_form.html.erb
+++ b/app/views/admin/corporate_information_pages/_legacy_form.html.erb
@@ -1,17 +1,8 @@
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <div class="js-external-url-set">
       <%= render partial: 'legacy_inline_attachments_info', locals: { form: form, edition: edition } %>
     </div>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-
-      <div class="js-external-url-set">
-        <%= render partial: 'legacy_inline_attachments_info', locals: { form: form, edition: edition } %>
-      </div>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/detailed_guides/_legacy_form.html.erb
+++ b/app/views/admin/detailed_guides/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p>Detailed guides tell users the steps they need to take to complete a specific task. They are usually aimed at specialist or professional audiences.</p><p>Read the <a href="https://www.gov.uk/guidance/content-design/content-types#detailed-guide" target="_blank">detailed guides guidance</a> in full.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <fieldset>
@@ -29,35 +29,5 @@
     </fieldset>
 
     <%= render partial: 'legacy_nation_fields', locals: { form: form, edition: edition } %>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
-
-        <%= render "legacy_topical_event_fields", form: form, edition: edition %>
-
-        <% cache_if edition.related_detailed_guide_ids.empty?, taggable_detailed_guides_cache_digest do %>
-          <%= form.label :related_detailed_guide_ids, 'Related guides' %>
-          <%= form.select :related_detailed_guide_ids, options_for_select(taggable_detailed_guides_container, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related detailed guides…"} %>
-        <% end %>
-      </fieldset>
-
-      <%= render partial: 'legacy_inline_attachments_info', locals: { form: form, edition: edition } %>
-
-      <fieldset>
-        <legend>Related mainstream content</legend>
-        <p>
-          Link to the top-level URL for mainstream content - not a specific chapter.
-        </p>
-        <%= form.text_field :related_mainstream_content_url %>
-        <%= form.text_field :additional_related_mainstream_content_url %>
-      </fieldset>
-
-      <%= render partial: 'legacy_nation_fields', locals: { form: form, edition: edition } %>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -4,15 +4,9 @@
 <% initialise_script 'GOVUK.documentFinder' %>
 <% initialise_script 'GOVUK.documentCollectionCheckboxSelector' %>
 
-<% if current_user.can_remove_edit_tabs? %>
-  <span class="back">
-    <%= link_to 'Back', admin_edition_path(@collection) %>
-  </span>
-<% end %>
-
 <h1><%= @collection.title %></h1>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(@collection) do %>
   <%= render partial: 'collection_size_warning' %>
   <%= form_tag admin_document_collection_new_whitehall_member_path(@collection) do %>
     <h2>Add document to a group</h2>
@@ -109,103 +103,4 @@
       <i class="glyphicon glyphicon-plus"></i> Add a new group
     <% end %>
   </p>
-<% else %>
-  <%= edition_editing_tabs(@collection) do %>
-    <%= render partial: 'collection_size_warning' %>
-    <%= form_tag admin_document_collection_new_whitehall_member_path(@collection) do %>
-      <h2>Add document to a group</h2>
-      <div id="document-finder" class="document-finder form-inline well remove-top-margin">
-        <label for="title">Add</label>
-        <div class="document-finder-fields">
-          <%= search_field_tag :title, '', placeholder: 'Title or slug&hellip;'.html_safe, results: 5, autosave: 'unique', autofocus: true, class: 'form-control input-sm' %>
-          <%= button_tag 'Find', type: 'button', id: 'find-documents', class: 'btn btn-default btn-sm add-right-margin' %>
-          <%= image_tag 'loading-666666.gif', class: 'js-loader' %>
-          <p class="tip">
-            Only the first 10 results are returned – be as specific as you can
-          </p>
-        </div>
-        to the
-        <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :heading, session[:document_collection_selected_group_id]), class: 'form-control input-sm' %>
-        group
-        <%= submit_tag 'Add', class: 'btn btn-sm btn-info' %>
-        <%= hidden_field_tag :document_id %>
-      </div>
-    <% end %>
-
-    <details class="non-whitehall-disclosure"<% if flash[:open_non_whitehall] %> open<% end %>>
-      <summary>
-        Add GOV.UK content created outside of Whitehall to a group
-      </summary>
-      <%= form_tag admin_document_collection_new_non_whitehall_member_path(@collection), class: 'document-finder' do %>
-        <div class="document-finder form-inline well remove-top-margin">
-          <label for="url">Add</label>
-          <%= text_field_tag :url, flash[:url], placeholder: 'GOV.UK URL', class: 'form-control input-sm' %>
-          to the
-          <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :heading, session[:document_collection_selected_group_id]), class: 'form-control input-sm' %>
-          group
-          <%= submit_tag 'Add', class: 'btn btn-sm btn-info' %>
-        </div>
-      <% end %>
-    </details>
-
-    <div class="js-group-container">
-      <div class="reorder-buttons">
-        <%= button_tag 'Reorder groups', class: 'btn btn-sm btn-info js-reorder' %><%= button_tag 'Finish reordering', class: 'btn btn-sm btn-success js-finish-reorder' %>
-      </div>
-      <% @groups.each do |group| %>
-        <section class="group">
-          <header class="js-group-header">
-            <h2>
-              <span class="small">Group</span><br/>
-              <%= group.heading %>
-            </h2>
-            <ul class="actions">
-              <li>
-                <%= link_to 'Edit group heading and body', edit_admin_document_collection_group_path(@collection, group) %>
-              </li>
-              <li>
-                <%= link_to 'Delete group', delete_admin_document_collection_group_path(@collection, group) %>
-              </li>
-            </ul>
-          </header>
-          <div class="js-group-body">
-            <% if group.editable_members.empty? %>
-              <p class="no-content no-content-bordered js-document-group" data-group-id="<%= group.id %>">
-                No documents in this group<br />
-                Add documents by searching or dragging them from another group.
-              </p>
-            <% else %>
-              <%= form_tag admin_document_collection_group_members_path(@collection, group), method: 'delete' do %>
-                <ul class="controls list-unstyled">
-                  <li>
-                    <%= check_box_tag :select_all, group.id, false, id: nil, class: 'checkbox' %>
-                  </li>
-                  <li class="remove">
-                    <%= submit_tag 'Remove', class: 'btn btn-sm btn-default' %>
-                  </li>
-                  <% other_groups = @groups - [group] %>
-                  <% if other_groups.size > 0 %>
-                    <li class="move form-inline">
-                      Move selected to
-                      <%= select_tag :new_group_id, options_from_collection_for_select(other_groups, :id, :heading), class: 'form-control input-sm' %>
-                      <%= submit_tag 'Move', class: 'btn btn-sm btn-default' %>
-                    </li>
-                  <% end %>
-                </ul>
-                <ol class="document-list js-document-group list-unstyled" data-group-id="<%= group.id %>">
-                  <%= render partial: 'collection_document', collection: group.editable_members, as: :membership, locals: { document_collection: @collection } %>
-                </ol>
-              <% end %>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
-    </div>
-
-    <p class="add-group">
-      <%= link_to new_admin_document_collection_group_path(@collection), class: 'btn btn-default' do %>
-        <i class="glyphicon glyphicon-plus"></i> Add a new group
-      <% end %>
-    </p>
-  <% end %>
 <% end %>

--- a/app/views/admin/document_collections/_legacy_form.html.erb
+++ b/app/views/admin/document_collections/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Continuously curated, permanent lists of closely related documents for a specific audience – not just by subject.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <fieldset>
@@ -10,16 +10,5 @@
       <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'legacy_topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
-        <%= render partial: 'legacy_topical_event_fields', locals: { form: form, edition: edition } %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -153,45 +153,6 @@
   </section>
 <% end %>
 
-<% if @edition.is_a?(DocumentCollection) && current_user.can_remove_edit_tabs? %>
-  <section>
-    <h2>Collection documents</h2>
-      <% if @edition.editable? %>
-        <span>
-          <%= link_to admin_document_collection_groups_path(@edition), title: "Modify collection documents of #{@edition.title}", class: "btn btn-default" do %>
-            <i class="glyphicon glyphicon-edit"></i> Modify collection documents
-          <% end %>
-        </span>
-      <% end %>
-  </section>
-<% end %>
-
-<% if @edition.is_a?(Consultation) && current_user.can_remove_edit_tabs? %>
-  <section>
-    <h2>Public feedback</h2>
-      <% if @edition.editable? %>
-        <span>
-          <%= link_to admin_consultation_public_feedback_path(@edition), title: "Modify public feedback for #{@edition.title}", class: "btn btn-default" do %>
-            <i class="glyphicon glyphicon-edit"></i> Modify public feedback
-          <% end %>
-        </span>
-      <% end %>
-  </section>
-<% end %>
-
-<% if @edition.is_a?(Consultation) && current_user.can_remove_edit_tabs? %>
-  <section>
-    <h2>Final outcome</h2>
-      <% if @edition.editable? %>
-        <span>
-          <%= link_to admin_consultation_outcome_path(@edition), title: "Modify final outcome of #{@edition.title}", class: "btn btn-default" do %>
-            <i class="glyphicon glyphicon-edit"></i> Modify final outcome
-          <% end %>
-        </span>
-      <% end %>
-  </section>
-<% end %>
-
 <% if @edition.document.document_sources.any? or current_user.can_import? %>
   <section id="document-sources-section">
     <h2>Legacy URL redirects</h2>

--- a/app/views/admin/editions/edit_legacy.html.erb
+++ b/app/views/admin/editions/edit_legacy.html.erb
@@ -1,9 +1,3 @@
-<% if current_user.can_remove_edit_tabs? %>
-  <span class="back">
-    <%= link_to 'Back', admin_edition_path(@edition) %>
-  </span>
-<% end %>
-
 <% page_title "Editing: #{@edition.title}"  %>
 <% if @conflicting_edition %>
   <section>

--- a/app/views/admin/fatality_notices/_legacy_form.html.erb
+++ b/app/views/admin/fatality_notices/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Initial fatality notices and subsequent obituaries of forces and MOD personnel. Don’t publish a news story which duplicates this announcement.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Associations</legend>
@@ -22,28 +22,5 @@
         </div>
       <% end %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <fieldset>
-        <legend>Associations</legend>
-        <p>You'll be able to specialist sectors later.</p>
-        <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
-        <%= render partial: 'legacy_appointment_fields', locals: { form: form, edition: edition } %>
-        <%= render partial: 'legacy_operational_field_fields', locals: { form: form, edition: edition } %>
-      </fieldset>
-
-      <fieldset class="named fatality-notice-casualties js-duplicate-fields">
-        <legend>Roll call info (displays on the field of operation)</legend>
-        <%= form.text_area :roll_call_introduction, rows: 2, label_text: 'Introduction' %>
-        <h3>Casualties</h3>
-        <%= form.fields_for :fatality_notice_casualties do |casualty_form| %>
-          <div class="js-duplicate-fields-set well">
-            <%= casualty_form.text_area :personal_details, rows: 2 %>
-          </div>
-        <% end %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/news_articles/_legacy_form.html.erb
+++ b/app/views/admin/news_articles/_legacy_form.html.erb
@@ -4,7 +4,7 @@
   <p>Do <em>not</em> use for: promoting the publication of other content (eg statistics).</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <%= render 'legacy_inline_attachments_info', form: form, edition: edition %>
 
@@ -16,20 +16,5 @@
       <%= render 'legacy_world_location_fields', form: form, edition: edition %>
       <%= render 'legacy_organisation_fields', form: form, edition: edition %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <%= render 'legacy_inline_attachments_info', form: form, edition: edition %>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render 'legacy_appointment_fields', form: form, edition: edition %>
-        <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
-        <%= render 'legacy_worldwide_organisation_fields', form: form, edition: edition %>
-        <%= render 'legacy_world_location_fields', form: form, edition: edition %>
-        <%= render 'legacy_organisation_fields', form: form, edition: edition %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/publications/_legacy_form.html.erb
+++ b/app/views/admin/publications/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Stand-alone government documents, issued on a specified date through GOV.UK for distribution.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <%= form.hidden_field :statistics_announcement_id %>
 
@@ -19,25 +19,5 @@
       <%= render 'legacy_organisation_fields', form: form, edition: edition %>
       <%= render 'legacy_nation_fields', form: form, edition: edition %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <%= form.hidden_field :statistics_announcement_id %>
-
-      <%= render 'legacy_inline_attachments_info', form: form, edition: edition %>
-      <%= render 'legacy_html_version_fields', form: form, edition: edition %>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <p>You'll be able to select Topics and Specialist Sectors later.</p>
-        <%= render 'legacy_appointment_fields', form: form, edition: edition %>
-        <%= render 'legacy_statistical_data_set_fields', form: form, edition: edition %>
-        <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
-        <%= render 'legacy_world_location_fields', form: form, edition: edition %>
-        <%= render 'legacy_organisation_fields', form: form, edition: edition %>
-        <%= render 'legacy_nation_fields', form: form, edition: edition %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/responses/show.html.erb
+++ b/app/views/admin/responses/show.html.erb
@@ -4,15 +4,8 @@
 
 <div class="row">
   <section class="col-md-8">
-    <% if current_user.can_remove_edit_tabs? %>
-      <span class="back">
-        <%= link_to 'Back', admin_edition_path(@edition) %>
-      </span>
-    <% end %>
-
     <h1><%= @response.friendly_name.capitalize %> for consultation</h1>
-
-    <% if current_user.can_remove_edit_tabs? %>
+    <%= consultation_editing_tabs(@edition) do %>
       <% if @response.persisted? %>
         <div class="summary">
           <h3><%= @response.friendly_name.capitalize %> summary</h3>
@@ -36,35 +29,7 @@
           <%= consulation_response_help_text(@response) %>
         </p>
 
-        <%= render partial: 'form', locals: { consultation: @edition, consultation_response: @response } %>
-      <% end %>
-    <% else %>
-      <%= consultation_editing_tabs(@edition) do %>
-        <% if @response.persisted? %>
-          <div class="summary">
-            <h3><%= @response.friendly_name.capitalize %> summary</h3>
-            <%= govspeak_to_html @response.summary %>
-            <p>Published on <%= @response.published_on.to_fs(:long_ordinal) %></p>
-          </div>
-
-          <ul class="actions">
-            <li><%= link_to "Edit #{@response.friendly_name}", [:edit, :admin, @edition, @response.singular_routing_symbol] %></li>
-          </ul>
-
-          <h3>Attachments (optional)</h3>
-          <ul class="actions">
-            <li><%= link_to 'Upload new file attachment', new_admin_response_attachment_path(@response) %></li>
-            <li><%= link_to 'Add new HTML attachment', new_admin_response_attachment_path(@response, type: "html") %></li>
-          </ul>
-          <%= render('admin/attachments/attachments', attachable: @response) if @response.attachments.any? %>
-
-        <% else %>
-          <p class="alert alert-info">
-            <%= consulation_response_help_text(@response) %>
-          </p>
-
-          <%= render partial: 'legacy_form', locals: { consultation: @edition, consultation_response: @response } %>
-        <% end %>
+        <%= render partial: 'legacy_form', locals: { consultation: @edition, consultation_response: @response } %>
       <% end %>
     <% end %>
   </section>

--- a/app/views/admin/speeches/_legacy_form.html.erb
+++ b/app/views/admin/speeches/_legacy_form.html.erb
@@ -5,7 +5,7 @@
   <p>Do <em>not</em> use for: statements <em>not</em> made to Parliament (use the “news article” format for those).</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
     <fieldset>
       <legend>Associations</legend>
@@ -13,16 +13,5 @@
       <%= render 'legacy_world_location_fields', form: form, edition: edition %>
       <%= render 'legacy_organisation_fields', form: form, edition: edition %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render 'legacy_topical_event_fields', form: form, edition: edition %>
-        <%= render 'legacy_world_location_fields', form: form, edition: edition %>
-        <%= render 'legacy_organisation_fields', form: form, edition: edition %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/statistical_data_sets/_legacy_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_legacy_form.html.erb
@@ -4,8 +4,7 @@
   <p>Do <em>not</em> use for: less frequently updated (eg quarterly) data. Use a publication (subtype: statistics) instead.</p>
 </div>
 
-
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <%= render partial: 'legacy_inline_attachments_info', locals: { form: form, edition: edition } %>
@@ -14,17 +13,5 @@
       <legend>Associations</legend>
       <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-
-      <%= render partial: 'legacy_inline_attachments_info', locals: { form: form, edition: edition } %>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render partial: 'legacy_organisation_fields', locals: { form: form, edition: edition } %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/supporting_pages/_legacy_form.html.erb
+++ b/app/views/admin/supporting_pages/_legacy_form.html.erb
@@ -2,7 +2,7 @@
   <p><strong>Use this format for:</strong> Detailed background or information about an action government is taking in relation to a policy.</p>
 </div>
 
-<% if current_user.can_remove_edit_tabs? %>
+<%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition, @information) do |form| %>
 
     <div class="js-external-url-set">
@@ -13,19 +13,5 @@
       <legend>Associations</legend>
       <%= render partial: 'legacy_specialist_sector_fields', locals: { form: form, edition: edition } %>
     </fieldset>
-  <% end %>
-<% else %>
-  <%= edition_editing_tabs(edition) do %>
-    <%= standard_edition_form(edition, @information) do |form| %>
-
-      <div class="js-external-url-set">
-        <%= render 'legacy_inline_attachments_info', form: form, edition: edition %>
-      </div>
-
-      <fieldset>
-        <legend>Associations</legend>
-        <%= render partial: 'legacy_specialist_sector_fields', locals: { form: form, edition: edition } %>
-      </fieldset>
-    <% end %>
   <% end %>
 <% end %>

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -14,14 +14,6 @@ Feature: Grouping documents into a collection
     Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
 
   @javascript
-  Scenario: Admin creates a document collection with the `Remove edit tabs` permission
-    Given a published document "Wombats of Wimbledon" exists
-    And I have the "Remove edit tabs" permission
-    When I draft a new document collection called "Wildlife of Wimbledon Common"
-    And I add the document "Wombats of Wimbledon" to the document collection
-    Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
-
-  @javascript
   Scenario: Admin creates a document collection in another language
     Given a published publication "Wombats of Wimbledon" with locale "cy" exists
     When I draft a new "Cymraeg" language document collection called "Wildlife of Wimbledon Common"

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -31,14 +31,7 @@ end
 When(/^I add an outcome to the consultation$/) do
   visit edit_admin_consultation_path(Consultation.last)
   click_button "Create new edition"
-  if @user.can_remove_edit_tabs?
-    fill_in_change_note_if_required
-    apply_to_all_nations_if_required
-    click_button "Save"
-    click_link "Modify final outcome"
-  else
-    click_link "Final outcome"
-  end
+  click_link "Final outcome"
 
   fill_in "Detail/Summary", with: "Outcome summary"
   click_button "Save"
@@ -49,14 +42,7 @@ end
 When(/^I add public feedback to the consultation$/) do
   visit edit_admin_consultation_path(Consultation.last)
   click_button "Create new edition"
-  if @user.can_remove_edit_tabs?
-    fill_in_change_note_if_required
-    apply_to_all_nations_if_required
-    click_button "Save"
-    click_link "Modify public feedback"
-  else
-    click_link "Public feedback"
-  end
+  click_link "Public feedback"
 
   fill_in "Summary", with: "Feedback summary"
   click_button "Save"

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -41,12 +41,8 @@ end
 
 When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
   visit admin_document_collection_path(@document_collection)
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   base_path = URI.parse(url).path
   content_id = SecureRandom.uuid
@@ -76,12 +72,8 @@ When(/^I add the document "(.*?)" to the document collection$/) do |document_tit
 
   visit admin_document_collection_path(@document_collection)
 
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   fill_in "title", with: document_title
   click_on "Find"
@@ -97,12 +89,8 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   # Simulate drag-droping document.
   execute_script %{
@@ -126,12 +114,8 @@ Then(/^I (?:can )?view the document collection in the admin$/) do
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   expect(page).to have_selector("h1", text: @document_collection.title)
 end
@@ -156,12 +140,8 @@ end
 
 Then(/^I can see in the admin that "(.*?)" is part of the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   assert_document_is_part_of_document_collection(document_title)
 end
@@ -182,13 +162,8 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   click_on "Create new edition to edit"
   fill_in_change_note_if_required
   click_on "Save"
-
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   check document_title
   click_on "Remove"
@@ -205,13 +180,8 @@ end
 
 And(/^I search for "(.*?)" to add it to the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
-
-  if @user.can_remove_edit_tabs?
-    click_on "Modify collection documents"
-  else
-    click_on "Edit draft"
-    click_on "Collection documents"
-  end
+  click_on "Edit draft"
+  click_on "Collection documents"
 
   fill_in "title", with: document_title
   click_on "Find"

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -61,15 +61,7 @@ When(/^I replace the data file of the attachment in a new draft of the publicati
   visit edit_admin_publication_path(@old_edition)
   click_button "Create new edition"
   @new_edition = Publication.last
-
-  if @user.can_remove_edit_tabs?
-    fill_in_change_note_if_required
-    apply_to_all_nations_if_required
-    click_button "Save"
-    click_link "Modify attachments"
-  else
-    click_on "Attachments"
-  end
+  click_on "Attachments"
 
   within record_css_selector(@new_edition.attachments.first.becomes(Attachment)) do
     click_on "Edit"

--- a/features/support/document_collection_helper.rb
+++ b/features/support/document_collection_helper.rb
@@ -1,23 +1,13 @@
 module DocumentCollectionStepHelpers
   def assert_document_is_part_of_document_collection(document_title)
-    if @user.can_remove_edit_tabs?
-      within ".document-row" do
-        expect(page).to have_content(document_title)
-      end
-    else
-      within ".tab-content" do
-        expect(page).to have_content(document_title)
-      end
+    within ".tab-content" do
+      expect(page).to have_content(document_title)
     end
   end
 
   def refute_document_is_part_of_document_collection(document_title)
-    if @user.can_remove_edit_tabs?
+    within ".tab-content" do
       expect(page).to_not have_content(document_title)
-    else
-      within ".tab-content" do
-        expect(page).to_not have_content(document_title)
-      end
     end
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
@@ -24,14 +24,6 @@ class AttachableEditionTest < ActionController::TestCase
     assert_tab "Document", edit_admin_news_article_path(edition)
     assert_tab "Attachments", admin_edition_attachments_path(edition)
   end
-
-  view_test 'GET :edit does not display "Document" and "Attachments" tabs when user has the `Remove edit tabs` permission' do
-    @current_user.permissions << "Remove edit tabs"
-    edition = create(:news_article)
-    get :edit, params: { id: edition }
-    assert_not_tab "Document"
-    assert_not_tab "Attachments"
-  end
 end
 
 class AttachableEditionsWithInlineSupportTest < ActionController::TestCase

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -169,16 +169,6 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_redirect_to_summary_page?
   end
 
-  test "cannot remove edit tabs by default" do
-    user = build(:user)
-    assert_not user.can_remove_edit_tabs?
-  end
-
-  test "can remove edit tabs if given permission" do
-    user = build(:user, permissions: [User::Permissions::REMOVE_EDIT_TABS])
-    assert user.can_remove_edit_tabs?
-  end
-
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
### Description

We're going to be going with a sub nav approach and retain the tabs going forward. That means that this permission and related code can now be removed.

## Trello card

https://trello.com/c/RPVzmLpx/805-remove-code-related-to-history-and-notes-and-removing-sub-nav-tabs-permissions

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
