### PR TITLE
Add history tab in the GOV.UK Design System

### DIFF
--- a/app/assets/stylesheets/admin/components/editions/_document-history-tab.scss
+++ b/app/assets/stylesheets/admin/components/editions/_document-history-tab.scss
@@ -1,0 +1,8 @@
+.app-component-document-history-tab__pagination-link:last-child {
+  float: right;
+  margin-right: govuk-spacing(3);
+}
+
+.app-component-document-history-tab__pagination-link {
+  margin-left: govuk-spacing(3);
+}

--- a/app/assets/stylesheets/admin/components/editions/_editorial-remarks.scss
+++ b/app/assets/stylesheets/admin/components/editions/_editorial-remarks.scss
@@ -1,0 +1,4 @@
+.app-component-editions-editorial-remark__list-item {
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(4);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-page-width: 1140px;
 @import "./components/govspeak-editor";
 @import "./components/inset-prompt";
 @import "./components/miller-columns";
+@import "./admin/components/editions/editorial-remarks";
 @import "./components/secondary-navigation";
 
 @import "./admin/views/attachments";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-page-width: 1140px;
 @import "./components/govspeak-editor";
 @import "./components/inset-prompt";
 @import "./components/miller-columns";
+@import "./admin/components/editions/document-history-tab";
 @import "./admin/components/editions/editorial-remarks";
 @import "./components/secondary-navigation";
 

--- a/app/components/admin/editions/audit_trail_entry_component.html.erb
+++ b/app/components/admin/editions/audit_trail_entry_component.html.erb
@@ -1,0 +1,8 @@
+<li class="app-component-editions-audit-trail-entry__list-item govuk-!-margin-bottom-4">
+  <% if compare_with_previous_version? %>
+    <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: entry.version.item_id), class: "govuk-link" %>
+  <% end %>
+  <%= action %> <%= actor %>
+  <br>
+  <%= time %>
+</li>

--- a/app/components/admin/editions/audit_trail_entry_component.rb
+++ b/app/components/admin/editions/audit_trail_entry_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Admin::Editions::AuditTrailEntryComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :entry, :edition
+
+  def initialize(entry:, edition:)
+    @entry = entry
+    @edition = edition
+  end
+
+private
+
+  def action
+    "#{entry.action.capitalize} by "
+  end
+
+  def actor
+    entry.actor ? linked_author(entry.actor, class: "govuk-link") : "User (removed)"
+  end
+
+  def time
+    absolute_time(entry.created_at)
+  end
+
+  def compare_with_previous_version?
+    entry.action == "published" && edition.id != entry.version.item_id
+  end
+end

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -10,6 +10,8 @@
   text: sanitize("History and notes have been merged. #{tag.a('Read more about the change', href: admin_whats_new_path)}")
 } %>
 
+<%= paginate(@document_history, theme: 'history') %>
+
 <% if entries_on_newer_editions.present? %>
   <div class="app-component-editions__newer-edition-entries">
     <h3 class="govuk-heading-m">On newer editions</h3>

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -1,0 +1,47 @@
+<h2 class="govuk-heading-l">History</h2>
+
+<% if editing %>
+  <p class="govuk-body">To add an internal note, save your changes.</p>
+<% end %>
+
+<p class="govuk-body"><%= link_to("Add internal note", new_admin_edition_editorial_remark_path(edition), class: "govuk-body govuk-link") %></p>
+
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: sanitize("History and notes have been merged. #{tag.a('Read more about the change', href: admin_whats_new_path)}")
+} %>
+
+<% if entries_on_newer_editions.present? %>
+  <div class="app-component-editions__newer-edition-entries">
+    <h3 class="govuk-heading-m">On newer editions</h3>
+
+    <ul class="gem-c-list govuk-list">
+      <% entries_on_newer_editions.each do |entry| %>
+        <%= render_entry(entry) %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if entries_on_current_edition.present? %>
+  <div class="app-component-editions__current-edition-entries">
+    <h3 class="govuk-heading-m">On this edition</h3>
+
+    <ul class="gem-c-list govuk-list">
+      <% entries_on_current_edition.each do |entry| %>
+        <%= render_entry(entry) %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if entries_on_previous_editions.present? %>
+  <div class="app-component-editions__previous-edition-entries">
+    <h3 class="govuk-heading-m">On previous editions</h3>
+
+    <ul class="gem-c-list govuk-list">
+      <% entries_on_previous_editions.each do |entry| %>
+        <%= render_entry(entry) %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/components/admin/editions/document_history_tab_component.rb
+++ b/app/components/admin/editions/document_history_tab_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Admin::Editions::DocumentHistoryTabComponent < ViewComponent::Base
+  attr_reader :edition, :document_history, :editing
+
+  def initialize(edition:, document_history:, editing: false)
+    @edition = edition
+    @document_history = document_history
+    @editing = editing
+  end
+
+private
+
+  def entries_on_newer_editions
+    @entries_on_newer_editions ||= document_history.entries_on_newer_editions(edition)
+  end
+
+  def entries_on_current_edition
+    @entries_on_current_edition ||= document_history.entries_on_current_edition(edition)
+  end
+
+  def entries_on_previous_editions
+    @entries_on_previous_editions ||= document_history.entries_on_previous_editions(edition)
+  end
+
+  def render_entry(entry)
+    if entry.is_a?(EditorialRemark)
+      render(Admin::Editions::EditorialRemarkComponent.new(editorial_remark: entry))
+    else
+      render(Admin::Editions::AuditTrailEntryComponent.new(entry:, edition:))
+    end
+  end
+end

