### PR TITLE
Apply requested release 1.4 changes

### DIFF
--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -26,7 +26,7 @@ module Admin::TabbedNavHelper
       },
       *(if edition.persisted? && edition.allows_attachments?
           [{
-            label: "Attachments#{tag.span(edition.attachments.count, class: 'govuk-tag govuk-tag--grey') if edition.attachments.count.positive?}".html_safe,
+            label: sanitize("Attachments #{tag.span(edition.attachments.count, class: 'govuk-tag govuk-tag--grey') if edition.attachments.count.positive?}"),
             href: admin_edition_attachments_path(edition),
             current: current_path == admin_edition_attachments_path(edition),
           }]
@@ -65,7 +65,7 @@ module Admin::TabbedNavHelper
         current: current_path == edit_admin_policy_group_path(group),
       },
       {
-        label: "Attachments#{tag.span(group.attachments.count, class: 'govuk-tag govuk-tag--grey') if group.attachments.count.positive?}".html_safe,
+        label: sanitize("Attachments #{tag.span(group.attachments.count, class: 'govuk-tag govuk-tag--grey') if group.attachments.count.positive?}"),
         href: admin_policy_group_attachments_path(group),
         current: current_path == admin_policy_group_attachments_path(group),
       },

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -17,7 +17,7 @@
       text: "Type"
     },
     {
-      text: "File"
+      text: "Attachment"
     },
     {},
     {}

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -25,7 +25,7 @@
   rows: attachable.attachments.includes(:attachment_data).map do |attachment|
     [
       {
-        text: attachment.title
+        text: sanitize("#{attachment.title} #{tag.span("Uploading", class: 'govuk-tag govuk-tag--green') unless attachment.attachment_data&.uploaded_to_asset_manager?}")
       },
       {
         text: attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -14,6 +14,9 @@
       text: "Title"
     },
     {
+      text: "Type"
+    },
+    {
       text: "File"
     },
     {},
@@ -23,6 +26,9 @@
     [
       {
         text: attachment.title
+      },
+      {
+        text: attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize
       },
       {
         text: link_to_attachment(attachment, preview: true, full_url: true, class: "govuk-link govuk-link--no-visited-state")

--- a/app/views/admin/attachments/reorder.html.erb
+++ b/app/views/admin/attachments/reorder.html.erb
@@ -6,6 +6,11 @@
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <%= form_tag [:order, :admin, typecast_for_attachable_routing(attachable), Attachment], method: :put do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder attachments, or select and hold on an attachment to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
       <%= render "govuk_publishing_components/components/reorderable_list", {
         items: attachable.attachments.includes(:attachment_data).map do |attachment|
           {

--- a/test/unit/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/helpers/admin/tabbed_nav_helper_test.rb
@@ -14,7 +14,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
-        label: "Attachments",
+        label: "Attachments ",
         href: admin_edition_attachments_path(consultation),
         current: false,
       },
@@ -44,7 +44,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
-        label: "Attachments<span class=\"govuk-tag govuk-tag--grey\">2</span>",
+        label: "Attachments <span class=\"govuk-tag govuk-tag--grey\">2</span>",
         href: admin_edition_attachments_path(consultation),
         current: false,
       },
@@ -114,7 +114,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
           current: true,
         },
         {
-          label: "Attachments",
+          label: "Attachments ",
           href: admin_edition_attachments_path(edition),
           current: false,
         },
@@ -142,7 +142,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
           current: true,
         },
         {
-          label: "Attachments<span class=\"govuk-tag govuk-tag--grey\">2</span>",
+          label: "Attachments <span class=\"govuk-tag govuk-tag--grey\">2</span>",
           href: admin_edition_attachments_path(edition),
           current: false,
         },
@@ -183,7 +183,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: true,
       },
       {
-        label: "Attachments",
+        label: "Attachments ",
         href: admin_policy_group_attachments_path(policy_group),
         current: false,
       },
@@ -203,7 +203,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
-        label: "Attachments<span class=\"govuk-tag govuk-tag--grey\">2</span>",
+        label: "Attachments <span class=\"govuk-tag govuk-tag--grey\">2</span>",
         href: admin_policy_group_attachments_path(policy_group),
         current: true,
       },


### PR DESCRIPTION
## Description

JP and Ollie have left some notes in this doc https://docs.google.com/document/d/1pZ1_RR34x_bzi5BTrFoIdcEWyyc2K82PztDDz5vcxn8/edit#

with 4 requested changes that are required prior to us going live with 1.4.

### 1. ‘Uploading’ after adding a file attachment & 3. Add type column 

#### Before

<img width="673" alt="image" src="https://user-images.githubusercontent.com/42515961/207895381-52742834-6887-4e98-88d9-baac8510ec59.png">

#### After

<img width="621" alt="image" src="https://user-images.githubusercontent.com/42515961/207895253-b936f30f-78a2-4721-a207-ba059afb3732.png">


### 2. Spacing in the sub-navigation between ‘Attachments’ and the number

#### Before

<img width="383" alt="image" src="https://user-images.githubusercontent.com/42515961/207874434-2fef3306-a9f8-4301-911c-bbc33d50913d.png">

#### After 

<img width="643" alt="image" src="https://user-images.githubusercontent.com/42515961/207873907-f87fdd30-b582-48bc-a13c-461fc02f06c2.png">

### 4. Reorder attachments page help/hint text

### Before

<img width="697" alt="image" src="https://user-images.githubusercontent.com/42515961/207874518-e6da57bb-7401-4493-a241-57f23b75a5a5.png">

#### After

<img width="613" alt="image" src="https://user-images.githubusercontent.com/42515961/207872382-3dc7020c-a9e1-4060-a916-ea7710809532.png">

## Trello card 

https://trello.com/c/i1QzFheQ/1004-implement-changes-requested-in-14-pre-release-review

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
