### PR TITLE
Remove redundant feature tests

### DIFF
--- a/features/bulk-upload.feature
+++ b/features/bulk-upload.feature
@@ -4,26 +4,13 @@ Feature: Bulk uploading attachments to editions
   Background:
     Given I am a writer
 
-    Scenario: Uploading mulitple attachments from a zip file
-      Given a draft news article "Stubble to be Outlawed" exists
-      When I upload a zip file containing several attachments and give them titles
-      Then I should see that the news article has attachments
+  Scenario: Uploading mulitple attachments from a zip file
+    Given a draft news article "Stubble to be Outlawed" exists
+    When I upload a zip file containing several attachments and give them titles
+    Then I should see that the news article has attachments
 
-    Scenario: Replacing existing attachments with a zip file
-      Given a draft publication "Results of beards survey" with a file attachment exists
-      When I upload a zip file that contains a file "greenpaper.pdf"
-      Then the greenpaper.pdf attachment file should be replaced with the new file
-      And any other files should be added as new attachments
-
-    Scenario: Uploading mulitple attachments from a zip file with preview design system permission
-      Given a draft news article "Stubble to be Outlawed" exists
-      And I have the "Preview design system" permission
-      When I upload a zip file containing several attachments and give them titles
-      Then I should see that the news article has attachments
-
-    Scenario: Replacing existing attachments with a zip file with preview design system permission
-      Given a draft publication "Results of beards survey" with a file attachment exists
-      And I have the "Preview design system" permission
-      When I upload a zip file that contains a file "greenpaper.pdf"
-      Then the greenpaper.pdf attachment file should be replaced with the new file
-      And any other files should be added as new attachments
+  Scenario: Replacing existing attachments with a zip file
+    Given a draft publication "Results of beards survey" with a file attachment exists
+    When I upload a zip file that contains a file "greenpaper.pdf"
+    Then the greenpaper.pdf attachment file should be replaced with the new file
+    And any other files should be added as new attachments

--- a/features/destroy-draft.feature
+++ b/features/destroy-draft.feature
@@ -8,10 +8,3 @@ Feature: Discarding a draft of a document
     When I draft a new publication "My Publication"
     And I discard the draft publication
     Then the publication is deleted
-
-  Scenario: Unwithdrawing a withdrawn document with design system permission
-    Given I am a writer
-    And I have the "Preview design system" permission
-    When I draft a new publication "My Publication"
-    And I discard the draft publication
-    Then the publication is deleted

--- a/features/document-sources.feature
+++ b/features/document-sources.feature
@@ -10,18 +10,10 @@ Feature: Managing Document Sources
     When I visit the list of draft documents
     And I view the publication "One must have many urls"
     Then I should see the legacy url "http://im-old.com"
-     And I should see the legacy url "http://im-really-old.com"
+    And I should see the legacy url "http://im-really-old.com"
 
   Scenario: Creating a legacy URL
     Given a draft publication "One must have many urls" exists
-    When I add "http://im-old.com" as a legacy url to the "One must have many urls" publication
-    And I visit the list of draft documents
-    And I view the publication "One must have many urls"
-    Then I should see the legacy url "http://im-old.com"
-
-  Scenario: Creating a legacy URL with design system permission
-    Given a draft publication "One must have many urls" exists
-    And I have the "Preview design system" permission
     When I add "http://im-old.com" as a legacy url to the "One must have many urls" publication
     And I visit the list of draft documents
     And I view the publication "One must have many urls"
@@ -34,24 +26,8 @@ Feature: Managing Document Sources
     And I view the publication "One must have many urls"
     Then I should see the legacy url "http://im-really-old.com"
 
-  Scenario: Editing a legacy URL with design system permission
-    Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
-    And I have the "Preview design system" permission
-    When I change the legacy url "http://im-old.com" to "http://im-really-old.com" on the "One must have many urls" publication
-    And I visit the list of draft documents
-    And I view the publication "One must have many urls"
-    Then I should see the legacy url "http://im-really-old.com"
-
   Scenario: Removing a legacy URL
     Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
