### PR TITLE
Add confirm force scheduling page

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -36,7 +36,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
       enforce_permission!(:reject, @edition)
     when "publish", "schedule"
       enforce_permission!(:publish, @edition)
-    when "force_publish", "confirm_force_publish", "force_schedule"
+    when "force_publish", "confirm_force_publish", "force_schedule", "confirm_force_schedule"
       enforce_permission!(:force_publish, @edition)
     when "unpublish", "confirm_unpublish"
       enforce_permission!(:unpublish, @edition)
@@ -134,6 +134,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
     end
   end
 
+  def confirm_force_schedule; end
+
   def force_schedule
     force_scheduler = Whitehall.edition_services.force_scheduler(@edition)
     if force_scheduler.perform!
@@ -166,7 +168,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_approve_retrospectively confirm_force_publish confirm_unpublish confirm_unwithdraw unpublish]
+    design_system_actions = %w[confirm_approve_retrospectively confirm_force_publish confirm_force_schedule confirm_unpublish confirm_unwithdraw unpublish]
     design_system_actions << "confirm_force_publish" if preview_design_system?(next_release: true)
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/edition_workflow/confirm_force_schedule.html.erb
+++ b/app/views/admin/edition_workflow/confirm_force_schedule.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "Force schedule: #{@edition.title}" %>
+<% content_for :title, "Are you sure you want to force schedule?" %>
+<% content_for :context, @edition.title %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag force_schedule_admin_edition_path(@edition, lock_version: @edition.lock_version) do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">This will force schedule this document for publication.</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Force schedule",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Whitehall::Application.routes.draw do
             get  :confirm_unwithdraw, to: "edition_workflow#confirm_unwithdraw"
             post :unwithdraw, to: "edition_workflow#unwithdraw"
             post :schedule, to: "edition_workflow#schedule"
+            get  :confirm_force_schedule, to: "edition_workflow#confirm_force_schedule"
             post :force_schedule, to: "edition_workflow#force_schedule"
             post :unschedule, to: "edition_workflow#unschedule"
             get  :audit_trail, to: "edition_audit_trail#index"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Introduce confirm page for force scheduling using the new design system.](https://trello.com/c/5pYEDxMF/952-add-confirm-page-for-force-scheduling)
The PR does not use the confirm page or introduce a bootstrap version of the page - the old edition summary page can continue to use a modal.
The confirm_force_scheduling page can be reached at URLs similar to http://whitehall-admin.dev.gov.uk/government/admin/editions/1374130/confirm_force_schedule?lock_version=16

## Why

The new design system does not use modals. Currently confirmation that an edition should be force scheduled is performed using a modal. This PR introduces a new page to be linked to in the new edition summary.

## Screenshots
### After
![whitehall-admin dev gov uk_government_admin_editions_1374130_confirm_force_schedule_lock_version=72(iPad Pro)](https://user-images.githubusercontent.com/9594455/203836867-3b1d807d-efe8-4322-a635-5c5639f819ea.png)
![whitehall-admin dev gov uk_government_admin_editions_1374130_confirm_force_schedule_lock_version=72(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/203836877-0f188315-bb9d-4dec-8e4a-e15427d9b443.png)

### Before
<img width="539" alt="Screenshot 2022-11-24 at 15 00 23" src="https://user-images.githubusercontent.com/9594455/203836943-418198e4-55c3-4ff7-9b55-7f0d0884771e.png">
