### PR TITLE
Fix newly added cancel links

### DIFF
--- a/app/views/admin/attachments/confirm_destroy.html.erb
+++ b/app/views/admin/attachments/confirm_destroy.html.erb
@@ -14,7 +14,7 @@
         destructive: true,
       } %>
 
-      <a class="govuk-link" href="attachable_attachments_path(attachable)">Cancel</a>
+      <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
     </div>
     <% end %>
   </section>

--- a/app/views/admin/attachments/reorder.html.erb
+++ b/app/views/admin/attachments/reorder.html.erb
@@ -21,7 +21,7 @@
           text: "Update order",
         } %>
 
-        <a class="govuk-link" href="attachable_attachments_path(attachable)">Cancel</a>
+        <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -72,7 +72,7 @@
           }
         } %>
 
-        <a class="govuk-link" href="<%= admin_edition_path(@edition) %>">Cancel</a>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link") %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

The cancel links added in https://github.com/alphagov/whitehall/pull/6941 do not work.
This PR uses the link_to function to generate the anchor tags.