### PR TITLE
Add ability to manual trigger CI for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main


### PR DESCRIPTION
This is a temporary change to allow manually triggering CI, so we can test changes to CI workflow.
