### PR TITLE
Tidy `TakePartPresenter`

### DIFF
--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -47,20 +47,8 @@ module PublishingApi
       }
     end
 
-    def description
-      item.summary
-    end
-
-    def public_updated_at
-      item.updated_at
-    end
-
     def body
       Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body)
-    end
-
-    def rendering_app
-      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
     end
   end
 end

--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -18,10 +18,10 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details:,
-        document_type: schema_name,
+        document_type: "take_part",
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-        schema_name:,
+        schema_name: "take_part",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
     end
@@ -32,23 +32,15 @@ module PublishingApi
 
   private
 
-    def schema_name
-      "take_part"
-    end
-
     def details
       {
-        body:,
+        body: Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body),
         image: {
           url: item.image_url(:s300),
           alt_text: item.image_alt_text,
         },
         ordering: item.ordering,
       }
-    end
-
-    def body
-      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body)
     end
   end
 end


### PR DESCRIPTION
This removes unused methods, inlines methods that are only used once and fixed an incorrect usage of `schema_name` in place of `document_type`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
