### PR TITLE
Add search to 'Topic taxonomy tags' (Autocomplete + Miller Columns component)

### DIFF
--- a/app/assets/javascripts/components/miller-columns.js
+++ b/app/assets/javascripts/components/miller-columns.js
@@ -1,1 +1,88 @@
 //= require miller-columns-element
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function MillerColumns (module) {
+    this.module = module
+    this.searchable = module.getAttribute('data-searchable') === 'true'
+  }
+
+  MillerColumns.prototype.init = function () {
+    if (this.searchable) this.initSearch()
+  }
+
+  MillerColumns.prototype.initSearch = function () {
+    var element = this.module.querySelector('#js-app-c-miller-columns__search')
+    var input = this.module.querySelector('#js-app-c-miller-columns__search-input')
+    var millerColumns = this.module.querySelector('miller-columns')
+
+    if (!window.accessibleAutocomplete) {
+      element.parentNode.removeChild(element)
+      return
+    }
+
+    var topics = millerColumns.taxonomy.flattenedTopics
+    var topicSuggestions = []
+
+    topics.forEach(function (topic) {
+      topicSuggestions.push({
+        topic: topic,
+        highlightedTopicName: topic.topicName.replace(/<\/?mark>/gm, ''), // strip existing <mark> tags
+        breadcrumbs: topic.topicNames
+      })
+    })
+
+    if (!topicSuggestions.length) {
+      element.parentNode.removeChild(element)
+      return
+    }
+
+    new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
+      id: input.id,
+      name: input.name,
+      element: element,
+      minLength: 3,
+      autoselect: false,
+      source: function (query, syncResults) {
+        var results = topicSuggestions
+        var resultMatcher = function (result) {
+          var topicName = result.topic.topicName
+          var indexOf = topicName.toLowerCase().indexOf(query.toLowerCase())
+          var resultContainsQuery = indexOf !== -1
+          if (resultContainsQuery) {
+            // Wrap query in <mark> tags
+            var queryRegex = new RegExp('(' + query + ')', 'ig')
+            result.highlightedTopicName = topicName.replace(queryRegex, '<mark>$1</mark>')
+          }
+          return resultContainsQuery
+        }
+
+        syncResults(query ? results.filter(resultMatcher) : [])
+      },
+      templates: {
+        inputValue: function (result) {
+          return ''
+        },
+        suggestion: function (result) {
+          var suggestionsBreadcrumbs
+          if (result && result.breadcrumbs) {
+            result.breadcrumbs[result.breadcrumbs.length - 1] = result.highlightedTopicName
+            suggestionsBreadcrumbs = result.breadcrumbs.join(' › ')
+          }
+          return suggestionsBreadcrumbs
+        }
+      },
+      onConfirm: function (result) {
+        if (result && !result.topic.selected && !result.topic.selectedChildren.length) {
+          millerColumns.taxonomy.topicClicked(result.topic)
+        }
+      }
+    })
+
+    element.classList.add('app-c-autocomplete--search')
+    input.parentNode.removeChild(input)
+  }
+
+  Modules.MillerColumns = MillerColumns
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,20 @@
 @import "./admin/views/whats-new";
 @import "./admin/views/edit-edition";
 
+.app-js-only {
+  display: none;
+}
+
+.js-enabled {
+  .app-no-js {
+    display: none;
+  }
+
+  .app-js-only {
+    display: block;
+  }
+}
+
 .legacy-whitehall {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 

--- a/app/assets/stylesheets/components/_miller-columns.scss
+++ b/app/assets/stylesheets/components/_miller-columns.scss
@@ -1,1 +1,5 @@
 @import "miller-columns-element/dist/miller-columns";
+
+.app-c-miller-columns__search {
+  margin-bottom: govuk-spacing(6);
+}

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -32,6 +32,7 @@
       <% if @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons).count() %>
         <%= render partial: "/components/miller-columns", locals: {
           id: "taxonomy_tag_form[taxons]",
+          searchable: true,
           items: @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons),
         } %>
       <% else %>

--- a/app/views/components/_miller-columns-list.html.erb
+++ b/app/views/components/_miller-columns-list.html.erb
@@ -1,19 +1,21 @@
 <ul id="<%= id %>-list" class="govuk-list">
   <% items.each_with_index do | item, index | %>
     <li>
