### PR TITLE
Switch on the the feature flag for Release 1.3

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -46,6 +46,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily override so that Release 1.3 is available to everyone
+    return true if next_release
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -2,10 +2,10 @@
 
 <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "What's new",
-    message: sanitize("20 October: change to saving documents -
+    message: sanitize("Attachments, unpublishing and withdrawing pages move to the GOV.UK Design System -
       #{
         link_to(
-          "find out more about the change",
+          "read more about the changes",
           admin_whats_new_path,
           {
             class: "govuk-link",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     whats_new:
-      show_banner: false
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
@@ -18,6 +18,19 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: Attachment, unpublishing and withdrawing, and specialist topic tagging pages move to the Design System
+            area: Creating and updating documents
+            type: improved
+            date: 8 November 2022
+            body_govspeak: |
+              The following pages have moved to the GOV.UK Design System:
+              
+              * adding and editing external, HTML and file attachments (including bulk uploads)
+              * withdrawing or unpublishing an edition
+              * unwithdrawing an edition
+              * adding or changing specialist topic tagging
+              
+              To add a specialist topic tag, type the first 3 letters of the topic you want to apply. You’ll then get a list of tagging options on that topic.
           - heading: Change to saving documents
             area: Creating and updating documents
             type: change

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -257,13 +257,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
-    assert_template :new_legacy
-    assert_equal 0, @edition.reload.attachments.size
-  end
-
-  test "POST :create with bad data does not save the attachment and re-renders the new template when the user has the 'Preview design system' permission" do
-    @current_user.permissions << "Preview design system"
-    post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new
     assert_equal 0, @edition.reload.attachments.size
   end

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -64,21 +64,22 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
 
   view_test "POST :upload_zip with no zip file requests that zip file be specified" do
     post_to_upload_zip(nil)
-    assert_select "ul.errors", /file can't be blank/
+    assert_select ".gem-c-error-summary__list-item", /file can't be blank/
   end
 
   view_test "POST :upload_zip prompts for metadata for each file in the zip" do
     post_to_upload_zip("two-pages-and-greenpaper.zip")
     assert_response :success
-    assert_select "li input[name*=title]", count: 2
-    assert_select "li", /two-pages.pdf/
-    assert_select "li", /greenpaper.pdf/
+    assert_select "input[name='bulk_upload[attachments_attributes][0][title]']"
+    assert_select "input[name='bulk_upload[attachments_attributes][1][title]']"
+    assert_select ".gem-c-heading", /two-pages.pdf/
+    assert_select ".gem-c-heading", /greenpaper.pdf/
   end
 
   view_test "POST :upload_zip lists errors and re-renders form when zip invalid" do
     post_to_upload_zip("whitepaper.pdf")
     assert_response :success
-    assert_select ".errors", /not a zip file/
+    assert_select ".gem-c-error-summary__list-item", /not a zip file/
     assert_select "input[type=file]"
   end
 
@@ -93,7 +94,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
   view_test "POST :upload_zip with illegal zip contents shows an error" do
     post_to_upload_zip("sample_attachment_containing_exe.zip")
     assert_response :success
-    assert_select ".errors", /contains invalid files/
+    assert_select ".gem-c-error-summary__list-item", /contains invalid files/
     assert_select "input[type=file]"
   end
 
@@ -109,16 +110,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
     post :create, params: { edition_id: @edition, bulk_upload: invalid_create_params }
 
     assert_response :success
-    assert_select ".form-errors", text: /enter missing fields/
-  end
-
-  view_test "POST :create with invalid attachments re-renders the bulk upload form with design system permission" do
-    @current_user.permissions << "Preview design system"
-
-    post :create, params: { edition_id: @edition, bulk_upload: invalid_create_params }
-
-    assert_response :success
-    assert_select ".govuk-error-summary", text: /enter missing fields/
+    assert_select ".gem-c-error-summary__list-item", text: /enter missing fields/
   end
 
   test "POST :create associates the attachment's attachment_data object with the edition" do

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -15,16 +15,6 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     get :edit, params: { edition_id: @edition.id }
 
     assert_response :success
-    assert_template :edit_legacy
-    assert_equal unpublishing, assigns(:unpublishing)
-  end
-
-  test "#edit loads the unpublishing and renders the unpublish edit template when the user has the 'Preview design system' permission" do
-    @current_user.permissions << "Preview design system"
-    unpublishing = @edition.unpublishing
-    get :edit, params: { edition_id: @edition.id }
-
-    assert_response :success
     assert_template :edit
     assert_equal unpublishing, assigns(:unpublishing)
   end
@@ -62,17 +52,6 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   end
 
   test "#update shows legacy form with error if the update was not possible" do
-    unpublishing = @edition.unpublishing
-    original_explanation = unpublishing.explanation
-    put :update, params: { edition_id: @edition, unpublishing: { explanation: nil } }
-
-    assert_template :edit_legacy
-    assert_equal "The public explanation could not be updated", flash[:alert]
-    assert_equal original_explanation, unpublishing.reload.explanation
-  end
-
-  test "#update shows form with error if the update was not possible when the user has the 'Preview design system' permission" do
-    @current_user.permissions << "Preview design system"
     unpublishing = @edition.unpublishing
     original_explanation = unpublishing.explanation
     put :update, params: { edition_id: @edition, unpublishing: { explanation: nil } }

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -223,7 +223,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     get :confirm_unpublish, params: { id: publication, lock_version: publication.lock_version }
 
     assert_response :success
-    assert_template :confirm_unpublish_legacy
+    assert_template :confirm_unpublish
     assert_equal publication, assigns(:edition)
   end
 
@@ -321,7 +321,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
                                unpublishing: unpublish_params }
 
     assert_response :success
-    assert_template :confirm_unpublish_legacy
+    assert_template :confirm_unpublish
     assert_equal "Select which withdrawal date you want to use", flash[:alert]
     assert published_edition.reload.published?
   end
@@ -334,7 +334,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     }
     post :unpublish, params: { id: published_edition, lock_version: published_edition.lock_version, unpublishing: unpublish_params }
     assert_response :success
-    assert_template :confirm_unpublish_legacy
+    assert_template :confirm_unpublish
     assert_match %r{Alternative url must be provided}, flash[:alert]
     assert published_edition.reload.published?
   end

--- a/test/functional/edition_legacy_associations_controller_test.rb
+++ b/test/functional/edition_legacy_associations_controller_test.rb
@@ -52,19 +52,19 @@ class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCas
   view_test "should render the cancel button back to the admin page" do
     @edition = create(:publication)
     get :edit, params: { edition_id: @edition.id }
-    assert_select ".form-actions a:contains('cancel')[href='#{@controller.admin_edition_path(@edition)}']"
+    assert_select ".govuk-button-group  a:contains('Cancel')[href='#{@controller.admin_edition_path(@edition)}']"
   end
 
   view_test "should render the cancel button back to the tags page" do
     @edition = create(:publication)
     get :edit, params: { edition_id: @edition.id, return: "tags" }
-    assert_select ".form-actions a:contains('cancel')[href='#{@controller.edit_admin_edition_tags_path(@edition)}']"
+    assert_select ".govuk-button-group a:contains('Cancel')[href='#{@controller.edit_admin_edition_tags_path(@edition)}']"
   end
 
   view_test "should render the cancel button back to the edit page" do
     @edition = create(:publication)
     get :edit, params: { edition_id: @edition.id, return: "edit" }
-    assert_select ".form-actions a:contains('cancel')[href='#{@controller.edit_admin_edition_path(@edition)}']"
+    assert_select ".govuk-button-group  a:contains('Cancel')[href='#{@controller.edit_admin_edition_path(@edition)}']"
   end
 
   test "should update the edition with the selected legacy tags" do

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -172,7 +172,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
     def unpublish_document_published_in_error
       click_link "Withdraw or unpublish"
-      within "#js-published-in-error-form" do
+      within ".js-unpublish-withdraw-form__published-in-error" do
         click_button "Unpublish"
       end
       assert_text "This document has been unpublished"

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -259,7 +259,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def unpublish_document_published_in_error
       click_link "Withdraw or unpublish"
-      within "#js-published-in-error-form" do
+      within ".js-unpublish-withdraw-form__published-in-error" do
         click_button "Unpublish"
       end
       assert_text "This document has been unpublished"
@@ -267,7 +267,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def consolidate_document
       click_link "Withdraw or unpublish"
-      within "#js-consolidated-form" do
+      within ".js-unpublish-withdraw-form__consolidated" do
         fill_in "consolidated_alternative_url", with: "https://www.test.gov.uk/example"
         click_button "Unpublish"
       end
@@ -276,7 +276,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def withdraw_document
       click_link "Withdraw or unpublish"
-      within "#js-withdraw-form" do
+      within ".js-unpublish-withdraw-form__withdrawal" do
         fill_in "withdrawal_explanation", with: "testing"
         click_button "Withdraw"
       end


### PR DESCRIPTION
This force-enables the flag for the Whitehall transition to Design System release 1.3.

This is an easy way to make the release available to all users quickly, but should be followed up by the removal of `preview_design_system?` for all pages currently flagged as `next_release: true` since they'll no longer be 'unreleased' changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