--- a/app/components/admin/editions/editorial_remark_component.html.erb
+++ b/app/components/admin/editions/editorial_remark_component.html.erb
@@ -1,0 +1,4 @@
+<li class="app-component-editions-editorial-remark__list-item govuk-!-margin-bottom-4">
+  <p><%= editorial_remark.body %></p>
+  <%= actor %> <%= time %>
+</li>

--- a/app/components/admin/editions/editorial_remark_component.rb
+++ b/app/components/admin/editions/editorial_remark_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Admin::Editions::EditorialRemarkComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :editorial_remark
+
+  def initialize(editorial_remark:)
+    @editorial_remark = editorial_remark
+  end
+
+private
+
+  def actor
+    editorial_remark.author ? linked_author(editorial_remark.author, class: "govuk-link") : "User (removed)"
+  end
+
+  def time
+    absolute_time(editorial_remark.created_at)
+  end
+end

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -54,8 +54,12 @@ private
   end
 
   def load_translated_models
-    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
-    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    if preview_design_system?(next_release: false)
+      @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
+    else
+      @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
+      @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    end
     @translated_edition = LocalisedModel.new(@edition, translation_locale.code)
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -208,8 +208,12 @@ private
   end
 
   def fetch_version_and_remark_trails
-    @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
-    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    if preview_design_system?(next_release: false)
+      @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
+    else
+      @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])
+      @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    end
   end
 
   def edition_class

--- a/app/models/document/paginated_timeline.rb
+++ b/app/models/document/paginated_timeline.rb
@@ -24,6 +24,36 @@ class Document::PaginatedTimeline
     end
   end
 
+  def entries_on_newer_editions(edition)
+    @entries_on_newer_editions ||= entries.select do |entry|
+      if entry.is_a?(EditorialRemark)
+        entry.edition_id > edition.id
+      else
+        entry.version.item_id > edition.id
+      end
+    end
+  end
+
+  def entries_on_current_edition(edition)
+    @entries_on_current_edition ||= entries.select do |entry|
+      if entry.is_a?(EditorialRemark)
+        entry.edition_id == edition.id
+      else
+        entry.version.item_id == edition.id
+      end
+    end
+  end
+
+  def entries_on_previous_editions(edition)
+    @entries_on_previous_editions ||= entries.select do |entry|
+      if entry.is_a?(EditorialRemark)
+        entry.edition_id < edition.id
+      else
+        entry.version.item_id < edition.id
+      end
+    end
+  end
+
   def total_count
     @total_count ||= begin
       sql = "SELECT COUNT(*) FROM (#{union_query}) x"

--- a/app/models/document/paginated_timeline.rb
+++ b/app/models/document/paginated_timeline.rb
@@ -1,5 +1,5 @@
 class Document::PaginatedTimeline
