### PR TITLE
Revert "Fix specialist topic tagging in design system pages"

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -24,22 +24,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       selectElement: $select,
       minLength: 3,
       showNoOptionsFound: true,
-      onConfirm: function (query) {
+      onConfirm: function (value) {
         var category = $select.getAttribute('data-track-category')
         var label = $select.getAttribute('data-track-label')
-        var action = query
+        var action = value
         if (category && label) {
           window.GOVUK.analytics.trackEvent(category, action, { label: label })
         }
-
-        const options = $select.options
-        let matchingOption
-        if (query) {
-          matchingOption = [].filter.call(options, option => (option.textContent || option.innerText) === query)[0]
-        } else {
-          matchingOption = [].filter.call(options, option => option.value === '')[0]
-        }
-        if (matchingOption) { matchingOption.selected = true }
       }
     })
   }


### PR DESCRIPTION
Reverts alphagov/whitehall#7024

## Why
The PR includes ES6 syntax that cannot be deployed to integration