### PR TITLE
Implement previewable text area for govspeak

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,8 +4,9 @@
 
 //= require govuk-admin-template
 
-//= require components/miller-columns
 //= require components/autocomplete
+//= require components/govspeak-editor
+//= require components/miller-columns
 
 //= require admin/modules/analytics
 //= require admin/modules/navbar-toggle

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -4,11 +4,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function GovspeakEditor (module) {
     this.module = module
-    this.preview = module.getAttribute('data-previewable') === 'true'
   }
 
   GovspeakEditor.prototype.init = function () {
-    if (this.preview) this.initPreview()
+    this.initPreview()
   }
 
   GovspeakEditor.prototype.getCsrfToken = function () {

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -1,0 +1,64 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function GovspeakEditor (module) {
+    this.module = module
+    this.preview = module.getAttribute('data-previewable') === 'true'
+  }
+
+  GovspeakEditor.prototype.init = function () {
+    if (this.preview) this.initPreview()
+  }
+
+  GovspeakEditor.prototype.getCsrfToken = function () {
+    return document.querySelector('meta[name="csrf-token"]').content
+  }
+
+  GovspeakEditor.prototype.getRenderedGovspeak = function (content, callback) {
+    var body = new FormData()
+    body.append('body', content)
+
+    var request = new XMLHttpRequest()
+    request.open('POST', '/government/admin/preview', false)
+    request.setRequestHeader('X-CSRF-Token', this.getCsrfToken())
+    request.onreadystatechange = callback
+    request.send(body)
+  }
+
+  GovspeakEditor.prototype.initPreview = function () {
+    var previewToggle = this.module.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var trackToggle = previewToggle.getAttribute('data-preview-toggle-tracking') === 'true'
+    var preview = this.module.querySelector('.app-c-govspeak-editor__preview')
+    var textareaWrapper = this.module.querySelector('.app-c-govspeak-editor__textarea')
+    var textarea = this.module.querySelector(previewToggle.getAttribute('data-content-target'))
+
+    previewToggle.addEventListener('click', function (e) {
+      var previewMode = previewToggle.innerText === 'Preview'
+
+      previewToggle.innerText = previewMode ? 'Back to edit' : 'Preview'
+      textareaWrapper.classList.toggle('app-c-govspeak-editor__textarea--hidden')
+      preview.classList.toggle('app-c-govspeak-editor__preview--show')
+
+      if (previewMode) {
+        this.getRenderedGovspeak(textarea.value, function (event) {
+          var response = event.currentTarget
+
+          if (response.readyState === 4 && response.status === 200) {
+            preview.innerHTML = response.responseText
+          }
+        })
+      }
+
+      if (trackToggle) {
+        GOVUK.analytics.trackEvent(
+          previewToggle.getAttribute('data-preview-toggle-track-category'),
+          previewToggle.getAttribute('data-preview-toggle-track-action'),
+          { label: previewMode ? 'preview' : 'edit' }
+        )
+      }
+    }.bind(this))
+  }
+
+  Modules.GovspeakEditor = GovspeakEditor
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,8 @@
 @import "govuk_publishing_components/all_components";
 
-@import "./components/miller-columns";
 @import "./components/autocomplete";
+@import "./components/govspeak-editor";
+@import "./components/miller-columns";
 
 @import "./admin/modules/unpublish-display-conditions";
 

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -1,0 +1,17 @@
+.app-c-govspeak-editor__preview-button-wrapper {
+  text-align: right;
+}
+
+.app-c-govspeak-editor__textarea--hidden {
+  display: none;
+}
+
+.app-c-govspeak-editor__preview {
+  display: none;
+  border: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(4);
+}
+
+.app-c-govspeak-editor__preview--show {
+  display: block;
+}

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -1,31 +1,62 @@
 <%
+  id ||= "#{name}-#{SecureRandom.hex(4)}"
   label[:bold] ||= false
   value ||= nil
   error_items ||= nil
   rows ||= 12
   paste_html_to_govspeak ||= false
+  preview ||= false
+
+  track_preview_toggle ||= false
+  track_category ||= false
+  track_action ||= false
 
   data_attributes ||= {}
   data_attributes[:module] ||= []
+  data_attributes[:module] << "govspeak-editor"
+  data_attributes[:module] = data_attributes[:module].join(' ')
+  data_attributes[:previewable] = true if preview
 
   textarea_data_attributes ||= {}
   textarea_data_attributes[:module] ||= []
-
   textarea_data_attributes[:module] << "paste-html-to-govspeak" if paste_html_to_govspeak
   textarea_data_attributes[:module] = textarea_data_attributes[:module].join(' ')
+
+  preview_button_data_attributes ||= {}
+  preview_button_data_attributes["content-target"] = "##{id}"
+  preview_button_data_attributes["preview-toggle-tracking"] = "true" if track_preview_toggle
+  preview_button_data_attributes["preview-toggle-track-category"] = track_category if track_category
+  preview_button_data_attributes["preview-toggle-track-action"] = track_action if track_action
 %>
 
 <%= tag.div class:"app-c-govspeak-editor", data: data_attributes do %>
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: label[:text],
-      bold: label[:bold]
-    },
-    name: name,
-    id: name,
-    rows: rows,
-    value: value,
-    error_items: error_items,
-    data: textarea_data_attributes,
-  } %>
+  <div class="govuk-grid-row">
+    <div class="<%= preview ? "govuk-grid-column-three-quarters" : "govuk-grid-column-full" %>">
+      <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
+    </div>
+    <% if preview %>
+      <div class="govuk-grid-column-one-quarter app-c-govspeak-editor__preview-button-wrapper">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Preview",
+          secondary_quiet: true,
+          margin_bottom: 2,
+          classes: "js-app-c-govspeak-editor__preview-button",
+          data_attributes: preview_button_data_attributes
+        } %>
+      </div>
+    <% end %>
+  </div>
+  <div class="app-c-govspeak-editor__textarea">
+    <%= render "govuk_publishing_components/components/textarea", {
+      name: name,
+      id: id,
+      rows: rows,
+      value: value,
+      error_items: error_items,
+      data: textarea_data_attributes,
+    } %>
+  </div>
+  <div class="app-c-govspeak-editor__preview">
+    <p class="govuk-body">Generating preview, please wait.</p>
+  </div>
 <% end %>

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -1,0 +1,31 @@
+<%
+  label[:bold] ||= false
+  value ||= nil
+  error_items ||= nil
+  rows ||= 12
+  paste_html_to_govspeak ||= false
+
+  data_attributes ||= {}
+  data_attributes[:module] ||= []
+
+  textarea_data_attributes ||= {}
+  textarea_data_attributes[:module] ||= []
+
+  textarea_data_attributes[:module] << "paste-html-to-govspeak" if paste_html_to_govspeak
+  textarea_data_attributes[:module] = textarea_data_attributes[:module].join(' ')
+%>
+
+<%= tag.div class:"app-c-govspeak-editor", data: data_attributes do %>
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: label[:text],
+      bold: label[:bold]
+    },
+    name: name,
+    id: name,
+    rows: rows,
+    value: value,
+    error_items: error_items,
+    data: textarea_data_attributes,
+  } %>
+<% end %>

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -4,23 +4,18 @@
   value ||= nil
   error_items ||= nil
   rows ||= 12