-  PER_PAGE = 30
+  PER_PAGE = 10
 
   def initialize(document:, page:)
     @document = document

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -78,7 +78,11 @@
         {
           id: "history_tab",
           label: "History",
-          content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: true))
+          content: render(Admin::Editions::DocumentHistoryTabComponent.new(
+            edition: @edition,
+            document_history: @document_history,
+            editing: true,
+          ))
         },
         *([{
           id: "fact_checking_tab",

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -78,7 +78,7 @@
         {
           id: "history_tab",
           label: "History",
-          content: ""
+          content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: true))
         },
         *([{
           id: "fact_checking_tab",

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -47,7 +47,7 @@
          {
            id: "history_tab",
            label: "History",
-           content: "",
+           content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: true))
          },
          *([{
            id: "fact_checking_tab",

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -47,7 +47,11 @@
          {
            id: "history_tab",
            label: "History",
-           content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: true))
+           content: render(Admin::Editions::DocumentHistoryTabComponent.new(
+             edition: @edition,
+             document_history: @document_history,
+             editing: true,
+           ))
          },
          *([{
            id: "fact_checking_tab",

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -12,11 +12,14 @@
 
   <%= render "govuk_publishing_components/components/tabs", {
    tabs: [
-     {
-       id: "history_tab",
-       label: "History",
-       content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history))
-     },
+   {
+     id: "history_tab",
+     label: "History",
+     content: render(Admin::Editions::DocumentHistoryTabComponent.new(
+       edition: @edition,
+       document_history: @document_history,
+     ))
+   },
      *([{
        id: "fact_checking_tab",
        label: "Fact checking",

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -15,7 +15,7 @@
      {
        id: "history_tab",
        label: "History",
-       content: "",
+       content: render(Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history))
      },
      *([{
        id: "fact_checking_tab",

--- a/app/views/kaminari/history/_next_page.html.erb
+++ b/app/views/kaminari/history/_next_page.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-component-document-history-tab__pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1) } %>

--- a/app/views/kaminari/history/_paginator.html.erb
+++ b/app/views/kaminari/history/_paginator.html.erb
@@ -1,0 +1,6 @@
+<%= paginator.render do -%>
+  <nav class="govuk-grid-row govuk-!-margin-bottom-4" role="navigation">
+    <%= prev_page_tag unless current_page.first? %>
+    <%= next_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/history/_prev_page.html.erb
+++ b/app/views/kaminari/history/_prev_page.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-component-document-history-tab__pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page - 1) } %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -92,29 +92,6 @@
       "note": "We don't link directly to any unescaped model attribute."
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "4d250d3bacd4d7d123d789e58a4fbb381f1ddcdce341a292b5b368d826357a6a",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/document/paginated_timeline.rb",
-      "line": 109,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ApplicationRecord.connection.exec_query(\"#{union_query}\\nORDER BY created_at DESC\\nLIMIT ? OFFSET ?\\n\", \"SQL\", [ActiveRecord::Relation::QueryAttribute.new(\"\", 30, ActiveRecord::Type::Integer.new), ActiveRecord::Relation::QueryAttribute.new(\"\", ((@page - 1) * 30), ActiveRecord::Type::Integer.new)])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Document::PaginatedTimeline",
-        "method": "paginated_query"
-      },
-      "user_input": "union_query",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Custom SQL UNION query formed of two Rails-generated SQL statements. No user input is included."
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "6536a4d099ce4dde6f007e943e61dd078ba220703e0e0cab6ed152ac12b2abfc",
@@ -258,7 +235,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/document/paginated_timeline.rb",
-      "line": 30,
+      "line": 60,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ApplicationRecord.connection.exec_query(\"SELECT COUNT(*) FROM (#{union_query}) x\")",
       "render_path": null,
@@ -468,6 +445,29 @@
       "note": "We don't use the user data directly to find the template, it comes from the database."
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "f44e782dd922feefbc469ef874ce7bfd100991912b8133363b822488e2c8f58c",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/document/paginated_timeline.rb",
+      "line": 139,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationRecord.connection.exec_query(\"#{union_query}\\nORDER BY created_at DESC\\nLIMIT ? OFFSET ?\\n\", \"SQL\", [ActiveRecord::Relation::QueryAttribute.new(\"\", 10, ActiveRecord::Type::Integer.new), ActiveRecord::Relation::QueryAttribute.new(\"\", ((@page - 1) * 10), ActiveRecord::Type::Integer.new)])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Document::PaginatedTimeline",
+        "method": "paginated_query"
+      },
+      "user_input": "union_query",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Custom SQL UNION query formed of two Rails-generated SQL statements. No user input is included."
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "f77ca1269299a6304017454456ff5d3a70c3434d8a643dae59f61b245da12fdb",
@@ -512,6 +512,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-11-28 11:02:47 +0000",
-  "brakeman_version": "5.3.1"
+  "updated": "2022-12-14 15:00:41 +0000",
+  "brakeman_version": "5.4.0"
 }

--- a/test/components/admin/editions/audit_trail_entry_component_test.rb
+++ b/test/components/admin/editions/audit_trail_entry_component_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "it constructs output based on the entry when an actor is present" do
+    actor = create(:user)
+    edition = create(:edition)
+    version = edition.versions.create!(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id)
+    audit = Document::PaginatedHistory::AuditTrailEntry.new(version, is_first_edition: true)
+
+    render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition:))
+
+    assert_equal page.text, "\n  Created by  #{actor.name}\n  \n   1 January 2020 11:11am\n\n"
+    assert_equal page.find("li a").text, actor.name
+    assert_equal page.find("li a")[:href], "/government/admin/authors/#{actor.id}"
+  end
+
+  test "it constructs output based on the entry when an actor is absent" do
+    edition = build_stubbed(:edition)
+    version = edition.versions.new(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: nil)
+    audit = Document::PaginatedHistory::AuditTrailEntry.new(version, is_first_edition: true)
+
+    render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition:))
+
+    assert_equal page.text, "\n  Created by  User (removed)\n  \n   1 January 2020 11:11am\n\n"
+  end
+
+  test "it links to the diff page is the action is published and the edition passed in is different to the versions" do
+    actor = create(:user)
+    edition = create(:edition, :published)
+    edition.versions.create!(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id)
+    version = edition.versions.create!(event: "published", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id, state: "published")
+    audit = Document::PaginatedHistory::AuditTrailEntry.new(version, is_first_edition: true)
+    newer_edition = create(:edition, :draft)
+
+    render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition: newer_edition))
+
+    assert_equal page.text, "\n    [Compare with previous version]\n  Published by  #{actor.name}\n  \n   1 January 2020 11:11am\n\n"
+    assert_equal page.all("li a")[0].text, "[Compare with previous version]"
+    assert_equal page.all("li a")[0][:href], diff_admin_edition_path(newer_edition, audit_trail_entry_id: version.item_id)
+    assert_equal page.all("li a")[1].text, actor.name
+    assert_equal page.all("li a")[1][:href], admin_author_path(actor)
+  end
+end

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -10,6 +10,12 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
     @user2 = create(:departmental_editor)
     seed_document_event_history
     @timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+
+    pagination = "<nav class='govuk-grid-row govuk-!-margin-bottom-4' role='navigation'>
+                    <a class='govuk-body govuk-link app-component-document-history-tab__pagination-link' data-remote-pagination='/government/admin/editions/1321865/audit_trail?page=2' rel='next' href='/government/admin/consultations/1321865?page=2'>Older</a>
+                   </nav>".html_safe
+
+    Admin::Editions::DocumentHistoryTabComponent.any_instance.stubs(:paginate).returns(pagination)
   end
 
   test "it renders a link to the add remark page" do
@@ -31,6 +37,12 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
     assert_selector ".gem-c-inset-text", text: "History and notes have been merged. Read more about the change"
     assert_equal page.all(".gem-c-inset-text a")[0].text, "Read more about the change"
     assert_equal page.all(".gem-c-inset-text a")[0][:href], admin_whats_new_path
+  end
+
+  test "it renders pagination links based on the pagination attribute" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline))
+
+    assert_selector ".app-component-document-history-tab__pagination-link", text: "Older"
   end
 
   test "it renders the timeline entries in the correct sections for, future, current and previous editions" do

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  setup do
+    @user = create(:departmental_editor)
+    @user2 = create(:departmental_editor)
+    seed_document_event_history
+    @timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+  end
+
+  test "it renders a link to the add remark page" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline))
+
+    assert_equal page.all("a")[0].text, "Add internal note"
+    assert_equal page.all("a")[0][:href], new_admin_edition_editorial_remark_path(@first_edition)
+  end
+
+  test "it renders content telling a user to save changes when editing is `true`" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline, editing: true))
+
+    assert_selector "p", text: "To add an internal note, save your changes."
+  end
+
+  test "it renders a inset component which links to the whats new page" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline))
+
+    assert_selector ".gem-c-inset-text", text: "History and notes have been merged. Read more about the change"
+    assert_equal page.all(".gem-c-inset-text a")[0].text, "Read more about the change"
+    assert_equal page.all(".gem-c-inset-text a")[0][:href], admin_whats_new_path
+  end
+
+  test "it renders the timeline entries in the correct sections for, future, current and previous editions" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @second_edition, document_history: @timeline))
+
+    assert_selector ".app-component-editions__newer-edition-entries h3", text: "On newer editions"
+    assert_selector ".app-component-editions__newer-edition-entries li.app-component-editions-audit-trail-entry__list-item", count: 2
+    assert_selector ".app-component-editions__newer-edition-entries li.app-component-editions-editorial-remark__list-item", count: 1
+
+    assert_selector ".app-component-editions__current-edition-entries h3", text: "On this edition"
+    assert_selector ".app-component-editions__current-edition-entries li.app-component-editions-audit-trail-entry__list-item", count: 4
+    assert_selector ".app-component-editions__current-edition-entries li.app-component-editions-editorial-remark__list-item", count: 1
+
+    assert_selector ".app-component-editions__previous-edition-entries h3", text: "On previous editions"
+    assert_selector ".app-component-editions__previous-edition-entries li.app-component-editions-audit-trail-entry__list-item", count: 2
+    assert_selector ".app-component-editions__previous-edition-entries li.app-component-editions-editorial-remark__list-item", count: 0
+  end
+
+  def seed_document_event_history
+    acting_as(@user) do
+      @document = create(:document)
+      @first_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+      some_time_passes
+      @first_edition.submit!
+    end
+
+    some_time_passes
+
+    acting_as(@user2) do
+      create(:editorial_remark, edition: @first_edition, author: @user2, body: "This is terrible. Make it better!")
+      some_time_passes
+      @first_edition.reject!
+    end
+
+    some_time_passes
+
+    acting_as(@user) do
+      @first_edition.update!(body: "New and improved")
+      some_time_passes
+      create(:editorial_remark, edition: @first_edition, author: @user, body: "I've made it better.")
+      some_time_passes
+      @first_edition.submit!
+    end
+
+    some_time_passes
+
+    acting_as(@user2) do
+      @first_edition.publish!
+    end
+
+    some_time_passes
+
+    acting_as(@user) do
+      @second_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+      some_time_passes
+      @second_edition.update!(body: "New draft changes")
+      some_time_passes
+      create(:editorial_remark, edition: @second_edition, author: @user, body: "Drafted to include new changes.")
+      @second_edition.submit!
+      @second_edition.publish!
+    end
+
+    some_time_passes
+
+    acting_as(@user2) do
+      @third_edition = create(:draft_edition, document: @document, major_change_published_at: Time.zone.now)
+      some_time_passes
+      @third_edition.update!(body: "New draft changes")
+      some_time_passes
+      create(:editorial_remark, edition: @third_edition, author: @user, body: "Drafted to include newer changes.")
+    end
+  end
+
+  def some_time_passes
+    Timecop.travel rand(1.hour..1.week).from_now
+  end
+end

