### PR TITLE
Add order column to appointment roles

### DIFF
--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -64,6 +64,7 @@ class RoleAppointment < ApplicationRecord
   scope :alphabetical_by_person, -> { includes(:person).order("people.surname", "people.forename") }
   scope :ascending_start_date, -> { order("started_at DESC") }
 
+  after_create :set_order
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
@@ -160,6 +161,10 @@ private
       oa.ended_at = started_at
       oa.save!
     end
+  end
+
+  def set_order
+    update!(order: person.role_appointments.count)
   end
 
   def prevent_destruction_unless_destroyable

--- a/db/migrate/20221207105237_add_order_to_role_appointments.rb
+++ b/db/migrate/20221207105237_add_order_to_role_appointments.rb
@@ -1,0 +1,5 @@
+class AddOrderToRoleAppointments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :role_appointments, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_134008) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_07_105237) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -799,6 +799,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_17_134008) do
     t.datetime "started_at", precision: nil
     t.datetime "ended_at", precision: nil
     t.string "content_id"
+    t.integer "order"
     t.index ["ended_at"], name: "index_role_appointments_on_ended_at"
     t.index ["person_id"], name: "index_role_appointments_on_person_id"
     t.index ["role_id"], name: "index_role_appointments_on_role_id"

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -407,4 +407,13 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     non_minister_appointment = create(:role_appointment, role: non_minister)
     assert_not non_minister_appointment.ministerial?
   end
+
+  test "sets the order value after creation" do
+    person = create(:person)
+    role_appointment1 = create(:role_appointment, person:)
+    role_appointment2 = create(:role_appointment, person:)
+
+    assert_equal 1, role_appointment1.reload.order
+    assert_equal 2, role_appointment2.reload.order
+  end
 end


### PR DESCRIPTION
## Description 

At the moment, when a reshuffle happens and role appointments are added to a person, the title of the person on collections is determined by which role appointment was added first (id in the db). 

When they are added in the wrong order and the titles render in the wrong order we have to go into the Rails console and manually switch the ids in the database which is bad for obvious reasons. 

To get around we can add an order column and use that to determine the correct role orders.

This does the work to add an order column to the RoleAppointments table and ensures that when one is created, the correct order is set via a callback on the RoleAppointments model.

## Trello card 

https://trello.com/c/Tpq1mo6W/4-allow-ministers-roles-to-be-reordered-in-the-ui-probably-quite-a-large-task

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