-    When I remove the legacy url "http://im-old.com" on the "One must have many urls" publication
-    And I visit the list of draft documents
-    And I view the publication "One must have many urls"
-    Then I should see that "http://im-old.com" has been removed
-
-  Scenario: Removing a legacy URL with design system permission
-    Given a draft publication "One must have many urls" with a legacy url "http://im-old.com"
-    And I have the "Preview design system" permission
     When I remove the legacy url "http://im-old.com" on the "One must have many urls" publication
     And I visit the list of draft documents
     And I view the publication "One must have many urls"

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -13,33 +13,12 @@ Feature: Managing attachments on editions
     And I add an external attachment with the title "Beard Length Illustrations" and the URL "http://www.beardlengths.gov.uk"
     Then the publication "Standard Beard Lengths" should have 3 attachments
     When I set the order of attachments to:
-      |         title                | order |
-      | Beard Length Graphs 2012     |   0   |
-      | Beard Length Statistics 2014 |   1   |
-      | Beard Length Illustrations   |   2   |
+      | title                        | order |
+      | Beard Length Graphs 2012     | 0     |
+      | Beard Length Statistics 2014 | 1     |
+      | Beard Length Illustrations   | 2     |
     Then the attachments should be in the following order:
-      |         title                |
-      | Beard Length Graphs 2012     |
-      | Beard Length Statistics 2014 |
-      | Beard Length Illustrations   |
-
-  Scenario: Adding and reordering attachments with design system permission
-    Given I am an writer
-    And I have the "Preview design system" permission
-    And I start drafting a new publication "Standard Beard Lengths"
-    When I start editing the attachments from the publication page
-    And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
-    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
-    And I add an external attachment with the title "Beard Length Illustrations" and the URL "http://www.beardlengths.gov.uk"
-    Then the publication "Standard Beard Lengths" should have 3 attachments
-    When I visit the reorder attachments page
-    And I set the order of attachments to:
-      |         title                | order |
-      | Beard Length Graphs 2012     |   0   |
-      | Beard Length Statistics 2014 |   1   |
-      | Beard Length Illustrations   |   2   |
-    Then the attachments should be in the following order:
-      |         title                |
+      | title                        |
       | Beard Length Graphs 2012     |
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |

--- a/features/edition-needs.feature
+++ b/features/edition-needs.feature
@@ -13,12 +13,3 @@ Feature: Managing needs on editions
     And I start editing the needs from the publication page
     And I choose the first need in the dropdown
     Then I should see the first need in the list of associated needs
-
-  Scenario: Adding and removing needs with design system permission
-    Given I have the "Preview design system" permission
-    And a submitted publication "Extended goatee for the modern man" with a PDF attachment
-    When I visit the list of documents awaiting review
-    And I view the publication "Extended goatee for the modern man"
-    And I start editing the needs from the publication page
-    And I choose the first need in the dropdown
-    Then I should see the first need in the list of associated needs

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -10,12 +10,3 @@ Feature: Tagging content with specialist sectors
     And I continue to the tagging page
     And I continue to the legacy tagging page
     Then I can tag it to some specialist sectors
-
-  Scenario: writer can tag documents with specialist sectors
-    Given I am a writer
-    And I have the "Preview design system" permission
-    And there are some specialist sectors
-    When I start editing a draft document
-    And I continue to the tagging page
-    And I continue to the legacy tagging page
-    Then I can tag it to some specialist sectors

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -10,11 +10,6 @@ When(/^I visit the attachments page$/) do
   first(:link, "Attachments").click
 end
 
-When(/^I visit the reorder attachments page$/) do
-  @edition = Edition.last
-  visit reorder_admin_edition_attachments_path(@edition)
-end
-
 When(/^the attachment has been uploaded to the asset-manager$/) do
   Attachment.last.attachment_data.uploaded_to_asset_manager!
 end

