### PR TITLE
Run feature tests with the 'Preview design system' flag

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -3,8 +3,11 @@ rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun = rerun.strip.gsub /\s/, ' '
 rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
+
+default_tags = "--tags 'not @design-system-only'"
+design_system_tags = "--tags 'not (@design-system-wip or @bootstrap-only)'"
 %>
-default: <%= std_opts %> features --publish-quiet
-preview_design_system: <%= std_opts %> CUCUMBER_PREVIEW_DESIGN_SYSTEM=true features --publish-quiet
+default: <%= std_opts %> <%= default_tags %> features --publish-quiet
+preview_design_system: <%= std_opts %> <%= design_system_tags %> CUCUMBER_PREVIEW_DESIGN_SYSTEM=true features --publish-quiet
 wip: --tags @wip:3 --wip features --publish-quiet
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip' --publish-quiet

--- a/features/admin-audit-trail.feature
+++ b/features/admin-audit-trail.feature
@@ -3,7 +3,7 @@ Feature: Audit trail information on a document
   Background:
     Given I am a GDS editor
 
-  @javascript
+  @javascript @design-system-wip
   Scenario: Audit trail is paginated
     Given a document that has gone through many changes
     When I visit the document to see the audit trail

--- a/features/admin-broken-link-reporting.feature
+++ b/features/admin-broken-link-reporting.feature
@@ -9,7 +9,7 @@ Feature: Checking a document for broken links
     When I check the document for broken links
     Then I should see a list of the broken links
 
-  @javascript
+  @javascript @design-system-wip
   Scenario: correcting broken links on a document
     Given I am a writer
     And a draft document with broken links exists

--- a/features/admin-editorial-remarks.feature
+++ b/features/admin-editorial-remarks.feature
@@ -1,8 +1,8 @@
 Feature: Creating and viewing editorial remarks
 
-Background:
-  Given I am a writer
+  Background:
+    Given I am a writer
 
-Scenario: Adding an editorial remark
-  When I add an editorial remark "Try using a spellchecker" to the document "Badddly Rittin"
-  Then my editorial remark should be visible with the document
+  Scenario: Adding an editorial remark
+    When I add an editorial remark "Try using a spellchecker" to the document "Badddly Rittin"
+    Then my editorial remark should be visible with the document

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -1,54 +1,54 @@
 Feature: Filtering documents by author in admin
 
-Scenario: Viewing only documents written by me
-  Given I am a writer
-  And I draft a new publication "My Publication"
-  And a draft publication "Another Publication" exists
-  And I visit the list of draft documents
+  Scenario: Viewing only documents written by me
+    Given I am a writer
+    And I draft a new publication "My Publication"
+    And a draft publication "Another Publication" exists
+    And I visit the list of draft documents
 
-  When I filter by author "Me"
-  Then I should see the publication "My Publication"
-  And I should not see the publication "Another Publication"
+    When I filter by author "Me"
+    Then I should see the publication "My Publication"
+    And I should not see the publication "Another Publication"
 
-@design-system-wip
-Scenario: Viewing only publications written by me
-  Given I am a writer
-  And there is a user called "Janice"
-  And "Janice" drafts a new publication "Janice's Publication"
-  And I draft a new "English" language consultation "My Consultation"
-  And I visit the list of draft documents
+  @design-system-wip
+  Scenario: Viewing only publications written by me
+    Given I am a writer
+    And there is a user called "Janice"
+    And "Janice" drafts a new publication "Janice's Publication"
+    And I draft a new "English" language consultation "My Consultation"
+    And I visit the list of draft documents
 
-  When I filter by author "Janice"
-  And I select the "Publications" edition filter
-  Then I should see the publication "Janice's Publication"
-  And I should not see the consultation "My Consultation"
+    When I filter by author "Janice"
+    And I select the "Publications" edition filter
+    Then I should see the publication "Janice's Publication"
+    And I should not see the consultation "My Consultation"
 
-Scenario: Viewing only documents related to my department
-  Given two organisations "Department of Thumbtacks" and "Ministry of Post-it Notes" exist
-  And I am a writer in the organisation "Department of Thumbtacks"
-  And a draft publication "Thumbtack Publication" was produced by the "Department of Thumbtacks" organisation
-  And a draft publication "Another Publication" was produced by the "Ministry of Post-it Notes" organisation
-  And I visit the list of draft documents
+  Scenario: Viewing only documents related to my department
+    Given two organisations "Department of Thumbtacks" and "Ministry of Post-it Notes" exist
+    And I am a writer in the organisation "Department of Thumbtacks"
+    And a draft publication "Thumbtack Publication" was produced by the "Department of Thumbtacks" organisation
+    And a draft publication "Another Publication" was produced by the "Ministry of Post-it Notes" organisation
+    And I visit the list of draft documents
 
-  When I filter by organisation "Department of Thumbtacks"
-  Then I should see the publication "Thumbtack Publication"
-  And I should not see the publication "Another Publication"
+    When I filter by organisation "Department of Thumbtacks"
+    Then I should see the publication "Thumbtack Publication"
+    And I should not see the publication "Another Publication"
 
-@javascript
-Scenario: Using the document filter with javascript enabled
-  Given two organisations "Department of Thumbtacks" and "Ministry of Post-it Notes" exist
-  And I am a writer in the organisation "Department of Thumbtacks"
-  And a draft publication "Thumbtack Publication" was produced by the "Department of Thumbtacks" organisation
-  And a draft publication "The nocturnal habits of bluetack and why it is evil" was produced by the "Department of Thumbtacks" organisation
-  And a draft publication "Another Publication" was produced by the "Ministry of Post-it Notes" organisation
-  And I visit the list of draft documents
+  @javascript
+  Scenario: Using the document filter with javascript enabled
+    Given two organisations "Department of Thumbtacks" and "Ministry of Post-it Notes" exist
+    And I am a writer in the organisation "Department of Thumbtacks"
+    And a draft publication "Thumbtack Publication" was produced by the "Department of Thumbtacks" organisation
+    And a draft publication "The nocturnal habits of bluetack and why it is evil" was produced by the "Department of Thumbtacks" organisation
+    And a draft publication "Another Publication" was produced by the "Ministry of Post-it Notes" organisation
+    And I visit the list of draft documents
 
-  When I filter by organisation "Department of Thumbtacks" with javascript enabled
-  Then I should see the publication "Thumbtack Publication"
-  And I should see the publication "The nocturnal habits of bluetack and why it is evil"
-  And I should not see the publication "Another Publication"
+    When I filter by organisation "Department of Thumbtacks" with javascript enabled
+    Then I should see the publication "Thumbtack Publication"
+    And I should see the publication "The nocturnal habits of bluetack and why it is evil"
+    And I should not see the publication "Another Publication"
 
-  When I filter by title or slug "Thumbtack" with javascript enabled
-  Then I should see the publication "Thumbtack Publication"
-  And I should not see the publication "The nocturnal habits of bluetack and why it is evil"
-  And I should not see the publication "Another Publication"
+    When I filter by title or slug "Thumbtack" with javascript enabled
+    Then I should see the publication "Thumbtack Publication"
+    And I should not see the publication "The nocturnal habits of bluetack and why it is evil"
+    And I should not see the publication "Another Publication"

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -10,6 +10,7 @@ Scenario: Viewing only documents written by me
   Then I should see the publication "My Publication"
   And I should not see the publication "Another Publication"
 
+@design-system-wip
 Scenario: Viewing only publications written by me
   Given I am a writer
   And there is a user called "Janice"

--- a/features/admin-highlight-words-to-avoid.feature
+++ b/features/admin-highlight-words-to-avoid.feature
@@ -3,9 +3,9 @@ Feature: Highlighting words to avoid
   This feature only exists in the Bootstrap (legacy) admin interface.
   It is not being transitioned over to the Design System layout.
 
-@javascript
-Scenario: Should see the count of words to avoid (3 used: foster, facilitate, progress)
-  Given I am a writer
-  And a draft news article "Q2 Plan" with summary "Foster growth and facilitate progress" exists
-  When I am on the edit page for news article "Q2 Plan"
-  Then I should see the text "3 highlighted word(s) appear on the words to avoid list: Foster facilitate progress"
+  @javascript
+  Scenario: Should see the count of words to avoid (3 used: foster, facilitate, progress)
+    Given I am a writer
+    And a draft news article "Q2 Plan" with summary "Foster growth and facilitate progress" exists
+    When I am on the edit page for news article "Q2 Plan"
+    Then I should see the text "3 highlighted word(s) appear on the words to avoid list: Foster facilitate progress"

--- a/features/admin-highlight-words-to-avoid.feature
+++ b/features/admin-highlight-words-to-avoid.feature
@@ -1,4 +1,7 @@
+@bootstrap-only
 Feature: Highlighting words to avoid
+  This feature only exists in the Bootstrap (legacy) admin interface.
+  It is not being transitioned over to the Design System layout.
 
 @javascript
 Scenario: Should see the count of words to avoid (3 used: foster, facilitate, progress)

--- a/features/admin-statistical-data-sets.feature
+++ b/features/admin-statistical-data-sets.feature
@@ -3,6 +3,7 @@ Feature: Adding stastical data set references to a publication
   In order to reference relevant stastics
   I want to be able to add those references to a publication
 
+@design-system-wip
 Scenario: Creating a new draft publication that references statistical data sets
     Given I am an editor
     And a published statistical data set "Historical Beard Lengths"

--- a/features/admin-statistical-data-sets.feature
+++ b/features/admin-statistical-data-sets.feature
@@ -3,8 +3,8 @@ Feature: Adding stastical data set references to a publication
   In order to reference relevant stastics
   I want to be able to add those references to a publication
 
-@design-system-wip
-Scenario: Creating a new draft publication that references statistical data sets
+  @design-system-wip
+  Scenario: Creating a new draft publication that references statistical data sets
     Given I am an editor
     And a published statistical data set "Historical Beard Lengths"
     When I draft a new publication "Beard Lengths 2012" referencing the data set "Historical Beard Lengths"

