### PR TITLE
896 add RTL support for attachments

### DIFF
--- a/app/assets/javascripts/admin/modules/locale-switcher.js
+++ b/app/assets/javascripts/admin/modules/locale-switcher.js
@@ -1,0 +1,32 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function LocaleSwitcher (module) {
+    this.module = module
+    this.rightToLeftLocales = module.dataset.rtlLocales.split(' ')
+  }
+
+  LocaleSwitcher.prototype.init = function () {
+    this.setupLocaleSwitching()
+  }
+
+  LocaleSwitcher.prototype.setupLocaleSwitching = function () {
+    var form = this.module
+    var rightToLeftLocales = this.rightToLeftLocales
+    var title = form.querySelector('.attachment-form__title')
+    var body = form.querySelector('.attachment-form__body')
+
+    form.querySelector('#attachment_locale').addEventListener('change', function () {
+      if (rightToLeftLocales.indexOf(this.value) > -1) {
+        title.classList.add('right-to-left')
+        body.classList.add('right-to-left')
+      } else {
+        title.classList.remove('right-to-left')
+        body.classList.remove('right-to-left')
+      }
+    })
+  }
+
+  Modules.LocaleSwitcher = LocaleSwitcher
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require components/miller-columns
 
 //= require admin/modules/analytics
+//= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak
 //= require admin/modules/unpublish-display-conditions

--- a/app/assets/stylesheets/admin/views/_attachments.scss
+++ b/app/assets/stylesheets/admin/views/_attachments.scss
@@ -1,0 +1,6 @@
+.right-to-left {
+  input,
+  textarea {
+    direction: rtl;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import "./admin/views/edition-translations";
 @import "./admin/views/whats-new";
 @import "./admin/views/edit-edition";
+@import "./admin/views/attachments";
 
 .app-js-only {
   display: none;

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,9 +1,7 @@
-<% initialise_script "GOVUK.AdminAttachmentsForm", selector: '.js-attachment-form', right_to_left_locales: Locale.right_to_left.collect(&:to_param) %>
-
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "js-attachment-form" }, multipart: true do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "attachment-form", :"data-module" => "LocaleSwitcher", :"data-rtl-locales" => Locale.right_to_left.collect(&:to_param) }, multipart: true do |form| %>
   <% content_for :error_summary, render('shared/error_summary', object: attachment, parent_class: "attachment", class_name: @attachment.class.name.demodulize.underscore.humanize.downcase) %>
 
-  <div class="govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-bottom-8 attachment-form__title <%= "right-to-left" if form.object.rtl_locale? %>">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Title (required)"
@@ -25,7 +23,7 @@
     <%= form.fields_for :govspeak_content do |govspeak_fields| %>
       <%= hidden_field_tag 'attachment[govspeak_content_attributes][manually_numbered_headings]', "0" %>
 
-      <div class="govuk-!-margin-bottom-8">
+      <div class="govuk-!-margin-bottom-8 attachment-form__manually-numbered-headings">
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: "attachment[govspeak_content_attributes][manually_numbered_headings]",
           heading: "Manually numbered headings",
@@ -43,20 +41,22 @@
         } %>
       </div>
 
-      <%= render "components/govspeak-editor", {
-        label: {
-          heading_size: "l",
-          text: "Body (required)"
-        },
-        name: "attachment[govspeak_content_attributes][body]",
-        rows: 20,
-        id: "attachment_govspeak_content_body",
-        value: form.object.govspeak_content.body,
-        error_items: errors_for(attachment.errors, :"govspeak_content.body"),
-      } %>
+      <div class="govuk-!-margin-bottom-8 attachment-form__body <%= "right-to-left" if form.object.rtl_locale? %>">
+        <%= render "components/govspeak-editor", {
+          label: {
+            heading_size: "l",
+            text: "Body (required)"
+          },
+          name: "attachment[govspeak_content_attributes][body]",
+          rows: 20,
+          id: "attachment_govspeak_content_body",
+          value: form.object.govspeak_content.body,
+          error_items: errors_for(attachment.errors, :"govspeak_content.body"),
+        } %>
+      </div>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
-    <div class="govuk-!-margin-bottom-8">
+    <div class="govuk-!-margin-bottom-8 attachment-form__external-url">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "External url (required)"
@@ -70,7 +70,7 @@
       } %>
     </div>
   <% else %>
-    <div class="govuk-!-margin-bottom-8">
+    <div class="govuk-!-margin-bottom-8 attachment-form__attachment-data-attributes">
       <%= render 'attachment_data_fields', form: form %>
     </div>
   <% end %>