-  paste_html_to_govspeak ||= false
-  preview ||= false
 
   track_preview_toggle ||= false
   track_category ||= false
   track_action ||= false
 
   data_attributes ||= {}
-  data_attributes[:module] ||= []
-  data_attributes[:module] << "govspeak-editor"
-  data_attributes[:module] = data_attributes[:module].join(' ')
-  data_attributes[:previewable] = true if preview
+  data_attributes[:module] ||= ""
+  data_attributes[:module] << " govspeak-editor"
 
   textarea_data_attributes ||= {}
-  textarea_data_attributes[:module] ||= []
-  textarea_data_attributes[:module] << "paste-html-to-govspeak" if paste_html_to_govspeak
-  textarea_data_attributes[:module] = textarea_data_attributes[:module].join(' ')
+  textarea_data_attributes[:module] ||= ""
+  textarea_data_attributes[:module] << " paste-html-to-govspeak"
 
   preview_button_data_attributes ||= {}
   preview_button_data_attributes["content-target"] = "##{id}"
@@ -31,20 +26,18 @@
 
 <%= tag.div class:"app-c-govspeak-editor", data: data_attributes do %>
   <div class="govuk-grid-row">
-    <div class="<%= preview ? "govuk-grid-column-three-quarters" : "govuk-grid-column-full" %>">
+    <div class="govuk-grid-column-three-quarters">
       <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
     </div>
