### PR TITLE
Add UI that allows GDS Editor to update a documents slug

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,4 +1,9 @@
 class Admin::DocumentsController < Admin::BaseController
+  before_action :find_document, only: %i[edit_slug update_slug]
+  before_action :find_published_edition, only: %i[edit_slug update_slug]
+  before_action :enforce_permissions!, only: %i[edit_slug update_slug]
+  layout "design_system"
+
   def by_content_id
     document = (
       Document.find_by(content_id: params[:content_id]) ||
@@ -14,5 +19,32 @@ class Admin::DocumentsController < Admin::BaseController
       flash[:error] = "The requested content was not found"
       redirect_to url_maker.admin_editions_path
     end
+  end
+
+  def edit_slug; end
+
+  def update_slug
+    @document.assign_attributes(slug: params.dig("document", "slug"))
+
+    if DataHygiene::DocumentReslugger.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
+      flash[:notice] = "Slug updated successfully"
+      redirect_to admin_edition_path(@published_edition)
+    else
+      render :edit_slug
+    end
+  end
+
+private
+
+  def find_document
+    @document = Document.find(params[:id])
+  end
+
+  def find_published_edition
+    @published_edition = @document.editions.published.last
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:perform_administrative_tasks, @document)
   end
 end

--- a/app/views/admin/documents/edit_slug.html.erb
+++ b/app/views/admin/documents/edit_slug.html.erb
@@ -1,0 +1,37 @@
+<% content_for :page_title, "#{@published_edition.title}: Update slug" %>
+<% content_for :context, @published_edition.title %>
+<% content_for :title, "Update slug" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @document)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @document, method: :patch, url: admin_update_admin_document_slug_path(@document.id) do |form| %>
+
+      <p class="govuk-body">Updating the slug for a document performs the following steps:</p>
+
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "changes the documents slug",
+          "reindexes the document with it's new slug",
+          "republishes the document to Publishing API (automatically handles the redirect)",
+        ]
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Slug",
+          bold: true,
+        },
+        name: "document[slug]",
+        id: "document_slug",
+        value: params.dig("document", "slug") || @document.slug,
+        error_items: errors_for(@document.errors, :slug)
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Update"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,8 @@ Whitehall::Application.routes.draw do
         get "find-in-admin-bookmarklet" => "find_in_admin_bookmarklet#index", as: :find_in_admin_bookmarklet_instructions_index
         get "find-in-admin-bookmarklet/:browser" => "find_in_admin_bookmarklet#show", as: :find_in_admin_bookmarklet_instructions
         get "by-content-id/:content_id" => "documents#by_content_id"
+        get "/documents/:id/edit_slug" => "documents#edit_slug", as: :edit_admin_document_slug
+        patch "/documents/:id/update_slug" => "documents#update_slug", as: :update_admin_document_slug
         get "/:content_id/needs" => "needs#edit", as: :edit_needs
         patch "/:content_id/needs" => "needs#update", as: :update_needs
 

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -1,0 +1,15 @@
+Feature: Edition update slug
+  This feature allows GDS editors to update a documents slug
+
+  Scenario: GDS editor updates a slug
+    Given I am a GDS editor
+    And a published news article "You will never guess" exists
+    And I visit the edit slug page for "You will never guess"
+    And I update the slug to "/new-slug"
+    Then I can see the slug has been updated to "/new-slug"
+
+  Scenario: Admin attempts to update a slug
+    Given I am an admin
+    And a published news article "You will never guess" exists
+    And I visit the edit slug page for "You will never guess"
+    Then I am told I do not have access to the document

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -1,0 +1,19 @@
+And(/^I visit the edit slug page for "([^"]*)"$/) do |edition_title|
+  @edition = Edition.find_by!(title: edition_title)
+  visit admin_edit_admin_document_slug_path(@edition.document)
+end
+
+And(/^I update the slug to "([^"]*)"$/) do |new_slug|
+  fill_in "Slug", with: new_slug
+  click_button "Update"
+end
+
+Then(/^I can see the slug has been updated to "([^"]*)"$/) do |new_slug|
+  visit admin_edition_path(@edition)
+  click_button "Create new edition to edit"
+  expect(find("#edition_slug").value).to eq new_slug
+end
+
+Then(/^I am told I do not have access to the document$/) do
+  expect(page).to have_content "Sorry, you don’t have access to this document"
+end

