### PR TITLE
Add permission for performing administrative tasks

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -13,6 +13,7 @@ module Whitehall::Authority::Rules
         make_fact_check
         mark_political
         modify
+        perform_administrative_tasks
         publish
         reject
         review_editorial_remark
@@ -78,7 +79,12 @@ module Whitehall::Authority::Rules
     end
 
     def gds_admin_can?(action)
-      gds_editor_can?(action)
+      case action
+      when :perform_administrative_tasks
+        true
+      else
+        gds_editor_can?(action)
+      end
     end
 
     def gds_editor_can?(action)
@@ -89,6 +95,8 @@ module Whitehall::Authority::Rules
         can_publish?
       when :force_publish
         can_force_publish?
+      when :perform_administrative_tasks
+        false
       when :unpublish
         false
       else
@@ -161,7 +169,7 @@ module Whitehall::Authority::Rules
         can_publish?
       when :force_publish
         can_force_publish?
-      when :unpublish, :mark_political
+      when :unpublish, :mark_political, :perform_administrative_tasks
         false
       else
         true
@@ -183,7 +191,7 @@ module Whitehall::Authority::Rules
 
     def departmental_writer_can?(action)
       case action
-      when :approve, :publish, :unpublish, :force_publish, :reject, :mark_political
+      when :approve, :publish, :unpublish, :force_publish, :reject, :mark_political, :perform_administrative_tasks
         false
       else
         true


### PR DESCRIPTION
Only users with the 'GDS Admin' permission can perform this action.

This will be used for general administrative tasks, e.g. reslugging a document.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
