### PR TITLE
Introduce Document::PaginatedTimeline

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -25,7 +25,7 @@ class Attachment < ApplicationRecord
           joins(:attachment_data).where("attachment_data.carrierwave_file = ?", basename)
         }
 
-  scope :files, -> { where(type: FileAttachment) }
+  scope :files, -> { where(type: "FileAttachment") }
 
   scope :for_current_locale, -> { where(locale: [nil, I18n.locale]) }
 

--- a/app/models/document/paginated_history.rb
+++ b/app/models/document/paginated_history.rb
@@ -41,6 +41,12 @@ class Document::PaginatedHistory
       @preloaded_previous_version = previous_version
     end
 
+    def ==(other)
+      self.class == other.class &&
+        version == other.version &&
+        action == other.action
+    end
+
     def actor
       version.user
     end

--- a/app/models/document/paginated_timeline.rb
+++ b/app/models/document/paginated_timeline.rb
@@ -1,0 +1,127 @@
+class Document::PaginatedTimeline
+  PER_PAGE = 30
+
+  def initialize(document:, page:)
+    @document = document
+    @page = page.to_i
+  end
+
+  def entries
+    @entries ||= begin
+      raw_entries = paginated_query.rows.map { |r| RawEntry.new(r) }
+
+      remarks = get_remarks_hash raw_entries.select { |r| r.model == "EditorialRemark" }.map(&:id)
+      versions = get_versions_hash raw_entries.select { |r| r.model == "Version" }.map(&:id)
+
+      raw_entries.map do |entry|
+        case entry.model
+        when "Version"
+          versions.fetch(entry.id)
+        when "EditorialRemark"
+          remarks.fetch(entry.id)
+        end
+      end
+    end
+  end
+
+  def total_count
+    @total_count ||= begin
+      sql = "SELECT COUNT(*) FROM (#{union_query}) x"
+      ApplicationRecord.connection.exec_query(sql).rows[0][0]
+    end
+  end
+
+  def total_pages
+    (total_count / PER_PAGE.to_f).ceil
+  end
+
+  def current_page
+    @page
+  end
+
+  def limit_value
+    PER_PAGE
+  end
+
+  def next_page
+    if current_page < total_pages
+      current_page + 1
+    else
+      false
+    end
+  end
+
+  def prev_page
+    if current_page > 1
+      current_page - 1
+    else
+      false
+    end
+  end
+
+private
+
+  class RawEntry
+    attr_reader :model, :id
+
+    def initialize(row)
+      @model = row[0]
+      @id = row[1]
+    end
+  end
+  private_constant :RawEntry
+
+  def document_versions
+    @document.edition_versions
+  end
+
+  def document_remarks
+    @document.editorial_remarks
+  end
+
+  def first_edition_id
+    @first_edition_id ||= @document.editions.pick(:id)
+  end
+
+  def union_query
+    common_fields = %i[id created_at]
+    versions_query = document_versions.select("'#{document_versions.class_name}' AS model_name", *common_fields)
+    remarks_query = document_remarks.select("'#{document_remarks.class_name}' AS model_name", *common_fields)
+
+    "(#{versions_query.to_sql}) UNION (#{remarks_query.to_sql})"
+  end
+
+  def paginated_query
+    sql = <<~SQL
+      #{union_query}
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    SQL
+
+    limit = PER_PAGE
+    offset = (@page - 1) * PER_PAGE
+
+    bind_params = [
+      ActiveRecord::Relation::QueryAttribute.new("", limit, ActiveRecord::Type::Integer.new),
+      ActiveRecord::Relation::QueryAttribute.new("", offset, ActiveRecord::Type::Integer.new),
+    ]
+
+    ApplicationRecord.connection.exec_query(sql, "SQL", bind_params)
+  end
+
+  def get_versions_hash(ids)
+    versions = document_versions.where(id: ids)
+    versions.map.with_index { |version, index|
+      presenter = Document::PaginatedHistory::AuditTrailEntry.new(
+        version,
+        is_first_edition: version.item_id == first_edition_id,
+        previous_version: versions[index - 1],
+      )
+      [version.id, presenter]
+    }.to_h
+  end
+
+  def get_remarks_hash(ids)
+    document_remarks.where(id: ids).index_by(&:id)
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -115,6 +115,29 @@
       "note": "We don't link directly to any unescaped model attribute."
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "4d250d3bacd4d7d123d789e58a4fbb381f1ddcdce341a292b5b368d826357a6a",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/document/paginated_timeline.rb",
+      "line": 109,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationRecord.connection.exec_query(\"#{union_query}\\nORDER BY created_at DESC\\nLIMIT ? OFFSET ?\\n\", \"SQL\", [ActiveRecord::Relation::QueryAttribute.new(\"\", 30, ActiveRecord::Type::Integer.new), ActiveRecord::Relation::QueryAttribute.new(\"\", ((@page - 1) * 30), ActiveRecord::Type::Integer.new)])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Document::PaginatedTimeline",
+        "method": "paginated_query"
+      },
+      "user_input": "union_query",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Custom SQL UNION query formed of two Rails-generated SQL statements. No user input is included."
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "6536a4d099ce4dde6f007e943e61dd078ba220703e0e0cab6ed152ac12b2abfc",
@@ -235,7 +258,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "app/models/bulk_upload.rb",
-      "line": 150,
+      "line": 149,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "Open3.popen3(\"#{Whitehall.system_binaries[:zipinfo]} -1 #{temp_location.shellescape} > /dev/null\")",
       "render_path": null,
