### PR TITLE
Present additional links for International Delegation pages

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -42,6 +42,16 @@ class WorldLocationNews < ApplicationRecord
     Whitehall.url_maker.world_location_news_index_path(world_location)
   end
 
+  def contacts
+    return [] unless world_location.international_delegation?
+
+    world_location
+      .worldwide_organisations
+      .filter_map(&:main_office)
+      .map(&:contact)
+      .flatten
+  end
+
   def organisations
     return [] unless world_location.international_delegation?
 

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -61,6 +61,13 @@ class WorldLocationNews < ApplicationRecord
       .flatten
   end
 
+  def worldwide_organisations
+    return [] unless world_location.international_delegation?
+
+    world_location
+      .worldwide_organisations
+  end
+
   extend FriendlyId
   friendly_id
 end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -42,6 +42,15 @@ class WorldLocationNews < ApplicationRecord
     Whitehall.url_maker.world_location_news_index_path(world_location)
   end
 
+  def organisations
+    return [] unless world_location.international_delegation?
+
+    world_location
+      .worldwide_organisations
+      .map(&:sponsoring_organisations)
+      .flatten
+  end
+
   extend FriendlyId
   friendly_id
 end

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -38,7 +38,9 @@ module PublishingApi
     end
 
     def links
-      {}
+      {
+        organisations: world_location_news.organisations.map(&:content_id),
+      }
     end
 
   private

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -41,6 +41,7 @@ module PublishingApi
       {
         ordered_contacts: world_location_news.contacts.map(&:content_id),
         organisations: world_location_news.organisations.map(&:content_id),
+        worldwide_organisations: world_location_news.worldwide_organisations.map(&:content_id),
       }
     end
 

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -39,6 +39,7 @@ module PublishingApi
 
     def links
       {
+        ordered_contacts: world_location_news.contacts.map(&:content_id),
         organisations: world_location_news.organisations.map(&:content_id),
       }
     end

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -101,4 +101,22 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
       assert_equal "/world/aardistan/news.fr", base_path
     end
   end
+
+  test "it does not include links to sponsoring organisations for world locations" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, :with_worldwide_organisations, world_location_news:)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal [], presented_links[:organisations]
+  end
+
+  test "it includes a link to sponsoring organisations for international delegation" do
+    world_location_news = build(:world_location_news)
+    create(:international_delegation, :with_worldwide_organisations, world_location_news:)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal world_location_news.world_location.worldwide_organisations.map(&:sponsoring_organisations).flatten.pluck(:content_id), presented_links[:organisations]
+  end
 end

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -102,6 +102,34 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  test "it does not include contact details for world locations" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, :with_worldwide_organisations, world_location_news:)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal [], presented_links[:ordered_contacts]
+  end
+
+  test "it does not include contact details for international delegation where location has no main office" do
+    world_location_news = build(:world_location_news)
+    create(:international_delegation, :with_worldwide_organisations, world_location_news:)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal [], presented_links[:ordered_contacts]
+  end
+
+  test "it includes contact details for international delegation" do
+    world_location_news = build(:world_location_news)
+    world_location = create(:international_delegation, :with_worldwide_organisations, world_location_news:)
+    create(:worldwide_office, worldwide_organisation: world_location.worldwide_organisations.first)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal world_location_news.world_location.worldwide_organisations.map(&:main_office).map(&:contact).flatten.pluck(:content_id), presented_links[:ordered_contacts]
+  end
+
   test "it does not include links to sponsoring organisations for world locations" do
     world_location_news = build(:world_location_news)
     create(:world_location, :with_worldwide_organisations, world_location_news:)

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -147,4 +147,23 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
 
     assert_equal world_location_news.world_location.worldwide_organisations.map(&:sponsoring_organisations).flatten.pluck(:content_id), presented_links[:organisations]
   end
+
+  test "it does not include links to worldwide organisations for world locations" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, :with_worldwide_organisations, world_location_news:)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal [], presented_links[:worldwide_organisations]
+  end
+
+  test "it includes a link to worldwide organisations for international delegation" do
+    world_location_news = build(:world_location_news)
+    world_location = create(:international_delegation, :with_worldwide_organisations, world_location_news:)
+    create(:about_corporate_information_page, organisation: nil, worldwide_organisation: world_location.worldwide_organisations.first)
+
+    presented_links = present(world_location_news).links
+
+    assert_equal world_location.worldwide_organisations.map(&:content_id), presented_links[:worldwide_organisations]
+  end
 end


### PR DESCRIPTION
This adds additional information into the content item for World Location News pages that allows us to present the following links on International Delegation pages (and therefore remove their rendering from Whitehall):
- sponsoring organisations (including information about their crest and colour scheme)
- contact details for the associated Worldwide Office(s)
- the Worldwide Organisation(s), to give us the description which is included alongside a link to the organisation itself

This change is dependent on https://github.com/alphagov/publishing-api/pull/2185, otherwise we will not have the 'description' field present on the about page link.

<details>
<summary>Example JSON for links</summary>

