### PR TITLE
Add 'youtube_video_url' column the 'promotional_features' table

### DIFF
--- a/db/migrate/20221228103350_add_youtube_video_url_to_promotional_features.rb
+++ b/db/migrate/20221228103350_add_youtube_video_url_to_promotional_features.rb
@@ -1,0 +1,5 @@
+class AddYoutubeVideoUrlToPromotionalFeatures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :promotional_feature_items, :youtube_video_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_21_100655) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_28_103350) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -744,6 +744,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_21_100655) do
     t.boolean "double_width", default: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.string "youtube_video_url"
     t.index ["promotional_feature_id"], name: "index_promotional_feature_items_on_promotional_feature_id"
   end
 


### PR DESCRIPTION
## Description

We're adding the ability for a promotional feature to embed a Youtube video in place of an image.

This adds the 'youtube_video_url' to the 'promotional_feature_items' table to store the Youtube url.

## Trello card

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
