### PR TITLE
[843] Ensure errors link to a fields container not the input for attachments and withdrawal pages

### DIFF
--- a/app/helpers/admin/field_container_helper.rb
+++ b/app/helpers/admin/field_container_helper.rb
@@ -1,0 +1,6 @@
+module Admin::FieldContainerHelper
+  def field_container(id:, &block)
+    content = capture(&block)
+    content_tag(:div, content, id:)
+  end
+end

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -4,17 +4,19 @@
   <% content_for :error_summary, render('shared/error_summary', object: attachment, parent_class: "attachment", class_name: @attachment.class.name.demodulize.underscore.humanize.downcase) %>
 
   <div class="govuk-!-margin-bottom-8">
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: "Title (required)"
-      },
-      name: "attachment[title]",
-      id: "attachment_title",
-      heading_level: 2,
-      heading_size: "l",
-      value: form.object.title,
-      error_items: errors_for(attachment.errors, :title)
-    } %>
+    <%= field_container(id: "attachment_title") do %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title (required)"
+        },
+        name: "attachment[title]",
+        id: "attachment_title_field",
+        heading_level: 2,
+        heading_size: "l",
+        value: form.object.title,
+        error_items: errors_for(attachment.errors, :title)
+      } %>
+    <% end %>
   </div>
 
   <% if attachable.allows_attachment_references? %>
@@ -42,32 +44,35 @@
           ]
         } %>
       </div>
-
-      <%= render "components/govspeak-editor", {
-        label: {
-          heading_size: "l",
-          text: "Body (required)"
-        },
-        name: "attachment[govspeak_content_attributes][body]",
-        rows: 20,
-        id: "attachment_govspeak_content_body",
-        value: form.object.govspeak_content.body,
-        error_items: errors_for(attachment.errors, :"govspeak_content.body"),
-      } %>
+      <%= field_container(id: "attachment_govspeak_content_body") do %>
+        <%= render "components/govspeak-editor", {
+          label: {
+            heading_size: "l",
+            text: "Body (required)"
+          },
+          name: "attachment[govspeak_content_attributes][body]",
+          rows: 20,
+          id: "attachment_govspeak_content_body_field",
+          value: form.object.govspeak_content.body,
+          error_items: errors_for(attachment.errors, :"govspeak_content.body"),
+        } %>
+      <% end %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
     <div class="govuk-!-margin-bottom-8">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "External url (required)"
-        },
-        name: "attachment[external_url]",
-        id: "attachment_external_url",
-        heading_level: 2,
-        heading_size: "l",
-        value: form.object.external_url,
-        error_items: errors_for(attachment.errors, :external_url)
-      } %>
+      <%= field_container(id: "attachment_external_url_field") do %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "External url (required)"
+          },
+          name: "attachment[external_url]",
+          id: "attachment_external_url_field",
+          heading_level: 2,
+          heading_size: "l",
+          value: form.object.external_url,
+          error_items: errors_for(attachment.errors, :external_url)
+        } %>
+      <% end %>
     </div>
   <% else %>
     <%= render 'attachment_data_fields', form: form %>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,15 +1,17 @@
 <div class="govuk-!-margin-bottom-8">
-  <%= render("govuk_publishing_components/components/input", {
-    label: {
-      text: "House of Commons paper number",
-    },
-    name: "attachment[hoc_paper_number]",
-    id: "attachment_hoc_paper_number",
-    value: form.object.hoc_paper_number,
-    error_items: errors_for(attachment.errors, :unnumbered_hoc_paper),
-    heading_size: heading_size,
-    hint: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
-  }) %>
+  <%= field_container(id: "attachment_hoc_paper_number") do %>
+    <%= render("govuk_publishing_components/components/input", {
+      label: {
+        text: "House of Commons paper number",
+      },
+      name: "attachment[hoc_paper_number]",
+      id: "attachment_hoc_paper_number_field",
+      value: form.object.hoc_paper_number,
+      error_items: errors_for(attachment.errors, :unnumbered_hoc_paper),
+      heading_size: heading_size,
+      hint: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
+    }) %>
+  <% end %>
 
   <%= form.hidden_field :unnumbered_hoc_paper, value: "0" %>
 
