### PR TITLE
Track when users upload an image

### DIFF
--- a/app/assets/javascripts/admin_legacy/multiple_file_upload.js
+++ b/app/assets/javascripts/admin_legacy/multiple_file_upload.js
@@ -27,6 +27,11 @@
         clone.find('.already_uploaded').text('')
         $(this).parents('.file_upload').after(clone)
       })
+
+      // Track when a user chooses a file to upload
+      $(this).on('change', '.js-upload-image-input', function () {
+        GOVUKAdmin.trackEvent('UploadFile', 'ChooseImageFile', { label: 'Choose file' })
+      })
     })
   }
 

--- a/spec/javascripts/admin_legacy/multiple_file_upload.spec.js
+++ b/spec/javascripts/admin_legacy/multiple_file_upload.spec.js
@@ -93,6 +93,16 @@ describe('jquery.enableMultipleFileUploads', function () {
     expect(fieldset.find('.already_uploaded:last').text()).toEqual('')
   })
 
+  it('should send a tracking event when a file is chosen', function () {
+    spyOn(GOVUKAdmin, 'trackEvent')
+    fieldset.enableMultipleFileUploads()
+
+    // Emulate the 'change' event triggered when a user has browsed & chosen a file to upload
+    fieldset.find('input[type=file]').trigger('change')
+
+    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('UploadFile', 'ChooseImageFile', { label: 'Choose file' })
+  })
+
   describe('uploading files after a file field validation error', function () {
     beforeEach(function () {
       fieldset.remove()


### PR DESCRIPTION
This adds tracking to the legacy Bootstrap admin interface so that we can work out when a user is uploading an image.

This has been requested by our Performance Analysts to help with understanding user behaviour and success metrics.

Specifically, this should allow us to work out how many image uploads result in errors, vs. those which are successful. Without this tracking, it's not possible to tell which form submissions included an image upload vs. those which didn't add/change images.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
