### PR TITLE
Reimplement previous save button behaviour on edit edition page

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -27,7 +27,7 @@ class Admin::EditionTagsController < Admin::BaseController
 private
 
   def redirect_path
-    if params[:save] || current_user.can_redirect_to_summary_page?
+    if params[:save]
       admin_edition_path(@edition)
     else
       edit_admin_edition_legacy_associations_path(@edition, return: :tags)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -322,8 +322,8 @@ private
   end
 
   def show_or_edit_path
-    if current_user.can_redirect_to_summary_page? || params[:save].present?
-      [:admin, @edition]
+    if params[:save].present?
+      [:edit, :admin, @edition]
     else
       edit_admin_edition_tags_path(@edition.id)
     end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -229,11 +229,7 @@ module Admin::EditionsHelper
           locals: { form:, edition: },
         )
       end
-      if current_user.can_redirect_to_summary_page?
-        concat form.save_or_cancel
-      else
-        concat form.save_or_continue_or_cancel
-      end
+      concat form.save_or_continue_or_cancel
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,6 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
-    REDIRECT_TO_SUMMARY_PAGE = "Redirect to summary page".freeze
   end
 
   def role
@@ -95,10 +94,6 @@ class User < ApplicationRecord
 
   def can_preview_design_system?
     has_permission?(Permissions::PREVIEW_DESIGN_SYSTEM)
-  end
-
-  def can_redirect_to_summary_page?
-    has_permission?(Permissions::REDIRECT_TO_SUMMARY_PAGE)
   end
 
   def organisation_name

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -65,20 +65,18 @@
           }
         } %>
 
-        <% unless current_user.can_redirect_to_summary_page? %>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Update and review specialist topic tags",
-            name: "legacy_tags",
-            value: "legacy_tags",
-            secondary_solid: true,
-            data_attributes: {
-              module: 'gem-track-click',
-              track_category: 'form-button',
-              track_label: "Save and review specialist topic tagging",
-              track_action: "taxonomy-tag-form-button",
-            }
-          } %>
-        <% end %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update and review specialist topic tags",
+          name: "legacy_tags",
+          value: "legacy_tags",
+          secondary_solid: true,
+          data_attributes: {
+            module: 'gem-track-click',
+            track_category: 'form-button',
+            track_label: "Save and review specialist topic tagging",
+            track_action: "taxonomy-tag-form-button",
+          }
+        } %>
       </div>
     <% end %>
   </div>

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -14,6 +14,7 @@ Feature: New Tagging Workflow
 Scenario: Publication that does not support the new taxonomy
   Given I am a writer
   When I start editing a draft document which cannot be tagged to the new taxonomy
+  And I continue to the tagging page
   And I continue to the legacy tagging page
   Then I should be on the legacy tagging page
   And I should be able to update the legacy tags

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -7,5 +7,6 @@ Feature: Tagging content with specialist sectors
     Given I am a writer
     And there are some specialist sectors
     When I start editing a draft document
+    And I continue to the tagging page
     And I continue to the legacy tagging page
     Then I can tag it to some specialist sectors

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -6,7 +6,8 @@ When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/
       fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
     end
   end
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   add_external_attachment
 end
 

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -1,7 +1,8 @@
 When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/) do |title, location_name|
   begin_drafting_publication(title)
   select location_name, from: "Select the world locations this publication is about"
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   add_external_attachment
 end
 

--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -1,6 +1,6 @@
 Given(/^a document that has gone through many changes$/) do
   begin_drafting_publication("An frequently changed publication")
-  click_button "Save"
+  click_button "Save and continue"
   expect(page).to have_content("An frequently changed publication")
   @the_publication = Publication.find_by(title: "An frequently changed publication")
   # fake it

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -56,7 +56,8 @@ When(/^I save and publish the amended consultation$/) do
   ensure_path edit_admin_consultation_path(consultation)
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   publish force: true
 end
 

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -25,7 +25,8 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
   apply_to_all_nations_if_required
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   publish(force: true)
 end
 

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -161,7 +161,9 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   visit admin_document_collection_path(@document_collection)
   click_on "Create new edition to edit"
   fill_in_change_note_if_required
