### PR TITLE
Render conditional guidance for subtypes on edit edition page

### DIFF
--- a/app/assets/javascripts/admin/modules/edition-form.js
+++ b/app/assets/javascripts/admin/modules/edition-form.js
@@ -1,0 +1,41 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function EditionForm (module) {
+    this.module = module
+  }
+
+  EditionForm.prototype.init = function () {
+    this.setupFormatAdviceForSelectedSubtypeEventListener()
+  }
+
+  EditionForm.prototype.setupFormatAdviceForSelectedSubtypeEventListener = function () {
+    var form = this.module
+    var subtypeDiv = form.querySelector('.edition-form__subtype-fields')
+
+    if (!subtypeDiv) { return }
+
+    var subtypeSelect = subtypeDiv.querySelector('select')
+
+    subtypeSelect.addEventListener('change', function () {
+      var formatAdviceMap = JSON.parse(subtypeDiv.dataset.formatAdvice)
+      var subtypeFormatAdvice = form.querySelector('.edition-form__subtype-format-advice')
+
+      if (subtypeFormatAdvice) {
+        subtypeDiv.removeChild(subtypeFormatAdvice)
+      }
+
+      var adviceText = formatAdviceMap[subtypeSelect.value]
+
+      if (adviceText) {
+        var div = document.createElement('div')
+        div.classList.add('edition-form__subtype-format-advice', 'govuk-body', 'govuk-!-margin-top-4')
+        div.innerHTML = '<strong>Use this subformat for…</strong> ' + adviceText
+        subtypeDiv.append(div)
+      }
+    })
+  }
+
+  Modules.EditionForm = EditionForm
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/admin/modules/edition-form.js
+++ b/app/assets/javascripts/admin/modules/edition-form.js
@@ -7,10 +7,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   EditionForm.prototype.init = function () {
-    this.setupFormatAdviceForSelectedSubtypeEventListener()
+    this.setupSubtypeFormatAdviceEventListener()
   }
 
-  EditionForm.prototype.setupFormatAdviceForSelectedSubtypeEventListener = function () {
+  EditionForm.prototype.setupSubtypeFormatAdviceEventListener = function () {
     var form = this.module
     var subtypeDiv = form.querySelector('.edition-form__subtype-fields')
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require components/miller-columns
 
 //= require admin/modules/analytics
+//= require admin/modules/edition-form
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -127,7 +127,7 @@ module Admin::EditionsHelper
   def standard_edition_form(edition, information = nil, preview_design_system: false)
     initialise_script "GOVUK.adminEditionsForm", selector: ".js-edition-form", right_to_left_locales: Locale.right_to_left.collect(&:to_param)
     if preview_design_system
-      form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true } do |form|
+      form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm" } do |form|
         concat render("standard_fields", form:, edition:)
         yield(form)
         concat render("access_limiting_fields", form:, edition:)

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -6,7 +6,7 @@ class PublicationType
   include ActiveRecordLikeInterface
 
   FORMAT_ADVICE = {
-    1 => "<p>A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.</p><p>Read the <a href=\"https://www.gov.uk/guidance/content-design/content-types#policy-paper\" target=\"_blank\">policy papers guidance</a> in full.</p>",
+    1 => "<p>A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.</p><p>Read the <a href=\"https://www.gov.uk/guidance/content-design/content-types#policy-paper\" target=\"_blank\" class=\"govuk-link\">policy papers guidance</a> in full.</p>",
     2 => "<p>Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.</p>",
     3 => "<p>Non-statutory guidance publications. Includes: manuals, handbooks and other documents that offer advice.</p><p>Do <em>not</em> use for: statutory guidance (use the “statutory guidance” publication type) or guidance about completing a form (attach to same publication as the form itself).</p>",
     4 => "<p>Pro-forma or form documents that need to be completed by the user. Can include guidance on how to fill in forms (ie no need to create a separate “guidance” publication for form instructions).</p>",

--- a/app/views/admin/editions/_subtype_format_advice.html.erb
+++ b/app/views/admin/editions/_subtype_format_advice.html.erb
@@ -1,0 +1,3 @@
+<div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+  <strong>Use this subformat for…</strong> <%= guidance %>
+</div>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -1,22 +1,24 @@
-<%= render "govuk_publishing_components/components/select", {
-  name: "edition[news_article_type_id]",
-  id: "edition_news_article_type_id",
-  label: "News article type",
-  heading_size: "s",
-  full_width: true,
-  value: edition.news_article_type_id,
-  error_message: errors_for(edition.errors, :news_article_type_id),
-  options: ([nil]+ NewsArticleType.all).map do |type|
-    {
-      text: type&.singular_name,
-      value: type&.id,
-      selected: edition.news_article_type_id == type&.id
-    }
-  end
-} %>
+<div class="edition-form__subtype-fields" data-format-advice="<%= NewsArticleType::FORMAT_ADVICE %>">
+  <%= render "govuk_publishing_components/components/select", {
+    name: "edition[news_article_type_id]",
+    id: "edition_news_article_type_id",
+    label: "News article type",
+    heading_size: "s",
+    full_width: true,
+    value: edition.news_article_type_id,
+    error_message: errors_for(edition.errors, :news_article_type_id),
+    options: ([nil]+ NewsArticleType.all).map do |type|
+      {
+        text: type&.singular_name,
+        value: type&.id,
+        selected: edition.news_article_type_id == type&.id
+      }
+    end
+  } %>
 
-<% if edition.news_article_type_id.present? %>
-  <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-    <strong>Use this subformat for…</strong> <%= JSON.parse(NewsArticleType::FORMAT_ADVICE)[edition.news_article_type_id.to_s].html_safe %>
-  </div>
-<% end %>
+  <% if edition.news_article_type_id.present? %>
+    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+      <strong>Use this subformat for…</strong> <%= JSON.parse(NewsArticleType::FORMAT_ADVICE)[edition.news_article_type_id.to_s].html_safe %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -6,7 +6,7 @@
     heading_size: "s",
     full_width: true,
     value: edition.news_article_type_id,
-    error_message: errors_for(edition.errors, :news_article_type_id),
+    error_message: errors_for_input(edition.errors, :news_article_type_id),
     options: ([nil]+ NewsArticleType.all).map do |type|
       {
         text: type&.singular_name,

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -17,8 +17,6 @@
   } %>
 
   <% if edition.news_article_type_id.present? %>
-    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-      <strong>Use this subformat for…</strong> <%= JSON.parse(NewsArticleType::FORMAT_ADVICE)[edition.news_article_type_id.to_s].html_safe %>
-    </div>
+    <%= render "subtype_format_advice", guidance: JSON.parse(NewsArticleType::FORMAT_ADVICE)[edition.news_article_type_id.to_s].html_safe %>
   <% end %>
 </div>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -14,3 +14,9 @@
     }
   end
 } %>
