### PR TITLE
Add no-visted-state to cancel links

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -86,6 +86,6 @@
       }
     } %>
 
-    <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
+    <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link govuk-link--no-visited-state") %>
   </div>
 <% end %>

--- a/app/views/admin/attachments/confirm_destroy.html.erb
+++ b/app/views/admin/attachments/confirm_destroy.html.erb
@@ -14,7 +14,7 @@
         destructive: true,
       } %>
 
-      <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
+      <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link govuk-link--no-visited-state") %>
     </div>
     <% end %>
   </section>

--- a/app/views/admin/attachments/reorder.html.erb
+++ b/app/views/admin/attachments/reorder.html.erb
@@ -21,7 +21,7 @@
           text: "Update order",
         } %>
 
-        <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link") %>
+        <%= link_to("Cancel", attachable_attachments_path(attachable), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -27,7 +27,7 @@
           }
         } %>
 
-        <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>
+        <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -65,7 +65,7 @@
             }
           } %>
 
-          <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link") %>
+          <%= link_to("Cancel", admin_edition_attachments_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/document_sources/edit.html.erb
+++ b/app/views/admin/document_sources/edit.html.erb
@@ -22,7 +22,7 @@
           text: "Save",
         } %>
 
-        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -20,7 +20,7 @@
           }
         } %>
 
-        <%= link_to("Cancel", @path, class: "govuk-link") %>
+        <%= link_to("Cancel", @path, class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -73,7 +73,7 @@
           }
         } %>
 
-        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link") %>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -59,7 +59,7 @@
           text: "Save"
         } %>
 
-        <%= link_to("Cancel", admin_cancel_path(@edition), class: "govuk-link") %>
+        <%= link_to("Cancel", admin_cancel_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -34,7 +34,7 @@
           text: "Update #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation",
         } %>
 
-        <%= link_to("Cancel", [:admin, @unpublishing.edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @unpublishing.edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_workflow/confirm_force_publish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_force_publish.html.erb
@@ -26,7 +26,7 @@
           destructive: true,
         } %>
 
-        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -111,7 +111,7 @@
             destructive: true,
           } %>
 
-          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
         </div>
       <% end %>
     </div>
@@ -162,7 +162,7 @@
             destructive: true,
           } %>
 
-          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
         </div>
       <% end %>
     </div>
@@ -192,7 +192,7 @@
             destructive: true,
           } %>
 
-          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
@@ -14,7 +14,7 @@
           destructive: true,
         } %>
 
-        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
+++ b/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
@@ -18,5 +18,5 @@
     data_attributes: data_attributes
   } %>
 
-  <%= link_to "Cancel", admin_cancel_path(edition), class: "govuk-link", data_attributes: data_attributes %>
+  <%= link_to "Cancel", admin_cancel_path(edition), class: "govuk-link govuk-link--no-visited-state", data_attributes: data_attributes %>
 </div>

--- a/app/views/admin/editions/confirm_destroy.html.erb
+++ b/app/views/admin/editions/confirm_destroy.html.erb
@@ -14,7 +14,7 @@
           destructive: true,
         } %>
 
-        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -26,7 +26,7 @@
           text: "Save"
         } %>
 
-        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link") %>
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add the `govuk-link--no-visted-state` class to cancel links.

## Why

As per the design system, when linking to the dashboard for an admin interface, it is not helpful to distinguish between visited and unvisited states.
https://design-system.service.gov.uk/styles/typography/#links