### PR TITLE
Fixes secondary nav alignment

### DIFF
--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -7,12 +7,12 @@
   } %>
 <% end %>
 <div class="govuk-grid-row">
-  <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
-    items: secondary_navigation_tabs_items(@edition, request.path)
-  } %>
-
   <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@edition, request.path)
+    } %>
+
     <p class="govuk-body">Note: <%= attachment_note(attachment.attachable_model_name) %></p>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Add new attachment",

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -6,16 +6,15 @@
 <% content_for :error_summary, render('shared/error_summary', object: @edition, parent_class: "edition", class_name: @edition.format_name) %>
 
 <div class="govuk-grid-row">
-  <%= render "govuk_publishing_components/components/title", {
-    title: sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}")
-  } %>
-
-  <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
-    items: secondary_navigation_tabs_items(@edition, request.path)
-  } %>
-
   <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      title: sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}")
+    } %>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@edition, request.path)
+    } %>
 
     <%= render "form", edition: @edition %>
   </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -1,4 +1,6 @@
 <% content_for :page_title, "Edit #{@edition.format_name}"%>
+<% content_for :title, "Editing #{@edition.format_name}" %>
+<% content_for :context, @edition.title %>
 <% content_for :back_link, (render "govuk_publishing_components/components/back_link", {
     href: admin_edition_path(@edition)
   })
@@ -7,16 +9,12 @@
 <% content_for :banner, render("recent_openings", edition: @edition, recent_openings: @recent_openings) %>
 
 <div class="govuk-grid-row">
-  <%= render "govuk_publishing_components/components/title", {
-    context: @edition.title,
-    title: "Editing #{@edition.format_name}"
-  } %>
-  <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
-    items: secondary_navigation_tabs_items(@edition, request.path)
-  } %>
-
   <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@edition, request.path)
+    } %>
+
     <% if @conflicting_edition %>
       <%= render "govuk_publishing_components/components/error_alert", {
         message: "This document has been updated by another user since you started editing it.",

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "New #{@edition.type.titleize}" %>
+<% content_for :title, "New #{@edition.format_name}" %>
 <% content_for :back_link, (render "govuk_publishing_components/components/back_link", {
     href: admin_editions_path
   })
@@ -6,16 +7,12 @@
 <% content_for :error_summary, render('shared/error_summary', object: @edition, parent_class: "edition", class_name: @edition.format_name) %>
 
 <div class="govuk-grid-row">
-  <%= render "govuk_publishing_components/components/title", {
-    title: "New #{@edition.format_name}"
-  } %>
-
-  <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
-    items: secondary_navigation_tabs_items(@edition, request.path)
-  } %>
-
   <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@edition, request.path)
+    } %>
+
     <%= render "form", edition: @edition %>
   </div>
 </div>


### PR DESCRIPTION
The secondary nav was not included as part of the column, therefore, was misaligned.

This changes fixes this by moving it within teh `column-two-thirds`and also moving title to use `content_for` where appropriate.

## Before

<img width="921" alt="Screenshot 2022-11-08 at 12 20 25 pm" src="https://user-images.githubusercontent.com/4599889/200563955-b7b87fa1-9294-4232-a259-cba2c78a2db8.png">

## After

<img width="745" alt="Screenshot 2022-11-08 at 12 25 17 pm" src="https://user-images.githubusercontent.com/4599889/200563994-f2d46635-bdf3-4042-8d3a-025aab15ae92.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
