### PR TITLE
Bump Rails Translation Manager and use new plural file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "ptools"
 gem "rack"
 gem "rack_strip_client_ip"
 gem "rails-i18n"
+gem "rails_translation_manager"
 gem "rake"
 gem "record_tag_helper", require: false
 gem "responders"
@@ -67,7 +68,6 @@ group :development, :test do
   gem "pact_broker-client"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "rails_translation_manager"
   gem "rubocop-govuk", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
     rails-i18n (7.0.6)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_translation_manager (1.6.0)
+    rails_translation_manager (1.6.3)
       activesupport
       csv (~> 3.2)
       i18n-tasks

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,1 +1,0 @@
-GovukI18n.plurals

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -124,232 +124,156 @@ zh-hk:
       written_on: 撰寫於：
     type:
       about:
-        one: 關於
         other: 關於
       about_our_services:
-        one: 關於我們的服務
         other: 關於我們的服務
       access_and_opening:
-        one: 訪問及開放
         other: 訪問及開放
       accessible_documents_policy:
-        one: 無障礙文件政策
         other: 其他無障礙文件政策
       alert:
-        one: 警示
         other: 其他警示
       announcement:
-        one: 公告
         other: 其他公告
       authored_article:
-        one: 撰寫文章
         other: 其他撰寫文章
       blog_post:
-        one: 網誌發佈內容
         other: 其他網誌發佈內容
       campaign:
-        one: 活動
         other: 其他活動
       careers:
-        one: 職位
         other: 職位
       case_study:
-        one: 案例研究
         other: 其他案例研究
       closed_consultation:
-        one: 專屬諮詢
         other: 其他專屬諮詢
       complaints_procedure:
-        one: 投訴程序
         other: 其他投訴程序
       consultation:
-        one: 諮詢
         other: 其他諮詢
       consultation_outcome:
-        one: 諮詢結果
         other: 其他諮詢結果
       corporate_report:
-        one: 政府報告
         other: 其他政府報告
       correspondence:
-        one: 通信
         other: 其他通信
       decision:
-        one: 決定
         other: 其他決定
       detailed_guidance:
-        one: 詳細指引
         other: 其他詳細指引
       document_collection:
-        one: 系列
         other: 其他系列
       draft_text:
-        one: 內容
         other: 其他內容
       edition:
-        one: 修訂
         other: 其他修訂
       edition_with_appointment:
-        one: 有預約之修訂
         other: 其他有預約之修訂
       equality_and_diversity:
-        one: 平等及多元
         other: 平等及多元
       fatality_notice:
-        one: 死亡通知
         other: 其他死亡通知
       foi_release:
-        one: 資訊自由(FOI)資訊發布
         other: 其他資訊自由(FOI)資訊發布
       form:
-        one: 表格
         other: 其他表格
       generic_edition:
-        one: 通用版本
         other: 其他通用版本
       government_response:
-        one: 政府回應
         other: 政府其他回應
       guidance:
-        one: 指引
         other: 其他指引
       impact_assessment:
-        one: 影響評估
         other: 其他影響評估
       imported:
-        one: 輸入-等待類型中
         other: 輸入-等待類型中
       independent_report:
-        one: 獨立報告
         other: 其他獨立報告
       international_treaty:
-        one: 國際條約
         other: 其他國際條約
       manual:
-        one: 手冊
         other: 其他手冊
       map:
-        one: 地圖
         other: 其他地圖
       media_enquiries:
-        one: 媒體查詢
         other: 其他媒體查詢
       membership:
-        one: 會員資格
         other: 會員資格
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: 國家統計數據
         other: 其他國家統計數據
       news_article:
-        one: 新聞
         other: 其他新聞
       news_story:
-        one: 新聞
         other: 其他新聞
       nhs_content:
-        one: NHS 內容
         other: NHS 內容
       notice:
-        one: 通知
         other: 其他通知
       official_statistics:
-        one: 統計資料
         other: 其他統計資料
       open_consultation:
-        one: 公開諮詢
         other: 其他公開諮詢
       oral_statement:
-        one: 提交國會的口頭聲明
         other: 提交國會的其他口頭聲明
       our_energy_use:
-        one: 我們的能源使用
         other: 我們的能源使用
       our_governance:
-        one: 我們的行政管理
         other: 我們的行政管理
       personal_information_charter:
-        one: 個人資訊章程
         other: 其他個人資訊章程
       petitions_and_campaigns:
-        one: 訴願及活動
         other: 訴願及活動
       policy_paper:
-        one: 政策文件
         other: 其他政策文件
       press_release:
-        one: 新聞稿
         other: 其他新聞稿
       procurement:
-        one: 採購
         other: 採購
       promotional:
-        one: 宣傳資料
         other: 其他宣傳資料
       publication:
-        one: 出版物
         other: 其他出版物
       publication_scheme:
-        one: 出版計劃
         other: 其他出版計劃
       recruitment:
-        one: 招聘
         other: 招聘
       regulation:
-        one: 規定
         other: 其他規定
       research:
-        one: 研究與分析
         other: 其他研究與分析
       service:
-        one: 服務
         other: 其他服務
       social_media_use:
-        one: 社交媒體使用
         other: 社交媒體使用
       speaking_notes:
-        one: 演講稿
         other: 其他演講稿
       speech:
-        one: 演講
         other: 其他演講
       staff_update:
-        one: 員工更新
         other: 其他員工更新
       standard:
-        one: 標準
         other: 其他標準
       statement_to_parliament:
-        one: 提交國會的聲明
         other: 提交國會的其他聲明
       statistical_data_set:
-        one: 統計數據資料
         other: 其他統計數據資料
       statistics:
-        one: 統計資料
         other: 統計資料
       statutory_guidance:
-        one: 法定指引
         other: 法定指引
       terms_of_reference:
-        one: 職權範圍
         other: 職權範圍
       transcript:
-        one: 談話副本
         other: 其他談話副本
       transparency:
-        one: 透明化數據
         other: 其他透明化數據
       welsh_language_scheme:
-        one: 威爾士語計劃
         other: 其他威爾士語計劃
       world_news_story:
-        one: 世界範圍新聞故事
         other: 其他世界範圍新聞故事
       written_statement:
-        one: 提交國會的書面聲明
         other: 提交國會的其他書面聲明
     updated: 已更新
   document_filters:
@@ -541,10 +465,8 @@ zh-hk:
       world_location:
     type:
       international_delegation:
-        one: 國際代表
         other: 其他國際代表
       world_location:
-        one: 全球駐點
         other: 其他全球駐點
   world_news:
     uk_updates_in_country: 英國政府關於 %{country} 的更新、新聞及活動

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -124,232 +124,156 @@ zh-tw:
       written_on: 寫在：
     type:
       about:
-        one: 關於
         other: 關於
       about_our_services:
-        one: 關於我們的服務
         other: 關於我們的服務
       access_and_opening:
-        one: 訪問與開啟
         other: 訪問與開啟
       accessible_documents_policy:
-        one: 訪問文檔策略
         other: 訪問文檔策略
       alert:
-        one: 警示
         other: 警示
       announcement:
-        one: 公告
         other: 公告
       authored_article:
-        one: 授權文章
         other: 授權文章
       blog_post:
-        one: 部落格文章
         other: 部落格文章
       campaign:
-        one: 活動
         other: 活動
       careers:
-        one: 職業
         other: 職業
       case_study:
-        one: 案例分析
         other: 案例分析
       closed_consultation:
-        one: 非公開協商
         other: 非公開協商
       complaints_procedure:
-        one: 投訴程序
         other: 投訴程序
       consultation:
-        one: 諮詢
         other: 諮詢
       consultation_outcome:
-        one: 協商結果
         other: 協商結果
       corporate_report:
-        one: 企業報告
         other: 企業報告
       correspondence:
-        one: 信函
         other: 信函
       decision:
-        one: 決定
         other: 決定
       detailed_guidance:
-        one: 指導
         other: 指導
       document_collection:
-        one: 收集
         other: 收集
       draft_text:
-        one: 草稿文本
         other: 草稿文本
       edition:
-        one: 版本
         other: 版本
       edition_with_appointment:
-        one: 預約版本
         other: 預約版本
       equality_and_diversity:
-        one: 平等和多元
         other: 平等和多元
       fatality_notice:
-        one: 死亡通知
         other: 死亡通知
       foi_release:
-        one: 資訊自由發布
         other: 資訊自由發布
       form:
-        one: 形式
         other: 形式
       generic_edition:
