### PR TITLE
Copy inset prompt component from Content Publisher

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@ $govuk-page-width: 1140px;
 
 @import "./components/autocomplete";
 @import "./components/govspeak-editor";
+@import "./components/inset-prompt";
 @import "./components/miller-columns";
 @import "./admin/components/govspeak-help";
 @import "./components/secondary-navigation";

--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -1,0 +1,61 @@
+.app-c-inset-prompt {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(6, "bottom");
+
+  border-left: $govuk-border-width-narrow solid govuk-colour("dark-grey");
+  background-color: govuk-colour("light-grey");
+
+  @include govuk-media-query($from: tablet) {
+    border-left: $govuk-border-width solid govuk-colour("dark-grey");
+  }
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}
+
+.app-c-inset-prompt--error {
+  border-color: $govuk-error-colour;
+  background-color: govuk-tint($govuk-error-colour, 90%);
+}
+
+.app-c-inset-prompt__title {
+  @include govuk-font($size: 24, $weight: bold);
+
+  margin-top: 0;
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+.app-c-inset-prompt__body {
+  @include govuk-font($size: 19);
+
+  p {
+    margin-top: 0;
+    @include govuk-responsive-margin(4, "bottom");
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.app-c-inset-prompt__list {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.app-c-inset-prompt__list a {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active,
+  &:focus {
+    color: $govuk-link-colour;
+    text-decoration: underline;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+}

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -1,0 +1,34 @@
+<%
+  title ||= false
+  description ||= false
+  items ||= []
+  id ||= nil
+  error = false if error.nil?
+  data_attributes ||= {}
+  root_classes = %w[app-c-inset-prompt]
+  root_classes << "app-c-inset-prompt--error" if error
+%>
+
+<%= tag.div class: root_classes, id: id, data: data_attributes do %>
+  <%= tag.h3 title, class: "app-c-inset-prompt__title" %>
+
+  <%= tag.div class: "app-c-inset-prompt__body" do %>
+    <%= description if description %>
+
+    <% if items.any? %>
+      <%= tag.ul class: "govuk-list app-c-inset-prompt__list" do %>
+        <% items.each_with_index do |item, index| %>
+          <%= tag.li do %>
+            <% if item[:href] %>
+              <%= link_to(item[:text], item[:href], data: item[:data_attributes], class: "govuk-link govuk-link--no-visited-state") %>
+            <% else %>
+              <%= tag.span data: item[:data_attributes] do %>
+                <%= item[:text] %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -1,0 +1,38 @@
+name: Inset prompt
+description: A prompt to users represented as inset content
+body: |
+  This is similar to the [inset text][] component, however it has more of an
+  emphasis of informing a user they need to take an action.
+
+  [inset text]: https://design-system.service.gov.uk/components/inset-text/
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Please meet these requirements before publishing
+      description: Document needs a summary before publishing (at least 10 characters)
+  with_items:
+    data:
+      title: Message to alert the user to a problem goes here
+      items:
+      - text: Document needs a title before publishing (at least 10 characters)
+        href: '#content'
+        data_attributes:
+          tracking: GTM-123AA
+      - text: Document needs a summary before publishing (at least 10 characters)
+        data_attributes:
+          tracking: GTM-123AB
+  error:
+    data:
+      error: true
+      title: There is a problem
+      description: |
+        <p class="govuk-body">&lsquo;Title here&rsquo; was not published</p>
+  with_data_attributes:
+    data:
+      title: Message to alert the user to a problem goes here
+      data_attributes:
+        tracking: GTM-123AB
+      items:
+      - text: Descriptive link to the question with an error 1


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Copy the inset prompt component from Content Publisher

## Why

The inset, warning and notification components do not suit all messages displayed in the summary page. To move the summary page to the design system we need this component.

## Screenshot

![whitehall-admin dev gov uk_component-guide_inset_prompt(iPad Pro)](https://user-images.githubusercontent.com/9594455/204589223-24b3b65f-5b07-43ef-809b-66f45cde799a.png)