--- a/features/admin-users.feature
+++ b/features/admin-users.feature
@@ -7,27 +7,27 @@ Feature: User administration
   - Only GDS editors can change users' organisations
   - GDS editors are able to see a list of users to allow them to easily operate on their records
 
-Scenario: Logged in writers should see their role
-  Given I am a writer
-  Then I should see that I am logged in as a "Writer"
+  Scenario: Logged in writers should see their role
+    Given I am a writer
+    Then I should see that I am logged in as a "Writer"
 
-Scenario: Logged in editors should see their role
-  Given I am an editor
-  Then I should see that I am logged in as a "Departmental Editor"
+  Scenario: Logged in editors should see their role
+    Given I am an editor
+    Then I should see that I am logged in as a "Departmental Editor"
 
-Scenario: Logged in GDS editors should see their role
-  Given I am a GDS editor
-  Then I should see that I am logged in as a "GDS Editor"
+  Scenario: Logged in GDS editors should see their role
+    Given I am a GDS editor
+    Then I should see that I am logged in as a "GDS Editor"
 
-Scenario: Logged in users should be able to view but not edit their record
-  Given I am a writer called "John Smith"
-  And the organisation "Department of Beards" exists
-  When I view my own user record
-  Then I can see my user details
-  But I cannot change my user details
+  Scenario: Logged in users should be able to view but not edit their record
+    Given I am a writer called "John Smith"
+    And the organisation "Department of Beards" exists
+    When I view my own user record
+    Then I can see my user details
+    But I cannot change my user details
 
-Scenario: Logged in users should be able to see other users' contact details
-  Given I am a writer
-  And there is a user called "John Smith" with email address "johnsmith@example.com"
-  When I visit the admin author page for "John Smith"
-  Then I should see an email address "johnsmith@example.com"
+  Scenario: Logged in users should be able to see other users' contact details
+    Given I am a writer
+    And there is a user called "John Smith" with email address "johnsmith@example.com"
+    When I visit the admin author page for "John Smith"
+    Then I should see an email address "johnsmith@example.com"

--- a/features/admin-world-locations.feature
+++ b/features/admin-world-locations.feature
@@ -3,9 +3,9 @@ Feature: Tagging world locations to publications
   In order to show which location a publication is about
   I want to be able to tag world locations to publications
 
-@design-system-wip
-Scenario: The publication is about a country
-  Given I am an editor
-  And a world location "British Antarctic Territory" exists
-  When I draft a new publication "Penguins have rights too" about the world location "British Antarctic Territory"
-  Then the publication should be about the "British Antarctic Territory" world location
+  @design-system-wip
+  Scenario: The publication is about a country
+    Given I am an editor
+    And a world location "British Antarctic Territory" exists
+    When I draft a new publication "Penguins have rights too" about the world location "British Antarctic Territory"
+    Then the publication should be about the "British Antarctic Territory" world location

--- a/features/admin-world-locations.feature
+++ b/features/admin-world-locations.feature
@@ -3,6 +3,7 @@ Feature: Tagging world locations to publications
   In order to show which location a publication is about
   I want to be able to tag world locations to publications
 
+@design-system-wip
 Scenario: The publication is about a country
   Given I am an editor
   And a world location "British Antarctic Territory" exists

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -1,66 +1,66 @@
 Feature: Consultations
 
-@design-system-wip
-Scenario: Creating a new draft consultation
-  Given I am a writer
-  When I draft a new "English" language consultation "Beard Length Review"
-  Then I should see the consultation "Beard Length Review" in the list of draft documents
+  @design-system-wip
+  Scenario: Creating a new draft consultation
+    Given I am a writer
+    When I draft a new "English" language consultation "Beard Length Review"
+    Then I should see the consultation "Beard Length Review" in the list of draft documents
 
-Scenario: Submitting a draft consultation to a second pair of eyes
-  Given I am a writer
-  And a draft consultation "Beard Length Review" exists
-  When I submit the consultation "Beard Length Review"
-  Then I should see the consultation "Beard Length Review" in the list of submitted documents
+  Scenario: Submitting a draft consultation to a second pair of eyes
+    Given I am a writer
+    And a draft consultation "Beard Length Review" exists
+    When I submit the consultation "Beard Length Review"
+    Then I should see the consultation "Beard Length Review" in the list of submitted documents
 
-@not-quite-as-fake-search
-Scenario: Publishing a submitted consultation
-  Given I am an editor
-  And a submitted consultation "Beard Length Review" exists
-  When I check "Beard Length Review" adheres to the consultation principles
-  And I publish the consultation "Beard Length Review"
-  Then I should see the consultation "Beard Length Review" in the list of published documents
+  @not-quite-as-fake-search
+  Scenario: Publishing a submitted consultation
+    Given I am an editor
+    And a submitted consultation "Beard Length Review" exists
+    When I check "Beard Length Review" adheres to the consultation principles
+    And I publish the consultation "Beard Length Review"
+    Then I should see the consultation "Beard Length Review" in the list of published documents
 
-@disable-sidekiq-test-mode @design-system-wip
-Scenario: Adding an outcome to a closed consultation
-  Given I am an editor
-  And a closed consultation exists
-  When I add an outcome to the consultation
-  And I save and publish the amended consultation
-  Then I can see that the consultation has been published
+  @disable-sidekiq-test-mode @design-system-wip
+  Scenario: Adding an outcome to a closed consultation
+    Given I am an editor
+    And a closed consultation exists
+    When I add an outcome to the consultation
+    And I save and publish the amended consultation
+    Then I can see that the consultation has been published
 
-@disable-sidekiq-test-mode @design-system-wip
-Scenario: Adding public feedback to a closed consultation
-  Given I am an editor
-  And a closed consultation exists
-  When I add public feedback to the consultation
-  And I save and publish the amended consultation
-  Then I can see that the consultation has been published
+  @disable-sidekiq-test-mode @design-system-wip
+  Scenario: Adding public feedback to a closed consultation
+    Given I am an editor
+    And a closed consultation exists
+    When I add public feedback to the consultation
+    And I save and publish the amended consultation
+    Then I can see that the consultation has been published
 
-@javascript
-Scenario: Associating an offsite consultation with topical events
-  Given I am an editor
-  And a draft consultation "Beard Length Review" exists
-  When I am on the edit page for consultation "Beard Length Review"
-  And I mark the consultation as offsite
-  Then the consultation can be associated with topical events
+  @javascript
+  Scenario: Associating an offsite consultation with topical events
+    Given I am an editor
+    And a draft consultation "Beard Length Review" exists
+    When I am on the edit page for consultation "Beard Length Review"
+    And I mark the consultation as offsite
+    Then the consultation can be associated with topical events
 
-@javascript @design-system-wip
-Scenario: Creating a new draft consultation in another language
-  Given I am a writer
-  When I draft a new "Cymraeg" language consultation "Beard Length Review"
-  Then I can see the primary locale for consultation "Beard Length Review" is "cy"
+  @javascript @design-system-wip
+  Scenario: Creating a new draft consultation in another language
+    Given I am a writer
+    When I draft a new "Cymraeg" language consultation "Beard Length Review"
+    Then I can see the primary locale for consultation "Beard Length Review" is "cy"
 
-Scenario: Adding and reordering a responses attachments
-  Given I am an writer
-  And a closed consultation exists
-  When I add an outcome to the consultation
-  And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
-  Then the consultation response should have 2 attachments
-  When I set the order of attachments to:
-    | title                        | order |
-    | Beard Length Graphs 2012     | 0     |
-    | Outcome attachment title   | 1     |
-  Then the attachments should be in the following order:
-    | title                        |
-    | Beard Length Graphs 2012     |
-    | Outcome attachment title   |
+  Scenario: Adding and reordering a responses attachments
+    Given I am an writer
+    And a closed consultation exists
+    When I add an outcome to the consultation
+    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
+    Then the consultation response should have 2 attachments
+    When I set the order of attachments to:
+      | title                        | order |
+      | Beard Length Graphs 2012     | 0     |
+      | Outcome attachment title   | 1     |
+    Then the attachments should be in the following order:
+      | title                        |
+      | Beard Length Graphs 2012     |
+      | Outcome attachment title   |

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -1,5 +1,6 @@
 Feature: Consultations
 
+@design-system-wip
 Scenario: Creating a new draft consultation
   Given I am a writer
   When I draft a new "English" language consultation "Beard Length Review"
@@ -19,7 +20,7 @@ Scenario: Publishing a submitted consultation
   And I publish the consultation "Beard Length Review"
   Then I should see the consultation "Beard Length Review" in the list of published documents
 
-@disable-sidekiq-test-mode
+@disable-sidekiq-test-mode @design-system-wip
 Scenario: Adding an outcome to a closed consultation
   Given I am an editor
   And a closed consultation exists
@@ -27,7 +28,7 @@ Scenario: Adding an outcome to a closed consultation
   And I save and publish the amended consultation
   Then I can see that the consultation has been published
 
-@disable-sidekiq-test-mode
+@disable-sidekiq-test-mode @design-system-wip
 Scenario: Adding public feedback to a closed consultation
   Given I am an editor
   And a closed consultation exists
@@ -43,7 +44,7 @@ Scenario: Associating an offsite consultation with topical events
   And I mark the consultation as offsite
   Then the consultation can be associated with topical events
 
-@javascript
+@javascript @design-system-wip
 Scenario: Creating a new draft consultation in another language
   Given I am a writer
   When I draft a new "Cymraeg" language consultation "Beard Length Review"

--- a/features/detailed-guides.feature
+++ b/features/detailed-guides.feature
@@ -5,7 +5,7 @@ Scenario: Creating a new draft detailed guide
   When I draft a new detailed guide "The finer points of moustache trimming"
   Then I should see the detailed guide "The finer points of moustache trimming" in the list of draft documents
 
