### PR TITLE
Republish organisation when promotional feature is saved or destroyed

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -11,6 +11,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   def create
     @promotional_feature_item = @promotional_feature.promotional_feature_items.build(promotional_feature_item_params)
     if @promotional_feature_item.save
+      Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
       redirect_to_feature "Feature item added."
     else
       render :new
@@ -23,6 +24,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def update
     if @promotional_feature_item.update(promotional_feature_item_params)
+      Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
       redirect_to_feature "Feature item updated."
     else
       render :edit
@@ -31,6 +33,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def destroy
     @promotional_feature_item.destroy!
+    Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
     redirect_to_feature "Feature item deleted."
   end
 

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -15,6 +15,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
   def create
     @promotional_feature = @organisation.promotional_features.build(promotional_feature_params)
     if @promotional_feature.save
+      Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature created"
     else
       render :new
@@ -27,6 +28,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def update
     if @promotional_feature.update(promotional_feature_params)
+      Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature updated"
     else
       render :edit
@@ -35,6 +37,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def destroy
     @promotional_feature.destroy!
+    Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
     redirect_to [:admin, @organisation, PromotionalFeature], notice: "Promotional feature deleted."
   end
 

--- a/app/views/admin/promotional_feature_items/new.html.erb
+++ b/app/views/admin/promotional_feature_items/new.html.erb
@@ -1,4 +1,5 @@
 <% page_title "Feature item for #{@promotional_feature.title}" %>
 <h1>New feature item for <%= @promotional_feature.title %></h1>
+<p class="warning">Warning: newly created feature items will appear instantly on the live site.</p>
 
 <%= render "form", promotional_feature_item: @promotional_feature_item, promotional_feature: @promotional_feature, organisation: @organisation %>

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -20,7 +20,9 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal 1, assigns(:promotional_feature_item).links.size
   end
 
-  test "POST :create saves the new promotional item to the feature" do
+  test "POST :create saves the new promotional item to the feature and republishes the organisation to the PublishingApi" do
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+
     post :create,
          params: {
            organisation_id: @organisation,
@@ -64,9 +66,11 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert link.is_a?(PromotionalFeatureLink)
   end
 
-  test "PUT :update updates the item and redirects to the feature" do
+  test "PUT :update updates the item and redirects to the feature and republishes the organisation to the PublishingApi" do
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
+
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
 
     put :update,
         params: { organisation_id: @organisation,
@@ -90,9 +94,12 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal "Old summary", promotional_feature_item.reload.summary
   end
 
-  test "DELETE :destroy deletes the promotional item" do
+  test "DELETE :destroy deletes the promotional item and republishes the organisation to the PublishingApi" do
     Services.asset_manager.stubs(:whitehall_asset).returns("id" => "http://asset-manager/assets/asset-id")
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+
     delete :destroy, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 
     assert_redirected_to admin_organisation_promotional_feature_url(@organisation, @promotional_feature)

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -34,7 +34,9 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     assert assigns(:promotional_feature).is_a?(PromotionalFeature)
   end
 
-  test "POST :create saves the new promotional feature and redirects to the show page" do
+  test "POST :create saves the new promotional feature, republishes the organisation to the PublishingApi and redirects to the show page" do
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+
     post :create, params: { organisation_id: @organisation, promotional_feature: { title: "Promotional feature title" } }
 
     assert promotional_feature = @organisation.reload.promotional_features.last
@@ -60,16 +62,22 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     assert_equal promotional_feature, assigns(:promotional_feature)
   end
 
-  test "PUT :update saves the promotional feature and redirects to the show page" do
+  test "PUT :update saves the promotional feature, republishes the organisation to the PublishingApi and redirects to the show page" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+
     put :update, params: { organisation_id: @organisation, id: promotional_feature, promotional_feature: { title: "New title" } }
 
     assert_redirected_to admin_organisation_promotional_feature_url(@organisation, promotional_feature)
     assert_equal "New title", promotional_feature.reload.title
   end
 
-  test "DELETE :destroy deletes the promotional feature" do
+  test "DELETE :destroy deletes the promotional feature and republishes the organisation to the PublishingApi" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+
     delete :destroy, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_redirected_to admin_organisation_promotional_features_url(@organisation)


### PR DESCRIPTION
## Description

Currently, you have to return to the organisation page and click save to push changes to promotional features and promotional feature links downstream to the PublishingApi

This updates the `PromotionalFeatureItemsController` and `PromotionalFeaturesController` `create`, `update` and `destroy` actions to republish the organisation on a successful action (save or delete).

## Trello card

https://trello.com/c/bmFyYErA/1008-automatically-republish-organisation-when-promotional-features-are-changed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
