### PR TITLE
Add async pagination for the History tab

### DIFF
--- a/app/assets/javascripts/admin/modules/document-history-paginator.js
+++ b/app/assets/javascripts/admin/modules/document-history-paginator.js
@@ -1,0 +1,49 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function DocumentHistoryPaginator (module) {
+    this.module = module
+  }
+
+  DocumentHistoryPaginator.prototype.init = function () {
+    var fetch = window.fetch
+    if (!fetch) { return }
+
+    this.setupEventListeners()
+  }
+
+  DocumentHistoryPaginator.prototype.setupEventListeners = function () {
+    var module = this.module
+    var newerLink = module.querySelector('.app-view-document-history-tab__newer-pagination-link')
+    var olderLink = module.querySelector('.app-view-document-history-tab__older-pagination-link')
+
+    if (newerLink) {
+      this.addLinkEventListener(newerLink)
+    }
+
+    if (olderLink) {
+      this.addLinkEventListener(olderLink)
+    }
+  }
+
+  DocumentHistoryPaginator.prototype.addLinkEventListener = function (link) {
+    var module = this.module
+
+    link.addEventListener('click', function (e) {
+      e.preventDefault()
+
+      window.fetch(new URL(document.location.origin + link.dataset.remotePagination))
+        .then(function (response) { return response.text() })
+        .catch(function () { window.location.replace(new URL(link.href)) })
+        .then(function (html) {
+          module.innerHTML = html
+
+          var documentHistoryModule = new GOVUK.Modules.DocumentHistoryPaginator(module)
+          documentHistoryModule.init()
+        })
+    })
+  }
+
+  Modules.DocumentHistoryPaginator = DocumentHistoryPaginator
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //= require admin/analytics
 
 //= require admin/modules/app-analytics
+//= require admin/modules/document-history-paginator
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak
 

--- a/app/assets/stylesheets/admin/views/_document-history-tab.scss
+++ b/app/assets/stylesheets/admin/views/_document-history-tab.scss
@@ -1,8 +1,8 @@
-.app-view-document-history-tab__pagination-link {
-  margin-left: govuk-spacing(3);
-}
-
-.app-view-document-history-tab__pagination-link:last-child {
+.app-view-document-history-tab__older-pagination-link {
   float: right;
   margin-right: govuk-spacing(3);
+}
+
+.app-view-document-history-tab__newer-pagination-link {
+  margin-left: govuk-spacing(3);
 }

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -10,7 +10,7 @@
   text: sanitize("History and notes have been merged. #{tag.a('Read more about the change', href: admin_whats_new_path)}")
 } %>
 
-<%= paginate(@document_history, theme: 'history') %>
+<%= paginate(@document_history, theme: 'history', editing:) %>
 
 <% if entries_on_newer_editions.present? %>
   <div class="app-view-editions__newer-edition-entries">

--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -3,6 +3,12 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
 
   def index
     @edition = Edition.find(params[:id])
-    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    if preview_design_system?(next_release: false)
+      @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
+
+      render(html: Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: params[:editing]).render_in(view_context))
+    else
+      @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
+    end
   end
 end

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -18,10 +18,10 @@ module Admin::AuditTrailHelper
     html << absolute_time(entry.created_at, class: "created_at")
   end
 
