### PR TITLE
Update last updated and entry date for release 1.4

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -5,7 +5,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 21 December 2022
+      last_updated: Last updated 22 December 2022
       introduction:
         heading: Moving to the Design System
         body_govspeak: |
@@ -25,7 +25,7 @@ en:
           - heading: Attachments page, comparing editions and other pages move to the Design System
             area: Creating and updating documents
             type: improvement
-            date: 21 December 2022
+            date: 22 December 2022
             body_govspeak: |
               The following pages have moved to the GOV.UK Design System:
               

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -22,7 +22,7 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
-          - heading: Attachments page, comparing editions and other pages move to the Design System
+          - heading: Attachments page, comparing previous editions and other pages move to the Design System
             area: Creating and updating documents
             type: improvement
             date: 22 December 2022


### PR DESCRIPTION
Small change to the last updated date and recent entry date for release 1.4.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
