### PR TITLE
Add ADR and documentation for View Components

### DIFF
--- a/adr/0001-add-view-components.md
+++ b/adr/0001-add-view-components.md
@@ -1,6 +1,6 @@
 # 1. Add View Components
 
-Date: 2012-11-09
+Date: 2022-11-09
 
 ## Status
 
@@ -14,20 +14,20 @@ These specs are slow when it comes to performance. They're also often somewhat l
 
 Often there is quite a lot of logic that sits within partials in the form of conditionals, or is pulled in from the controller or helpers.
 
-This issue has been documented in this [Github Issue] (https://github.com/alphagov/whitehall/issues/6954)
+This issue has been documented in GitHub Issue [#6954](https://github.com/alphagov/whitehall/issues/6954).
 
 ## Decision
 
-To resolve these issues, going forward, we are going to use View Components with the following guidelines:
+To resolve these issues going forward, we are going to use [View Components](https://viewcomponent.org/) with the following guidelines:
 
-View components are intended for controller specific view needs, particularly to provide an easier way to test views, for components used in multiple places we have govuk_publishing_components.
+1. View Components are intended for controller specific view needs, particularly to provide an easier way to test views. For components used in multiple places we have [govuk_publishing_components](https://docs.publishing.service.gov.uk/repos/govuk_publishing_components.html).
 
-We consider view components to be a part of the view layer of the application so should only contain logic that relates to converting the input arguments into HTML, if more complex business logic is needed you can use Helper functions or add it to methods on the object passed to the component.
+2. We consider View Components to be a part of the View layer of the application, so should only contain logic that relates to converting the input arguments into HTML. If more complex business logic is needed you can use Helper functions or add it to methods on the object passed into the component.
 
-Tests for view components should be all based on HTML output, If you need to test something more that it's likely not something that belongs in a ViewComponent.
+3. Tests for View Components should be all based on HTML output. If you need to test something more than that, it's likely not something that belongs in a View Component.
 
 ## Consequences
 
 We will adopt View Components as described.
 
-We will follow the [documentation] (https://github.com/alphagov/link-checker-api/blob/master/docs/view_components.md) for implementation.
+We will follow the [documentation](/docs/view_components.md) for implementation.

--- a/adr/0001-add-view-components.md
+++ b/adr/0001-add-view-components.md
@@ -1,0 +1,33 @@
+# 1. Add View Components
+
+Date: 2012-11-09
+
+## Status
+
+Accepted
+
+## Context
+
+Whitehall has large complex views. The established pattern is to break down the pages into many partials. Each of these partials have different functions and vary in levels of complexity. We then test these views through a combination of feature specs and view controller specs.
+
+These specs are slow when it comes to performance. They're also often somewhat laborious to write as you are unable to isolate the section of the view that you are working on and subsequently interested in testing. As many views are large and complex, you often have to handle interactions with other applications. For example you may well have to stub out some calls to Publishing API when you only want to ensure specific fields are rendered on the page.
+
+Often there is quite a lot of logic that sits within partials in the form of conditionals, or is pulled in from the controller or helpers.
+
+This issue has been documented in this [Github Issue] (https://github.com/alphagov/whitehall/issues/6954)
+
+## Decision
+
+To resolve these issues, going forward, we are going to use View Components with the following guidelines:
+
+View components are intended for controller specific view needs, particularly to provide an easier way to test views, for components used in multiple places we have govuk_publishing_components.
+
+We consider view components to be a part of the view layer of the application so should only contain logic that relates to converting the input arguments into HTML, if more complex business logic is needed you can use Helper functions or add it to methods on the object passed to the component.
+
+Tests for view components should be all based on HTML output, If you need to test something more that it's likely not something that belongs in a ViewComponent.
+
+## Consequences
+
+We will adopt View Components as described.
+
+We will follow the [documentation] (https://github.com/alphagov/link-checker-api/blob/master/docs/view_components.md) for implementation.

--- a/docs/view_components.md
+++ b/docs/view_components.md
@@ -1,0 +1,62 @@
+# View Components
+
+[View Components](https://viewcomponent.org/) are an extension of the presenter pattern and allows you to consolidate the logic needed for a partial/template into a single class. Unlike a presenter this class is directly coupled to a html.erb file. They allow you to encapsulate and test view logic easily and effectively.
+
+## When we should be using them
+
+View components are intended for controller specific view needs, particularly to provide an easier way to test views, for components used in multiple places we have govuk_publishing_components.
+
+We consider view components to be a part of the view layer of the application so should only contain logic that relates to converting the input arguments into HTML, if more complex business logic is needed you can use Helper functions or add it to methods on the object passed to the component.
+
+Tests for view components should be all based on HTML output, If you need to test something more that it's likely not something that belongs in a ViewComponent.
+
+## How to generate them
+
+You can use:
+
+```
+govuk-docker-run rails g component admin/ComponentName
+```
+
+or
+
+```
+govuk-docker-run rails g component admin/component_name
+```
+
+## File structure and namespacing
+
+
+View Components are linked to specific views, and will follow use the same file structure, with the controller action appended as a directory. For example, if it a component that is used on the edit edition page to encapsulate fields for an image, the file structure would be the following:
+
+```
+components/admin/editions/edit/image_component.rb
+components/admin/editions/edit/image_component.html.erb
+test/components/admin/editions/edit/image_component_test.rb
+```
+
+Any components used in multiple controller actions will sit in the top level folder for that controller. For example, if the image_component is used in the new and edit views, the file structure would be:
+
+```
+components/admin/editions/image_component.rb
+components/admin/editions/image_component.html.erb
+test/components/admin/editions/image_component_test.rb
+```
+
+If there is CSS or JS specific to the component it should sit in the top level folder like a component shared by multiple views.
+
+For example, for JS:
+
+```
+assets/javascript/admin/views/edition/image_component.scss
+```
+
+And CSS:
+
+```
+assets/stylesheets/admin/views/edition/image_component.scss
+```
+
+## Github Issue
+
+A [Github Issue] (https://github.com/alphagov/whitehall/issues/6954) was opened to discuss using View Components.

--- a/docs/view_components.md
+++ b/docs/view_components.md
@@ -1,14 +1,14 @@
 # View Components
 
-[View Components](https://viewcomponent.org/) are an extension of the presenter pattern and allows you to consolidate the logic needed for a partial/template into a single class. Unlike a presenter this class is directly coupled to a html.erb file. They allow you to encapsulate and test view logic easily and effectively.
+[View Components](https://viewcomponent.org/) are an extension of the [presenter pattern](https://www.rubyguides.com/2019/09/rails-patterns-presenter-service/). They allow you to consolidate the logic needed for a partial/template into a single class. Unlike a presenter, this class is directly coupled to a `.html.erb` file. They allow you to encapsulate and test view logic easily and effectively.
 
 ## When we should be using them
 
-View components are intended for controller specific view needs, particularly to provide an easier way to test views, for components used in multiple places we have govuk_publishing_components.
+1. View Components are intended for controller specific view needs, particularly to provide an easier way to test views. For components used in multiple places we have [govuk_publishing_components](https://docs.publishing.service.gov.uk/repos/govuk_publishing_components.html).
 
-We consider view components to be a part of the view layer of the application so should only contain logic that relates to converting the input arguments into HTML, if more complex business logic is needed you can use Helper functions or add it to methods on the object passed to the component.
+2. We consider View Components to be a part of the View layer of the application, so should only contain logic that relates to converting the input arguments into HTML. If more complex business logic is needed you can use Helper functions or add it to methods on the object passed into the component.
 
-Tests for view components should be all based on HTML output, If you need to test something more that it's likely not something that belongs in a ViewComponent.
+3. Tests for View Components should be all based on HTML output. If you need to test something more than that, it's likely not something that belongs in a View Component.
 
 ## How to generate them
 
@@ -27,7 +27,7 @@ govuk-docker-run rails g component admin/component_name
 ## File structure and namespacing
 
 
-View Components are linked to specific views, and will follow use the same file structure, with the controller action appended as a directory. For example, if it a component that is used on the edit edition page to encapsulate fields for an image, the file structure would be the following:
+View Components are linked to specific views, and should follow the same file structure as the `app/views` directory. For example, a component that is used on the edit edition page to encapsulate fields for an image could exist as:
 
 ```
 components/admin/editions/edit/image_component.rb
@@ -35,7 +35,7 @@ components/admin/editions/edit/image_component.html.erb
 test/components/admin/editions/edit/image_component_test.rb
 ```
 
-Any components used in multiple controller actions will sit in the top level folder for that controller. For example, if the image_component is used in the new and edit views, the file structure would be:
+Any components used in multiple controller actions should sit in the top level folder for that controller. For example, if the image component is used in the new and edit views, the file structure would be:
 
 ```
 components/admin/editions/image_component.rb
@@ -43,20 +43,13 @@ components/admin/editions/image_component.html.erb
 test/components/admin/editions/image_component_test.rb
 ```
 
-If there is CSS or JS specific to the component it should sit in the top level folder like a component shared by multiple views.
-
-For example, for JS:
+If the component needs specific CSS or JavaScript, that should sit in the equivalent path under `assets/(javascripts|stylesheets)/admin/views`. For example, given an image component shared by multiple views of the editions controller:
 
 ```
-assets/javascript/admin/views/edition/image_component.scss
-```
-
-And CSS:
-
-```
+assets/javascript/admin/views/edition/image_component.js
 assets/stylesheets/admin/views/edition/image_component.scss
 ```
 
-## Github Issue
+## GitHub Issue
 
-A [Github Issue] (https://github.com/alphagov/whitehall/issues/6954) was opened to discuss using View Components.
+The GitHub Issue [#6954](https://github.com/alphagov/whitehall/issues/6954) was opened to discuss using View Components.


### PR DESCRIPTION
## Description

We've come to a consensus on how we want to proceed using View Components. The discussion surrounding this can be found in this Github Issue https://github.com/alphagov/whitehall/issues/6954.

This adds an ADR outlining this, and a view components doc, which outlines when to use them and the file structure they should follow.

## Trello card

https://trello.com/c/KXx0qxRl/824-spike-and-write-up-document-on-view-components

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
