### PR TITLE
Release 1.3 attachment page fixes (part1)

### DIFF
--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -62,6 +62,7 @@ private
       :hoc_paper_number,
       :unnumbered_hoc_paper,
       :parliamentary_session,
+      :accessible,
     ])
   end
 end

--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -1,7 +1,7 @@
 <%= form.fields_for(:attachment_data, include_id: false) do |attachment_data_fields| %>
   <% if attachment_data_fields.object.filename %>
     <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id || attachment_data_fields.object.id) %>
-    <p class="govuk-body">Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url %></p>
+    <p class="govuk-body">Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url, class: "govuk-link" %></p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/file_upload", {
@@ -11,7 +11,7 @@
       heading_size: "l",
     },
     name: "attachment[attachment_data_attributes][file]",
-    hint: raw("You must upload attachments in an <a href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>.")
+    hint: raw("You must upload attachments in an <a class='govuk-link' href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>.")
   } %>
 
   <% form.hidden_field :accessible, value: "0" %>

--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -14,12 +14,15 @@
     hint: raw("You must upload attachments in an <a href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>.")
   } %>
 
+  <% form.hidden_field :accessible, value: "0" %>
+
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "attachment[accessible]",
     items: [
       {
         label: "Attachment is accessible",
-        value: "1"
+        value: "1",
+        checked: attachment.accessible
       }
     ]
   } %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -76,25 +76,15 @@
   <%= hidden_field_tag :type, params[:type] %>
 
   <div class="govuk-button-group">
-    <% if attachment.is_a?(ExternalAttachment) %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Next",
-        data_attributes: {
-          module: "track-button-click",
-          "track-category": "form-button",
-          "track-action": "#{attachment.readable_type}-attachment-button"
-        }
-      } %>
-    <% else %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        data_attributes: {
-          module: "track-button-click",
-          "track-category": "form-button",
-          "track-action": "#{attachment.readable_type}-attachment-button"
-        }
-      } %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save",
+      data_attributes: {
+        module: "track-button-click",
+        "track-category": "form-button",
+        "track-action": "#{attachment.readable_type}-attachment-button"
+      }
+    } %>
+
     <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
   </div>
 <% end %>

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -23,6 +23,8 @@
 
   <% if attachment.is_a?(HtmlAttachment) %>
     <%= form.fields_for :govspeak_content do |govspeak_fields| %>
+      <%= hidden_field_tag 'attachment[govspeak_content_attributes][manually_numbered_headings]', "0" %>
+
       <div class="govuk-!-margin-bottom-8">
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: "attachment[govspeak_content_attributes][manually_numbered_headings]",

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -21,9 +21,13 @@
         error_items: errors_for(@zip_file.errors, :zip_file)
       } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Next",
-      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Upload zip",
+        } %>
+
+        <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -1,11 +1,6 @@
 <% content_for :page_title, "Bulk upload for: #{@edition.title}" %>
 <% content_for :title, "Bulk upload" %>
 <% content_for :context, "Attachments for #{@edition.format_name}" %>
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_attachments_path(@edition)
-  } %>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -14,7 +14,7 @@
 
       <%= render "govuk_publishing_components/components/file_upload", {
         label: {
-          text: "Upload a zip file"
+          text: "Zip file"
         },
         name: "bulk_upload_zip_file[zip_file]",
         id: "zip_file_zip_file",

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -26,6 +26,7 @@
                 text: "Title (required)"
               },
               name: "bulk_upload[attachments_attributes][#{i}][title]",
+              id: "bulk_upload_attachments_#{i}_title",
               autofocus: true,
               margin_top: 10,
               heading_level: 2,

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -1,11 +1,6 @@
 <% content_for :page_title, "Bulk upload for: #{@edition.title}" %>
 <% content_for :title, "Edit file attachments" %>
 <% content_for :context, "Attachments for publication" %>
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_attachments_path(@edition)
-  } %>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -57,9 +57,14 @@
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
           <% end %>
         <% end %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Save",
-        } %>
+
+        <div class="govuk-button-group">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save",
+          } %>
+
+          <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -38,11 +38,12 @@
             <% end %>
 
             <%= render "govuk_publishing_components/components/checkboxes", {
-              name: "Attachment is accessible",
+              name: "bulk_upload[attachments_attributes][#{i}][accessible]",
               items: [
                 {
                   label: "Attachment is accessible",
-                  value: true
+                  value: "1",
+                  checked: attachment.accessible
                 }
               ]
             } %>

--- a/features/bulk-upload.feature
+++ b/features/bulk-upload.feature
@@ -14,3 +14,16 @@ Feature: Bulk uploading attachments to editions
       When I upload a zip file that contains a file "greenpaper.pdf"
       Then the greenpaper.pdf attachment file should be replaced with the new file
       And any other files should be added as new attachments
