### PR TITLE
Adapt Design System feature flag so users can preview the next release

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -18,7 +18,7 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def new
-    render(preview_design_system_user? ? "new" : "new_legacy")
+    render_design_system("new", "new_legacy", next_release: true)
   end
 
   def create
@@ -26,12 +26,12 @@ class Admin::AttachmentsController < Admin::BaseController
       attachment_updater(attachment.attachment_data)
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
-      render(preview_design_system_user? ? "new" : "new_legacy")
+      render_design_system("new", "new_legacy", next_release: true)
     end
   end
 
   def edit
-    render(preview_design_system_user? ? "edit" : "edit_legacy")
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
@@ -44,7 +44,7 @@ class Admin::AttachmentsController < Admin::BaseController
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
-      render(preview_design_system_user? ? "edit" : "edit_legacy")
+      render_design_system("edit", "edit_legacy", next_release: true)
     end
   end
 
@@ -89,10 +89,8 @@ class Admin::AttachmentsController < Admin::BaseController
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "edit", "update", "new", "create", "confirm_destroy", "reorder"
+    design_system_actions = %w[edit update new create confirm_destroy reorder]
+    if preview_design_system?(next_release: true) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -56,6 +56,14 @@ class Admin::BaseController < ApplicationController
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 
+  def render_design_system(design_system_view, legacy_view, next_release: false)
+    if preview_design_system?(next_release:)
+      render design_system_view
+    else
+      render legacy_view
+    end
+  end
+
 private
 
   def forbidden!

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -52,8 +52,8 @@ class Admin::BaseController < ApplicationController
     end
   end
 
-  def preview_design_system_user?
-    current_user.can_preview_design_system?
+  def preview_design_system?(next_release: false)
+    current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 
 private

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -7,7 +7,7 @@ class Admin::BulkUploadsController < Admin::BaseController
 
   def new
     @zip_file = BulkUpload::ZipFile.new
-    render(preview_design_system_user? ? "new" : "new_legacy")
+    render_design_system("new", "new_legacy", next_release: true)
   end
 
   def upload_zip
@@ -16,9 +16,9 @@ class Admin::BulkUploadsController < Admin::BaseController
     if @zip_file.valid?
       @bulk_upload = BulkUpload.from_files(@edition, @zip_file.extracted_file_paths)
       @zip_file.cleanup_extracted_files
-      render(preview_design_system_user? ? "set_titles" : "set_titles_legacy")
+      render_design_system("set_titles", "set_titles_legacy", next_release: true)
     else
-      render(preview_design_system_user? ? "new" : "new_legacy")
+      render_design_system("new", "new_legacy", next_release: true)
     end
   end
 
@@ -31,14 +31,14 @@ class Admin::BulkUploadsController < Admin::BaseController
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)
     else
-      render(preview_design_system_user? ? "set_titles" : "set_titles_legacy")
+      render_design_system("set_titles", "set_titles_legacy", next_release: true)
     end
   end
 
 private
 
   def get_layout
-    preview_design_system_user? ? "design_system" : "admin"
+    preview_design_system?(next_release: true) ? "design_system" : "admin"
   end
 
   def find_edition

--- a/app/controllers/admin/document_sources_controller.rb
+++ b/app/controllers/admin/document_sources_controller.rb
@@ -5,7 +5,7 @@ class Admin::DocumentSourcesController < Admin::BaseController
   layout :get_layout
 
   def edit
-    render :edit_legacy unless preview_design_system_user?
+    render_design_system("edit", "edit_legacy", next_release: false)
   end
 
   def update
@@ -25,13 +25,6 @@ private
   end
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "edit"
-      "design_system"
-    else
-      "admin"
-    end
+    preview_design_system?(next_release: false) ? "design_system" : "admin"
   end
 end

--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -7,7 +7,7 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
 
   def edit
     @path = get_path
-    render(preview_design_system_user? ? "edit" : "edit_legacy")
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
@@ -21,7 +21,7 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
 private
 
   def get_layout