--- a/test/components/admin/editions/editorial_remark_component_test.rb
+++ b/test/components/admin/editions/editorial_remark_component_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Editions::EditorialRemarkComponentTest < ViewComponent::TestCase
+  test "it constructs output based on the editorial remark when an author is present" do
+    editorial_remark = build_stubbed(:editorial_remark, created_at: Time.zone.local(2020, 1, 1, 11, 11))
+    author = editorial_remark.author
+    render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
+
+    assert_equal page.text.strip, "#{editorial_remark.body}\n  #{author.name}  1 January 2020 11:11am"
+    assert_equal page.find("li a").text, author.name
+    assert_equal page.find("li a")[:href], "/government/admin/authors/#{author.id}"
+  end
+
+  test "it constructs output based on the editorial remark when an author is absent" do
+    editorial_remark = build_stubbed(:editorial_remark, author: nil, created_at: Time.zone.local(2020, 1, 1, 11, 11))
+
+    render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
+
+    assert_equal page.text.strip, "#{editorial_remark.body}\n  User (removed)  1 January 2020 11:11am"
+  end
+end

--- a/test/unit/models/document/paginated_timeline_test.rb
+++ b/test/unit/models/document/paginated_timeline_test.rb
@@ -64,18 +64,20 @@ class PaginatedTimelineTest < ActiveSupport::TestCase
   end
 
   test "AuditTrailEntry correctly determines actions" do