-        one: 通用版本
         other: 通用版本
       government_response:
-        one: 政府回應
         other: 政府回應
       guidance:
-        one: 指導
         other: 指導
       impact_assessment:
-        one: 影響評估
         other: 影響評估
       imported:
-        one: 進口－等待類型
         other: 進口－等待類型
       independent_report:
-        one: 獨立報告
         other: 獨立報告
       international_treaty:
-        one: 國際條約
         other: 國際條約
       manual:
-        one: 手冊
         other: 手冊
       map:
-        one: 地圖
         other: 地圖
       media_enquiries:
-        one: 媒體資料查詢
         other: 媒體資料查詢
       membership:
-        one: 會員資格
         other: 會員資格
       modern_slavery_statement:
-        one:
         other:
       national_statistics:
-        one: 國家統計
         other: 國家統計
       news_article:
-        one: 新聞文章
         other: 新聞文章
       news_story:
-        one: 新聞報導
         other: 新聞報導
       nhs_content:
-        one: 免費醫療服務系統內容
         other: 免費醫療服務系統內容
       notice:
-        one: 通知
         other: 通知
       official_statistics:
-        one: 官方統計
         other: 官方統計
       open_consultation:
-        one: 公開諮詢
         other: 公開諮詢
       oral_statement:
-        one: 對議會的口頭聲明
         other: 對議會的口頭聲明
       our_energy_use:
-        one: 我們的能源使用
         other: 我們的能源使用
       our_governance:
-        one: 我們的治理
         other: 我們的治理
       personal_information_charter:
-        one: 個資憲章
         other: 個資憲章
       petitions_and_campaigns:
-        one: 請願和活動
         other: 請願和活動
       policy_paper:
-        one: 政策文件
         other: 政策文件
       press_release:
-        one: 新聞稿
         other: 新聞稿
       procurement:
-        one: 宣傳材料
         other: 宣傳材料
       promotional:
-        one: 宣傳資料
         other: 宣傳資料
       publication:
-        one: 出版
         other: 出版
       publication_scheme:
-        one: 出版格式
         other: 出版格式
       recruitment:
-        one: 招募
         other: 招募
       regulation:
-        one: 法規
         other: 法規
       research:
-        one: 研究
         other: 研究
       service:
-        one: 服務
         other: 服務
       social_media_use:
-        one: 使用社群媒體
         other: 使用社群媒體
       speaking_notes:
-        one: 發言筆記
         other: 發言筆記
       speech:
-        one: 演說
         other: 演說
       staff_update:
-        one: 雇員更新
         other: 雇員更新
       standard:
-        one: 標準
         other: 標準
       statement_to_parliament:
-        one: 向議會發表聲明
         other: 向議會發表聲明
       statistical_data_set:
-        one: 統計數據組
         other: 統計數據組
       statistics:
-        one: 統計數據
         other: 統計數據
       statutory_guidance:
-        one: 法令指導
         other: 法令指導
       terms_of_reference:
-        one: 職權範疇
         other: 職權範疇
       transcript:
-        one: 副本
         other: 副本
       transparency:
-        one: 透明數據
         other: 透明數據
       welsh_language_scheme:
-        one: 威爾斯語格式
         other: 威爾斯語格式
       world_news_story:
-        one: 世界新聞報導
         other: 世界新聞報導
       written_statement:
-        one: 對議會的書面聲明
         other: 對議會的書面聲明
     updated: 更新
   document_filters:
@@ -541,10 +465,8 @@ zh-tw:
       world_location:
     type:
       international_delegation:
-        one: 國際代表團
         other: 國際代表團
       world_location:
-        one: 世界地點
         other: 世界地點
   world_news:
     uk_updates_in_country: 來自 %{country} 的英國政府的更新、新聞和事件


### PR DESCRIPTION
We're now using the extra plural rules defined by RTM as a prod
dependency [1]. This will replace the list defined in govuk_app_config
and so the reference has also been removed. RTM's version loads
automatically [2] and so we don't have to explicitly include the file in
the app.

[1]: https://github.com/alphagov/rails_translation_manager/blob/main/config/locales/plurals.rb
[2]: https://github.com/alphagov/rails_translation_manager/blob/f18fd2e178719dd0a103981160f898771957fa43/lib/rails_translation_manager.rb#L24

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
