### PR TITLE
Add confirm delete page for translations

### DIFF
--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -20,10 +20,12 @@ class Admin::EditionTranslationsController < Admin::BaseController
     end
   end
 
+  def confirm_destroy; end
+
 private
 
   def get_layout
-    design_system_actions = %w[edit update new]
+    design_system_actions = %w[edit update new confirm_destroy]
     if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
       "design_system"
     else

--- a/app/views/admin/edition_translations/confirm_destroy.html.erb
+++ b/app/views/admin/edition_translations/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Delete #{@translation_locale.native_language_name} (#{@translation_locale.english_language_name}) translation" %>
+<% content_for :title, "Delete #{@translation_locale.native_language_name} (#{@translation_locale.english_language_name}) translation" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag admin_edition_translation_path(@edition, @translation_locale), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this translation?</p>
+
+    <div class="govuk-button-group govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Delete translation",
+        destructive: true,
+      } %>
+
+      <%= link_to("Cancel", admin_cancel_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,7 +266,9 @@ Whitehall::Application.routes.draw do
           end
           resources :link_check_reports
           resource :unpublishing, controller: "edition_unpublishing", only: %i[edit update]
-          resources :translations, controller: "edition_translations", except: %i[index show]
+          resources :translations, controller: "edition_translations", except: %i[index show] do
+            get :confirm_destroy, on: :member
+          end
           resources :editorial_remarks, only: %i[new create], shallow: true
           resources :fact_check_requests, only: %i[show create edit update], shallow: true
           resources :attachments, except: [:show] do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Introduce confirm delete page for translations using the new design system.](https://trello.com/c/tPDF5qIJ/948-add-confirm-delete-page-for-translations)
The PR does not use the confirm delete page or introduce a bootstrap version of the page - the old edition summary page can continue to use a modal.
The confirm_destroy page can be reached at URLs similar to http://whitehall-admin.dev.gov.uk/government/admin/editions/1374130/translations/ar/confirm_destroy

## Why

The new design system does not use modals. Currently confirmation that a translation should be deleted is performed using a modal. This PR introduces a new page to be linked to in the new edition summary.

## Screenshots
### After
![whitehall-admin dev gov uk_government_admin_editions_1374130_translations_ar_confirm_destroy(iPad Pro)](https://user-images.githubusercontent.com/9594455/203773731-f847831f-821f-4d87-85de-c6f582348671.png)
![whitehall-admin dev gov uk_government_admin_editions_1374130_translations_ar_confirm_destroy(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/203773746-cd785422-3361-46c1-8c3f-4fc00b231909.png)

### Before
<img width="450" alt="Screenshot 2022-11-24 at 11 23 10" src="https://user-images.githubusercontent.com/9594455/203773884-a81ed693-3dea-4a65-86c5-c6f0826ca5d5.png">
