### PR TITLE
Use govspeak-editor component for editing withdrawal message

### DIFF
--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -19,7 +19,7 @@
     <p class="govuk-body govuk-!-margin-bottom-6"><%= @unpublishing.unpublishing_reason.as_sentence.capitalize %></p>
 
     <%= form_for @unpublishing, url: admin_edition_unpublishing_path(@unpublishing.edition) do |f| %>
-      <%= render "govuk_publishing_components/components/textarea", {
+      <%= render "components/govspeak-editor", {
         label: {
           heading_size: "l",
           text: "Public explanation",


### PR DESCRIPTION
## Description

We've recently added a govspeak preview component, which allows users to toggle between a text area and what it would look like in govspeak. This was added to a bunch of pages but this one was missed

## Trello card 

https://trello.com/c/CV2Ixy2Q/846-fix-issues-on-edit-withdrawal-message-journey

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
