### PR TITLE
Design system sidebar details

### DIFF
--- a/app/assets/stylesheets/admin/components/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin/components/_govspeak-help.scss
@@ -1,0 +1,7 @@
+.govspeak_help__pre {
+  padding: govuk-spacing(2);
+  background-color: govuk-colour("light-grey");
+  word-break: normal;
+  word-wrap: normal;
+  overflow: auto;
+}

--- a/app/assets/stylesheets/admin/components/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin/components/_govspeak-help.scss
@@ -1,4 +1,9 @@
+.govspeak_help {
+  margin-bottom: govuk-spacing(6);
+}
+
 .govspeak_help__pre {
+  font-size: 13px;
   padding: govuk-spacing(2);
   background-color: govuk-colour("light-grey");
   word-break: normal;

--- a/app/assets/stylesheets/admin_legacy/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin_legacy/_govspeak-help.scss
@@ -11,10 +11,5 @@
 
   pre {
     white-space: pre-wrap;
-    padding: govuk-spacing(2);
-    background-color: govuk-colour("light-grey");
-    word-break: normal;
-    word-wrap: normal;
-    overflow: auto;
   }
 }

--- a/app/assets/stylesheets/admin_legacy/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin_legacy/_govspeak-help.scss
@@ -11,5 +11,10 @@
 
   pre {
     white-space: pre-wrap;
+    padding: govuk-spacing(2);
+    background-color: govuk-colour("light-grey");
+    word-break: normal;
+    word-wrap: normal;
+    overflow: auto;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 
 @import "./components/miller-columns";
 @import "./components/autocomplete";
+@import "./admin/govspeak-help";
 
 @import "./admin/modules/unpublish-display-conditions";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,8 @@
 
 @import "./components/miller-columns";
 @import "./components/autocomplete";
-@import "./admin/govspeak-help";
+@import "./admin_legacy/govspeak-help";
+@import "./admin/components/govspeak-help";
 
 @import "./admin/modules/unpublish-display-conditions";
 

--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -1,15 +1,22 @@
 module Admin::SidebarHelper
   def simple_formatting_sidebar(options = {})
-    sidebar_tabs govspeak_help: "Help" do |tabs|
-      tabs.pane id: "govspeak_help", class: "govspeak_help" do
-        tab_content = []
-        tab_content << render("admin/editions/govspeak_help", options)
-        tab_content << render("admin/editions/words_to_avoid_guidance")
-        tab_content << tag.h3("Style", class: "style-title")
-        tab_content << tag.p do
-          raw %(For style, see the #{link_to('style guide', 'https://www.gov.uk/guidance/style-guide')})
+    if current_user.has_permission? "Preview design system"
+      sidebar_content = []
+      sidebar_content << render("admin/editions/govspeak_help", options)
+      sidebar_content << render("admin/editions/style_guidance", options)
+      raw sidebar_content.join("\n")
+    else
+      sidebar_tabs govspeak_help: "Help" do |tabs|
+        tabs.pane id: "govspeak_help", class: "govspeak_help" do
+          tab_content = []
+          tab_content << render("admin/editions/govspeak_help_legacy", options)
+          tab_content << render("admin/editions/words_to_avoid_guidance")
+          tab_content << tag.h3("Style", class: "style-title")
+          tab_content << tag.p do
+            raw %(For style, see the #{link_to('style guide', 'https://www.gov.uk/guidance/style-guide')})
+          end
+          raw tab_content.join("\n")
         end
-        raw tab_content.join("\n")
       end
     end
   end

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -23,23 +23,36 @@
 
   <% if attachment.is_a?(HtmlAttachment) %>
     <%= form.fields_for :govspeak_content do |govspeak_fields| %>
-
-      <%= govspeak_fields.check_box :manually_numbered_headings %>
-      <div class="js-manual-numbering-help<%= ' js-hidden' unless attachment.manually_numbered_headings? %>">
-        <pre>
-  ## 1. First heading
-  ### 1.1 First sub-heading
-  ### 1.2 Second sub-heading
-  ### Unnumbered sub-heading
-
-  Manually number your headings as appropriate using the above numbering scheme.</pre>
+      <div class="govuk-!-margin-bottom-8">
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: "attachment[govspeak_content_attributes][manually_numbered_headings]",
+          heading: "Manually numbered headings",
+          heading_level: 2,
+          heading_size: "l",
+          hint_text: "",
+          items: [
+            {
+              label: "Use manually numbered headings",
+              value: "1",
+              checked: form.object.govspeak_content.manually_numbered_headings,
+              conditional: sanitize("<p>Manually number your headings using the numbering scheme below.</p><code>## 1. First heading<br />### 1.1 First sub-heading<br />### 1.2 Second sub-heading<br />### Unnumbered sub-heading</code>")
+            }
+          ]
+        } %>
       </div>
 
-      <%= content_tag :fieldset, class: ("right-to-left" if form.object.rtl_locale?) do %>
-        <%= govspeak_fields.text_area :body, rows: 20, class: "previewable", data: {
-          module: "paste-html-to-govspeak"
-        } %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "l",
+          text: "Body (required)"
+        },
+        name: "attachment[govspeak_content_attributes][body]",
+        rows: 20,
+        id: "attachment_govspeak_content.body",
+        value: form.object.govspeak_content.body,
+        error_items: errors_for(attachment.errors, :"govspeak_content.body"),
+        margin_bottom: 8
+      } %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
     <div class="govuk-!-margin-bottom-8">
@@ -64,6 +77,10 @@
   <% if attachment.is_a?(ExternalAttachment) %>
     <%= render "govuk_publishing_components/components/button", {
       text: "Next"
+    } %>
+  <% elsif attachment.is_a?(HtmlAttachment) %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save"
     } %>
   <% else %>
     <div class="govuk-button-group">

--- a/app/views/admin/attachments/edit.html.erb
+++ b/app/views/admin/attachments/edit.html.erb
@@ -11,8 +11,8 @@
   </section>
 
   <% if attachment.html? %>
-    <div class="col-md-4">
+    <aside class="govuk-grid-column-one-third">
       <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>
-    </div>
+    </aside>
   <% end %>
 </div>

