### PR TITLE
Include needs, diff and edition confirm destroy in the next release

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -171,7 +171,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def confirm_destroy
-    render_design_system(:confirm_destroy, :confirm_destroy_legacy, next_release: false)
+    render_design_system(:confirm_destroy, :confirm_destroy_legacy, next_release: true)
   end
 
   def destroy
@@ -196,9 +196,9 @@ class Admin::EditionsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[edit update new create confirm_destroy]
-    design_system_actions << "diff" if preview_design_system?(next_release: true)
-    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+    design_system_actions = %w[confirm_destroy diff]
+    design_system_actions += %w[edit update new create] if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -3,7 +3,7 @@ class Admin::NeedsController < Admin::BaseController
   layout :get_layout
 
   def edit
-    render_design_system("edit", "edit_legacy", next_release: false)
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
@@ -16,7 +16,7 @@ class Admin::NeedsController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
[Add needs and edition confirm destroy to the next release.](https://trello.com/c/SjIbBXmi/968-ensure-next-release-permission-works-for-14-features)
Fix the logic adding diff to the next release.

## Why
The next release is 1.4 of which these are all a part.