-      <input class="govuk-checkboxes__input" type="checkbox" name="<%= name %>" value="<%= item[:value] %>" id="<%= id %>-<%= index %>"
-        <% if item[:checked].present? && item[:checked] %> checked <% end %>
-      >
-      <label class="govuk-label govuk-checkboxes__label" for="<%= id %>-<%= index %>">
-        <%= item[:label] %>
-      </label>
-      <% if item[:items].present? %>
-        <%= render "components/miller-columns-list", {
-          id: "#{id}-#{index}",
-          name: "#{name}",
-          items: item[:items],
-         } %>
-      <% end %>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" type="checkbox" name="<%= name %>" value="<%= item[:value] %>" id="<%= id %>-<%= index %>"
+          <% if item[:checked].present? && item[:checked] %> checked <% end %>
+        >
+        <label class="govuk-label govuk-checkboxes__label" for="<%= id %>-<%= index %>">
+          <%= item[:label] %>
+        </label>
+        <% if item[:items].present? %>
+          <%= render "components/miller-columns-list", {
+            id: "#{id}-#{index}",
+            name: "#{name}",
+            items: item[:items],
+          } %>
+        <% end %>
+      </div>
     </li>
   <% end %>
 </ul>

--- a/app/views/components/_miller-columns.html.erb
+++ b/app/views/components/_miller-columns.html.erb
@@ -12,7 +12,7 @@
   <miller-columns-selected id="selected-items" for="<%= id %>" class="miller-columns-selected"></miller-columns-selected>
 
   <% if searchable %>
-    <div id="js-app-c-miller-columns__search" class="app-c-miller-columns__search">
+    <div id="js-app-c-miller-columns__search" class="app-c-miller-columns__search app-js-only">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Search for topic"

--- a/app/views/components/_miller-columns.html.erb
+++ b/app/views/components/_miller-columns.html.erb
@@ -1,14 +1,27 @@
 <%
   id ||= "miller-columns-#{SecureRandom.hex(4)}"
   items ||= []
+  searchable ||= false
 %>
 
-<div class="app-c-miller-columns">
+<div class="app-c-miller-columns" data-module="miller-columns" data-searchable="<%= searchable %>">
   <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">
     Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.
   </p>
 
   <miller-columns-selected id="selected-items" for="<%= id %>" class="miller-columns-selected"></miller-columns-selected>
+
+  <% if searchable %>
+    <div id="js-app-c-miller-columns__search" class="app-c-miller-columns__search">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Search for topic"
+        },
+        id: "js-app-c-miller-columns__search-input",
+        name: "app-c-miller-columns__search-input"
+      } %>
+    </div>
+  <% end %>
 
   <miller-columns class="miller-columns" for="<%= id %>-list" selected="selected-items" id="<%= id %>" aria-describedby="navigation-instructions">
     <%= render "components/miller-columns-list", {

--- a/app/views/components/docs/miller-columns.yml
+++ b/app/views/components/docs/miller-columns.yml
@@ -43,3 +43,17 @@ examples:
               items:
                 - label: Childcare vouchers
                   value: childcare-vouchers
+  with_search:
+    data:
+      searchable: true
+      items:
+        - label: Parenting, childcare and children's services
+          value: parenting-childcare-and-children-s-services
+          items:
+            - label: Divorce, separation and legal issues
+              value: divorce-separation-and-legal-issues
+            - label: Childcare and early years
+              value: childcare-and-early-years
+              items:
+                - label: Childcare vouchers
+                  value: childcare-vouchers


### PR DESCRIPTION
## What

Add search/filtering functionality to the 'Topic taxonomy tags' page. This will involve integrating the Autocomplete and Miller Columns components so they work together.

This functionality already exists in Content Publisher, so we should be able to port it across relatively easily*.

*Kevin has created a proof of concept branch here, but its lacking tests: [https://github.com/alphagov/whitehall/compare/search-on-taxonomy](https://github.com/alphagov/whitehall/compare/search-on-taxonomy "‌")

## Why

User feedback tells us this is needed – [https://gds.slack.com/archives/C03R56148PR/p1666710324163929](https://gds.slack.com/archives/C03R56148PR/p1666710324163929 "‌")

[https://govuk.zendesk.com/agent/#/tickets/5102286](https://govuk.zendesk.com/agent/#/tickets/5102286 "‌")


https://trello.com/c/evNn3X8N/856-add-search-to-topic-taxonomy-tags-autocomplete-miller-columns-component

## Before

![Screenshot 2022-11-04 at 2 55 56 pm](https://user-images.githubusercontent.com/4599889/200006379-eef5eb57-8163-4926-b5a7-7ca3b98f77f3.png)

## After

![Screenshot 2022-11-04 at 2 55 33 pm](https://user-images.githubusercontent.com/4599889/200006420-159fd563-b871-42d8-8bc8-f1361a48df9b.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
