### PR TITLE
Rework the edit document slug flow to take edition_id rather than document_id in the url

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,9 +1,4 @@
 class Admin::DocumentsController < Admin::BaseController
-  before_action :find_document, only: %i[edit_slug update_slug]
-  before_action :find_published_edition, only: %i[edit_slug update_slug]
-  before_action :enforce_permissions!, only: %i[edit_slug update_slug]
-  layout "design_system"
-
   def by_content_id
     document = (
       Document.find_by(content_id: params[:content_id]) ||
@@ -19,32 +14,5 @@ class Admin::DocumentsController < Admin::BaseController
       flash[:error] = "The requested content was not found"
       redirect_to url_maker.admin_editions_path
     end
-  end
-
-  def edit_slug; end
-
-  def update_slug
-    @document.assign_attributes(slug: params.dig("document", "slug"))
-
-    if DataHygiene::DocumentReslugger.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
-      flash[:notice] = "Slug updated successfully"
-      redirect_to admin_edition_path(@published_edition)
-    else
-      render :edit_slug
-    end
-  end
-
-private
-
-  def find_document
-    @document = Document.find(params[:id])
-  end
-
-  def find_published_edition
-    @published_edition = @document.editions.published.last
-  end
-
-  def enforce_permissions!
-    enforce_permission!(:perform_administrative_tasks, @document)
   end
 end

--- a/app/controllers/admin/edition_slug_controller.rb
+++ b/app/controllers/admin/edition_slug_controller.rb
@@ -8,8 +8,6 @@ class Admin::EditionSlugController < Admin::BaseController
   def edit_slug; end
 
   def update_slug
-    @document.assign_attributes(slug: params.dig("document", "slug"))
-
     if DataHygiene::DocumentReslugger.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
       flash[:notice] = "Slug updated successfully"
       redirect_to admin_edition_path(@published_edition)

--- a/app/controllers/admin/edition_slug_controller.rb
+++ b/app/controllers/admin/edition_slug_controller.rb
@@ -1,0 +1,38 @@
+class Admin::EditionSlugController < Admin::BaseController
+  before_action :find_edition
+  before_action :find_document
+  before_action :find_published_edition
+  before_action :enforce_permissions!
+  layout "design_system"
+
+  def edit_slug; end
+
+  def update_slug
+    @document.assign_attributes(slug: params.dig("document", "slug"))
+
+    if DataHygiene::DocumentReslugger.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
+      flash[:notice] = "Slug updated successfully"
+      redirect_to admin_edition_path(@published_edition)
+    else
+      render :edit_slug
+    end
+  end
+
+private
+
+  def find_edition
+    @edition = Edition.find(params[:id])
+  end
+
+  def find_document
+    @document = @edition.document
+  end
+
+  def find_published_edition
+    @published_edition = @document.editions.published.last
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:perform_administrative_tasks, @edition)
+  end
+end

--- a/app/views/admin/edition_slug/edit_slug.html.erb
+++ b/app/views/admin/edition_slug/edit_slug.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @document, method: :patch, url: admin_update_admin_document_slug_path(@document.id) do |form| %>
+    <%= form_for @document, url: update_slug_admin_edition_path(@document.id), method: :patch do |form| %>
 
       <p class="govuk-body">Updating the slug for a document performs the following steps:</p>
 

--- a/app/views/admin/edition_slug/edit_slug.html.erb
+++ b/app/views/admin/edition_slug/edit_slug.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @document, url: update_slug_admin_edition_path(@document.id), method: :patch do |form| %>
+    <%= form_for @document, url: update_slug_admin_edition_path(@edition.id), method: :patch do |form| %>
 
       <p class="govuk-body">Updating the slug for a document performs the following steps:</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,8 +140,6 @@ Whitehall::Application.routes.draw do
         get "find-in-admin-bookmarklet" => "find_in_admin_bookmarklet#index", as: :find_in_admin_bookmarklet_instructions_index
         get "find-in-admin-bookmarklet/:browser" => "find_in_admin_bookmarklet#show", as: :find_in_admin_bookmarklet_instructions
         get "by-content-id/:content_id" => "documents#by_content_id"
