### PR TITLE
Release 1.4 of Design System changes

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,10 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force the 'next release' of Design System to be shown to everybody.
+    # This will be tidied up alongside the removal of now-defunct Bootstrap code for affected features.
+    return true if next_release
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -4,6 +4,8 @@ module Admin::TabbedNavHelper
   def secondary_navigation_tabs_items(model, current_path)
     if model.is_a?(Edition)
       edition_nav_items(model, current_path)
+    elsif model.respond_to? :consultation
+      edition_nav_items(model.consultation, current_path)
     else
       send("#{model.class.model_name.param_key}_nav_items", model, current_path)
     end

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -1,11 +1,11 @@
 <% tracking_module ||= "gem-track-click" %>
 
 <%= render "govuk_publishing_components/components/phase_banner", {
-    phase: "User research",
-    message: sanitize("Help make Whitehall Publisher better - find out
+    phase: "What's new",
+    message: sanitize("Attachments page and comparing previous editions move to the GOV.UK Design System -
       #{
         link_to(
-          "how to take part in user research",
+          "read more about the changes",
           admin_whats_new_path,
           {
             class: "govuk-link",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,11 +1,11 @@
 en:
   admin:
     whats_new:
-      show_banner: false
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 9 November 2022
+      last_updated: Last updated 21 December 2022
       introduction:
         heading: Moving to the Design System
         body_govspeak: |
@@ -22,6 +22,20 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: Attachments page, comparing editions and other pages move to the Design System
+            area: Creating and updating documents
+            type: improvement
+            date: 21 December 2022
+            body_govspeak: |
+              The following pages have moved to the GOV.UK Design System:
+              
+              * attachments page
+              * comparing previous versions
+              * force publishing
+              * deleting a draft
+              * adding or editing associated user needs
+              
+              To reorder attachments, select ‘reorder attachments’ on the attachments page. On the reorder attachments page, use the up and down buttons to reorder attachments, or select and hold on an attachment to reorder using drag and drop.
           - heading: Search added to topic taxonomy tags page
             area: Creating and updating documents
             type: new

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -50,6 +50,7 @@ Feature: Consultations
     When I draft a new "Cymraeg" language consultation "Beard Length Review"
     Then I can see the primary locale for consultation "Beard Length Review" is "cy"
 
+  @design-system-wip
   Scenario: Adding and reordering a responses attachments
     Given I am an writer
     And a closed consultation exists
@@ -57,10 +58,10 @@ Feature: Consultations
     And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
     Then the consultation response should have 2 attachments
     When I set the order of attachments to:
-      | title                        | order |
-      | Beard Length Graphs 2012     | 0     |
-      | Outcome attachment title   | 1     |
+      | title                    | order |
+      | Beard Length Graphs 2012 | 0     |
+      | Outcome attachment title | 1     |
     Then the attachments should be in the following order:
-      | title                        |
-      | Beard Length Graphs 2012     |
-      | Outcome attachment title   |
+      | title                    |
+      | Beard Length Graphs 2012 |
+      | Outcome attachment title |

--- a/features/destroy-draft.feature
+++ b/features/destroy-draft.feature
@@ -3,6 +3,7 @@ Feature: Discarding a draft of a document
   I can discard the draft of a document
   So that the document will not appear in the list of draft documents
 
+  @design-system-only
   Scenario: Unwithdrawing a withdrawn document
     Given I am a writer
     When I draft a new publication "My Publication"

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -4,7 +4,7 @@ Feature: Managing attachments on editions
   I want to attach files and additional HTML content to publications and consultations
   In order to support the publications and consultations with statistics and other relevant documents
 
-  @design-system-wip
+  @design-system-only
   Scenario: Adding and reordering attachments
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
@@ -24,7 +24,7 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
-  @design-system-wip
+  @design-system-only
   Scenario: Previewing HTML attachment
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"

--- a/features/edition-needs.feature
+++ b/features/edition-needs.feature
@@ -6,6 +6,7 @@ Feature: Managing needs on editions
   Background:
     Given I am an editor
 
+  @design-system-only
   Scenario: Adding and removing needs
     Given a submitted publication "Extended goatee for the modern man" with a PDF attachment
     When I visit the list of documents awaiting review

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -54,19 +54,33 @@ Then(/^the .* "(.*?)" should have (\d+) attachments$/) do |title, expected_numbe
 end
 
 When(/^I set the order of attachments to:$/) do |attachment_order|
+  # Editions use the Design System but Consultations still use Bootstrap,
+  # so this step needs to handle both
+  click_link "Reorder attachments" if using_design_system?
   attachment_order.hashes.each do |attachment_info|
     attachment = Attachment.find_by(title: attachment_info[:title])
     fill_in "ordering[#{attachment.id}]", with: attachment_info[:order]
   end
-  click_on "Save attachment order"
+  click_on using_design_system? ? "Update order" : "Save attachment order"
 end
 
 Then(/^the attachments should be in the following order:$/) do |attachment_list|
-  attachment_ids = all(".existing-attachments > li").map { |element| element[:id] }
+  # Editions use the Design System but Consultations still use Bootstrap,
+  # so this step needs to handle both
+  if using_design_system?
+    attachment_names = all("table td:first").map(&:text).map { |t| t.chomp("Uploading").strip }
 
-  attachment_list.hashes.each_with_index do |attachment_info, index|
-    attachment = Attachment.find_by(title: attachment_info[:title])
-    expect("attachment_#{attachment.id}").to eq(attachment_ids[index])
+    attachment_list.hashes.each_with_index do |attachment_info, index|
+      attachment = Attachment.find_by(title: attachment_info[:title])
+      expect(attachment.title).to eq(attachment_names[index])
+    end
+  else
+    attachment_ids = all(".existing-attachments > li").map { |element| element[:id] }
+
+    attachment_list.hashes.each_with_index do |attachment_info, index|
+      attachment = Attachment.find_by(title: attachment_info[:title])
+      expect("attachment_#{attachment.id}").to eq(attachment_ids[index])
+    end
   end
 end
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -43,12 +43,12 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   supported_attachable_types.each do |type, param_name|
     view_test "GET :index handles #{type} as attachable" do
       attachable = create(type) # rubocop:disable Rails/SaveBang
-      create(:file_attachment, isbn: "817525766-0", attachable:)
+      create(:file_attachment, attachable:, title: "Lorem Ipsum")
 
       get :index, params: { param_name => attachable.id }
 
       assert_response :success
-      assert_select "p", text: /ISBN: 817525766-0/
+      assert_select "table td", "Lorem Ipsum"
     end
 
     view_test "GET :new handles #{type} as attachable" do
@@ -97,7 +97,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :index, params: { edition_id: @edition }
 
     assert_response :success
-    assert_select ".existing-attachments li strong", text: "An HTML attachment"
+    assert_select "table td", text: "An HTML attachment"
   end
 
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
@@ -194,7 +194,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :index, params: { edition_id: @edition }
 
     assert_response :success
-    assert_select ".existing-attachments li strong", text: "An external attachment"
+    assert_select "table td", text: "An external attachment"
   end
 
   test "POST :create handles external attachments when attachable allows them" do

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -47,21 +47,12 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal "All workflow actions require a lock version", response.body
   end
 
-  test "GET #confirm_force_publish renders force publishing form with next release permission" do
+  test "GET #confirm_force_publish renders force publishing form" do
     stub_publishing_api_links_with_taxons(draft_edition.content_id, %w[a-taxon-content-id])
-    @current_user.permissions << "Preview next release"
     get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
     assert_response :success
     assert_template :confirm_force_publish
-  end
-
-  test "GET #confirm_force_publish renders legacy force publishing form" do
-    stub_publishing_api_links_with_taxons(draft_edition.content_id, %w[a-taxon-content-id])
-    get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }
-
-    assert_response :success
-    assert_template :confirm_force_publish_legacy
   end
 
   test "GET #confirm_force_publish redirects when edition must tagged be taxons but is not" do

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -73,26 +73,6 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :diff, params: { id: draft_publication, audit_trail_entry_id: Document::PaginatedHistory.new(draft_publication.document, 1).query.last.item_id }
 
     assert_response :success
-    assert_template :diff_legacy
-    assert_equal draft_publication, assigns(:edition)
-    assert_equal publication, assigns(:audit_trail_entry)
-  end
-
-  test "diffing against a previous version with next release permission" do
-    @current_user.permissions << "Preview next release"
-    publication = create(:draft_publication)
-    editor = create(:departmental_editor)
-    Edition::AuditTrail.whodunnit = editor
-    publication.first_published_at = Time.zone.now
-    publication.major_change_published_at = Time.zone.now
-    force_publish(publication)
-    draft_publication = Timecop.freeze 1.hour.from_now do
-      publication.reload.create_draft(editor)
-    end
-
-    get :diff, params: { id: draft_publication, audit_trail_entry_id: Document::PaginatedHistory.new(draft_publication.document, 1).query.last.item_id }
-
-    assert_response :success
     assert_template :diff
     assert_equal draft_publication, assigns(:edition)
     assert_equal publication, assigns(:audit_trail_entry)

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -56,15 +56,6 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   view_test "should explain why the editorial remark could not be saved" do
     edition = create(:submitted_consultation)
     post :create, params: { edition_id: edition, editorial_remark: { body: "" } }
-    assert_template "new_legacy"
-    assert_select ".form-errors"
-  end
-
-  view_test "should explain why the editorial remark could not be saved with preview next release flag" do
-    @logged_in_user.permissions << "Preview next release"
-
-    edition = create(:submitted_consultation)
-    post :create, params: { edition_id: edition, editorial_remark: { body: "" } }
     assert_template "new"
     assert_select ".gem-c-error-summary"
   end

--- a/test/functional/admin/needs_controller_test.rb
+++ b/test/functional/admin/needs_controller_test.rb
@@ -55,7 +55,7 @@ class Admin::NeedsControllerTest < ActionController::TestCase
 
     assert_select "form[action='#{admin_update_needs_path(content_id: document.content_id)}']"
     assert_select "select#need_ids" do
-      assert_select "option", count: 2
+      assert_select "option:not([value=''])", count: 2
     end
   end
 end

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -143,7 +143,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           click_button "Upload zip"
           fill_in "Title", with: "file-title"
           click_button "Save"
-          assert find(".existing-attachments a", text: "greenpaper.pdf")
+          assert find("table td a", text: "greenpaper.pdf")
         end
 
         it "marks attachment as access limited in Asset Manager" do

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -44,9 +44,10 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
         before do
           visit admin_news_article_path(edition)
           click_link "Modify attachments"
-          within "#attachment_#{first_attachment.id}" do
+          within row_containing(first_attachment.title) do
             click_link "Delete"
           end
+          click_button "Delete attachment"
           assert_text "Attachment deleted"
         end
 
@@ -66,7 +67,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
         before do
           visit admin_news_article_path(edition)
           click_link "Discard draft"
-          click_button "Discard"
+          click_button "Delete"
         end
 
         it "deletes all corresponding assets in Asset Manager" do

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -34,7 +34,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
           stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
           visit admin_news_article_path(edition)
           click_link "Modify attachments"
-          within ".existing-attachments" do
+          within row_containing(filename) do
             click_link "Edit"
           end
           fill_in "Title", with: "Attachment Title"
@@ -67,7 +67,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
           visit admin_news_article_path(edition)
           click_button "Create new edition to edit"
           click_link "Attachments 1"
-          within ".existing-attachments" do
+          within row_containing(filename) do
             click_link "Edit"
           end
           attach_file "Replace file", path_to_attachment(replacement_filename)

--- a/test/integration/attachments_test.rb
+++ b/test/integration/attachments_test.rb
@@ -8,11 +8,15 @@ class AttachmentsTest < ActionDispatch::IntegrationTest
     login_as_admin
   end
 
+  def attachment_note
+    page.find("p", text: "Note:")
+  end
+
   test "displays attachment helper copy for non-publications" do
     edition = create(:edition)
     visit "/government/admin/editions/#{edition.id}/attachments"
 
-    within ".qa-helper-copy" do
+    within attachment_note do
       assert_text "need to be referenced"
     end
   end
@@ -21,7 +25,7 @@ class AttachmentsTest < ActionDispatch::IntegrationTest
     publication = create(:publication)
     visit "/government/admin/editions/#{publication.id}/attachments"
 
-    within ".qa-helper-copy" do
+    within attachment_note do
       assert_text "publication will appear automatically"
     end
   end
@@ -30,7 +34,7 @@ class AttachmentsTest < ActionDispatch::IntegrationTest
     consultation = create(:consultation)
     visit "/government/admin/editions/#{consultation.id}/attachments"
 
-    within ".qa-helper-copy" do
+    within attachment_note do
       assert_text "consultation will appear automatically"
       assert_no_text "need to be referenced"
     end

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -124,4 +124,8 @@ module CssSelectors
   def policy_group_selector
     ".document-policy-groups"
   end
+
+  def row_containing(text)
+    page.find("tr", text:)
+  end
 end


### PR DESCRIPTION
This PR force enables the 'next release' Design System flag, meaning all users will see features tagged under the next release regardless of their user permissions.

This is a 'quick' way to deploy Release 1.4 changes to everybody, and will be followed up by changes to remove the old Bootstrap code and re-tag 'next release' features ready for Release 1.5.

Features which have moved to the Design System layout in this release:

1. **'Force publish' journey**
2. **'Delete draft' journey**
3. **Diff checker**
4. **Associated user needs**
5. **Attachment hub page**
  Note: Attachment hub changes don't apply to Consultation Outcomes and Consultation Public Feedback responses – they still use the legacy Bootstrap layout.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
