### PR TITLE
Change WorldwideOrganisations to new schema, from the placeholder out…

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
+        schema_name: "worldwide_organisation",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       base_path: public_path,
       title: "Locationia Embassy",
       description: nil,
-      schema_name: "placeholder",
+      schema_name: "worldwide_organisation",
       document_type: "worldwide_organisation",
       locale: "en",
       publishing_app: "whitehall",
@@ -34,6 +34,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     assert_equal "major", presented_item.update_type
     assert_equal worldwide_org.content_id, presented_item.content_id
 
-    assert_valid_against_publisher_schema(presented_item.content, "placeholder")
+    assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
   end
 end


### PR DESCRIPTION
Change WorldwideOrganisations to new schema, from the placeholder put in for content-schemas migration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