-    <% if preview %>
-      <div class="govuk-grid-column-one-quarter app-c-govspeak-editor__preview-button-wrapper">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Preview",
-          secondary_quiet: true,
-          margin_bottom: 2,
-          classes: "js-app-c-govspeak-editor__preview-button",
-          data_attributes: preview_button_data_attributes
-        } %>
-      </div>
-    <% end %>
+    <div class="govuk-grid-column-one-quarter app-c-govspeak-editor__preview-button-wrapper">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Preview",
+        secondary_quiet: true,
+        margin_bottom: 2,
+        classes: "js-app-c-govspeak-editor__preview-button",
+        data_attributes: preview_button_data_attributes
+      } %>
+    </div>
   </div>
   <div class="app-c-govspeak-editor__textarea">
     <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/components/docs/govspeak-editor.yml
+++ b/app/views/components/docs/govspeak-editor.yml
@@ -31,3 +31,53 @@ examples:
         bold: true
       name: "with_paste_html_to_govspeak"
       paste_html_to_govspeak: true
+  with_preview_enabled:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_preview"
+      preview: true
+  with_paste_govspeak_and_preview:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_paste_govspeak_and_preview"
+      preview: true
+      paste_html_to_govspeak: true
+  with_tracking:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_tracking"
+      preview: true
+      track_preview_toggle: true
+      track_category: category
+      track_action: action
+  with_data_attributes:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_data_attributes"
+      preview: true
+      data_attributes:
+        some_attribute: "This is for the main component"
+      textarea_data_attributes:
+        some_attribute: "This is for the textarea"
+      preview_button_data_attributes:
+        some_attribute: "This is for the toggle preview button"
+  with_value:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_value"
+      value: |
+        ## What is Lorem Ipsum?
+
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+      preview: true
+      paste_html_to_govspeak: true

--- a/app/views/components/docs/govspeak-editor.yml
+++ b/app/views/components/docs/govspeak-editor.yml
@@ -23,36 +23,13 @@ examples:
       label:
         text: "Document content body"
         bold: true
-      name: "body"
-  with_paste_html_to_govspeak_enabled:
-    data:
-      label:
-        text: "Document content body"
-        bold: true
-      name: "with_paste_html_to_govspeak"
-      paste_html_to_govspeak: true
-  with_preview_enabled:
-    data:
-      label:
-        text: "Document content body"
-        bold: true
-      name: "with_preview"
-      preview: true
-  with_paste_govspeak_and_preview:
-    data:
-      label:
-        text: "Document content body"
-        bold: true
-      name: "with_paste_govspeak_and_preview"
-      preview: true
-      paste_html_to_govspeak: true
+      name: "default"
   with_tracking:
     data:
       label:
         text: "Document content body"
         bold: true
       name: "with_tracking"
-      preview: true
       track_preview_toggle: true
       track_category: category
       track_action: action
@@ -62,7 +39,6 @@ examples:
         text: "Document content body"
         bold: true
       name: "with_data_attributes"
-      preview: true
       data_attributes:
         some_attribute: "This is for the main component"
       textarea_data_attributes:
@@ -79,5 +55,3 @@ examples:
         ## What is Lorem Ipsum?
 
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-      preview: true
-      paste_html_to_govspeak: true

