### PR TITLE
Add tracking for GA4 to share links

### DIFF
--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -22,6 +22,7 @@
       <div class="content">
         <h2 class="govuk-heading-s"><%= t("worldwide_organisation.headings.follow_us") %></h2>
         <%= render "govuk_publishing_components/components/share_links", {
+          track_as_follow: true,
           links: @worldwide_organisation.social_media_accounts.map do |account|
             {
               href: account.url,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Adds the `track_as_follow` option to this use of the share links component, to enable tracking in GA4, as described here: https://components.publishing.service.gov.uk/component-guide/share_links/track_as_follow_links

Trello card: https://trello.com/c/Bf4OkoBJ/384-add-tracking-follow-us