--- a/lib/data_hygiene/document_reslugger.rb
+++ b/lib/data_hygiene/document_reslugger.rb
@@ -1,0 +1,72 @@
+module DataHygiene
+  # Reslugs a document to new_slug.
+  #
+  # When run, the following happens:
+  #
+  #  - changes the documents slug
+  #  - reindexes the document with it's new slug
+  #  - republishes the document to Publishing API (automatically handles the redirect)
+  #
+  class DocumentReslugger
+    attr_reader :document, :published_edition, :current_user, :new_slug
+
+    def initialize(document, published_edition, current_user, new_slug)
+      @document = document
+      @published_edition = published_edition
+      @current_user = current_user
+      @new_slug = new_slug
+    end
+
+    def run!
+      add_errors_if_invalid
+      return false if document.errors.present?
+
+      remove_from_search_index
+      save_document
+      republish_document
+      add_to_search_index
+      create_editorial_remark
+      true
+    end
+
+  private
+
+    def add_errors_if_invalid
+      document.errors.add(:slug, "is blank") and return if new_slug.blank?
+
+      document.errors.add(:slug, "must be unique") and return if new_slug_is_a_duplicate
+
+      document.errors.add(:slug, "is invalid") unless new_slug.starts_with?("/") && new_slug !~ %r{//} && new_slug !~ %r{./\z}
+    end
+
+    def new_slug_is_a_duplicate
+      documents = Document.where(slug: new_slug)
+      documents.present? && documents != [document]
+    end
+
+    def remove_from_search_index
+      Whitehall::SearchIndex.delete(published_edition)
+    end
+
+    def save_document
+      document.update!(slug: new_slug)
+    end
+
+    def republish_document
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+
+    def add_to_search_index
+      Whitehall::SearchIndex.add(published_edition)
+    end
+
+    def create_editorial_remark
+      published_edition.editorial_remarks.create!(
+        body: "Updated document slug to #{document.slug}",
+        author: current_user,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      )
+    end
+  end
+end

--- a/lib/whitehall/authority/rules/document_rules.rb
+++ b/lib/whitehall/authority/rules/document_rules.rb
@@ -8,7 +8,12 @@ module Whitehall::Authority::Rules
     end
 
     def can?(action)
-      actor.gds_editor? || actor.departmental_editor? || action == :create
+      case action
+      when :perform_administrative_tasks
+        actor.gds_editor?
+      else
+        actor.gds_editor? || actor.departmental_editor? || action == :create
+      end
     end
   end
 end

--- a/test/unit/data_hygiene/document_reslugger_test.rb
+++ b/test/unit/data_hygiene/document_reslugger_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class DocumentResluggerTest < ActiveSupport::TestCase
+  setup do
+    stub_any_publishing_api_call
+    @user = create(:user)
+    @document = create(:document, slug: "/old-slug")
+    @published_edition = create(:edition, :published)
+  end
+
+  test "updates the slug to the new slug, updated the publishing API, reindexes the slug on search index and creates an EditorialRemark" do
+    reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "/new-slug")
+
+    Whitehall::SearchIndex.expects(:delete).with(@published_edition)
+    PublishingApiDocumentRepublishingWorker.expects(:new).returns(worker = mock)
+    worker.expects(:perform).with(@document.id)
+    Whitehall::SearchIndex.expects(:add).with(@published_edition)
+
+    reslugger.run!
+
+    assert_equal "/new-slug", @document.slug
+    assert_equal @published_edition.editorial_remarks.count, 1
+    assert_equal @published_edition.editorial_remarks.first.author_id, @user.id
+    assert_equal @published_edition.editorial_remarks.first.body, "Updated document slug to /new-slug"
+  end
+
+  test "returns false and the adds an error to the document when new_slug is blank" do
+    reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "")
+    assert_equal false, reslugger.run!
+    assert_equal @document.errors.full_messages, ["Slug is blank"]
+  end
+
+  test "returns false and the adds an error when the new slug is present on an another document" do
+    create(:document, slug: "/new-slug")
+
+    reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "/new-slug")
+    assert_equal false, reslugger.run!
+    assert_equal @document.errors.full_messages, ["Slug must be unique"]
+  end
+
+  test "returns false and the adds an error to the document when new_slug is invalid" do
+    reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "invalid slug")
+    assert_equal false, reslugger.run!
+    assert_equal @document.errors.full_messages, ["Slug is invalid"]
+  end
+end


### PR DESCRIPTION
## Description

One of the common support requests that we get is to update the slug for a document. Currently we run a rake task to do this https://docs.publishing.service.gov.uk/manual/howto-change-slug-and-create-redirect.html

This PR adds the ability for a GDS Editor to update a documents slug via the UI.

This will likely (although TBD) will be accessible via either the edition summary or edit edition page.  You only have access to this page if you have the GDS Editor permission.

I've added in validating that the slug prior to updating it and pushing it downstream to the Publishing API and Search Index so the user doesn't get sent a 422 from the Publishing API and have an invalid slug persisted on the document.

## Screenshots

### Invalid slug

<img width="985" alt="image" src="https://user-images.githubusercontent.com/42515961/205927931-b5696da3-eb7e-454f-8479-39f42b5f9cd6.png">


### Slug not present

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/42515961/205927998-7bee6db1-fb6e-482e-bb96-2314b73df019.png">


### Slug is not unique

<img width="906" alt="image" src="https://user-images.githubusercontent.com/42515961/205928141-cc65fc19-0849-482a-a4e1-d37c17d24d7c.png">


### Successful 

<img width="962" alt="image" src="https://user-images.githubusercontent.com/42515961/205929512-ba099158-5748-4c07-8d41-7e8eb05795c6.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
