### PR TITLE
Fix error input not linking for attachment upload

### DIFF
--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -11,7 +11,9 @@
       heading_size: "l",
     },
     name: "attachment[attachment_data_attributes][file]",
-    hint: raw("You must upload attachments in an <a class='govuk-link' href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>.")
+    id: "attachment_attachment_data_file",
+    hint: raw("You must upload attachments in an <a class='govuk-link' href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>."),
+    error_items: errors_for(attachment_data_fields.object.errors, :file),
   } %>
 
   <% form.hidden_field :accessible, value: "0" %>


### PR DESCRIPTION
## Description 

At the moment, the file upload input on the attachment form has two issues

1. it doesn't have an id set so the error doesn't link from the error summary
2. the errors don't display above the input 

this fixes that

## Screenshot

<img width="689" alt="image" src="https://user-images.githubusercontent.com/42515961/199453535-6d9d8be7-d9e2-4ec5-a8de-d32417968d69.png">


## Trello card 

https://trello.com/c/KjdWREUw/843-fixes-for-attachments-prior-to-13-release

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
