### PR TITLE
Add classes to the forbidden template so that it renders in both bootstrap and the design system

### DIFF
--- a/app/views/admin/editions/forbidden.html.erb
+++ b/app/views/admin/editions/forbidden.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Access denied" %>
 <div class="no-content no-content-bordered">
-  <h1>Sorry, you don’t have access to this document</h1>
-  <p class="back">
+  <h1 class="govuk-heading-l">Sorry, you don’t have access to this document</h1>
+  <p class="back govuk-back-link">
     <%= link_to 'Back to document list', admin_editions_path %>
   </p>
 </div>


### PR DESCRIPTION
## What
Add `govuk-heading-l` and `govuk-back-link` to the appropriate elements in the forbidden template.

## Why
The forbidden template is used across whitehall when a user attempts to access or edit something that they do not have access to, currently when this occurs on a page rendered using the design system layout the content is unstyled.

As adding the logic to check the layout currently being used across all of the pages that could render the forbidden message is complex and the template itself is very simple, this PR adds classes that will be ignored by the bootstrap layout but improve the appearance of the page when using the design system.

## Screenshots
|   | Before | After |
| - | ------- | ----- |
| Design System | ![whitehall-admin dev gov uk_government_admin_editorial_remarks_662568_confirm_destroy(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/206280935-c57c5de1-e627-41c6-a84d-709a8de87471.png) | ![whitehall-admin dev gov uk_government_admin_editorial_remarks_662568_confirm_destroy(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/206280952-8b3a3d99-89b1-4706-ab67-328de548f4b6.png) |
| Bootstrap | ![whitehall-admin dev gov uk_government_admin_editorial_remarks_662568_confirm_destroy(iPad Pro) (3)](https://user-images.githubusercontent.com/9594455/206280976-5f58bb70-8ba3-405d-9226-50f39a130fc0.png) | ![whitehall-admin dev gov uk_government_admin_editorial_remarks_662568_confirm_destroy(iPad Pro) (4)](https://user-images.githubusercontent.com/9594455/206280997-c1e8dc97-665a-498b-902e-e7d41359f375.png) |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