--- a/features/translated-content.feature
+++ b/features/translated-content.feature
@@ -14,13 +14,6 @@ Feature: Providing translated content from gov.uk/government
     When I add a french translation "Échange officier de l'armée" to the "Military officer exchange" document
     Then I should see on the admin edition page that "Military officer exchange" has a french translation "Échange officier de l'armée"
 
-  Scenario: Adding a translation to a draft translatable document with design system permission
-    Given I am a GDS editor
-    And I have drafted a translatable document "Military officer exchange"
-    And I have the "Preview design system" permission
-    When I add a french translation "Échange officier de l'armée" to the "Military officer exchange" document
-    Then I should see on the admin edition page that "Military officer exchange" has a french translation "Échange officier de l'armée"
-
   Scenario: Adding a translation for contact details
     Given I am a GDS editor
     And the organisation "Wales Office" is translated into Welsh and has a contact "Wales Office, Cardiff"

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -13,13 +13,6 @@ Feature: Unpublishing published documents
     Then there should be an editorial remark recording the fact that the document was unpublished
     And there should be an unpublishing explanation of "This page should never have existed" and a reason of "Published in error"
 
-  Scenario: Unpublishing a published document with design system permission
-    Given a published document "Published by accident" exists
-    And I have the "Preview design system" permission
-    When I unpublish the document because it was published in error
-    Then there should be an editorial remark recording the fact that the document was unpublished
-    And there should be an unpublishing explanation of "This page should never have existed" and a reason of "Published in error"
-
   Scenario: Draft resulting from an unpublishing should not be deletable
     Given a published document exists with a slug that does not match the title
     When I unpublish the document because it was published in error
@@ -35,21 +28,8 @@ Feature: Unpublishing published documents
     When I unpublish the duplicate, marking it as consolidated into the other page
     Then the unpublishing should redirect to the existing edition
 
-  Scenario: Consolidating a document into another GOV.UK page with design system permission
-    Given there is a published document that is a duplicate of another page
-    And I have the "Preview design system" permission
-    When I unpublish the duplicate, marking it as consolidated into the other page
-    Then the unpublishing should redirect to the existing edition
-
   Scenario: Withdraw a document that is no longer current
     Given a published publication "Shaving kits for all" exists
-    When I withdraw the publication with the explanation "Policy change"
-    Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
-    And the withdrawal date should be today
-
-  Scenario: Withdraw a document that is no longer current with design system permission
-    Given a published publication "Shaving kits for all" exists
-    And I have the "Preview design system" permission
     When I withdraw the publication with the explanation "Policy change"
     Then there should be an unpublishing explanation of "Policy change" and a reason of "No longer current government policy/activity"
     And the withdrawal date should be today
@@ -62,16 +42,6 @@ Feature: Unpublishing published documents
 
   Scenario: Withdraw a document using a previous withdrawal date & explanation
     Given a published publication "Free ice creams" exists
-    And the publication was withdrawn on 01/12/2020 with the explanation "It's too cold for ice cream"
-    And it was subsequently unwithdrawn
-    When I go to withdraw the publication again
-    And I choose to reuse the withdrawal from 01/12/2020
-    Then there should be an unpublishing explanation of "It's too cold for ice cream" and a reason of "No longer current government policy/activity"
-    And the withdrawal date should be 01/12/2020
-
-  Scenario: Withdraw a document using a previous withdrawal date & explanation with design system permission
-    Given a published publication "Free ice creams" exists
-    And I have the "Preview design system" permission
     And the publication was withdrawn on 01/12/2020 with the explanation "It's too cold for ice cream"
     And it was subsequently unwithdrawn
     When I go to withdraw the publication again

