### PR TITLE
Add margin to navbar for admin template when Whats new banner is absent

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% content_for :navbar do %>
-  <%= render "shared/header", show_legacy_notices: true %>
+  <%= render "shared/header", admin_template: true %>
   <% if t('admin.whats_new.show_banner') %>
     <div class="govuk-design-system-styling">
       <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <% environment_style = GovukAdminTemplate.environment_style %>
 <% environment_label = GovukAdminTemplate.environment_label %>
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
-<% show_legacy_notices ||= false %>
+<% admin_template ||= false %>
 
 <header class="
   masthead
@@ -9,6 +9,7 @@
   navbar-default
   navbar-inverse
   navbar-static-top
+  <% if !t('admin.whats_new.show_banner') && admin_template %>add-bottom-margin<% end %>
   <% if environment_style %>environment-indicator<% end %>" role="banner">
   <div class="navbar-container container-fluid">
     <div class="navbar-header">
@@ -79,7 +80,7 @@
       </li>
     </ul>
   </div>
-  <% if show_legacy_notices %>
+  <% if admin_template %>
     <section class="notices">
       <%= render partial: "shared/notices" %>
     </section>


### PR DESCRIPTION
## Description

The design system and admin layout use a shared header. When it was merged into a shared file and the 'Whats new' banner was added, the top-margin was removed as the banner provides margin.

Now when the banner is removed between releases, we no longer have that margin.

This adds margin to admin views, when the banner is not present.

## Screenshots 

### Before

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/42515961/198016567-6b8ec09a-ac40-4c9e-a7a9-9afac28c86c8.png">

### After 

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/42515961/198016444-3ccced66-5949-42b9-ae8d-0a985d573a9d.png">

## Trello card

https://trello.com/c/pN983JVZ/834-temporarily-remove-whats-new-phase-banner

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