-@javascript
+@javascript @design-system-wip
 Scenario: Adding multiple images
   Given I am a writer in the organisation "Department of Examples"
   Given I start drafting a new detailed guide

--- a/features/detailed-guides.feature
+++ b/features/detailed-guides.feature
@@ -1,25 +1,25 @@
 Feature: Detailed guides
 
-Scenario: Creating a new draft detailed guide
-  Given I am a writer in the organisation "Department of Examples"
-  When I draft a new detailed guide "The finer points of moustache trimming"
-  Then I should see the detailed guide "The finer points of moustache trimming" in the list of draft documents
+  Scenario: Creating a new draft detailed guide
+    Given I am a writer in the organisation "Department of Examples"
+    When I draft a new detailed guide "The finer points of moustache trimming"
+    Then I should see the detailed guide "The finer points of moustache trimming" in the list of draft documents
 
-@javascript @design-system-wip
-Scenario: Adding multiple images
-  Given I am a writer in the organisation "Department of Examples"
-  Given I start drafting a new detailed guide
-  When I select an image for the detailed guide
-  Then I should be able to select another image for the detailed guide
+  @javascript @design-system-wip
+  Scenario: Adding multiple images
+    Given I am a writer in the organisation "Department of Examples"
+    Given I start drafting a new detailed guide
+    When I select an image for the detailed guide
+    Then I should be able to select another image for the detailed guide
 
-Scenario: Publishing a submitted detailed guide
-  Given I am an editor in the organisation "Department of Examples"
-  And a submitted detailed guide "Finer points of moustache trimming" exists
-  When I publish the detailed guide "Finer points of moustache trimming"
-  Then I should see the detailed guide "Finer points of moustache trimming" in the list of published documents
+  Scenario: Publishing a submitted detailed guide
+    Given I am an editor in the organisation "Department of Examples"
+    And a submitted detailed guide "Finer points of moustache trimming" exists
+    When I publish the detailed guide "Finer points of moustache trimming"
+    Then I should see the detailed guide "Finer points of moustache trimming" in the list of published documents
 
-Scenario: Viewing detailed guide publishing history
-  Given I am an editor in the organisation "Department of Examples"
-  Given a published detailed guide "Ban Beards" exists
-  When I publish a new edition of the detailed guide "Ban Beards" with a change note "Exempted Santa Claus"
-  And I publish a new edition of the detailed guide "Ban Beards" with a change note "Exempted Gimli son of Gloin"
+  Scenario: Viewing detailed guide publishing history
+    Given I am an editor in the organisation "Department of Examples"
+    Given a published detailed guide "Ban Beards" exists
+    When I publish a new edition of the detailed guide "Ban Beards" with a change note "Exempted Santa Claus"
+    And I publish a new edition of the detailed guide "Ban Beards" with a change note "Exempted Gimli son of Gloin"

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -1,3 +1,4 @@
+@design-system-wip
 Feature: Grouping documents into a collection
   As an organisation,
   I want to present regularly published documents as collection

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -4,6 +4,7 @@ Feature: Managing attachments on editions
   I want to attach files and additional HTML content to publications and consultations
   In order to support the publications and consultations with statistics and other relevant documents
 
+  @design-system-wip
   Scenario: Adding and reordering attachments
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
@@ -23,6 +24,7 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
+  @design-system-wip
   Scenario: Previewing HTML attachment
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
@@ -44,6 +46,7 @@ Feature: Managing attachments on editions
     When I try and upload an attachment but there are validation errors
     Then I should be able to submit the attachment without re-uploading the file
 
+  @design-system-wip
   Scenario: Attempting to publish attachment which is still being uploaded to the asset manager
     Given I am an editor
     And a published publication "Standard Beard Lengths" with a PDF attachment

--- a/features/executive-office-promotional-features.feature
+++ b/features/executive-office-promotional-features.feature
@@ -4,26 +4,26 @@ Feature: Promotional features for executive offices
     Given I am an admin
     And the executive office organisation "Number 32 - The Cheese Office" exists
 
-    Scenario: Add a promotional feature to an executive office
-      When I add a new promotional feature with a single item
-      Then I should see the promotional feature on the organisation's page
+  Scenario: Add a promotional feature to an executive office
+    When I add a new promotional feature with a single item
+    Then I should see the promotional feature on the organisation's page
 
-    Scenario: Deleting a promotional feature
-      And the executive office has a promotional feature with an item
-      When I delete the promotional feature
-      Then I should no longer see the promotional feature
+  Scenario: Deleting a promotional feature
+    And the executive office has a promotional feature with an item
+    When I delete the promotional feature
+    Then I should no longer see the promotional feature
 
-    Scenario: Editing an existing promotional feature item
-      And the executive office has a promotional feature with an item
-      When I edit the promotional item, set the summary to "Edited summary"
-      Then I should see the promotional feature item's summary has been updated to "Edited summary"
+  Scenario: Editing an existing promotional feature item
+    And the executive office has a promotional feature with an item
+    When I edit the promotional item, set the summary to "Edited summary"
+    Then I should see the promotional feature item's summary has been updated to "Edited summary"
 
-    Scenario: Deleting a promotional feature item
-      And the executive office has a promotional feature with an item
-      When I delete the promotional item
-      Then I should no longer see the promotional item
+  Scenario: Deleting a promotional feature item
+    And the executive office has a promotional feature with an item
+    When I delete the promotional item
+    Then I should no longer see the promotional item
 
-    Scenario: Limiting the number of feature items to a maximum of three
-      And the executive office has a promotional feature with the maximum number of items
-      When I view the promotional feature
-      Then I should not be able to add any further feature items
+  Scenario: Limiting the number of feature items to a maximum of three
+    And the executive office has a promotional feature with the maximum number of items
+    When I view the promotional feature
+    Then I should not be able to add any further feature items

--- a/features/fatalities.feature
+++ b/features/fatalities.feature
@@ -38,6 +38,7 @@ Feature: Fatalities
     When I create a new field of operation called "New Field" with description "Description"
     Then I am able to associate fatality notices with "New Field"
 
+  @design-system-wip
   Scenario: Writer manages casualty entries for a fatality shown on the field of operation page
     Given there is a fatality notice titled "Death of Joe" in the field "Iraq"
     When I add a casualty to the fatality notice

--- a/features/fatalities.feature
+++ b/features/fatalities.feature
@@ -8,8 +8,8 @@ Feature: Fatalities
 
   See the following Examples:
 
-    http://www.mod.uk/DefenceInternet/FactSheets/OperationsFactsheets/OperationsInIraqBritishFatalities.htm
-    http://www.mod.uk/DefenceInternet/FactSheets/OperationsFactsheets/OperationsInAfghanistanBritishFatalities.htm
+  http://www.mod.uk/DefenceInternet/FactSheets/OperationsFactsheets/OperationsInIraqBritishFatalities.htm
+  http://www.mod.uk/DefenceInternet/FactSheets/OperationsFactsheets/OperationsInAfghanistanBritishFatalities.htm
 
   Detail (confirmed by MOD):
 

--- a/features/force-publishing-editions.feature
+++ b/features/force-publishing-editions.feature
@@ -1,16 +1,16 @@
 Feature: Force Publishing editions
 
-Background:
-  Given I am an editor
+  Background:
+    Given I am an editor
 
-@not-quite-as-fake-search
-Scenario: Force-publishing a submitted edition
-  Given I draft a new publication "Ban Beards"
-  When I force publish the publication "Ban Beards"
-  Then the publication "Ban Beards" should have a force publish reason
+  @not-quite-as-fake-search
+  Scenario: Force-publishing a submitted edition
+    Given I draft a new publication "Ban Beards"
+    When I force publish the publication "Ban Beards"
+    Then the publication "Ban Beards" should have a force publish reason
 
-Scenario: Retrospective second-pair of eyes
-  Given I draft a new publication "Ban Beards"
-  And I force publish the publication "Ban Beards"
-  When another editor retrospectively approves the "Ban Beards" publication
-  Then the "Ban Beards" publication should not be flagged as force-published any more
+  Scenario: Retrospective second-pair of eyes
+    Given I draft a new publication "Ban Beards"
+    And I force publish the publication "Ban Beards"
+    When another editor retrospectively approves the "Ban Beards" publication
+    Then the "Ban Beards" publication should not be flagged as force-published any more

--- a/features/governments.feature
+++ b/features/governments.feature
@@ -1,40 +1,40 @@
 Feature: governments
 
-As an editor
-I want to be able to associate content with a specific government
-So that we can appropriately identify less relevant content after elections.
+  As an editor
+  I want to be able to associate content with a specific government
+  So that we can appropriately identify less relevant content after elections.
 
-Scenario: creating a government
-  Given I am a GDS admin
-  When I create a government called "2005 to 2010 Labour government" starting on "06/05/2005"
-  Then there should be a government called "2005 to 2010 Labour government" starting on "6 May 2005"
+  Scenario: creating a government
+    Given I am a GDS admin
+    When I create a government called "2005 to 2010 Labour government" starting on "06/05/2005"
+    Then there should be a government called "2005 to 2010 Labour government" starting on "6 May 2005"
 
-Scenario: ending a government
-  Given there is a current government
-  And two cabinet ministers "Alice" and "Ben"
-  And I am a GDS admin
-  When I close the current government
-  Then there should be no active ministerial role appointments
+  Scenario: ending a government
+    Given there is a current government
+    And two cabinet ministers "Alice" and "Ben"
+    And I am a GDS admin
+    When I close the current government
+    Then there should be no active ministerial role appointments
 
-Scenario: editing a government's start and end dates
-  Given a government exists called "2005 to 2010 Labour government" between dates "06/05/2004" and "11/05/2009"
-  And I am a GDS admin
-  When I edit the government called "2005 to 2010 Labour government" to have dates "06/05/2005" and "11/05/2010"
-  Then there should be a government called "2005 to 2010 Labour government" between dates "6 May 2005" and "11 May 2010"
+  Scenario: editing a government's start and end dates
+    Given a government exists called "2005 to 2010 Labour government" between dates "06/05/2004" and "11/05/2009"
+    And I am a GDS admin
+    When I edit the government called "2005 to 2010 Labour government" to have dates "06/05/2005" and "11/05/2010"
+    Then there should be a government called "2005 to 2010 Labour government" between dates "6 May 2005" and "11 May 2010"
 
