### PR TITLE
Fix layout for legacy force publish confirmation

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -170,7 +170,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_approve_retrospectively confirm_force_publish confirm_force_schedule confirm_unpublish confirm_unschedule confirm_unwithdraw unpublish]
+    design_system_actions = %w[confirm_approve_retrospectively confirm_force_schedule confirm_unpublish confirm_unschedule confirm_unwithdraw unpublish]
     design_system_actions << "confirm_force_publish" if preview_design_system?(next_release: true)
     if design_system_actions.include?(action_name)
       "design_system"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

The confirm force publish page should only be rendered using the design system layout if the user has the next release permission.
