### PR TITLE
Add accessibility improvements to Preview Govspeak component

### DIFF
--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -62,7 +62,7 @@
       describedby: hint_id,
     } %>
   </div>
-  <div class="app-c-govspeak-editor__preview">
+  <div class="app-c-govspeak-editor__preview" aria-live="polite">
     <p class="govuk-body">Generating preview, please wait.</p>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
[Accessibility improvements to Preview Govspeak component.](https://trello.com/c/oGsq2F3m/828-add-accessibility-improvements-to-preview-govspeak-component)
Add aria labels to the govspeak preview button.
Add aria-live to the govspeak preview.

## Why
The preview button relies on visual context to associate it with the field. This alone is unsuitable for screen reader users.
Changing label was [seen to be more informative than a selected or pressed state](https://www.smashingmagazine.com/2017/09/building-inclusive-toggle-buttons/#changing-labels).