### PR TITLE
Fix failing feature test on main

### DIFF
--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -10,7 +10,11 @@ end
 
 Then(/^I can see the slug has been updated to "([^"]*)"$/) do |new_slug|
   visit admin_edition_path(@edition)
-  click_button "Create new edition to edit"
+  if using_design_system?
+    click_button "Create new edition"
+  else
+    click_button "Create new edition to edit"
+  end
   expect(find("#edition_slug").value).to eq new_slug
 end
 


### PR DESCRIPTION
## Description

The summary page was merged in at around the same time as the edit slug feature. This has led to a failing test on main as the create new edition button has slightly different copy.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