-  click_on "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
+
   click_on "Edit draft"
   click_on "Collection documents"
 

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -160,7 +160,8 @@ When("I force publish {edition}") do |edition|
   click_link "Edit draft"
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   publish(force: true)
 end
 

--- a/features/step_definitions/new_tagging_workflow_steps.rb
+++ b/features/step_definitions/new_tagging_workflow_steps.rb
@@ -33,7 +33,7 @@ Then(/^I should be on the legacy tagging page$/) do
   @publication = Publication.last
 
   expect(page).to have_current_path(
-    edit_admin_edition_legacy_associations_path(@publication),
+    edit_admin_edition_legacy_associations_path(@publication, return: "tags"),
   )
 end
 

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -28,7 +28,8 @@ When(/^I draft a French-only "World news story" news article associated with "([
   select location_name, from: "Select the world locations this news article is about"
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
   select "", from: "edition_lead_organisation_ids_1"
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   @news_article = find_news_article_in_locale!(:fr, "French-only news article")
 end
 

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -15,12 +15,14 @@ end
 
 When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
 end
 
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   add_external_attachment
 end
 
@@ -28,14 +30,16 @@ Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   user = User.find_by(name: user_name)
   as_user(user) do
     begin_drafting_publication(title)
-    click_button "Save"
+    click_button "Save and continue"
+    click_button "Update tags"
   end
 end
 
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
   select data_set_name, from: "Related statistical data sets"
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   add_external_attachment
 end
 

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -18,8 +18,8 @@ Then(/^I can tag it to some specialist sectors$/) do
 
   click_on "Edit draft"
   check "Applies to all UK nations"
-  click_on "Save"
-  click_on "Change specialist topic tags"
+  click_on "Save and continue"
+  click_on "Update and review specialist topic tags"
 
   expect("WELLS").to eq(find_field("Primary specialist topic tag").value)
   expect(%w[OFFSHORE FIELDS DISTILL].to_set)

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -7,7 +7,8 @@ Given(/^"([^"]*)" submitted a speech "([^"]*)" with body "([^"]*)"$/) do |author
   step %(I am a writer called "#{author}")
   visit new_admin_speech_path
   begin_drafting_speech title: title, body: body
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update tags"
   click_button "Submit"
 end
 