-Scenario: changing government after an election
-  Given there is a current government
-  And I am a GDS admin
-  When I close the current government
-  And I create a government called "Robo-alien Overlords"
-  Then the current government should be "Robo-alien Overlords"
+  Scenario: changing government after an election
+    Given there is a current government
+    And I am a GDS admin
+    When I close the current government
+    And I create a government called "Robo-alien Overlords"
+    Then the current government should be "Robo-alien Overlords"
 
-Scenario: appointing a minister to the new government
-  Given I am a GDS admin
-  And a person called "Fred Fancy"
-  And "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
-  And there is a current government
-  When I close the current government
-  And I create a government called "Robo-alien Overlords"
-  And I appoint "Fred Fancy" as the "Minister of Crazy"
-  Then I should be able to create a news article associated with "Fred Fancy" as the "Minister of Crazy"
+  Scenario: appointing a minister to the new government
+    Given I am a GDS admin
+    And a person called "Fred Fancy"
+    And "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+    And there is a current government
+    When I close the current government
+    And I create a government called "Robo-alien Overlords"
+    And I appoint "Fred Fancy" as the "Minister of Crazy"
+    Then I should be able to create a news article associated with "Fred Fancy" as the "Minister of Crazy"

--- a/features/historical-accounts.feature
+++ b/features/historical-accounts.feature
@@ -11,9 +11,9 @@ Feature: Historical accounts
     When I add an historical account to "Barry White" for his role as "Prime Minister"
     Then I should see a historical account for him in that role
 
-  # Scenario: Viewing historic appointments
-  #   Given there are previous prime ministers
-  #   When I view the past prime ministers page
-  #   Then I should see the previous prime ministers listed according the century in which they served
-  #   When I view the most recent past prime minister
-  #   Then I should see the most recent past priminister's historical account on the page
+# Scenario: Viewing historic appointments
+#   Given there are previous prime ministers
+#   When I view the past prime ministers page
+#   Then I should see the previous prime ministers listed according the century in which they served
+#   When I view the most recent past prime minister
+#   Then I should see the most recent past priminister's historical account on the page

--- a/features/linking-to-public-website-from-administration-screens.feature
+++ b/features/linking-to-public-website-from-administration-screens.feature
@@ -3,9 +3,9 @@ Feature: Linking to public website from administration screens
   A writer
   Should be able navigate to the public documents from the admin interfaces
 
-Background:
-  Given I am a writer
+  Background:
+    Given I am a writer
 
-Scenario: Viewing a published document
-  Given a published publication "A Publication" with a PDF attachment
-  Then I should see a link to the public version of the publication "A Publication"
+  Scenario: Viewing a published document
+    Given a published publication "A Publication" with a PDF attachment
+    Then I should see a link to the public version of the publication "A Publication"

--- a/features/managing-contact-details-on-homepages.feature
+++ b/features/managing-contact-details-on-homepages.feature
@@ -1,9 +1,9 @@
 Feature: managing contact details on home pages
-  Editors need to be able to manage contact details on homepages, so that 
-  they can show important contact details first, and skip showing 
-  unimportant details. 
-  
-  Contact details comprise contact records on organisation pages, and 
+  Editors need to be able to manage contact details on homepages, so that
+  they can show important contact details first, and skip showing
+  unimportant details.
+
+  Contact details comprise contact records on organisation pages, and
   offices on world organisation pages.
 
   Contacts can also be marked with their type, and on organisation pages

--- a/features/ministers.feature
+++ b/features/ministers.feature
@@ -1,53 +1,53 @@
 Feature: Minister pages
-As a citizen
-I want to be able to view a page gathering information about a minister
-So that I can see what government activities they are involved with
-As the No 10/Cabinet Office digital team
-We want curate the order in which ministers are listed in the Cabinet
-section of the ministers page and in the whips section
-So that the seniority of members of cabinet and whips are accurately
-reflected
+  As a citizen
+  I want to be able to view a page gathering information about a minister
+  So that I can see what government activities they are involved with
+  As the No 10/Cabinet Office digital team
+  We want curate the order in which ministers are listed in the Cabinet
+  section of the ministers page and in the whips section
+  So that the seniority of members of cabinet and whips are accurately
+  reflected
 
-Scenario: Viewing all ministers
-  Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
-  And "Fred Bloggs" is the "Minister of Sane" for the "Department of Foo"
-  When I visit the ministers page
-  Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
-  And I should see that "Fred Bloggs" is a minister in the "Department of Foo"
+  Scenario: Viewing all ministers
+    Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+    And "Fred Bloggs" is the "Minister of Sane" for the "Department of Foo"
+    When I visit the ministers page
+    Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
+    And I should see that "Fred Bloggs" is a minister in the "Department of Foo"
 
-Scenario: Ministers show only once even if they have two roles
-  Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
-  And "Johnny Macaroon" is the "Minister of Fun" for the "Department of Woah"
-  When I visit the ministers page
-  Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah" with role "Minister of Crazy, Minister of Fun"
+  Scenario: Ministers show only once even if they have two roles
+    Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+    And "Johnny Macaroon" is the "Minister of Fun" for the "Department of Woah"
+    When I visit the ministers page
+    Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah" with role "Minister of Crazy, Minister of Fun"
 
-Scenario: Viewing ministers and whips
-  Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
-  And "Fred Bloggs" is a commons whip "Deputy Chief Whip, Comptroller of HM Household" for the "Department of Foo"
-  When I visit the ministers page
-  Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
-  And I should see that "Fred Bloggs" is a commons whip "Deputy Chief Whip, Comptroller of HM Household"
+  Scenario: Viewing ministers and whips
+    Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+    And "Fred Bloggs" is a commons whip "Deputy Chief Whip, Comptroller of HM Household" for the "Department of Foo"
+    When I visit the ministers page
+    Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
+    And I should see that "Fred Bloggs" is a commons whip "Deputy Chief Whip, Comptroller of HM Household"
 
-Scenario: Viewing ministers and ministers that also attend cabinet
-  Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
-  And "Fred Bloggs" is the "Minister of Sane" for the "Department of Foo" and also attends cabinet
-  When I visit the ministers page
-  Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
-  And I should see that "Fred Bloggs" also attends cabinet
-  And I should see that "Fred Bloggs" is a minister in the "Department of Foo"
+  Scenario: Viewing ministers and ministers that also attend cabinet
+    Given "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+    And "Fred Bloggs" is the "Minister of Sane" for the "Department of Foo" and also attends cabinet
+    When I visit the ministers page
+    Then I should see that "Johnny Macaroon" is a minister in the "Department of Woah"
+    And I should see that "Fred Bloggs" also attends cabinet
+    And I should see that "Fred Bloggs" is a minister in the "Department of Foo"
 
-Scenario: Administering the order of cabinet ministers
-  Given I am a GDS editor called "Jane"
-  And two cabinet ministers "Mary Moffet" and "Catherine Tuffet"
-  When I order the cabinet ministers "Mary Moffet", "Catherine Tuffet"
-  Then I should see "Mary Moffet", "Catherine Tuffet" in that order on the ministers page
-  When I order the cabinet ministers "Catherine Tuffet", "Mary Moffet"
-  Then I should see "Catherine Tuffet", "Mary Moffet" in that order on the ministers page
+  Scenario: Administering the order of cabinet ministers
+    Given I am a GDS editor called "Jane"
+    And two cabinet ministers "Mary Moffet" and "Catherine Tuffet"
+    When I order the cabinet ministers "Mary Moffet", "Catherine Tuffet"
+    Then I should see "Mary Moffet", "Catherine Tuffet" in that order on the ministers page
+    When I order the cabinet ministers "Catherine Tuffet", "Mary Moffet"
+    Then I should see "Catherine Tuffet", "Mary Moffet" in that order on the ministers page
 
-Scenario: Administering the order of whips
-  Given I am a GDS editor called "Jane"
-  Given two whips "Wilma the Whip" and "Jake the Junior Whip"
-  When I order the whips "Wilma the Whip", "Jake the Junior Whip"
-  Then I should see "Wilma the Whip", "Jake the Junior Whip" in that order on the whips section of the ministers page
-  When I order the whips "Jake the Junior Whip", "Wilma the Whip"
-  Then I should see "Jake the Junior Whip", "Wilma the Whip" in that order on the whips section of the ministers page
+  Scenario: Administering the order of whips
+    Given I am a GDS editor called "Jane"
+    Given two whips "Wilma the Whip" and "Jake the Junior Whip"
+    When I order the whips "Wilma the Whip", "Jake the Junior Whip"
+    Then I should see "Wilma the Whip", "Jake the Junior Whip" in that order on the whips section of the ministers page
+    When I order the whips "Jake the Junior Whip", "Wilma the Whip"
+    Then I should see "Jake the Junior Whip", "Wilma the Whip" in that order on the whips section of the ministers page

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -7,22 +7,22 @@ Feature: New Tagging Workflow
   The flow is now as follows:
 
   For a publication that uses the new taxonomy :
-    Edit Screen > Next > Taxonomy Tagging Screen > Save > Admin Screen
+  Edit Screen > Next > Taxonomy Tagging Screen > Save > Admin Screen
 
   For a publication that does not use the new taxonomy:
-    Edit Screen > Next > Legacy Tagging Screen > Save > Admin Screen
+  Edit Screen > Next > Legacy Tagging Screen > Save > Admin Screen
 
