### PR TITLE
Add Govspeak help to relevant pages

### DIFF
--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -1,17 +1,18 @@
 <% content_for :page_title, "New corporate information page for #{@organisation.name}" %>
+<% content_for :title, sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}") %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}")
-    } %>
-
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
       items: secondary_navigation_tabs_items(@edition, request.path)
     } %>
 
     <%= render "form", edition: @edition %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= simple_formatting_sidebar %>
   </div>
 </div>

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -64,43 +64,28 @@
     <% end %>
   </section>
 
-  <%= sidebar_tabs edition_tabs(
-    @edition,
-    remarks_count: @document_remarks.total_count,
-    history_count: @document_history.total_count,
-    editing: true,
-  ) do |tabs| %>
-
-    <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
-      <%= render partial: "admin/editions/govspeak_help",
-                 locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
-    <% end %>
-
-    <%= tabs.pane class: "audit-trail", id: "notes" do %>
-      <h1>Notes</h1>
-      <p>To add a remark, save your changes.</p>
-      <%= link_to "Add new remark", new_admin_edition_editorial_remark_path(@edition), class: "btn btn-default add-remark" %>
-      <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
-      <%= render_editorial_remarks(@document_remarks, @edition) %>
-      <%= paginate @document_remarks.query, theme: 'remarks', param_name: 'remarks_page' %>
-    <% end %>
-
-    <%= tabs.pane class: "audit-trail", id: "history" do %>
-      <div class="audit-trail-page">
-        <h1>Activity</h1>
-        <%= paginate @document_history.query, theme: 'audit_trail' %>
-        <ul class="list-unstyled">
-          <%= render partial: "admin/editions/audit_trail_entry", collection: @document_history.audit_trail %>
-        </ul>
-        <%= paginate @document_history.query, theme: 'audit_trail' %>
-      </div>
-    <% end %>
-      <% if @edition.can_be_fact_checked? %>
-        <%= tabs.pane class: "fact_checking", id: "fact_checking" do %>
-          <h1>Fact checking</h1>
-          <%= render partial: 'admin/editions/fact_check_responses', locals: {edition: @edition}  %>
-          <p>To send a fact check request, save your changes.</p>
-        <% end %>
-      <% end %>
-  <% end %>
+  <section class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/tabs", {
+      tabs: [
+        {
+          id: "govspeak_tab",
+          label: "Help",
+          content: simple_formatting_sidebar(
+            hide_inline_attachments_help: !@edition.allows_inline_attachments?,
+            show_attachments_tab_help: true,
+          )
+        },
+        {
+          id: "history_tab",
+          label: "History",
+          content: ""
+        },
+        *([{
+          id: "fact_checking_tab",
+          label: "Fact checking",
+          content: ""
+        }] if @edition.can_be_fact_checked?)
+      ]
+    } %>
+  </section>
 </div>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -4,30 +4,9 @@
   show_footnote_help ||= false
   show_stat_headline_help ||= false
   link_check_report ||= nil
-  govspeak_link_errors ||= []
 %>
 
-<% if govspeak_link_errors.any? %>
-  <section id='link-errors' class='alert alert-danger'>
-    <h3 class="govuk-heading-m">Link errors</h3>
-
-    <p class="govuk-body">You will not be able to publish this document until these are fixed.</p>
-
-    <dl>
-      <% govspeak_link_errors.each do |link_error| %>
-        <dt><%= link_error[:link] %></dt>
-        <dd data-start='<%= link_error[:start] %>' data-end='<%= link_error[:end] %>'>
-          <%= link_error[:fix] %>
-        </dd>
-      <% end %>
-    </dl>
-  </section>
-  <% initialise_script "GOVUK.govspeakLinkErrors", selector: '#link-errors' %>
-<% end %>
-
-<% if link_check_report.present? %>
-  <%= render 'admin/link_check_reports/link_check_report', report: link_check_report %>
-<% end %>
+<%= render('admin/editions/show/sidebar_link_checker', report: link_check_report) if link_check_report %>
 
 <div class="govspeak_help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -31,5 +31,31 @@
 
       <%= render "form", edition: @edition %>
     </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= render "govuk_publishing_components/components/tabs", {
+       tabs: [
+         {
+           id: "govspeak_tab",
+           label: "Help",
+           content: simple_formatting_sidebar(
+             hide_inline_attachments_help: !@edition.allows_inline_attachments?,
+             show_attachments_tab_help: true,
+             link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_reports.last : nil,
+           )
+         },
+         {
+           id: "history_tab",
+           label: "History",
+           content: "",
+         },
+         *([{
+           id: "fact_checking_tab",
+           label: "Fact checking",
+           content: ""
+         }] if @edition.can_be_fact_checked?)
+       ]
+      } %>
+    </div>
   </div>
 <% end %>

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -11,4 +11,8 @@
 
     <%= render "form", edition: @edition %>
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= simple_formatting_sidebar hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true %>
+  </div>
 </div>

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -9,4 +9,19 @@
       ) if show_link_check_report?(@edition)
   %>
   <%= render partial: 'admin/editions/show/sidebar_history_state', locals: { edition: @edition } %>
