### PR TITLE
Add tracking for release 1.4

### DIFF
--- a/app/assets/javascripts/admin/modules/analytics.js
+++ b/app/assets/javascripts/admin/modules/analytics.js
@@ -1,6 +1,18 @@
 (function (GOVUK) {
   'use strict'
 
+  GOVUK.setCustomDimensionsFromMetaTags = function () {
+    var metas = document.querySelectorAll("meta[name^='custom-dimension']")
+
+    for (var i = 0; i < metas.length; i++) {
+      var meta = metas[i]
+      var dimensionId = parseInt(meta.getAttribute('name').split('custom-dimension:')[1])
+      var content = meta.getAttribute('content')
+
+      GOVUK.analytics.setDimension(dimensionId, content)
+    }
+  }
+
   GOVUK.Analytics.load()
   GOVUK.analyticsVars = { primaryLinkedDomains: [document.domain] }
   GOVUK.analytics = new GOVUK.Analytics({
@@ -8,6 +20,7 @@
     cookieDomain: document.domain
   })
 
+  GOVUK.setCustomDimensionsFromMetaTags()
   GOVUK.analytics.trackPageview()
   GOVUK.analyticsPlugins.externalLinkTracker()
 })(window.GOVUK)

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,5 +1,11 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
 
+<% if user_signed_in? %>
+  <% content_for :head do %>
+    <meta name="custom-dimension:8" content="<%= current_user.organisation_slug.presence || '(not set)' %>">
+  <% end %>
+<% end %>
+
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Whitehall Publisher",
   environment: environment,

--- a/spec/javascripts/admin/modules/analytics.spec.js
+++ b/spec/javascripts/admin/modules/analytics.spec.js
@@ -1,0 +1,69 @@
+describe('GOVUK.analytics', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  function addGoogleAnalyticsSpy () {
+    if (typeof window.ga === 'undefined') {
+      window.ga = function () {}
+    }
+    spyOn(window, 'ga')
+  }
+
+  describe('setCustomDimensionsFromMetaTags', function () {
+    var metaTag
+
+    beforeEach(function () {
+      metaTag = document.createElement('meta')
+      metaTag.setAttribute('name', 'custom-dimension:8')
+      metaTag.setAttribute('content', 'Custom dimension 8')
+      document.getElementsByTagName('head')[0].appendChild(metaTag)
+    })
+
+    afterEach(function () {
+      var head = document.getElementsByTagName('head')[0]
+      var metaTags = document.querySelectorAll("[name^='custom-dimension']")
+      for (var i = 0; i < metaTags.length; i++) {
+        head.removeChild(metaTags[i])
+      }
+    })
+
+    it('calls setDimension with the correct arguments', function () {
+      spyOn(GOVUK.analytics, 'setDimension')
+
+      GOVUK.setCustomDimensionsFromMetaTags()
+
+      expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(
+        8,
+        'Custom dimension 8'
+      )
+    })
+
+    it('makes a call to GA to set a custom dimension with the correct dimension and value', function () {
+      addGoogleAnalyticsSpy()
+
+      GOVUK.setCustomDimensionsFromMetaTags()
+
+      expect(window.ga.calls.mostRecent().args).toEqual(
+        ['set', 'dimension8', 'Custom dimension 8']
+      )
+    })
+
+    it('can accept additional custom dimensions without overriding old ones', function () {
+      addGoogleAnalyticsSpy()
+      metaTag = document.createElement('meta')
+      metaTag.setAttribute('name', 'custom-dimension:21')
+      metaTag.setAttribute('content', 'Additional custom dimension 21')
+      document.getElementsByTagName('head')[0].appendChild(metaTag)
+
+      GOVUK.setCustomDimensionsFromMetaTags()
+
+      expect(window.ga.calls.count()).toEqual(2)
+      expect(window.ga.calls.argsFor(0)).toEqual(
+        ['set', 'dimension8', 'Custom dimension 8']
+      )
+      expect(window.ga.calls.mostRecent().args).toEqual(
+        ['set', 'dimension21', 'Additional custom dimension 21']
+      )
+    })
+  })
+})


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello ticket link](https://trello.com/c/oi4jFQW5/1012-add-app-wide-page-view-user-organisation-tracking)

## What
- Extends the `analyics.js` file to allow custom dimensions to be added using meta tags.
- Adds accompanying spec file to test the extension
- Uses meta tags to add page view tracking for user organisation to custom dimension 8 on the design system layout page, providing tracking throughout the app.

## Why
This behaviour was present in the bootstrap admin layout and needed to be replicated with the move to design system.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/94846816/208647147-6e4d67f2-96a7-4051-83a6-9f0514c80806.png)

### After
![image](https://user-images.githubusercontent.com/94846816/208647268-d23a665b-da35-4839-a01a-9d2407c148cf.png)