### PR TITLE
Fix unpublish page issues

### DIFF
--- a/app/assets/javascripts/admin/modules/unpublish-display-conditions.js
+++ b/app/assets/javascripts/admin/modules/unpublish-display-conditions.js
@@ -25,7 +25,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     checkbox.addEventListener('change', function (e) {
       var display = e.currentTarget.checked ? 'none' : 'block'
-      this.module.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display = display
+      this.module.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display = display
     }.bind(this))
 
     if (checkbox.checked) {

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -113,7 +113,11 @@ class Admin::EditionWorkflowController < Admin::BaseController
       redirect_to admin_edition_path(@edition), notice: message
     else
       @unpublishing = @edition.unpublishing || @edition.build_unpublishing(unpublishing_params)
-      flash.now[:alert] = message unless preview_design_system?(next_release: true)
+      if preview_design_system?(next_release: true) && @unpublishing.errors.blank?
+        flash.now[:alert] = message
+      elsif !preview_design_system?
+        flash.now[:alert] = message
+      end
       render_design_system("confirm_unpublish", "confirm_unpublish_legacy", next_release: true)
     end
   end

--- a/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
+++ b/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
@@ -37,9 +37,8 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
               <label for="checkboxes-cb24c6f1-0" class="govuk-label govuk-checkboxes__label">Redirect to URL automatically?</label>
             </div>
           </div>
-          <div class="gem-c-textarea govuk-form-group govuk-!-margin-bottom-6">
-            <label for="published_in_error_explanation" class="gem-c-label govuk-label govuk-label--s">Public explanation</label>
-            <textarea name="unpublishing[explanation]" class="govuk-textarea" id="published_in_error_explanation" rows="5"></textarea>
+          <div class="app-c-govspeak-editor govuk-form-group">
+            This is the public explanation section
           </div>
         </div>
         <div class="unpublish-withdraw-form-wrapper js-unpublish-withdraw-form__consolidated">
@@ -108,7 +107,7 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
   })
 
   it('should hide public explanation section when "Redirect to URL automatically?" is pre-checked', function () {
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('none')
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
   })
 
   it('should show/hide public explanation section when "Redirect to URL automatically?" is unchecked/checked', function () {
@@ -116,11 +115,11 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     checkbox.checked = false
     checkbox.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('block')
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('block')
 
     checkbox.checked = true
     checkbox.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.gem-c-textarea').style.display).toEqual('none')
+    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
   })
 })


### PR DESCRIPTION
[Trello card link](https://trello.com/c/zAbTrr7C/847-fix-issues-on-unpublish-withdraw-journey)

# What

This commit fixes two issues on the Withdraw/Unpublish page:

1. Checking "Redirect to URL automatically?" now hides the entire public explanation section, rather than just the text input field
2. Top level errors are now handled by being displayed in a flash message, previously they were not displayed. 
**Note:** The behaviour mimics that of the Bootstrap system, in that if both top level errors and form input errors are present, only top level errors will be displayed (in the form of a flash message). Once top level errors are no longer present, form input errors will render.

# Why

This replicates the Bootstrap behaviour when transitioning to the Design System.

# Screenshots
## Show/hide public explanation
### Before
![image](https://user-images.githubusercontent.com/94846816/199556088-9f9c75cb-42bf-494f-ab5a-8ab2741a2728.png)

### After
![image](https://user-images.githubusercontent.com/94846816/199555711-163c01ae-9380-4e2a-8345-3f472b48af0f.png)

## Error handling
### Before
![image](https://user-images.githubusercontent.com/94846816/199556290-c349163b-72e9-468a-8bf2-15d60b72e519.png)


### After
![image](https://user-images.githubusercontent.com/94846816/199555483-bcdd7e2a-5950-4bf0-82e1-c4723f53e7d9.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
