### PR TITLE
Add order column to the promotional_features table

### DIFF
--- a/db/migrate/20221220162125_add_ordering_column_to_promotional_features.rb
+++ b/db/migrate/20221220162125_add_ordering_column_to_promotional_features.rb
@@ -1,0 +1,5 @@
+class AddOrderingColumnToPromotionalFeatures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :promotional_features, :ordering, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_07_105634) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_20_162125) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -761,6 +761,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_07_105634) do
     t.string "title"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.integer "ordering"
     t.index ["organisation_id"], name: "index_promotional_features_on_organisation_id"
   end
 


### PR DESCRIPTION
## Description

We're adding the ability to reorder an organisations promotional features. In order to do this we need a column to keep track of the order.

## Tello card

https://trello.com/c/jRDR4jMo/1009-add-custom-sorting-to-promotional-features

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
