### PR TITLE
Move specialist topic tagging edition page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -3,9 +3,11 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
   before_action :enforce_permissions!
   before_action :limit_edition_access!
   before_action :forbid_editing_of_locked_documents
+  layout :get_layout
 
   def edit
     @path = get_path
+    render(preview_design_system_user? ? "edit" : "edit_legacy")
   end
 
   def update
@@ -17,6 +19,10 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    preview_design_system_user? ? "design_system" : "admin"
+  end
 
   def get_path
     paths = {

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -295,7 +295,11 @@ module Admin::EditionsHelper
   end
 
   def specialist_sector_options_for_select
-    @specialist_sector_options_for_select ||= LinkableTopics.new.topics
+    @specialist_sector_options_for_select ||= LinkableTopics.new.raw_topics.sort
+  end
+
+  def legacy_specialist_sector_options_for_select
+    @legacy_specialist_sector_options_for_select ||= LinkableTopics.new.topics
   end
 
   def specialist_sector_names(sector_content_ids)

--- a/app/views/admin/base/_legacy_specialist_sector_fields.html.erb
+++ b/app/views/admin/base/_legacy_specialist_sector_fields.html.erb
@@ -7,7 +7,7 @@
 
   <%= form.label :primary_specialist_sector_tag, 'Primary specialist topic tag' %>
   <%= form.select :primary_specialist_sector_tag,
-                  specialist_sector_options_for_select,
+                  legacy_specialist_sector_options_for_select,
                   { include_blank: true },
                   class: 'chzn-select form-control',
                   data: {
@@ -19,7 +19,7 @@
 
   <%= form.label :secondary_specialist_sector_tags, 'Additional specialist topics' %>
   <%= form.select :secondary_specialist_sector_tags,
-                  specialist_sector_options_for_select,
+                  legacy_specialist_sector_options_for_select,
                   {},
                   multiple: true,
                   class: 'chzn-select form-control',

--- a/app/views/admin/base/_specialist_sector_fields.html.erb
+++ b/app/views/admin/base/_specialist_sector_fields.html.erb
@@ -1,0 +1,30 @@
+<p class="govuk-body govuk-!-margin-bottom-7">
+  Do not tag to a specialist topic unless your organisation maintains that topic page.
+</p>
+
+<%= render "components/autocomplete", {
+  id: "edition_primary_specialist_sector_tag",
+  name: "edition[primary_specialist_sector_tag]",
+  label: {
+    text: "Primary specialist sector tag",
+    heading_size: "l",
+  },
+  select: {
+    options: [""] + specialist_sector_options_for_select,
+    selected: @edition.primary_specialist_sector_tag,
+  },
+} %>
+
+<%= render "components/autocomplete", {
+  id: "edition_secondary_specialist_sector_tags",
+  name: "edition[secondary_specialist_sector_tags]",
+  label: {
+    text: "Additional specialist sector tags",
+    heading_size: "l",
+  },
+  select: {
+    options: [""] + specialist_sector_options_for_select,
+    multiple: true,
+    selected: @edition.secondary_specialist_sector_tags,
+  },
+} %>

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -1,17 +1,24 @@
-<% page_title "Edit legacy associations: " + @edition.title %>
-<div class="row">
-  <h1><%= @edition.title %></h1>
-</div>
-<div class="row">
-  <div class="col-md-12">
-    <% initialise_script "GOVUK.adminEditionsForm", selector: '.js-edition-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Specialist topic tagging" %>
+<% content_for :title, "Specialist topic tagging" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition)
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
     <%= form_for @edition, url: admin_edition_legacy_associations_path(@edition), as: :edition, method: :put,
         html: { class: edition_form_classes(@edition) } do |form| %>
 
-      <%= render 'legacy_specialist_sector_fields', form: form, edition: @edition %>
-      <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save' }, cancel: @path) %>
-      </div>
+      <%= render 'specialist_sector_fields', form: form, edition: @edition %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Update specialist topics",
+        margin_bottom: 8,
+      } %>
     <% end %>
-  </div>
+  </section>
 </div>