-Scenario: Publication that does not support the new taxonomy
-  Given I am a writer
-  When I start editing a draft document which cannot be tagged to the new taxonomy
-  And I continue to the tagging page
-  And I continue to the legacy tagging page
-  Then I should be on the legacy tagging page
-  And I should be able to update the legacy tags
+  Scenario: Publication that does not support the new taxonomy
+    Given I am a writer
+    When I start editing a draft document which cannot be tagged to the new taxonomy
+    And I continue to the tagging page
+    And I continue to the legacy tagging page
+    Then I should be on the legacy tagging page
+    And I should be able to update the legacy tags
 
-Scenario: Publication that supports the new taxonomy with the Preview design system permission
-  Given I am a writer
-  When I start editing a draft document which can be tagged to the new taxonomy
-  And I continue to the tagging page
-  Then I should be on the taxonomy tagging page
-  And I should be able to update the taxonomy and click the "Update tags" button
+  Scenario: Publication that supports the new taxonomy with the Preview design system permission
+    Given I am a writer
+    When I start editing a draft document which can be tagged to the new taxonomy
+    And I continue to the tagging page
+    Then I should be on the taxonomy tagging page
+    And I should be able to update the taxonomy and click the "Update tags" button

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -1,3 +1,4 @@
+@design-system-wip
 Feature: New Tagging Workflow
   In order to get more publishers tagging to the new taxonomy
   Whitehall Needs to alter it's tagging workflow to remove editing

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -18,6 +18,7 @@ Feature: News articles
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
     Then the news article "A thing happened in X" should have been created
 
+  @design-system-wip
   Scenario: Create a news article of type 'World news story', then changing its locale from en
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
     Then the news article "A thing happened in X" should have been created

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -1,56 +1,56 @@
 Feature: Administering Organisations
 
-Background:
-  Given I am an admin in the organisation "Ministry of Pop"
-  And a directory of organisations exists
-  And a world location "United Kingdom" exists
+  Background:
+    Given I am an admin in the organisation "Ministry of Pop"
+    And a directory of organisations exists
+    And a world location "United Kingdom" exists
 
-Scenario: Adding an Organisation
-  Given I have the "GDS Admin" permission
-  When I add a new organisation called "Ministry of Jazz"
-  Then I should be able to see "Ministry of Jazz" in the list of organisations
+  Scenario: Adding an Organisation
+    Given I have the "GDS Admin" permission
+    When I add a new organisation called "Ministry of Jazz"
+    Then I should be able to see "Ministry of Jazz" in the list of organisations
 
-Scenario: Adding a translation to an Organisation
-  Given I have the "GDS Admin" permission
-  When I add a new organisation called "Ministry of Jazz"
-  And I add a translation for an organisation called "Ministry of Jazz"
-  Then I should be able to see the translation for "Ministry of Jazz" in the list of translations
+  Scenario: Adding a translation to an Organisation
+    Given I have the "GDS Admin" permission
+    When I add a new organisation called "Ministry of Jazz"
+    And I add a translation for an organisation called "Ministry of Jazz"
+    Then I should be able to see the translation for "Ministry of Jazz" in the list of translations
 
-Scenario: Administering organisation contact details
-  When I visit the organisation admin page for "Ministry of Pop"
-  And I add a new contact "Main office" with address "1 Acacia Avenue"
-  Then I should see the "Main office" contact in the admin interface with address "1 Acacia Avenue"
-  When I edit the contact to have address "1 Acacia Road"
-  Then I should see the "Main office" contact in the admin interface with address "1 Acacia Road"
+  Scenario: Administering organisation contact details
+    When I visit the organisation admin page for "Ministry of Pop"
+    And I add a new contact "Main office" with address "1 Acacia Avenue"
+    Then I should see the "Main office" contact in the admin interface with address "1 Acacia Avenue"
+    When I edit the contact to have address "1 Acacia Road"
+    Then I should see the "Main office" contact in the admin interface with address "1 Acacia Road"
 
-Scenario: Creating offsite content on an organisation page
-  When I add the offsite link "Offsite Thing" of type "Alert" to the organisation "Ministry of Pop"
-  Then I should see the edit offsite link "Offsite Thing" on the "Ministry of Pop" organisation page
+  Scenario: Creating offsite content on an organisation page
+    When I add the offsite link "Offsite Thing" of type "Alert" to the organisation "Ministry of Pop"
+    Then I should see the edit offsite link "Offsite Thing" on the "Ministry of Pop" organisation page
 
-@javascript
-Scenario: Filtering items to feature on an organisation page
-  Given an organisation and some documents exist
-  When I go to the organisation feature page
-  Then I can filter instantaneously the list of documents by title, author, organisation, and document type
+  @javascript
+  Scenario: Filtering items to feature on an organisation page
+    Given an organisation and some documents exist
+    When I go to the organisation feature page
+    Then I can filter instantaneously the list of documents by title, author, organisation, and document type
 
-Scenario: Requesting publications in alternative format
-  And I set the alternative format contact email of "Ministry of Pop" to "alternative.format@ministry-of-pop.gov.uk"
-  And a published publication "Charleston styles today" with a PDF attachment and alternative format provider "Ministry of Pop"
-  Then the alternative format contact email is "alternative.format@ministry-of-pop.gov.uk"
+  Scenario: Requesting publications in alternative format
+    And I set the alternative format contact email of "Ministry of Pop" to "alternative.format@ministry-of-pop.gov.uk"
+    And a published publication "Charleston styles today" with a PDF attachment and alternative format provider "Ministry of Pop"
+    Then the alternative format contact email is "alternative.format@ministry-of-pop.gov.uk"
 
-Scenario: Organisation pages links to transparency data publications
-  Given the organisation "Cabinet Office" exists
-  Then I cannot see links to Transparency data on the "Cabinet Office" about page
-  When I associate a Transparency data publication to the "Cabinet Office"
-  Then I can see a link to "Transparency data" on the "Cabinet Office" about page
+  Scenario: Organisation pages links to transparency data publications
+    Given the organisation "Cabinet Office" exists
+    Then I cannot see links to Transparency data on the "Cabinet Office" about page
+    When I associate a Transparency data publication to the "Cabinet Office"
+    Then I can see a link to "Transparency data" on the "Cabinet Office" about page
 
-Scenario: deleting an organisation with no children or roles
-  Given I am an editor in the organisation "Department of Fun"
-  When I delete the organisation "Department of Fun"
-  Then there should not be an organisation called "Department of Fun"
+  Scenario: deleting an organisation with no children or roles
+    Given I am an editor in the organisation "Department of Fun"
+    When I delete the organisation "Department of Fun"
+    Then there should not be an organisation called "Department of Fun"
 
-Scenario: Admin closes an organisation, superseding it with another one
-  Given I am an editor in the organisation "Department of wombat population control"
-  And the organisation "Wimbledon council of wombat population control" exists
-  When I close the organisation "Department of wombat population control", superseding it with the organisation "Wimbledon council of wombat population control"
-  Then I can see that the organisation "Department of wombat population control" has been superseded with the organisaion "Wimbledon council of wombat population control"
+  Scenario: Admin closes an organisation, superseding it with another one
+    Given I am an editor in the organisation "Department of wombat population control"
+    And the organisation "Wimbledon council of wombat population control" exists
+    When I close the organisation "Department of wombat population control", superseding it with the organisation "Wimbledon council of wombat population control"
+    Then I can see that the organisation "Department of wombat population control" has been superseded with the organisaion "Wimbledon council of wombat population control"

--- a/features/people.feature
+++ b/features/people.feature
@@ -1,28 +1,28 @@
 Feature: Managing a person
 
-Background:
-  Given I am an admin
+  Background:
+    Given I am an admin
 
-Scenario: Adding a person
-  When I add a new person called "Dave Cameroon"
-  Then I should be able to see "Dave Cameroon" in the list of people
+  Scenario: Adding a person
+    When I add a new person called "Dave Cameroon"
+    Then I should be able to see "Dave Cameroon" in the list of people
 
-Scenario: Editing a person
-  Given a person called "Dave Camerine"
-  When I update the person called "Dave Camerine" to have the name "Nick Clogg"
-  Then I should be able to see "Nick Clogg" in the list of people
+  Scenario: Editing a person
+    Given a person called "Dave Camerine"
+    When I update the person called "Dave Camerine" to have the name "Nick Clogg"
+    Then I should be able to see "Nick Clogg" in the list of people
 
-Scenario: Removing a person
-  Given a person called "Liam Fixx"
-  When I remove the person "Liam Fixx"
-  Then I should not be able to see "Liam Fixx" in the list of people
+  Scenario: Removing a person
+    Given a person called "Liam Fixx"
+    When I remove the person "Liam Fixx"
+    Then I should not be able to see "Liam Fixx" in the list of people
 
-Scenario: Adding a new translation
-  Given a person called "Amanda Appleford" exists with the biography "She was born. She lived. She died."
-  When I add a new "Français" translation to the person "Amanda Appleford" setting biography to "Ca va"
-  Then I should see the translation "Français" and body text "Ca va"
+  Scenario: Adding a new translation
+    Given a person called "Amanda Appleford" exists with the biography "She was born. She lived. She died."
+    When I add a new "Français" translation to the person "Amanda Appleford" setting biography to "Ca va"
+    Then I should see the translation "Français" and body text "Ca va"
 
-Scenario: Editing an existing translation
-  Given a person called "Amanda Appleford" exists with a translation for the locale "Français"
-  When I edit the "Français" translation for the person "Amanda Appleford" updating the biography to "Ca va bien"
-  Then I should see the translation "Français" and body text "Ca va bien"
+  Scenario: Editing an existing translation
+    Given a person called "Amanda Appleford" exists with a translation for the locale "Français"
+    When I edit the "Français" translation for the person "Amanda Appleford" updating the biography to "Ca va bien"
+    Then I should see the translation "Français" and body text "Ca va bien"

--- a/features/policy-groups.feature
+++ b/features/policy-groups.feature
@@ -20,7 +20,7 @@ Feature: Policy groups
   Background:
     Given I am an editor
 
