### PR TITLE
Add sub-navigation tabs component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "./components/govspeak-editor";
 @import "./components/miller-columns";
 @import "./admin/components/govspeak-help";
+@import "./components/secondary-navigation";
 
 @import "./admin/modules/unpublish-display-conditions";
 

--- a/app/assets/stylesheets/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/components/_secondary-navigation.scss
@@ -2,8 +2,6 @@
   @include govuk-font(19);
   @include govuk-responsive-margin(6, "bottom");
 
-  display: block;
-
   @include govuk-media-query($from: tablet) {
     box-shadow: inset 0 -1px 0 $govuk-border-colour;
     display: flex;
@@ -39,9 +37,9 @@
     box-shadow: none;
   }
 
-  a,
-  a:link,
-  a:visited {
+  .app-c-secondary-navigation__list-item-link,
+  .app-c-secondary-navigation__list-item-link:link,
+  .app-c-secondary-navigation__list-item-link:visited {
     background-color: inherit;
     border-left: 4px solid transparent;
     color: govuk-colour("blue");
@@ -57,11 +55,11 @@
     }
   }
 
-  a:hover {
+  .app-c-secondary-navigation__list-item-link:hover {
     color: $govuk-link-hover-colour;
   }
 
-  a:focus {
+  .app-c-secondary-navigation__list-item-link:focus {
     @include govuk-focused-text;
 
     border-color: $govuk-focus-text-colour;
@@ -75,13 +73,13 @@
 }
 
 .app-c-secondary-navigation__list-item--current {
-  a:link,
-  a:visited {
+  .app-c-secondary-navigation__list-item-link:link,
+  .app-c-secondary-navigation__list-item-link:visited {
     border-color: govuk-colour("blue");
     color: $govuk-text-colour;
   }
 
-  a:focus {
+  .app-c-secondary-navigation__list-item-link:focus {
     @include govuk-focused-text;
 
     border-color: $govuk-focus-text-colour;

--- a/app/assets/stylesheets/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/components/_secondary-navigation.scss
@@ -1,0 +1,94 @@
+.app-c-secondary-navigation {
+  @include govuk-font(19);
+  @include govuk-responsive-margin(6, "bottom");
+
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    display: flex;
+  }
+}
+
+.app-c-secondary-navigation__list {
+  list-style: none;
+  margin-bottom: govuk-spacing(4);
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: none;
+    display: flex;
+    margin: 0;
+    white-space: nowrap;
+  }
+}
+
+.app-c-secondary-navigation__list-item {
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    margin-right: 20px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  &:last-child {
+    box-shadow: none;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    background-color: inherit;
+    border-left: 4px solid transparent;
+    color: govuk-colour("blue");
+    display: block;
+    padding: govuk-spacing(2);
+    text-decoration: none;
+
+    @include govuk-media-query($from: tablet) {
+      border-bottom: 4px solid transparent;
+      border-left: 0;
+      padding: govuk-spacing(2) 0;
+      padding-bottom: govuk-spacing(2) - 4px; // Compensate for 4px border
+    }
+  }
+
+  a:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  a:focus {
+    @include govuk-focused-text;
+
+    border-color: $govuk-focus-text-colour;
+    border-left-color: transparent;
+    position: relative;
+
+    @include govuk-media-query($from: tablet) {
+      box-shadow: none;
+    }
+  }
+}
+
+.app-c-secondary-navigation__list-item--current {
+  a:link,
+  a:visited {
+    border-color: govuk-colour("blue");
+    color: $govuk-text-colour;
+  }
+
+  a:focus {
+    @include govuk-focused-text;
+
+    border-color: $govuk-focus-text-colour;
+    border-left-color: transparent;
+
+    @include govuk-media-query($from: tablet) {
+      box-shadow: none;
+    }
+  }
+}

--- a/app/views/components/_secondary_navigation.html.erb
+++ b/app/views/components/_secondary_navigation.html.erb
@@ -11,7 +11,7 @@
         item_aria_attributes = { current: "page" } if item[:current]
       %>
       <%= tag.li class: item_classes do %>
-        <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state", data: item[:data_attributes], aria: item_aria_attributes %>
+        <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state app-c-secondary-navigation__list-item-link", data: item[:data_attributes], aria: item_aria_attributes %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/components/_secondary_navigation.html.erb
+++ b/app/views/components/_secondary_navigation.html.erb
@@ -1,0 +1,18 @@
+<%
+  id ||= nil
+  items ||= []
+%>
+<%= tag.nav class: "app-c-secondary-navigation", id: id, role: 'navigation', aria: { label: aria_label } do %>
+  <%= tag.ul class: "app-c-secondary-navigation__list" do %>
+    <% items.each do |item| %>
+      <%
+        item_classes = %w( app-c-secondary-navigation__list-item )
+        item_classes << "app-c-secondary-navigation__list-item--current" if item[:current]
+        item_aria_attributes = { current: "page" } if item[:current]
+      %>
+      <%= tag.li class: item_classes do %>
+        <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state", data: item[:data_attributes], aria: item_aria_attributes %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/secondary_navigation.yml
+++ b/app/views/components/docs/secondary_navigation.yml
@@ -1,0 +1,22 @@
+name: Secondary navigation
+description: Displays a secondary navigation with the current page marked accordingly
+accessibility_criteria: |
+  The component must:
+  * indicate that it is navigation landmark
+  * indicate if a navigation item links to the currently-displayed page
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      aria_label: Document tabs
+      items:
+        - label: Document
+          href: government/admin/editions/:id"
+          current: true
+          data_attributes:
+            gtm: document-tab
+        - label: Attachments
+          href: /government/admin/editions/:id/attachments"
+          data_attributes:
+            gtm: attachments-tab


### PR DESCRIPTION
## Description 

A need has arisen for sub navigation tabs for us to complete a like for like port of Whitehall to the GOV.UK Design System.

This PR essentially lift and shifts the component from Content Publisher which was added in this PR https://github.com/alphagov/content-publisher/pull/1576

## Screenshots (what it will look like)

<img width="842" alt="image" src="https://user-images.githubusercontent.com/42515961/198353382-377ab613-ca13-484d-bd31-16f9f75f9bdc.png">

## Trello card

https://trello.com/c/Ep4TxVXu/794-introduce-sub-nav-to-design-system-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
