### PR TITLE
Conditionally render WorldNewsStory fields

### DIFF
--- a/app/assets/javascripts/admin/modules/edition-form.js
+++ b/app/assets/javascripts/admin/modules/edition-form.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   EditionForm.prototype.init = function () {
     this.setupSubtypeFormatAdviceEventListener()
+    this.setupWorldNewsStoryVisibilityToggle()
   }
 
   EditionForm.prototype.setupSubtypeFormatAdviceEventListener = function () {
@@ -33,6 +34,34 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         div.classList.add('edition-form__subtype-format-advice', 'govuk-body', 'govuk-!-margin-top-4')
         div.innerHTML = '<strong>Use this subformat for…</strong> ' + adviceText
         subtypeDiv.append(div)
+      }
+    })
+  }
+
+  EditionForm.prototype.setupWorldNewsStoryVisibilityToggle = function () {
+    var form = this.module
+
+    var select = form.querySelector('#edition_news_article_type_id')
+
+    if (!select) { return }
+
+    var container = form.querySelector('.edition-form--locale-fields')
+    var localeCheckbox = container.querySelector('#edition_create_foreign_language_only-0')
+    var localeSelect = container.querySelector('#edition_primary_locale')
+    const newArticleTypeId = '4'
+
+    if (select.value !== newArticleTypeId) {
+      container.style.display = 'none'
+    }
+
+    select.addEventListener('change', function () {
+      if (select.value !== newArticleTypeId) {
+        container.style.display = 'none'
+        localeCheckbox.value = '0'
+        localeCheckbox.checked = false
+        localeSelect.value = ''
+      } else {
+        container.style.display = 'block'
       }
     })
   }

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,37 +1,39 @@
 <% if edition.locale_can_be_changed? %>
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    name: "edition[create_foreign_language_only]",
-    id: "edition_create_foreign_language_only",
-    heading: "Foreign language only #{edition.model_name.human.downcase}",
-    heading_size: "l",
-    no_hint_text: true,
-    error_items: errors_for_input(edition.errors, :create_foreign_language_only),
-    items: [
-      {
-        label: "Create a foreign language only #{edition.model_name.human.downcase}",
-        value: "1",
-        checked: form.object.primary_locale != "en",
-        conditional: (render "govuk_publishing_components/components/select", {
-          id: "edition_primary_locale",
-          name: "edition[primary_locale]",
-          label: "Document language",
-          heading_size: "s",
-          full_width: true,
-          allow_blank: true,
-          errors: errors_for(edition.errors, :primary_locale),
-          options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
-            {
-              text: language,
-              value: value,
-              selected: edition.primary_locale == value
-            }
-          end
-        })
-      }
-    ]
-  } %>
+  <div class="edition-form--locale-fields">
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "edition[create_foreign_language_only]",
+      id: "edition_create_foreign_language_only",
+      heading: "Foreign language only #{edition.model_name.human.downcase}",
+      heading_size: "l",
+      no_hint_text: true,
+      error_items: errors_for_input(edition.errors, :create_foreign_language_only),
+      items: [
+        {
+          label: "Create a foreign language only #{edition.model_name.human.downcase}",
+          value: "1",
+          checked: form.object.primary_locale != "en",
+          conditional: (render "govuk_publishing_components/components/select", {
+            id: "edition_primary_locale",
+            name: "edition[primary_locale]",
+            label: "Document language",
+            heading_size: "s",
+            full_width: true,
+            allow_blank: true,
+            errors: errors_for(edition.errors, :primary_locale),
+            options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
+              {
+                text: language,
+                value: value,
+                selected: edition.primary_locale == value
+              }
+            end
+          })
+        }
+      ]
+    } %>
 
-  <% if edition.is_a?(NewsArticle) %>
-    <p class="govuk-body govuk-!-font-weight-bold">Warning: News stories without an English version cannot have other translations.</p>
-  <% end %>
+    <% if edition.is_a?(NewsArticle) %>
+      <p class="govuk-body govuk-!-font-weight-bold">Warning: News stories without an English version cannot have other translations.</p>
+    <% end %>
+  </div>
 <% end %>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -17,6 +17,17 @@ describe('GOVUK.Modules.EditionForm', function () {
           <option value="4">World news story</option></select>
       </div>
     </div>
+
+    <div class="edition-form--locale-fields">
+      <input type="checkbox" name="edition[create_foreign_language_only]" id="edition_create_foreign_language_only-0" value="0" checked="checked">
+
+      <select name="edition[primary_locale]" id="edition_primary_locale" class="govuk-select gem-c-select__select--full-width">
+        <option value=""></option>
+        <option value="ar">العربيَّة (Arabic)</option>
+        <option value="az">Azeri (Azeri)</option>
+        <option value="be">Беларуская (Belarusian)</option>
+      </select>
+    </div>
     `
     var editionForm = new GOVUK.Modules.EditionForm(form)
     editionForm.init()
@@ -42,5 +53,41 @@ describe('GOVUK.Modules.EditionForm', function () {
 
     var subtypeAdvice = form.querySelector('.edition-form__subtype-format-advice')
     expect(subtypeAdvice).toBe(null)
+  })
+
+  it('should hide the locale fields when a NewsArticle is not a WorldNewsStory', function () {
+    var localeFields = form.querySelector('.edition-form--locale-fields')
+
+    expect(localeFields.style.display).toEqual('none')
+  })
+
+  it('should render the locale fields when the WorldNewsStory is selected', function () {
+    var select = form.querySelector('#edition_news_article_type_id')
+
+    select.value = '4'
+    select.dispatchEvent(new Event('change'))
+
+    var localeFields = form.querySelector('.edition-form--locale-fields')
+
+    expect(localeFields.style.display).toEqual('block')
+  })
+
+  it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {
+    var select = form.querySelector('#edition_news_article_type_id')
+    var localeCheckbox = form.querySelector('#edition_create_foreign_language_only-0')
+    var localeSelect = form.querySelector('#edition_primary_locale')
+
+    select.value = '4'
+    select.dispatchEvent(new Event('change'))
+
+    localeCheckbox.checked = true
+    localeCheckbox.value = '1'
+    localeSelect.value = 'ar'
+    select.value = '1'
+    select.dispatchEvent(new Event('change'))
+
+    expect(localeCheckbox.value).toEqual('0')
+    expect(localeCheckbox.checked).toEqual(false)
+    expect(localeSelect.value).toEqual('')
   })
 })


### PR DESCRIPTION
## Description

World news stories are the only subtype of news articles which can be foreign language only.

Due to this, when the subtype is selected, we need to conditionally reveal the foreign language only checkbox and document language select fields.

This adds this functionality to the edition-form.js module.

## Screenshots

Hides fields non-World news story sub types

<img width="722" alt="image" src="https://user-images.githubusercontent.com/42515961/205305633-c71cb1c5-68b9-4c9e-b19c-2b56f866ba6c.png">

Shows fields when World news story is selected

<img width="849" alt="image" src="https://user-images.githubusercontent.com/42515961/205305778-e3728a68-81bd-4ad5-8154-aff233a27f0e.png">

## Trello card 

https://trello.com/c/kSRCMAvH/983-javascript-conditionally-reveal-foreign-language-only-checkbox-for-world-news-story-subtype

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
