### PR TITLE
Updates payload to support images in Preview

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -14,15 +14,28 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return document.querySelector('meta[name="csrf-token"]').content
   }
 
-  GovspeakEditor.prototype.getRenderedGovspeak = function (content, callback) {
-    var body = new FormData()
-    body.append('body', content)
+  GovspeakEditor.prototype.getRenderedGovspeak = function (body, callback) {
+    var data = this.generateFormData(body)
 
     var request = new XMLHttpRequest()
     request.open('POST', '/government/admin/preview', false)
     request.setRequestHeader('X-CSRF-Token', this.getCsrfToken())
     request.onreadystatechange = callback
-    request.send(body)
+    request.send(data)
+  }
+
+  GovspeakEditor.prototype.generateFormData = function (body) {
+    var data = new FormData()
+    data.append('body', body)
+    data.append('authenticity_token', this.getCsrfToken())
+    data.append('alternative_format_provider_id', this.alternativeFormatProviderId())
+
+    var imageIds = this.getImageIds()
+    for (var index = 0; index < imageIds.length; index++) {
+      data.append('image_ids[]', imageIds[index])
+    }
+
+    return data
   }
 
   GovspeakEditor.prototype.initPreview = function () {
@@ -59,6 +72,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         )
       }
     }.bind(this))
+  }
+
+  GovspeakEditor.prototype.getImageIds = function () {
+    var imagesIds = this.module.getAttribute('data-image-ids')
+    imagesIds = imagesIds ? JSON.parse(imagesIds) : []
+
+    return imagesIds.filter(function (id) { return id })
+  }
+
+  GovspeakEditor.prototype.alternativeFormatProviderId = function () {
+    return this.module.getAttribute('data-alternative-format-provider-id')
   }
 
   Modules.GovspeakEditor = GovspeakEditor

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -50,6 +50,10 @@
           id: "attachment_govspeak_content_body",
           value: form.object.govspeak_content.body,
           error_items: errors_for(attachment.errors, :"govspeak_content.body"),
+          data_attributes: {
+            image_ids: @edition && @edition.images.any? ? @edition.images.map { |img| img[:id] } : [],
+            alternative_format_provider_id: @edition && @edition.alternative_format_provider_id ? @edition.alternative_format_provider_id : current_user.organisation.try(:id),
+          }
         } %>
       </div>
     <% end %>

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -41,6 +41,10 @@
     value: edition.body,
     rows: 20,
     error_items: errors_for(form.object.errors, :body),
+    data_attributes: {
+      image_ids: edition.images.map { |img| img[:id] }.to_json,
+      alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+    }
   } %>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -26,7 +26,11 @@
         data: {
           module: "paste-html-to-govspeak"
         },
-        error_items: errors_for(@unpublishing.errors, :explanation)
+        error_items: errors_for(@unpublishing.errors, :explanation),
+        data_attributes: {
+          image_ids: @unpublishing.edition.images.map { |img| img[:id] }.to_json,
+          alternative_format_provider_id: (@unpublishing.edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+        }
       } %>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -31,7 +31,11 @@
     name: "unpublishing[explanation]",
     id: "withdrawal_explanation",
     value: @unpublishing.explanation,
-    error_items: errors_for(@unpublishing.errors, :explanation)
+    error_items: errors_for(@unpublishing.errors, :explanation),
+    data_attributes: {
+      image_ids: @edition.images.map { |img| img[:id] }.to_json,
+      alternative_format_provider_id: (@edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+    }
   })
 %>
 
@@ -153,7 +157,11 @@
           name: "unpublishing[explanation]",
           id: "published_in_error_explanation",
           value: @unpublishing.explanation,
-          error_items: errors_for(@unpublishing.errors, :explanation)
+          error_items: errors_for(@unpublishing.errors, :explanation),
+          data_attributes: {
+            image_ids: @edition.images.map { |img| img[:id] }.to_json,
+            alternative_format_provider_id: (@edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+          }
         } %>
 
         <div class="govuk-button-group govuk-!-margin-bottom-6">

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -42,6 +42,10 @@
     value: edition.body,
     rows: 20,
     error_items: errors_for(edition.errors, :body),
+    data_attributes: {
+      image_ids: edition.images.map { |img| img[:id] }.to_json,
+      alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+    }
   } %>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -8,6 +8,8 @@
   value ||= nil
   error_items ||= nil
   rows ||= 12
+  image_ids ||= []
+  alternative_format_provider_id ||= nil
 
   track_preview_toggle ||= false
   track_category ||= false

--- a/app/views/components/docs/govspeak-editor.yml
+++ b/app/views/components/docs/govspeak-editor.yml
@@ -55,3 +55,20 @@ examples:
         ## What is Lorem Ipsum?
 
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+  with_image_ids_and_alternative_format_provider_id:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_image_ids_and_alternative_format_provider_id"
+      data_attributes:
+        alternative_format_provider_id: 123
+        image_ids:
+          - 1
+          - 2
+          - 3
+      value: |
+        ## What is Lorem Ipsum?
+
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.

--- a/spec/javascripts/components/govspeak-editor.spec.js
+++ b/spec/javascripts/components/govspeak-editor.spec.js
@@ -3,7 +3,10 @@ describe('GOVUK.Modules.GovspekEditor', function () {
 
   beforeEach(function () {
     component = document.createElement('div')
+    component.setAttribute('data-image-ids', JSON.stringify([1, 2, 3, 4]))
+    component.setAttribute('data-alternative-format-provider-id', 11)
 
+    // Preview Button
     var previewButton = document.createElement('button')
     previewButton.classList.add('js-app-c-govspeak-editor__preview-button')
     previewButton.setAttribute('data-preview-toggle-tracking', true)
@@ -12,6 +15,7 @@ describe('GOVUK.Modules.GovspekEditor', function () {
     previewButton.setAttribute('data-content-target', '#textarea_id')
     previewButton.innerText = 'Preview'
 
+    // Textarea
     var textareaSection = document.createElement('div')
     textareaSection.classList.add('app-c-govspeak-editor__textarea')
 
@@ -20,9 +24,11 @@ describe('GOVUK.Modules.GovspekEditor', function () {
     textarea.innerText = '## Hello'
     textareaSection.appendChild(textarea)
 
+    // Preview section
     var previewSection = document.createElement('div')
     previewSection.classList.add('app-c-govspeak-editor__preview')
 
+    // Append to component
     component.appendChild(previewButton)
     component.appendChild(textareaSection)
     component.appendChild(previewSection)
@@ -186,5 +192,19 @@ describe('GOVUK.Modules.GovspekEditor', function () {
       'pressed-preview-button',
       { label: 'edit' }
     )
+  })
+
+  it('generates form data correctly', function () {
+    var formData = module.generateFormData('some text')
+
+    expect(Array.from(formData.entries())).toEqual([
+      ['body', 'some text'],
+      ['authenticity_token', 'a-csrf-token'],
+      ['alternative_format_provider_id', '11'],
+      ['image_ids[]', '1'],
+      ['image_ids[]', '2'],
+      ['image_ids[]', '3'],
+      ['image_ids[]', '4']
+    ])
   })
 })


### PR DESCRIPTION
## What

Fixes payload so images load correctly when users are previewing.

## Why

A bug was reported where image attachments would not show when previewing in the new design system layout.

![Dec-23-2022 11-42-56 am](https://user-images.githubusercontent.com/4599889/209330563-04f934ec-2f73-4c5e-a6f2-38f0ced77b82.gif)


https://trello.com/c/XHW0LKvX/1023-images-are-not-working-in-preview-mode

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
