### PR TITLE
Revert consultation response attachments section to use the Bootstrap implementation

### DIFF
--- a/app/views/admin/responses/show.html.erb
+++ b/app/views/admin/responses/show.html.erb
@@ -22,7 +22,7 @@
           <li><%= link_to 'Upload new file attachment', new_admin_response_attachment_path(@response) %></li>
           <li><%= link_to 'Add new HTML attachment', new_admin_response_attachment_path(@response, type: "html") %></li>
         </ul>
-        <%= render('admin/attachments/attachments', attachable: @response) if @response.attachments.any? %>
+        <%= render('admin/attachments/attachments_legacy', attachable: @response) if @response.attachments.any? %>
 
       <% else %>
         <p class="alert alert-info">


### PR DESCRIPTION
## Description

We recently ported the attachment index page to use a GOV.UK Design System implementation. When we renamed the Bootstrap partial to attachments_legacy.html.erb, we missed updating the name of the partial in the response show page.

This has led to the Design System partial being used on a page that otherwise has not been ported to use the Design System. Breaking the styling and functionality.

## Screenshots

### Before

<img width="770" alt="image" src="https://user-images.githubusercontent.com/42515961/200606648-6c6cbaa3-7674-4180-8000-643704458cbe.png">

### After 

<img width="915" alt="image" src="https://user-images.githubusercontent.com/42515961/200606580-722b7f8b-5d22-4917-9dc7-a86e9616a400.png">


## Trello card 

https://trello.com/c/YT2A1nUc/864-fix-bug-design-system-attachments-are-showing-on-the-consultation-response-pages-but-they-should-still-be-bootstrap

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

