### PR TITLE
Reintroduce historical route changes

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -350,7 +350,7 @@ class HistoricAppointmentsController < PublicFacingController
   end
 
   def show
-    @person = PersonPresenter.new(Person.friendly.find(params[:person_id]), view_context)
+    @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
     @historical_account = @person.historical_accounts.for_role(@role).first
     raise(ActiveRecord::RecordNotFound, "Couldn't find HistoricalAccount for #{@person.inspect}  and #{@role.inspect}") unless @historical_account
   end
@@ -374,11 +374,7 @@ private
   end
 
   def load_role
-    @role = Role.friendly.find(role_id)
-  end
-
-  def role_id
-    Role::HISTORIC_ROLE_PARAM_MAPPINGS[params[:role]]
+    @role = Role.friendly.find("prime-minister")
   end
 
   def previous_appointments

--- a/app/views/admin/historical_accounts/_historical_account.html.erb
+++ b/app/views/admin/historical_accounts/_historical_account.html.erb
@@ -6,7 +6,7 @@
     <%= historical_account.summary %>
   </td>
   <td class="actions">
-    <%= link_to 'View', historic_appointment_path(historical_account.role.historic_param, person), class: "btn btn-default" %>
+    <%= link_to 'View', historic_appointment_path(person), class: "btn btn-default" %>
     <%= link_to 'Edit', edit_admin_person_historical_account_path(person, historical_account), class: "btn btn-default" %>
     <%= button_to 'Delete',
           admin_person_historical_account_path(person, historical_account),

--- a/app/views/historic_appointments/_role_appointment.html.erb
+++ b/app/views/historic_appointments/_role_appointment.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag_for :div, role_appointment, class: 'govuk-grid-column-one-quarter', role: "listitem" do %>
   <% if role_appointment.has_historical_account? %>
     <%= render "govuk_publishing_components/components/image_card", {
-      href: historic_appointment_path(role.historic_param, role_appointment.person),
+      href: historic_appointment_path(role_appointment.person),
       image_src: role_appointment.person.image_url(:s216),
       image_loading: "lazy",
       heading_text: role_appointment.person.name,

--- a/app/views/historic_appointments/_role_appointments_list.html.erb
+++ b/app/views/historic_appointments/_role_appointments_list.html.erb
@@ -11,7 +11,7 @@
         <% previous_appointments_with_unique_people.each do |role_appointment| %>
           <li>
             <% if role_appointment.has_historical_account? %>
-              <%= link_to_unless_current role_appointment.person.name, historic_appointment_path(role.historic_param, role_appointment.person), class: "govuk-link" %>
+              <%= link_to_unless_current role_appointment.person.name, historic_appointment_path(role_appointment.person), class: "govuk-link" %>
             <% else %>
               <%= role_appointment.person.name %>
             <% end %>

--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -8,7 +8,7 @@
         {
           title: "Home",
           url: "/"
-        },    
+        },
         {
           title: "History of the UK Government",
           url: "/government/history"
@@ -39,7 +39,9 @@
     <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-bottom-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-      <%= image_tag @person.image_url, class: "govuk-!-margin-bottom-4 govuk-!-width-full", alt: "", loading: "lazy"%>
+      <% if @person.image_url %>
+        <%= image_tag @person.image_url, class: "govuk-!-margin-bottom-4 govuk-!-width-full", alt: "", loading: "lazy"%>
+      <% end %>
       </div>
     </div>
 
@@ -73,4 +75,3 @@
     </p>
   </div>
 </div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,18 +84,13 @@ Whitehall::Application.routes.draw do
     resource :email_signups, path: "email-signup", only: %i[create new]
     resources :fatality_notices, path: "fatalities", only: [:show]
     scope "/history" do
-      # Past foreign secretaries are currently hard-coded, so this
-      # resource falls straight through to views.
-      resources :past_foreign_secretaries, path: "/past-foreign-secretaries", only: %i[index show]
-      # Past chancellors is also hard-coded
-      get "/past-chancellors" => "historic_appointments#past_chancellors"
+      get "/past-chancellors", to: "historic_appointments#past_chancellors"
 
-      # Past foreign secretaries and past chancellors are here for the
-      # purposes of reversing URLs in a consistent way from other views.
+      get "/past-foreign-secretaries", to: "past_foreign_secretaries#index"
+      get "/past-foreign-secretaries/:id", to: "past_foreign_secretaries#show"
 
-      # TODO: make these dynamic, they're hard-coded above.
-      get "/:role" => "historic_appointments#index", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointments"
-      get "/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: "historic_appointment"
+      get "/past-prime-ministers", to: "historic_appointments#index"
+      get "/past-prime-ministers/:id", to: "historic_appointments#show", as: :historic_appointment
     end
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,4 +81,54 @@ if WorldLocation.where(name: "Test International Delegation").blank?
     title: "GOV.UK Homepage",
     linkable: international_delegation_news,
   )