--- a/app/views/admin/attachments/new.html.erb
+++ b/app/views/admin/attachments/new.html.erb
@@ -11,8 +11,8 @@
   </section>
 
   <% if attachment.html? %>
-    <div>
+    <aside class="govuk-grid-column-one-third">
       <%= simple_formatting_sidebar hide_inline_attachments_help: true, show_footnote_help: true, show_stat_headline_help: true %>
-    </div>
+    </aside>
   <% end %>
 </div>

--- a/app/views/admin/editions/_govspeak_attachments_help.html.erb
+++ b/app/views/admin/editions/_govspeak_attachments_help.html.erb
@@ -1,0 +1,14 @@
+<% if show_attachments_tab_help %>
+  <p class="govuk-body">Upload your attachment(s) on the ‘Attachments’ tab (you must save a draft edition to make the tab visible).</p>
+<% else %>
+  <p class="govuk-body">Upload your attachment(s) using the attachment fields in the form.</p>
+<% end %>
+
+<p class="govuk-body">Add an attachment as a callout box:</p>
+<pre>!@<em>n</em></pre>
+<p class="govuk-body">Or, if you want to use a link to an attachment in a sentence or list:</p>
+<pre>[InlineAttachment:<em>n</em>]</pre>
+<p class="govuk-body">eg for the first file:</p>
+<pre>!@1</pre>
+<p class="govuk-body">or:</p>
+<pre>[InlineAttachment:1]</pre>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -7,13 +7,11 @@
   govspeak_link_errors ||= []
 %>
 
-<h2>Govspeak help</h2>
-
 <% if govspeak_link_errors.any? %>
   <section id='link-errors' class='alert alert-danger'>
-    <h3>Link errors</h3>
+    <h3 class="govuk-heading-m">Link errors</h3>
 
-    <p>You will not be able to publish this document until these are fixed.</p>
+    <p class="govuk-body">You will not be able to publish this document until these are fixed.</p>
 
     <dl>
       <% govspeak_link_errors.each do |link_error| %>
@@ -31,259 +29,231 @@
   <%= render 'admin/link_check_reports/link_check_report', report: link_check_report %>
 <% end %>
 
-<div data-module="gem-track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
-  <h3>Formatting</h3>
-  <p>For details, read the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown">guide to using Markdown</a></p>
-  <h3><a data-toggle="collapse" href="#govspeak-paste-to-markdown" aria-expanded="false">Paste and convert to Markdown</a></h3>
-  <div class="collapse" id="govspeak-paste-to-markdown">
-    <p>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
-    <p>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
-    <p>It will convert:</p>
-    <ul>
-      <li>headings</li>
-      <li>bullets</li>
-      <li>numbered lists</li>
-      <li>links</li>
-      <li>email links</li>
-    </ul>
-    <p>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
-  </div>
+<div class="govspeak_help" data-module="gem-track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
+  <h2 class="govuk-heading-l">Formatting</h2>
 
