### PR TITLE
Fix flakey scheduled publishing test

### DIFF
--- a/test/support/sidekiq_test_helpers.rb
+++ b/test/support/sidekiq_test_helpers.rb
@@ -2,10 +2,10 @@ require "govuk_sidekiq/testing"
 require "sidekiq/api"
 
 module SidekiqTestHelpers
-  def with_real_sidekiq
+  def with_real_sidekiq(worker_name = "whitehall-test")
     Sidekiq::Testing.disable! do
       Sidekiq.configure_client do |config|
-        config.redis = { namespace: "whitehall-test" }
+        config.redis = { namespace: worker_name }
       end
 
       Sidekiq::ScheduledSet.new.clear


### PR DESCRIPTION
When running tests in parallel the scheduled publishing worker test has a tendency to randomly fail. This seems to be because old editions are not properly discarded or are running at the same time which causes the test to fail.

To fix this we have have added a method to pass in a different worker name to the test sidekiq, this means that the editions should no longer overlap since they are in different queues.

Trello card: https://trello.com/c/DhRIp7Nu/830-flaky-scheduled-publishing-worker-tests-in-whitehall

Co-authored-by: BeckaL <becka.lelew@digital.cabinet-office.gov.uk >

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