```json
"links": {
  "ordered_contacts": [{
    "content_id": "bbb22ee2-c571-4f87-8ad2-f3305cdda7bf",
    "title": "UKDel NATO",
    "locale": "en",
    "document_type": "contact",
    "public_updated_at": "2020-09-10T13:12:56Z",
    "schema_name": "contact",
    "withdrawn": false,
    "details": {
      "description": null,
      "title": "UKDel NATO",
      "contact_form_links": null,
      "post_addresses": [{
        "locality": "Brussels",
        "postal_code": "1110",
        "street_address": "Boulevard Leopold III",
        "world_location": "Belgium",
        "iso2_country_code": "be"
      }],
      "email_addresses": [{
        "email": "UKDEL.NATOGeneralEnquiries@fcdo.gov.uk"
      }],
      "phone_numbers": [{
          "title": "Telephone",
          "number": "+32 2 707 7501"
        },
        {
          "title": "Fax",
          "number": "+32 2 707 7596"
        }
      ]
    },
    "links": {}
  }],
  "organisations": [{
      "content_id": "d994e55c-48c9-4795-b872-58d8ec98af12",
      "title": "Ministry of Defence",
      "locale": "en",
      "analytics_identifier": "D17",
      "api_path": "/api/content/government/organisations/ministry-of-defence",
      "base_path": "/government/organisations/ministry-of-defence",
      "document_type": "organisation",
      "schema_name": "organisation",
      "withdrawn": false,
      "details": {
        "logo": {
          "crest": "mod",
          "formatted_title": "Ministry<br/>of Defence"
        },
        "brand": "ministry-of-defence",
        "default_news_image": {
          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/569/s300_ministry-of-defence-building.jpg",
          "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/569/s960_ministry-of-defence-building.jpg"
        },
        "organisation_govuk_status": {
          "url": null,
          "status": "live",
          "updated_at": null
        }
      },
      "links": {},
      "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/ministry-of-defence",
      "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/ministry-of-defence"
    },
    {
      "content_id": "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
      "title": "Foreign, Commonwealth & Development Office",
      "locale": "en",
      "analytics_identifier": "D1315",
      "api_path": "/api/content/government/organisations/foreign-commonwealth-development-office",
      "base_path": "/government/organisations/foreign-commonwealth-development-office",
      "document_type": "organisation",
      "schema_name": "organisation",
      "withdrawn": false,
      "details": {
        "logo": {
          "crest": "single-identity",
          "formatted_title": "Foreign, Commonwealth<br/>&amp; Development Office"
        },
        "brand": "foreign-commonwealth-development-office",
        "default_news_image": {
          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s300_fcdo-main-building.jpg",
          "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s960_fcdo-main-building.jpg"
        },
        "organisation_govuk_status": {
          "url": null,
          "status": "live",
          "updated_at": null
        }
      },
      "links": {},
      "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/organisations/foreign-commonwealth-development-office",
      "web_url": "https://www.integration.publishing.service.gov.uk/government/organisations/foreign-commonwealth-development-office"
    }
  ],
  "worldwide_organisation_about_pages": [{
    "content_id": "5f5bfa0f-7631-11e4-a3cb-005056011aef",
    "title": "About us",
    "locale": "en",
    "api_path": "/api/content/world/organisations/uk-joint-delegation-to-nato/about/about",
    "base_path": "/world/organisations/uk-joint-delegation-to-nato/about/about",
    "document_type": "about",
    "public_updated_at": "2016-05-26T13:29:44Z",
    "schema_name": "placeholder_corporate_information_page",
    "withdrawn": false,
    "description": "The United Kingdom’s Joint Delegation to NATO is the vital link between the UK government and the North Atlantic Treaty Organisation. Its principal roles are to promote British interests in NATO and to keep UK ministers and government departments informed about NATO discussions.  ",
    "links": {},
    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/world/organisations/uk-joint-delegation-to-nato/about/about",
    "web_url": "https://www.integration.publishing.service.gov.uk/world/organisations/uk-joint-delegation-to-nato/about/about"
  }],
  "available_translations": [{
    "title": "UK and NATO",
    "public_updated_at": "2022-11-07T12:08:59Z",
    "analytics_identifier": "WL149",
    "document_type": "world_location_news",
    "schema_name": "world_location_news",
    "base_path": "/world/uk-joint-delegation-to-nato/news",
    "api_path": "/api/content/world/uk-joint-delegation-to-nato/news",
    "withdrawn": false,
    "content_id": "30be2e13-6db3-487b-b97f-910feeb5e6a1",
    "locale": "en",
    "api_url": "https://www.integration.publishing.service.gov.uk/api/content/world/uk-joint-delegation-to-nato/news",
    "web_url": "https://www.integration.publishing.service.gov.uk/world/uk-joint-delegation-to-nato/news",
    "links": {}
  }]
},
```

</details>

[Trello card](https://trello.com/c/4FWd2mRD/363-add-international-delegation-page-content-to-their-content-item)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
