### PR TITLE
Normalize locale files

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -14,7 +14,7 @@ en:
           [Read more about the changes on the content community Basecamp](https://3.basecamp.com/4322319/buckets/15005645/messages/5287245970).
       upcoming_changes:
         heading: Upcoming changes
-      recent_changes:     
+      recent_changes:
         heading: Recent changes
         updates:
           - heading: Change to saving documents
@@ -29,10 +29,10 @@ en:
             date: 6 October 2022
             body_govspeak: |
               The topic taxonomy tags page has moved to the GOV.UK Design System.
-              
+
               Topics that are tagged to a document are now listed under the ‘Selected topics’ header on the ‘Topic taxonomy tags’ page. You can also remove tags in this section.
-              
-              You can use the ‘back’ button on these pages to return to a previous page. 
+
+              You can use the ‘back’ button on these pages to return to a previous page.
           - heading: Reusing previous withdrawal dates and public explanations
             area: Creating and updating documents
             type: improvement


### PR DESCRIPTION
Ongoing work to remove finders involves updating locale files in bulk, which requires us to run `rake translations:normalize`.

As the locale files are not currently normalized, this will result in this diff being added each time we run this.

Updating them now before we start manipulating the files in bulk.

[Trello card](https://trello.com/c/ul5lL6y3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