+
+<% if edition.news_article_type_id.present? %>
+  <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+    <strong>Use this subformat for…</strong> <%= JSON.parse(NewsArticleType::FORMAT_ADVICE)[edition.news_article_type_id.to_s].html_safe %>
+  </div>
+<% end %>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,35 +1,37 @@
-<div class="govuk-form-group">
-  <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
-    Publication type
-  </label>
-  <% if errors_for_input(edition.errors, :publication_type_id).present? %>
-    <p class="gem-c-error-message govuk-error-message">
-      <span class="govuk-visually-hidden">Error: <%= errors_for_input(edition.errors, :publication_type_id) %></span>
-    </p>
-  <% end %>
+<div class="edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
+  <div class="govuk-form-group">
+    <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
+      Publication type
+    </label>
+    <% if errors_for_input(edition.errors, :publication_type_id).present? %>
+      <p class="gem-c-error-message govuk-error-message">
+        <span class="govuk-visually-hidden">Error: <%= errors_for_input(edition.errors, :publication_type_id) %></span>
+      </p>
+    <% end %>
 
-  <select class="govuk-select govuk-select gem-c-select__select--full-width" id="edition_publication_type_id" name="edition[publication_type_id]">
-    <option></option>
-    <optgroup label="Common types">
-      <% PublicationType.primary.each do |publication_type| %>
-        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-      <% end %>
-    <optgroup/>
-    <optgroup label="Less common types">
-      <% PublicationType.less_common.each do |publication_type| %>
-        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-      <% end %>
-    <optgroup/>
-    <optgroup label="Use discouraged">
-      <% PublicationType.use_discouraged.each do |publication_type| %>
-        <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-      <% end %>
-    <optgroup/>
-  </select>
+    <select class="govuk-select govuk-select gem-c-select__select--full-width" id="edition_publication_type_id" name="edition[publication_type_id]">
+      <option></option>
+      <optgroup label="Common types">
+        <% PublicationType.primary.each do |publication_type| %>
+          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+        <% end %>
+      <optgroup/>
+      <optgroup label="Less common types">
+        <% PublicationType.less_common.each do |publication_type| %>
+          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+        <% end %>
+      <optgroup/>
+      <optgroup label="Use discouraged">
+        <% PublicationType.use_discouraged.each do |publication_type| %>
+          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
+        <% end %>
+      <optgroup/>
+    </select>
 
