### PR TITLE
Remove e2e tests from ci build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,8 @@ REPOSITORY = 'whitehall'
 DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-whitehall")
   govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/whitehall_test")
   govuk.buildProject(
-    publishingE2ETests: true,
     brakeman: true,
     overrideTestTask: {
       stage("Run tests") {


### PR DESCRIPTION
## Description

We're removing the E2E tests from our Publishing apps as we've transitioned to contract testing. This removes the E2E tests from being built in CI. A subsequent PR will remove the code from the Publishing E2E repo, but this will reduce immediate pain from flaky builds

## Trello card 

https://trello.com/c/qgR41OnR/837-disable-publishing-end-to-end-tests-on-our-apps

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
