### PR TITLE
Add new Govspeak Preview component to 1.3 features (HTML attachments, edit edition withdrawal messages)

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -33,6 +33,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var textarea = this.module.querySelector(previewToggle.getAttribute('data-content-target'))
 
     previewToggle.addEventListener('click', function (e) {
+      e.preventDefault()
+
       var previewMode = previewToggle.innerText === 'Preview'
 
       previewToggle.innerText = previewMode ? 'Back to edit' : 'Preview'

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -1,3 +1,7 @@
+.app-c-govspeak-editor {
+  margin-bottom: govuk-spacing(6);
+}
+
 .app-c-govspeak-editor__preview-button-wrapper {
   text-align: right;
 }

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -48,7 +48,7 @@
         },
         name: "attachment[govspeak_content_attributes][body]",
         rows: 20,
-        id: "attachment_govspeak_content.body",
+        id: "attachment_govspeak_content_body",
         value: form.object.govspeak_content.body,
         error_items: errors_for(attachment.errors, :"govspeak_content.body"),
       } %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -41,7 +41,7 @@
         } %>
       </div>
 
-      <%= render "govuk_publishing_components/components/textarea", {
+      <%= render "components/govspeak-editor", {
         label: {
           heading_size: "l",
           text: "Body (required)"
@@ -51,7 +51,6 @@
         id: "attachment_govspeak_content.body",
         value: form.object.govspeak_content.body,
         error_items: errors_for(attachment.errors, :"govspeak_content.body"),
-        margin_bottom: 8
       } %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -30,20 +30,17 @@
     error_items: errors_for(form.object.errors, :summary),
   } %>
 
-  <div class="previewable">
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: "Body (required)",
-         bold: true
-      },
-      name: "edition[body]",
-      id: "edition_body",
-      value: edition.body,
-      rows: 20,
-      data: { module: "paste-html-to-govspeak" },
-      error_items: errors_for(form.object.errors, :body),
-    } %>
-  </div>
+  <%= render "components/govspeak-editor", {
+    label: {
+      text: "Body (required)",
+        bold: true
+    },
+    name: "edition[body]",
+    id: "edition_body",
+    value: edition.body,
+    rows: 20,
+    error_items: errors_for(form.object.errors, :body),
+  } %>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 </div>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -27,7 +27,7 @@
     },
   }
 
-  withdrawal_public_explanation_field = render("govuk_publishing_components/components/textarea", {
+  withdrawal_public_explanation_field = render("components/govspeak-editor", {
     label: {
       text: "Public explanation",
       bold: true,
@@ -36,9 +36,6 @@
     name: "unpublishing[explanation]",
     id: "withdrawal_explanation",
     value: @unpublishing.explanation,
-    data: {
-      module: "paste-html-to-govspeak"
-    },
     error_items: errors_for(@unpublishing.errors, :explanation)
   })
 %>
@@ -148,7 +145,7 @@
           ]
         } %>
 
-        <%= render "govuk_publishing_components/components/textarea", {
+        <%= render "components/govspeak-editor", {
           label: {
             text: "Public explanation",
             bold: true,
@@ -157,9 +154,6 @@
           name: "unpublishing[explanation]",
           id: "published_in_error_explanation",
           value: @unpublishing.explanation,
-          data: {
-            module: "paste-html-to-govspeak"
-          },
           error_items: errors_for(@unpublishing.errors, :explanation)
         } %>
 

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -32,20 +32,17 @@
     error_items: errors_for(edition.errors, :summary),
   } %>
 
-  <div class="previewable">
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: "Body" + "#{' (required)' if form.object.body_required?}",
-         bold: true
-      },
-      name: "edition[body]",
-      id: "edition_body",
-      value: edition.body,
-      rows: 20,
-      data: { module: "paste-html-to-govspeak" },
-      error_items: errors_for(edition.errors, :body),
-    } %>
-  </div>
+  <%= render "components/govspeak-editor", {
+    label: {
+      text: "Body" + "#{' (required)' if form.object.body_required?}",
+        bold: true
+    },
+    name: "edition[body]",
+    id: "edition_body",
+    value: edition.body,
+    rows: 20,
+    error_items: errors_for(edition.errors, :body),
+  } %>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -12,19 +12,24 @@
   data_attributes ||= {}
   data_attributes[:module] ||= ""
   data_attributes[:module] << " govspeak-editor"
