### PR TITLE
Add temporary rake task to unpublish non-English finders

### DIFF
--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -8,4 +8,61 @@ namespace :finders do
       PublishFinder.call(content_item)
     end
   end
+
+  desc "Temporary task to unpublish non-English finders - this can be removed after running in production"
+  task temp_unpublish_non_english_finders: :environment do
+    announcements_finder_content_id = "88936763-df8a-441f-8b96-9ea0dc0758a1"
+    publications_finder_content_id = "b13317e9-3753-47b2-95da-c173071e621d"
+
+    locales = Locale.non_english.map(&:code)
+
+    locales.each do |locale|
+      puts "Publishing content item for /government/announcements.#{locale}"
+      publish_finder_for_locale(announcements_finder_content_id, "/government/announcements.#{locale}", locale)
+
+      puts "Unpublishing /government/announcements.#{locale}"
+      Whitehall::PublishingApi.publish_gone_async(announcements_finder_content_id, "/search/news-and-communications", nil, locale.to_s)
+
+      puts "Publishing content item for /government/publications.#{locale}"
+      publish_finder_for_locale(publications_finder_content_id, "/government/publications.#{locale}", locale)
+
+      puts "Unpublishing /government/publications.#{locale}"
+      Whitehall::PublishingApi.publish_gone_async(publications_finder_content_id, "/search/all", nil, locale.to_s)
+    end
+  end
+end
+
+def publish_finder_for_locale(content_id, base_path, locale)
+  finder_content_item = {
+    base_path:,
+    document_type: "finder",
+    locale: locale.to_s,
+    publishing_app: "whitehall",
+    rendering_app: "whitehall-frontend",
+    schema_name: "placeholder",
+    title: "Placeholder",
+    details: {},
+    update_type: "major",
+    routes: [
+      {
+        type: "exact",
+        path: base_path,
+      },
+      {
+        type: "exact",
+        path: "#{base_path}.atom",
+      },
+      {
+        type: "exact",
+        path: "#{base_path}.json",
+      },
+    ],
+  }
+
+  Services.publishing_api.put_content(
+    content_id,
+    finder_content_item,
+  )
+
+  Services.publishing_api.publish(content_id, nil, locale:)
 end

--- a/test/unit/tasks/publish_finders_test.rb
+++ b/test/unit/tasks/publish_finders_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+require "rake"
+
+class PublishFindersRakeTest < ActiveSupport::TestCase
+  setup do
+    Rake::Task["finders:temp_unpublish_non_english_finders"].reenable
+  end
+
+  test "it publishes then marks as gone each non-English finder" do
+    Locale.stubs(:non_english).returns([
+      Locale.new(:cy),
+      Locale.new(:fr),
+    ])
+
+    Services.publishing_api.expects(:put_content).with("88936763-df8a-441f-8b96-9ea0dc0758a1", has_entries(
+                                                                                                 base_path: "/government/announcements.cy",
+                                                                                                 locale: "cy",
+                                                                                               ))
+    Services.publishing_api.expects(:publish).with("88936763-df8a-441f-8b96-9ea0dc0758a1", nil, locale: :cy)
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("88936763-df8a-441f-8b96-9ea0dc0758a1", "/search/news-and-communications", nil, "cy")
+
+    Services.publishing_api.expects(:put_content).with("88936763-df8a-441f-8b96-9ea0dc0758a1", has_entries(
+                                                                                                 base_path: "/government/announcements.fr",
+                                                                                                 locale: "fr",
+                                                                                               ))
+    Services.publishing_api.expects(:publish).with("88936763-df8a-441f-8b96-9ea0dc0758a1", nil, locale: :fr)
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("88936763-df8a-441f-8b96-9ea0dc0758a1", "/search/news-and-communications", nil, "fr")
+
+    Services.publishing_api.expects(:put_content).with("b13317e9-3753-47b2-95da-c173071e621d", has_entries(
+                                                                                                 base_path: "/government/publications.cy",
+                                                                                                 locale: "cy",
+                                                                                               ))
+    Services.publishing_api.expects(:publish).with("b13317e9-3753-47b2-95da-c173071e621d", nil, locale: :cy)
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("b13317e9-3753-47b2-95da-c173071e621d", "/search/all", nil, "cy")
+
+    Services.publishing_api.expects(:put_content).with("b13317e9-3753-47b2-95da-c173071e621d", has_entries(
+                                                                                                 base_path: "/government/publications.fr",
+                                                                                                 locale: "fr",
+                                                                                               ))
+    Services.publishing_api.expects(:publish).with("b13317e9-3753-47b2-95da-c173071e621d", nil, locale: :fr)
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("b13317e9-3753-47b2-95da-c173071e621d", "/search/all", nil, "fr")
+
+    Rake.application.invoke_task "finders:temp_unpublish_non_english_finders"
+  end
+
+  test "it does not unpublish the English finder" do
+    Services.publishing_api.expects(:put_content).with("88936763-df8a-441f-8b96-9ea0dc0758a1", has_entries(
+                                                                                                 base_path: "/government/announcements",
+                                                                                                 locale: "en",
+                                                                                               )).never
+    Services.publishing_api.expects(:publish).with("88936763-df8a-441f-8b96-9ea0dc0758a1", nil, locale: :en).never
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("88936763-df8a-441f-8b96-9ea0dc0758a1", "/search/news-and-communications", nil, "en").never
+
+    Services.publishing_api.expects(:put_content).with("b13317e9-3753-47b2-95da-c173071e621d", has_entries(
+                                                                                                 base_path: "/government/publications",
+                                                                                                 locale: "en",
+                                                                                               )).never
+    Services.publishing_api.expects(:publish).with("b13317e9-3753-47b2-95da-c173071e621d", nil, locale: :en).never
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("b13317e9-3753-47b2-95da-c173071e621d", "/search/all", nil, "en").never
+
+    Services.publishing_api.expects(:put_content).at_least_once
+    Services.publishing_api.expects(:publish).at_least_once
+    Whitehall::PublishingApi.expects(:publish_gone_async).at_least_once
+
+    Rake.application.invoke_task "finders:temp_unpublish_non_english_finders"
+  end
+end


### PR DESCRIPTION
This rake task will need to be run in production (then deleted) and serves the purpose of marking the non-English finders (and their equivalent atom and JSON feeds) as 'gone' (410 response code).

These finders don't actually have content items at the moment (the content item redirects to `/government` so we automatically fall back to Whitehall), so we first need to publish a content item for each translation before marking it as 'gone'.

FCDO have agreed these finders can be switched off, so this PR stops us from serving the finders at those routes by marking them as "gone" (which has the effect of changing the rendering application to `government-frontend`).

Syntax for running the task:
```
rake finders:temp_unpublish_non_english_finders
```

Once run in production, the rake task can be removed.

| Screenshot of a French language finder that has been marked as 'gone' |
| -- |
| ![Screenshot showing page marked as gone.  The text (in French) says La page que vous recherchez n'est plus disponible. Les informations présentées sur cette page ont été supprimées car elles ont été publiées par erreur.](https://user-images.githubusercontent.com/6329861/197546009-12bba9fd-1853-4463-b7e5-eb2619d4016f.png) |

This task is to be run before https://github.com/alphagov/whitehall/pull/6950 is merged.

[Trello card](https://trello.com/c/ul5lL6y3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
