### PR TITLE
[848 ] Fixes for Govspeak help

### DIFF
--- a/app/assets/stylesheets/admin/components/_govspeak-help.scss
+++ b/app/assets/stylesheets/admin/components/_govspeak-help.scss
@@ -9,4 +9,5 @@
   word-break: normal;
   word-wrap: normal;
   overflow: auto;
+  white-space: pre-wrap;
 }

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -53,7 +53,7 @@
   <%= render "govuk_publishing_components/components/details", {
     title: "Headings"
   } do %>
-    <pre class="govspeak_help__pre">## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br />Don’t use a single # – this is H1 and is for the title only</pre>
+    <pre class="govspeak_help__pre">## Top level heading – H2<br />### Second level heading – H3<br />#### Third level heading – H4<br /><br />Don’t use a single # – this is H1 and is for the title only</pre>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
@@ -150,14 +150,14 @@
   } do %>
     <p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
     <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
-    <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br />*[TLA]: three-letter acronym</pre>
+    <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br /><br />*[TLA]: three-letter acronym</pre>
     <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
     title: "Blockquotes"
   } do %>
-    <pre class='govspeak_help__pre'>Introduction to the quote:<br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
+    <pre class='govspeak_help__pre'>Introduction to the quote:<br /><br />> First paragraph of the quote.<br />><br />> Second paragraph of the quote.</pre>
     <p class='govuk-body'>The > in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
   <% end %>
 
@@ -176,14 +176,14 @@
     <%= render "govuk_publishing_components/components/details", {
       title: "Footnotes"
     } do %>
-      <pre class='govspeak_help__pre'>Footnotes can be added[^1].< br/>[^1]: And then later defined.</pre>
+      <pre class='govspeak_help__pre'>Footnotes can be added[^1].<br /><br />[^1]: And then later defined.</pre>
       <p class='govuk-body'>
         You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
       </p>
       <p class='govuk-body'>
         Footnote content can hold more than one paragraph by indenting the content 4 spaces:
       </p>
-      <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br />    This paragraph is also indented, so will be considered part of the footnote content.</pre>
+      <pre class='govspeak_help__pre'>[^1]:<br />    This is some footnote content and is indented 4 spaces.<br /><br />   This paragraph is also indented, so will be considered part of the footnote content.</pre>
     <% end %>
   <% end %>
 

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -149,7 +149,7 @@
     title: "Abbreviations and acronyms"
   } do %>
     <p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
-    <p class='govuk-body'>Add the <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+    <p class='govuk-body'>Add the <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
     <pre class='govspeak_help__pre'>Example content that includes a three-letter acronym (TLA).<br /><br />*[TLA]: three-letter acronym</pre>
     <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>
   <% end %>
@@ -168,7 +168,7 @@
     <p class='govuk-body'>You can also embed contact information:</p>
     <pre class='govspeak_help__pre'>[Contact:<em>n</em>]</pre>
     <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
-    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
+    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path, class: "govuk-link" %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path, class: "govuk-link" %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
     <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
   <% end %>
 

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -172,6 +172,12 @@
     <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
   <% end %>
 
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Email links"
+  } do %>
+    <p class='govuk-body'>Use ‘less than’ (<em>&lt</em>) and ‘greater than’ (<em>&gt;</em>) arrows around email addresses to make them a link.<p></p>
+  <% end %>
+
   <% if show_footnote_help %>
     <%= render "govuk_publishing_components/components/details", {
       title: "Footnotes"

--- a/app/views/admin/editions/_style_guidance.html.erb
+++ b/app/views/admin/editions/_style_guidance.html.erb
@@ -1,6 +1,4 @@
-<h2 class="govuk-heading-l">Style</h2>
-
-<p class="govuk-body">For styles, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>
+<h3 class="govuk-heading-m">Use plain English</h3>
 
 <p class="govuk-body">For details, see the <%= link_to "guideline on using plain English", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english", class: "govuk-link" %>
 
@@ -51,3 +49,5 @@
     <li>ring fencing</li>
   </ul>
 <% end %>
+
+<p class="govuk-body">For styles, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>


### PR DESCRIPTION
## Description

There's some stuff that has come out of our 1.3 review that needed to be fixed on the govspeak help sidebar. They're outlined in point 10.1 - 10.4 of this document https://docs.google.com/document/d/1QBQl5s-576_HsfUfKCWDAvwETvqukrNZLY6a-KLJtGw/edit#heading=h.ugbkc5gjfg1w

## Changes

### Pre block wraps

#### Before

<img width="306" alt="image" src="https://user-images.githubusercontent.com/42515961/199448067-533587ff-b885-4654-9d41-544519dbce4e.png">


#### After

<img width="297" alt="image" src="https://user-images.githubusercontent.com/42515961/199447470-25d44b3f-c692-45bb-b993-797b3e7ac59c.png">


### Line breaks added 

#### Before

<img width="311" alt="image" src="https://user-images.githubusercontent.com/42515961/199448364-9a307422-f92d-4dd2-88f9-c283a3f59f42.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/42515961/199448553-976959cb-1ce0-44af-82f2-1481e1d7783f.png">

<img width="321" alt="image" src="https://user-images.githubusercontent.com/42515961/199448625-da5898b0-a497-4bd5-8857-ebb8d8dd9506.png">

<img width="371" alt="image" src="https://user-images.githubusercontent.com/42515961/199448706-bb5f3103-1780-4dfe-b982-4e1607245193.png">



#### After

<img width="395" alt="image" src="https://user-images.githubusercontent.com/42515961/199449497-5aa29df1-8d01-4f22-a410-fd8b20ad40c4.png">

<img width="307" alt="image" src="https://user-images.githubusercontent.com/42515961/199449536-39bc9fe9-5ff2-41b8-b4de-71b626876856.png">

<img width="321" alt="image" src="https://user-images.githubusercontent.com/42515961/199449568-c8d7dce9-0cce-4218-b61c-fa6b6a43e21f.png">

<img width="325" alt="image" src="https://user-images.githubusercontent.com/42515961/199449635-292882b4-80ef-467f-bffa-99f69131b0ff.png">



### Email links section added 

<img width="359" alt="image" src="https://user-images.githubusercontent.com/42515961/199449367-5045ea8d-cb57-41e6-ac21-349cade3671d.png">



### Revert style section

#### Before 

<img width="372" alt="image" src="https://user-images.githubusercontent.com/42515961/199448965-b1b56f6e-2626-4c0f-b76f-3d2ebfabadc4.png">


#### After 

<img width="394" alt="image" src="https://user-images.githubusercontent.com/42515961/199449335-c269f088-7b6c-427c-bc09-b33110326fe2.png">


## Trello card 

https://trello.com/c/86yTDh3A/848-fix-issues-with-govspeak-guidance-on-sidebar-for-release-13

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