-  <% if edition.publication_type_id.present? %>
-    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-      <strong>Use this subformat for…</strong> <%= JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
-    </div>
-  <% end %>
+    <% if edition.publication_type_id.present? %>
+      <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+        <strong>Use this subformat for…</strong> <%= JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -29,9 +29,7 @@
     </select>
 
     <% if edition.publication_type_id.present? %>
-      <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-        <strong>Use this subformat for…</strong> <%= JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
-      </div>
+      <%= render "subtype_format_advice", guidance: JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -26,4 +26,10 @@
       <% end %>
     <optgroup/>
   </select>
+
+  <% if edition.publication_type_id.present? %>
+    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+      <strong>Use this subformat for…</strong> <%= JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -6,7 +6,7 @@
     heading_size: "s",
     full_width: true,
     value: edition.speech_type_id,
-    error_message: errors_for(edition.errors, :speech_type_id),
+    error_message: errors_for_input(edition.errors, :speech_type_id),
     options: ([nil] + SpeechType.primary).map do |type|
       {
         text: type&.singular_name,

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -17,8 +17,6 @@
   } %>
 
   <% if edition.speech_type_id.present? %>
-    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-      <strong>Use this subformat for…</strong> <%= JSON.parse(SpeechType::FORMAT_ADVICE)[edition.speech_type_id.to_s].html_safe %>
-    </div>
+    <%= render "subtype_format_advice", guidance: JSON.parse(SpeechType::FORMAT_ADVICE)[edition.speech_type_id.to_s].html_safe %>
   <% end %>
 </div>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -14,3 +14,9 @@
     }
   end
 } %>
+
+<% if edition.speech_type_id.present? %>
+  <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+    <strong>Use this subformat for…</strong> <%= JSON.parse(SpeechType::FORMAT_ADVICE)[edition.speech_type_id.to_s].html_safe %>
+  </div>
+<% end %>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -1,22 +1,24 @@
-<%= render "govuk_publishing_components/components/select", {
-  name: "edition[speech_type_id]",
-  id: "edition_speech_type_id",
-  label: "Speech type",
-  heading_size: "s",
-  full_width: true,
-  value: edition.speech_type_id,
-  error_message: errors_for(edition.errors, :speech_type_id),
-  options: ([nil] + SpeechType.primary).map do |type|
-    {
-      text: type&.singular_name,
-      value: type&.id,
-      selected: edition.speech_type_id == type&.id
-    }
-  end
-} %>
+<div class="edition-form__subtype-fields" data-format-advice="<%= SpeechType::FORMAT_ADVICE %>">
+  <%= render "govuk_publishing_components/components/select", {
+    name: "edition[speech_type_id]",
+    id: "edition_speech_type_id",
+    label: "Speech type",
+    heading_size: "s",
+    full_width: true,
+    value: edition.speech_type_id,
+    error_message: errors_for(edition.errors, :speech_type_id),
+    options: ([nil] + SpeechType.primary).map do |type|
+      {
+        text: type&.singular_name,
+        value: type&.id,
+        selected: edition.speech_type_id == type&.id
+      }
+    end
+  } %>
 
