### PR TITLE
Extends CSS to include govspeak preview section for RTL languages

### DIFF
--- a/app/assets/javascripts/admin/modules/locale-switcher.js
+++ b/app/assets/javascripts/admin/modules/locale-switcher.js
@@ -19,11 +19,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     form.querySelector('#attachment_locale').addEventListener('change', function () {
       if (rightToLeftLocales.indexOf(this.value) > -1) {
-        title.classList.add('right-to-left')
-        body.classList.add('right-to-left')
+        title.classList.add('attachment-form__title--right-to-left')
+        body.classList.add('attachment-form__body--right-to-left')
       } else {
-        title.classList.remove('right-to-left')
-        body.classList.remove('right-to-left')
+        title.classList.remove('attachment-form__title--right-to-left')
+        body.classList.remove('attachment-form__body--right-to-left')
       }
     })
   }

--- a/app/assets/stylesheets/admin/views/_attachments.scss
+++ b/app/assets/stylesheets/admin/views/_attachments.scss
@@ -1,6 +1,12 @@
-.right-to-left {
-  input,
-  textarea {
+.attachment-form__title--right-to-left {
+  .gem-c-input {
+    direction: rtl;
+  }
+}
+
+.attachment-form__body--right-to-left {
+  .app-c-govspeak-editor__textarea,
+  .app-c-govspeak-editor__preview {
     direction: rtl;
   }
 }

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "attachment-form", :"data-module" => "LocaleSwitcher", :"data-rtl-locales" => Locale.right_to_left.collect(&:to_param) }, multipart: true do |form| %>
-  <div class="govuk-!-margin-bottom-8 attachment-form__title <%= "right-to-left" if form.object.rtl_locale? %>">
+  <div class="govuk-!-margin-bottom-8 attachment-form__title <%= "attachment-form__title--right-to-left" if form.object.rtl_locale? %>">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Title (required)"
@@ -39,7 +39,7 @@
         } %>
       </div>
 
-      <div class="govuk-!-margin-bottom-8 attachment-form__body <%= "right-to-left" if form.object.rtl_locale? %>">
+      <div class="govuk-!-margin-bottom-8 attachment-form__body <%= "attachment-form__body--right-to-left" if form.object.rtl_locale? %>">
         <%= render "components/govspeak-editor", {
           label: {
             heading_size: "l",

--- a/spec/javascripts/admin/modules/locale-switcher.spec.js
+++ b/spec/javascripts/admin/modules/locale-switcher.spec.js
@@ -1,11 +1,10 @@
 describe('GOVUK.Modules.LocaleSwitcher', function () {
-  var form, rtlClass, localeSwitcher
+  var form, localeSwitcher
 
   beforeEach(function () {
     form = document.createElement('form')
     form.setAttribute('data-module', 'LocaleSwitcher')
     form.setAttribute('data-rtl-locales', 'ar dr fa he pa-pk ps ur yi')
-    rtlClass = 'right-to-left'
 
     form.innerHTML = `
       <form>
@@ -18,10 +17,6 @@ describe('GOVUK.Modules.LocaleSwitcher', function () {
           <option value="ar">العربيَّة</option>
           <option value="en">English</option>
         </select>
-
-        <div class="attachment-form__isbn">
-          <input id="attachment_isbn">
-        </div>
 
         <div class="attachment-form__body">
           <textarea></textarea>
@@ -36,21 +31,18 @@ describe('GOVUK.Modules.LocaleSwitcher', function () {
   it('should add the correct class to the appropriate elements when the laguage select element is changed', function () {
     var select = form.querySelector('#attachment_locale')
     var title = form.querySelector('.attachment-form__title')
-    var isbn = form.querySelector('.attachment-form__isbn')
     var body = form.querySelector('.attachment-form__body')
 
     select.value = 'ar'
     select.dispatchEvent(new Event('change'))
 
-    expect(title.classList).toContain(rtlClass)
-    expect(isbn.classList).not.toContain(rtlClass)
-    expect(body.classList).toContain(rtlClass)
+    expect(title.classList).toContain('attachment-form__title--right-to-left')
+    expect(body.classList).toContain('attachment-form__body--right-to-left')
 
     select.value = 'en'
     select.dispatchEvent(new Event('change'))
 
-    expect(title.classList).not.toContain(rtlClass)
-    expect(isbn.classList).not.toContain(rtlClass)
-    expect(body.classList).not.toContain(rtlClass)
+    expect(title.classList).not.toContain('attachment-form__title--right-to-left')
+    expect(body.classList).not.toContain('attachment-form__body--right-to-left')
   })
 })


### PR DESCRIPTION
[Trello Card](https://trello.com/c/MM57dqgI/917-update-govspeak-preview-for-rtl-languages)

Support for right-to-left languages on the page to create/edit HTML attachments was restored in a previous piece of work but this was not included in the "Preview" window of the editor for the body text. 

This update extends the CSS in this section to include that. 

||Before|After|
|---|---|---|
|**Left to right**|![Screenshot 2022-11-15 at 17 06 36](https://user-images.githubusercontent.com/6080548/201982500-dca911f5-95cc-490f-8742-c5d9946613ea.png)|![Screenshot 2022-11-15 at 17 12 15](https://user-images.githubusercontent.com/6080548/201983238-2b95b9c5-3de7-4e27-aec6-341cb4a927c8.png)|
|**Right to left**|![Screenshot 2022-11-15 at 17 07 09](https://user-images.githubusercontent.com/6080548/201982599-634abe54-7072-47d5-9e99-2564943a63c0.png)|![Screenshot 2022-11-15 at 17 14 06](https://user-images.githubusercontent.com/6080548/201983740-2aa6350a-4cd6-42b7-bd31-f24ac1bdba81.png)|