### PR TITLE
Move diff page to the new design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "uglifier"
 gem "validates_email_format_of"
 gem "view_component"
 gem "whenever", require: false
+gem "diffy"
 
 group :development, :test do
   gem "pact", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "carrierwave"
 gem "carrierwave-i18n"
 gem "chronic"
 gem "dalli"
+gem "diffy"
 gem "faraday"
 gem "fog-aws"
 gem "friendly_id"
@@ -60,7 +61,6 @@ gem "uglifier"
 gem "validates_email_format_of"
 gem "view_component"
 gem "whenever", require: false
-gem "diffy"
 
 group :development, :test do
   gem "pact", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     database_cleaner-core (2.0.1)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
+    diffy (3.4.2)
     dig_rb (1.0.1)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -758,6 +759,7 @@ DEPENDENCIES
   cucumber-rails
   dalli
   database_cleaner-active_record
+  diffy
   equivalent-xml
   factory_bot
   faraday

--- a/app/assets/stylesheets/admin/views/_audit-trail.scss
+++ b/app/assets/stylesheets/admin/views/_audit-trail.scss
@@ -1,0 +1,85 @@
+// stylelint-disable max-nesting-depth
+
+// Diff of two editions
+
+$added-color: #ddffdd;
+$strong-added-color: #77f177;
+$removed-color: #ffdddd;
+$strong-removed-color: #ffaaaa;
+$gray-lighter: govuk-colour("light-grey");
+$state-danger-text: govuk-colour("red");
+$state-success-text: govuk-colour("green");
+
+.audit-trail__history-comparison {
+  .diff {
+    border: 1px solid $gray-lighter;
+    border-left: 40px solid $gray-lighter;
+    border-radius: 3px;
+    padding: 15px;
+
+    ul {
+      padding-left: 0;
+
+      li {
+        min-height: 24px;
+        margin: 0 -15px;
+        padding: 0 15px;
+        word-wrap: break-word;
+        list-style: none;
+        position: relative;
+
+        del,
+        ins {
+          text-decoration: none;
+        }
+      }
+
+      .del,
+      .ins {
+        padding-top: 2px;
+      }
+
+      .del {
+        background-color: $removed-color;
+
+        strong {
+          font-weight: normal;
+          background-color: $strong-removed-color;
+        }
+      }
+
+      .ins {
+        background-color: $added-color;
+
+        strong {
+          font-weight: normal;
+          background-color: $strong-added-color;
+        }
+      }
+
+      .del:before,
+      .ins:before {
+        position: absolute;
+        font-weight: bold;
+        margin-left: -55px;
+        width: 40px;
+        text-align: center;
+        min-height: 24px;
+        top: 0;
+        bottom: 0;
+      }
+
+      .del:before {
+        color: $state-danger-text;
+        background-color: $removed-color;
+        content: "−";
+      }
+
+      .ins:before {
+        color: $state-success-text;
+        background-color: $added-color;
+        content: "+";
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/whats-new";
 @import "./admin/views/edit-edition";
 @import "./admin/views/attachments";
+@import "./admin/views/audit-trail";
 
 .app-js-only {
   display: none;

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -167,6 +167,7 @@ class Admin::EditionsController < Admin::BaseController
   def diff
     audit_trail_entry = edition_class.find(params[:audit_trail_entry_id])
     @audit_trail_entry = LocalisedModel.new(audit_trail_entry, audit_trail_entry.primary_locale)
+    render_design_system(:diff, :diff_legacy, next_release: true)
   end
 
   def confirm_destroy
@@ -196,6 +197,7 @@ private
 
   def get_layout
     design_system_actions = %w[edit update new create confirm_destroy]
+    design_system_actions << "diff" if preview_design_system?(next_release: true)
     if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
       "design_system"
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,4 +198,8 @@ module ApplicationHelper
       raw(Govspeak::Document.new(content, sanitize: true).to_html)
     end
   end
+
+  def diff_html(version1, version2)
+    Diffy::Diff.new(version1, version2, allow_empty_diff: false).to_s(:html).html_safe
+  end
 end

--- a/app/views/admin/editions/diff.html.erb
+++ b/app/views/admin/editions/diff.html.erb
@@ -1,28 +1,49 @@
-<% page_title @edition.title, @edition.format_name %>
-<% initialise_script "GOVUK.adminEditionsDiff" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition)
+  } %>
+<% end %>
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Compare versions: #{@edition.title}" %>
+<% content_for :title, "Compare versions" %>
+<% content_for :title_margin_bottom, 6 %>
 
-<h1>Changes to &lsquo;<%= @edition.title %>&rsquo;</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<p>This page shows changes to the title, summary and body in this edition. It does not show changes to attachments or associations.</p>
+    <p class="govuk-body">This page shows changes to the title, summary and body in this edition. It does not show changes to attachments or associations.</p>
 
-<div id="diff">
-  <section id='title'>
-    <h2>Title</h2>
-    <p class='previous-version'><%= @audit_trail_entry.title %></p>
-    <p class='current-version'><%= @edition.title %></p>
-  </section>
+    <div class="govuk-!-margin-bottom-5">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Title",
+        margin_bottom: 3
+      } %>
 
-  <section id='summary'>
-    <h2>Summary</h2>
-    <p class='previous-version'><%= @audit_trail_entry.summary %></p>
-    <p class='current-version'><%= @edition.summary %></p>
-  </section>
+      <div class="govuk-body audit-trail__history-comparison">
+        <%= diff_html(@audit_trail_entry.title, @edition.title) %>
+      </div>
+    </div>
 
-  <section id='body'>
-    <h2>Body</h2>
-    <p class='previous-version'><%= @audit_trail_entry.body %></p>
-    <p class='current-version'><%= @edition.body %></p>
-  </section>
+    <div class="govuk-!-margin-bottom-5">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Summary",
+        margin_bottom: 3
+      } %>
+
+      <div class="govuk-body audit-trail__history-comparison">
+        <%= diff_html(@audit_trail_entry.summary, @edition.summary) %>
+      </div>
+    </div>
+
+    <div class="govuk-!-margin-bottom-5">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Body",
+        margin_bottom: 3
+      } %>
+
+      <div class="govuk-body audit-trail__history-comparison">
+        <%= diff_html(@audit_trail_entry.body, @edition.body) %>
+      </div>
+    </div>
+  </div>
 </div>
