### PR TITLE
Add fact checking tabs

### DIFF
--- a/app/components/admin/editions/fact_checking_tab_component.html.erb
+++ b/app/components/admin/editions/fact_checking_tab_component.html.erb
@@ -1,0 +1,62 @@
+<h2 class="govuk-heading-l">Fact checking</h2>
+
+<section class="responses">
+  <% if edition.all_completed_fact_check_requests.any? %>
+    <h3 class="govuk-heading-m">Responses</h3>
+
+    <%= render "govuk_publishing_components/components/list", {
+      visible_counters: true,
+      items: completed_fact_check_requests.map do |fact_check_request|
+        "#{fact_check_request.email_address} #{distance_of_time_in_words_to_now(fact_check_request.updated_at)} ago" +
+        format_in_paragraphs(fact_check_request.comments) +
+        "#{'(This refers to an older edition.)' unless fact_check_request.edition == edition}"
+      end
+    } %>
+  <% else %>
+    <p class="govuk-body">Document doesn't have any fact checking responses yet.</p>
+  <% end %>
+</section>
+
+<section class="pending">
+  <% if pending_fact_check_requests.any? %>
+    <h3 class="govuk-heading-m">Pending requests</h3>
+
+    <%= render "govuk_publishing_components/components/list", {
+      visible_counters: true,
+      items: pending_fact_check_requests.map do |fact_check_request|
+        "#{fact_check_request.email_address} #{distance_of_time_in_words_to_now(fact_check_request.updated_at)} ago"
+      end
+    } %>
+  <% end %>
+</section>
+
+<section class="send-request">
+  <% if send_request_section %>
+    <h3 class="govuk-heading-m">Send request</h3>
+    <%= form_for FactCheckRequest.new, url: admin_edition_fact_check_requests_path(@edition) do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email address (required)",
+          bold: true,
+        },
+        name: "fact_check_request[email_address]",
+        id: "fact_check_request_email_address",
+      } %>
+
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Extra instructions",
+          bold: true,
+        },
+        name: "fact_check_request[instructions]",
+        id: "fact_check_request_instructions"
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Send request"
+      } %>
+    <% end %>
+  <% else %>
+    <p class="govuk-body">To send a fact check request, save your changes.</p>
+  <% end %>
+</section>

--- a/app/components/admin/editions/fact_checking_tab_component.rb
+++ b/app/components/admin/editions/fact_checking_tab_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Admin::Editions::FactCheckingTabComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :edition, :send_request_section
+
+  def initialize(edition:, send_request_section: false)
+    @edition = edition
+    @send_request_section = send_request_section
+  end
+
+private
+
+  def completed_fact_check_requests
+    @completed_fact_check_requests ||= edition.all_completed_fact_check_requests.includes(:edition)
+  end
+
+  def pending_fact_check_requests
+    @pending_fact_check_requests ||= edition.fact_check_requests.pending
+  end
+end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -87,7 +87,7 @@
         *([{
           id: "fact_checking_tab",
           label: "Fact checking",
-          content: ""
+          content: render(Admin::Editions::FactCheckingTabComponent.new(edition: @edition))
         }] if @edition.can_be_fact_checked?)
       ]
     } %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -56,7 +56,7 @@
          *([{
            id: "fact_checking_tab",
            label: "Fact checking",
-           content: ""
+           content: render(Admin::Editions::FactCheckingTabComponent.new(edition: @edition))
          }] if @edition.can_be_fact_checked?)
        ]
       } %>

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -23,7 +23,7 @@
      *([{
        id: "fact_checking_tab",
        label: "Fact checking",
-       content: "",
+       content: render(Admin::Editions::FactCheckingTabComponent.new(edition: @edition, send_request_section: true))
      }] if @edition.can_be_fact_checked?)
    ]
  } %>

