### PR TITLE
Ensure attachment uploading tag is rendering correctly

### DIFF
--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -25,7 +25,7 @@
   rows: attachable.attachments.includes(:attachment_data).map do |attachment|
     [
       {
-        text: sanitize("#{attachment.title} #{tag.span("Uploading", class: 'govuk-tag govuk-tag--green') unless attachment.attachment_data&.uploaded_to_asset_manager?}")
+        text: sanitize("#{attachment.title} #{tag.span("Uploading", class: 'govuk-tag govuk-tag--green') unless attachment.attachment_data.blank? || attachment.attachment_data.uploaded_to_asset_manager?}")
       },
       {
         text: attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -100,6 +100,24 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select ".existing-attachments li strong", text: "An HTML attachment"
   end
 
+  view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
+    @current_user.permissions << "Preview next release"
+
+    create(:html_attachment, title: "An HTML attachment", attachable: @edition)
+    create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)
+    attachment_data = create(:attachment_data, uploaded_to_asset_manager_at: nil)
+    create(:file_attachment, title: "An uploading file attachment", attachable: @edition, attachment_data:)
+    create(:external_attachment, title: "An external attachment", attachable: @edition)
+
+    get :index, params: { edition_id: @edition }
+
+    assert_response :success
+    assert_select ".govuk-table__cell", text: "An HTML attachment"
+    assert_select ".govuk-table__cell", text: "An uploaded file attachment"
+    assert_select ".govuk-table__cell", text: "An uploading file attachment Uploading"
+    assert_select ".govuk-table__cell", text: "An external attachment"
+  end
+
   test "POST :create handles html attachments when attachable allows them" do
     post :create, params: { edition_id: @edition, type: "html", attachment: valid_html_attachment_params }
 


### PR DESCRIPTION
## Description

At the moment, the uploading tag is always showing for external and html attachments.

The tag should only be shown when attachment data is present and the has not yet been sent to asset manager (`uploaded_to_asset_manager_at` is nil on the attachment data).


## Before 

<img width="773" alt="image" src="https://user-images.githubusercontent.com/42515961/208426471-3d582744-0735-4926-a186-97e4b408b81d.png">

## After 

<img width="805" alt="image" src="https://user-images.githubusercontent.com/42515961/208426433-d94a162a-b531-4680-b3d5-9fc9062c5fe1.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
