### PR TITLE
Fix flaky Organisation model test

### DIFF
--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1090,10 +1090,10 @@ class OrganisationTest < ActiveSupport::TestCase
 
     params = ActionController::Parameters.new({
       ordering: {
-        "3": "1",
-        "4": "2",
-        "2": "3",
-        "1": "4",
+        "#{promotional_feature3.id}": "1",
+        "#{promotional_feature4.id}": "2",
+        "#{promotional_feature2.id}": "3",
+        "#{promotional_feature1.id}": "4",
       },
     })
 


### PR DESCRIPTION
This test assumes that the ids of the 4 promotional features is 1-4. This is not always the case. Explicitly using the ids of the objects fixes the issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
