### PR TITLE
Updates tracking module to `gem-track-click` for design system

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -81,7 +81,7 @@
     <%= render "govuk_publishing_components/components/button", {
       text: "Save",
       data_attributes: {
-        module: "track-button-click",
+        module: "gem-track-click",
         "track-category": "form-button",
         "track-action": "#{attachment.readable_type}-attachment-button"
       }


### PR DESCRIPTION
This PR updates the code for tracking, which was not giving the expected results as it was originally implemented. The reason is that the Design System uses tracking from the component which requires the `GemTrackClick` script and replaces the previous tracking functionality.