-    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
-    entries = timeline.entries.select { |e| e.instance_of?(Document::PaginatedHistory::AuditTrailEntry) }
-    expected_actions = %w[updated
-                          editioned
-                          published
-                          submitted
-                          updated
-                          rejected
-                          submitted
-                          created]
+    mock_pagination(per_page: 30) do
+      timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+      entries = timeline.entries.select { |e| e.instance_of?(Document::PaginatedHistory::AuditTrailEntry) }
+      expected_actions = %w[updated
+                            editioned
+                            published
+                            submitted
+                            updated
+                            rejected
+                            submitted
+                            created]
 
-    assert_equal expected_actions, entries.map(&:action)
+      assert_equal expected_actions, entries.map(&:action)
+    end
   end
 
   test "AuditTrailEntry correctly determines actors" do
@@ -87,7 +89,6 @@ class PaginatedTimelineTest < ActiveSupport::TestCase
                        @user,
                        @user,
                        @user2,
-                       @user,
                        @user]
 
     assert_equal expected_actors, entries.map(&:actor)

--- a/test/unit/models/document/paginated_timeline_test.rb
+++ b/test/unit/models/document/paginated_timeline_test.rb
@@ -93,6 +93,27 @@ class PaginatedTimelineTest < ActiveSupport::TestCase
     assert_equal expected_actors, entries.map(&:actor)
   end
 
