### PR TITLE
Upgrade mocha to v1.16.0 & fix deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     minitest-stub-const (0.6)
     mlanett-redis-lock (0.2.7)
       redis
-    mocha (1.15.0)
+    mocha (1.16.0)
     msgpack (1.5.6)
     multi_json (1.15.0)
     multi_test (1.1.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,6 @@ Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 Whitehall::Application.load_tasks if Rake::Task.tasks.empty?
 
 Mocha.configure do |c|
-  c.reinstate_undocumented_behaviour_from_v1_9 = false
   c.stubbing_non_existent_method = :prevent
 end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
