### PR TITLE
Allow reordering of ministerial roles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,9 +3,9 @@ class Person < ApplicationRecord
 
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
 
-  has_many :role_appointments
+  has_many :role_appointments, -> { order(:order) }
   has_many :current_role_appointments,
-           -> { where(RoleAppointment::CURRENT_CONDITION) },
+           -> { where(RoleAppointment::CURRENT_CONDITION).order(:order) },
            class_name: "RoleAppointment"
   has_many :speeches, through: :role_appointments
   has_many :news_articles, through: :role_appointments

--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -42,7 +42,7 @@ module PublishingApi
     def details
       {
         current: item.current?,
-        person_appointment_order: item.id,
+        person_appointment_order: item.order,
       }.tap do |details|
         details[:started_on] = item.started_at.rfc3339 if item.started_at.present?
         details[:ended_on] = item.ended_at.rfc3339 if item.ended_at.present?

--- a/app/views/admin/people/reorder_role_appointments.html.erb
+++ b/app/views/admin/people/reorder_role_appointments.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, "Reorder current role appointments"%>
+<% content_for :title, "Reorder current role appointments" %>
+<% content_for :context, @person.name %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @role_appointments.many? %>
+      <%= form_for @person, url: update_order_role_appointments_admin_person_path(@person), method: :patch do |form| %>
+        <%= render "govuk_publishing_components/components/reorderable_list", {
+          items: @role_appointments.map do |role_appointment|
+            {
+              id: role_appointment.id,
+              title: role_appointment.role.name
+            }
+          end
+        } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order"
+        } %>
+      <% end %>
+    <% else %>
+      <p class="govuk-body">You can only reorder current role appointments if a person has 2 or more.</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,7 +324,10 @@ Whitehall::Application.routes.draw do
         resources :people do
           resources :translations, controller: "person_translations"
           resources :historical_accounts
+          get :reorder_role_appointments, on: :member
+          patch :update_order_role_appointments, on: :member
         end
+
         resource :cabinet_ministers, only: %i[show update]
         resources :roles, except: [:show] do
           resources :role_appointments, only: %i[new create edit update destroy], shallow: true

--- a/db/migrate/20221207105634_backfill_role_appointments_order.rb
+++ b/db/migrate/20221207105634_backfill_role_appointments_order.rb
@@ -1,0 +1,13 @@
+class BackfillRoleAppointmentsOrder < ActiveRecord::Migration[7.0]
+  def up
+    Person.joins(:role_appointments).find_each do |person|
+      person.role_appointments.each_with_index do |role_appointment, index|
+        role_appointment.update_column("order", index + 1)
+      end
+    end
+  end
+
+  def down
+    RoleAppointment.update_all(order: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_07_105237) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_07_105634) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"

--- a/lib/whitehall/authority/rules/person_rules.rb
+++ b/lib/whitehall/authority/rules/person_rules.rb
@@ -1,8 +1,10 @@
 module Whitehall::Authority::Rules
   PersonRules = Struct.new(:actor, :subject) do
-    def can?(_action)
+    def can?(action)
       if subject.slug == "boris-johnson"
         actor.vip_editor? || actor.gds_admin?
+      elsif action == :perform_administrative_tasks
+        actor.gds_admin?
       else
         true
       end

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -32,7 +32,7 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
       details: {
         started_on: "2011-11-10T11:11:11+00:00",
         current: true,
-        person_appointment_order: role_appointment.id,
+        person_appointment_order: role_appointment.order,
       },
     }
     expected_links = {


### PR DESCRIPTION
## Description

During a reshuffle, a minister can gain two positions of state, known as RoleAppointments in Whitehall. One of these is perceived to be a more senior role than the other. However, Collections will just render these by ascending order of ActiveRecord IDs as default.

This PR does 3 main things

1. Backfills the RoleAppointment#order column
2. Ensures that the order is passed into the `person_appointment_order` row of the details hash in the `RoleAppointmentPresenter` rather than the id.
3. Builds a UI into Whitehall which allows RoleAppointments to be reordered

## Screenshot

<img width="818" alt="image" src="https://user-images.githubusercontent.com/42515961/206677139-7f5b3721-c189-447c-816d-866fc7e63cd1.png">

## Trello card 

https://trello.com/c/Tpq1mo6W/4-allow-ministers-roles-to-be-reordered-in-the-ui-probably-quite-a-large-task
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
