### PR TITLE
Turn off phase banner and amend type label for entry

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     whats_new:
-      show_banner: true
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
@@ -20,7 +20,7 @@ en:
         updates:
           - heading: Search added to topic taxonomy tags page
             area: Creating and updating documents
-            type: improvement
+            type: new
             date: 9 November 2022
             body_govspeak: |
               You can now search taxonomy topic tags and select relevant tags for your content. The search will show all topic tags which include the search term you’ve put into the search box. You only need to start typing the first 3 letters to start getting suggested topics.


### PR DESCRIPTION
This PR:

- turns off the phase banner for 'what's new' following release 1.3 
- amends the 'type' label for the taxonomy topic tags entry

https://trello.com/c/ifocFCcd

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
