### PR TITLE
Fix label on World Locations index page

### DIFF
--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -27,7 +27,7 @@
   <% @world_locations.each do |type, locations| %>
     <section id="<%= I18n.t("world_location.type.#{type}", count: 2).parameterize %>" class="world-location-type js-filter-block">
       <header class="type-heading">
-        <h2 class="world-locations__heading"><%= type.pluralize %></h2>
+        <h2 class="world-locations__heading"><%= I18n.t("world_location.type.#{type}", count: 2) %></h2>
         <p class="govuk-body"><span class="js-filter-count"><%= locations.length %></span> <span class="govuk-visually-hidden">locations</span></p>
       </header>
       <div class="content">


### PR DESCRIPTION
There is currently a label on the World Locations index page that says `world_locations` and `international_delegations`, when it should say `World Locations` and `International Delegations`.

This fixes that issue, which was introduced in 052cbed975cc4c5be4c9281186e2a52e73231549.

| Current text | Updated text |
|---|---|
| ![Screenshot of World Location index page showing the heading world_locations](https://user-images.githubusercontent.com/6329861/204249893-c6f718b1-154c-4364-b467-1d22fb050436.png)  |  ![Screenshot of World Location index page showing the heading World Locations](https://user-images.githubusercontent.com/6329861/204249951-09221f5d-2346-4778-bf3a-59057211e04c.png) |
| ![Screenshot of World Location index page showing the heading international_delegations](https://user-images.githubusercontent.com/6329861/204250021-92108b59-9519-4b0a-850d-69be8f64779b.png) | ![Screenshot of World Location index page showing the heading International Delegations](https://user-images.githubusercontent.com/6329861/204250046-22cc8178-b56d-41e4-a320-ae57eb05c7f3.png)  |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
