### PR TITLE
Upgrade Mocha to pre-release version (v2.0.0.alpha)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     minitest-stub-const (0.6)
     mlanett-redis-lock (0.2.7)
       redis
-    mocha (1.15.0)
+    mocha (2.0.0.alpha)
     msgpack (1.5.6)
     multi_json (1.15.0)
     multi_test (1.1.0)


### PR DESCRIPTION
It would be great if you could run this change through your CI pipeline and let me know if you run into any problems so I can fix them before the official release of v2.0.0. Thank you!

I suggest you don't merge this PR, but hold off until the official release.

Note that you may see deprecation warnings relating to the new strict keyword argument parameter matching. Let me know if those don't make sense.

Release notes: https://github.com/freerange/mocha/blob/9cd08be9628f3b7a95e2d52e84488b19775b4352/RELEASE.md#200alpha

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
