### PR TITLE
Update what's new content for change to saving documents

### DIFF
--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "What's new",
-    message: sanitize("6 October: topic taxonomy tags page moves to the GOV.UK Design System -
+    message: sanitize("20 October: change to saving documents -
       #{
         link_to(
           "find out more about the change",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -17,6 +17,12 @@ en:
       recent_changes:     
         heading: Recent changes
         updates:
+          - heading: Change to saving documents
+            area: Creating and updating documents
+            type: change
+            date: 20 October 2022
+            body_govspeak: |
+              If you select the ‘Save’ button when creating or editing documents, you’ll stay on the edit document page so you can continue working. You’ll no longer be taken to the edition summary page.
           - heading: Topic taxonomy tags page moves to the Design System
             area: Creating and updating documents
             type: improvement

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -4,7 +4,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 6 October 2022
+      last_updated: Last updated 20 October 2022
       introduction:
         heading: Moving to the Design System
         body_govspeak: |


### PR DESCRIPTION
This PR:

- adds 'recent changes' entry for changes to saving documents
- updates phase banner

https://trello.com/c/6lZphXit/806-revert-changes-to-save-redirect

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
