### PR TITLE
Fix flakey scheduled publishing test

### DIFF
--- a/test/support/sidekiq_test_helpers.rb
+++ b/test/support/sidekiq_test_helpers.rb
@@ -5,7 +5,10 @@ module SidekiqTestHelpers
   def with_real_sidekiq
     Sidekiq::Testing.disable! do
       Sidekiq.configure_client do |config|
-        config.redis = { namespace: "whitehall-test" }
+        # The Rails built-in test parallelization doesn't make it easy to find the worker number.
+        # So here we're using the number suffixed to the Postgres database name, because that is unique for each worker.
+        parallel_test_runner_number = ActiveRecord::Base.connection.current_database.split("-").last.to_i
+        config.redis = { db: parallel_test_runner_number }
       end
 
       Sidekiq::ScheduledSet.new.clear


### PR DESCRIPTION
When running tests in parallell the scheduled publishing worker test has a tendency to randomly fail. This seems to be because old editions are not properly discarded or are running at the same time which causes the test to fail.

To fox this we have set up the tests to run in a different queue for each parallel process that runs. This should prevent the other queues from interfering with the current running test.

We have also move away from using the redis namespace config as it is being removed in the next major version.

Trello card: https://trello.com/c/DhRIp7Nu/830-flaky-scheduled-publishing-worker-tests-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