--- a/app/views/components/docs/govspeak-editor.yml
+++ b/app/views/components/docs/govspeak-editor.yml
@@ -1,0 +1,33 @@
+name: Govspeak Editor
+description: |
+  A progressively enhanced textarea with added Govspeak specific functionality
+body: |
+  Typically it is used to enhance a textarea field and add enhancements that help make it easy to
+  edit and publish Govspeak content.
+part_of_admin_layout: true
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form textarea elements
+  - have correctly associated labels
+
+  Enhances the [GOVUK Textarea component](https://components.publishing.service.gov.uk/component-guide/textarea)
+examples:
+  default:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "body"
+  with_paste_html_to_govspeak_enabled:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_paste_html_to_govspeak"
+      paste_html_to_govspeak: true

--- a/spec/javascripts/components/govspeak-editor.spec.js
+++ b/spec/javascripts/components/govspeak-editor.spec.js
@@ -1,0 +1,222 @@
+describe('GOVUK.Modules.GovspekEditor', function () {
+  var component, module
+
+  describe('Without preview mode', function () {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.setAttribute('data-previewable', false)
+
+      var textareaSection = document.createElement('div')
+      textareaSection.classList.add('app-c-govspeak-editor__textarea')
+      textareaSection.appendChild(document.createElement('textarea'))
+
+      component.appendChild(textareaSection)
+
+      module = new GOVUK.Modules.GovspeakEditor(component)
+      module.init()
+    })
+
+    it('renders component correctly', function () {
+      expect(component.getAttribute('data-previewable')).toEqual('false')
+
+      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea').length).toEqual(1)
+      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea textarea').length).toEqual(1)
+      expect(component.querySelector('.app-c-govspeak-editor__textarea')).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+
+      expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(0)
+      expect(component.querySelectorAll('.js-app-c-govspeak-editor__preview-button').length).toEqual(0)
+    })
+  })
+
+  describe('With preview mode', function () {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.setAttribute('data-previewable', true)
+
+      var previewButton = document.createElement('button')
+      previewButton.classList.add('js-app-c-govspeak-editor__preview-button')
+      previewButton.setAttribute('data-preview-toggle-tracking', true)
+      previewButton.setAttribute('data-preview-toggle-track-category', 'govspeak-editor')
+      previewButton.setAttribute('data-preview-toggle-track-action', 'pressed-preview-button')
+      previewButton.setAttribute('data-content-target', '#textarea_id')
+      previewButton.innerText = 'Preview'
+
+      var textareaSection = document.createElement('div')
+      textareaSection.classList.add('app-c-govspeak-editor__textarea')
+
+      var textarea = document.createElement('textarea')
+      textarea.id = 'textarea_id'
+      textarea.innerText = '## Hello'
+      textareaSection.appendChild(textarea)
+
+      var previewSection = document.createElement('div')
+      previewSection.classList.add('app-c-govspeak-editor__preview')
+
+      component.appendChild(previewButton)
+      component.appendChild(textareaSection)
+      component.appendChild(previewSection)
+
+      module = new GOVUK.Modules.GovspeakEditor(component)
+      module.init()
+
+      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+
+      jasmine.Ajax.install()
+    })
+
+    afterEach(function () {
+      jasmine.Ajax.uninstall()
+    })
+
+    it('renders component correctly', function () {
+      expect(component.getAttribute('data-previewable')).toEqual('true')
+
+      expect(component.querySelectorAll('.js-app-c-govspeak-editor__preview-button').length).toEqual(1)
+      expect(component.querySelector('.js-app-c-govspeak-editor__preview-button').getAttribute('data-preview-toggle-tracking')).toEqual('true')
+
+      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea').length).toEqual(1)
+      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea textarea').length).toEqual(1)
+      expect(component.querySelector('.app-c-govspeak-editor__textarea')).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+
+      expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(1)
+      expect(component.querySelector('.app-c-govspeak-editor__preview')).not.toHaveClass('app-c-govspeak-editor__preview--show')
+    })
+
+    it('shows preview section when button clicked', function () {
+      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+      var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
+      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+
+      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
+      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton.innerText).toEqual('Back to edit')
+    })
+
+    it('shows textarea section when you toggle back to edit', function () {
+      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+      var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
+      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+
+      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton.innerText).toEqual('Preview')
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
+      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton.innerText).toEqual('Back to edit')
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton.innerText).toEqual('Preview')
+    })
+
+    it('renders govspeak correctly on preview', function () {
+      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+      var html = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: html
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(html)
+    })
+
+    it('renders govspeak correctly with changing content', function () {
+      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+      var textarea = component.querySelector('#textarea_id')
+      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+      var html = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: html
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(html)
+
+      // back to edit
+      previewButton.dispatchEvent(new Event('click'))
+
+      textarea.innerText = '## Hello this is a heading'
+      var newHtml = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello this is a heading</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: newHtml
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(newHtml)
+    })
+
+    it('sends tracking events correctly', function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'govspeak-editor',
+        'pressed-preview-button',
+        { label: 'preview' }
+      )
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'govspeak-editor',
+        'pressed-preview-button',
+        { label: 'edit' }
+      )
+    })
+  })
+})