-<% if edition.speech_type_id.present? %>
-  <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
-    <strong>Use this subformat for…</strong> <%= JSON.parse(SpeechType::FORMAT_ADVICE)[edition.speech_type_id.to_s].html_safe %>
-  </div>
-<% end %>
+  <% if edition.speech_type_id.present? %>
+    <div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+      <strong>Use this subformat for…</strong> <%= JSON.parse(SpeechType::FORMAT_ADVICE)[edition.speech_type_id.to_s].html_safe %>
+    </div>
+  <% end %>
+</div>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -1,0 +1,46 @@
+describe('GOVUK.Modules.EditionForm', function () {
+  var form
+
+  beforeEach(function () {
+    form = document.createElement('form')
+    form.setAttribute('data-module', 'EditionForm')
+
+    form.innerHTML = `
+    <div class="edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">
+      <div class="govuk-form-group gem-c-select">
+        <label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>
+        <select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">
+          <option value=""></option>
+          <option value="1">News story</option>
+          <option value="2">Press release</option>
+          <option value="3">Government response</option>
+          <option value="4">World news story</option></select>
+      </div>
+    </div>
+    `
+    var editionForm = new GOVUK.Modules.EditionForm(form)
+    editionForm.init()
+  })
+
+  it('should render subtype guidance based when the subtype format select changes value', function () {
+    var select = form.querySelector('#edition_news_article_type_id')
+
+    select.value = '1'
+    select.dispatchEvent(new Event('change'))
+    var subtypeAdvice = form.querySelector('.edition-form__subtype-format-advice')
+
+    expect(subtypeAdvice.innerHTML).toBe('<strong>Use this subformat for…</strong> <p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>')
+  })
+
+  it('should remove subtype guidance when the subtype format select is unselected', function () {
+    var select = form.querySelector('#edition_news_article_type_id')
+
+    select.value = '1'
+    select.dispatchEvent(new Event('change'))
+    select.value = '0'
+    select.dispatchEvent(new Event('change'))
+
+    var subtypeAdvice = form.querySelector('.edition-form__subtype-format-advice')
+    expect(subtypeAdvice).toBe(null)
+  })
+})

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -30,6 +30,17 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "edit displays news article field and guidance" do
+    news_article = create(:news_article)
+
+    get :edit, params: { id: news_article }
+
+    assert_select "form#edit_edition" do
+      assert_select "select[name*='edition[news_article_type_id']"
+      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… Unedited press releases as sent to the media, and official statements from the organisation or a minister.Do not use for: statements to Parliament. Use the “Speech” format for those."
+    end
+  end
+
   view_test "show renders the summary" do
     draft_news_article = create(:draft_news_article, summary: "a-simple-summary")
     stub_publishing_api_expanded_links_with_taxons(draft_news_article.content_id, [])

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_equal "First published at can't be blank", assigns(:edition).errors.full_messages.last
   end
 
-  view_test "edit displays publication fields" do
+  view_test "edit displays publication fields and guidance" do
     publication = create(:publication)
 
     get :edit, params: { id: publication }
@@ -98,6 +98,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "form#edit_edition" do
       assert_select "select[name='edition[publication_type_id]']"
       assert_select "select[name*='edition[first_published_at']", count: 5
+      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.Read the policy papers guidance in full."
     end
   end
 

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -30,6 +30,21 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "edit renders subtype guidance" do
+    speech = create(:speech)
+
+    get :edit, params: { id: speech }
+
+    assert_select "form#edit_edition" do
+      assert_select "select[name='edition[speech_type_id]']"
+      assert_select "select[name='edition[role_appointment_id]']"
+      assert_select "input[name='edition[person_override]']"
+      assert_select "select[name*='edition[delivered_on']", count: 5
+      assert_select "input[name='edition[location]'][type='text']"
+      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… A verbatim report of exactly what the speaker said (checked against delivery)."
+    end
+  end
+
   test "create should create a new speech" do
     role_appointment = create(:role_appointment)
     speech_type = SpeechType::Transcript


### PR DESCRIPTION
## Description

Publications, Speeches and News Articles all have subtypes that a user selects from. Each of these has guidance that needs to be rendered when the subtype is selected.

This PR adds this functionality.

Previously, the subtype advice was loaded via JS on page load, then updated when the value of the select changed.

I think it makes more sense to render the conditional guidance on load and only use JS to update the guidance on change. 

I've added this as the EditionForm module, rather than SubtypeAdvice module or similar, as additional functionality will be added later. For example, conditionally rendering the news world story language select when a news article subtype is changed to world news story.

## Screenshots

### Publications

<img width="805" alt="image" src="https://user-images.githubusercontent.com/42515961/205090418-051c15ae-6d6c-4f40-adb0-caaa8eb6f104.png">

<img width="685" alt="image" src="https://user-images.githubusercontent.com/42515961/205090472-fb6f912f-6d5b-4d15-81c4-a07811d3f431.png">


### Speeches

<img width="835" alt="image" src="https://user-images.githubusercontent.com/42515961/205090300-1e014d4d-75f6-4062-acf9-c28324465a13.png">

<img width="735" alt="image" src="https://user-images.githubusercontent.com/42515961/205090362-b786d09d-5ea7-4665-b13d-77ef86ceb4a4.png">


### News stories 

<img width="775" alt="image" src="https://user-images.githubusercontent.com/42515961/205090169-32bc40b9-8295-4334-90f3-7200c8f3b512.png">


<img width="704" alt="image" src="https://user-images.githubusercontent.com/42515961/205090208-1ee253a1-5e86-4113-b60c-2596da8a41eb.png">

## Guidance for review

Its probs best to go per commit, then give it a manual test as it's hard to cover the functionality for each subtype with screenshots (there would be 30 or 40 screenshots)

## Trello card

https://trello.com/c/ba3Tc8DN/807-javascript-wire-in-format-advice-module-in-the-govuk-design-system-for-publications-speeches-and-news-articles


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