-    preview_design_system_user? ? "design_system" : "admin"
+    preview_design_system?(next_release: true) ? "design_system" : "admin"
   end
 
   def get_path

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -4,11 +4,11 @@ class Admin::EditionTranslationsController < Admin::BaseController
   before_action :forbid_editing_of_locked_documents
 
   def new
-    render "legacy_new" unless preview_design_system_user?
+    render_design_system("new", "legacy_new", next_release: false)
   end
 
   def edit
-    render "edit_legacy" unless preview_design_system_user?
+    render_design_system("edit", "edit_legacy", next_release: false)
   end
 
   def update
@@ -17,17 +17,15 @@ class Admin::EditionTranslationsController < Admin::BaseController
       save_draft_translation if send_downstream?
       redirect_to update_redirect_path, notice: notice_message("saved")
     else
-      render action: preview_design_system_user? ? "edit" : "edit_legacy"
+      render_design_system("edit", "edit_legacy", next_release: false)
     end
   end
 
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "edit", "update", "new"
+    design_system_actions = %w[edit update new]
+    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionUnpublishingController < Admin::BaseController
   before_action :enforce_permissions!
 
   def edit
-    render "edit_legacy" unless preview_design_system_user?
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
@@ -16,25 +16,16 @@ class Admin::EditionUnpublishingController < Admin::BaseController
         services.unpublisher(@unpublishing.edition).perform!
       end
       redirect_to admin_edition_path(@unpublishing.edition), notice: "The public explanation was updated"
-    elsif preview_design_system_user?
-      render "edit"
     else
-      flash.now[:alert] = "The public explanation could not be updated"
-      render "edit_legacy"
+      flash.now[:alert] = "The public explanation could not be updated" unless preview_design_system?(next_release: true)
+      render_design_system("edit", "edit_legacy", next_release: true)
     end
   end
 
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "edit", "update", "new"
-      "design_system"
-    else
-      "admin"
-    end
+    preview_design_system?(next_release: true) ? "design_system" : "admin"
   end
 
   def load_unpublishing

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -103,7 +103,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   def confirm_unpublish
     @unpublishing = @edition.build_unpublishing
 
-    render(preview_design_system_user? ? :confirm_unpublish : :confirm_unpublish_legacy)
+    render_design_system(:confirm_unpublish, :confirm_unpublish_legacy, next_release: true)
   end
 
   def unpublish
@@ -113,17 +113,13 @@ class Admin::EditionWorkflowController < Admin::BaseController
       redirect_to admin_edition_path(@edition), notice: message
     else
       @unpublishing = @edition.unpublishing || @edition.build_unpublishing(unpublishing_params)
-      if preview_design_system_user?
-        render :confirm_unpublish
-      else
-        flash.now[:alert] = message
-        render :confirm_unpublish_legacy
-      end
+      flash.now[:alert] = message unless preview_design_system?(next_release: true)
+      render_design_system("confirm_unpublish", "confirm_unpublish_legacy", next_release: true)
     end
   end
 
   def confirm_unwithdraw
-    render(preview_design_system_user? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy)
+    render_design_system(:confirm_unwithdraw, :confirm_unwithdraw_legacy, next_release: true)
   end
 
   def unwithdraw
@@ -133,7 +129,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
       redirect_to admin_edition_path(new_edition), notice: "This document has been unwithdrawn"
     else
       flash.now[:alert] = edition_unwithdrawer.failure_reason
-      render(preview_design_system_user? ? :confirm_unwithdraw : :confirm_unwithdraw_legacy)
+      render_design_system(:confirm_unwithdraw, :confirm_unwithdraw_legacy, next_release: true)
     end
   end
 
@@ -183,14 +179,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "confirm_unpublish"
-      "design_system"
-    when "confirm_unwithdraw"
-      "design_system"
-    when "unpublish"
+    design_system_actions = %w[confirm_unpublish confirm_unwithdraw unpublish]
+    if preview_design_system?(next_release: true) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -4,7 +4,7 @@ class Admin::NeedsController < Admin::BaseController
   layout :get_layout
 
   def edit
