### PR TITLE
823, Bulk upload attachment - add tracking

### DIFF
--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -19,6 +19,11 @@
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
           text: "Upload zip",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "zip-file-button"
+          }
         } %>
 
         <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -57,6 +57,11 @@
         <div class="govuk-button-group">
           <%= render "govuk_publishing_components/components/button", {
             text: "Save",
+            data_attributes: {
+              module: "gem-track-click",
+              "track-category": "form-button",
+              "track-action": "bulk-upload-button"
+            }
           } %>
 
           <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>


### PR DESCRIPTION
Trello Card: [bulk upload attachment - tracking needed](https://trello.com/c/TSsyZS1w/823-bulk-upload-attachment-tracking-needed)

This PR adds tracking data which was omitted on the initial port to the design system. Specifically it restores the data attributes that were in place in the Bootstrap version to two buttons as shown below. 

| "Next" button on Step 1 | "Save" button on Step 2 |
|---|---|
| ![Screenshot 2022-10-27 at 12 48 04](https://user-images.githubusercontent.com/6080548/198301078-8d0e62d7-1332-4689-8648-6dd69bc25f50.png) | ![Screenshot 2022-10-27 at 12 51 11](https://user-images.githubusercontent.com/6080548/198301336-0e4e7358-67e0-4322-9568-43e464a176a7.png) |
| Bootstrap values:<br>- data-module="track-button-click"<br>- data-track-category="form-button"<br>- data-track-action="zip-file-button" | Bootstrap values:<br>- data-module="track-button-click"<br>- data-track-category="form-button"<br>- data-track-action="bulk-upload-button" |
