### PR TITLE
Add conflict partial for edit page in the GOV.UK Design System

### DIFF
--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -1,0 +1,36 @@
+<h2 class="govuk-heading-m"><%= edition.title %></h2>
+<pre class="govspeak_help__pre"><%= edition.body %></pre>
+
+<% if edition.allows_attachments? %>
+  <h2 class="govuk-heading-m">Attachments</h2>
+  <% edition.attachments.each do |attachment| %>
+    <p class="govuk-body govuk-!-margin-bottom-1"><%= link_to_attachment(attachment, preview: true, class: "govuk-link") %></p>
+  <% end %>
+<% end %>
+
+<% if edition.can_be_related_to_organisations? %>
+  <h2 class="govuk-heading-m">Organisations</h2>
+  <% if edition.organisations.any? %>
+    <%= render "admin/organisations/organisations_name_list", organisations: edition.sorted_organisations %>
+  <% else %>
+    <p class="govuk-body">This document isn’t assigned to any organisations.</p>
+  <% end %>
+<% end %>
+
+<% if edition.can_be_associated_with_world_locations? %>
+  <h2 class="govuk-heading-m">World locations</h2>
+  <% if edition.world_locations.any? %>
+    <%= render "world_locations/list", world_locations: edition.world_locations %>
+  <% else %>
+    <p class="govuk-body">This document isn’t assigned to any world locations.</p>
+  <% end %>
+<% end %>
+
+<% if edition.can_apply_to_subset_of_nations? %>
+  <h2 class="govuk-heading-m">Excluded nations</h2>
+  <% if edition.nation_inapplicabilities.any? %>
+    <%= render "nation_inapplicabilities/list", nation_inapplicabilities: edition.nation_inapplicabilities %>
+  <% else %>
+    <p class="govuk-body">This document is applicable to all nations.</p>
+  <% end %>
+<% end %>

--- a/app/views/admin/editions/_legacy_conflict.html.erb
+++ b/app/views/admin/editions/_legacy_conflict.html.erb
@@ -15,7 +15,7 @@
     <section>
       <h1>Organisations</h1>
       <% if edition.organisations.any? %>
-        <%= render partial: "admin/organisations/organisations_name_list", locals: {organisations: edition.sorted_organisations} %>
+        <%= render partial: "admin/organisations/legacy_organisations_name_list", locals: {organisations: edition.sorted_organisations} %>
       <% else %>
         <p>This document isn’t assigned to any organisations.</p>
       <% end %>
@@ -26,7 +26,7 @@
     <section>
       <h1>World locations</h1>
       <% if edition.world_locations.any? %>
-        <%= render partial: "world_locations/list", locals: {world_locations: edition.world_locations} %>
+        <%= render partial: "world_locations/legacy_list", locals: {world_locations: edition.world_locations} %>
       <% else %>
         <p>This document isn’t assigned to any world locations.</p>
       <% end %>
@@ -37,7 +37,7 @@
     <section>
       <h1>Excluded nations</h1>
       <% if edition.nation_inapplicabilities.any? %>
-        <%= render partial: "nation_inapplicabilities/list", locals: {nation_inapplicabilities: edition.nation_inapplicabilities} %>
+        <%= render partial: "nation_inapplicabilities/legacy_list", locals: {nation_inapplicabilities: edition.nation_inapplicabilities} %>
       <% else %>
         <p>This document is applicable to all nations.</p>
       <% end %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -16,7 +16,7 @@
       <%= render "form", edition: @edition %>
     </div>
 
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-half conflict">
       <h2 class="govuk-heading-l">Current saved version</h2>
       <%= render "conflict", edition: @conflicting_edition %>
     </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -4,32 +4,32 @@
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
 <% content_for :banner, render("recent_openings", edition: @edition, recent_openings: @recent_openings) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
-      items: secondary_navigation_tabs_items(@edition, request.path)
+<% if @conflicting_edition %>
+  <div class="govuk-grid-row">
+    <%= render "govuk_publishing_components/components/error_alert", {
+      message: "This document has been updated by another user since you started editing it.",
+      description: "Please review conflicts between the two versions and incorporate any changes before pressing save again."
     } %>
 
-    <% if @conflicting_edition %>
-      <%= render "govuk_publishing_components/components/error_alert", {
-        message: "This document has been updated by another user since you started editing it.",
-        description: "Please review conflicts between the two versions and incorporate any changes before pressing save again."
-      } %>
-
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l">Your version</h2>
       <%= render "form", edition: @edition %>
+    </div>
 
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l">Current saved version</h2>
-      <%= render "legacy_conflict", edition: @conflicting_edition %>
-    <% else %>
-      <div class="row">
-        <div class="col-md-8">
-          <section>
-            <%= render "form", edition: @edition %>
-          </section>
-        </div>
-      </div>
-    <% end %>
+      <%= render "conflict", edition: @conflicting_edition %>
+    </div>
   </div>