--- a/test/components/admin/editions/fact_checking_tab_component_test.rb
+++ b/test/components/admin/editions/fact_checking_tab_component_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Editions::FactCheckingTabComponentTest < ViewComponent::TestCase
+  test "renders fact checking responses and requests correctly when an edition has fact checks" do
+    edition = create(:case_study)
+    create(:fact_check_request, email_address: "user-1@example.com", comments: "This is accurate.", updated_at: 2.days.ago, edition:)
+    create(:fact_check_request, email_address: "user-2@example.com", comments: "This is inaccurate.", updated_at: 1.day.ago, edition:)
+    create(:fact_check_request, email_address: "user-3@example.com", edition:)
+
+    render_inline(Admin::Editions::FactCheckingTabComponent.new(edition:))
+
+    assert_selector ".responses h3", text: "Responses"
+    assert_selector ".responses li", count: 2
+    assert_selector ".responses li", text: "user-2@example.com 1 day agoThis is inaccurate."
+    assert_selector ".responses li", text: "user-1@example.com 2 days agoThis is accurate."
+
+    assert_selector ".pending h3", text: "Pending requests"
+    assert_selector ".pending li", count: 1
+    assert_selector ".pending li", text: "user-3@example.com less than a minute ago"
+  end
+
+  test "renders `Document doesn't have any fact checking responses yet.` when none have been requested" do
+    edition = create(:case_study)
+
+    render_inline(Admin::Editions::FactCheckingTabComponent.new(edition:))
+
+    assert_selector ".responses h3", text: "Responses", count: 0
+    assert_selector ".responses p", text: "Document doesn't have any fact checking responses yet."
+  end
+
+  test "renders guidance on requested a fact check when `send_request_section` isnt set to true" do
+    edition = create(:case_study)
+
+    render_inline(Admin::Editions::FactCheckingTabComponent.new(edition:))
+
+    assert_selector ".send-request p", text: "To send a fact check request, save your changes."
+
+    assert_selector ".send-request h3", text: "Send request", count: 0
+    assert_selector "input[type='text'][name='fact_check_request[email_address]']", count: 0
+    assert_selector "textarea[name='fact_check_request[instructions]']", count: 0
+  end
+
+  test "renders fact check request form fields when `send_request_section` is set to true" do
+    edition = create(:case_study)
+
+    render_inline(Admin::Editions::FactCheckingTabComponent.new(edition:, send_request_section: true))
+
+    assert_selector ".send-request h3", text: "Send request"
+    assert_selector "input[type='text'][name='fact_check_request[email_address]']"
+    assert_selector "textarea[name='fact_check_request[instructions]']"
+
+    assert_selector ".send-request p", text: "To send a fact check request, save your changes.", count: 0
+  end
+end

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -96,6 +96,22 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     refute_select "input#edition_title"
   end
 
+  view_test "renders the govspeak help, history and fact checking tabs with the 'Preview design system' permission" do
+    @writer.permissions << "Preview design system"
+    edition = create(:publication)
+
+    fact_checking_view_component = Admin::Editions::FactCheckingTabComponent.new(edition:)
+    Admin::Editions::FactCheckingTabComponent.expects(:new).with { |value|
+      value[:edition].title == edition.title
+    }.returns(fact_checking_view_component)
+
+    get :edit, params: { edition_id: edition, id: "cy" }
+
+    assert_select ".govuk-tabs__tab", text: "Help"
+    assert_select ".govuk-tabs__tab", text: "History"
+    assert_select ".govuk-tabs__tab", text: "Fact checking"
+  end
+
   test "update creates a translation for an edition that's yet to be published, and redirect back to the edition admin page" do
     edition = create(:draft_edition)
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1544,6 +1544,11 @@ module AdminEditionControllerTestHelpers
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
         stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
+        fact_checking_view_component = Admin::Editions::FactCheckingTabComponent.new(edition:)
+        Admin::Editions::FactCheckingTabComponent.expects(:new).with { |value|
+          value[:edition].title == edition.title && value[:send_request_section] == true
+        }.returns(fact_checking_view_component)
+
         get :show, params: { id: edition }
 
         assert_select ".govuk-tabs__tab", text: "History"
@@ -1553,6 +1558,11 @@ module AdminEditionControllerTestHelpers
       view_test "GET :edit renders a side nav bar with govspeak help, history and fact checking" do
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
         stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+        fact_checking_view_component = Admin::Editions::FactCheckingTabComponent.new(edition:)
+        Admin::Editions::FactCheckingTabComponent.expects(:new).with { |value|
+          value[:edition].title == edition.title
+        }.returns(fact_checking_view_component)
 
         get :edit, params: { id: edition }
 


### PR DESCRIPTION
## Description

This PR follows on from https://github.com/alphagov/whitehall/pull/7144 which added tabs to the edit edition, edition summary and edit translation page.

It populated the govspeak help tab, but left the history and fact checking tabs blank.

This adds the fact checking tab.

## Screenshots

### Edition summary page

<img width="614" alt="image" src="https://user-images.githubusercontent.com/42515961/207827155-8288d0f1-5a85-45ea-acbd-3a7347f63bae.png">


### Edit edition page

<img width="486" alt="image" src="https://user-images.githubusercontent.com/42515961/207827343-30503217-06c5-46e0-b982-ed342df78624.png">


### Edit translation page

<img width="969" alt="image" src="https://user-images.githubusercontent.com/42515961/207827665-587201fc-4942-44e5-9896-5d40da441396.png">


## Trello card 

https://trello.com/c/xiy8xs27/888-move-notes-history-fact-checking-tabs-to-the-design-system



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