--- a/features/unwithdrawing-withdrawn-documents.feature
+++ b/features/unwithdrawing-withdrawn-documents.feature
@@ -9,11 +9,3 @@ Feature: Unpublishing published documents
     When I withdraw the publication with the explanation "Policy change"
     And I unwithdraw the publication
     Then I should be redirected to the latest edition of the publication
-
-  Scenario: Unwithdrawing a withdrawn document with design system permission
-    Given I am a managing editor
-    And I have the "Preview design system" permission
-    And a published publication "Shaving kits for all" exists
-    When I withdraw the publication with the explanation "Policy change"
-    And I unwithdraw the publication
-    Then I should be redirected to the latest edition of the publication

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -1,19 +1,19 @@
 Feature: Administering worldwide organisation
-  As a citizen interested in UK gov activity around the world, I want there to
-  be profiles of the world organisation (eg embassies, DFID offices, UKTI
-  branches) in each worldwide location, so I can see which organisation are
-  active in each location and read more about them.
+    As a citizen interested in UK gov activity around the world, I want there to
+    be profiles of the world organisation (eg embassies, DFID offices, UKTI
+    branches) in each worldwide location, so I can see which organisation are
+    active in each location and read more about them.
 
-  Acceptance criteria:
+    Acceptance criteria:
 
-  * Each world organisation has:
+    * Each world organisation has:
     * a unique name e.g. "British Embassy in Madrid" and a URL "/world/offices/british-embassy-in-madrid" which is generated from the name
     * multiple social media links (like orgs)
     * multiple sets of office information (like orgs)
-      * with the addition of a list of services (chosen from a set) that the office provides
+    * with the addition of a list of services (chosen from a set) that the office provides
     * a logo formatted name (always using the standard HMG crest for now)
-  * Each world organisation can be associated with 1+ world locations, and shows on the world locations page to which they are associated (see mock up on the [ticket](https://www.pivotaltracker.com/story/show/41026113))
-  * Each can have corporate information pages (like orgs)
+    * Each world organisation can be associated with 1+ world locations, and shows on the world locations page to which they are associated (see mock up on the [ticket](https://www.pivotaltracker.com/story/show/41026113))
+    * Each can have corporate information pages (like orgs)
 
   Background:
     Given I am a GDS editor
@@ -89,28 +89,20 @@ Feature: Administering worldwide organisation
   Scenario: Adding a new translation
     Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "Français"
     When I add a new translation to the worldwide organisation "Department of Beards in France" with:
-      | locale      | Français                                          |
-      | name        | Département des barbes en France                  |
+      | locale | Français                         |
+      | name   | Département des barbes en France |
     Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
-      | name        | Département des barbes en France                  |
+      | name | Département des barbes en France |
 
   Scenario: Editing an existing translation
     Given a worldwide organisation "Department of Beards in France" exists with a translation for the locale "Français"
     When I edit the "Français" translation for the worldwide organisation "Department of Beards in France" setting:
-      | name        | Le super département des barbes en France         |
+      | name | Le super département des barbes en France |
     Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
-      | name        | Le super département des barbes en France         |
+      | name | Le super département des barbes en France |
 
   Scenario: Translating a corporate information page for a worldwide organisation
     Given a worldwide organisation "Department of Beards in France"
-    And I add a "Terms of reference" corporate information page to the worldwide organisation
-    When I translate the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
-    And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
-    Then I should be able to read the translated "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France" on the site
-
-  Scenario: Translating a corporate information page for a worldwide organisation with design system permission
-    Given a worldwide organisation "Department of Beards in France"
-    And I have the "Preview design system" permission
     And I add a "Terms of reference" corporate information page to the worldwide organisation
     When I translate the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"


### PR DESCRIPTION
Following on from PR #7001, we can now remove these feature tests since they're now redundant. This functionality will be covered by the existing feature tests that these duplicated, now that the Cucumber tests run against the Design System too.

Trello: https://trello.com/c/PGu7wSXE/845-fix-failing-feature-tests-for-preview-design-system-flag

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