-    render(preview_design_system_user? ? "edit" : "edit_legacy")
+    render_design_system("edit", "edit_legacy", next_release: false)
   end
 
   def update
@@ -17,10 +17,7 @@ class Admin::NeedsController < Admin::BaseController
 private
 
   def get_layout
-    return "admin" unless preview_design_system_user?
-
-    case action_name
-    when "edit"
+    if preview_design_system?(next_release: false)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/speeches_controller.rb
+++ b/app/controllers/admin/speeches_controller.rb
@@ -8,9 +8,11 @@ private
   end
 
   def clear_role_appointment_param_on_override
-    if preview_design_system_user? && params[:speaker_radios] == "yes"
+    design_system = preview_design_system?(next_release: false)
+
+    if design_system && params[:speaker_radios] == "yes"
       edition_params[:person_override] = nil
-    elsif preview_design_system_user? && params[:speaker_radios] == "no"
+    elsif design_system && params[:speaker_radios] == "no"
       edition_params[:role_appointment_id] = nil
     elsif params[:person_override_active] == "1" || edition_params[:person_override].present?
       edition_params[:role_appointment_id] = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     EXPORT_DATA = "Export data".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
+    PREVIEW_NEXT_RELEASE = "Preview next release".freeze
   end
 
   def role
@@ -94,6 +95,10 @@ class User < ApplicationRecord
 
   def can_preview_design_system?
     has_permission?(Permissions::PREVIEW_DESIGN_SYSTEM)
+  end
+
+  def can_preview_next_release?
+    has_permission?(Permissions::PREVIEW_NEXT_RELEASE)
   end
 
   def organisation_name

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -139,14 +139,20 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_force_publish_anything?
   end
 
-  test "cannot preview the design system by default" do
+  test "cannot preview unreleased Design System changes by default" do
     user = build(:user)
     assert_not user.can_preview_design_system?
+    assert_not user.can_preview_next_release?
   end
 
-  test "can preview the design system if given permission" do
+  test "can preview unreleased Design System changes if given permission" do
     user = build(:user, permissions: [User::Permissions::PREVIEW_DESIGN_SYSTEM])
     assert user.can_preview_design_system?
+  end
+
+  test "can preview the upcoming Design System release if given permission" do
+    user = build(:user, permissions: [User::Permissions::PREVIEW_NEXT_RELEASE])
+    assert user.can_preview_next_release?
   end
 
   test "can handle fatalities if our organisation is set to handle them" do


### PR DESCRIPTION
## Background

As part of our work to transition Whitehall to the GOV.UK Design System, we have a need for Design System changes to be previewed behind a 'feature flag' prior to releasing them to end users.

We need Design System feature flags for a couple of purposes:

1. **Preview all unreleased Design System changes**
   This is useful for developers and those testing Design System changes that are still being worked on.

2. **Preview the next release**
   Useful when reviewing an upcoming release as it'll appear to users, without other changes that are still being worked on.

We already have an established pattern for previewing unreleased changes (i.e. point 1 above). This Pull Request attempts to rationalise that pattern and extend it to support the second need: specifically previewing only those changes lined up for the next release.

## Overview of changes

- Rename `preview_design_system_user?` to `preview_design_system?`
- Add keyword parameter `next_release` so we can differentiate between things that are lined up for the next release vs. things that are still being worked on.
- Add helper method `render_design_system` to DRY up conditional code that decides which view to render

It may be helpful to review each commit independently, as that'll allow you to see what I've introduced and why, followed by using the methods in existing code.

## Other benefits

This will make it easier to deploy a release for general use before performing clean-up to remove "preview" feature flags.

For example, we could change:

```diff
def preview_design_system?(next_release: false)
-  current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
+  current_user.can_preview_design_system? || next_release
end
```

To immediately release changes to users. And then in a follow-up PR, we can remove the use of feature flags altogether – e.g. as was done for Release 1.2 in #6893.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
