### PR TITLE
Add show/hide functionality to 'Public explanation' field on unpublish page

### DIFF
--- a/app/assets/javascripts/admin/modules/unpublish-display-conditions.js
+++ b/app/assets/javascripts/admin/modules/unpublish-display-conditions.js
@@ -17,6 +17,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   UnpublishDisplayConditions.prototype.init = function () {
     this.initUnpublishTypeListener()
+    this.initUnpublishRedirectListener()
+  }
+
+  UnpublishDisplayConditions.prototype.initUnpublishRedirectListener = function () {
+    var checkbox = this.module.querySelector('.govuk-checkboxes__item input[name="unpublishing[redirect]"]')
+
+    checkbox.addEventListener('change', function (e) {
+      var display = e.currentTarget.checked ? 'none' : 'block'
+      this.module.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display = display
+    }.bind(this))
+
+    if (checkbox.checked) {
+      var event = new Event('change')
+      checkbox.dispatchEvent(event)
+    }
   }
 
   UnpublishDisplayConditions.prototype.initUnpublishTypeListener = function () {

--- a/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
+++ b/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
@@ -31,13 +31,24 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
         </div>
         <div class="unpublish-withdraw-form-wrapper js-unpublish-withdraw-form__published-in-error">
           this is the error section
+          <div class="gem-c-checkboxes govuk-form-group">
+            <div class="govuk-checkboxes__item">
+              <input type="checkbox" name="unpublishing[redirect]" id="checkboxes-cb24c6f1-0" value="1" class="govuk-checkboxes__input">
+              <label for="checkboxes-cb24c6f1-0" class="govuk-label govuk-checkboxes__label">Redirect to URL automatically?</label>
+            </div>
+          </div>
+          <div class="gem-c-textarea govuk-form-group govuk-!-margin-bottom-6">
+            <label for="published_in_error_explanation" class="gem-c-label govuk-label govuk-label--s">Public explanation</label>
+            <textarea name="unpublishing[explanation]" class="govuk-textarea" id="published_in_error_explanation" rows="5"></textarea>
+          </div>
         </div>
         <div class="unpublish-withdraw-form-wrapper js-unpublish-withdraw-form__consolidated">
           this is the consolidated section
         </div>
       </div>
     `
-
+    var checkbox = body.querySelector('.govuk-checkboxes__item input[name="unpublishing[redirect]"]')
+    checkbox.checked = true
     var unpublishDisplayConditions = new GOVUK.Modules.UnpublishDisplayConditions(body)
     unpublishDisplayConditions.init()
   })
@@ -94,5 +105,22 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
     expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).toEqual('block')
     expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
+  })
+
+  it('should hide public explanation section when "Redirect to URL automatically?" is pre-checked', function () {
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('none')
+  })
+
+  it('should show/hide public explanation section when "Redirect to URL automatically?" is unchecked/checked', function () {
+    var checkbox = body.querySelector('.govuk-checkboxes__item input[name="unpublishing[redirect]"]')
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('change'))
+
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('block')
+
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change'))
+
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('none')
   })
 })


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/0ukVIxC4/790-add-show-hide-js-functionality-to-unpublish-page)

## What
Hides the **Public explanation** field when the **Redirect to URL automatically?** checkbox is checked.

## Why
To replicate existing behaviour from the Bootstrap design.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
