### PR TITLE
Add Kwasi Kwarteng to Past Chancellors List

### DIFF
--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -10,6 +10,9 @@ class HistoricAppointmentsController < PublicFacingController
 
   def past_chancellors
     @twentyfirst_century_chancellors = {
+      "Kwasi Kwarteng" => {
+        service: "2022",
+      },
       "Nadhim Zahawi" => {
         service: "2022",
       },


### PR DESCRIPTION
Adds Kwasi Kwarteng to this list following his departure from government: https://www.gov.uk/government/history/past-chancellors
