### PR TITLE
Release 1.3 attachment page fixes (part2)

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <% if attachable.allows_attachment_references? %>
-    <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: heading_size %>
+    <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: heading_size, subheading_size: subheading_size %>
   <% end %>
 
   <% if attachment.is_a?(HtmlAttachment) %>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -27,7 +27,7 @@
 </div>
 
 <%
-  options = [{text: "Choose the right Parliamentary session", value: ""}]
+  options = [{text: "", value: ""}]
   options.concat(Attachment.parliamentary_sessions.map do |session|
     {
       text: session,
@@ -45,6 +45,7 @@
     heading_level: 3,
     heading_size: heading_size,
     options: options,
+    hint: "Choose the right Parliamentary session",
     error_message: errors_for_input(attachment.errors, :parliamentary_session)
   } %>
 </div>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,29 +1,26 @@
 <div class="govuk-!-margin-bottom-8">
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: "House of Commons paper number",
-    heading_level: 2,
+  <%= render("govuk_publishing_components/components/input", {
+    label: {
+      text: "House of Commons paper number",
+    },
+    name: "attachment[hoc_paper_number]",
+    id: "attachment_hoc_paper_number",
+    value: form.object.hoc_paper_number,
+    error_items: errors_for(attachment.errors, :unnumbered_hoc_paper),
     heading_size: heading_size,
+    hint: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
+  }) %>
+
+  <%= form.hidden_field :unnumbered_hoc_paper, value: "0" %>
+
+  <%= render "govuk_publishing_components/components/checkboxes", {
     name: "attachment[unnumbered_hoc_paper]",
-    id_prefix: "hoc_paper_number_conditional",
+    id: "attachment_unnumbered_hoc_paper",
     items: [
       {
-        value: "0",
-        text: "Numbered",
-        checked: form.object.unnumbered_hoc_paper.eql?(false),
-        conditional: render("govuk_publishing_components/components/input", {
-          label: {
-            text: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
-          },
-          name: "attachment[hoc_paper_number]",
-          id: "attachment_hoc_paper_number",
-          value: form.object.hoc_paper_number,
-          error_items: errors_for(attachment.errors, :command_paper_number)
-        })
-      },
-      {
+        label: "Unnumbered act paper",
         value: "1",
-        text: "Unnumbered",
-        checked: form.object.unnumbered_hoc_paper
+        checked: attachment.unnumbered_hoc_paper
       }
     ]
   } %>
@@ -45,7 +42,7 @@
     label: "Parliamentary session",
     name: "attachment[parliamentary_session]",
     id: "attachment_parliamentary_session",
-    heading_level: 2,
+    heading_level: 3,
     heading_size: heading_size,
     options: options,
     error_message: errors_for_input(attachment.errors, :parliamentary_session)

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -49,36 +49,39 @@
 </div>
 
 <div class="govuk-!-margin-bottom-8">
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: "Command paper number",
-    heading_level: 2,
-    heading_size: heading_size,
+  <% if attachable.can_have_attached_house_of_commons_papers? %>
+    <h2 class="govuk-heading-<%= heading_size %>">Command and House of Commons papers</h2>
+
+    <p class="govuk-body">Fill in the command or House of Commons box to publish an official document which will appear in the list of official documents.</p>
+  <% end %>
+
+  <%= render("govuk_publishing_components/components/input", {
+    label: {
+      text: "Command paper number"
+    },
+    name: "attachment[command_paper_number]",
+    id: "attachment_command_paper_number",
+    value: form.object.command_paper_number,
+    error_items: errors_for(attachment.errors, :command_paper_number),
+    heading_size: attachable.can_have_attached_house_of_commons_papers? ? subheading_size : heading_size,
+    hint: "The number must start with one of " + Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') + ", followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
+  }) %>
+
+  <%= form.hidden_field :unnumbered_command_paper, value: "0" %>
+
+  <%= render "govuk_publishing_components/components/checkboxes", {
     name: "attachment[unnumbered_command_paper]",
-    id_prefix: "command_paper_number_conditional",
+    id: "attachment_unnumbered_command_paper",
     items: [
       {
-        value: "0",
-        text: "Numbered",
-        checked: form.object.unnumbered_command_paper.eql?(false),
-        conditional: render("govuk_publishing_components/components/input", {
-          label: {
-            text: "The number must start with one of " + Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') + ", followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
-          },
-          name: "attachment[command_paper_number]",
-          id: "attachment_command_paper_number",
-          value: form.object.command_paper_number,
-          error_items: errors_for(attachment.errors, :command_paper_number)
-        })
-      },
-      {
+        label: "Unnumbered",
         value: "1",
-        text: "Unnumbered",
-        checked: form.object.unnumbered_command_paper
+        checked: attachment.unnumbered_command_paper
       }
     ]
   } %>
 </div>
 
 <% if attachable.can_have_attached_house_of_commons_papers? %>
-  <%= render 'admin/attachments/hoc_reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: heading_size %>
+  <%= render 'admin/attachments/hoc_reference_fields', attachable: attachable, form: form, attachment: attachment, heading_size: subheading_size %>
 <% end %>

--- a/app/views/admin/attachments/edit.html.erb
+++ b/app/views/admin/attachments/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <%= render partial: 'form', locals: { attachable: attachable, attachment: attachment, heading_size: "l" } %>
+    <%= render partial: 'form', locals: { attachable: attachable, attachment: attachment, heading_size: "l", subheading_size: "m" } %>
   </section>
 
   <% if attachment.html? %>

--- a/app/views/admin/attachments/new.html.erb
+++ b/app/views/admin/attachments/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <%= render 'form', attachable: attachable, heading_size: "l" %>
+    <%= render 'form', attachable: attachable, heading_size: "l", subheading_size: "m" %>
   </section>
 
   <% if attachment.html? %>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -30,7 +30,7 @@
             } %>
 
             <% if @edition.allows_attachment_references? %>
-              <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields, attachment: attachment, heading_size: "m" %>
+              <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields, attachment: attachment, heading_size: "m", subheading_size: "s" %>
             <% end %>
 
             <%= render "govuk_publishing_components/components/checkboxes", {


### PR DESCRIPTION
## Description

We updated the Command Paper Number and House of commons paper number to use radio buttons. This had some undesirable behaviour. If nothing was selected by the user, when they clicked save,  unnumbered field was set to true when the user had left the radios to blank.

We've decided to revert to using fields and checkboxes like the Bootstrap implementation

These changes are outlined in point 1 of this document https://docs.google.com/document/d/1QBQl5s-576_HsfUfKCWDAvwETvqukrNZLY6a-KLJtGw/edit#heading=h.ugbkc5gjfg1w


## Screenshots

### Before

<img width="577" alt="image" src="https://user-images.githubusercontent.com/42515961/199205575-49a98bcb-9f29-4ea1-a4a5-b5c124bda971.png">

### After

#### With HOC fields

<img width="610" alt="image" src="https://user-images.githubusercontent.com/42515961/199216294-0f749c1c-3acb-4738-91d5-2d94df838533.png">

#### Without HOC fields 

<img width="606" alt="image" src="https://user-images.githubusercontent.com/42515961/199216351-380a3eee-dee4-4a25-adb5-a63b1e61ade7.png">


## Trello card

https://trello.com/c/Ep4TxVXu/794-introduce-sub-nav-to-design-system-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
