### PR TITLE
Adds tracking to success alerts

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -23,9 +23,11 @@
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank?%>" id="main-content" role="main">
       <% if flash["notice"].present? %>
-        <%= render "govuk_publishing_components/components/success_alert", {
-          message: flash["notice"]
-        } %>
+        <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-success" data-track-label="<%= flash["notice"] %>">
+          <%= render "govuk_publishing_components/components/success_alert", {
+            message: flash["notice"]
+          } %>
+        </div>
       <% end %>
 
       <% if flash["alert"].present? %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/WmZKUNkr/854-add-tracking-to-html-attachment-page)

This work adds one instance of missing tracking data that was identified on the HTML Attachments page. This referred to tracking attached to the flash message that appears when the user has successfully saved an attachment. 

This is a generic component, not confined to this page, so the update has been made at that level. The component used to display the message is the [Success alert](https://components.publishing.service.gov.uk/component-guide/success_alert) component. This has no available tracking or data properties so the data has been added to an element that wraps the component. This feels a little bit unsatisfactory but I can't see a better way to achieve what is required. 

There are no layout/content/design changes.