+  data_attributes[:module] = data_attributes[:module].strip!
 
   textarea_data_attributes ||= {}
   textarea_data_attributes[:module] ||= ""
   textarea_data_attributes[:module] << " paste-html-to-govspeak"
+  textarea_data_attributes[:module] = textarea_data_attributes[:module].strip!
 
   preview_button_data_attributes ||= {}
   preview_button_data_attributes["content-target"] = "##{id}"
   preview_button_data_attributes["preview-toggle-tracking"] = "true" if track_preview_toggle
   preview_button_data_attributes["preview-toggle-track-category"] = track_category if track_category
   preview_button_data_attributes["preview-toggle-track-action"] = track_action if track_action
+
+  classes = "app-c-govspeak-editor govuk-form-group"
+  classes << " govuk-form-group--error" if error_items
 %>
 
-<%= tag.div class:"app-c-govspeak-editor", data: data_attributes do %>
+<%= tag.div class: classes, data: data_attributes do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
@@ -47,6 +52,7 @@
       value: value,
       error_items: error_items,
       data: textarea_data_attributes,
+      margin_bottom: 0,
     } %>
   </div>
   <div class="app-c-govspeak-editor__preview">

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -1,6 +1,8 @@
 <%
   id ||= "#{name}-#{SecureRandom.hex(4)}"
   label[:bold] ||= false
+  hint ||= nil
+  hint_id ||= "#{id}-hint"
   value ||= nil
   error_items ||= nil
   rows ||= 12
@@ -31,14 +33,18 @@
 
 <%= tag.div class: classes, data: data_attributes do %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
+    <div class="govuk-grid-column-three-quarters ">
+      <%= render "govuk_publishing_components/components/label", {
+        html_for: id,
+        hint_id: hint_id,
+        hint_text: hint,
+      }.merge(label.symbolize_keys) %>
     </div>
     <div class="govuk-grid-column-one-quarter app-c-govspeak-editor__preview-button-wrapper">
       <%= render "govuk_publishing_components/components/button", {
         text: "Preview",
         secondary_quiet: true,
-        margin_bottom: 2,
+        margin_bottom: hint ? 5 : 2,
         classes: "js-app-c-govspeak-editor__preview-button",
         data_attributes: preview_button_data_attributes
       } %>
@@ -53,6 +59,7 @@
       error_items: error_items,
       data: textarea_data_attributes,
       margin_bottom: 0,
+      describedby: hint_id,
     } %>
   </div>
   <div class="app-c-govspeak-editor__preview">


### PR DESCRIPTION
## What

We need to add the [previewable text area component](https://trello.com/c/FAig6Fn0/792-implement-previewable-text-area-for-govspeak "‌") on HTML attachments, edit edition and Withdrawal Messages.

## Why

So users can quickly preview Govspeak

https://trello.com/c/fB7EzPg5/817-add-new-govspeak-preview-component-to-13-features-html-attachments-edit-edition-withdrawal-messages

## Before

<img width="680" alt="Screenshot 2022-10-27 at 3 18 13 pm" src="https://user-images.githubusercontent.com/4599889/198311695-0d5d17c6-5ff0-42a4-9afa-968eecff8b95.png">

<img width="671" alt="Screenshot 2022-10-27 at 3 28 29 pm" src="https://user-images.githubusercontent.com/4599889/198314448-43d4c4e7-7125-4dd3-8d90-3f3c0b7c17d1.png">


## After

<img width="675" alt="Screenshot 2022-10-27 at 3 18 23 pm" src="https://user-images.githubusercontent.com/4599889/198311756-aa0123c7-7008-4a1d-b4e5-478a616173fc.png">

![screenshot-whitehall-admin dev gov uk-2022 10 27-15_18_48](https://user-images.githubusercontent.com/4599889/198311595-5959027b-1670-48e0-8094-885b266464bd.png)

<img width="690" alt="Screenshot 2022-10-27 at 3 27 40 pm" src="https://user-images.githubusercontent.com/4599889/198314516-9014588f-c0c3-4aea-801c-bbe8203f49ac.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
