### PR TITLE
Apply sub nav component new edition, edit edition & attachment index pages

### DIFF
--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -7,6 +7,11 @@
   } %>
 <% end %>
 <div class="govuk-grid-row">
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document navigation tabs",
+    items: secondary_navigation_tabs_items(@edition, request.path)
+  } %>
+
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Note: <%= attachment_note(attachment.attachable_model_name) %></p>
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -6,10 +6,16 @@
 <% content_for :error_summary, render('shared/error_summary', object: @edition, parent_class: "edition", class_name: @edition.format_name) %>
 
 <div class="govuk-grid-row">
+  <%= render "govuk_publishing_components/components/title", {
+    title: sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}")
+  } %>
+
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document navigation tabs",
+    items: secondary_navigation_tabs_items(@edition, request.path)
+  } %>
+
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}")
-    } %>
 
     <%= render "form", edition: @edition %>
   </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -7,12 +7,16 @@
 <% content_for :banner, render("recent_openings", edition: @edition, recent_openings: @recent_openings) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      context: @edition.title,
-      title: "Editing #{@edition.format_name}"
-    } %>
+  <%= render "govuk_publishing_components/components/title", {
+    context: @edition.title,
+    title: "Editing #{@edition.format_name}"
+  } %>
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document navigation tabs",
+    items: secondary_navigation_tabs_items(@edition, request.path)
+  } %>
 
+  <div class="govuk-grid-column-two-thirds">
     <% if @conflicting_edition %>
       <%= render "govuk_publishing_components/components/error_alert", {
         message: "This document has been updated by another user since you started editing it.",

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -6,11 +6,16 @@
 <% content_for :error_summary, render('shared/error_summary', object: @edition, parent_class: "edition", class_name: @edition.format_name) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: "New #{@edition.format_name}"
-    } %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: "New #{@edition.format_name}"
+  } %>
 
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document navigation tabs",
+    items: secondary_navigation_tabs_items(@edition, request.path)
+  } %>
+
+  <div class="govuk-grid-column-two-thirds">
     <%= render "form", edition: @edition %>
   </div>
 </div>

--- a/test/unit/helpers/admin/editions_helper_test.rb
+++ b/test/unit/helpers/admin/editions_helper_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
 
 class Admin::EditionsHelperTest < ActionView::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
   def govspeak_embedded_contacts(*_args)
     []
   end
@@ -49,5 +52,174 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     edition = stub(body: one_hundred_thousand_words)
     LinkCheckerApiService.expects(:has_links?).never
     show_link_check_report?(edition)