--- a/app/views/admin/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/attachments/_hoc_reference_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-!-margin-bottom-8">
+<div class="govuk-!-margin-bottom-8 attachment-form__hoc-paper-number">
   <%= render("govuk_publishing_components/components/input", {
     label: {
       text: "House of Commons paper number",
@@ -36,7 +36,7 @@
   end)
 %>
 
-<div class="govuk-!-margin-bottom-8">
+<div class="govuk-!-margin-bottom-8 attachment-form__parliamentary-session">
   <%= render "govuk_publishing_components/components/select", {
     label: "Parliamentary session",
     name: "attachment[parliamentary_session]",

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -9,7 +9,7 @@
       }
     end)
   %>
-  <div class="govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-bottom-8 attachment-form__language">
     <%= render "govuk_publishing_components/components/select", {
       id: "attachment_locale",
       label: "Display language",
@@ -22,7 +22,7 @@
   </div>
 <% end %>
 
-<div class="govuk-!-margin-bottom-8">
+<div class="govuk-!-margin-bottom-8 attachment-form__isbn">
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "ISBN"
@@ -36,7 +36,7 @@
   } %>
 </div>
 
-<div class="govuk-!-margin-bottom-8">
+<div class="govuk-!-margin-bottom-8 attachment-form__unique-reference">
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Unique reference"
@@ -48,7 +48,7 @@
   } %>
 </div>
 
-<div class="govuk-!-margin-bottom-8">
+<div class="govuk-!-margin-bottom-8 attachment-form__unique-command-paper-number">
   <% if attachable.can_have_attached_house_of_commons_papers? %>
     <h2 class="govuk-heading-<%= heading_size %>">Command and House of Commons papers</h2>
 

--- a/spec/javascripts/admin/modules/locale-switcher.spec.js
+++ b/spec/javascripts/admin/modules/locale-switcher.spec.js
@@ -1,0 +1,56 @@
+describe('GOVUK.Modules.LocaleSwitcher', function () {
+  var form, rtlClass, localeSwitcher
+
+  beforeEach(function () {
+    form = document.createElement('form')
+    form.setAttribute('data-module', 'LocaleSwitcher')
+    form.setAttribute('data-rtl-locales', 'ar dr fa he pa-pk ps ur yi')
+    rtlClass = 'right-to-left'
+
+    form.innerHTML = `
+      <form>
+        <div class="attachment-form__title">
+          <input id="attachment_title">
+        </div>
+
+        <select id="attachment_locale">
+          <option value="">All languages</option>
+          <option value="ar">العربيَّة</option>
+          <option value="en">English</option>
+        </select>
+
+        <div class="attachment-form__isbn">
+          <input id="attachment_isbn">
+        </div>
+
+        <div class="attachment-form__body">
+          <textarea></textarea>
+        </div>
+      </form>
+    `
+
+    localeSwitcher = new GOVUK.Modules.LocaleSwitcher(form)
+    localeSwitcher.init()
+  })
+
+  it('should add the correct class to the appropriate elements when the laguage select element is changed', function () {
+    var select = form.querySelector('#attachment_locale')
+    var title = form.querySelector('.attachment-form__title')
+    var isbn = form.querySelector('.attachment-form__isbn')
+    var body = form.querySelector('.attachment-form__body')
+
+    select.value = 'ar'
+    select.dispatchEvent(new Event('change'))
+
+    expect(title.classList).toContain(rtlClass)
+    expect(isbn.classList).not.toContain(rtlClass)
+    expect(body.classList).toContain(rtlClass)
+
+    select.value = 'en'
+    select.dispatchEvent(new Event('change'))
+
+    expect(title.classList).not.toContain(rtlClass)
+    expect(isbn.classList).not.toContain(rtlClass)
+    expect(body.classList).not.toContain(rtlClass)
+  })
+})


### PR DESCRIPTION
[Trello card](https://trello.com/c/RT5RbtmT/896-add-rtl-support-for-attachments)

This work fixes a bug introduced in the port to the Design System on the Attachments pages.

Previously, if the user changed the value of the Display Language to a language that is written right to left, there was a change to the class in the container elements around the title and body inputs and a corresponding style change to allow for a right to left language. This functionality was initially lost and is restored here. 

Additionally the means by which text direction on the relevant elements is implemented by the browser is updated to use the `dir` attribute in the HTML in place of using CSS. This is more semantic and allows the text to render correctly in cases where CSS is not present (such as search engines).

The changes introduced by this PR: 
- add a new module to handle the language change
- adds the `dir` attributes required to display the text direction correctly

Additionally some class names have been updated throughout the form for consistency.