### PR TITLE
Add task for re-indexing an organisation in search

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -4,6 +4,11 @@ namespace :search do
     Document.find_by(content_id: args[:content_id]).live_edition.update_in_search_index
   end
 
+  desc "resend an organisation to search. Do not use for e.g. reslugging where the existing entry needs to first be deleted from search"
+  task :resend_organisation, [:content_id] => [:environment] do |_, args|
+    Organisation.find_by(content_id: args[:content_id]).update_in_search_index
+  end
+
   desc "Re-index a collection of Documents with specified world location. Takes a `world_location_slug` as argument."
   task :resend_documents_in_world_location, [:world_location_slug] => [:environment] do |_, args|
     world_location = WorldLocation.find_by(slug: args[:world_location_slug])

--- a/test/unit/tasks/search_test.rb
+++ b/test/unit/tasks/search_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class SearchRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  let(:task) { Rake::Task["search:resend_organisation"] }
+
+  test "updates an organisation in search" do
+    organisation = create(:organisation)
+
+    Whitehall::SearchIndex.expects(:add).with(organisation)
+
+    task.invoke(organisation.content_id)
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