-  <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>
-  <div class="collapse" id="govspeak-headings">
-    <pre>## Top level heading – H2
-  ### Second level heading – H3
-  #### Third level heading – H4
-
-  Don’t use a single # – this is H1 and is for the title only</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-links" aria-expanded="false">Links</a></h3>
-  <div class="collapse" id="govspeak-links">
-    <p>
-      All documents created in the publisher – publications, news, speeches, detailed guides etc –
-      should be linked to using absolute admin paths or full public URLs:
-    </p>
-    <pre>
-  [an admin path](/government/admin/policies/12345)
-  [a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
-
-    <p>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
-    <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
-
-    <p>For external websites, use the full URL including http://:</p>
-    <pre>[link text](http://www.example.com)</pre>
-
-    <h4>Linking to paragraphs</h4>
-    <p>
-      If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable
-      by placing an anchor tag <strong>below</strong> the paragraph:
-    </p>
-  <pre>
-  Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.
-  {:#eel-decline}
-  </pre>
-
-    <p>The paragraph can then be linked to from the same document:</p>
-    <pre>[Sample link text](#eel-decline)</pre>
-
-    <p>or from another document:</p>
-    <pre>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-bullets" aria-expanded="false">Bullets</a></h3>
-  <div class="collapse" id="govspeak-bullets">
-    <pre>* item 1
-    * item 2
-    * item 3</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-numbered-list" aria-expanded="false">Numbered list</a></h3>
-  <div class="collapse" id="govspeak-numbered-list">
-    <pre>1. item 1
-  2. item 2
-  3. item 3</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-images" aria-expanded="false">Images</a></h3>
-  <div class="collapse" id="govspeak-images">
-    <p>First upload your image(s), then:</p>
-    <pre>!!<em>n</em></pre>
-    <p>eg for the first image:</p>
-    <pre>!!1</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-video-links" aria-expanded="false">Video links</a></h3>
-  <div class="collapse" id="govspeak-video-links">
-    <p>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
-    <pre>[title of video](youtube-video-url)</pre>
-    <p>Only YouTube videos will work at present:</p>
-    <pre>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
-    <p>The title text does not show. The video will display in an embedded media player automatically.</p>
-  </div>
-
-  <% unless hide_inline_attachments_help %>
-    <h3><a data-toggle="collapse" href="#govspeak-attachments" aria-expanded="false">Attachments</a></h3>
-    <div class="collapse" id="govspeak-attachments">
-      <% if show_attachments_tab_help %>
-        <p>Upload your attachment(s) on the ‘Attachments’ tab (you must save a draft edition to make the tab visible).</p>
-      <% else %>
-        <p>Upload your attachment(s) using the attachment fields in the form.</p>
-      <% end %>
-      <p>Add an attachment as a callout box:</p>
-      <pre>!@<em>n</em></pre>
-      <p>Or, if you want to use a link to an attachment in a sentence or list:</p>
-      <pre>[InlineAttachment:<em>n</em>]</pre>
-      <p>eg for the first file:</p>
-      <pre>!@1</pre>
-      <p>or:</p>
-      <pre>[InlineAttachment:1]</pre>
-    </div>
-  <% end %>
-
-  <h3><a data-toggle="collapse" href="#govspeak-tables" aria-expanded="false">Tables</a></h3>
-  <div class="collapse" id="govspeak-tables">
-    <p>Insert tables by splitting your content into cells using the pipe (|) character. </p>
-    <pre>
-  |  name   |  colour |
-  |---------|---------|
-  | apple   | green   |
-  | banana  | yellow  |</pre>
-
-    <p>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
-
-    <pre>
-  |             | Fruit | Vegetables |
-  |-------------|-------|------------|
-  |# per gram   |   5p  |     8p     |
-  |# per kilo   |   7p  |     6p     |
-    </pre>
-
-  <p>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
-  <pre>
-  |  name   |  cost  |
-  |---------|-------:|
-  | apple   | 0.45   |
-  | banana  | 0.32   |
-  | guava   | 10.32  |
-  </pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-charts" aria-expanded="false">Charts</a></h3>
-  <div class="collapse" id="govspeak-charts">
-    <p>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
-    <pre>Department   | Short Speeches | Long Speeches
-  -|-|-
-  Department 1 | 6              | 6
-  Department 2 | 6              | 8
-  Department 3 | 18             | 2
-  {barchart}</pre>
-    <p>Stacked bars can be created. The final column is used to display the total.</p>
-    <pre>Department | Short Speeches | Long Speeches | Total
-  -|-|-|-
-  Dept 1     | 6              | 6             | 12
-  Dept 2     | 6              | 8             | 14
-  Dept 3     | 18             | 2             | 20
-  {barchart stacked}</pre>
-    <p>Large graphs can be displayed compactly to save space.</p>
-    <pre>Department   | Short Speeches | Long Speeches
-  -|-|-
-  Department 1 | 6              | 6
-  Department 2 | 6              | 8
-  Department 3 | 18             | 2
-  Department 4 | 5              | 4
-  Department 4 | 7              | 7
-  Department 6 | 11             | 1
-  {barchart compact}</pre>
-    <p>If you include negative values, you must indicate this.</p>
-    <pre>Department   | Change in Number of Buildings
-  -|-
-  Department 1 | -12
-  Department 1 | 3
-  Department 1 | -4
-  Department 1 | 2
-  {barchart negative}</pre>
-    <p>All effects can be combined.</p>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-cta" aria-expanded="false">Call to action</a></h3>
-  <div class="collapse" id="govspeak-cta">
-    <pre>$CTA
-  [Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)
-  $CTA</pre>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-acronyms" aria-expanded="false">Abbreviations and acronyms</a></h3>
-  <div class="collapse" id="govspeak-acronyms">
-    <p>The first time you use an abbreviation or acroynm, write it out in full.</p>
-    <p>Add the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms">acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
-    <pre>Example content that includes a three-letter acronym (TLA).
-
-  *[TLA]: three-letter acronym</pre>
-    <p>When a user hovers their mouse over a <abbr title="three-letter acronym">TLA</abbr>, they will see it written in full.</p>
-
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-blockquotes" aria-expanded="false">Blockquotes</a></h3>
-  <div class="collapse" id="govspeak-blockquotes">
-    <pre>Introduction to the quote:
-
-  > First paragraph of the quote.
-  >
-  > Second paragraph of the quote.</pre>
-    <p>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
-  </div>
-
-  <h3><a data-toggle="collapse" href="#govspeak-addresses" aria-expanded="false">Addresses</a></h3>
-  <div class="collapse" id="govspeak-addresses">
-    <pre>$A
-  Address
-  Only
-  Here
-  $A</pre>
-
-    <p>You can also embed contact information:</p>
-    <pre>[Contact:<em>n</em>]</pre>
-    <p>(n is the ID of the contact you want to embed.)</p>
-    <p>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
-    <p>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
-  </div>
-
-
-  <h3><a data-toggle="collapse" href="#govspeak-email-links" aria-expanded="false">Email links</a></h3>
-  <div class="collapse" id="govspeak-email-links">
-    <p>Use ‘less than’ (<code>&lt;</code>) and ‘greater than’ (<code>&gt;</code>) arrows around email addresses to make them a link.</pre>
-  </div>
-
-  <% if show_footnote_help %>
-    <h3><a data-toggle="collapse" href="#govspeak-footnotes" aria-expanded="false">Footnotes</a></h3>
-    <div class="collapse" id="govspeak-footnotes">
-      <pre>Footnotes can be added[^1].
-
-  [^1]: And then later defined.</pre>
-      <p>
-        You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
-      </p>
-      <p>
-        Footnote content can hold more than one paragraph by indenting the content 4 spaces:
-      </p>
-
-      <pre>[^1]:
-      This is some footnote content and is indented 4 spaces.
-
-      This paragraph is also indented, so will be considered part of the footnote content.</pre>
-    </div>
-  <% end %>
-
-  <% if show_stat_headline_help %>
-    <h3><a data-toggle="collapse" href="#govspeak-stat-headline" aria-expanded="false">Statistic headlines</a></h3>
-    <div class="collapse" id="govspeak-stat-headline">
-      <p>
-        Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.
-      </p>
-      <pre>{stat-headline}
-  *13.8bn* years since the big bang
-  {/stat-headline}</pre>
-    </div>
-  <% end %>
+  <p class="govuk-body">For details, read the <%=link_to("guide to using Markdown", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link") %>
+  <%= render "govuk_publishing_components/components/accordion", {
+    heading_level: 4,
+    items: [
+      {
+        heading: {
+          text: "Paste and convert to Markdown"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
+            <p class='govuk-body'>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+            <p class='govuk-body'>It will convert:</p>
+            <ul class='gem-c-list govuk-list govuk-list--bullet'>
+              <li>headings</li>
+              <li>bullets</li>
+              <li>numbered lists</li>
+              <li>links</li>
+              <li>email links</li>
+            </ul>
+            <p class='govuk-body'>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>"
+          )
+        },
+      },
+      {
+        heading: {
+          text: "Headings"
+        },
+        content: {
+          html: sanitize(
+            "<pre>## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>"
+          )
+        },
+      },
+      {
+        heading: {
+          text: "Links"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
+            <pre>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+            <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
+            <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+            <p class='govuk-body'>For external websites, use the full URL including http://:</p>
+            <pre>[link text](http://www.example.com)</pre>
+            <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
+            <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
+            </p>
+            <pre>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
+            <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
+            <pre>[Sample link text](#eel-decline)</pre>
+            <p class='govuk-body'>or from another document:</p>
+            <pre>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>"
+          )
+        },
+      },
+      {
+        heading: {
+          text: "Bullets"
+        },
+        content: {
+          html: sanitize(
+            "<pre>* item 1<br />* item 2<br />* item 3<br /></pre>"
+          )
+        },
+      },
+      {
+        heading: {
+          text: "Numbered lists"
+        },
+        content: {
+          html: sanitize(
+            "<pre>1. item 1<br />2. item 2<br />3. item 3<br /></pre>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Images"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>First upload your image(s), then:</p>
+            <pre>!!<em>n</em></pre>
+            <p class='govuk-body'>eg for the first image:</p>
+            <pre>!!1</pre>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Video links"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
+            <pre>[title of video](youtube-video-url)</pre>
+            <p class='govuk-body'>Only YouTube videos will work at present:</p>
+            <pre>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
+            <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>"
+          )
+        }
+      },
+      *([{
+        heading: {
+          text: "Attachments"
+        },
+        content: {
+          html: (render "admin/editions/govspeak_attachments_help", show_attachments_tab_help: show_attachments_tab_help)
+        }
+      }] unless hide_inline_attachments_help),
+      {
+        heading: {
+          text: "Tables"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
+            <pre>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
+            <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
+            <pre>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
+            <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
+            <pre>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Charts"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
+            <pre>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
+            <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
+            <pre>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
+            <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
+            <pre>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
+            <p class='govuk-body'>If you include negative values, you must indicate this.</p>
+            <pre>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
+            <p class='govuk-body'>All effects can be combined.</p>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Call to action"
+        },
+        content: {
+          html: sanitize(
+            "<pre>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Abbreviations and acronyms"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
+            <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+            <pre>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
+            <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Blockquotes"
+        },
+        content: {
+          html: sanitize(
+            "<pre>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
+            <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>"
+          )
+        }
+      },
+      {
+        heading: {
+          text: "Addresses"
+        },
+        content: {
+          html: sanitize(
+            "<pre>$A<br />Address<br />Only<br />Here<br />$A</pre>
+            <p class='govuk-body'>You can also embed contact information:</p>
+            <pre>[Contact:<em>n</em>]</pre>
+            <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
+            <p class='govuk-body'>You can find the ID on the list of contacts for an #{link_to 'organisation', admin_organisations_path} or #{link_to 'worldwide organisation', admin_worldwide_organisations_path} or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
+            <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>"
+          )
+        }
+      },
+      *([{
+        heading: {
+          text: "Footnotes"
+        },
+        content: {
+          html: sanitize(
+            "<pre>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
+            <p class='govuk-body'>
+              You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
+            </p>
+            <p class='govuk-body'>
+              Footnote content can hold more than one paragraph by indenting the content 4 spaces:
+            </p>
+            <pre>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>"
+          )
+        }
+      }] if show_footnote_help),
+      *([{
+        heading: {
+          text: "Statistic headlines"
+        },
+        content: {
+          html: sanitize(
+            "<p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
+            <pre>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>"
+          )
+        }
+      }] if show_stat_headline_help),
+    ]
+  } %>
 </div>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -62,7 +62,7 @@
         },
         content: {
           html: sanitize(
-            "<pre>## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>"
+            "<pre class='govspeak_help__pre'>## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>"
           )
         },
       },
@@ -73,19 +73,19 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
-            <pre>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+            <pre class='govspeak_help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
             <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
-            <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+            <pre class='govspeak_help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
             <p class='govuk-body'>For external websites, use the full URL including http://:</p>
-            <pre>[link text](http://www.example.com)</pre>
+            <pre class='govspeak_help__pre'>[link text](http://www.example.com)</pre>
             <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
             <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
             </p>
-            <pre>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
+            <pre class='govspeak_help__pre'>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
             <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
-            <pre>[Sample link text](#eel-decline)</pre>
+            <pre class='govspeak_help__pre'>[Sample link text](#eel-decline)</pre>
             <p class='govuk-body'>or from another document:</p>
-            <pre>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>"
+            <pre class='govspeak_help__pre'>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>"
           )
         },
       },
@@ -95,7 +95,7 @@
         },
         content: {
           html: sanitize(
-            "<pre>* item 1<br />* item 2<br />* item 3<br /></pre>"
+            "<pre class='govspeak_help__pre'>* item 1<br />* item 2<br />* item 3<br /></pre>"
           )
         },
       },
@@ -105,7 +105,7 @@
         },
         content: {
           html: sanitize(
-            "<pre>1. item 1<br />2. item 2<br />3. item 3<br /></pre>"
+            "<pre class='govspeak_help__pre'>1. item 1<br />2. item 2<br />3. item 3<br /></pre>"
           )
         }
       },
@@ -116,9 +116,9 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>First upload your image(s), then:</p>
-            <pre>!!<em>n</em></pre>
+            <pre class='govspeak_help__pre'>!!<em>n</em></pre>
             <p class='govuk-body'>eg for the first image:</p>
-            <pre>!!1</pre>"
+            <pre class='govspeak_help__pre'>!!1</pre>"
           )
         }
       },
