### PR TITLE
Updates sidebar to use `Details` component

### DIFF
--- a/app/assets/stylesheets/admin/components/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin/components/_govspeak-help.scss
@@ -1,0 +1,12 @@
+.govspeak_help {
+  margin-bottom: govuk-spacing(6);
+}
+
+.govspeak_help__pre {
+  font-size: 13px;
+  padding: govuk-spacing(2);
+  background-color: govuk-colour("light-grey");
+  word-break: normal;
+  word-wrap: normal;
+  overflow: auto;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
 @import "./components/autocomplete";
 @import "./components/govspeak-editor";
 @import "./components/miller-columns";
-@import "./admin/views/govspeak-help";
+@import "./admin/components/govspeak-help";
 
 @import "./admin/modules/unpublish-display-conditions";
 

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -33,227 +33,166 @@
   <h2 class="govuk-heading-l">Formatting</h2>
 
   <p class="govuk-body">For details, read the <%=link_to("guide to using Markdown", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link") %>
-  <%= render "govuk_publishing_components/components/accordion", {
-    heading_level: 4,
-    items: [
-      {
-        heading: {
-          text: "Paste and convert to Markdown"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
-            <p class='govuk-body'>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
-            <p class='govuk-body'>It will convert:</p>
-            <ul class='gem-c-list govuk-list govuk-list--bullet'>
-              <li>headings</li>
-              <li>bullets</li>
-              <li>numbered lists</li>
-              <li>links</li>
-              <li>email links</li>
-            </ul>
-            <p class='govuk-body'>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Headings"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Links"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
-            <pre class='govspeak_help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
-            <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
-            <pre class='govspeak_help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
-            <p class='govuk-body'>For external websites, use the full URL including http://:</p>
-            <pre class='govspeak_help__pre'>[link text](http://www.example.com)</pre>
-            <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
-            <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
-            </p>
-            <pre class='govspeak_help__pre'>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
-            <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
-            <pre class='govspeak_help__pre'>[Sample link text](#eel-decline)</pre>
-            <p class='govuk-body'>or from another document:</p>
-            <pre class='govspeak_help__pre'>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Bullets"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>* item 1<br />* item 2<br />* item 3<br /></pre>"
-          )
-        },
-      },
-      {
-        heading: {
-          text: "Numbered lists"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>1. item 1<br />2. item 2<br />3. item 3<br /></pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Images"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>First upload your image(s), then:</p>
-            <pre class='govspeak_help__pre'>!!<em>n</em></pre>
-            <p class='govuk-body'>eg for the first image:</p>
-            <pre class='govspeak_help__pre'>!!1</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Video links"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
-            <pre class='govspeak_help__pre'>[title of video](youtube-video-url)</pre>
-            <p class='govuk-body'>Only YouTube videos will work at present:</p>
-            <pre class='govspeak_help__pre'>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
-            <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>"
-          )
-        }
-      },
-      *([{
-        heading: {
-          text: "Attachments"
-        },
-        content: {
-          html: (render "admin/editions/govspeak_attachments_help", show_attachments_tab_help: show_attachments_tab_help)
-        }
-      }] unless hide_inline_attachments_help),
-      {
-        heading: {
-          text: "Tables"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
-            <pre class='govspeak_help__pre'>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
-            <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
-            <pre class='govspeak_help__pre'>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
-            <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
-            <pre class='govspeak_help__pre'>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Charts"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
-            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
-            <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
-            <pre class='govspeak_help__pre'>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
-            <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
-            <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
-            <p class='govuk-body'>If you include negative values, you must indicate this.</p>
-            <pre class='govspeak_help__pre'>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
-            <p class='govuk-body'>All effects can be combined.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Call to action"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Abbreviations and acronyms"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
-            <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
-            <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
-            <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Blockquotes"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
-            <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>"
-          )
-        }
-      },
-      {
-        heading: {
-          text: "Addresses"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>$A<br />Address<br />Only<br />Here<br />$A</pre>
-            <p class='govuk-body'>You can also embed contact information:</p>
-            <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
-            <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
-            <p class='govuk-body'>You can find the ID on the list of contacts for an #{link_to 'organisation', admin_organisations_path} or #{link_to 'worldwide organisation', admin_worldwide_organisations_path} or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
-            <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>"
-          )
-        }
-      },
-      *([{
-        heading: {
-          text: "Footnotes"
-        },
-        content: {
-          html: sanitize(
-            "<pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
-            <p class='govuk-body'>
-              You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
-            </p>
-            <p class='govuk-body'>
-              Footnote content can hold more than one paragraph by indenting the content 4 spaces:
-            </p>
-            <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>"
-          )
-        }
-      }] if show_footnote_help),
-      *([{
-        heading: {
-          text: "Statistic headlines"
-        },
-        content: {
-          html: sanitize(
-            "<p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
-            <pre class='govspeak_help__pre'>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>"
-          )
-        }
-      }] if show_stat_headline_help),
-    ]
-  } %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Paste and convert to Markdown"
+  } do %>
+    <p class='govuk-body'>You can paste formatted text into the body field and Whitehall publisher will try to convert it into GOV.UK’s version of Markdown, Govspeak.</p>
+    <p class='govuk-body'>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+    <p class='govuk-body'>It will convert:</p>
+    <ul class='gem-c-list govuk-list govuk-list--bullet'>
+      <li>headings</li>
+      <li>bullets</li>
+      <li>numbered lists</li>
+      <li>links</li>
+      <li>email links</li>
+    </ul>
+    <p class='govuk-body'>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Headings"
+  } do %>
+    <pre class="govspeak_help__pre">## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Links"
+  } do %>
+    <p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
+    <pre class='govspeak_help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+    <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
+    <pre class='govspeak_help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+    <p class='govuk-body'>For external websites, use the full URL including http://:</p>
+    <pre class='govspeak_help__pre'>[link text](http://www.example.com)</pre>
+    <h4 class='govuk-heading-m'>Linking to paragraphs</h4>
+    <p class='govuk-body'>If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable by placing an anchor tag <strong>below</strong> the paragraph:
+    </p>
+    <pre class='govspeak_help__pre'>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.<br />{:#eel-decline}</pre>
+    <p class='govuk-body'>The paragraph can then be linked to from the same document:</p>
+    <pre class='govspeak_help__pre'>[Sample link text](#eel-decline)</pre>
+    <p class='govuk-body'>or from another document:</p>
+    <pre class='govspeak_help__pre'>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Bullets"
+  } do %>
+    <pre class='govspeak_help__pre'>* item 1<br />* item 2<br />* item 3<br /></pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Numbered lists"
+  } do %>
+    <pre class='govspeak_help__pre'>1. item 1<br />2. item 2<br />3. item 3<br /></pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Images"
+  } do %>
+    <p class='govuk-body'>First upload your image(s), then:</p>
+    <pre class='govspeak_help__pre'>!!<em>n</em></pre>
+    <p class='govuk-body'>eg for the first image:</p>
+    <pre class='govspeak_help__pre'>!!1</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Video links"
+  } do %>
+    <p class='govuk-body'>Use the title of the video and the URL of the YouTube page that shows the video for watching. Don’t use the embed code or the ‘Share this video’ URL:</p>
+    <pre class='govspeak_help__pre'>[title of video](youtube-video-url)</pre>
+    <p class='govuk-body'>Only YouTube videos will work at present:</p>
+    <pre class='govspeak_help__pre'>[The Queen’s Diamond Jubilee Concert](http://www.youtube.com/watch?v=OXHPWmnycno)</pre>
+    <p class='govuk-body'>The title text does not show. The video will display in an embedded media player automatically.</p>
+  <% end %>
+
+  <% unless hide_inline_attachments_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Attachments"
+    } do %>
+      <%= render "admin/editions/govspeak_attachments_help", show_attachments_tab_help: show_attachments_tab_help %>
+    <% end %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Tables"
+  } do %>
+    <p class='govuk-body'>Insert tables by splitting your content into cells using the pipe (|) character. </p>
+    <pre class='govspeak_help__pre'>|  name   |  colour |<br />|---------|---------|<br />| apple   | green   |<br />| banana  | yellow  |</pre>
+    <p class='govuk-body'>Add row titles by putting a hashtag (#) character directly next to the pipe (|) at the start of the row:</p>
+    <pre class='govspeak_help__pre'>|             | Fruit | Vegetables |<br />|-------------|-------|------------|<br />|# per gram   |   5p  |     8p     |<br />|# per kilo   |   7p  |     6p     |</pre>
+    <p class='govuk-body'>Right align a column by including a colon at the end of a separator, eg <code>|---:|</code>. In the example below the cost column will be right aligned.</p>
+    <pre class='govspeak_help__pre'>|  name   |  cost  |<br />|---------|-------:|<br />| apple   | 0.45   |<br />| banana  | 0.32   |<br />| guava   | 10.32  |</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Charts"
+  } do %>
+    <p class='govuk-body'>Numeric data can be shown as a simple bar chart. Grouped bars are used for multiple columns.</p>
+    <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />{barchart}</pre>
+    <p class='govuk-body'>Stacked bars can be created. The final column is used to display the total.</p>
+    <pre class='govspeak_help__pre'>Department | Short Speeches | Long Speeches | Total<br />-|-|-|-<br />Dept 1     | 6              | 6             | 12<br />Dept 2     | 6              | 8             | 14<br />Dept 3     | 18             | 2             | 20<br />{barchart stacked}</pre>
+    <p class='govuk-body'>Large graphs can be displayed compactly to save space.</p>
+    <pre class='govspeak_help__pre'>Department   | Short Speeches | Long Speeches<br />-|-|-<br />Department 1 | 6              | 6<br />Department 2 | 6              | 8<br />Department 3 | 18             | 2<br />Department 4 | 5              | 4<br />Department 4 | 7              | 7<br />Department 6 | 11             | 1<br />{barchart compact}</pre>
+    <p class='govuk-body'>If you include negative values, you must indicate this.</p>
+    <pre class='govspeak_help__pre'>Department   | Change in Number of Buildings<br />-|-<br />Department 1 | -12<br />Department 1 | 3<br />Department 1 | -4<br />Department 1 | 2<br />{barchart negative}</pre>
+    <p class='govuk-body'>All effects can be combined.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Call to action"
+  } do %>
+    <pre class='govspeak_help__pre'>$CTA<br />[Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)<br />$CTA</pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Abbreviations and acronyms"
+  } do %>
+    <p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
+    <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+    <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
+    <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Blockquotes"
+  } do %>
+    <pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
+    <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Addresses"
+  } do %>
+    <pre class='govspeak_help__pre'>$A<br />Address<br />Only<br />Here<br />$A</pre>
+    <p class='govuk-body'>You can also embed contact information:</p>
+    <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
+    <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
+    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
+    <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
+  <% end %>
+
+  <% if show_footnote_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Footnotes"
+    } do %>
+      <pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
+      <p class='govuk-body'>
+        You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
+      </p>
+      <p class='govuk-body'>
+        Footnote content can hold more than one paragraph by indenting the content 4 spaces:
+      </p>
+      <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>
+    <% end %>
+  <% end %>
+
+  <% if show_stat_headline_help %>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Statistic headlines"
+    } do %>
+      <p class='govuk-body'>Use statistic headlines to highlight important numbers in your content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud.</p>
+      <pre class='govspeak_help__pre'>{stat-headline}<br />*13.8bn* years since the big bang<br />{/stat-headline}</pre>
+    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
Some Whitehall pages require a section that helps users input the correct markdown to documents they are creating. An example is the page to add or edit an HTML attachment. This has been implemented using the [Accordion](https://components.publishing.service.gov.uk/component-guide/accordion) component which results in a lengthy page.

The changes in this PR use the [Details](https://components.publishing.service.gov.uk/component-guide/details) component for each of the categories instead so that the guidance is displayed in a more compact way, as displayed in the screenshots below.

| **Full page, accordion component** | **Full page, details component** |
|---|---|
| ![HTML_accordion](https://user-images.githubusercontent.com/6080548/196937822-1160f447-aef9-41d3-ab72-a0772f11fae6.png) | ![HTML_details](https://user-images.githubusercontent.com/6080548/196937913-a9ee9319-f678-44fa-9225-d97ad35ab850.png) |
| **Detail, accordion component** | **Detail, details component** |
| ![Screenshot 2022-10-20 at 12 47 50](https://user-images.githubusercontent.com/6080548/196940521-b604517a-4c1c-4ea3-a52a-5baf5d4e3192.png) | ![Screenshot 2022-10-20 at 12 53 01](https://user-images.githubusercontent.com/6080548/196941682-0d54b878-c98d-46eb-87d5-9c3c5e6ff526.png) |