--- a/features/step_definitions/statistical_data_set_steps.rb
+++ b/features/step_definitions/statistical_data_set_steps.rb
@@ -1,5 +1,6 @@
 When(/^I draft a new statistical data set "([^"]*)" for organisation "([^"]*)"$/) do |title, organisation_name|
   begin_drafting_statistical_data_set(title:)
   set_lead_organisation_on_document(Organisation.find_by(name: organisation_name))
-  click_button "Save"
+  click_button "Save and continue"
+  click_button "Update and review specialist topic tags"
 end

--- a/features/step_definitions/tagging_steps.rb
+++ b/features/step_definitions/tagging_steps.rb
@@ -1,9 +1,7 @@
 When(/^I continue to the tagging page$/) do
-  click_button "Save"
-  click_link "Add tag"
+  click_button "Save and continue"
 end
 
 When(/^I continue to the legacy tagging page$/) do
-  click_button "Save"
-  click_link "Add specialist topic tags"
+  click_button "Update and review specialist topic tags"
 end

--- a/features/support/corporate_information_page_helper.rb
+++ b/features/support/corporate_information_page_helper.rb
@@ -14,7 +14,8 @@ module CorporateInformationPageHelper
     click_link "Edit draft"
     markdown = find_markdown_snippet_to_insert_attachment(attachment)
     fill_in "Body", with: "#{page.body}\n\n#{markdown}"
-    click_button "Save"
+    click_button "Save and continue"
+    click_button "Update and review specialist topic tags"
   end
 
   def check_attachment_appears_on_corporate_information_page(attachment, page)

--- a/features/support/fatalities_helper.rb
+++ b/features/support/fatalities_helper.rb
@@ -4,7 +4,8 @@ module FatalitiesHelper
     begin_drafting_document type: "fatality_notice", title: title, summary: "fatality notice summary", previously_published: false
     fill_in "Introduction", with: "fatality notice roll call introduction"
     select field, from: "Field of operation"
-    click_button "Save"
+    click_button "Save and continue"
+    click_button "Update and review specialist topic tags"
   end
 end
 

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -114,19 +114,6 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     assert_redirected_to [:admin, @organisation, CorporateInformationPage]
   end
 
-  view_test "GET :show corporate information pages continues to render side nav bar with notes, history and fact checking when user has `Redirect to summary page` permission" do
-    @current_user.permissions << "Redirect to summary page"
-    corporate_information_page = create(:corporate_information_page, :published, organisation: @organisation)
-    stub_publishing_api_expanded_links_with_taxons(corporate_information_page.content_id, [])
-
-    get :show, params: { organisation_id: @organisation, id: corporate_information_page }
-
-    assert_select "a", text: "Notes", count: 0
-    assert_select "a", text: "History", count: 0
-    assert_select ".nav-tabs a", text: "Notes 0"
-    assert_select ".nav-tabs a", text: "History 1"
-  end
-
 private
 
   def corporate_information_page_attributes(overrides = {})

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -79,14 +79,6 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     assert_redirected_to edit_admin_edition_legacy_associations_path(@edition, return: :tags)
   end
 
-  view_test "should not render the `Save and review specialist topic tagging` button when the user has the `Redirect to summary page` permission" do
-    @user.permissions << "Redirect to summary page"
-
-    get :edit, params: { edition_id: @edition }
-
-    assert_select ".btn-primary", count: 0
-  end
-
   test "should post empty array to publishing api if no taxons are selected" do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 

--- a/test/functional/admin/legacy_corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/legacy_corporate_information_pages_controller_test.rb
@@ -114,19 +114,6 @@ class Admin::LegacyCorporateInformationPagesControllerTest < ActionController::T
     assert_redirected_to [:admin, @organisation, CorporateInformationPage]
   end
 
-  view_test "GET :show corporate information pages continues to render side nav bar with notes, history and fact checking when user has `Redirect to summary page` permission" do
-    @current_user.permissions << "Redirect to summary page"
-    corporate_information_page = create(:corporate_information_page, :published, organisation: @organisation)
-    stub_publishing_api_expanded_links_with_taxons(corporate_information_page.content_id, [])
-
-    get :show, params: { organisation_id: @organisation, id: corporate_information_page }
-
-    assert_select "a", text: "Notes", count: 0
-    assert_select "a", text: "History", count: 0
-    assert_select ".nav-tabs a", text: "Notes 0"
-    assert_select ".nav-tabs a", text: "History 1"
-  end
-
 private
 
   def corporate_information_page_attributes(overrides = {})

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -66,9 +66,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
           stub_publishing_api_has_linkables([], document_type: "topic")
           visit admin_news_article_path(edition)
           click_button "Create new edition to edit"
-          fill_in "edition_change_note", with: "changes"
-          click_button "Save"
-          click_link "Modify attachments"
+          click_link "Attachments 1"
           within ".existing-attachments" do
             click_link "Edit"
           end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -149,16 +149,6 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_preview_design_system?
   end
 
-  test "cannot redirect to the summary page by default" do
-    user = build(:user)
-    assert_not user.can_redirect_to_summary_page?
-  end
-
-  test "can redirect to the summary page if given permission" do
-    user = build(:user, permissions: [User::Permissions::REDIRECT_TO_SUMMARY_PAGE])
-    assert user.can_redirect_to_summary_page?
-  end
-
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
**Comms is going out about this so we shouldn't merge until JP gives the go ahead**

## Description

As we're going for a like for like implementation and moving away from using the summary page as an anchor for the user between sections, we need to reimplement the previous behaviour of the save button on the edition edit page.

This ensures that when a user clicks save, they are not redirected to the summary page. They stay on the edit page.

It also removes the "Redirect to summary page" flag as it's no longer needed.

## Trello card 

https://trello.com/c/6lZphXit/806-revert-changes-to-save-redirect

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