@@ -38,14 +40,16 @@
 %>
 
 <div class="govuk-!-margin-bottom-8">
-  <%= render "govuk_publishing_components/components/select", {
-    label: "Parliamentary session",
-    name: "attachment[parliamentary_session]",
-    id: "attachment_parliamentary_session",
-    heading_level: 3,
-    heading_size: heading_size,
-    options: options,
-    hint: "Choose the right Parliamentary session",
-    error_message: errors_for_input(attachment.errors, :parliamentary_session)
-  } %>
+  <%= field_container(id: "attachment_parliamentary_session") do %>
+    <%= render "govuk_publishing_components/components/select", {
+      label: "Parliamentary session",
+      name: "attachment[parliamentary_session]",
+      id: "attachment_parliamentary_session_field",
+      heading_level: 3,
+      heading_size: heading_size,
+      options: options,
+      hint: "Choose the right Parliamentary session",
+      error_message: errors_for_input(attachment.errors, :parliamentary_session)
+    } %>
+  <% end %>
 </div>

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -11,7 +11,7 @@
 <% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
   <div class="govuk-!-margin-bottom-8">
     <%= render "govuk_publishing_components/components/select", {
-      id: "attachment_parliamentary_session",
+      id: "attachment_locale",
       label: "Display language",
       name: "attachment[locale]",
       heading_level: 2,
@@ -23,17 +23,19 @@
 <% end %>
 
 <div class="govuk-!-margin-bottom-8">
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "ISBN"
-    },
-    name: "attachment[isbn]",
-    id: "attachment_isbn",
-    heading_level: 2,
-    heading_size: heading_size,
-    value: form.object.isbn,
-    error_items: errors_for(attachment.errors, :isbn)
-  } %>
+  <%= field_container(id: "attachment_isbn") do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "ISBN"
+      },
+      name: "attachment[isbn]",
+      id: "attachment_isbn_field",
+      heading_level: 2,
+      heading_size: heading_size,
+      value: form.object.isbn,
+      error_items: errors_for(attachment.errors, :isbn)
+    } %>
+  <% end %>
 </div>
 
 <div class="govuk-!-margin-bottom-8">
@@ -55,17 +57,19 @@
     <p class="govuk-body">Fill in the command or House of Commons box to publish an official document which will appear in the list of official documents.</p>
   <% end %>
 
-  <%= render("govuk_publishing_components/components/input", {
-    label: {
-      text: "Command paper number"
-    },
-    name: "attachment[command_paper_number]",
-    id: "attachment_command_paper_number",
-    value: form.object.command_paper_number,
-    error_items: errors_for(attachment.errors, :command_paper_number),
-    heading_size: attachable.can_have_attached_house_of_commons_papers? ? subheading_size : heading_size,
-    hint: "The number must start with one of " + Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') + ", followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
-  }) %>
+  <%= field_container(id: "attachment_command_paper_number") do %>
+    <%= render("govuk_publishing_components/components/input", {
+      label: {
+        text: "Command paper number"
+      },
+      name: "attachment[command_paper_number]",
+      id: "attachment_command_paper_number_field",
+      value: form.object.command_paper_number,
+      error_items: errors_for(attachment.errors, :command_paper_number),
+      heading_size: attachable.can_have_attached_house_of_commons_papers? ? subheading_size : heading_size,
+      hint: "The number must start with one of " + Attachment::VALID_COMMAND_PAPER_NUMBER_PREFIXES.join(', ') + ", followed by a space. If a suffix is provided, it must be a Roman numeral. Example: CP 521-IV"
+    }) %>
+  <% end %>
 
   <%= form.hidden_field :unnumbered_command_paper, value: "0" %>
 

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -7,14 +7,17 @@
     <%= form_for @zip_file, url: upload_zip_admin_edition_bulk_uploads_path(@edition), multipart: true do |form| %>
       <% content_for :error_summary, render('shared/error_summary', object: @zip_file, parent_class: "zip_file", class_name: @zip_file.class.name.demodulize.underscore.humanize.downcase) %>
 
