### PR TITLE
Bump Plek to version 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     brakeman (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.37.1)
+    capybara (3.38.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -185,10 +185,10 @@ GEM
       parslet
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    faraday (2.6.0)
+    faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.1)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
@@ -220,11 +220,11 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    gds-sso (17.1.0)
+    gds-sso (17.1.1)
       oauth2 (~> 2.0)
       omniauth (~> 2.1)
       omniauth-oauth2 (~> 1.8)
-      plek (~> 4.0)
+      plek (>= 4, < 6)
       rails (>= 6)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
@@ -250,9 +250,9 @@ GEM
       jquery-rails (~> 4.3)
       plek (>= 2.1)
       rails (>= 6)
-    govuk_app_config (4.10.1)
+    govuk_app_config (4.11.0)
       logstasher (~> 2.1)
-      plek (~> 4)
+      plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
       puma (>= 5.6, < 7.0)
       rack-proxy (~> 0.7)
@@ -485,8 +485,8 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    plek (4.1.0)
-    prometheus_exporter (2.0.3)
+    plek (5.0.0)
+    prometheus_exporter (2.0.5)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -498,12 +498,12 @@ GEM
       pry (>= 0.10.4)
     ptools (1.4.2)
     public_suffix (5.0.0)
-    puma (5.6.5)
+    puma (6.0.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-protection (3.0.2)
+    rack-protection (3.0.3)
       rack
     rack-proxy (0.7.4)
       rack
@@ -556,7 +556,7 @@ GEM
     redis (4.5.1)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
-    regexp_parser (2.6.0)
+    regexp_parser (2.6.1)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -735,7 +735,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   aarch64-linux

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -9,7 +9,7 @@ class CsvPreviewController < ApplicationController
         if attachment_data.csv? && attachment_visible? && visible_or_draft_edition_present?
           expires_headers
           @csv_preview = CsvFileFromPublicHost.csv_preview_from(@csv_response)
-          @page_base_href = Plek.new.website_root
+          @page_base_href = Plek.website_root
 
           if draft_assets_request_and_draft_edition_present?
             @attachment = attachment_data.draft_attachment_for(current_user)

--- a/app/helpers/admin/content_data_routes_helper.rb
+++ b/app/helpers/admin/content_data_routes_helper.rb
@@ -10,6 +10,6 @@ module Admin::ContentDataRoutesHelper
 private
 
   def content_data_base_url
-    Plek.new.external_url_for("content-data")
+    Plek.external_url_for("content-data")
   end
 end

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -93,6 +93,6 @@ module Admin::UrlHelper
   end
 
   def signon_link
-    link_to "Switch app", Plek.new.external_url_for("signon")
+    link_to "Switch app", Plek.external_url_for("signon")
   end
 end

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,6 +1,6 @@
 module AttachmentsHelper
   def default_url_options
-    { host: Plek.new.website_root, protocol: "https" }
+    { host: Plek.website_root, protocol: "https" }
   end
 
   def previewable?(attachment)

--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -24,7 +24,7 @@ private
   end
 
   def email_alert_frontend_signup_url(feed_uri)
-    "#{Plek.new.website_root}/email-signup?link=#{feed_uri.path.chomp('.atom')}"
+    "#{Plek.website_root}/email-signup?link=#{feed_uri.path.chomp('.atom')}"
   end
 
   def mhra_exists_for_atom_feed?(atom_feed_url)

--- a/app/helpers/legacy_url_helper.rb
+++ b/app/helpers/legacy_url_helper.rb
@@ -4,6 +4,6 @@ module LegacyUrlHelper
   end
 
   def atom_feed_url(_options)
-    "#{Plek.new.website_root}/government/feed"
+    "#{Plek.website_root}/government/feed"
   end
 end

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -38,7 +38,7 @@ module PublicDocumentRoutesHelper
 
   def preview_document_url(edition, options = {})
     if edition.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-      options[:host] = URI(Plek.new.external_url_for("draft-origin")).host
+      options[:host] = URI(Plek.external_url_for("draft-origin")).host
     else
       options[:preview] = edition.document.latest_edition_id
       options[:cachebust] = Time.zone.now.getutc.to_i
@@ -84,7 +84,7 @@ module PublicDocumentRoutesHelper
   end
 
   def organisation_preview_url(organisation, options = {})
-    polymorphic_url(organisation, options.merge(host: URI(Plek.new.external_url_for("draft-origin")).host))
+    polymorphic_url(organisation, options.merge(host: URI(Plek.external_url_for("draft-origin")).host))
   end
 
   def get_involved_path(options = {})
@@ -92,7 +92,7 @@ module PublicDocumentRoutesHelper
   end
 
   def get_involved_url(options = {})
-    Plek.new.website_root + get_involved_path(options)
+    Plek.website_root + get_involved_path(options)
   end
 
   def take_part_page_path(object, options = {})
@@ -109,7 +109,7 @@ module PublicDocumentRoutesHelper
   end
 
   def take_part_page_url(object, options = {})
-    Plek.new.website_root + take_part_page_path(object, options)
+    Plek.website_root + take_part_page_path(object, options)
   end
 
   def topical_event_path(object, options = {})
@@ -126,7 +126,7 @@ module PublicDocumentRoutesHelper
   end
 
   def topical_event_url(object, options = {})
-    Plek.new.website_root + topical_event_path(object, options)
+    Plek.website_root + topical_event_path(object, options)
   end
 
   def topical_event_about_pages_path(object, options = {})

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -61,9 +61,9 @@ class HtmlAttachment < Attachment
 
     if preview
       options[:preview] = id
-      options[:host] = URI(Plek.new.external_url_for("draft-origin")).host
+      options[:host] = URI(Plek.external_url_for("draft-origin")).host
     else
-      options[:host] = URI(Plek.new.website_root).host
+      options[:host] = URI(Plek.website_root).host
     end
 
     type = attachable.path_name

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -41,7 +41,7 @@ class RummagerDocumentPresenter < ActionView::Base
   end
 
   def url
-    Plek.new.website_root + link
+    Plek.website_root + link
   end
 
   def publication_collections
@@ -103,7 +103,7 @@ private
   def format_link(title, link)
     return unless title.present? && link.present?
 
-    link_to(title, Plek.new.website_root + link, class: "govuk-link")
+    link_to(title, Plek.website_root + link, class: "govuk-link")
   end
 
   def operational_field_link(operational_field)

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -49,7 +49,7 @@ class LinkCheckerApiService
   end
 
   def self.website_root
-    @website_root ||= Plek.new.website_root
+    @website_root ||= Plek.website_root
   end
 
   private_class_method :webhook_secret_token, :website_root, :convert_admin_links

--- a/app/views/admin/document_collection_groups/_collection_document.html.erb
+++ b/app/views/admin/document_collection_groups/_collection_document.html.erb
@@ -5,7 +5,7 @@
       <%= check_box_tag('memberships[]', membership.id, false, class: 'checkbox', id: nil) %>
       <%= non_whitehall_link.title %>
     </label>
-    (<%= link_to 'view on GOV.UK', Plek.new.website_root + non_whitehall_link.base_path %>)
+    (<%= link_to 'view on GOV.UK', Plek.website_root + non_whitehall_link.base_path %>)
     <ul class="metadata list-inline text-muted">
       <li>
         Document from: <%= non_whitehall_link.publishing_app.titleize %>

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -21,7 +21,7 @@
             <tr>
               <td class="locale">
                 <%= link_to locale.native_language_name, edit_admin_person_translation_path(@person, locale.code) %>
-                (<%= link_to "view", Plek.new.website_root + person_path(@person, locale: locale) %>)
+                (<%= link_to "view", Plek.website_root + person_path(@person, locale: locale) %>)
               </td>
               <td class="actions">
                 <%= button_to 'Delete', admin_person_translation_path(@person, locale.code),

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -57,7 +57,7 @@
       <% end %>
     </p>
     <% if attachment.is_official_document? %>
-      <%= link_to t('attachment.headings.order_a_copy'), "#{Plek.new.website_root}/guidance/how-to-buy-printed-copies-of-official-documents",
+      <%= link_to t('attachment.headings.order_a_copy'), "#{Plek.website_root}/guidance/how-to-buy-printed-copies-of-official-documents",
             class: "govuk-link order_url", title: t('attachment.headings.order_a_copy_full') %>
     <% end %>
 

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -72,7 +72,7 @@
         title: "Support and feedback",
         items: [
           {
-            href: Plek.new.external_url_for("support"),
+            href: Plek.external_url_for("support"),
             text: "Raise a support request"
           },
           {

--- a/config/initializers/content_store.rb
+++ b/config/initializers/content_store.rb
@@ -1,3 +1,3 @@
 require "gds_api/content_store"
 
-Whitehall.content_store = GdsApi::ContentStore.new(Plek.new.find("content-store"))
+Whitehall.content_store = GdsApi::ContentStore.new(Plek.find("content-store"))

--- a/config/initializers/maslow.rb
+++ b/config/initializers/maslow.rb
@@ -1,3 +1,3 @@
 require "gds_api/maslow"
 
-Whitehall.maslow = GdsApi::Maslow.new(Plek.new.external_url_for("maslow"))
+Whitehall.maslow = GdsApi::Maslow.new(Plek.external_url_for("maslow"))

--- a/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
+++ b/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
@@ -1,5 +1,5 @@
 require "gds_api/router"
-router_api = GdsApi::Router.new(Plek.new.find("router-api"))
+router_api = GdsApi::Router.new(Plek.find("router-api"))
 
 REDIRECT_TO = "/government/organisations/hm-revenue-customs".freeze
 

--- a/db/data_migration/20150423152138_redirect_policies.rb
+++ b/db/data_migration/20150423152138_redirect_policies.rb
@@ -1,6 +1,6 @@
 require "csv"
 require "gds_api/router"
-router_api = GdsApi::Router.new(Plek.new.find("router-api"))
+router_api = GdsApi::Router.new(Plek.find("router-api"))
 
 csv_file = File.join(File.dirname(__FILE__), "20150423152138_redirect_policies.csv")
 

--- a/features/step_definitions/attachment_preview_steps.rb
+++ b/features/step_definitions/attachment_preview_steps.rb
@@ -11,7 +11,7 @@ end
 When(/^I preview the contents of the attachment$/) do
   fn = Rails.root.join("test/fixtures/sample.csv")
 
-  asset_host = URI.parse(Plek.new.asset_root).host
+  asset_host = URI.parse(Plek.asset_root).host
   stub_request(:get, "https://#{asset_host}/government/uploads/system/uploads/attachment_data/file/#{@attachment.attachment_data.id}/sample.csv")
     .with(headers: { "Range" => "bytes=0-300000" })
     .to_return(status: 206, body: File.read(fn))

--- a/features/support/routes_helper.rb
+++ b/features/support/routes_helper.rb
@@ -1,6 +1,6 @@
 module PublicHostHelper
   def public_url(path)
-    (Plek.new.website_uri + path).to_s
+    (URI(Plek.website_root) + path).to_s
   end
 end
 

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -7,7 +7,7 @@ class CsvFileFromPublicHost
   MAXIMUM_RANGE_BYTES = "300000".freeze
 
   def self.csv_response(path, env: ENV)
-    connection = Faraday.new(url: Plek.new.asset_root)
+    connection = Faraday.new(url: Plek.asset_root)
 
     if env.key?("BASIC_AUTH_CREDENTIALS")
       basic_auth_credentials = env["BASIC_AUTH_CREDENTIALS"].split(":")

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -23,7 +23,7 @@ module Whitehall
   class NoConfigurationError < StandardError; end
 
   def self.public_protocol
-    Plek.new.website_uri.scheme
+    URI(Plek.website_root).scheme
   end
 
   def self.support_url
@@ -122,7 +122,7 @@ module Whitehall
   end
 
   def self.public_host
-    @public_host ||= Plek.new.website_uri.host
+    @public_host ||= URI(Plek.website_root).host
   end
 
   def self.public_root

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -27,7 +27,7 @@ module Whitehall
   end
 
   def self.support_url
-    Plek.new.external_url_for("support")
+    Plek.external_url_for("support")
   end
 
   def self.available_locales
@@ -118,19 +118,19 @@ module Whitehall
 
   def self.internal_admin_host
     @internal_admin_host ||=
-      URI(Plek.new.find("whitehall-admin")).host
+      URI(Plek.find("whitehall-admin")).host
   end
 
   def self.public_host
-    @public_host ||= URI(Plek.website_root).host
+    @public_host ||= URI(public_root).host
   end
 
   def self.public_root
-    @public_root ||= Plek.new.website_root
+    @public_root ||= Plek.website_root
   end
 
   def self.admin_root
-    @admin_root ||= Plek.new.external_url_for("whitehall-admin")
+    @admin_root ||= Plek.external_url_for("whitehall-admin")
   end
 
   # The base folder where uploads live.

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -38,7 +38,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def url
-      URI.join(Plek.new.asset_root, Addressable::URI.encode(@legacy_url_path)).to_s
+      URI.join(Plek.asset_root, Addressable::URI.encode(@legacy_url_path)).to_s
     end
 
     def filename

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -77,7 +77,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
     edit_translation_path = edit_admin_person_translation_path(person, "fr")
     view_person_path = person_path(person, locale: "fr")
     assert_select "a[href=?]", edit_translation_path, text: "Français"
-    assert_select "a[href=?]", Plek.new.website_root + view_person_path, text: "view"
+    assert_select "a[href=?]", Plek.website_root + view_person_path, text: "view"
   end
 
   view_test "index does not list the english translation" do

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -6,7 +6,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   # To avoid clashes between v1 and v2 helpers, we've reimplemented them here,
   # as `publish_intents` only exist in v1 and there's no plan to reimplement them
   # as their functionality will ultimately be included in `publishing-api`.
-  PUBLISHING_API_V1_ENDPOINT = Plek.new.find("publishing-api")
+  PUBLISHING_API_V1_ENDPOINT = Plek.find("publishing-api")
 
   def assert_publishing_api_put_intent(base_path, attributes = {}, times = 1)
     intent_url = "#{PUBLISHING_API_V1_ENDPOINT}/publish-intent#{base_path}"

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -4,7 +4,7 @@ module PublishingApiTestHelpers
   include GdsApi::TestHelpers::PublishingApi
 
   def stub_publishing_api_publish_intent
-    stub_request(:any, %r{\A#{Plek.new.find('publishing-api')}/publish-intent/.+})
+    stub_request(:any, %r{\A#{Plek.find('publishing-api')}/publish-intent/.+})
   end
 
   def stub_publishing_api_registration_for(editions)

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -6,7 +6,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
   end
 
   def stub_csv_request(status: 206, body: "", path: "some-path")
-    stub_request(:get, "#{Plek.new.asset_root}/#{path}")
+    stub_request(:get, "#{Plek.asset_root}/#{path}")
       .with(headers: { "Range" => "bytes=0-300000" })
       .to_return(status:, body:)
   end

--- a/test/unit/workers/publishing_api_services_and_information_worker_test.rb
+++ b/test/unit/workers/publishing_api_services_and_information_worker_test.rb
@@ -11,7 +11,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
   end
 
   test "publishes a services and information page for an eligible organisation" do
-    stub_request(:post, "#{Plek.new.find('publishing-api')}/lookup-by-base-path")
+    stub_request(:post, "#{Plek.find('publishing-api')}/lookup-by-base-path")
       .to_return(body: {}.to_json)
     Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
 


### PR DESCRIPTION
Whitehall is one of the few repos that needs amends for [Plek version 5](https://github.com/alphagov/plek/pull/93#issuecomment-1319922899) So I've done the update manually and updated related gems. 

More info in the commits

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