@@ -250,6 +273,29 @@
         77
       ],
       "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "98d07a7d2e2f7b478703cc0ba74a555738457db31f40604488723216c5802724",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/document/paginated_timeline.rb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationRecord.connection.exec_query(\"SELECT COUNT(*) FROM (#{union_query}) x\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Document::PaginatedTimeline",
+        "method": "total_count"
+      },
+      "user_input": "union_query",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Custom SQL UNION query formed of two Rails-generated SQL statements. No user input is included."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -394,7 +440,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "app/models/bulk_upload.rb",
-      "line": 139,
+      "line": 138,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`#{Whitehall.system_binaries[:unzip]} -o -d #{File.join(temp_dir, \"extracted\")} #{temp_location.shellescape}`",
       "render_path": null,
@@ -489,6 +535,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-11-01 10:29:48 +0000",
+  "updated": "2022-11-22 17:52:43 +0000",
   "brakeman_version": "5.3.1"
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 default: &default
   encoding: utf8
   adapter: mysql2
+  prepared_statements: true
   variables:
     sql_mode: TRADITIONAL
 

--- a/test/unit/models/document/paginated_timeline_test.rb
+++ b/test/unit/models/document/paginated_timeline_test.rb
@@ -1,0 +1,146 @@
+require "test_helper"
+
+class PaginatedTimelineTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:departmental_editor)
+    @user2 = create(:departmental_editor)
+    seed_document_event_history
+  end
+
+  test "#entries are ordered newest first (reverse chronological order)" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    entry_timestamps = timeline.entries.map(&:created_at)
+    assert_equal entry_timestamps.sort.reverse, entry_timestamps
+  end
+
+  test "#entries is a list of AuditTrailEntry and EditorialRemark objects" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    assert_equal [Document::PaginatedHistory::AuditTrailEntry, EditorialRemark].to_set,
+                 timeline.entries.map(&:class).to_set
+  end
+
+  test "#entries are paginated correctly" do
+    expect_total_count = 11
+    results_per_page = 4
+    expect_total_pages = 3
+
+    # Get paginated results
+    paginated_results = nil
+    mock_pagination(per_page: results_per_page) do
+      paginated_results = (1..expect_total_pages).map do |page|
+        Document::PaginatedTimeline.new(document: @document, page:).entries
+      end
+    end
+
+    # Get unpaginated results by setting per_page to the total count
+    unpaginated_results = mock_pagination(per_page: expect_total_count) do
+      Document::PaginatedTimeline.new(document: @document, page: 1).entries
+    end
+
+    # Compare unpaginated results to paginated results
+    assert_equal unpaginated_results.each_slice(results_per_page).to_a, paginated_results
+  end
+
+  test "it implements methods required by Kaminari for pagination" do
+    results_per_page = 4
+    expect_total_count = 11
+    expect_total_pages = 3
+
+    mock_pagination(per_page: results_per_page) do
+      [
+        { current_page: 1, next_page: 2, prev_page: false },
+        { current_page: 2, next_page: 3, prev_page: 1 },
+        { current_page: 3, next_page: false, prev_page: 2 },
+      ].each do |expected|
+        timeline = Document::PaginatedTimeline.new(document: @document, page: expected[:current_page])
+        assert_equal expect_total_count, timeline.total_count
+        assert_equal expect_total_pages, timeline.total_pages
+        assert_equal results_per_page, timeline.limit_value
+        assert_equal expected[:current_page], timeline.current_page
+        assert_equal expected[:next_page], timeline.next_page
+        assert_equal expected[:prev_page], timeline.prev_page
+      end
+    end
+  end
+
+  test "AuditTrailEntry correctly determines actions" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    entries = timeline.entries.select { |e| e.instance_of?(Document::PaginatedHistory::AuditTrailEntry) }
+    expected_actions = %w[updated
+                          editioned
+                          published
+                          submitted
+                          updated
+                          rejected
+                          submitted
+                          created]
+
+    assert_equal expected_actions, entries.map(&:action)
+  end
+
+  test "AuditTrailEntry correctly determines actors" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    entries = timeline.entries.select { |e| e.instance_of?(Document::PaginatedHistory::AuditTrailEntry) }
+    expected_actors = [@user,
+                       @user,
+                       @user2,
+                       @user,
+                       @user,
+                       @user2,
+                       @user,
+                       @user]
+
+    assert_equal expected_actors, entries.map(&:actor)
+  end
+
+  def seed_document_event_history
+    acting_as(@user) do
+      @document = create(:document)
+      @first_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+      some_time_passes
+      @first_edition.submit!
+    end
+
+    some_time_passes
+
+    acting_as(@user2) do
+      create(:editorial_remark, edition: @first_edition, author: @user2, body: "This is terrible. Make it better!")
+      some_time_passes
+      @first_edition.reject!
+    end
+
+    some_time_passes
+
+    acting_as(@user) do
+      @first_edition.update!(body: "New and improved")
+      some_time_passes
+      create(:editorial_remark, edition: @first_edition, author: @user, body: "I've made it better.")
+      some_time_passes
+      @first_edition.submit!
+    end
+
+    some_time_passes
+
+    acting_as(@user2) do
+      @first_edition.publish!
+    end
+
+    some_time_passes
+
+    acting_as(@user) do
+      @newest_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+      some_time_passes
+      @newest_edition.update!(body: "New draft changes")
+      some_time_passes
+      create(:editorial_remark, edition: @first_edition, author: @user, body: "Drafted to include new changes.")
+    end
+  end
+
+  def mock_pagination(per_page:, &block)
+    Document::PaginatedTimeline.stub_const(:PER_PAGE, per_page, &block)
+  end
+
+  def some_time_passes
+    Timecop.travel rand(1.hour..1.week).from_now
+  end
+end


