### PR TITLE
Run feature tests against the Design System

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -1,22 +1,21 @@
-<%
-  options = [{text: "All languages", value: ""}]
-  options.concat(attachable.translated_locales.map do |locale|
-    {
-      text: native_language_name_for(locale),
-      value: locale
-    }
-  end)
-%>
-
 <% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
+  <%
+    locale_options = [{text: "All languages", value: ""}]
+    locale_options.concat(attachable.translated_locales.map do |locale|
+      {
+        text: native_language_name_for(locale),
+        value: locale
+      }
+    end)
+  %>
   <div class="govuk-!-margin-bottom-8">
     <%= render "govuk_publishing_components/components/select", {
-      id: "attachment_parliamentary_session",
+      id: "attachment_locale",
       label: "Display language",
       name: "attachment[locale]",
       heading_level: 2,
       heading_size: heading_size,
-      options: options,
+      options: locale_options,
       hint: "This determines the translations of the publication that the attachment will appear in."
     } %>
   </div>

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -5,5 +5,6 @@ rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} fe
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
 %>
 default: <%= std_opts %> features --publish-quiet
+preview_design_system: <%= std_opts %> CUCUMBER_PREVIEW_DESIGN_SYSTEM=true features --publish-quiet
 wip: --tags @wip:3 --wip features --publish-quiet
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip' --publish-quiet

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -1,3 +1,11 @@
+def manually_numbered_headings
+  if using_design_system?
+    "Use manually numbered headings"
+  else
+    "Manually numbered headings"
+  end
+end
+
 When(/^I visit the attachments page$/) do
   first(:link, "Attachments").click
 end
@@ -26,7 +34,7 @@ When(/^I upload an html attachment with the title "(.*?)" and the body "(.*?)"$/
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
   fill_in "Body", with: body
-  check @user.can_preview_design_system? ? "Use manually numbered headings" : "Manually numbered headings"
+  check manually_numbered_headings
   click_on "Save"
 end
 
@@ -99,7 +107,7 @@ When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)"$/
   fill_in "Title", with: title
   fill_in "ISBN", with: isbn
   fill_in "Body", with: "Body"
-  check "Manually numbered headings"
+  check manually_numbered_headings
   click_on "Save"
 end
 

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -7,15 +7,15 @@ When(/^I start editing a draft document$/) do
 end
 
 Then(/^I can tag it to some specialist sectors$/) do
-  primary_select = @user.can_preview_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
-  secondary_select = @user.can_preview_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
+  primary_select = using_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
+  secondary_select = using_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
 
   select "Oil and Gas: Wells", from: primary_select
   select "Oil and Gas: Offshore", from: secondary_select
   select "Oil and Gas: Fields", from: secondary_select
   select "Oil and Gas: Distillation (draft)", from: secondary_select
 
-  click_button @user.can_preview_design_system? ? "Update specialist topics" : "Save"
+  click_button using_design_system? ? "Update specialist topics" : "Save"
 
   expect(page).to have_selector(".flash.notice")
 

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -1,7 +1,7 @@
 module AdminLegacyAssociationsHelper
   def set_all_legacy_associations
     tag_specialist_sectors
-    click_button "Save"
+    click_button using_design_system? ? "Update specialist topics" : "Save"
   end
 
   def check_associations_have_been_saved
@@ -15,9 +15,12 @@ module AdminLegacyAssociationsHelper
 private
 
   def tag_specialist_sectors
-    select "Oil and Gas: Wells", from: "Primary specialist topic tag"
-    select "Oil and Gas: Fields", from: "Additional specialist topics"
-    select "Oil and Gas: Offshore", from: "Additional specialist topics"
+    primary_select = using_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
+    secondary_select = using_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
+
+    select "Oil and Gas: Wells", from: primary_select
+    select "Oil and Gas: Fields", from: secondary_select
+    select "Oil and Gas: Offshore", from: secondary_select
   end
 
   def check_specialist_sectors

--- a/features/support/preview_design_system.rb
+++ b/features/support/preview_design_system.rb
@@ -1,0 +1,6 @@
+if ENV["CUCUMBER_PREVIEW_DESIGN_SYSTEM"] == "true"
+  Before do
+    # Enable 'Preview next release' flag by stubbing the user permission
+    User.any_instance.stubs(:can_preview_next_release?).returns(true)
+  end
+end

--- a/features/support/preview_design_system.rb
+++ b/features/support/preview_design_system.rb
@@ -4,3 +4,14 @@ if ENV["CUCUMBER_PREVIEW_DESIGN_SYSTEM"] == "true"
     User.any_instance.stubs(:can_preview_next_release?).returns(true)
   end
 end
+
+module DesignSystemHelper
+  def using_design_system?
+    find("html", class: "govuk-template", wait: false)
+    true
+  rescue Capybara::ElementNotFound
+    false
+  end
+end
+
+World(DesignSystemHelper)

--- a/features/support/whitehall.rb
+++ b/features/support/whitehall.rb
@@ -1,14 +1,3 @@
 Before do
   AttachmentUploader.enable_processing = true
 end
-
-module WhitehallHelper
-  def using_design_system?
-    find("html", class: "govuk-template", wait: false)
-    true
-  rescue Capybara::ElementNotFound
-    false
-  end
-end
-
-World(WhitehallHelper)

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -6,10 +6,16 @@ unless Rails.env.production?
       t.fork = true # You may get faster startup if you set this to false
       t.profile = "default"
     end
+
+    Cucumber::Rake::Task.new({ preview_design_system: "test:prepare" }, "Run features with the 'Preview design system' feature flag enabled") do |t|
+      t.fork = true # You may get faster startup if you set this to false
+      t.profile = "preview_design_system"
+    end
   end
 
-  desc "Alias for cucumber:ok"
-  task cucumber: "cucumber:ok"
+  desc "Run all feature tests"
+  # preview_design_system comes first because it's more likely to break tests, so we'll get a faster feedback loop
+  task cucumber: ["cucumber:preview_design_system", "cucumber:ok"]
 
   task default: :cucumber
 end


### PR DESCRIPTION
This PR adapts the `rake cucumber` task to run the feature tests twice:

1. With the 'Preview next release' flag enabled
2. Without the flag enabled (i.e. a normal run, as before)

This will ensure we're keeping our feature tests up to date as we work on new Design System styled pages.

For now it only applies the 'Preview next release' flag. We're currently focussing on preparing the next release (Release 1.3) of the Whitehall Design System transition, so this is the quickest/simplest thing to do. Later we should open this up to use the broader 'Preview design system' flag, which will include all changes even if they're not lined up for the next release.

Trello: https://trello.com/c/PGu7wSXE/845-fix-failing-feature-tests-for-preview-design-system-flag

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
