### PR TITLE
Use erb for cancel link on tags page

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -72,7 +72,7 @@
           }
         } %>
 
-        <a class="govuk-link" href="admin_edition_path(@edition)">Cancel</a>
+        <a class="govuk-link" href="<%= admin_edition_path(@edition) %>">Cancel</a>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Description 

At the moment this is just passing a string rather than constructing the path based off of the ruby object as it's not within tags.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
