### PR TITLE
Standardise feature tests for Design System pages

### DIFF
--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -59,7 +59,7 @@ When(/^I set the order of attachments to:$/) do |attachment_order|
     attachment = Attachment.find_by(title: attachment_info[:title])
     fill_in "ordering[#{attachment.id}]", with: attachment_info[:order]
   end
-  click_on @user.can_preview_design_system? ? "Update order" : "Save attachment order"
+  click_on using_design_system? ? "Update order" : "Save attachment order"
 end
 
 Then(/^the attachments should be in the following order:$/) do |attachment_list|

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -44,7 +44,7 @@ When(/^I translate the "([^"]*)" corporate information page for the worldwide or
   click_link corp_page
   click_link "Add translation"
 
-  if @user.can_preview_design_system?
+  if using_design_system?
     select "Français", from: "Choose language"
     click_button "Next"
     fill_in "Translated summary", with: "Le summary"

--- a/features/step_definitions/destroy_draft_steps.rb
+++ b/features/step_definitions/destroy_draft_steps.rb
@@ -1,7 +1,7 @@
 When("I discard the draft publication") do
   @publication = Publication.last
   visit confirm_destroy_admin_edition_path(@publication)
-  if @user.can_preview_design_system?
+  if using_design_system?
     click_on "Delete"
   else
     click_on "Discard"

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -17,7 +17,7 @@ When(/^I add a french translation$/) do
   visit admin_edition_path(@edition)
   click_link "Add translation"
 
-  if @user.can_preview_design_system?
+  if using_design_system?
     select "Français", from: "Choose language"
     click_button "Next"
   else

--- a/features/step_definitions/needs_steps.rb
+++ b/features/step_definitions/needs_steps.rb
@@ -5,7 +5,7 @@ end
 When(/^I choose the first need in the dropdown$/) do
   option = first("#need_ids option").text
   select option, from: "need_ids"
-  click_button @user.can_preview_design_system? ? "Save" : "Save needs"
+  click_button using_design_system? ? "Save" : "Save needs"
 end
 
 Then(/^I should see the first need in the list of associated needs$/) do

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -32,23 +32,20 @@ When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |fre
   visit admin_edition_path(Edition.find_by!(title: english_title))
   click_link "Add translation"
 
-  if @user.can_preview_design_system?
+  if using_design_system?
     select "Français", from: "Choose language"
     click_button "Next"
-  else
-    select "Français", from: "Locale"
-    click_button "Add translation"
-  end
-
-  if @user.can_preview_design_system?
     fill_in "Translated title (required)", with: french_title
     fill_in "Translated summary (required)", with: "French summary"
     fill_in "Translated body (required)", with: "French body"
   else
+    select "Français", from: "Locale"
+    click_button "Add translation"
     fill_in "Title", with: french_title
     fill_in "Summary", with: "French summary"
     fill_in "Body", with: "French body"
   end
+
   click_button "Save"
 end
 

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -11,28 +11,36 @@ Given(/^there is a published document that is a duplicate of another page$/) do
 end
 
 When(/^I unpublish the duplicate, marking it as consolidated into the other page$/) do
-  design_system_layout = @user.can_preview_design_system?
-
   visit admin_edition_path(@duplicate_edition)
   click_on "Withdraw or unpublish"
   choose "Unpublish: consolidated into another GOV.UK page"
 
-  within(design_system_layout ? ".js-unpublish-withdraw-form__consolidated" : "#js-consolidated-form") do
+  form_container = if using_design_system?
+                     ".js-unpublish-withdraw-form__consolidated"
+                   else
+                     "#js-consolidated-form"
+                   end
+
+  within form_container do
     fill_in "consolidated_alternative_url", with: Whitehall.url_maker.publication_url(@existing_edition.document)
     click_button "Unpublish"
   end
 end
 
 def withdraw_publication(explanation)
-  design_system_layout = @user.can_preview_design_system?
-
   @publication = Publication.last
   visit admin_edition_path(@publication)
   click_on "Withdraw or unpublish"
   choose "Withdraw: no longer current government policy/activity"
 