-      <%= render "govuk_publishing_components/components/file_upload", {
-        label: {
-          text: "Zip file"
-        },
-        name: "bulk_upload_zip_file[zip_file]",
-        id: "zip_file_zip_file",
-        error_items: errors_for(@zip_file.errors, :zip_file)
-      } %>
+      <%= field_container(id: "zip_file_zip_file") do %>
+        <%= render "govuk_publishing_components/components/file_upload", {
+          label: {
+            text: "Zip file",
+            bold: true,
+          },
+          name: "bulk_upload_zip_file[zip_file]",
+          id: "zip_file_zip_file_field",
+          error_items: errors_for(@zip_file.errors, :zip_file)
+        } %>
+      <% end %>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -19,20 +19,22 @@
     <p class="govuk-body govuk-!-margin-bottom-6"><%= @unpublishing.unpublishing_reason.as_sentence.capitalize %></p>
 
     <%= form_for @unpublishing, url: admin_edition_unpublishing_path(@unpublishing.edition) do |f| %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "l",
-          text: "Public explanation",
-        },
-        hint: "This is shown on the live site",
-        name: "unpublishing[explanation]",
-        id: "unpublishing_explanation",
-        value: @unpublishing.explanation,
-        data: {
-          module: "paste-html-to-govspeak"
-        },
-        error_items: errors_for(@unpublishing.errors, :explanation)
-      } %>
+      <%= field_container(id: "unpublishing_explanation") do %>
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            heading_size: "l",
+            text: "Public explanation",
+          },
+          hint: "This is shown on the live site",
+          name: "unpublishing[explanation]",
+          id: "unpublishing_explanation_field",
+          value: @unpublishing.explanation,
+          data: {
+            module: "paste-html-to-govspeak"
+          },
+          error_items: errors_for(@unpublishing.errors, :explanation)
+        } %>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation",

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -27,17 +27,19 @@
     },
   }
 
-  withdrawal_public_explanation_field = render("components/govspeak-editor", {
-    label: {
-      text: "Public explanation",
-      bold: true,
-    },
-    hint: "This is shown on the live site",
-    name: "unpublishing[explanation]",
-    id: "withdrawal_explanation",
-    value: @unpublishing.explanation,
-    error_items: errors_for(@unpublishing.errors, :explanation)
-  })
+  withdrawal_public_explanation_field = field_container(id: "withdrawal_explanation") do
+    render("components/govspeak-editor", {
+        label: {
+          text: "Public explanation",
+          bold: true,
+        },
+        hint: "This is shown on the live site",
+        name: "unpublishing[explanation]",
+        id: "withdrawal_explanation_field",
+        value: @unpublishing.explanation,
+        error_items: errors_for(@unpublishing.errors, :explanation)
+      })
+    end
 %>
 
 <div class="govuk-grid-row">
@@ -93,23 +95,28 @@
               checked: (params["previous_withdrawal_id"] == "new"),
             }
           %>
