### PR TITLE
Present Worldwide Organisation content to Publishing API

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -19,6 +19,10 @@ module PublishingApi
       content.merge!(
         description:,
         details: {
+          logo: {
+            crest: "single-identity",
+            formatted_title: item.logo_formatted_name,
+          },
           ordered_corporate_information_pages:,
           social_media_links:,
         },

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -18,7 +18,9 @@ module PublishingApi
 
       content.merge!(
         description:,
-        details: {},
+        details: {
+          social_media_links:,
+        },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
@@ -44,6 +46,18 @@ module PublishingApi
       return [] unless item.offices.any?
 
       item.offices.map(&:contact).map(&:content_id)
+    end
+
+    def social_media_links
+      return [] unless item.social_media_accounts.any?
+
+      item.social_media_accounts.map do |social_media_account|
+        {
+          href: social_media_account.url,
+          service_type: social_media_account.service_name.parameterize,
+          title: social_media_account.display_name,
+        }
+      end
     end
 
     def sponsoring_organisations

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -29,11 +29,19 @@ module PublishingApi
     end
 
     def links
-      {}
+      {
+        world_locations:,
+      }
     end
 
     def description
       item.summary
+    end
+
+    def world_locations
+      return [] unless item.world_locations.any?
+
+      item.world_locations.map(&:content_id)
     end
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -30,6 +30,7 @@ module PublishingApi
 
     def links
       {
+        ordered_contacts:,
         sponsoring_organisations:,
         world_locations:,
       }
@@ -37,6 +38,12 @@ module PublishingApi
 
     def description
       item.summary
+    end
+
+    def ordered_contacts
+      return [] unless item.offices.any?
+
+      item.offices.map(&:contact).map(&:content_id)
     end
 
     def sponsoring_organisations

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -30,12 +30,19 @@ module PublishingApi
 
     def links
       {
+        sponsoring_organisations:,
         world_locations:,
       }
     end
 
     def description
       item.summary
+    end
+
+    def sponsoring_organisations
+      return [] unless item.sponsoring_organisations.any?
+
+      item.sponsoring_organisations.map(&:content_id)
     end
 
     def world_locations

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -19,6 +19,7 @@ module PublishingApi
       content.merge!(
         description:,
         details: {
+          ordered_corporate_information_pages:,
           social_media_links:,
         },
         document_type: item.class.name.underscore,
@@ -32,6 +33,7 @@ module PublishingApi
 
     def links
       {
+        corporate_information_pages:,
         ordered_contacts:,
         sponsoring_organisations:,
         world_locations:,
@@ -46,6 +48,58 @@ module PublishingApi
       return [] unless item.offices.any?
 
       item.offices.map(&:contact).map(&:content_id)
+    end
+
+    def corporate_information_pages
+      return [] unless item.corporate_information_pages.any?
+
+      item.corporate_information_pages.map(&:content_id)
+    end
+
+    def ordered_corporate_information_pages
+      corporate_information_pages = item.corporate_information_pages&.published
+      return [] unless corporate_information_pages
+
+      links = []
+
+      %i[our_information jobs_and_contracts].each do |page_type|
+        corporate_information_pages.by_menu_heading(page_type).each do |corporate_information_page|
+          links << {
+            content_id: corporate_information_page.content_id,
+            title: corporate_information_page.title,
+          }
+        end
+      end
+
+      publication_scheme = corporate_information_pages.find_by(corporate_information_page_type_id: CorporateInformationPageType::PublicationScheme.id)
+      if publication_scheme.present?
+        links << {
+          content_id: publication_scheme.content_id,
+          title: I18n.t("worldwide_organisation.corporate_information.publication_scheme_html", link: corporate_information_page_link_text("publication_scheme")),
+        }
+      end
+
+      welsh_language_scheme = corporate_information_pages.find_by(corporate_information_page_type_id: CorporateInformationPageType::WelshLanguageScheme.id)
+      if welsh_language_scheme.present?
+        links << {
+          content_id: welsh_language_scheme.content_id,
+          title: I18n.t("worldwide_organisation.corporate_information.welsh_language_scheme_html", link: corporate_information_page_link_text("welsh_language_scheme")),
+        }
+      end
+
+      personal_information_charter = corporate_information_pages.find_by(corporate_information_page_type_id: CorporateInformationPageType::PersonalInformationCharter.id)
+      if personal_information_charter.present?
+        links << {
+          content_id: personal_information_charter.content_id,
+          title: I18n.t("worldwide_organisation.corporate_information.personal_information_charter_html", link: corporate_information_page_link_text("personal_information_charter")),
+        }
+      end
+
+      links
+    end
+
+    def corporate_information_page_link_text(key)
+      I18n.t("corporate_information_page.type.link_text.#{key}", default: I18n.t("corporate_information_page.type.title.#{key}"))
     end
 
     def social_media_links

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -2,6 +2,12 @@ FactoryBot.define do
   factory :worldwide_organisation, traits: [:translated] do
     sequence(:name) { |index| "worldwide-organisation-#{index}" }
 
+    trait(:with_office) do
+      after :create do |organisation, _evaluator|
+        FactoryBot.create(:worldwide_office, worldwide_organisation: organisation)
+      end
+    end
+
     trait(:with_sponsorships) do
       after :create do |organisation, _evaluator|
         FactoryBot.create(:sponsorship, worldwide_organisation: organisation)

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
         FactoryBot.create(:sponsorship, worldwide_organisation: organisation)
       end
     end
+
+    trait(:with_world_location) do
+      after :create do |worldwide_organisation, _evaluator|
+        worldwide_organisation.world_locations << FactoryBot.create(:world_location)
+      end
+    end
   end
 end

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -2,6 +2,16 @@ FactoryBot.define do
   factory :worldwide_organisation, traits: [:translated] do
     sequence(:name) { |index| "worldwide-organisation-#{index}" }
 
+    trait(:with_corporate_information_pages) do
+      after :create do |organisation, _evaluator|
+        FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
+        FactoryBot.create(:personal_information_charter_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
+        FactoryBot.create(:publication_scheme_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
+        FactoryBot.create(:recruitment_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
+        FactoryBot.create(:welsh_language_scheme_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
+      end
+    end
+
     trait(:with_office) do
       after :create do |organisation, _evaluator|
         FactoryBot.create(:worldwide_office, worldwide_organisation: organisation)

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :worldwide_organisation, traits: [:translated] do
     sequence(:name) { |index| "worldwide-organisation-#{index}" }
+    logo_formatted_name { name.to_s.split.join("\n") }
 
     trait(:with_corporate_information_pages) do
       after :create do |organisation, _evaluator|

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -8,6 +8,14 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_social_media_accounts) do
+      after :create do |organisation, _evaluator|
+        social_media_service = create(:social_media_service, name: "Facebook")
+        social_media_account = create(:social_media_account, title: "Our Facebook Page", url: "https://www.facebook.com/UKgovernment", social_media_service:)
+        organisation.social_media_accounts << social_media_account
+      end
+    end
+
     trait(:with_sponsorships) do
       after :create do |organisation, _evaluator|
         FactoryBot.create(:sponsorship, worldwide_organisation: organisation)

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -8,6 +8,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:worldwide_organisation,
                            :with_office,
+                           :with_social_media_accounts,
                            :with_sponsorships,
                            :with_world_location,
                            name: "Locationia Embassy",
@@ -26,7 +27,15 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      details: {},
+      details: {
+        social_media_links: [
+          {
+            href: "https://www.facebook.com/UKgovernment",
+            service_type: "facebook",
+            title: "Our Facebook Page",
+          },
+        ],
+      },
       analytics_identifier: "WO123",
       update_type: "major",
     }

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -7,6 +7,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:worldwide_organisation,
+                           :with_corporate_information_pages,
                            :with_office,
                            :with_social_media_accounts,
                            :with_sponsorships,
@@ -28,6 +29,28 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
+        ordered_corporate_information_pages: [
+          {
+            content_id: worldwide_org.corporate_information_pages[0].content_id,
+            title: "Complaints procedure",
+          },
+          {
+            content_id: worldwide_org.corporate_information_pages[3].content_id,
+            title: "Working for Locationia Embassy",
+          },
+          {
+            content_id: worldwide_org.corporate_information_pages[2].content_id,
+            title: "Read about the types of information we routinely publish in our Publication scheme.",
+          },
+          {
+            content_id: worldwide_org.corporate_information_pages[4].content_id,
+            title: "Find out about our commitment to publishing in Welsh.",
+          },
+          {
+            content_id: worldwide_org.corporate_information_pages[1].content_id,
+            title: "Our Personal information charter explains how we treat your personal information.",
+          },
+        ],
         social_media_links: [
           {
             href: "https://www.facebook.com/UKgovernment",
@@ -41,6 +64,13 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     }
 
     expected_links = {
+      corporate_information_pages: [
+        worldwide_org.corporate_information_pages[0].content_id,
+        worldwide_org.corporate_information_pages[1].content_id,
+        worldwide_org.corporate_information_pages[2].content_id,
+        worldwide_org.corporate_information_pages[3].content_id,
+        worldwide_org.corporate_information_pages[4].content_id,
+      ],
       ordered_contacts: [
         worldwide_org.offices.first.contact.content_id,
       ],

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -29,6 +29,10 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
+        logo: {
+          crest: "single-identity",
+          formatted_title: "Locationia\nEmbassy",
+        },
         ordered_corporate_information_pages: [
           {
             content_id: worldwide_org.corporate_information_pages[0].content_id,

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -7,6 +7,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:worldwide_organisation,
+                           :with_sponsorships,
                            :with_world_location,
                            name: "Locationia Embassy",
                            analytics_identifier: "WO123")
@@ -30,6 +31,9 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     }
 
     expected_links = {
+      sponsoring_organisations: [
+        worldwide_org.sponsoring_organisations.first.content_id,
+      ],
       world_locations: [
         worldwide_org.world_locations.first.content_id,
       ],

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -6,7 +6,10 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
   end
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
-    worldwide_org = create(:worldwide_organisation, name: "Locationia Embassy", analytics_identifier: "WO123")
+    worldwide_org = create(:worldwide_organisation,
+                           :with_world_location,
+                           name: "Locationia Embassy",
+                           analytics_identifier: "WO123")
     public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)
 
     expected_hash = {
@@ -25,7 +28,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       analytics_identifier: "WO123",
       update_type: "major",
     }
-    expected_links = {}
+
+    expected_links = {
+      world_locations: [
+        worldwide_org.world_locations.first.content_id,
+      ],
+    }
 
     presented_item = present(worldwide_org)
 

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -7,6 +7,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:worldwide_organisation,
+                           :with_office,
                            :with_sponsorships,
                            :with_world_location,
                            name: "Locationia Embassy",
@@ -31,6 +32,9 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     }
 
     expected_links = {
+      ordered_contacts: [
+        worldwide_org.offices.first.contact.content_id,
+      ],
       sponsoring_organisations: [
         worldwide_org.sponsoring_organisations.first.content_id,
       ],


### PR DESCRIPTION
In order to migrate the rendering of Worldwide Organisations out of Whitehall, we need to add further information into the content item.
    
The adds the following to the content item:
- world Location(s) associated with the organisation
- sponsoring organisations
- contacts
- social media links
- links to corporate information pages
- correct way of formatting logo text

The body text will be added in a separate piece of work.

Not to be merged until https://github.com/alphagov/publishing-api/pull/2236 is merged and deployed.

[Trello card](https://trello.com/c/3r6TFSCF)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