+
+  <%= render "govuk_publishing_components/components/tabs", {
+   tabs: [
+     {
+       id: "history_tab",
+       label: "History",
+       content: "",
+     },
+     *([{
+       id: "fact_checking_tab",
+       label: "Fact checking",
+       content: "",
+     }] if @edition.can_be_fact_checked?)
+   ]
+ } %>
 </aside>

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -18,6 +18,7 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_association_with_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
   should_send_drafts_to_content_preview_environment_for :case_study
+  should_render_govspeak_history_and_fact_checking_tabs_for :case_study
 
   view_test "case studies show image display options radio buttons" do
     get :new
@@ -29,16 +30,5 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
       assert_select "textarea[name='edition[images_attributes][0][caption]']"
       assert_select "input[name='edition[images_attributes][0][image_data_attributes][file]'][type='file']"
     end
-  end
-
-  view_test "GET :show renders a side nav bar with notes, history and fact checking" do
-    edition = create(:draft_case_study)
-    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-    get :show, params: { id: edition }
-
-    # @TODO to renable after adding in notes and history sections
-    # assert_select ".nav-tabs a", text: "Notes 0"
-    # assert_select ".nav-tabs a", text: "History 1"
   end
 end

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -20,6 +20,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
   should_allow_access_limiting_of :consultation
+  should_render_govspeak_history_and_fact_checking_tabs_for :consultation
 
   view_test "new displays consultation fields" do
     get :new

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -27,6 +27,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
   should_allow_access_limiting_of :detailed_guide
+  should_render_govspeak_history_and_fact_checking_tabs_for :detailed_guide
 
   view_test "user needs associated with a detailed guide" do
     content_id_a = SecureRandom.uuid

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -22,6 +22,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   should_have_summary :fatality_notice
   should_allow_scheduled_publication_of :fatality_notice
   should_allow_access_limiting_of :fatality_notice
+  should_render_govspeak_history_and_fact_checking_tabs_for :fatality_notice
 
   view_test "show renders the summary" do
     draft_fatality_notice = create(:draft_fatality_notice, summary: "a-simple-summary")

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -21,6 +21,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
   should_allow_scheduled_publication_of :news_article
   should_allow_access_limiting_of :news_article
   should_allow_association_with_topical_events :news_article
+  should_render_govspeak_history_and_fact_checking_tabs_for :news_article
 
   view_test "new displays news article fields" do
     get :new

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -24,6 +24,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
   should_allow_access_limiting_of :publication
+  should_render_govspeak_history_and_fact_checking_tabs_for :publication
 
   view_test "new displays publication fields" do
     get :new

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1538,6 +1538,29 @@ module AdminEditionControllerTestHelpers
         assert_equal [first_world_organisation, second_world_organisation], edition.worldwide_organisations
       end
     end
+
+    def should_render_govspeak_history_and_fact_checking_tabs_for(edition_type)
+      view_test "GET :show renders a side nav bar with history and fact checking" do
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+        get :show, params: { id: edition }
+
+        assert_select ".govuk-tabs__tab", text: "History"
+        assert_select ".govuk-tabs__tab", text: "Fact checking"
+      end
+
+      view_test "GET :edit renders a side nav bar with govspeak help, history and fact checking" do
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+        get :edit, params: { id: edition }
+
+        assert_select ".govuk-tabs__tab", text: "Help"
+        assert_select ".govuk-tabs__tab", text: "History"
+        assert_select ".govuk-tabs__tab", text: "Fact checking"
+      end
+    end
   end
 
 private


### PR DESCRIPTION
## Description

This is the first PR in a series of PRs that will add the govspeak help, history and fact checking tabs to the edition summary, edition edit and edit translation pages.

The scope of this PR is to add the govspeak help tab to the edit edition and edit translation page in the final state (i.e. guidance showing), and to add blank tabs for the history and fact checking tabs. These will be added in subsequent PRs.

While working on this, i noticed that we weren't rendering govspeak guidance on the new edition and new corporate information pages so i've added that too.

## Screenshots

### Edit edition page

<img width="958" alt="image" src="https://user-images.githubusercontent.com/42515961/207310737-0911068a-8023-47a8-b281-ff9274272e6f.png">

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/42515961/207310377-312b3834-bfd2-4703-b46a-63148d4824f0.png">

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/42515961/207310416-06ffc73f-ec96-4536-bcfb-caacf239d4ec.png">


### Edit translation page

<img width="940" alt="image" src="https://user-images.githubusercontent.com/42515961/207310549-b5a9c797-ff1b-4e11-a2d8-827dd40a5674.png">

<img width="841" alt="image" src="https://user-images.githubusercontent.com/42515961/207310609-cb007f86-a0a6-4415-a6f6-e1a1a39b8fb2.png">

<img width="875" alt="image" src="https://user-images.githubusercontent.com/42515961/207310642-f4dfc215-553e-409b-9512-60cdb545b37c.png">

### Edition summary page 

<img width="832" alt="image" src="https://user-images.githubusercontent.com/42515961/207310876-f37aff5f-327e-42dc-9a52-b9ec7904d84e.png">

<img width="876" alt="image" src="https://user-images.githubusercontent.com/42515961/207310903-5e69caf7-1961-4d2a-beee-bdf9fa602176.png">


## Trello card

https://trello.com/c/xiy8xs27/888-move-notes-history-fact-checking-tabs-to-the-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
