### PR TITLE
Remove ES6 const syntax

### DIFF
--- a/app/assets/javascripts/admin/modules/edition-form.js
+++ b/app/assets/javascripts/admin/modules/edition-form.js
@@ -48,7 +48,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var container = form.querySelector('.edition-form--locale-fields')
     var localeCheckbox = container.querySelector('#edition_create_foreign_language_only-0')
     var localeSelect = container.querySelector('#edition_primary_locale')
-    const newArticleTypeId = '4'
+    var newArticleTypeId = '4'
 
     if (select.value !== newArticleTypeId) {
       container.style.display = 'none'


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Why
This is causing build issues
https://github.com/alphagov/whitehall/actions/runs/3694320200/jobs/6255369226#step:7:950