@@ -129,9 +129,9 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
-            <pre>[title of video](youtube-video-url)</pre>
+            <pre class='govspeak_help__pre'>[title of video](youtube-video-url)</pre>
             <p class='govuk-body'>Only YouTube videos will work at present:</p>
-            <pre>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
+            <pre class='govspeak_help__pre'>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
             <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>"
           )
         }
@@ -151,11 +151,11 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
-            <pre>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
+            <pre class='govspeak_help__pre'>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
             <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
-            <pre>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
+            <pre class='govspeak_help__pre'>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
             <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
-            <pre>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>"
+            <pre class='govspeak_help__pre'>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>"
           )
         }
       },
@@ -166,13 +166,13 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
-            <pre>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
+            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
             <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
-            <pre>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
+            <pre class='govspeak_help__pre'>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
             <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
-            <pre>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
+            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
             <p class='govuk-body'>If you include negative values, you must indicate this.</p>
-            <pre>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
+            <pre class='govspeak_help__pre'>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
             <p class='govuk-body'>All effects can be combined.</p>"
           )
         }
@@ -183,7 +183,7 @@
         },
         content: {
           html: sanitize(
-            "<pre>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>"
+            "<pre class='govspeak_help__pre'>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>"
           )
         }
       },
@@ -195,7 +195,7 @@
           html: sanitize(
             "<p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
             <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
-            <pre>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
+            <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
             <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>"
           )
         }
