### PR TITLE
Return 404 on detailed guide routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,7 +387,7 @@ Whitehall::Application.routes.draw do
   get "healthcheck/unenqueued_scheduled_editions" => "healthcheck#unenqueued_scheduled_editions"
 
   # TODO: Remove when paths for new content can be generated without a route helper
-  get "/guidance/:id(.:locale)", as: "detailed_guide", to: "detailed_guides#show", constraints: { id: /[A-z0-9-]+/, locale: valid_locales_regex }
+  get "/guidance/:id(.:locale)", as: "detailed_guide", constraints: { id: /[A-z0-9-]+/, locale: valid_locales_regex }, to: rack_404
 
   resources :broken_links_export_request, path: "/export/broken_link_reports", param: :export_id, only: [:show]
   resources :document_list_export_request, path: "/export/:document_type_slug", param: :export_id, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,7 +373,7 @@ Whitehall::Application.routes.draw do
   end
 
   # TODO: the organisations controller has been removed but this route is still required to get the relevant helper methods. This can be removed once new helpers have been created.
-  get "/courts-tribunals/:id(.:locale)", as: "court", to: "organisations#show", courts_only: true, constraints: { locale: valid_locales_regex }
+  get "/courts-tribunals/:id(.:locale)", as: "court", courts_only: true, constraints: { locale: valid_locales_regex }, to: rack_404
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(


### PR DESCRIPTION
This relates to the problem addressed in: https://github.com/alphagov/whitehall/pull/7113

If Whitehall receives a request for a detailed guide it will log an error of:

```
uninitialized constant DetailedGuidesController

      Object.const_get(camel_cased_word)
            ^^^^^^^^^^
Did you mean?  DetailedGuidePresenter

            raise MissingController.new(error.message, error.name)
            ^^^^^
```

Before returning a 404.

This changes that to just return a 404 as a rack response and resolve wiring this to a non-existent controller. This stops the logging but continues returning a 404 response.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
