### PR TITLE
Remove ES6 syntax from the autocomplete

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -32,12 +32,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           window.GOVUK.analytics.trackEvent(category, action, { label: label })
         }
 
-        const options = $select.options
-        let matchingOption
+        var matchingOption
         if (query) {
-          matchingOption = [].filter.call(options, option => (option.textContent || option.innerText) === query)[0]
+          matchingOption = [].filter.call($select.options, function (option) {
+            return (option.textContent || option.innerText) === query
+          })[0]
         } else {
-          matchingOption = [].filter.call(options, option => option.value === '')[0]
+          matchingOption = [].filter.call($select.options, function (option) {
+            return option.value === ''
+          })[0]
         }
         if (matchingOption) { matchingOption.selected = true }
       }


### PR DESCRIPTION
## What

Remove ES6 syntax from the autocomplete

## Why

#7024 moved copied code from the autocomplete into whitehall including ES6 syntax resulting in the [deploy failing](https://github.com/alphagov/whitehall/actions/runs/3411927509/jobs/5676765946#step:7:2290).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