--- a/app/views/admin/edition_legacy_associations/edit_legacy.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit_legacy.html.erb
@@ -1,0 +1,17 @@
+<% page_title "Edit legacy associations: " + @edition.title %>
+<div class="row">
+  <h1><%= @edition.title %></h1>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <% initialise_script "GOVUK.adminEditionsForm", selector: '.js-edition-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
+    <%= form_for @edition, url: admin_edition_legacy_associations_path(@edition), as: :edition, method: :put,
+        html: { class: edition_form_classes(@edition) } do |form| %>
+
+      <%= render 'legacy_specialist_sector_fields', form: form, edition: @edition %>
+      <div class="publishing-controls well">
+        <%= form.form_actions(buttons: { save: 'Save' }, cancel: @path) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -10,3 +10,12 @@ Feature: Tagging content with specialist sectors
     And I continue to the tagging page
     And I continue to the legacy tagging page
     Then I can tag it to some specialist sectors
+
+  Scenario: writer can tag documents with specialist sectors
+    Given I am a writer
+    And I have the "Preview design system" permission
+    And there are some specialist sectors
+    When I start editing a draft document
+    And I continue to the tagging page
+    And I continue to the legacy tagging page
+    Then I can tag it to some specialist sectors

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -7,12 +7,15 @@ When(/^I start editing a draft document$/) do
 end
 
 Then(/^I can tag it to some specialist sectors$/) do
-  select "Oil and Gas: Wells", from: "Primary specialist topic tag"
-  select "Oil and Gas: Offshore", from: "Additional specialist topics"
-  select "Oil and Gas: Fields", from: "Additional specialist topics"
-  select "Oil and Gas: Distillation (draft)", from: "Additional specialist topics"
+  primary_select = @user.can_preview_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
+  secondary_select = @user.can_preview_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
 
-  click_button "Save"
+  select "Oil and Gas: Wells", from: primary_select
+  select "Oil and Gas: Offshore", from: secondary_select
+  select "Oil and Gas: Fields", from: secondary_select
+  select "Oil and Gas: Distillation (draft)", from: secondary_select
+
+  click_button @user.can_preview_design_system? ? "Update specialist topics" : "Save"
 
   expect(page).to have_selector(".flash.notice")
 
@@ -21,9 +24,9 @@ Then(/^I can tag it to some specialist sectors$/) do
   click_on "Save and continue"
   click_on "Update and review specialist topic tags"
 
-  expect("WELLS").to eq(find_field("Primary specialist topic tag").value)
+  expect("WELLS").to eq(find_field(primary_select).value)
   expect(%w[OFFSHORE FIELDS DISTILL].to_set)
-    .to eq(find_field("Additional specialist topics").value.to_set)
+    .to eq(find_field(secondary_select).value.to_set)
 end
 
 Given(/^there is a document tagged to specialist sectors$/) do

--- a/test/functional/edition_legacy_associations_controller_test.rb
+++ b/test/functional/edition_legacy_associations_controller_test.rb
@@ -3,6 +3,10 @@ require "test_helper"
 class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCase
   include Admin::EditionRoutesHelper
 
+  setup do
+    login_as :gds_editor
+  end
+
   should_be_an_admin_controller
 
   view_test "should render edit form correctly populated" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Move specialist topic tagging edition page to the GOV.UK Design System.
](https://trello.com/c/WpB7xxzc/614-move-specialist-topic-tagging-edition-page-to-the-govuk-design-system)

This PR does not address any of the differences between the behaviour of the bootstrap select and the design system autocomplete or include the cancel button as these will be tackled in other tickets.

## Why

This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

## Screenshots

### After

![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/195562694-0bd3321c-62e8-4067-b1e7-61021ca56709.png)
![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPad Pro) (3)](https://user-images.githubusercontent.com/9594455/195562868-ce148831-2333-460b-b3aa-6ed1ab70806f.png)
![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/9594455/195562894-bd9771bf-3d33-4848-91c6-5a12d74ab3fc.png)

### Before

![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/195562757-667cd3a9-2626-4eca-ba92-83bd1132c533.png)
![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/195562776-5b80dac9-45a0-456d-b3a2-13dd97871566.png)
![whitehall-admin dev gov uk_government_admin_editions_1372490_legacy_associations_edit(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/195562835-a0c2bb87-d89a-4270-846f-8542210a4df6.png)
