### PR TITLE
Retains tracking data on submit button from bootstrap

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -73,17 +73,26 @@
   <% end %>
 
   <%= hidden_field_tag :type, params[:type] %>
-  
+
   <div class="govuk-button-group">
     <% if attachment.is_a?(ExternalAttachment) %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Next"
+        text: "Next",
+        data_attributes: {
+          module: "track-button-click",
+          "track-category": "form-button",
+          "track-action": "#{attachment.readable_type}-attachment-button"
+        }
       } %>
     <% else %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Save"
+        text: "Save",
+        data_attributes: {
+          module: "track-button-click",
+          "track-category": "form-button",
+          "track-action": "#{attachment.readable_type}-attachment-button"
+        }
       } %>
     <% end %>
-    <a class="govuk-link" href="attachable_attachments_path(attachable)">Cancel</a>
   </div>
 <% end %>


### PR DESCRIPTION
Trello card: [External attachment - tracking needed](https://trello.com/c/X4Wj4I0U/822-external-attachment-tracking-needed)

The intention of this change is to restore the tracking that was lost in the transition from bootstrap to design system. To replicate that the button is wrapped in a div that contains the various `data` attributes that seem to be required. 