### PR TITLE
Fix a JS error by always rendering the foreign language only field

### DIFF
--- a/app/assets/javascripts/admin/modules/edition-form.js
+++ b/app/assets/javascripts/admin/modules/edition-form.js
@@ -45,23 +45,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     if (!select) { return }
 
-    var container = form.querySelector('.edition-form--locale-fields')
+    var container = form.querySelector('.app-view-edit-edition__locale-field')
     var localeCheckbox = container.querySelector('#edition_create_foreign_language_only-0')
     var localeSelect = container.querySelector('#edition_primary_locale')
     var newArticleTypeId = '4'
 
-    if (select.value !== newArticleTypeId) {
-      container.style.display = 'none'
-    }
-
     select.addEventListener('change', function () {
       if (select.value !== newArticleTypeId) {
-        container.style.display = 'none'
+        container.classList.add('app-view-edit-edition__locale-field--hidden')
         localeCheckbox.value = '0'
         localeCheckbox.checked = false
         localeSelect.value = ''
       } else {
-        container.style.display = 'block'
+        container.classList.remove('app-view-edit-edition__locale-field--hidden')
       }
     })
   }

--- a/app/assets/stylesheets/admin/views/_edit-edition.scss
+++ b/app/assets/stylesheets/admin/views/_edit-edition.scss
@@ -20,3 +20,7 @@
   margin: govuk-spacing(6) + 5 govuk-spacing(2) 0 0;
   margin-bottom: 0;
 }
+
+.app-view-edit-edition__locale-field--hidden {
+  display: none;
+}

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,39 +1,37 @@
-<% if edition.locale_can_be_changed? %>
-  <div class="edition-form--locale-fields">
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[create_foreign_language_only]",
-      id: "edition_create_foreign_language_only",
-      heading: "Foreign language only #{edition.model_name.human.downcase}",
-      heading_size: "l",
-      no_hint_text: true,
-      error_items: errors_for_input(edition.errors, :create_foreign_language_only),
-      items: [
-        {
-          label: "Create a foreign language only #{edition.model_name.human.downcase}",
-          value: "1",
-          checked: form.object.primary_locale != "en",
-          conditional: (render "govuk_publishing_components/components/select", {
-            id: "edition_primary_locale",
-            name: "edition[primary_locale]",
-            label: "Document language",
-            heading_size: "s",
-            full_width: true,
-            allow_blank: true,
-            errors: errors_for(edition.errors, :primary_locale),
-            options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
-              {
-                text: language,
-                value: value,
-                selected: edition.primary_locale == value
-              }
-            end
-          })
-        }
-      ]
-    } %>
+<div class="app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "edition[create_foreign_language_only]",
+    id: "edition_create_foreign_language_only",
+    heading: "Foreign language only #{edition.model_name.human.downcase}",
+    heading_size: "l",
+    no_hint_text: true,
+    error_items: errors_for_input(edition.errors, :create_foreign_language_only),
+    items: [
+      {
+        label: "Create a foreign language only #{edition.model_name.human.downcase}",
+        value: "1",
+        checked: form.object.primary_locale != "en",
+        conditional: (render "govuk_publishing_components/components/select", {
+          id: "edition_primary_locale",
+          name: "edition[primary_locale]",
+          label: "Document language",
+          heading_size: "s",
+          full_width: true,
+          allow_blank: true,
+          errors: errors_for(edition.errors, :primary_locale),
+          options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
+            {
+              text: language,
+              value: value,
+              selected: edition.primary_locale == value
+            }
+          end
+        })
+      }
+    ]
+  } %>
 
-    <% if edition.is_a?(NewsArticle) %>
-      <p class="govuk-body govuk-!-font-weight-bold">Warning: News stories without an English version cannot have other translations.</p>
-    <% end %>
-  </div>
-<% end %>
+  <% if edition.is_a?(NewsArticle) %>
+    <p class="govuk-body govuk-!-font-weight-bold">Warning: News stories without an English version cannot have other translations.</p>
+  <% end %>
+</div>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -18,7 +18,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       </div>
     </div>
 
-    <div class="edition-form--locale-fields">
+    <div class="app-view-edit-edition__locale-field app-view-edit-edition__locale-field--hidden">
       <input type="checkbox" name="edition[create_foreign_language_only]" id="edition_create_foreign_language_only-0" value="0" checked="checked">
 
       <select name="edition[primary_locale]" id="edition_primary_locale" class="govuk-select gem-c-select__select--full-width">
@@ -56,9 +56,9 @@ describe('GOVUK.Modules.EditionForm', function () {
   })
 
   it('should hide the locale fields when a NewsArticle is not a WorldNewsStory', function () {
-    var localeFields = form.querySelector('.edition-form--locale-fields')
+    var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
 
-    expect(localeFields.style.display).toEqual('none')
+    expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
   })
 
   it('should render the locale fields when the WorldNewsStory is selected', function () {
@@ -67,9 +67,9 @@ describe('GOVUK.Modules.EditionForm', function () {
     select.value = '4'
     select.dispatchEvent(new Event('change'))
 
-    var localeFields = form.querySelector('.edition-form--locale-fields')
+    var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
 
-    expect(localeFields.style.display).toEqual('block')
+    expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
   })
 
   it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Always render the foreign language only field.
Toggles CSS classes to hide and show the field.

## Why
Fixes a JS error that would occur when the page was rendered without one.

```js
Uncaught TypeError: Cannot read properties of
null (reading 'querySelector')
    at t.setupworldNewsStoryVisibilityToggle
    at t. init
    at Object.start
    at HTMLDocument.<anonymous>
```