-  def paginated_audit_trail_url(page)
+  def paginated_audit_trail_url(page, editing = nil)
     url_for(
       params.to_unsafe_hash
-            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page))
+            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page), editing:)
             .symbolize_keys,
     )
   end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -78,11 +78,14 @@
         {
           id: "history_tab",
           label: "History",
-          content: render(Admin::Editions::DocumentHistoryTabComponent.new(
-            edition: @edition,
-            document_history: @document_history,
-            editing: true,
-          ))
+          content: tag.div(
+              render(Admin::Editions::DocumentHistoryTabComponent.new(
+              edition: @edition,
+              document_history: @document_history,
+              editing: true,
+            )),
+            data: { module: "document-history-paginator" },
+          ),
         },
         *([{
           id: "fact_checking_tab",

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -47,11 +47,14 @@
          {
            id: "history_tab",
            label: "History",
-           content: render(Admin::Editions::DocumentHistoryTabComponent.new(
-             edition: @edition,
-             document_history: @document_history,
-             editing: true,
-           ))
+           content: tag.div(
+             render(Admin::Editions::DocumentHistoryTabComponent.new(
+               edition: @edition,
+               document_history: @document_history,
+               editing: true,
+             )),
+             data: { module: "document-history-paginator" },
+           ),
          },
          *([{
            id: "fact_checking_tab",

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -15,10 +15,13 @@
    {
      id: "history_tab",
      label: "History",
-     content: render(Admin::Editions::DocumentHistoryTabComponent.new(
-       edition: @edition,
-       document_history: @document_history,
-     ))
+     content: tag.div(
+       render(Admin::Editions::DocumentHistoryTabComponent.new(
+         edition: @edition,
+         document_history: @document_history,
+       )),
+       data: { module: "document-history-paginator" },
+     )
    },
      *([{
        id: "fact_checking_tab",

--- a/app/views/kaminari/history/_next_page.html.erb
+++ b/app/views/kaminari/history/_next_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1) } %>
+<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1) } %>

--- a/app/views/kaminari/history/_prev_page.html.erb
+++ b/app/views/kaminari/history/_prev_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-view-document-history-tab__pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page - 1) } %>
+<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-view-document-history-tab__newer-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page - 1) } %>

--- a/features/admin-audit-trail.feature
+++ b/features/admin-audit-trail.feature
@@ -3,7 +3,7 @@ Feature: Audit trail information on a document
   Background:
     Given I am a GDS editor
 
-  @javascript @design-system-wip
+  @javascript @bootstrap-only
   Scenario: Audit trail is paginated
     Given a document that has gone through many changes
     When I visit the document to see the audit trail

--- a/features/admin-history-pagination.feature
+++ b/features/admin-history-pagination.feature
@@ -1,0 +1,30 @@
+Feature: Viewing a documents history
+
+  Background:
+    Given I am a writer
+
+  @design-system-only
+  Scenario: Viewing multiple pages of history
+    Given a draft news article "Stubble to be Outlawed" exists
+    When "Stubble to be Outlawed" has two pages of history
+    Then I can see the first ten items in the History tab
+
+    When I click the "Older" link
+    Then I can see the second page of history
+
+    When I click the "Newer" link
+    Then I can see the first ten items in the History tab
+
+  @javascript @design-system-only
+  Scenario: Viewing multiple pages of history with JavaScript
+    Given a draft news article "Stubble to be Outlawed" exists
+    When "Stubble to be Outlawed" has two pages of history
+    Then I can see the first ten items in the History tab
+
+    When I click the "Older" link
+    Then I can see the second page of history
+    And the History tab is still showing
+
+    When I click the "Newer" link
+    Then I can see the first ten items in the History tab
+    And the History tab is still showing

--- a/features/step_definitions/admin_history_pagination_steps.rb
+++ b/features/step_definitions/admin_history_pagination_steps.rb
@@ -1,0 +1,33 @@
+When(/^"([^"]*)" has two pages of history$/) do |title|
+  @edition = Edition.find_by!(title:)
+  @edition.versions.first.update!(created_at: 20.minutes.ago)
+
+  [*1..11].each_with_index do |integer, index|
+    create(:editorial_remark, edition: @edition, body: "editorial-remark-body-#{integer}", created_at: index.seconds.ago)
+  end
+
+  @ten_most_recent_remarks = @edition.editorial_remarks.order(created_at: :desc).slice(0, 9)
+end
+
+Then(/^I can see the first ten items in the History tab$/) do
+  visit edit_admin_edition_path(@edition)
+  click_link "History"
+
+  @ten_most_recent_remarks.each do |editorial_remark|
+    expect(page).to have_content(editorial_remark.body)
+  end
+  expect(all(".app-view-editions-editorial-remark__list-item").count).to eq 10
+end
+
+When(/^I click the "([^"]*)" link$/) do |link|
+  click_link link
+end
+
+Then(/^I can see the second page of history$/) do
+  expect(page).to have_content("editorial-remark-body-11")
+  expect(all(".app-view-editions-editorial-remark__list-item").count).to eq 1
+end
+
+And(/^the History tab is still showing$/) do
+  expect(find(".govuk-tabs__list-item--selected").text).to eq "History"
+end


### PR DESCRIPTION
## Description

We've recently added the history tab to the edition, summary, edition edit and edit translation pages.

<img width="611" alt="image" src="https://user-images.githubusercontent.com/42515961/208649801-d9a73b34-24f5-47cc-8c13-4889f0b44717.png">


This tab already has pagination built into it, but using it reloads the page.

This adds in dynamic pagination via Ajax requests

## Guidance for review

I've left a couple of comments on things i'm unclear on.

## Trello card 

https://trello.com/c/xiy8xs27/888-move-notes-history-fact-checking-tabs-to-the-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
