### PR TITLE
Remove tag warning in worldwide tags section

### DIFF
--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -183,13 +183,6 @@
         <%= link_to(@edition_world_taxons.map(&:full_path).any? ? "Change tags" : "Add tags", edit_admin_edition_world_tags_path(@edition.id), class: 'govuk-link') %>
       </p>
 
-      
-      <% unless @edition_taxons.any? %>
-        <%= render "govuk_publishing_components/components/warning_text", {
-          text: "Please add a tag before publishing"
-        } %>
-      <% end %>
-
       <% if @edition_world_taxons.map(&:full_path).any? %>
         <% @edition_world_taxons.map(&:full_path).each do | tag_path | %>
           <div class="govuk-breadcrumbs">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove tag warning in worldwide tags section.

## Why
This tag is not require for publishing, only the topic taxonomy is.

## Screenshot
<img width="805" alt="Screenshot 2022-12-19 at 17 13 26" src="https://user-images.githubusercontent.com/9594455/208481984-80832a09-a0a7-4c28-8b87-7d833e6c2bb6.png">
