### PR TITLE
Add aria attributes to button and preview in Govspeak Preview component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (34.0.0)
+    govuk_publishing_components (34.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -359,7 +359,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.19.0)
+    loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.8.0)
@@ -534,8 +534,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     rails-i18n (7.0.6)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -1,5 +1,7 @@
 <%
   id ||= "#{name}-#{SecureRandom.hex(4)}"
+  preview_id = "#{id}-preview"
+  label_id = "#{id}-label"
   label[:bold] ||= false
   hint ||= nil
   hint_id ||= "#{id}-hint"
@@ -35,6 +37,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters ">
       <%= render "govuk_publishing_components/components/label", {
+        id: label_id,
         html_for: id,
         hint_id: hint_id,
         hint_text: hint,
@@ -47,7 +50,9 @@
         margin_bottom: hint ? 5 : 2,
         classes: "js-app-c-govspeak-editor__preview-button",
         data_attributes: preview_button_data_attributes,
-        type: "button"
+        aria_controls: preview_id,
+        aria_describedby: label_id,
+        type: "button",
       } %>
     </div>
   </div>
@@ -63,7 +68,7 @@
       describedby: hint_id,
     } %>
   </div>
-  <div class="app-c-govspeak-editor__preview">
+  <div class="app-c-govspeak-editor__preview" aria-live="polite" id="<%= preview_id %>">
     <p class="govuk-body">Generating preview, please wait.</p>
   </div>
 <% end %>


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/oGsq2F3m/828-add-accessibility-improvements-to-preview-govspeak-component)

## WHAT
- Adds `aria-controls` and `aria-describedby` attributes to the button render
- Adds `aria-live` and `id` attributes to the preview div
- Adds `id` attribute to label (needs [this PR](https://github.com/alphagov/govuk_publishing_components/pull/3093) to be merged and released before this change can be deployed)
- Updates `govuk_publishing_components` to 34.1.0 (required for the addition of ID attribute options on label)

## WHY
To improve accessibility of the Govspeak Preview component

⚠️ Not to be merged until [this change](https://github.com/alphagov/govuk_publishing_components/pull/3093) has been released in publishing components ⚠️

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
