### PR TITLE
Add confirm page for unscheduling

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -30,7 +30,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 
   def enforce_permissions!
     case action_name
-    when "submit", "unschedule"
+    when "submit", "unschedule", "confirm_unschedule"
       enforce_permission!(:update, @edition)
     when "reject"
       enforce_permission!(:reject, @edition)
@@ -141,6 +141,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
     end
   end
 
+  def confirm_unschedule; end
+
   def unschedule
     unscheduler = Whitehall.edition_services.unscheduler(@edition)
     if unscheduler.perform!
@@ -162,7 +164,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_unpublish confirm_unwithdraw unpublish]
+    design_system_actions = %w[confirm_force_publish confirm_unpublish confirm_unwithdraw unpublish confirm_unschedule]
     design_system_actions << "confirm_force_publish" if preview_design_system?(next_release: true)
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/edition_workflow/confirm_unschedule.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unschedule.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "Unschedule: #{@edition.title}" %>
+<% content_for :title, "Are you sure you want to unschedule?" %>
+<% content_for :context, @edition.title %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag unschedule_admin_edition_path(@edition, lock_version: @edition.lock_version) do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">This will unschedule this edition and return it to the submitted state.</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Unschedule",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Whitehall::Application.routes.draw do
             post :unwithdraw, to: "edition_workflow#unwithdraw"
             post :schedule, to: "edition_workflow#schedule"
             post :force_schedule, to: "edition_workflow#force_schedule"
+            get :confirm_unschedule, to: "edition_workflow#confirm_unschedule"
             post :unschedule, to: "edition_workflow#unschedule"
             get  :audit_trail, to: "edition_audit_trail#index"
             patch :update_bypass_id


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Introduce confirm page for unscheduling using the new design system.](https://trello.com/c/hLef4sCR/951-add-confirm-page-for-unscheduling)
The PR does not use the confirm page or introduce a bootstrap version of the page - the old edition summary page can continue to use a modal.
The confirm_unscheduling page can be reached at URLs similar to http://whitehall-admin.dev.gov.uk/government/admin/editions/1374131/confirm_unschedule?lock_version=72

## Why

The new design system does not use modals. Currently confirmation that an edition should be unscheduled is performed using a modal. This PR introduces a new page to be linked to in the new edition summary.

## Screenshots
### After
![whitehall-admin dev gov uk_government_admin_editions_1374131_confirm_unschedule_lock_version=72(iPad Pro)](https://user-images.githubusercontent.com/9594455/203825886-aa45137a-332d-4c6a-a1f0-ff10e754b197.png)
![whitehall-admin dev gov uk_government_admin_editions_1374131_confirm_unschedule_lock_version=72(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/203825888-c2dad0dc-b139-47ef-a127-1219c25cf7ab.png)


### Before
<img width="539" alt="Screenshot 2022-11-24 at 15 00 23" src="https://user-images.githubusercontent.com/9594455/203825805-285ff396-f9d4-428e-8256-1072c757662a.png">
