### PR TITLE
Fix specialist topic tagging in design system pages

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -24,13 +24,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       selectElement: $select,
       minLength: 3,
       showNoOptionsFound: true,
-      onConfirm: function (value) {
+      onConfirm: function (query) {
         var category = $select.getAttribute('data-track-category')
         var label = $select.getAttribute('data-track-label')
-        var action = value
+        var action = query
         if (category && label) {
           window.GOVUK.analytics.trackEvent(category, action, { label: label })
         }
+
+        const options = $select.options
+        let matchingOption
+        if (query) {
+          matchingOption = [].filter.call(options, option => (option.textContent || option.innerText) === query)[0]
+        } else {
+          matchingOption = [].filter.call(options, option => option.value === '')[0]
+        }
+        if (matchingOption) { matchingOption.selected = true }
       }
     })
   }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Copy the code to select the relevant option from the [accessible autocomplete `onConfirm` function](https://github.com/kevindew/accessible-autocomplete/blob/master/src/wrapper.js#L42) to our custom `onConfirm` function introduced for tracking.

## Why
These lines are required for the select to function property and were previously overwritten by the custom `onConfirm` function to tracking. This is a [known issue with the accessible autocomplete](https://github.com/alphagov/accessible-autocomplete/issues/322).
We cannot use the [`track-select-change`](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics/track-select-change.js) module as the accessible autocomplete does not trigger `changed` events when marking options as selected.
The loss in functionality that resulted from the tracking implementation was not detected in tests as the test [interacts directly with the select](https://github.com/alphagov/whitehall/blob/main/features/step_definitions/specialist_sector_steps.rb#L10).