-</div>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "components/secondary_navigation", {
+        aria_label: "Document navigation tabs",
+        items: secondary_navigation_tabs_items(@edition, request.path)
+      } %>
+
+      <%= render "form", edition: @edition %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
@@ -1,0 +1,7 @@
+<ul class="organisations-name-list">
+  <% organisations.each do |organisation| %>
+    <%= content_tag_for(:li, organisation, class: 'organisation') do %>
+      <%= link_to organisation.name, organisation_path(organisation) %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/admin/organisations/_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_organisations_name_list.html.erb
@@ -1,7 +1,5 @@
-<ul class="organisations-name-list">
-  <% organisations.each do |organisation| %>
-    <%= content_tag_for(:li, organisation, class: 'organisation') do %>
-      <%= link_to organisation.name, organisation_path(organisation) %>
-    <% end %>
-  <% end %>
-</ul>
+<%= render "govuk_publishing_components/components/list", {
+  items: organisations.map do |organisation|
+    link_to organisation.name, organisation_path(organisation), class: "govuk-link"
+  end
+} %>

--- a/app/views/nation_inapplicabilities/_legacy_list.html.erb
+++ b/app/views/nation_inapplicabilities/_legacy_list.html.erb
@@ -1,0 +1,10 @@
+<ul class="nation_inapplicabilities">
+  <% nation_inapplicabilities.each do |nation_inapplicability| %>
+    <%= content_tag_for(:li, nation_inapplicability) do %>
+      <%= nation_inapplicability.nation.name %>
+      <% if nation_inapplicability.alternative_url.present? %>
+        <span class="alternative_url">(<%= link_to "alternative URL", nation_inapplicability.alternative_url, class: "govuk-link" %>)</span>
+      <% end %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/nation_inapplicabilities/_list.html.erb
+++ b/app/views/nation_inapplicabilities/_list.html.erb
@@ -1,10 +1,9 @@
-<ul class="nation_inapplicabilities">
-  <% nation_inapplicabilities.each do |nation_inapplicability| %>
-    <%= content_tag_for(:li, nation_inapplicability) do %>
-      <%= nation_inapplicability.nation.name %>
-      <% if nation_inapplicability.alternative_url.present? %>
-        <span class="alternative_url">(<%= link_to "alternative URL", nation_inapplicability.alternative_url, class: "govuk-link" %>)</span>
-      <% end %>
-    <% end %>
-  <% end %>
-</ul>
+<%= render "govuk_publishing_components/components/list", {
+  items: nation_inapplicabilities.map do |nation_inapplicability|
+    if nation_inapplicability.alternative_url.present?
+      "#{nation_inapplicability.nation.name} #{tag.a('(alternative URL)', href: nation_inapplicability.alternative_url, class: 'govuk-link')}"
+    else
+      nation_inapplicability.nation.name
+    end
+  end
+} %>

--- a/app/views/world_locations/_legacy_list.html.erb
+++ b/app/views/world_locations/_legacy_list.html.erb
@@ -1,0 +1,3 @@
+<ul class="world-locations">
+  <%= render partial: "world_locations/world_location", collection: world_locations %>
+</ul>

--- a/app/views/world_locations/_list.html.erb
+++ b/app/views/world_locations/_list.html.erb
@@ -1,3 +1,9 @@
-<ul class="world-locations">
-  <%= render partial: "world_locations/world_location", collection: world_locations %>
-</ul>
+<%= render "govuk_publishing_components/components/list", {
+  items: world_locations.map do |world_location|
+    if world_location.active?
+      link_to world_location.name, world_location_path(world_location), class: 'location-link govuk-link'
+    else
+      world_location.name
+    end
+  end
+} %>

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -75,8 +75,8 @@ module AdminEditionWorldLocationsBehaviour
 
         put :update, params: { id: document, edition: { lock_version: } }
 
-        assert_select ".document.conflict" do
-          assert_select "h1", "World locations"
+        assert_select ".conflict" do
+          assert_select "h2", "World locations"
         end
       end
     end


### PR DESCRIPTION
## Description 

When a user has been making edits, but another user has saved during that period, a user is shown various things on the edition that been been persisted on the right hand side of the screen (body, orgs, nation inapplicabilities etc.)

Now the page width has been widened, we should be able to go with a like for like implementation for the edit edition conflict page in the GOV.UK Design System

## Screenshot

<img width="906" alt="image" src="https://user-images.githubusercontent.com/42515961/203280440-f4bbad4a-e0f3-4b90-80a1-b847acaa09f4.png">

## Trello card

https://trello.com/c/hBcPpwmn/946-move-edit-edition-conflict-page-to-the-govuk-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
