### PR TITLE
Rebuild Navbar toggle in Vanilla JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,15 +3,13 @@
 //= require govuk_publishing_components/analytics
 
 //= require govuk-admin-template
-//= require admin
 
 //= require components/miller-columns
 //= require components/autocomplete
 
 //= require modules/analytics
+//= require modules/navbar-toggle
 //= require modules/paste-html-to-govspeak
 //= require modules/unpublish-display-conditions
 //= require modules/unpublish-tracking
 //= require modules/track-selected-taxons
-
-window.GOVUK.navBarHelper.init()

--- a/app/assets/javascripts/modules/navbar-toggle.js
+++ b/app/assets/javascripts/modules/navbar-toggle.js
@@ -1,0 +1,34 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function NavbarToggle (module) {
+    this.module = module
+    this.toggler = this.module.querySelector('.js-navbar-toggle__toggler')
+    this.menu = this.module.querySelector('.js-navbar-toggle__menu')
+  }
+
+  NavbarToggle.prototype.init = function () {
+    this.menu.classList.add('govuk-visually-hidden')
+    this.toggler.setAttribute('tabindex', 0)
+    this.initToggleListeners()
+  }
+
+  NavbarToggle.prototype.initToggleListeners = function () {
+    this.toggler.addEventListener('click', this.toggle.bind(this))
+    this.toggler.addEventListener('keyup', this.toggle.bind(this))
+  }
+
+  NavbarToggle.prototype.toggle = function (e) {
+    // Toggle menu for users tabbing through the navigation bar
+    if (e.type === 'keyup' && (e.which !== 9 || this.module.classList.contains('open'))) return
+
+    e.stopPropagation()
+    e.preventDefault()
+
+    this.module.classList.toggle('open')
+    this.menu.classList.toggle('govuk-visually-hidden')
+  }
+
+  Modules.NavbarToggle = NavbarToggle
+})(window.GOVUK.Modules)

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -125,7 +125,7 @@ module Admin::EditionActionsHelper
   # If adding new models also update filter_options_for_edition
   def document_creation_dropdown
     tag.ul(
-      class: "masthead-menu list-unstyled js-hidden",
+      class: "masthead-menu list-unstyled js-hidden js-navbar-toggle__menu",
       id: "new-document-menu",
       role: "menu",
       "aria-labelledby" => "new-document-label",

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -52,17 +52,17 @@
 
   <div class="container-fluid">
     <ul id="global-nav" class="masthead-tabs list-unstyled">
-      <li class="masthead-tab-item js-create-new create-new">
-        <a href="#new-document-menu" class="toggler" id="new-document-label">New document</a>
+      <li class="masthead-tab-item js-create-new create-new" data-module="navbar-toggle">
+        <a href="#new-document-menu" class="toggler js-navbar-toggle__toggler" id="new-document-label">New document</a>
         <%= document_creation_dropdown %>
       </li>
       <%= admin_documents_header_link %>
       <%= admin_statistics_announcements_link %>
       <%= admin_featured_header_link %>
       <%= admin_user_organisation_header_link %>
-      <li class="js-more-nav masthead-tab-item">
-        <a href="#more-links-menu" id="more-links-label" class="toggler">More</a>
-        <ul id="more-links-menu" class="masthead-menu masthead-menu-right js-hidden unstyled" role="menu" aria-labelledby="more-links-label">
+      <li class="js-more-nav masthead-tab-item" data-module="navbar-toggle">
+        <a href="#more-links-menu" id="more-links-label" class="toggler js-navbar-toggle__toggler">More</a>
+        <ul id="more-links-menu" class="masthead-menu masthead-menu-right js-hidden unstyled js-navbar-toggle__menu" role="menu" aria-labelledby="more-links-label">
           <%= admin_organisations_header_menu_link %>
           <%= admin_policy_groups_header_menu_link %>
           <%= admin_roles_header_menu_link %>

--- a/spec/javascripts/modules/navbar-toggle.spec.js
+++ b/spec/javascripts/modules/navbar-toggle.spec.js
@@ -1,0 +1,62 @@
+describe('GOVUK.Modules.NavbarToggle', function () {
+  var navbarItem
+
+  beforeEach(function () {
+    navbarItem = document.createElement('li')
+    navbarItem.setAttribute('data-module', 'navbar-toggle')
+
+    // add toggle link
+    var toggler = document.createElement('a')
+    toggler.classList.add('js-navbar-toggle__toggler')
+    toggler.setAttribute('href', '#more-options')
+    toggler.innerText = 'More options'
+    navbarItem.appendChild(toggler)
+
+    // add sub menu
+    var menu = document.createElement('ul')
+    menu.classList.add('js-navbar-toggle__menu')
+    menu.appendChild(document.createElement('li'))
+    menu.appendChild(document.createElement('li'))
+    menu.appendChild(document.createElement('li'))
+    navbarItem.appendChild(menu)
+
+    var navbarToggle = new GOVUK.Modules.NavbarToggle(navbarItem)
+    navbarToggle.init()
+  })
+
+  it('should initialise correctly', function () {
+    expect(navbarItem.querySelector('.js-navbar-toggle__toggler').getAttribute('tabindex')).toEqual('0')
+    expect(navbarItem.querySelector('.js-navbar-toggle__menu')).toHaveClass('govuk-visually-hidden')
+  })
+
+  it('should show menu when toggler is clicked', function () {
+    var toggler = navbarItem.querySelector('.js-navbar-toggle__toggler')
+    var menu = navbarItem.querySelector('.js-navbar-toggle__menu')
+
+    expect(navbarItem).not.toHaveClass('open')
+    expect(menu).toHaveClass('govuk-visually-hidden')
+
+    toggler.dispatchEvent(new Event('click'))
+
+    expect(navbarItem).toHaveClass('open')
+    expect(menu).not.toHaveClass('govuk-visually-hidden')
+  })
+
+  it('should close menu when toggled', function () {
+    var toggler = navbarItem.querySelector('.js-navbar-toggle__toggler')
+    var menu = navbarItem.querySelector('.js-navbar-toggle__menu')
+
+    expect(navbarItem).not.toHaveClass('open')
+    expect(menu).toHaveClass('govuk-visually-hidden')
+
+    toggler.dispatchEvent(new Event('click'))
+
+    expect(navbarItem).toHaveClass('open')
+    expect(menu).not.toHaveClass('govuk-visually-hidden')
+
+    toggler.dispatchEvent(new Event('click'))
+
+    expect(navbarItem).not.toHaveClass('open')
+    expect(menu).toHaveClass('govuk-visually-hidden')
+  })
+})


### PR DESCRIPTION
This adds the navbar toggle module that shows and hides the navigation menu.

This allows us to remove admin_legacy js as everything needed has been recreated.

We do, however, need to keep the `govuk-admin-template` to keep the bootstrap navigation js operable.

https://trello.com/c/bUugAEEb/812-remove-legacy-js-from-design-system-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
