### PR TITLE
Fix to prevent comparing latest published edition with itself

### DIFF
--- a/app/views/admin/editions/_audit_trail_entry.html.erb
+++ b/app/views/admin/editions/_audit_trail_entry.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag(:li, class: "version") do %>
-  <% if audit_trail_entry.action == "published" %>
+  <% if audit_trail_entry.action == "published" && @edition.id != audit_trail_entry.version.item_id %>
     <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: audit_trail_entry.version.item_id) %>
   <% end %>
 


### PR DESCRIPTION
Currently in the history tab the latest edition is being compared with itself while previous ones work correctly. Like seen in this correct diff url:
https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/1385866/diff?audit_trail_entry_id=632365
and incorrect url of the latest diff (ids are the same)
https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/1385866/diff?audit_trail_entry_id=1385866


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
