### PR TITLE
Add ability to show or hide banner from `whats_new.yml` file

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -15,11 +15,13 @@
 
 <% content_for :navbar do %>
   <%= render "shared/header", show_legacy_notices: true %>
-  <div class="govuk-design-system-styling">
-    <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
-      <%= render "shared/whats_new_banner", tracking_module: "track-link-click" %>
+  <% if t('admin.whats_new.show_banner') %>
+    <div class="govuk-design-system-styling">
+      <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
+        <%= render "shared/whats_new_banner", tracking_module: "track-link-click" %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -14,7 +14,9 @@
   </div>
 
   <div class="govuk-width-container">
-    <%= render "shared/whats_new_banner" %>
+    <% if t('admin.whats_new.show_banner') %>
+      <%= render "shared/whats_new_banner" %>
+    <% end %>
 
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,6 +1,7 @@
 en:
   admin:
     whats_new:
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.

--- a/test/integration/whats_new_test.rb
+++ b/test/integration/whats_new_test.rb
@@ -20,12 +20,14 @@ class WhatsNewTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "shows whats new banner page" do
+  test "uses the show_banner value in the whats_new.yml file to determine whether to render the banner" do
     login_as create(:gds_editor)
     get admin_whats_new_path
 
-    assert_select ".gem-c-phase-banner"
-    assert_select ".gem-c-phase-banner .govuk-phase-banner__content__tag"
-    assert_select ".gem-c-phase-banner .govuk-phase-banner__text"
+    if I18n.t("admin.whats_new.show_banner")
+      assert_select ".gem-c-phase-banner"
+    else
+      assert_select ".gem-c-phase-banner", count: 0
+    end
   end
 end


### PR DESCRIPTION
## Description 

We've discovered a need to toggle showing or hiding the whats new banner between releases.

The simplest implementation of this is to just add a value to the YAML file that a Content Designer can set to true or false depending on whether they want it to render or not.

If required further down the line we can add additional automated functionality around length of display etc. but for now i think we should keep it simple.

## Trello card

https://trello.com/c/pN983JVZ/834-temporarily-remove-whats-new-phase-banner

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