+
+  if Role.where(slug: "prime-minister").blank?
+    Role.skip_callback(:commit, :after, :publish_to_publishing_api)
+    Person.skip_callback(:commit, :after, :publish_to_publishing_api)
+    RoleAppointment.skip_callback(:commit, :after, :publish_to_publishing_api)
+
+    prime_minister_role = Role.create!(
+      name: "Prime Minister",
+      slug: "prime-minister",
+      type: "MinisterialRole",
+      permanent_secretary: false,
+      cabinet_member: true,
+      chief_of_the_defence_staff: false,
+      supports_historical_accounts: true,
+    )
+
+    previous_prime_minister = Person.create!(
+      forename: "Previous",
+      surname: "Prime Minister",
+      slug: "previous-prime-minister",
+    )
+
+    RoleAppointment.create!(
+      role: prime_minister_role,
+      person: previous_prime_minister,
+      started_at: 2.years.ago,
+      ended_at: 1.year.ago,
+    )
+
+    HistoricalAccount.create!(
+      person: previous_prime_minister,
+      summary: "This person served as the previous Prime Minister",
+      body: "Some information about their work.",
+      political_party_ids: [1],
+      roles: [prime_minister_role],
+    )
+
+    current_prime_minister = Person.create!(
+      forename: "Current",
+      surname: "Prime Minister",
+      slug: "current-prime-minister",
+    )
+
+    RoleAppointment.create!(
+      role: prime_minister_role,
+      person: current_prime_minister,
+      started_at: 1.year.ago,
+      ended_at: nil,
+    )
+  end
 end

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -16,8 +16,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
       { path: "government/history/past-prime-ministers/barry", method: :get },
       controller: "historic_appointments",
       action: "show",
-      role: "past-prime-ministers",
-      person_id: "barry",
+      id: "barry",
     )
   end
 
@@ -49,7 +48,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Prime Ministers" do
     pm_account = create(:historical_account, roles: [pm_role])
     create(:role_appointment, person: pm_account.person, role: pm_role)
-    get :show, params: { role: "past-prime-ministers", person_id: pm_account.person.slug }
+    get :show, params: { role: "past-prime-ministers", id: pm_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -62,7 +61,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     chancellor_account = create(:historical_account, roles: [chancellor_role])
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :show, params: { role: "past-prime-ministers", person_id: chancellor_account.person.slug }
+      get :show, params: { role: "past-prime-ministers", id: chancellor_account.person.slug }
     end
   end
 


### PR DESCRIPTION
These changes were reverted in https://github.com/alphagov/whitehall/pull/6907 as there was an error in route generation on the 'Previous Prime Ministers' page.
    
This issue was fixed in https://github.com/alphagov/whitehall/pull/6905 and has been tested against the other route changes.

Example showing the correct link being rendered:
![Screenshot showing an example Past Prime Ministers page, including a link to a historical account giving the correct URL for that page](https://user-images.githubusercontent.com/6329861/195099841-654a8840-98fa-41c5-8da8-909b0ede35b8.png)

[Trello card](https://trello.com/c/EfhUs8ak)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