-        get "/documents/:id/edit_slug" => "documents#edit_slug", as: :edit_admin_document_slug
-        patch "/documents/:id/update_slug" => "documents#update_slug", as: :update_admin_document_slug
         get "/:content_id/needs" => "needs#edit", as: :edit_needs
         patch "/:content_id/needs" => "needs#update", as: :update_needs
 
@@ -237,6 +235,9 @@ Whitehall::Application.routes.draw do
           resources :change_notes, controller: :edition_change_notes do
             get :confirm_destroy, on: :member
           end
+
+          get :edit_slug, on: :member, controller: :edition_slug
+          patch :update_slug, on: :member, controller: :edition_slug
 
           collection do
             post :export

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -2,7 +2,7 @@ Feature: Edition update slug
   This feature allows GDS editors to update a documents slug
 
   Scenario: GDS editor updates a slug
-    Given I am a GDS editor
+    Given I am a GDS admin
     And a published news article "You will never guess" exists
     And I visit the edit slug page for "You will never guess"
     And I update the slug to "/new-slug"

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -1,6 +1,6 @@
 And(/^I visit the edit slug page for "([^"]*)"$/) do |edition_title|
   @edition = Edition.find_by!(title: edition_title)
-  visit admin_edit_admin_document_slug_path(@edition.document)
+  visit edit_slug_admin_edition_path(@edition)
 end
 
 And(/^I update the slug to "([^"]*)"$/) do |new_slug|

--- a/lib/whitehall/authority/rules/document_rules.rb
+++ b/lib/whitehall/authority/rules/document_rules.rb
@@ -8,12 +8,7 @@ module Whitehall::Authority::Rules
     end
 
     def can?(action)
-      case action
-      when :perform_administrative_tasks
-        actor.gds_editor?
-      else
-        actor.gds_editor? || actor.departmental_editor? || action == :create
-      end
+      actor.gds_editor? || actor.departmental_editor? || action == :create
     end
   end
 end

--- a/test/unit/tasks/reslugging_test.rb
+++ b/test/unit/tasks/reslugging_test.rb
@@ -2,39 +2,8 @@ require "test_helper"
 require "rake"
 
 class ResluggingTest < ActiveSupport::TestCase
-  setup do
-    Rake::Task["reslug:document"].reenable
-  end
-
   teardown do
     Sidekiq::Worker.clear_all
-  end
-
-  test "it should reslug a document" do
-    document = create(:document, slug: "slugs-are-not-snails")
-    edition = create(:published_publication, document:)
-
-    Whitehall::SearchIndex.expects(:delete).with(edition).returns(true)
-    PublishingApiDocumentRepublishingWorker.any_instance.expects(:perform).with(document.id).returns(true)
-
-    Rake.application.invoke_task "reslug:document[slugs-are-not-snails,snails-are-not-slugs]"
-
-    assert_equal 0, Document.where(slug: "slugs-are-not-snails").count
-    assert_equal 1, Document.where(slug: "snails-are-not-slugs").count
-  end
-
-  test "it should not reslug when there are multiple documents with the same slug" do
-    document_one = create(:document, document_type: "StatisticalDataSet", slug: "a-slug-that-is-not-unique")
-    document_two = create(:document, document_type: "Collection", slug: "a-slug-that-is-not-unique")
-
-    create(:published_statistical_data_set, document: document_one)
-    create(:published_document_collection, document: document_two)
-
-    assert_raises do
-      Rake.application.invoke_task "reslug:document[a-slug-that-is-not-unique,a-slug-that-wont-exist]"
-    end
-
-    assert_equal 2, Document.where(slug: "a-slug-that-is-not-unique").count
   end
 
   test "it should reslug the world location" do


### PR DESCRIPTION
## Description

A couple of days ago i merged https://github.com/alphagov/whitehall/pull/7122.

While looking through the previous it to update the dev docs it occurred to me that as we're not linking to this page via the UI there will be no easy way to access the page without dev intervention.

This is because the url takes a :document_id in the URL, which GDS Content Designers rather than an edition id.

This pr adds an EditionSlugController, moves the the edit_slug and update_slug actions to it and wires in the view.

It retains all other functionality.

## Trello card

https://trello.com/c/88EVzICu/2-allow-content-2nd-line-to-change-slugs-aka-reslug-of-previously-published-documents

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