-
-<%= link_to "Back to edition", admin_edition_path(@edition), class: "btn btn-default" %>

--- a/app/views/admin/editions/diff_legacy.html.erb
+++ b/app/views/admin/editions/diff_legacy.html.erb
@@ -1,0 +1,28 @@
+<% page_title @edition.title, @edition.format_name %>
+<% initialise_script "GOVUK.adminEditionsDiff" %>
+
+<h1>Changes to &lsquo;<%= @edition.title %>&rsquo;</h1>
+
+<p>This page shows changes to the title, summary and body in this edition. It does not show changes to attachments or associations.</p>
+
+<div id="diff">
+  <section id='title'>
+    <h2>Title</h2>
+    <p class='previous-version'><%= @audit_trail_entry.title %></p>
+    <p class='current-version'><%= @edition.title %></p>
+  </section>
+
+  <section id='summary'>
+    <h2>Summary</h2>
+    <p class='previous-version'><%= @audit_trail_entry.summary %></p>
+    <p class='current-version'><%= @edition.summary %></p>
+  </section>
+
+  <section id='body'>
+    <h2>Body</h2>
+    <p class='previous-version'><%= @audit_trail_entry.body %></p>
+    <p class='current-version'><%= @edition.body %></p>
+  </section>
+</div>
+
+<%= link_to "Back to edition", admin_edition_path(@edition), class: "btn btn-default" %>


### PR DESCRIPTION
Move Compare with previous version page to GOV.UK Design System, using diffy gem for styling.

[Trello card](https://trello.com/c/mlEUeqal/891-compare-with-previous-version-diff-page)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Before:

<img width="1272" alt="Screenshot 2022-11-24 at 10 34 02" src="https://user-images.githubusercontent.com/4563521/203762548-3fa759fb-966f-4731-9579-171557963e08.png">

After:

<img width="999" alt="Screenshot 2022-11-23 at 17 13 22" src="https://user-images.githubusercontent.com/4563521/203762610-5c44ae6d-0518-4b21-91fc-00e534eba5e9.png">


