### PR TITLE
Use govuk-body and govuk-link for the forbidden page

### DIFF
--- a/app/views/admin/editions/forbidden.html.erb
+++ b/app/views/admin/editions/forbidden.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Access denied" %>
 <div class="no-content no-content-bordered">
   <h1 class="govuk-heading-l">Sorry, you don’t have access to this document</h1>
-  <p class="back govuk-back-link">
-    <%= link_to 'Back to document list', admin_editions_path %>
+  <p class="back govuk-body">
+    <%= link_to 'Back to document list', admin_editions_path, class: "govuk-link" %>
   </p>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Why
The current use of `govuk-back-link` is incorrect.