### PR TITLE
Add Cancel Button to User Needs and other pages

### DIFF
--- a/app/views/admin/document_sources/edit.html.erb
+++ b/app/views/admin/document_sources/edit.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, "Edit legacy URL redirects" %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@edition)
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @edition.title %></span>
@@ -22,10 +16,14 @@
         value: @edition.document.document_sources.map(&:url).join("\n"),
         rows: 20
       } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        margin_bottom: 8
-      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -3,22 +3,20 @@
 <% content_for :title, "Specialist topic tagging" %>
 <% content_for :title_margin_bottom, 6 %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@edition)
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <%= form_for @edition, url: admin_edition_legacy_associations_path(@edition), as: :edition, method: :put,
         html: { class: edition_form_classes(@edition) } do |form| %>
 
       <%= render 'specialist_sector_fields', form: form, edition: @edition %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Update specialist topics",
-        margin_bottom: 8,
-      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update specialist topics",
+        } %>
+
+        <%= link_to("Cancel", @path, class: "govuk-link") %>
+      </div>
     <% end %>
   </section>
 </div>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -3,11 +3,6 @@
 <% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
 <% content_for :title_margin_bottom, 6 %>
 <% content_for :error_summary, render('shared/error_summary', object: @unpublishing, parent_class: "edition", class_name: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explanation") %>
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@unpublishing.edition)
-  } %>
-<% end %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
@@ -34,10 +29,13 @@
         error_items: errors_for(@unpublishing.errors, :explanation)
       } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation",
-        margin_bottom: 8
-      } %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation",
+        } %>
+
+        <%= link_to("Cancel", [:admin, @unpublishing.edition], class: "govuk-link") %>
+      </div>
     <% end %>
   </section>
 </div>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -2,11 +2,6 @@
 <% content_for :title, "Withdraw or unpublish" %>
 <% content_for :context, @edition.title %>
 <% content_for :error_summary, render('shared/error_summary', object: @unpublishing, parent_class: @unpublishing.reason_as_class, class_name: @unpublishing.edition.format_name, verb: "withdraw or unpublish") %>
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@edition)
-  } %>
-<% end %>
 
 <%
   unpublish_reasons = {
@@ -110,10 +105,14 @@
         <% else %>
           <%= withdrawal_public_explanation_field %>
         <% end %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Withdraw",
-          destructive: true,
-        } %>
+        <div class="govuk-button-group govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Withdraw",
+            destructive: true,
+          } %>
+
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        </div>
       <% end %>
     </div>
 
@@ -157,10 +156,14 @@
           error_items: errors_for(@unpublishing.errors, :explanation)
         } %>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Unpublish",
-          destructive: true,
-        } %>
+        <div class="govuk-button-group govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Unpublish",
+            destructive: true,
+          } %>
+
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        </div>
       <% end %>
     </div>
 
@@ -183,10 +186,14 @@
           error_items: errors_for(@unpublishing.errors, :alternative_url)
         } %>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Unpublish",
-          destructive: true,
-        } %>
+        <div class="govuk-button-group govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Unpublish",
+            destructive: true,
+          } %>
+
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
@@ -3,22 +3,19 @@
 <% content_for :context, @edition.title %>
 <% content_for :title_margin_bottom, 6 %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@edition)
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version) do %>
       <p class="govuk-body govuk-!-margin-bottom-7">This will create a new edition and publish it immediately. It won’t send an email alert to users.</p>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Unwithdraw",
-        destructive: true,
-        margin_bottom: 8,
-      } %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Unwithdraw",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/editions/confirm_destroy.html.erb
+++ b/app/views/admin/editions/confirm_destroy.html.erb
@@ -3,22 +3,19 @@
 <% content_for :title, "Delete draft" %>
 <% content_for :title_margin_bottom, 6 %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_edition_path(@edition)
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <%= form_tag admin_edition_path(@edition), method: :delete do %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this draft?</p>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Delete",
-        destructive: true,
-        margin_bottom: 8,
-      } %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+      </div>
     <% end %>
   </section>
 </div>

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title, @edition.title %>
 <% content_for :title, "Associated user needs" %>
 <% content_for :context, @edition.title %>
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", href: admin_edition_path(@edition) %>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">      
@@ -24,9 +21,13 @@
           },
       } %>
 
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save"
         } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
[Replace back button on the user needs page with a cancel button.](https://trello.com/c/PZ4Q11UG/835-add-cancel-button-to-user-needs-page)
Replaces the back buttons on the unpublishing, dcoument sources, legacy associations, edit translation, confirm unpublish, confirm unwithdraw and confirm destroy pages with cancel buttons.
All of these button use simple `link_to` methods.

## Why
In our like for like approach we're using the same buttons as before for the new design system pages.
The Cancel button behaviour on these pages is simple always going back to the same page.

## Screenshots
![whitehall-admin dev gov uk_government_admin_0557b6d4-7a50-4565-953c-c962473332e1_needs(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/199214102-1d662be9-3736-4e7a-be5e-6bedf7ca1d78.png)
![whitehall-admin dev gov uk_government_admin_0557b6d4-7a50-4565-953c-c962473332e1_needs(iPad Pro)](https://user-images.githubusercontent.com/9594455/199214105-8771166f-08b6-4f0c-a927-0b57779771a5.png)
![whitehall-admin dev gov uk_government_admin_editions_1374127_confirm_unwithdraw_lock_version=9(iPad Pro)](https://user-images.githubusercontent.com/9594455/199214107-6f43d412-7840-4c24-bfbe-6a5e463a28ec.png)
![whitehall-admin dev gov uk_government_admin_editions_1374127_confirm_unpublish_lock_version=8(iPad Pro)](https://user-images.githubusercontent.com/9594455/199214110-c797577f-53c9-49c2-bb3f-05c86447966a.png)
![whitehall-admin dev gov uk_government_admin_editions_1374127_document-sources_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/199214113-5c46d5ef-3a83-4ead-aaf4-d9950ec5c470.png)
![whitehall-admin dev gov uk_government_admin_editions_1374127_legacy_associations_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/199214114-3423d106-0e29-4632-b693-27757f1b8c5d.png)
![whitehall-admin dev gov uk_government_admin_editions_1374127_unpublishing_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/199214117-48ac6dcf-c786-4288-a214-963455d964a5.png)
