### PR TITLE
Remove locked column from documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,8 +46,6 @@ class Document < ApplicationRecord
 
   after_create :ensure_document_has_a_slug
 
-  self.ignored_columns = %w[locked]
-
   attr_accessor :sluggable_string
 
   def self.live

--- a/db/migrate/20221104091720_drop_locked_column_from_documents.rb
+++ b/db/migrate/20221104091720_drop_locked_column_from_documents.rb
@@ -1,0 +1,5 @@
+class DropLockedColumnFromDocuments < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :documents, :locked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_144551) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_091720) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -201,7 +201,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_16_144551) do
     t.string "slug"
     t.string "document_type"
     t.string "content_id", null: false
-    t.boolean "locked", default: false, null: false
     t.integer "latest_edition_id"
     t.integer "live_edition_id"
     t.index ["document_type"], name: "index_documents_on_document_type"


### PR DESCRIPTION
This is a draft which builds from: https://github.com/alphagov/whitehall/pull/7016. Once that is merged and deployed safely (i.e. we're confident we don't have to rollback) we can merge this in to complete the cleanup.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