+  end
+
+  test "#secondary_navigation_tabs_items for persisted consultations with no attachments" do
+    consultation = build_stubbed(:consultation)
+
+    expected_output = [
+      {
+        label: "Document",
+        href: edit_admin_edition_path(consultation),
+        current: false,
+      },
+      {
+        label: "Attachments",
+        href: admin_edition_attachments_path(consultation),
+        current: false,
+      },
+      {
+        label: "Public feedback",
+        href: admin_consultation_public_feedback_path(consultation),
+        current: true,
+      },
+      {
+        label: "Final outcome",
+        href: admin_consultation_outcome_path(consultation),
+        current: false,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(consultation, admin_consultation_public_feedback_path(consultation))
+  end
+
+  test "#secondary_navigation_tabs_items for persisted consultations with attachments" do
+    consultation = build_stubbed(:consultation)
+    consultation.stubs(:attachments).returns([build_stubbed(:file_attachment), build_stubbed(:file_attachment)])
+
+    expected_output = [
+      {
+        label: "Document",
+        href: edit_admin_edition_path(consultation),
+        current: false,
+      },
+      {
+        label: "Attachments<span class=\"govuk-tag govuk-tag--grey\">2</span>",
+        href: admin_edition_attachments_path(consultation),
+        current: false,
+      },
+      {
+        label: "Public feedback",
+        href: admin_consultation_public_feedback_path(consultation),
+        current: false,
+      },
+      {
+        label: "Final outcome",
+        href: admin_consultation_outcome_path(consultation),
+        current: true,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(consultation, admin_consultation_outcome_path(consultation))
+  end
+
+  test "#secondary_navigation_tabs_items for persisted document collections" do
+    document_collection = build_stubbed(:document_collection)
+
+    expected_output = [
+      {
+        label: "Document",
+        href: edit_admin_edition_path(document_collection),
+        current: false,
+      },
+      {
+        label: "Collection documents",
+        href: admin_document_collection_groups_path(document_collection),
+        current: true,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(document_collection, admin_document_collection_groups_path(document_collection))
+  end
+
+  test "#secondary_navigation_tabs_items for persisted editions which do not allow attachments" do
+    %i[case_study fatality_notice speech].each do |type|
+      edition = build_stubbed(type)
+
+      expected_output = [
+        {
+          label: "Document",
+          href: edit_admin_edition_path(edition),
+          current: true,
+        },
+      ]
+
+      assert_equal expected_output, secondary_navigation_tabs_items(edition, edit_admin_edition_path(edition))
+    end
+  end
+
+  test "#secondary_navigation_tabs_items for other persisted edition types with no attachments" do
+    %i[corporate_information_page detailed_guide news_article publication].each do |type|
+      if type == :corporate_information_page
+        organisation = build_stubbed(:organisation)
+        edition = build_stubbed(type, organisation:)
+      else
+        edition = build_stubbed(type)
+      end
+
+      expected_output = [
+        {
+          label: "Document",
+          href: tab_url_for_edition(edition),
+          current: true,
+        },
+        {
+          label: "Attachments",
+          href: admin_edition_attachments_path(edition),
+          current: false,
+        },
+      ]
+
+      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+    end
+  end
+
+  test "#secondary_navigation_tabs_items for other persisted edition types with attachments" do
+    %i[corporate_information_page detailed_guide news_article publication].each do |type|
+      if type == :corporate_information_page
+        organisation = build_stubbed(:organisation)
+        edition = build_stubbed(type, organisation:)
+      else
+        edition = build_stubbed(type)
+      end
+
+      edition.stubs(:attachments).returns([build_stubbed(:file_attachment), build_stubbed(:file_attachment)])
+
+      expected_output = [
+        {
+          label: "Document",
+          href: tab_url_for_edition(edition),
+          current: true,
+        },
+        {
+          label: "Attachments<span class=\"govuk-tag govuk-tag--grey\">2</span>",
+          href: admin_edition_attachments_path(edition),
+          current: false,
+        },
+      ]
+
+      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+    end
+  end
+
+  test "#secondary_navigation_tabs_items for non-persisted editions" do
+    %i[case_study consultation corporate_information_page detailed_guide document_collection fatality_notice news_article publication speech].each do |type|
+      if type == :corporate_information_page
+        organisation = build_stubbed(:organisation)
+        edition = build(type, organisation:)
+      else
+        edition = build(type)
+      end
+
+      expected_output = [
+        {
+          label: "Document",
+          href: tab_url_for_edition(edition),
+          current: true,
+        },
+      ]
+
+      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+    end
   end
 end


### PR DESCRIPTION
## Description 

We've introduced  a sub-nav tabs component in https://github.com/alphagov/whitehall/pull/6975. This PR applies this component on the edit editions page.

This can also be used on the attachment index page, response index page and public feedback index page once they're being ported to the GOV.UK Design System

## Screenshots

### Consultations

<img width="842" alt="image" src="https://user-images.githubusercontent.com/42515961/198353382-377ab613-ca13-484d-bd31-16f9f75f9bdc.png">


### Document collections

<img width="771" alt="image" src="https://user-images.githubusercontent.com/42515961/198353491-07a5be64-7382-4de3-bb3d-3500daf5966f.png">


### Case studies

<img width="744" alt="image" src="https://user-images.githubusercontent.com/42515961/198396087-6c2167d2-6226-4def-9292-2864f8d5e563.png">

### Other Edition types

<img width="651" alt="image" src="https://user-images.githubusercontent.com/42515961/198396211-927c41c7-8448-4a62-94f9-1b8c4e044fc7.png">


### New editions

<img width="657" alt="image" src="https://user-images.githubusercontent.com/42515961/198396299-7c0bc9ea-1f16-46b8-8b6c-af92b961ff09.png">

### Attachment index page

<img width="582" alt="image" src="https://user-images.githubusercontent.com/42515961/199742826-ecfbe330-4b49-4780-8398-b54c13628d14.png">


## Trello card

https://trello.com/c/Ep4TxVXu/794-introduce-sub-nav-to-design-system-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
