### PR TITLE
Add reordering of promotional features

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -11,7 +11,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   def create
     @promotional_feature_item = @promotional_feature.promotional_feature_items.build(promotional_feature_item_params)
     if @promotional_feature_item.save
-      Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
+      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item added."
     else
       render :new
@@ -24,7 +24,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def update
     if @promotional_feature_item.update(promotional_feature_item_params)
-      Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
+      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item updated."
     else
       render :edit
@@ -33,7 +33,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def destroy
     @promotional_feature_item.destroy!
-    Whitehall::PublishingApi.republish_async(@promotional_feature_item.organisation)
+    Whitehall::PublishingApi.republish_async(@organisation)
     redirect_to_feature "Feature item deleted."
   end
 

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -49,14 +49,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
   end
 
   def update_order
-    promotional_features_orderings = @organisation.promotional_features.map(&:ordering)
-
-    params[:ordering].each do |promotional_feature_row|
-      id, ordering = promotional_feature_row
-      promotional_feature = @organisation.promotional_features.find(id)
-      promotional_feature.update!(ordering: promotional_features_orderings[ordering.to_i - 1])
-    end
-
+    @organisation.reorder_promotional_features(params[:ordering])
     Whitehall::PublishingApi.republish_async(@organisation)
     flash[:notice] = "Promotional features reordered successfully"
 

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -1,6 +1,7 @@
 class Admin::PromotionalFeaturesController < Admin::BaseController
   before_action :load_organisation
   before_action :load_promotional_feature, only: %i[show edit update destroy]
+  layout :get_layout
 
   def index
     @promotional_features = @organisation.promotional_features
@@ -41,7 +42,37 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
     redirect_to [:admin, @organisation, PromotionalFeature], notice: "Promotional feature deleted."
   end
 
+  def reorder
+    redirect_to admin_organisation_promotional_features_path(@organisation) and return unless @organisation.promotional_features.many?
+
+    @promotional_features = @organisation.promotional_features
+  end
+
+  def update_order
+    promotional_features_orderings = @organisation.promotional_features.map(&:ordering)
+
+    params[:ordering].each do |promotional_feature_row|
+      id, ordering = promotional_feature_row
+      promotional_feature = @organisation.promotional_features.find(id)
+      promotional_feature.update!(ordering: promotional_features_orderings[ordering.to_i - 1])
+    end
+
+    Whitehall::PublishingApi.republish_async(@organisation)
+    flash[:notice] = "Promotional features reordered successfully"
+
+    redirect_to admin_organisation_promotional_features_path(@organisation)
+  end
+
 private
+
+  def get_layout
+    case action_name
+    when "reorder", "update_order"
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def load_organisation
     @organisation = Organisation.allowed_promotional.find(params[:organisation_id])

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -16,7 +16,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
   def create
     @promotional_feature = @organisation.promotional_features.build(promotional_feature_params)
     if @promotional_feature.save
-      Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
+      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature created"
     else
       render :new
@@ -29,7 +29,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def update
     if @promotional_feature.update(promotional_feature_params)
-      Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
+      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature updated"
     else
       render :edit
@@ -38,7 +38,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def destroy
     @promotional_feature.destroy!
-    Whitehall::PublishingApi.republish_async(@promotional_feature.organisation)
+    Whitehall::PublishingApi.republish_async(@organisation)
     redirect_to [:admin, @organisation, PromotionalFeature], notice: "Promotional feature deleted."
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -123,7 +123,7 @@ class Organisation < ApplicationRecord
     contacts.where(contact_type_id: ContactType::FOI.id)
   end
 
-  has_many :promotional_features
+  has_many :promotional_features, -> { order(:ordering) }
 
   has_many :featured_links, -> { order(:created_at) }, as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :featured_links, reject_if: ->(attributes) { attributes["url"].blank? }, allow_destroy: true

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -521,6 +521,16 @@ class Organisation < ApplicationRecord
     ]
   end
 
+  def reorder_promotional_features(new_order)
+    promotional_features_orderings = promotional_features.map(&:ordering)
+
+    new_order.each do |promotional_feature_row|
+      id, ordering = promotional_feature_row
+      promotional_feature = promotional_features.find(id)
+      promotional_feature.update!(ordering: promotional_features_orderings[ordering.to_i - 1])
+    end
+  end
+
 private
 
   def organisations_with_scoped_search

--- a/app/models/promotional_feature.rb
+++ b/app/models/promotional_feature.rb
@@ -6,6 +6,8 @@ class PromotionalFeature < ApplicationRecord
 
   accepts_nested_attributes_for :promotional_feature_items
 
+  before_save :set_ordering, if: -> { ordering.blank? }
+
   def items
     promotional_feature_items
   end