+
+    Scenario: Uploading mulitple attachments from a zip file with preview design system permission
+      Given a draft news article "Stubble to be Outlawed" exists
+      And I have the "Preview design system" permission
+      When I upload a zip file containing several attachments and give them titles
+      Then I should see that the news article has attachments
+
+    Scenario: Replacing existing attachments with a zip file with preview design system permission
+      Given a draft publication "Results of beards survey" with a file attachment exists
+      And I have the "Preview design system" permission
+      When I upload a zip file that contains a file "greenpaper.pdf"
+      Then the greenpaper.pdf attachment file should be replaced with the new file
+      And any other files should be added as new attachments

--- a/features/step_definitions/bulk_upload_steps.rb
+++ b/features/step_definitions/bulk_upload_steps.rb
@@ -5,8 +5,14 @@ When(/^I upload a zip file containing several attachments and give them titles$/
   attach_file "Zip file", Rails.root.join("test/fixtures/two-pages-and-greenpaper.zip")
   click_button "Upload zip"
 
-  fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
-  fill_in "bulk_upload_attachments_attributes_1_title", with: "Greenpaper title"
+  if using_design_system?
+    fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
+    fill_in "bulk_upload_attachments_1_title", with: "Greenpaper title"
+  else
+    fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
+    fill_in "bulk_upload_attachments_attributes_1_title", with: "Greenpaper title"
+  end
+
   click_button "Save"
 end
 
@@ -27,7 +33,11 @@ When(/^I upload a zip file that contains a file "(.*?)"$/) do |_file|
   click_link "Bulk upload from Zip file"
   attach_file "Zip file", Rails.root.join("test/fixtures/two-pages-and-greenpaper.zip")
   click_button "Upload zip"
-  fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
+  if using_design_system?
+    fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
+  else
+    fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
+  end
   click_button "Save"
 end
 

--- a/features/support/attachment_helper.rb
+++ b/features/support/attachment_helper.rb
@@ -27,7 +27,7 @@ module AttachmentHelper
     click_on "Add new external attachment"
     fill_in "Title", with: attachment_title
     fill_in "External url", with: url
-    click_on using_design_system? ? "Next" : "Save"
+    click_on "Save"
     Attachment.find_by(title: attachment_title)
   end
 


### PR DESCRIPTION
## Description 

This PR actions some of the changes requested for the attachments pages outlined in this document  https://docs.google.com/document/d/1QBQl5s-576_HsfUfKCWDAvwETvqukrNZLY6a-KLJtGw/edit#

## Scope 

It only focusses on the attachments page changes. Withdrawal and govspeak sidebar changes are not in scope.

It also does not include reverting the command paper number and house of commons number 

<img width="510" alt="image" src="https://user-images.githubusercontent.com/42515961/199055795-197ba870-ebb3-4b98-9e6d-2d6634ca9dcc.png">


Or fixing errors so they link to the div not the input itself. They will be actioned in follow up PRs

## Checkboxes not working

There were a few bugs around checkboxes not working correctly. This fixes the following bugs

1. Ensures the `manually_numbered_headings` and `attachment[accessible]` checkboxes are set to false is left unchecked by adding hidden fields
2. Checks the accessible checkboxes is the attachment is accessible

## Use the same text for submit values as Bootstrap & add cancel links where missed

### External attachment new/edit page

Updates `Next` to `Save` 

#### Before

<img width="623" alt="image" src="https://user-images.githubusercontent.com/42515961/199036694-846dd592-6522-4419-b25f-d5c07b01b8b1.png">


#### After

<img width="616" alt="image" src="https://user-images.githubusercontent.com/42515961/199036609-835a04af-bab0-4cd2-8f4c-96ca4c328ded.png">

### New bulk attachment page

- Removes backlink
- Adds cancel link
- Updates `Save` to `Upload zip`

#### Before

<img width="458" alt="image" src="https://user-images.githubusercontent.com/42515961/199039127-92e48276-e0d0-4d5f-bbe1-d8b862a68ab0.png">

#### After

<img width="640" alt="image" src="https://user-images.githubusercontent.com/42515961/199037828-2a7d3eb9-479d-49bd-823f-7f8b23f4156c.png">


### Edit title for bulk attachments

Adds a cancel button

#### Before

<img width="462" alt="image" src="https://user-images.githubusercontent.com/42515961/199037121-031d9998-b577-449c-abd5-60cb1b001ffc.png">


#### After 

<img width="509" alt="image" src="https://user-images.githubusercontent.com/42515961/199038180-5068cdf7-5ede-4dd4-8e9f-16c68c1bd6f9.png">


## Updates a few links to use govuk-link styling

### Before

<img width="507" alt="image" src="https://user-images.githubusercontent.com/42515961/199038644-12671609-0e5f-4abf-b522-e5d00658507f.png">


### After 


<img width="546" alt="image" src="https://user-images.githubusercontent.com/42515961/199038561-ea203eda-c2d8-4dfa-8d4c-79924b032492.png">


## Add feature specs for bulk upload in design system


There weren't any and there probs should be.


## Trello card 

https://trello.com/c/KjdWREUw/843-fixes-for-attachments-prior-to-13-release


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
