### PR TITLE
Adds `event-label` to save button for attachments

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -83,7 +83,8 @@
       data_attributes: {
         module: "gem-track-click",
         "track-category": "form-button",
-        "track-action": "#{attachment.readable_type}-attachment-button"
+        "track-action": "#{attachment.readable_type}-attachment-button",
+        "track-label": "Save"
       }
     } %>
 


### PR DESCRIPTION
Trello Card: [854 | Add tracking to HTML Attachment page](https://trello.com/c/WmZKUNkr/854-add-tracking-to-html-attachment-page)

This change adds the expected value for the `Event Label` parameter for the "Save" button on the attachment pages.