@@ -18,5 +20,9 @@ private
 
   def has_one_small_and_one_large_item?
     items.count == 2 && items.one?(&:double_width?)
+  end
+
+  def set_ordering
+    self.ordering = (organisation.promotional_features.maximum(:ordering) || 0) + 1
   end
 end

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -10,6 +10,10 @@
 
     <p class="warning">Warning: changes to promotional features appear instantly on the live site.</p>
 
+    <% if @promotional_features.many? %>
+      <p><%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation) %></p>
+    <% end %>
+
     <% if @promotional_features.present? %>
       <table class="table table-bordered">
         <thead>

--- a/app/views/admin/promotional_features/reorder.html.erb
+++ b/app/views/admin/promotional_features/reorder.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, "Reorder promotional features"%>
+<% content_for :title, "Reorder promotional features" %>
+<% content_for :context, @organisation.name %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @organisation, url: update_order_admin_organisation_promotional_features_path(@organisation), method: :patch do |form| %>
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @promotional_features.map do |promotional_feature|
+          {
+            id: promotional_feature.id,
+            title: promotional_feature.title
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save"
+        } %>
+        <%= link_to("Cancel", admin_organisation_promotional_features_path(@organisation), class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,8 @@ Whitehall::Application.routes.draw do
           resources :social_media_accounts
           resources :translations, controller: "organisation_translations"
           resources :promotional_features do
+            get :reorder, on: :collection
+            patch :update_order, on: :collection
             resources :promotional_feature_items, as: :items, path: "items", except: [:index]
           end
           member do

--- a/db/migrate/20221221100655_backfill_promotional_features_ordering_column.rb
+++ b/db/migrate/20221221100655_backfill_promotional_features_ordering_column.rb
@@ -1,0 +1,9 @@
+class BackfillPromotionalFeaturesOrderingColumn < ActiveRecord::Migration[7.0]
+  def change
+    Organisation.joins(:promotional_features).each do |organisation|
+      organisation.promotional_features.each_with_index do |promotional_feature, index|
+        promotional_feature.update!(ordering: index + 1)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_20_162125) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_21_100655) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"

--- a/features/executive-office-promotional-features.feature
+++ b/features/executive-office-promotional-features.feature
@@ -27,3 +27,18 @@ Feature: Promotional features for executive offices
     And the executive office has a promotional feature with the maximum number of items
     When I view the promotional feature
     Then I should not be able to add any further feature items
+
+  Scenario: Reordering promotional features
+    And the executive office has the promotional feature "Feature 1"
+    And the executive office has the promotional feature "Feature 2"
+    And the executive office has the promotional feature "Feature 3"
+    When I set the order of the promotional features to:
+      | title       | order |
+      | Feature 2   | 1     |
+      | Feature 3   | 2     |
+      | Feature 1   | 3     |
+    Then the promotional features should be in the following order:
+      | title       |
+      | Feature 2   |
+      | Feature 3   |
+      | Feature 1   |

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -120,3 +120,27 @@ Then(/^I should see the promotional feature on the executive office page$/) do
     end
   end
 end