-  @disable-sidekiq-test-mode
+  @disable-sidekiq-test-mode @design-system-wip
   Scenario:
     Given a policy group "Panel" exists
     Then I should be able to add attachments to the policy group "Panel"

--- a/features/policy-groups.feature
+++ b/features/policy-groups.feature
@@ -10,11 +10,11 @@ Feature: Policy groups
   - multiple policy groups can be associated to a single policy
   - doing so results in a line of metadata on the policy page, below the one for a policy team, which reads "Groups: [Title of group as a link]" with the +others JavaScript behaviour for multiple items.
   - An group page comprises:
-    - Title
-    - Summary
-    - Description (markdown field)
-    - Contact email
-    - Attachments (placed inline using markdown)
+  - Title
+  - Summary
+  - Description (markdown field)
+  - Contact email
+  - Attachments (placed inline using markdown)
   - consistent with the policy teams design, the H2s are pulled out into a contents list as anchor links
 
   Background:

--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -1,6 +1,6 @@
 Feature: Previewing unpublished editions
 
-Scenario: Unpublished editions link to preview
-  Given I am an editor
-  When I draft a new publication "Test publication"
-  Then I should see a link to the preview version of the publication "Test publication"
+  Scenario: Unpublished editions link to preview
+    Given I am an editor
+    When I draft a new publication "Test publication"
+    Then I should see a link to the preview version of the publication "Test publication"

--- a/features/previously_published.feature
+++ b/features/previously_published.feature
@@ -1,33 +1,33 @@
 Feature: Previously published options
 
-Scenario: Creating a new case study without selecting a 'previously published' option
-  Given I am a writer in the organisation "Department of Examples"
-  When I start a new case study
-  And I click save
-  Then I see a validation error for the 'previously published' option
+  Scenario: Creating a new case study without selecting a 'previously published' option
+    Given I am a writer in the organisation "Department of Examples"
+    When I start a new case study
+    And I click save
+    Then I see a validation error for the 'previously published' option
 
-@javascript
-Scenario: Creating a new case study and selecting a previously published date in the future
-  Given the date is 2018-06-07
-  And I am a writer in the organisation "Department of Examples"
-  When I start a new case study
-  And I select a previously published date in the future
-  And I click save
-  Then I see a validation error for the future date
+  @javascript
+  Scenario: Creating a new case study and selecting a previously published date in the future
+    Given the date is 2018-06-07
+    And I am a writer in the organisation "Department of Examples"
+    When I start a new case study
+    And I select a previously published date in the future
+    And I click save
+    Then I see a validation error for the future date
 
-Scenario: Creating a new case study and selecting previously published with no publication date
-  Given the date is 2018-06-07
-  And I am a writer in the organisation "Department of Examples"
-  When I start a new case study
-  And I select that this document has been previously published
-  And I click save
-  Then I see a validation error for the missing publication date
+  Scenario: Creating a new case study and selecting previously published with no publication date
+    Given the date is 2018-06-07
+    And I am a writer in the organisation "Department of Examples"
+    When I start a new case study
+    And I select that this document has been previously published
+    And I click save
+    Then I see a validation error for the missing publication date
 
-@javascript
-Scenario: Creating a new case study with a valid previously published date
-  Given the date is 2018-06-07
-  And I am a writer in the organisation "Department of Examples"
-  When I start a new case study
-  And I select a previously published date in the past
-  And I click save
-  Then I should not see a validation error on the previously published date
+  @javascript
+  Scenario: Creating a new case study with a valid previously published date
+    Given the date is 2018-06-07
+    And I am a writer in the organisation "Department of Examples"
+    When I start a new case study
+    And I select a previously published date in the past
+    And I click save
+    Then I should not see a validation error on the previously published date

--- a/features/publications.feature
+++ b/features/publications.feature
@@ -3,37 +3,37 @@ Feature: Publications
   A writer and editor
   Should be able to draft and publish publications
 
-Background:
-  Given I am a writer
+  Background:
+    Given I am a writer
 
-Scenario: Creating a new draft publication
-  When I draft a new publication "Standard Beard Lengths"
-  Then I should see the publication "Standard Beard Lengths" in the list of draft documents
+  Scenario: Creating a new draft publication
+    When I draft a new publication "Standard Beard Lengths"
+    Then I should see the publication "Standard Beard Lengths" in the list of draft documents
 
-Scenario: Submitting a draft publication to a second pair of eyes
-  Given a draft publication "Standard Beard Lengths" exists
-  When I submit the publication "Standard Beard Lengths"
-  Then I should see the publication "Standard Beard Lengths" in the list of submitted documents
+  Scenario: Submitting a draft publication to a second pair of eyes
+    Given a draft publication "Standard Beard Lengths" exists
+    When I submit the publication "Standard Beard Lengths"
+    Then I should see the publication "Standard Beard Lengths" in the list of submitted documents
 
-Scenario: Publishing an edition I submitted is forbidden
-  Given I am an editor
-  And there is a user called "Beardy"
-  And "Beardy" drafts a new publication "Britain's Hairiest Ministers"
-  When I submit the publication "Britain's Hairiest Ministers"
-  Then I should not be able to publish the publication "Britain's Hairiest Ministers"
+  Scenario: Publishing an edition I submitted is forbidden
+    Given I am an editor
+    And there is a user called "Beardy"
+    And "Beardy" drafts a new publication "Britain's Hairiest Ministers"
+    When I submit the publication "Britain's Hairiest Ministers"
+    Then I should not be able to publish the publication "Britain's Hairiest Ministers"
 
-@not-quite-as-fake-search
-Scenario: Publishing an edition I created but did not submit
-  Given I am an editor
-  And there is a user called "Beardy"
-  And I draft a new publication "Britain's Hairiest Ministers"
-  When "Beardy" submits the publication "Britain's Hairiest Ministers"
-  And I publish the publication "Britain's Hairiest Ministers"
-  Then I should see the publication "Britain's Hairiest Ministers" in the list of published documents
+  @not-quite-as-fake-search
+  Scenario: Publishing an edition I created but did not submit
+    Given I am an editor
+    And there is a user called "Beardy"
+    And I draft a new publication "Britain's Hairiest Ministers"
+    When "Beardy" submits the publication "Britain's Hairiest Ministers"
+    And I publish the publication "Britain's Hairiest Ministers"
+    Then I should see the publication "Britain's Hairiest Ministers" in the list of published documents
 
-Scenario: Viewing a publication that's been submitted for review with a PDF attachment
-  Given a submitted publication "Legalise beards" with a PDF attachment
-  And I am an editor
-  When I visit the list of documents awaiting review
-  And I view the publication "Legalise beards"
-  And I should see a link to the PDF attachment
+  Scenario: Viewing a publication that's been submitted for review with a PDF attachment
+    Given a submitted publication "Legalise beards" with a PDF attachment
+    And I am an editor
+    When I visit the list of documents awaiting review
+    And I view the publication "Legalise beards"
+    And I should see a link to the PDF attachment

--- a/features/roles.feature
+++ b/features/roles.feature
@@ -1,42 +1,42 @@
 Feature: Administering Roles
   tHis feature allows the administration of the various different roles in the system
 
-Background:
-  Given I am an admin
+  Background:
+    Given I am an admin
 
-Scenario: Adding a traffic commissioner role
-  Given the organisation "Department for Transport" exists
-  And a person called "Terence Traffic"
-  When I add a new "Traffic commissioner" role named "Traffic Commissioner for Scotland" to the "Department for Transport"
-  Then I should be able to appoint "Terence Traffic" to the new role
+  Scenario: Adding a traffic commissioner role
+    Given the organisation "Department for Transport" exists
+    And a person called "Terence Traffic"
+    When I add a new "Traffic commissioner" role named "Traffic Commissioner for Scotland" to the "Department for Transport"
+    Then I should be able to appoint "Terence Traffic" to the new role
 
-Scenario: Adding a chief scientist
-  Given the organisation "Foreign Office" exists
-  And a person called "Susan Scientist"
-  When I add a new "Chief scientific advisor" role named "Chief Scientific Advisor to the FCO" to the "Foreign Office"
-  Then I should be able to appoint "Susan Scientist" to the new role
+  Scenario: Adding a chief scientist
+    Given the organisation "Foreign Office" exists
+    And a person called "Susan Scientist"
+    When I add a new "Chief scientific advisor" role named "Chief Scientific Advisor to the FCO" to the "Foreign Office"
+    Then I should be able to appoint "Susan Scientist" to the new role
 
-Scenario: Adding a primary role to a worldwide organisation
-  Given the worldwide organisation "British embassy in Spain" exists
-  And a person called "Giles Paxman"
-  When I add a new "Ambassador" role named "Her Majesty's Ambassador to Spain" to the "British embassy in Spain" worldwide organisation
-  Then I should be able to appoint "Giles Paxman" to the new role
-  And I should see him listed as "Her Majesty's Ambassador to Spain" on the worldwide organisation page
+  Scenario: Adding a primary role to a worldwide organisation
+    Given the worldwide organisation "British embassy in Spain" exists
+    And a person called "Giles Paxman"
+    When I add a new "Ambassador" role named "Her Majesty's Ambassador to Spain" to the "British embassy in Spain" worldwide organisation
+    Then I should be able to appoint "Giles Paxman" to the new role
+    And I should see him listed as "Her Majesty's Ambassador to Spain" on the worldwide organisation page
 
-Scenario: Adding a deputy role to a worldwide organisation
-  Given the worldwide organisation "British embassy in Spain" exists
-  And a person called "Andrew Tomkins"
-  When I add a new "Deputy head of mission" role named "Deputy Head of Mission" to the "British embassy in Spain" worldwide organisation
-  Then I should be able to appoint "Andrew Tomkins" to the new role
-  And I should see him listed as "Deputy Head of Mission" on the worldwide organisation page
+  Scenario: Adding a deputy role to a worldwide organisation
+    Given the worldwide organisation "British embassy in Spain" exists
+    And a person called "Andrew Tomkins"
+    When I add a new "Deputy head of mission" role named "Deputy Head of Mission" to the "British embassy in Spain" worldwide organisation
+    Then I should be able to appoint "Andrew Tomkins" to the new role
+    And I should see him listed as "Deputy Head of Mission" on the worldwide organisation page
 
