### PR TITLE
Enable external link tracking plugin

### DIFF
--- a/app/assets/javascripts/admin/modules/analytics.js
+++ b/app/assets/javascripts/admin/modules/analytics.js
@@ -9,4 +9,5 @@
   })
 
   GOVUK.analytics.trackPageview()
+  GOVUK.analyticsPlugins.externalLinkTracker()
 })(window.GOVUK)


### PR DESCRIPTION
This is needed to track external links on whitehall.

Previously, we had external link tracking but this was lost during the transition. It was assumed that external links were automatically tracked but the implementation requires the plugin to be called.

<img width="590" alt="Screenshot 2022-11-08 at 10 31 36 am" src="https://user-images.githubusercontent.com/4599889/200541774-5bbf7d95-f0c5-4274-bd25-f5c18d04b3b7.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
