### PR TITLE
Replace custom error summary with component

### DIFF
--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -3,28 +3,17 @@
 <% verb = verb || "save" %>
 
 <% if object.errors.present? %>
-  <div class="gem-c-error-summary govuk-error-summary" data-module="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" id="error-summary" data-govuk-error-summary-module-started="true">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
-      To <%= verb %> the <%= class_name %> please fix the following issues:
-    </h2>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "To #{verb} the #{class_name} please fix the following issues:",
+    items: object.errors.map do |error|
+      analytics_action = "#{class_name}-error"
+      error_message = error.full_message
 
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <% object.errors.map do |error| %>
-          <% analytics_action = "#{class_name}-error" %>
-          <% error_message = error.full_message %>
-
-          <%= tag.li(
-            tag.a(
-              error_message,
-              href: "##{input_class_name}_#{error.attribute.to_s.gsub(".", "_")}",
-              class: "govuk-link"
-            ),
-            data: track_analytics_data("form-error", analytics_action, error_message),
-            class: "gem-c-error-summary__list-item"
-          ) %>
-        <% end %>
-      </ul>
-    </div>
-  </div>
+      {
+        text: error_message,
+        href: "##{input_class_name}_#{error.attribute.to_s.gsub(".", "_")}",
+        data_attributes: track_analytics_data("form-error", analytics_action, error_message)
+      }
+    end
+  } %>
 <% end %>


### PR DESCRIPTION
This will fix issues where clicking on the links would take users to the input rather than the label.

This also simplifies the code so we do not need to maintain more custom code.

## Before

<img width="663" alt="Screenshot 2022-11-03 at 10 32 38 am" src="https://user-images.githubusercontent.com/4599889/199699256-ec1802ce-4c7e-45f7-9c61-e660613930ad.png">

## After

<img width="695" alt="Screenshot 2022-11-03 at 10 32 17 am" src="https://user-images.githubusercontent.com/4599889/199699282-7ab40f3e-e4cd-47db-966f-448d1513ae0a.png">

### Proof that analytics is still working

<img width="1791" alt="Screenshot 2022-11-03 at 10 32 03 am" src="https://user-images.githubusercontent.com/4599889/199699356-a6acc7d6-3380-40f0-9e5b-2a26b8cfda37.png">

<img width="589" alt="Screenshot 2022-11-03 at 10 35 05 am" src="https://user-images.githubusercontent.com/4599889/199699561-5af6087e-1078-49f0-88d1-7d26a34a72f9.png">

https://trello.com/c/KjdWREUw/843-fixes-for-attachments-prior-to-13-release

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
