### PR TITLE
Increase max width of admin GOV.UK Design System pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-page-width: 1140px;
+
 @import "govuk_publishing_components/all_components";
 
 @import "./components/autocomplete";


### PR DESCRIPTION
## Description

This increases the max width of the pages in the admin interface of Whitehall in the GOV.UK Design System to 1140px so it is line with the Bootstrap implementation. This will allow us to develop feature parity in a like for like way.

In particular we need this to be able to port the history, notes and fact checking tabs.

## Trello card

https://trello.com/c/XQ6gelOt/894-do-we-need-to-increase-the-maximum-page-width

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
