### PR TITLE
Remove `govuk-admin-template`

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,8 @@
 //= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics
 
-//= require govuk-admin-template
+//= require jquery
+//= require bootstrap
 
 //= require components/autocomplete
 //= require components/govspeak-editor


### PR DESCRIPTION
## What

Remove `govuk-admin-template` and add in `bootstrap` and `jquery` specifically.

## Why

The `govuk-admin-template` package includes a duplicate module called `auto-track-event` which causes the `auto-track-event` module to run twice. This causes all error summaries (which uses this module) to run twice.

https://trello.com/c/baKAKp8q/844-fix-bug-with-auto-track-event

## Before

<img width="1728" alt="Screenshot 2022-10-31 at 6 20 44 pm" src="https://user-images.githubusercontent.com/4599889/199081148-07fe96b1-c151-4ddb-86ae-4749ca2d27da.png">

## After

<img width="1728" alt="Screenshot 2022-10-31 at 6 20 09 pm" src="https://user-images.githubusercontent.com/4599889/199081194-522bdbb4-5b90-4eed-b424-fef4e32a907f.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
