### PR TITLE
Extend  Rubocop ignore missing super calls for all component flies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,4 +42,4 @@ Style/OptionalBooleanParameter:
 
 Lint/MissingSuper:
   Exclude:
-    - 'app/components/*/*.rb'
+    - 'app/components/**/*.rb'


### PR DESCRIPTION
## Description

At the moment this only works for files 1 deep in the file structure. We want this to be extended to all levels so that we appropriately nest components as laid out in the View Components docs.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
