### PR TITLE
Use Collections to render non-English World Location News

### DIFF
--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -29,7 +29,7 @@ module PublishingApi
         },
         document_type: "world_location_news",
         public_updated_at: world_location_news.updated_at,
-        rendering_app:,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "world_location_news",
         base_path: path_for_news_page,
       )
@@ -50,10 +50,6 @@ module PublishingApi
           href: link.url,
         }
       end
-    end
-
-    def rendering_app
-      I18n.locale == :en ? Whitehall::RenderingApp::COLLECTIONS_FRONTEND : Whitehall::RenderingApp::WHITEHALL_FRONTEND
     end
 
     def path_for_news_page

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -101,13 +101,4 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
       assert_equal "/world/aardistan/news.fr", base_path
     end
   end
-
-  test "it uses whitehall as the rendering app for non-english locales" do
-    I18n.with_locale(:fr) do
-      presented_item = present(@world_location_news)
-      rendering_app = presented_item.content[:rendering_app]
-
-      assert_equal "whitehall-frontend", rendering_app
-    end
-  end
 end


### PR DESCRIPTION
Despite moving the rendering of English language World Location News pages from Whitehall to Collections, we kept non-English pages rendered by Whitehall.

This was to allow FCDO time to approve our plans regarding switching off non-English finders, as the Collections rendered page does not contain a link to the finders, nor does it list recent documents from the finders.

Now it has been confirmed these finders will be switched off, we can render non-English World Location News pages in Collections.

After deploying this change, the following rake task will need to be run to republish the existing World Location News pages:
```
publishing_api:bulk_republish:document_type[WorldLocationNews]
```

[Trello card](https://trello.com/c/5AWg31CN)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