--- a/spec/javascripts/components/govspeak-editor.spec.js
+++ b/spec/javascripts/components/govspeak-editor.spec.js
@@ -1,222 +1,190 @@
 describe('GOVUK.Modules.GovspekEditor', function () {
   var component, module
 
-  describe('Without preview mode', function () {
-    beforeEach(function () {
-      component = document.createElement('div')
-      component.setAttribute('data-previewable', false)
+  beforeEach(function () {
+    component = document.createElement('div')
 
-      var textareaSection = document.createElement('div')
-      textareaSection.classList.add('app-c-govspeak-editor__textarea')
-      textareaSection.appendChild(document.createElement('textarea'))
+    var previewButton = document.createElement('button')
+    previewButton.classList.add('js-app-c-govspeak-editor__preview-button')
+    previewButton.setAttribute('data-preview-toggle-tracking', true)
+    previewButton.setAttribute('data-preview-toggle-track-category', 'govspeak-editor')
+    previewButton.setAttribute('data-preview-toggle-track-action', 'pressed-preview-button')
+    previewButton.setAttribute('data-content-target', '#textarea_id')
+    previewButton.innerText = 'Preview'
 
-      component.appendChild(textareaSection)
+    var textareaSection = document.createElement('div')
+    textareaSection.classList.add('app-c-govspeak-editor__textarea')
 
-      module = new GOVUK.Modules.GovspeakEditor(component)
-      module.init()
-    })
+    var textarea = document.createElement('textarea')
+    textarea.id = 'textarea_id'
+    textarea.innerText = '## Hello'
+    textareaSection.appendChild(textarea)
 
-    it('renders component correctly', function () {
-      expect(component.getAttribute('data-previewable')).toEqual('false')
+    var previewSection = document.createElement('div')
+    previewSection.classList.add('app-c-govspeak-editor__preview')
 
-      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea').length).toEqual(1)
-      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea textarea').length).toEqual(1)
-      expect(component.querySelector('.app-c-govspeak-editor__textarea')).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    component.appendChild(previewButton)
+    component.appendChild(textareaSection)
+    component.appendChild(previewSection)
 
-      expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(0)
-      expect(component.querySelectorAll('.js-app-c-govspeak-editor__preview-button').length).toEqual(0)
-    })
+    module = new GOVUK.Modules.GovspeakEditor(component)
+    module.init()
+
+    spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+
+    jasmine.Ajax.install()
   })
 
-  describe('With preview mode', function () {
-    beforeEach(function () {
-      component = document.createElement('div')
-      component.setAttribute('data-previewable', true)
+  afterEach(function () {
+    jasmine.Ajax.uninstall()
+  })
 
-      var previewButton = document.createElement('button')
-      previewButton.classList.add('js-app-c-govspeak-editor__preview-button')
-      previewButton.setAttribute('data-preview-toggle-tracking', true)
-      previewButton.setAttribute('data-preview-toggle-track-category', 'govspeak-editor')
-      previewButton.setAttribute('data-preview-toggle-track-action', 'pressed-preview-button')
-      previewButton.setAttribute('data-content-target', '#textarea_id')
-      previewButton.innerText = 'Preview'
+  it('renders component correctly', function () {
+    expect(component.querySelectorAll('.js-app-c-govspeak-editor__preview-button').length).toEqual(1)
+    expect(component.querySelector('.js-app-c-govspeak-editor__preview-button').getAttribute('data-preview-toggle-tracking')).toEqual('true')
 
-      var textareaSection = document.createElement('div')
-      textareaSection.classList.add('app-c-govspeak-editor__textarea')
+    expect(component.querySelectorAll('.app-c-govspeak-editor__textarea').length).toEqual(1)
+    expect(component.querySelectorAll('.app-c-govspeak-editor__textarea textarea').length).toEqual(1)
+    expect(component.querySelector('.app-c-govspeak-editor__textarea')).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
 
-      var textarea = document.createElement('textarea')
-      textarea.id = 'textarea_id'
-      textarea.innerText = '## Hello'
-      textareaSection.appendChild(textarea)
+    expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(1)
+    expect(component.querySelector('.app-c-govspeak-editor__preview')).not.toHaveClass('app-c-govspeak-editor__preview--show')
+  })
 
-      var previewSection = document.createElement('div')
-      previewSection.classList.add('app-c-govspeak-editor__preview')
+  it('shows preview section when button clicked', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
+    var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
 
-      component.appendChild(previewButton)
-      component.appendChild(textareaSection)
-      component.appendChild(previewSection)
+    expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
 
-      module = new GOVUK.Modules.GovspeakEditor(component)
-      module.init()
+    previewButton.dispatchEvent(new Event('click'))
 
-      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+    expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton.innerText).toEqual('Back to edit')
+  })
 
-      jasmine.Ajax.install()
+  it('shows textarea section when you toggle back to edit', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
+    var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+
+    expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton.innerText).toEqual('Preview')
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton.innerText).toEqual('Back to edit')
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton.innerText).toEqual('Preview')
+  })
+
+  it('renders govspeak correctly on preview', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+    var html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
     })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(html)
+  })
+
+  it('renders govspeak correctly with changing content', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var textarea = component.querySelector('#textarea_id')
+    var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+    var html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
     })
 