+  test "#entries_on_newer_editions returns entries on newer editions than the one passed in" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    expected_entries = timeline.entries.slice(1, 2)
+
+    assert_equal expected_entries, timeline.entries_on_newer_editions(@first_edition)
+  end
+
+  test "#entries_on_current_edition returns entries for the edition passed in" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    expected_entries = timeline.entries - timeline.entries.slice(1, 2)
+
+    assert_equal expected_entries, timeline.entries_on_current_edition(@first_edition)
+  end
+
+  test "#entries_on_previous_editions returns entries on previous editions" do
+    timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
+    expected_entries = timeline.entries - timeline.entries.slice(1, 2)
+
+    assert_equal expected_entries, timeline.entries_on_previous_editions(@newest_edition)
+  end
+
   def seed_document_event_history
     acting_as(@user) do
       @document = create(:document)


### PR DESCRIPTION
## Description

This PR follows on from https://github.com/alphagov/whitehall/pull/7144 which added tabs to the edit edition, edition summary and edit translation page.

It populated the govspeak help tab, but left the history and fact checking tabs blank.

This PR populates the history tab.

_Note: It does not add pagination via JS, which will be added in a follow up PR. Pagination does work, but it will reload the page_

## Guidance for review

By commit will be easiest.

## Screenshots 

### Edit edition page 

<img width="786" alt="image" src="https://user-images.githubusercontent.com/7735945/207666682-01c5d9fa-0c87-4768-968a-9f9eacdc27df.png">

### Edition Summary page

<img width="678" alt="image" src="https://user-images.githubusercontent.com/7735945/207666777-1479f980-a583-4cc3-b8da-ce75592ba3a2.png">

### Edit translation page

<img width="776" alt="image" src="https://user-images.githubusercontent.com/7735945/207666840-db45b8f6-1d60-43cb-8445-3b60aca07db3.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
