### PR TITLE
Stop GovSpeak Preview button submitting an HTML Attachment

### DIFF
--- a/app/assets/javascripts/admin/modules/locale-switcher.js
+++ b/app/assets/javascripts/admin/modules/locale-switcher.js
@@ -14,10 +14,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   LocaleSwitcher.prototype.setupLocaleSwitching = function () {
     var form = this.module
     var rightToLeftLocales = this.rightToLeftLocales
+
+    var select = form.querySelector('#attachment_locale')
+    if (!select) {
+      return
+    }
+
     var title = form.querySelector('.attachment-form__title')
     var body = form.querySelector('.attachment-form__body')
 
-    form.querySelector('#attachment_locale').addEventListener('change', function () {
+    select.addEventListener('change', function () {
       if (rightToLeftLocales.indexOf(this.value) > -1) {
         title.classList.add('right-to-left')
         body.classList.add('right-to-left')

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -46,7 +46,8 @@
         secondary_quiet: true,
         margin_bottom: hint ? 5 : 2,
         classes: "js-app-c-govspeak-editor__preview-button",
-        data_attributes: preview_button_data_attributes
+        data_attributes: preview_button_data_attributes,
+        type: "button"
       } %>
     </div>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add type='button' to the govspeak editor preview button
Abort locale switcher set up if the local switcher is not present

## Why
These the lack of handling of these two in combination was causing the GovSpeak "Preview" button to submit HTML attachments

https://trello.com/c/Su3dBVFJ/923-stop-govspeak-preview-button-submitting-an-html-attachment
https://govuk.zendesk.com/agent/tickets/5129984