### PR TITLE
Follow up 1.3.fixes

### DIFF
--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -65,9 +65,8 @@ class BulkUpload
   end
 
   def attachments_must_be_valid
-    unless attachments.all? { |a| a.valid?(context: :user_input) }
-      errors.add(:base, message: "Please enter missing fields for each attachment")
-    end
+    invalid_attachments = attachments.reject { |a| a.valid?(context: :user_input) }
+    errors.add(:base, message: "Please enter missing fields for each attachment") if invalid_attachments.present?
   end
 
 private

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -8,7 +8,6 @@
     value: form.object.hoc_paper_number,
     error_items: errors_for(attachment.errors, :unnumbered_hoc_paper),
     heading_size: heading_size,
-    hint: "Fill in the command and House of Commons boxes to publish an official document which will appear in the list of official documents."
   }) %>
 
   <%= form.hidden_field :unnumbered_hoc_paper, value: "0" %>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -26,7 +26,8 @@
               margin_top: 10,
               heading_level: 2,
               heading_size: "m",
-              value: attachment_fields.object.title
+              value: attachment_fields.object.title,
+              error_message: errors_for_input(attachment.errors, :title)
             } %>
 
             <% if @edition.allows_attachment_references? %>

--- a/app/views/admin/editions/_style_guidance.html.erb
+++ b/app/views/admin/editions/_style_guidance.html.erb
@@ -50,4 +50,6 @@
   </ul>
 <% end %>
 
-<p class="govuk-body">For styles, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>
+<h3 class="govuk-heading-m">Style</h3>
+
+<p class="govuk-body">For style, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>


### PR DESCRIPTION
## Description

There were a few issues with the amends that were previously made in response to this document https://docs.google.com/document/d/1QBQl5s-576_HsfUfKCWDAvwETvqukrNZLY6a-KLJtGw/edit#

## Changes 

## Remove redundant hint text from house of commons number

### Before

<img width="656" alt="image" src="https://user-images.githubusercontent.com/42515961/199548819-f2528a90-0c68-4370-ac5d-02f2d0ee7c92.png">

### After

<img width="650" alt="image" src="https://user-images.githubusercontent.com/42515961/199548683-ab042c88-7f47-49ff-aef5-0962fbf7002f.png">

## Bulk upload show errors on title input

### Before 

<img width="781" alt="image" src="https://user-images.githubusercontent.com/42515961/199550098-1a804fed-90ab-4741-9c89-5e84b9442ee2.png">

### After 

<img width="525" alt="image" src="https://user-images.githubusercontent.com/42515961/199550168-a5aa57c5-79ad-43a0-9fd9-832328b36bc5.png">


## Govspeak style guidance

### Before

<img width="406" alt="image" src="https://user-images.githubusercontent.com/42515961/199552705-5d0c0575-1b97-4505-8081-b1b8a5f5e742.png">


### After 

<img width="322" alt="image" src="https://user-images.githubusercontent.com/42515961/199550291-4b09efc6-36d0-4d67-8563-4d6326398ca0.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
