### PR TITLE
Add feature spec for reordering attachments for consultation responses

### DIFF
--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -48,3 +48,18 @@ Scenario: Creating a new draft consultation in another language
   Given I am a writer
   When I draft a new "Cymraeg" language consultation "Beard Length Review"
   Then I can see the primary locale for consultation "Beard Length Review" is "cy"
+
+Scenario: Adding and reordering a responses attachments
+  Given I am an writer
+  And a closed consultation exists
+  When I add an outcome to the consultation
+  And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
+  Then the consultation response should have 2 attachments
+  When I set the order of attachments to:
+    | title                        | order |
+    | Beard Length Graphs 2012     | 0     |
+    | Outcome attachment title   | 1     |
+  Then the attachments should be in the following order:
+    | title                        |
+    | Beard Length Graphs 2012     |
+    | Outcome attachment title   |

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -82,3 +82,7 @@ And(/^I can see the primary locale for consultation "(.*?)" is "(.*?)"$/) do |ti
     expect(locale_code).to eq(consultation.primary_locale)
   end
 end
+
+Then(/^the consultation response should have (\d+) attachments$/) do |expected_number_of_attachments|
+  expect(expected_number_of_attachments.to_i).to eq(Response.last.attachments.count)
+end


### PR DESCRIPTION
## Description

We shipped a bug that this fixes https://github.com/alphagov/whitehall/pull/7039.

We were showing an incorrect partial for the attachments list/reordering functionality for consultation response attachments.

This adds a feature spec to ensure it doesn't happen again.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
