### PR TITLE
Ensure display language has selected value set when present

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -4,7 +4,8 @@
     locale_options.concat(attachable.translated_locales.map do |locale|
       {
         text: native_language_name_for(locale),
-        value: locale
+        value: locale,
+        selected: attachment.locale == locale.to_s,
       }
     end)
   %>


### PR DESCRIPTION
## Description

This was missing a selected value which means that when a user goes to edit the page, it will default back to all languages.


## Before 

<img width="706" alt="image" src="https://user-images.githubusercontent.com/42515961/201082910-89885d29-22aa-4e63-82fc-263f68bd3e82.png">


## After 

<img width="601" alt="image" src="https://user-images.githubusercontent.com/42515961/201082824-4db628cd-dc71-42aa-8b0d-e1dcb1dc1f35.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