### PR DESCRIPTION
This PR introduces the new class Document::PaginatedTimeline as a means to merge the [Document::PaginatedHistory] and [Document::PaginatedRemarks] classes. It builds upon the spike PR #6868 but adds test coverage and implements some of the remaining 'to do's from that spike.

The Document ‘Timeline’ is a representation of the History (Versions) and Notes (Editorial Remarks) of a Document, combined into one chronological list.

It will allow us to combine the 'history' and 'notes' tabs shown on the edition show & edit pages into one single tab.

How does the data get combined?
===============================

I've used a [union query] to merge the queries for `Document#edition_versions` and `Document#editorial_remarks` into one result set, sorted by creation date. This provides a single chronological timeline of ‘history’ and ‘note’ entries.

Union queries aren't natively supported by Active Record. While it's possible to [extend Active Record to support union queries][activerecord-union], that starts to make things more complicated than they really need to be. We have a very specific use case for union queries, so it seems simpler to perform the query manually rather than bending Active Record to support it.

Both queries need to return the same columns so they can be merged. So we return three fields that exist in both tables: id, created_at, and model_name (so we know which table the record came from). We include created_at so the list can be sorted chronologically.

How to render timeline entries?
===============================

Call the method `Document::PaginatedTimeline#entries` to retrieve the timeline entries for rendering to the page. These entries will either be `AuditTrailEntry` (History) objects or `EditorialRemark` (Note) objects.

Change to database.yml
======================

I've enabled ‘prepared queries’ in the MySQL database adapter config. This allows us to safely escape parameters in SQL queries (avoiding SQL injection attacks). They’re currently disabled in Whitehall (which is the Rails default), but will be [enabled by default in Rails 7.2] so this should be a non-controversial change.

[Document::PaginatedHistory]: https://github.com/alphagov/whitehall/blob/f0f0adfbc349293f9dc37a995b33e791021edf62/app/models/document/paginated_history.rb
[Document::PaginatedRemarks]: https://github.com/alphagov/whitehall/blob/f0f0adfbc349293f9dc37a995b33e791021edf62/app/models/document/paginated_remarks.rb
[union query]: https://dev.mysql.com/doc/refman/8.0/en/union.html
[activerecord-union]: https://joshfrankel.me/blog/a-journey-into-writing-union-queries-with-active-record/
[enabled by default in Rails 7.2]: https://github.com/rails/rails/blob/c41e2f1bca65b51bccda7dd465d525071c66264f/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L172

---

Trello: https://trello.com/c/xiy8xs27/888-move-notes-history-fact-checking-tabs-to-the-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