-Scenario: Adding a new translation
-  Given the worldwide organisation "British embassy in Spain" exists
-  And an ambassador role named "Her Majesty's Ambassador to Spain" in the "British embassy in Spain" worldwide organisation
-  And a person called "Giles Paxman" appointed as "Her Majesty's Ambassador to Spain" with a biography in "Español"
-  When I add a new "Español" translation to the role "Her Majesty's Ambassador to Spain" with:
-    | name              | Su Majestad Embajador en España                |
-    | responsibilities  | Retrato del Reino Unido en una buena luz.      |
-  Then I should see the role translation "Español" with:
-    | name              | Su Majestad Embajador en España                |
-    | responsibilities  | Retrato del Reino Unido en una buena luz.      |
+  Scenario: Adding a new translation
+    Given the worldwide organisation "British embassy in Spain" exists
+    And an ambassador role named "Her Majesty's Ambassador to Spain" in the "British embassy in Spain" worldwide organisation
+    And a person called "Giles Paxman" appointed as "Her Majesty's Ambassador to Spain" with a biography in "Español"
+    When I add a new "Español" translation to the role "Her Majesty's Ambassador to Spain" with:
+      | name             | Su Majestad Embajador en España           |
+      | responsibilities | Retrato del Reino Unido en una buena luz. |
+    Then I should see the role translation "Español" with:
+      | name             | Su Majestad Embajador en España           |
+      | responsibilities | Retrato del Reino Unido en una buena luz. |

--- a/features/speeches.feature
+++ b/features/speeches.feature
@@ -1,49 +1,49 @@
 Feature: Speeches
 
-Scenario: Creating a new draft speech
-  Given I am a writer
-  When I draft a new speech "Outlaw Moustaches"
-  Then I should see the speech "Outlaw Moustaches" in the list of draft documents
+  Scenario: Creating a new draft speech
+    Given I am a writer
+    When I draft a new speech "Outlaw Moustaches"
+    Then I should see the speech "Outlaw Moustaches" in the list of draft documents
 
-Scenario: Editing an existing draft speech
-  Given I am a writer
-  And a draft speech "Outlaw Moustaches" exists
-  When I edit the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
-  Then I should see the speech "Ban Moustaches" in the list of draft documents
+  Scenario: Editing an existing draft speech
+    Given I am a writer
+    And a draft speech "Outlaw Moustaches" exists
+    When I edit the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
+    Then I should see the speech "Ban Moustaches" in the list of draft documents
 
-@design-system-wip
-Scenario: Trying to save a speech that has been changed by another user
-  Given I am a writer
-  And a draft speech "Outlaw Moustaches" exists
-  And I start editing the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
-  And another user edits the speech "Outlaw Moustaches" changing the title to "Ban Beards"
-  When I save my changes to the speech
-  Then I should see the conflict between the speech titles "Ban Moustaches" and "Ban Beards"
-  When I edit the speech changing the title to "Ban Moustaches and Beards"
-  Then I should see the speech "Ban Moustaches and Beards" in the list of draft documents
+  @design-system-wip
+  Scenario: Trying to save a speech that has been changed by another user
+    Given I am a writer
+    And a draft speech "Outlaw Moustaches" exists
+    And I start editing the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
+    And another user edits the speech "Outlaw Moustaches" changing the title to "Ban Beards"
+    When I save my changes to the speech
+    Then I should see the conflict between the speech titles "Ban Moustaches" and "Ban Beards"
+    When I edit the speech changing the title to "Ban Moustaches and Beards"
+    Then I should see the speech "Ban Moustaches and Beards" in the list of draft documents
 
-Scenario: Submitting a draft speech to a second pair of eyes
-  Given I am a writer
-  And a draft speech "Outlaw Moustaches" exists
-  When I submit the speech "Outlaw Moustaches"
-  Then I should see the speech "Outlaw Moustaches" in the list of submitted documents
+  Scenario: Submitting a draft speech to a second pair of eyes
+    Given I am a writer
+    And a draft speech "Outlaw Moustaches" exists
+    When I submit the speech "Outlaw Moustaches"
+    Then I should see the speech "Outlaw Moustaches" in the list of submitted documents
 
-Scenario: Viewing a speech that's been submitted for review
-  Given "Ben Beardson" submitted a speech "Legalise beards" with body "Beards for everyone!"
-  When I visit the list of speeches awaiting review
-  Then I should see that "Legalise beards" is listed on the page
+  Scenario: Viewing a speech that's been submitted for review
+    Given "Ben Beardson" submitted a speech "Legalise beards" with body "Beards for everyone!"
+    When I visit the list of speeches awaiting review
+    Then I should see that "Legalise beards" is listed on the page
 
-@javascript @design-system-wip
-Scenario: Creating authored articles (originally published externally)
-  Given I am an editor
-  When I draft a new authored article "Colonel Mustard talks about beards to The Times"
-  Then I should be able to choose who wrote the article
-  And I should be able to choose the date it was written on
-  But I cannot choose a location for the article
+  @javascript @design-system-wip
+  Scenario: Creating authored articles (originally published externally)
+    Given I am an editor
+    When I draft a new authored article "Colonel Mustard talks about beards to The Times"
+    Then I should be able to choose who wrote the article
+    And I should be able to choose the date it was written on
+    But I cannot choose a location for the article
 
-@not-quite-as-fake-search
-Scenario: Publishing a submitted speech
-  Given I am an editor
-  And a submitted speech "Stubble to be Outlawed" exists
-  When I publish the speech "Stubble to be Outlawed"
-  Then I should see the speech "Stubble to be Outlawed" in the list of published documents
+  @not-quite-as-fake-search
+  Scenario: Publishing a submitted speech
+    Given I am an editor
+    And a submitted speech "Stubble to be Outlawed" exists
+    When I publish the speech "Stubble to be Outlawed"
+    Then I should see the speech "Stubble to be Outlawed" in the list of published documents

--- a/features/speeches.feature
+++ b/features/speeches.feature
@@ -11,6 +11,7 @@ Scenario: Editing an existing draft speech
   When I edit the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
   Then I should see the speech "Ban Moustaches" in the list of draft documents
 
+@design-system-wip
 Scenario: Trying to save a speech that has been changed by another user
   Given I am a writer
   And a draft speech "Outlaw Moustaches" exists
@@ -32,7 +33,7 @@ Scenario: Viewing a speech that's been submitted for review
   When I visit the list of speeches awaiting review
   Then I should see that "Legalise beards" is listed on the page
 
-@javascript
+@javascript @design-system-wip
 Scenario: Creating authored articles (originally published externally)
   Given I am an editor
   When I draft a new authored article "Colonel Mustard talks about beards to The Times"

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -1,9 +1,16 @@
 When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/) do |title, nations|
   begin_drafting_publication(title, all_nation_applicability: false)
   nations.raw.flatten.each do |nation_name|
-    within record_css_selector(Nation.find_by_name!(nation_name)) do
+    if using_design_system?
       check nation_name
-      fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
+      within_conditional_reveal nation_name do
+        fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
+      end
+    else
+      within record_css_selector(Nation.find_by_name!(nation_name)) do
+        check nation_name
+        fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
+      end
     end
   end
   click_button "Save and continue"

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -50,29 +50,19 @@ Then(/^the .* "(.*?)" should have (\d+) attachments$/) do |title, expected_numbe
 end
 
 When(/^I set the order of attachments to:$/) do |attachment_order|
-  click_link "Reorder attachments" if using_design_system?
   attachment_order.hashes.each do |attachment_info|
     attachment = Attachment.find_by(title: attachment_info[:title])
     fill_in "ordering[#{attachment.id}]", with: attachment_info[:order]
   end
-  click_on using_design_system? ? "Update order" : "Save attachment order"
+  click_on "Save attachment order"
 end
 
 Then(/^the attachments should be in the following order:$/) do |attachment_list|
-  if using_design_system?
-    attachment_names = all("table td:first").map(&:text)
+  attachment_ids = all(".existing-attachments > li").map { |element| element[:id] }
 
-    attachment_list.hashes.each_with_index do |attachment_info, index|
-      attachment = Attachment.find_by(title: attachment_info[:title])
-      expect(attachment.title).to eq(attachment_names[index])
-    end
-  else
-    attachment_ids = all(".existing-attachments > li").map { |element| element[:id] }
-
-    attachment_list.hashes.each_with_index do |attachment_info, index|
-      attachment = Attachment.find_by(title: attachment_info[:title])
-      expect("attachment_#{attachment.id}").to eq(attachment_ids[index])
-    end
+  attachment_list.hashes.each_with_index do |attachment_info, index|
+    attachment = Attachment.find_by(title: attachment_info[:title])
+    expect("attachment_#{attachment.id}").to eq(attachment_ids[index])
   end
 end
 

