### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     fuzzy_match (2.1.0)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -2,12 +2,12 @@ require "gds_api/search"
 
 Whitehall::Application.config.to_prepare do
   Whitehall.government_search_client = GdsApi::Search.new(
-    Plek.find("search") + Whitehall::SearchIndex.government_search_index_path,
+    Plek.find("search-api") + Whitehall::SearchIndex.government_search_index_path,
     bearer_token: ENV["RUMMAGER_BEARER_TOKEN"] || "example",
   )
 
   Whitehall.search_client = GdsApi::Search.new(
-    Plek.find("search"),
+    Plek.find("search-api"),
     bearer_token: ENV["RUMMAGER_BEARER_TOKEN"] || "example",
   )
 end

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -46,7 +46,7 @@ module Whitehall
     end
 
     def self.rummager_host
-      Plek.find("search")
+      Plek.find("search-api")
     end
   end
 

--- a/test/unit/whitehall/not_quite_as_fake_search_test.rb
+++ b/test/unit/whitehall/not_quite_as_fake_search_test.rb
@@ -7,7 +7,7 @@ module Whitehall
       setup do
         @store = Store.new
         SearchIndex.indexer_class.store = @store
-        @index = SearchIndex.indexer_class.new("http://search.test", "government")
+        @index = SearchIndex.indexer_class.new("http://search-api.test", "government")
       end
 
       teardown do

--- a/test/unit/whitehall/rummageable_test.rb
+++ b/test/unit/whitehall/rummageable_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RummageableTest < ActiveSupport::TestCase
   def rummager_url
-    "http://search.test.gov.uk"
+    "http://search-api.test.gov.uk"
   end
 
   def index_name


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.

Depends on alphagov/publishing-e2e-tests#512.