-  within(design_system_layout ? ".js-unpublish-withdraw-form__withdrawal" : "#js-withdraw-form") do
-    fill_in (design_system_layout ? "Public explanation" : "Public explanation (this is shown on the live site) *"), with: explanation
+  form_container = if using_design_system?
+                     ".js-unpublish-withdraw-form__withdrawal"
+                   else
+                     "#js-withdraw-form"
+                   end
+
+  within form_container do
+    fill_in "Public explanation", with: explanation
     click_button "Withdraw"
   end
 

--- a/features/support/attachment_helper.rb
+++ b/features/support/attachment_helper.rb
@@ -24,12 +24,10 @@ module AttachmentHelper
   end
 
   def create_external_attachment(url, attachment_title)
-    design_system = @user.has_permission? "Preview design system"
-
     click_on "Add new external attachment"
     fill_in "Title", with: attachment_title
     fill_in "External url", with: url
-    click_on design_system ? "Next" : "Save"
+    click_on using_design_system? ? "Next" : "Save"
     Attachment.find_by(title: attachment_title)
   end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -115,7 +115,7 @@ module DocumentHelper
   end
 
   def fill_in_publication_fields(first_published: "2010-01-01", publication_type: "Research and analysis")
-    if @user.can_preview_design_system?
+    if using_design_system?
       within "#edition_first_published_at" do
         choose "This document has previously been published on another website."
         fill_in_datetime_field(first_published)

--- a/features/support/unpublishing_helpers.rb
+++ b/features/support/unpublishing_helpers.rb
@@ -1,12 +1,17 @@
 module UnpublishingHelpers
   def unpublish_edition(edition)
-    design_system_layout = @user.can_preview_design_system?
-
     visit admin_edition_path(edition)
     click_on "Withdraw or unpublish"
     choose "Unpublish: published in error"
-    within(design_system_layout ? ".js-unpublish-withdraw-form__published-in-error" : "#js-published-in-error-form") do
-      fill_in (design_system_layout ? "Public explanation" : "Public explanation (this is shown on the live site)"), with: "This page should never have existed"
+
+    form_container = if using_design_system?
+                       ".js-unpublish-withdraw-form__published-in-error"
+                     else
+                       "#js-published-in-error-form"
+                     end
+
+    within form_container do
+      fill_in "Public explanation", with: "This page should never have existed"
       yield if block_given?
       click_button "Unpublish"
     end

--- a/features/support/whitehall.rb
+++ b/features/support/whitehall.rb
@@ -1,3 +1,14 @@
 Before do
   AttachmentUploader.enable_processing = true
 end
+
+module WhitehallHelper
+  def using_design_system?
+    find("html", class: "govuk-template", wait: false)
+    true
+  rescue Capybara::ElementNotFound
+    false
+  end
+end
+
+World(WhitehallHelper)


### PR DESCRIPTION
There are various step definitions that need to perform different actions depending on whether they're on a Design System page or a Bootstrap (legacy) page in the Whitehall admin. For example, the steps involved in publishing a new document differ slightly between the two design systems.

A couple of different approaches were used to detect which type of page we're on. These included:

- `@user.can_preview_design_system?`
- `@user.has_permission? "Preview design system"`

However, these depend on the `@user` object (i.e. the currently logged in user) and make the assumption that users with the "Preview design system" permission will be shown a Design System page, and those without will be shown the legacy Bootstrap interface. But ideally feature tests would use the application as if they were a real-life human user, without being able to 'see behind the scenes' and inspect objects directly.

To rationalise these approaches and remove their coupling to the `@user` object, I've introduced a new helper method called `using_design_system?`. This helper inspects the web page itself to work out if we're on a Design System or Bootstrap page.

It'll return `true` if the HTML page contains:
```
<html class="govuk-template">
```

This is the class name required to add Design System styling to the page.

Otherwise it'll return `false`, meaning the page isn't using the Design System layout.

---

Trello: https://trello.com/c/UuusFa1C

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