--- a/features/step_definitions/bulk_upload_steps.rb
+++ b/features/step_definitions/bulk_upload_steps.rb
@@ -4,15 +4,8 @@ When(/^I upload a zip file containing several attachments and give them titles$/
   click_link "Bulk upload from Zip file"
   attach_file "Zip file", Rails.root.join("test/fixtures/two-pages-and-greenpaper.zip")
   click_button "Upload zip"
-
-  if using_design_system?
-    fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
-    fill_in "bulk_upload_attachments_1_title", with: "Greenpaper title"
-  else
-    fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
-    fill_in "bulk_upload_attachments_attributes_1_title", with: "Greenpaper title"
-  end
-
+  fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
+  fill_in "bulk_upload_attachments_1_title", with: "Greenpaper title"
   click_button "Save"
 end
 
@@ -33,11 +26,7 @@ When(/^I upload a zip file that contains a file "(.*?)"$/) do |_file|
   click_link "Bulk upload from Zip file"
   attach_file "Zip file", Rails.root.join("test/fixtures/two-pages-and-greenpaper.zip")
   click_button "Upload zip"
-  if using_design_system?
-    fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
-  else
-    fill_in "bulk_upload_attachments_attributes_0_title", with: "Two pages title"
-  end
+  fill_in "bulk_upload_attachments_0_title", with: "Two pages title"
   click_button "Save"
 end
 

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -47,7 +47,7 @@ When(/^I add an editorial remark "([^"]*)" to the document "([^"]*)"$/) do |rema
   @edition = create(:draft_publication, title: document_title)
   @remark_text = remark_text
 
-  visit edit_admin_edition_path(@edition)
+  visit admin_edition_path(@edition)
   click_link "Add new remark"
   fill_in "Remark", with: @remark_text
   click_button "Submit remark"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -59,8 +59,8 @@ When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do
     create(:worldwide_organisation, name: "Afghanistan embassy")
     create(:world_location, name: "Afghanistan", active: true)
     begin_drafting_news_article(title:, first_published: Time.zone.today.to_s, announcement_type: news_type)
-    select "Afghanistan embassy", from: "Select the worldwide organisations associated with this news article"
-    select "Afghanistan", from: "Select the world locations this news article is about"
+    select "Afghanistan embassy", from: using_design_system? ? "Worldwide organisations" : "Select the worldwide organisations associated with this news article"
+    select "Afghanistan", from: using_design_system? ? "World locations" : "Select the world locations this news article is about"
     select "", from: "edition_lead_organisation_ids_1"
   else
     begin_drafting_news_article(title:, first_published: Time.zone.today.to_s, announcement_type: news_type)

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -7,15 +7,15 @@ When(/^I start editing a draft document$/) do
 end
 
 Then(/^I can tag it to some specialist sectors$/) do
-  primary_select = using_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
-  secondary_select = using_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
+  primary_select = "edition[primary_specialist_sector_tag]"
+  secondary_select = "edition[secondary_specialist_sector_tags][]"
 
   select "Oil and Gas: Wells", from: primary_select
   select "Oil and Gas: Offshore", from: secondary_select
   select "Oil and Gas: Fields", from: secondary_select
   select "Oil and Gas: Distillation (draft)", from: secondary_select
 
-  click_button using_design_system? ? "Update specialist topics" : "Save"
+  click_button "Update specialist topics"
 
   expect(page).to have_selector(".flash.notice")
 

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -1,7 +1,7 @@
 module AdminLegacyAssociationsHelper
   def set_all_legacy_associations
     tag_specialist_sectors
-    click_button using_design_system? ? "Update specialist topics" : "Save"
+    click_button "Update specialist topics"
   end
 
   def check_associations_have_been_saved
@@ -15,12 +15,9 @@ module AdminLegacyAssociationsHelper
 private
 
   def tag_specialist_sectors
-    primary_select = using_design_system? ? "edition[primary_specialist_sector_tag]" : "Primary specialist topic tag"
-    secondary_select = using_design_system? ? "edition[secondary_specialist_sector_tags][]" : "Additional specialist topics"
-
-    select "Oil and Gas: Wells", from: primary_select
-    select "Oil and Gas: Fields", from: secondary_select
-    select "Oil and Gas: Offshore", from: secondary_select
+    select "Oil and Gas: Wells", from: "edition[primary_specialist_sector_tag]"
+    select "Oil and Gas: Fields", from: "edition[secondary_specialist_sector_tags][]"
+    select "Oil and Gas: Offshore", from: "edition[secondary_specialist_sector_tags][]"
   end
 
   def check_specialist_sectors

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -3,6 +3,11 @@
 # so we've increased the default timeout.
 Capybara.default_max_wait_time = 5
 
+# Allow Capybara to click a <label> even if its corresponding <input> isn't visible on screen.
+# This needs to be enabled when using custom-styled checkboxes and radios, such as those
+# in the GOV.UK Design System.
+Capybara.automatic_label_click = true
+
 module ScreenshotHelper
   def screenshot(name = "capybara")
     page.driver.render(Rails.root.join("tmp/#{name}.png"), full: true)

--- a/features/support/preview_design_system.rb
+++ b/features/support/preview_design_system.rb
@@ -1,16 +1,13 @@
 if ENV["CUCUMBER_PREVIEW_DESIGN_SYSTEM"] == "true"
   Before do
-    # Enable 'Preview next release' flag by stubbing the user permission
-    User.any_instance.stubs(:can_preview_next_release?).returns(true)
+    # Enable 'Preview design system' flag
+    Admin::BaseController.any_instance.stubs(:preview_design_system?).returns(true)
   end
 end
 
 module DesignSystemHelper
   def using_design_system?
-    find("html", class: "govuk-template", wait: false)
-    true
-  rescue Capybara::ElementNotFound
-    false
+    ENV["CUCUMBER_PREVIEW_DESIGN_SYSTEM"] == "true"
   end
 end
 

--- a/features/support/preview_design_system.rb
+++ b/features/support/preview_design_system.rb
@@ -9,6 +9,13 @@ module DesignSystemHelper
   def using_design_system?
     ENV["CUCUMBER_PREVIEW_DESIGN_SYSTEM"] == "true"
   end
+
+  def within_conditional_reveal(label, &block)
+    input = find_field(label)
+    conditional_reveal_id = input["aria-controls"] || input["data-aria-controls"]
+    conditional_reveal = find_by_id(conditional_reveal_id)
+    within(conditional_reveal, &block)
+  end
 end
 
 World(DesignSystemHelper)

--- a/features/take-part-pages.feature
+++ b/features/take-part-pages.feature
@@ -9,10 +9,10 @@ Feature: Administering take part pages
 
   It has:
 
-    title: string
-    summary: text
-    body: govspeak
-    image: image
+  title: string
+  summary: text
+  body: govspeak
+  image: image
 
   They can be reordered so the /get-involved index lists them in a pleasing manner
 

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -3,24 +3,24 @@ Feature: Creating and publishing topical events
   I want to be able to create and publish topical events
   So that I can communicate about them
 
-Background:
-  Given I am an editor
-  Given search returns no results
+  Background:
+    Given I am an editor
+    Given search returns no results
 
-Scenario: Adding a new topical event
-  When I create a new topical event "An Event" with summary "A topical event" and description "About this topical event"
-  Then I should see the topical event "An Event" in the admin interface
+  Scenario: Adding a new topical event
+    When I create a new topical event "An Event" with summary "A topical event" and description "About this topical event"
+    Then I should see the topical event "An Event" in the admin interface
 
-Scenario: Archiving a new topical event
-  When I create a new topical event "An Event" with summary "A topical event", description "About this topical event" and it ends today
-  Then I should see the topical event "An Event" in the admin interface
+  Scenario: Archiving a new topical event
+    When I create a new topical event "An Event" with summary "A topical event", description "About this topical event" and it ends today
+    Then I should see the topical event "An Event" in the admin interface
 
-Scenario: Adding more information about the event
-  Given I'm administering a topical event
-  And I add a page of information about the event
-  Then I should be able to edit the event's about page
-  And I should see the about page is updated
+  Scenario: Adding more information about the event
+    Given I'm administering a topical event
+    And I add a page of information about the event
+    Then I should be able to edit the event's about page
+    And I should see the about page is updated
 
-Scenario: Deleting a topical event
-  Given a topical event called "An event" with summary "A topical event" and description "A topical event"
-  Then I should be able to delete the topical event "An event"
+  Scenario: Deleting a topical event
+    Given a topical event called "An event" with summary "A topical event" and description "A topical event"
+    Then I should be able to delete the topical event "An event"

--- a/features/world-locations.feature
+++ b/features/world-locations.feature
@@ -9,12 +9,12 @@ Feature: Administering world location information
     And an international delegation "UK and the World Government" exists
     When I visit the world locations page
     Then I should see the following world locations grouped under "E" in order:
-      | Échouéland |
-      | Egg Island |
+      | Échouéland                |
+      | Egg Island                |
       | The Excellent Free States |
     And I should see the following world locations grouped under "S" in order:
-      | Special Isles |
-      | Spëcial Kingdom |
+      | Special Isles    |
+      | Spëcial Kingdom  |
       | Special Republic |
     And I should see the following international delegations in order:
       | UK and the World Government |


### PR DESCRIPTION
This PR expands upon the changes made in #7001 which configured the Cucumber feature tests to run with the flag 'Preview next release' so that upcoming Design System changes would be covered by tests.

In this PR, I've configured Cucumber to run with the flag 'Preview design system', which supersedes the 'Preview next release' flag. This will run feature tests against all unreleased Design System changes, including those which haven't yet been tagged for inclusion in the next release.

I've tried to fix some of the more obvious test failures – for example, where button/label text differs – but came across a number of tests which need attention from someone more familiar with the current state of play (most likely @davidgisbey). So for those tests, I've tagged them as `@design-system-wip`.

### New tags: `@design-system-wip`, `@bootstrap-only`, `@design-system-only`

These tags will control which context feature specs will run in. By default, all feature specs must pass both with and without the 'Preview design system' flag enabled.

If a feature is still being worked on, it's possible to tag a test with `@design-system-wip` to skip it from the Design System run. Tests with this tag should be fixed prior to those features being released to the general userbase.

`@bootstrap-only` and `@design-system-only` can be used to denote functionality that only exists in one or the other layout. For example, the 'highlight words to avoid' feature is not being ported across to the Design System, so it is tagged as a `@bootstrap-only` feature.

### New helper method: `within_conditional_reveal`

Use this to scope Capybara finders to a 'conditional reveal' container belonging to a radio or checkbox.

For more details about using this, see the commit message f380f83ceb3e15ad57603b12e331fd9f600f3f69.

---

Trello: https://trello.com/c/PGu7wSXE/845-fix-failing-feature-tests-for-preview-design-system-flag

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
