### PR TITLE
Update banner and what's new page for user research recruitment

### DIFF
--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -1,11 +1,11 @@
 <% tracking_module ||= "gem-track-click" %>
 
 <%= render "govuk_publishing_components/components/phase_banner", {
-    phase: "What's new",
-    message: sanitize("Attachments, unpublishing and withdrawing pages move to the GOV.UK Design System -
+    phase: "User research",
+    message: sanitize("Help make Whitehall Publisher better - find out
       #{
         link_to(
-          "read more about the changes",
+          "how to take part in user research",
           admin_whats_new_path,
           {
             class: "govuk-link",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     whats_new:
-      show_banner: false
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
@@ -13,6 +13,10 @@ en:
           This will make Whitehall Publisher more accessible, more user friendly and give you a consistent user experience throughout your publishing journey on GOV.UK.
 
           [Read more about the changes on the content community Basecamp](https://3.basecamp.com/4322319/buckets/15005645/messages/5287245970).
+          
+          ### Take part in user research
+          
+          You can [sign up to take part in Whitehall Publisher user research](https://docs.google.com/forms/d/e/1FAIpQLSci1Ff7YGLWnvDiuaoAVKzSO06q32kgjVYnSX9A5Kf7jliLaQ/viewform). If you cannot access Google Forms, email <publishing-service-research@digital.cabinet-office.gov.uk>. Once you’ve signed up, you could be invited to feedback on new features and designs, user interviews or test products.
       upcoming_changes:
         heading: Upcoming changes
       recent_changes:


### PR DESCRIPTION
This PR updates:

- the phase banner content to support user research recruitment
- the what's new page to support user research recruitment

https://trello.com/c/XgXvSu7C

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
