### PR TITLE
Resend child and parent organisations of a reslugged org to search

### DIFF
--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -19,6 +19,7 @@ module DataHygiene
     def run!
       remove_from_search_index
       update_slug
+      update_child_and_parent_organisations_in_search if organisation.is_a? Organisation
       update_users if organisation.is_a? Organisation
       update_editions if organisation.is_a?(Organisation) || organisation.is_a?(WorldwideOrganisation)
     end
@@ -35,6 +36,15 @@ module DataHygiene
       # NOTE: This will trigger calls to both rummager and the Publishing API,
       # meaning that entries in both places will exist with the correct slug
       organisation.update!(slug: new_slug)
+    end
+
+    def update_child_and_parent_organisations_in_search
+      organisation.child_organisations.each do |child_org|
+        Whitehall::SearchIndex.add(child_org)
+      end
+      organisation.parent_organisations.each do |parent_org|
+        Whitehall::SearchIndex.add(parent_org)
+      end
     end
 
     def update_users

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -84,6 +84,20 @@ module OrganisationResluggerTest
       Whitehall::SearchIndex.expects(:add).with edition
       @reslugger.run!
     end
+
+    test "when an organisation has child and parent organisations, it also resends these to search api" do
+      child_organisation = create(:organisation, name: "child slug")
+      parent_organisation = create(:organisation, name: "parent slug")
+      organisation = create(:organisation, name: "ye olde slug", child_organisations: [child_organisation], parent_organisations: [parent_organisation])
+      reslugger = DataHygiene::OrganisationReslugger.new(organisation, "corrected-slug")
+
+      Whitehall::SearchIndex.expects(:delete).with(organisation)
+      Whitehall::SearchIndex.expects(:add).with { |org| org.slug == "corrected-slug" }
+      Whitehall::SearchIndex.expects(:add).with(child_organisation)
+      Whitehall::SearchIndex.expects(:add).with(parent_organisation)
+
+      reslugger.run!
+    end
   end
 
   class WorldwideOrganisationTest < ActiveSupport::TestCase


### PR DESCRIPTION
Since the search data for an organisation contains slugs for parent and child organisations, when an organisation is reslugged, its child and parent organisation entries in search can be out of sync, as they will contain the old slug for the reslugged organisation. This has caused issues for us since the organisations api uses search data, and so when this is out of sync it can cause problems in other parts of our stack.

The particular issue we saw recently was that the job to load config for transition was failing. This is because it depends on the data from the organisations api, and traverses parent organisations for each organisation from this data. Hence when a parent organisation referenced a slug that was no longer in use, the job failed.

[Trello](https://trello.com/c/ogzjwuCa/358-fix-transition-load-site-config-job)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
