### PR TITLE
Fix issue with bootstrap rendering on the unpublishing page

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -163,7 +163,7 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_unpublish confirm_unwithdraw unpublish]
-    if preview_design_system?(next_release: true) && design_system_actions.include?(action_name)
+    if design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"


### PR DESCRIPTION
## Description

This is rendering in the old layout

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