+
+And(/^the executive office has the promotional feature "([^"]*)"$/) do |title|
+  @executive_office.promotional_features.create!(title:)
+end
+
+When(/^I set the order of the promotional features to:$/) do |promotional_feature_order|
+  visit admin_organisation_promotional_features_path(@executive_office)
+  click_link "Reorder promotional features"
+
+  promotional_feature_order.hashes.each do |promotional_feature_info|
+    promotional_feature = PromotionalFeature.find_by(title: promotional_feature_info[:title])
+    fill_in "ordering[#{promotional_feature.id}]", with: promotional_feature_info[:order]
+  end
+  click_button "Save"
+end
+
+Then(/^the promotional features should be in the following order:$/) do |promotional_feature_list|
+  promotion_feature_ids = all(".promotional_feature").map { |element| element[:id] }
+
+  promotional_feature_list.hashes.each_with_index do |feature_info, index|
+    promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
+    expect("promotional_feature_#{promotional_feature.id}").to eq(promotion_feature_ids[index])
+  end
+end

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves the new promotional item to the feature and republishes the organisation to the PublishingApi" do
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     post :create,
          params: {
@@ -70,7 +70,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
 
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     put :update,
         params: { organisation_id: @organisation,
@@ -98,7 +98,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     Services.asset_manager.stubs(:whitehall_asset).returns("id" => "http://asset-manager/assets/asset-id")
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     delete :destroy, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -35,7 +35,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves the new promotional feature, republishes the organisation to the PublishingApi and redirects to the show page" do
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     post :create, params: { organisation_id: @organisation, promotional_feature: { title: "Promotional feature title" } }
 
@@ -65,7 +65,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   test "PUT :update saves the promotional feature, republishes the organisation to the PublishingApi and redirects to the show page" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     put :update, params: { organisation_id: @organisation, id: promotional_feature, promotional_feature: { title: "New title" } }
 
@@ -76,7 +76,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   test "DELETE :destroy deletes the promotional feature and republishes the organisation to the PublishingApi" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     delete :destroy, params: { organisation_id: @organisation, id: promotional_feature }
 
@@ -110,7 +110,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     @organisation.expects(:reorder_promotional_features).with do |value|
       value["2"] == "1" && value["1"] == "2"
     end
-    Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
+    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
 
     put :update_order, params: {
       organisation_id: @organisation,

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -105,27 +105,21 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   test "PATCH on :update_order reorders the promotional_features and republishes the organisation" do
-    promotional_feature1 = create(:promotional_feature, organisation: @organisation, ordering: 1)
-    promotional_feature2 = create(:promotional_feature, organisation: @organisation, ordering: 2)
-    promotional_feature3 = create(:promotional_feature, organisation: @organisation, ordering: 4)
-    promotional_feature4 = create(:promotional_feature, organisation: @organisation, ordering: 5)
-
+    Organisation.stubs(:allowed_promotional).returns(organisations_array = mock)
+    organisations_array.expects(:find).with(@organisation.slug).returns(@organisation)
+    @organisation.expects(:reorder_promotional_features).with do |value|
+      value["2"] == "1" && value["1"] == "2"
+    end
     Whitehall::PublishingApi.expects(:republish_async).with(@organisation)
 
     put :update_order, params: {
       organisation_id: @organisation,
       ordering: {
-        "#{promotional_feature3.id}": "1",
-        "#{promotional_feature4.id}": "2",
-        "#{promotional_feature2.id}": "3",
-        "#{promotional_feature1.id}": "4",
+        "2": "1",
+        "1": "2",
       },
     }
 
-    assert_equal 1, promotional_feature3.reload.ordering
-    assert_equal 2, promotional_feature4.reload.ordering
-    assert_equal 4, promotional_feature2.reload.ordering
-    assert_equal 5, promotional_feature1.reload.ordering
     assert_redirected_to admin_organisation_promotional_features_path(@organisation)
     assert_equal "Promotional features reordered successfully", flash[:notice]
   end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1079,4 +1079,29 @@ class OrganisationTest < ActiveSupport::TestCase
 
     organisation.update!(alternative_format_contact_email: "test@test.com")
   end
+
+  test "#reorder_promotional_features reorders a orgs promotional features ordering attribute" do
+    organisation = create(:organisation)
+
+    promotional_feature1 = create(:promotional_feature, organisation:, ordering: 1)
+    promotional_feature2 = create(:promotional_feature, organisation:, ordering: 2)
+    promotional_feature3 = create(:promotional_feature, organisation:, ordering: 4)
+    promotional_feature4 = create(:promotional_feature, organisation:, ordering: 5)
+
+    params = ActionController::Parameters.new({
+      ordering: {
+        "3": "1",
+        "4": "2",
+        "2": "3",
+        "1": "4",
+      },
+    })
+
+    organisation.reorder_promotional_features(params[:ordering])
+
+    assert_equal 1, promotional_feature3.reload.ordering
+    assert_equal 2, promotional_feature4.reload.ordering
+    assert_equal 4, promotional_feature2.reload.ordering
+    assert_equal 5, promotional_feature1.reload.ordering
+  end
 end

--- a/test/unit/promotional_feature_test.rb
+++ b/test/unit/promotional_feature_test.rb
@@ -19,4 +19,13 @@ class PromotionalFeatureTest < ActiveSupport::TestCase
     create(:promotional_feature_item, promotional_feature: feature)
     assert feature.has_reached_item_limit?
   end
+
+  test "it sets the ordering value before_save when ordering is blank" do
+    organisation = create(:executive_office)
+    feature1 = create(:promotional_feature, organisation:)
+    feature2 = create(:promotional_feature, organisation:)
+
+    assert_equal feature1.ordering, 1
+    assert_equal feature2.ordering, 2
+  end
 end


### PR DESCRIPTION
## Description

We are adding the ability to reorder promotional features. 

This PR does the following:

1. Backfills the `PromotionalFeature#ordering` column.
2. Sets the ordering value before save if blank (should mainly just assign before creation)
3. Orders the `Organisation#promotional_features` or `order` 
4. Adds the reorder endpoint

## Screenshot

### Promotional feature index page

<img width="661" alt="image" src="https://user-images.githubusercontent.com/42515961/209003156-6f3fd8ee-fff7-475c-a235-6b48ede3f074.png">

### Reorder page 

<img width="703" alt="image" src="https://user-images.githubusercontent.com/42515961/209002962-5935043a-654c-4d1f-832c-78e90045e1ca.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
