### PR TITLE
Add tracking to specialist topic tagging page

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -23,7 +23,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     new window.accessibleAutocomplete.enhanceSelectElement({ // eslint-disable-line no-new, new-cap
       selectElement: $select,
       minLength: 3,
-      showNoOptionsFound: true
+      showNoOptionsFound: true,
+      onConfirm: function (value) {
+        var category = $select.getAttribute('data-track-category')
+        var label = $select.getAttribute('data-track-label')
+        var action = value
+        if (category && label) {
+          window.GOVUK.analytics.trackEvent(category, action, { label: label })
+        }
+      }
     })
   }
 

--- a/app/views/admin/base/_specialist_sector_fields.html.erb
+++ b/app/views/admin/base/_specialist_sector_fields.html.erb
@@ -13,6 +13,8 @@
     options: [""] + specialist_sector_options_for_select,
     selected: @edition.primary_specialist_sector_tag,
   },
+  track_category: "taxonSelectionPrimarySpecialist",
+  track_label: request.path
 } %>
 
 <%= render "components/autocomplete", {
@@ -27,4 +29,6 @@
     multiple: true,
     selected: @edition.secondary_specialist_sector_tags,
   },
+  track_category: "taxonSelectionAdditionalSpecialist",
+  track_label: request.path
 } %>

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -13,6 +13,11 @@
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {
           text: "Update specialist topics",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "publication-button"
+          }
         } %>
 
         <%= link_to("Cancel", @path, class: "govuk-link") %>

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -7,6 +7,8 @@
   width ||= nil
   aria = error_id if error_items.any?
   data_attributes ||= {}
+  track_category ||= nil
+  track_label ||= nil
   select ||= {}
   input ||= {}
   search ||= false
@@ -44,7 +46,8 @@
       id: id,
       class: "govuk-select",
       size: select[:size],
-      multiple: select[:multiple]
+      multiple: select[:multiple],
+      data: { track_category:, track_label: }
     %>
   <% else %>
     <% options = Array(input[:options]) %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds tracking functionality to the autocomplete using the `onConfirm` callback.
[Uses this functionality to add missing tracking to the specialist topic tagging page.](https://trello.com/c/plXuFwJo/850-add-tracking-to-specialist-topic-tagging-page)

## Why
The current select2 component uses the [`TrackSelectClick` module](https://github.com/alphagov/whitehall/blob/main/app/assets/javascripts/admin_legacy/modules/track_select_click.js) to for GA tracking, this functionality does not work for the accessible autocomplete.
The accessible autocomplete [suggests instead using the `onConfirm` callback](https://github.com/kevindew/accessible-autocomplete#analytics-and-tracking) to perform tracking.