### PR TITLE
Remove redundant user.can_preview_design_system? call

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -226,11 +226,8 @@ module Admin::EditionsHelper
       if edition.change_note_required?
         concat render("change_notes", form:, edition:)
       end
-      if current_user.can_preview_design_system?
-        concat render("save_or_continue_or_cancel", form:, edition:)
-      else
-        concat form.save_or_continue_or_cancel
-      end
+
+      concat render("save_or_continue_or_cancel", form:, edition:)
     end
   end
 


### PR DESCRIPTION
This method is only ever called when the design system should render and can be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
