### PR TITLE
Fix error message not rendering for publication type

### DIFF
--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,12 +1,12 @@
 <div class="edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
-  <div class="govuk-form-group">
+  <div class="govuk-form-group <%= "govuk-form-group--error" if errors_for_input(edition.errors, :publication_type_id).present? %>">
     <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
       Publication type
     </label>
     <% if errors_for_input(edition.errors, :publication_type_id).present? %>
-      <p class="gem-c-error-message govuk-error-message">
-        <span class="govuk-visually-hidden">Error: <%= errors_for_input(edition.errors, :publication_type_id) %></span>
-      </p>
+      <%= render "govuk_publishing_components/components/error_message", {
+        text: errors_for_input(edition.errors, :publication_type_id),
+      } %>
     <% end %>
 
     <select class="govuk-select govuk-select gem-c-select__select--full-width" id="edition_publication_type_id" name="edition[publication_type_id]">


### PR DESCRIPTION
## Description

The error message for publication type isn't showing. This is due to it  being rendered in a visually hidden span. It also is not adding the `govuk-form-group--error` class to the form group.

## Screenshots 

### Before

<img width="849" alt="image" src="https://user-images.githubusercontent.com/42515961/208117882-0869013d-91a4-4584-a7eb-afb5986bcd4f.png">

### After 

<img width="797" alt="image" src="https://user-images.githubusercontent.com/42515961/208117808-7f63e957-c000-4836-90d9-a9cd4f05ffa5.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