@@ -206,7 +206,7 @@
         },
         content: {
           html: sanitize(
-            "<pre>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
+            "<pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
             <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>"
           )
         }
@@ -217,9 +217,9 @@
         },
         content: {
           html: sanitize(
-            "<pre>$A<br />Address<br />Only<br />Here<br />$A</pre>
+            "<pre class='govspeak_help__pre'>$A<br />Address<br />Only<br />Here<br />$A</pre>
             <p class='govuk-body'>You can also embed contact information:</p>
-            <pre>[Contact:<em>n</em>]</pre>
+            <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
             <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
             <p class='govuk-body'>You can find the ID on the list of contacts for an #{link_to 'organisation', admin_organisations_path} or #{link_to 'worldwide organisation', admin_worldwide_organisations_path} or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
             <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>"
@@ -232,14 +232,14 @@
         },
         content: {
           html: sanitize(
-            "<pre>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
+            "<pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
             <p class='govuk-body'>
               You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
             </p>
             <p class='govuk-body'>
               Footnote content can hold more than one paragraph by indenting the content 4 spaces:
             </p>
-            <pre>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>"
+            <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>"
           )
         }
       }] if show_footnote_help),
@@ -250,7 +250,7 @@
         content: {
           html: sanitize(
             "<p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
-            <pre>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>"
+            <pre class='govspeak_help__pre'>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>"
           )
         }
       }] if show_stat_headline_help),

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -33,227 +33,166 @@
   <h2 class="govuk-heading-l">Formatting</h2>
 
   <p class="govuk-body">For details, read the <%=link_to("guide to using Markdown", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link") %>
-  <%= render "govuk_publishing_components/components/accordion", {
-    heading_level: 4,
-    items: [
-      {
-        heading: {
-          text: "Paste and convert to Markdown"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
-            <p class='govuk-body'>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
-            <p class='govuk-body'>It will convert:</p>
-            <ul class='gem-c-list govuk-list govuk-list--bullet'>
-              <li>headings</li>
-              <li>bullets</li>
-              <li>numbered lists</li>
-              <li>links</li>
-              <li>email links</li>
-            </ul>
-            <p class='govuk-body'>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Headings"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Links"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
-            <pre class='govspeak_help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
-            <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
-            <pre class='govspeak_help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
-            <p class='govuk-body'>For external websites, use the full URL including http://:</p>
-            <pre class='govspeak_help__pre'>[link text](http://www.example.com)</pre>
-            <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
-            <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
-            </p>
-            <pre class='govspeak_help__pre'>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
-            <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
-            <pre class='govspeak_help__pre'>[Sample link text](#eel-decline)</pre>
-            <p class='govuk-body'>or from another document:</p>
-            <pre class='govspeak_help__pre'>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Bullets"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>* item 1<br />* item 2<br />* item 3<br /></pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Numbered lists"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>1. item 1<br />2. item 2<br />3. item 3<br /></pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Images"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>First upload your image(s), then:</p>
-            <pre class='govspeak_help__pre'>!!<em>n</em></pre>
-            <p class='govuk-body'>eg for the first image:</p>
-            <pre class='govspeak_help__pre'>!!1</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Video links"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
-            <pre class='govspeak_help__pre'>[title of video](youtube-video-url)</pre>
-            <p class='govuk-body'>Only YouTube videos will work at present:</p>
-            <pre class='govspeak_help__pre'>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
-            <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>"
-          )
-        }
-      },
-      *([{
-        heading: {
-          text: "Attachments"
-        },
-        content: {
-          html: (render "admin/editions/govspeak_attachments_help", show_attachments_tab_help: show_attachments_tab_help)
-        }
-      }] unless hide_inline_attachments_help),
-      {
-        heading: {
-          text: "Tables"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
-            <pre class='govspeak_help__pre'>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
-            <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
-            <pre class='govspeak_help__pre'>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
-            <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
-            <pre class='govspeak_help__pre'>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Charts"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
-            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
-            <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
-            <pre class='govspeak_help__pre'>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
-            <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
-            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
-            <p class='govuk-body'>If you include negative values, you must indicate this.</p>
-            <pre class='govspeak_help__pre'>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
-            <p class='govuk-body'>All effects can be combined.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Call to action"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Abbreviations and acronyms"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
-            <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
-            <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
-            <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Blockquotes"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
-            <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Addresses"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>$A<br />Address<br />Only<br />Here<br />$A</pre>
-            <p class='govuk-body'>You can also embed contact information:</p>
-            <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
-            <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
-            <p class='govuk-body'>You can find the ID on the list of contacts for an #{link_to 'organisation', admin_organisations_path} or #{link_to 'worldwide organisation', admin_worldwide_organisations_path} or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
-            <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>"
-          )
-        }
-      },
-      *([{
-        heading: {
-          text: "Footnotes"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
-            <p class='govuk-body'>
-              You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
-            </p>
-            <p class='govuk-body'>
-              Footnote content can hold more than one paragraph by indenting the content 4 spaces:
-            </p>
-            <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>"
-          )
-        }
-      }] if show_footnote_help),
-      *([{
-        heading: {
-          text: "Statistic headlines"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
-            <pre class='govspeak_help__pre'>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>"
-          )
-        }
-      }] if show_stat_headline_help),
-    ]
-  } %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Paste and convert to Markdown"
+  } do %>
+    <p class='govuk-body'>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
+    <p class='govuk-body'>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+    <p class='govuk-body'>It will convert:</p>
+    <ul class='gem-c-list govuk-list govuk-list--bullet'>
+      <li>headings</li>
+      <li>bullets</li>
+      <li>numbered lists</li>
+      <li>links</li>
+      <li>email links</li>
+    </ul>
+    <p class='govuk-body'>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Headings"
+  } do %>
+    <pre class="govspeak_help__pre">## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Links"
+  } do %>
+    <p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
+    <pre class='govspeak_help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+    <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
+    <pre class='govspeak_help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+    <p class='govuk-body'>For external websites, use the full URL including http://:</p>
+    <pre class='govspeak_help__pre'>[link text](http://www.example.com)</pre>
+    <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
+    <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
+    </p>
+    <pre class='govspeak_help__pre'>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
+    <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
+    <pre class='govspeak_help__pre'>[Sample link text](#eel-decline)</pre>
+    <p class='govuk-body'>or from another document:</p>
+    <pre class='govspeak_help__pre'>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Bullets"
+  } do %>
+    <pre class='govspeak_help__pre'>* item 1<br />* item 2<br />* item 3<br /></pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Numbered lists"
+  } do %>
+    <pre class='govspeak_help__pre'>1. item 1<br />2. item 2<br />3. item 3<br /></pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Images"
+  } do %>
+    <p class='govuk-body'>First upload your image(s), then:</p>
+    <pre class='govspeak_help__pre'>!!<em>n</em></pre>
+    <p class='govuk-body'>eg for the first image:</p>
+    <pre class='govspeak_help__pre'>!!1</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Video links"
+  } do %>
+    <p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
+    <pre class='govspeak_help__pre'>[title of video](youtube-video-url)</pre>
+    <p class='govuk-body'>Only YouTube videos will work at present:</p>
+    <pre class='govspeak_help__pre'>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
+    <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>
+  <% end %>
+
+  <% unless hide_inline_attachments_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Attachments"
+    } do %>
+      <%= render "admin/editions/govspeak_attachments_help", show_attachments_tab_help: show_attachments_tab_help %>
+    <% end %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Tables"
+  } do %>
+    <p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
+    <pre class='govspeak_help__pre'>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
+    <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
+    <pre class='govspeak_help__pre'>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
+    <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
+    <pre class='govspeak_help__pre'>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Charts"
+  } do %>
+    <p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
+    <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
+    <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
+    <pre class='govspeak_help__pre'>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
+    <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
+    <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
+    <p class='govuk-body'>If you include negative values, you must indicate this.</p>
+    <pre class='govspeak_help__pre'>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
+    <p class='govuk-body'>All effects can be combined.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Call to action"
+  } do %>
+    <pre class='govspeak_help__pre'>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Abbreviations and acronyms"
+  } do %>
+    <p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
+    <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+    <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
+    <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Blockquotes"
+  } do %>
+    <pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
+    <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Addresses"
+  } do %>
+    <pre class='govspeak_help__pre'>$A<br />Address<br />Only<br />Here<br />$A</pre>
+    <p class='govuk-body'>You can also embed contact information:</p>
+    <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
+    <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
+    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
+    <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
+  <% end %>
+
+  <% if show_footnote_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Footnotes"
+    } do %>
+      <pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
+      <p class='govuk-body'>
+        You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
+      </p>
+      <p class='govuk-body'>
+        Footnote content can hold more than one paragraph by indenting the content 4 spaces:
+      </p>
+      <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>
+    <% end %>
+  <% end %>
+
+  <% if show_stat_headline_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Statistic headlines"
+    } do %>
+      <p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
+      <pre class='govspeak_help__pre'>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/admin/editions/_govspeak_help_legacy.html.erb
+++ b/app/views/admin/editions/_govspeak_help_legacy.html.erb
@@ -1,0 +1,289 @@
+<%
+  hide_inline_attachments_help ||= false
+  show_attachments_tab_help ||= false
+  show_footnote_help ||= false
+  show_stat_headline_help ||= false
+  link_check_report ||= nil
+  govspeak_link_errors ||= []
+%>
+
+<h2>Govspeak help</h2>
+
+<% if govspeak_link_errors.any? %>
+  <section id='link-errors' class='alert alert-danger'>
+    <h3>Link errors</h3>
+
+    <p>You will not be able to publish this document until these are fixed.</p>
+
+    <dl>
+      <% govspeak_link_errors.each do |link_error| %>
+        <dt><%= link_error[:link] %></dt>
+        <dd data-start='<%= link_error[:start] %>' data-end='<%= link_error[:end] %>'>
+          <%= link_error[:fix] %>
+        </dd>
+      <% end %>
+    </dl>
+  </section>
+  <% initialise_script "GOVUK.govspeakLinkErrors", selector: '#link-errors' %>
+<% end %>
+
+<% if link_check_report.present? %>
+  <%= render 'admin/link_check_reports/link_check_report', report: link_check_report %>
+<% end %>
+
+<div data-module="gem-track-click" data-track-category="formatting-help" data-track-action="formatting-help-link" data-track-selector="a[data-toggle]">
+  <h3>Formatting</h3>
+  <p>For details, read the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown">guide to using Markdown</a></p>
+  <h3><a data-toggle="collapse" href="#govspeak-paste-to-markdown" aria-expanded="false">Paste and convert to Markdown</a></h3>
+  <div class="collapse" id="govspeak-paste-to-markdown">
+    <p>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
+    <p>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+    <p>It will convert:</p>
+    <ul>
+      <li>headings</li>
+      <li>bullets</li>
+      <li>numbered lists</li>
+      <li>links</li>
+      <li>email links</li>
+    </ul>
+    <p>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-headings" aria-expanded="false">Headings</a></h3>
+  <div class="collapse" id="govspeak-headings">
+    <pre>## Top level heading – H2
+  ### Second level heading – H3
+  #### Third level heading – H4
+
+  Don’t use a single # – this is H1 and is for the title only</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-links" aria-expanded="false">Links</a></h3>
+  <div class="collapse" id="govspeak-links">
+    <p>
+      All documents created in the publisher – publications, news, speeches, detailed guides etc –
+      should be linked to using absolute admin paths or full public URLs:
+    </p>
+    <pre>
+  [an admin path](/government/admin/policies/12345)
+  [a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+
+    <p>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
+    <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+
+    <p>For external websites, use the full URL including http://:</p>
+    <pre>[link text](http://www.example.com)</pre>
+
+    <h4>Linking to paragraphs</h4>
+    <p>
+      If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable
+      by placing an anchor tag <strong>below</strong> the paragraph:
+    </p>
+  <pre>
+  Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.
+  {:#eel-decline}
+  </pre>
+
+    <p>The paragraph can then be linked to from the same document:</p>
+    <pre>[Sample link text](#eel-decline)</pre>
+
+    <p>or from another document:</p>
+    <pre>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-bullets" aria-expanded="false">Bullets</a></h3>
+  <div class="collapse" id="govspeak-bullets">
+    <pre>* item 1
+    * item 2
+    * item 3</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-numbered-list" aria-expanded="false">Numbered list</a></h3>
+  <div class="collapse" id="govspeak-numbered-list">
+    <pre>1. item 1
+  2. item 2
+  3. item 3</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-images" aria-expanded="false">Images</a></h3>
+  <div class="collapse" id="govspeak-images">
+    <p>First upload your image(s), then:</p>
+    <pre>!!<em>n</em></pre>
+    <p>eg for the first image:</p>
+    <pre>!!1</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-video-links" aria-expanded="false">Video links</a></h3>
+  <div class="collapse" id="govspeak-video-links">
+    <p>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
+    <pre>[title of video](youtube-video-url)</pre>
+    <p>Only YouTube videos will work at present:</p>
+    <pre>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
+    <p>The title text does not show. The video will display in an embedded media player automatically.</p>
+  </div>
+
+  <% unless hide_inline_attachments_help %>
+    <h3><a data-toggle="collapse" href="#govspeak-attachments" aria-expanded="false">Attachments</a></h3>
+    <div class="collapse" id="govspeak-attachments">
+      <% if show_attachments_tab_help %>
+        <p>Upload your attachment(s) on the ‘Attachments’ tab (you must save a draft edition to make the tab visible).</p>
+      <% else %>
+        <p>Upload your attachment(s) using the attachment fields in the form.</p>
+      <% end %>
+      <p>Add an attachment as a callout box:</p>
+      <pre>!@<em>n</em></pre>
+      <p>Or, if you want to use a link to an attachment in a sentence or list:</p>
+      <pre>[InlineAttachment:<em>n</em>]</pre>
+      <p>eg for the first file:</p>
+      <pre>!@1</pre>
+      <p>or:</p>
+      <pre>[InlineAttachment:1]</pre>
+    </div>
+  <% end %>
+
+  <h3><a data-toggle="collapse" href="#govspeak-tables" aria-expanded="false">Tables</a></h3>
+  <div class="collapse" id="govspeak-tables">
+    <p>Insert tables by splitting your content into cells using the pipe (|) character. </p>
+    <pre>
+  |  name   |  colour |
+  |---------|---------|
+  | apple   | green   |
+  | banana  | yellow  |</pre>
+
+    <p>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
+
+    <pre>
+  |             | Fruit | Vegetables |
+  |-------------|-------|------------|
+  |# per gram   |   5p  |     8p     |
+  |# per kilo   |   7p  |     6p     |
+    </pre>
+
+  <p>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
+  <pre>
+  |  name   |  cost  |
+  |---------|-------:|
+  | apple   | 0.45   |
+  | banana  | 0.32   |
+  | guava   | 10.32  |
+  </pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-charts" aria-expanded="false">Charts</a></h3>
+  <div class="collapse" id="govspeak-charts">
+    <p>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
+    <pre>Department   | Short Speeches | Long Speeches
+  -|-|-
+  Department 1 | 6              | 6
+  Department 2 | 6              | 8
+  Department 3 | 18             | 2
+  {barchart}</pre>
+    <p>Stacked bars can be created. The final column is used to display the total.</p>
+    <pre>Department | Short Speeches | Long Speeches | Total
+  -|-|-|-
+  Dept 1     | 6              | 6             | 12
+  Dept 2     | 6              | 8             | 14
+  Dept 3     | 18             | 2             | 20
+  {barchart stacked}</pre>
+    <p>Large graphs can be displayed compactly to save space.</p>
+    <pre>Department   | Short Speeches | Long Speeches
+  -|-|-
+  Department 1 | 6              | 6
+  Department 2 | 6              | 8
+  Department 3 | 18             | 2
+  Department 4 | 5              | 4
+  Department 4 | 7              | 7
+  Department 6 | 11             | 1
+  {barchart compact}</pre>
+    <p>If you include negative values, you must indicate this.</p>
+    <pre>Department   | Change in Number of Buildings
+  -|-
+  Department 1 | -12
+  Department 1 | 3
+  Department 1 | -4
+  Department 1 | 2
+  {barchart negative}</pre>
+    <p>All effects can be combined.</p>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-cta" aria-expanded="false">Call to action</a></h3>
+  <div class="collapse" id="govspeak-cta">
+    <pre>$CTA
+  [Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)
+  $CTA</pre>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-acronyms" aria-expanded="false">Abbreviations and acronyms</a></h3>
+  <div class="collapse" id="govspeak-acronyms">
+    <p>The first time you use an abbreviation or acroynm, write it out in full.</p>
+    <p>Add the <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms">acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+    <pre>Example content that includes a three-letter acronym (TLA).
+
+  *[TLA]: three-letter acronym</pre>
+    <p>When a user hovers their mouse over a <abbr title="three-letter acronym">TLA</abbr>, they will see it written in full.</p>
+
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-blockquotes" aria-expanded="false">Blockquotes</a></h3>
+  <div class="collapse" id="govspeak-blockquotes">
+    <pre>Introduction to the quote:
+
+  > First paragraph of the quote.
+  >
+  > Second paragraph of the quote.</pre>
+    <p>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
+  </div>
+
+  <h3><a data-toggle="collapse" href="#govspeak-addresses" aria-expanded="false">Addresses</a></h3>
+  <div class="collapse" id="govspeak-addresses">
+    <pre>$A
+  Address
+  Only
+  Here
+  $A</pre>
+
+    <p>You can also embed contact information:</p>
+    <pre>[Contact:<em>n</em>]</pre>
+    <p>(n is the ID of the contact you want to embed.)</p>
+    <p>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
+    <p>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
+  </div>
+
+
+  <h3><a data-toggle="collapse" href="#govspeak-email-links" aria-expanded="false">Email links</a></h3>
+  <div class="collapse" id="govspeak-email-links">
+    <p>Use ‘less than’ (<code>&lt;</code>) and ‘greater than’ (<code>&gt;</code>) arrows around email addresses to make them a link.</pre>
+  </div>
+
+  <% if show_footnote_help %>
+    <h3><a data-toggle="collapse" href="#govspeak-footnotes" aria-expanded="false">Footnotes</a></h3>
+    <div class="collapse" id="govspeak-footnotes">
+      <pre>Footnotes can be added[^1].
+
+  [^1]: And then later defined.</pre>
+      <p>
+        You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
+      </p>
+      <p>
+        Footnote content can hold more than one paragraph by indenting the content 4 spaces:
+      </p>
+
+      <pre>[^1]:
+      This is some footnote content and is indented 4 spaces.
+
+      This paragraph is also indented, so will be considered part of the footnote content.</pre>
+    </div>
+  <% end %>
+
+  <% if show_stat_headline_help %>
+    <h3><a data-toggle="collapse" href="#govspeak-stat-headline" aria-expanded="false">Statistic headlines</a></h3>
+    <div class="collapse" id="govspeak-stat-headline">
+      <p>
+        Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.
+      </p>
+      <pre>{stat-headline}
+  *13.8bn* years since the big bang
+  {/stat-headline}</pre>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/editions/_style_guidance.html.erb
+++ b/app/views/admin/editions/_style_guidance.html.erb
@@ -1,0 +1,53 @@
+<h2 class="govuk-heading-l">Style</h2>
+
+<p class="govuk-body">For styles, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>
+
+<p class="govuk-body">For details, see the <%= link_to "guideline on using plain English", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english", class: "govuk-link" %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: "List of words to avoid"
+} do %>
+  <ul class='gem-c-list govuk-list govuk-list--bullet'>
+    <li>agenda (unless it’s for a meeting)</li>
+    <li>advancing</li>
+    <li>collaborate (use ‘working with’)</li>
+    <li>combating</li>
+    <li>commit/pledge (we need to be more specific – we’re either doing something or we’re not)</li>
+    <li>countering</li>
+    <li>deliver (pizzas, post and services are delivered – not abstract concepts like ‘improvements’ or ‘priorities’)</li>
+    <li>deploy (unless it’s military or software)</li>
+    <li>dialogue (we speak to people)</li>
+    <li>disincentivise (and incentivise)</li>
+    <li>empower</li>
+    <li>facilitate (instead, say something specific about how you are helping)</li>
+    <li>focusing</li>
+    <li>foster (unless it’s children)</li>
+    <li>impact (as a verb)</li>
+    <li>initiate</li>
+    <li>key (unless it unlocks something. A subject/thing isn’t ‘key’ – it’s probably ‘important’)</li>
+    <li>land (as a verb. Only use if you are talking about aircraft)</li>
+    <li>leverage (unless in the financial sense)</li>
+    <li>liaise</li>
+    <li>overarching</li>
+    <li>progress (as a verb – what are you actually doing?)</li>
+    <li>promote (unless you are talking about an ad campaign or some other marketing promotion)</li>
+    <li>robust</li>
+    <li>slimming down (processes don’t diet – we are probably removing x amount of paperwork, etc)</li>
+    <li>streamline</li>
+    <li>strengthening (unless it’s strengthening bridges or other structures)</li>
+    <li>tackling (unless it’s rugby, football or some other sport)</li>
+    <li>transforming (what are you actually doing to change it?)</li>
+    <li>utilise</li>
+  </ul>
+
+  <p style="govuk-body">Always avoid metaphors. For example:</p>
+
+  <ul class='gem-c-list govuk-list govuk-list--bullet'>
+    <li>drive (you can only drive vehicles; not schemes or people)</li>
+    <li>drive out (unless it’s cattle)</li>
+    <li>going forward (unlikely we are giving travel directions)</li>
+    <li>in order to (superfluous – don’t use it)</li>
+    <li>one-stop shop (we are government, not a retail outlet)</li>
+    <li>ring fencing</li>
+  </ul>
+<% end %>

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -26,7 +26,7 @@ When(/^I upload an html attachment with the title "(.*?)" and the body "(.*?)"$/
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
   fill_in "Body", with: body
-  check "Manually numbered headings"
+  check @user.can_preview_design_system? ? "Use manually numbered headings" : "Manually numbered headings"
   click_on "Save"
 end
 


### PR DESCRIPTION
Some Whitehall pages require a section that helps users input the correct markdown to documents they are creating. An example is the page to add or edit an HTML attachment. This has been implemented using the [Accordion](https://components.publishing.service.gov.uk/component-guide/accordion) component. This results in a lengthy page.

The purpose of this PR is to demonstrate an alternative approach using the [Details](https://components.publishing.service.gov.uk/component-guide/details) component for each of the categories, and may be to begin to consider other alternatives as well. 

The screenshots below show a full page with both alternatives implemented and a detailed view of an expanded section. 

| **Full page, accordion component** | **Full page, details component** |
|---|---|
| ![HTML_accordion](https://user-images.githubusercontent.com/6080548/196937822-1160f447-aef9-41d3-ab72-a0772f11fae6.png) | ![HTML_details](https://user-images.githubusercontent.com/6080548/196937913-a9ee9319-f678-44fa-9225-d97ad35ab850.png) |
| **Detail, accordion component** | **Detail, details component** |
| ![Screenshot 2022-10-20 at 12 47 50](https://user-images.githubusercontent.com/6080548/196940521-b604517a-4c1c-4ea3-a52a-5baf5d4e3192.png) | ![Screenshot 2022-10-20 at 12 53 01](https://user-images.githubusercontent.com/6080548/196941682-0d54b878-c98d-46eb-87d5-9c3c5e6ff526.png) |