-    it('renders component correctly', function () {
-      expect(component.getAttribute('data-previewable')).toEqual('true')
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(component.querySelectorAll('.js-app-c-govspeak-editor__preview-button').length).toEqual(1)
-      expect(component.querySelector('.js-app-c-govspeak-editor__preview-button').getAttribute('data-preview-toggle-tracking')).toEqual('true')
+    expect(previewSection.innerHTML).toEqual(html)
 
-      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea').length).toEqual(1)
-      expect(component.querySelectorAll('.app-c-govspeak-editor__textarea textarea').length).toEqual(1)
-      expect(component.querySelector('.app-c-govspeak-editor__textarea')).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
+    // back to edit
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(1)
-      expect(component.querySelector('.app-c-govspeak-editor__preview')).not.toHaveClass('app-c-govspeak-editor__preview--show')
+    textarea.innerText = '## Hello this is a heading'
+    var newHtml = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello this is a heading</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: newHtml
     })
 
-    it('shows preview section when button clicked', function () {
-      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
-      var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
-      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
-      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewSection.innerHTML).toEqual(newHtml)
+  })
 
-      previewButton.dispatchEvent(new Event('click'))
+  it('sends tracking events correctly', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
 
-      expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
-      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton.innerText).toEqual('Back to edit')
-    })
+    previewButton.dispatchEvent(new Event('click'))
 
-    it('shows textarea section when you toggle back to edit', function () {
-      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
-      var textareaSection = component.querySelector('.app-c-govspeak-editor__textarea')
-      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'govspeak-editor',
+      'pressed-preview-button',
+      { label: 'preview' }
+    )
 
-      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
-      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton.innerText).toEqual('Preview')
+    previewButton.dispatchEvent(new Event('click'))
 
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(textareaSection).toHaveClass('app-c-govspeak-editor__textarea--hidden')
-      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton.innerText).toEqual('Back to edit')
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(textareaSection).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
-      expect(previewSection).not.toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton.innerText).toEqual('Preview')
-    })
-
-    it('renders govspeak correctly on preview', function () {
-      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
-      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
-      var html = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: html
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(html)
-    })
-
-    it('renders govspeak correctly with changing content', function () {
-      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
-      var textarea = component.querySelector('#textarea_id')
-      var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
-      var html = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: html
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(html)
-
-      // back to edit
-      previewButton.dispatchEvent(new Event('click'))
-
-      textarea.innerText = '## Hello this is a heading'
-      var newHtml = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello this is a heading</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: newHtml
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(newHtml)
-    })
-
-    it('sends tracking events correctly', function () {
-      spyOn(GOVUK.analytics, 'trackEvent')
-      var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'govspeak-editor',
-        'pressed-preview-button',
-        { label: 'preview' }
-      )
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'govspeak-editor',
-        'pressed-preview-button',
-        { label: 'edit' }
-      )
-    })
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'govspeak-editor',
+      'pressed-preview-button',
+      { label: 'edit' }
+    )
   })
 })


### PR DESCRIPTION
## What

We need a component that can be used for Govspeak textarea input fields.

It must include an 'inline preview' feature so that users can preview their Govspeak/Markdown rendered as HTML.

## Why

So publishers can preview Govspeak content before saving/publishing it. We know that this is an important feature for publishers.

## Preview

![govspeak-preview](https://user-images.githubusercontent.com/4599889/196705352-9e830888-5777-4156-8152-be7ee71760d1.gif)

## Screenshot of guide

![whitehall-admin dev gov uk_component-guide_govspeak-editor(iPad Pro)](https://user-images.githubusercontent.com/4599889/197535319-4292f4aa-8d92-47e6-bb12-d529644c4646.png)

https://trello.com/c/FAig6Fn0/792-implement-previewable-text-area-for-govspeak

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