-          <%= render "govuk_publishing_components/components/radio", {
-            name: "previous_withdrawal_id",
-            heading: "Do you need to reuse a previous withdrawal?",
-            description: sanitize("
-              <p class=\"govuk-body\">You should only reuse a previous withdrawal date and public explanation if you have:</p>
-              <ul class=\"govuk-list govuk-list--bullet\">
-                <li>updated file attachments to mark them ‘withdrawn’</li>
-                <li>made a minor edit, for example fixing a broken link</li>
-                <li>fixed an error or mistake in the content which existed when it was originally withdrawn</li>
-              </ul>
-            "),
-            items: items,
-            error_items: errors_for(@unpublishing.errors, :previous_withdrawal_id)
-          } %>
+
+          <%= field_container(id: "previous_withdrawal_id") do %>
+            <%= render "govuk_publishing_components/components/radio", {
+              name: "previous_withdrawal_id",
+              id: "previous_withdrawal_id_field",
+              heading: "Do you need to reuse a previous withdrawal?",
+              description: sanitize("
+                <p class=\"govuk-body\">You should only reuse a previous withdrawal date and public explanation if you have:</p>
+                <ul class=\"govuk-list govuk-list--bullet\">
+                  <li>updated file attachments to mark them ‘withdrawn’</li>
+                  <li>made a minor edit, for example fixing a broken link</li>
+                  <li>fixed an error or mistake in the content which existed when it was originally withdrawn</li>
+                </ul>
+              "),
+              items: items,
+              error_items: errors_for(@unpublishing.errors, :previous_withdrawal_id)
+            } %>
+          <% end %>
         <% else %>
           <%= withdrawal_public_explanation_field %>
         <% end %>
+
         <%= render "govuk_publishing_components/components/button", {
           text: "Withdraw",
           destructive: true,
@@ -124,26 +131,29 @@
       } do |form| %>
         <%= hidden_field_tag 'unpublishing[unpublishing_reason_id]', unpublish_reasons[:published_in_error][:id] %>
 
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Alternative URL",
-            bold: true,
-          },
-          name: "unpublishing[alternative_url]",
-          id: "published_in_error_alternative_url",
-          value: @unpublishing.alternative_url,
-          error_items: errors_for(@unpublishing.errors, :alternative_url)
-        } %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: "unpublishing[redirect]",
-          items: [
-            {
-              label: "Redirect to URL automatically?",
-              value: 1,
-              checked: @unpublishing.redirect,
-            }
-          ]
-        } %>
+        <%= field_container(id: "published_in_error_alternative_url") do %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Alternative URL",
+              bold: true,
+            },
+            name: "unpublishing[alternative_url]",
+            id: "published_in_error_alternative_url_field",
+            value: @unpublishing.alternative_url,
+            error_items: errors_for(@unpublishing.errors, :alternative_url)
+          } %>
+
+          <%= render "govuk_publishing_components/components/checkboxes", {
+            name: "unpublishing[redirect]",
+            items: [
+              {
+                label: "Redirect to URL automatically?",
+                value: 1,
+                checked: @unpublishing.redirect,
+              }
+            ]
+          } %>
+        <% end %>
 
         <%= render "components/govspeak-editor", {
           label: {
@@ -171,17 +181,19 @@
       } do |form| %>
         <%= hidden_field_tag 'unpublishing[unpublishing_reason_id]', unpublish_reasons[:consolidated][:id] %>
 
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Alternative URL",
-            bold: true,
-          },
-          id: "consolidated_alternative_url",
-          name: "unpublishing[alternative_url]",
-          hint: "This will be automatically redirected",
-          value: @unpublishing.alternative_url,
-          error_items: errors_for(@unpublishing.errors, :alternative_url)
-        } %>
+        <%= field_container(id: "consolidated_alternative_url") do %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Alternative URL",
+              bold: true,
+            },
+            id: "consolidated_alternative_url_field",
+            name: "unpublishing[alternative_url]",
+            hint: "This will be automatically redirected",
+            value: @unpublishing.alternative_url,
+            error_items: errors_for(@unpublishing.errors, :alternative_url)
+          } %>
+        <% end %>
 
         <%= render "govuk_publishing_components/components/button", {
           text: "Unpublish",

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -22,7 +22,7 @@ When(/^I unpublish the duplicate, marking it as consolidated into the other page
                    end
 
   within form_container do
-    fill_in "consolidated_alternative_url", with: Whitehall.url_maker.publication_url(@existing_edition.document)
+    fill_in using_design_system? ? "consolidated_alternative_url_field" : "Alternative URL", with: Whitehall.url_maker.publication_url(@existing_edition.document)
     click_button "Unpublish"
   end
 end


### PR DESCRIPTION
## Description

At the moment, errors in the error summary component link directly to the inout. This means the label and hint text are not visible on the screen and a user loses context.

Instead of linking directly to the input, we're going to wrap the input in a div with the current input id. We will then append the id of the input with '_field'.

This adds a helper which takes an id and a block. It creates a div with the id passed in and renders the block within it.

This is scoped to the 1.3. release. I'll pick this up with stuff on the edit edition page afterwards.

## Screenshot example - anchor point when you click the error summary

### Before 

<img width="630" alt="image" src="https://user-images.githubusercontent.com/42515961/199250820-2ff5dd50-6bb0-4095-911f-d7a6288dee09.png">


### After

<img width="717" alt="image" src="https://user-images.githubusercontent.com/42515961/199250641-0c96abcd-f356-455d-81c8-4000c673de2b.png">

## Trello card 



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
