### PR TITLE
Allow youtube video url to be added to a promotional feature

### DIFF
--- a/app/assets/javascripts/admin_legacy/views/promotional_feature_items/_form.js
+++ b/app/assets/javascripts/admin_legacy/views/promotional_feature_items/_form.js
@@ -1,0 +1,53 @@
+(function () {
+  'use strict'
+  window.GOVUK = window.GOVUK || {}
+
+  var promotionalFeatureItemsForm = {
+    init: function init (options) {
+      this.form = document.querySelector(options.selector)
+
+      var youtubeAndImageRadioFieldset = this.form.querySelector('.image-and-youtube-radios')
+      if (!youtubeAndImageRadioFieldset) { return }
+
+      this.toggleImageAndYoutubeFieldsVisibility()
+      this.addRadioButtonEventListeners()
+    },
+
+    toggleImageAndYoutubeFieldsVisibility: function toggleImageAndYoutubeFieldsVisibility () {
+      var form = this.form
+      var checked = form.querySelector('.image-and-youtube-radios input[type=radio]:checked')
+      var imageFields = form.querySelector('.image-fields')
+      var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+      if (!checked) {
+        imageFields.hidden = true
+        youtubeFields.hidden = true
+      } else if (checked.value === 'image') {
+        youtubeFields.hidden = true
+      } else {
+        imageFields.hidden = true
+      }
+    },
+
+    addRadioButtonEventListeners: function addRadioButtonEventListeners () {
+      var form = this.form
+      var radioElements = form.querySelectorAll('.image-and-youtube-radios input[type=radio]')
+      var imageFields = form.querySelector('.image-fields')
+      var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+      for (var i = 0; i < radioElements.length; i++) {
+        radioElements[i].addEventListener('change', function (event) {
+          if (event.currentTarget.value === 'youtube_video_url') {
+            imageFields.hidden = true
+            youtubeFields.hidden = false
+          } else {
+            imageFields.hidden = false
+            youtubeFields.hidden = true
+          }
+        })
+      }
+    }
+  }
+
+  window.GOVUK.adminPromotionalFeatureItemsForm = promotionalFeatureItemsForm
+}())

--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -24,8 +24,15 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   end
 
   def update
+    legacy_image_url = @promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
+
     if @promotional_feature_item.update(promotional_feature_item_params)
       Whitehall::PublishingApi.republish_async(@organisation)
+      if legacy_image_url.present?
+        current_legacy_image_url = @promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
+        AssetManager::AssetDeleter.call(legacy_image_url) if legacy_image_url != current_legacy_image_url
+      end
+
       redirect_to_feature "Feature item updated."
     else
       render :edit

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -6,8 +6,15 @@ class PromotionalFeatureItem < ApplicationRecord
   validates :summary, presence: true, length: { maximum: 500 }
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
   validates :title_url, uri: true, allow_blank: true
+  validate :image_or_youtube_url_is_present
 
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: ->(attributes) { attributes["url"].blank? }
 
   mount_uploader :image, ImageUploader
+
+private
+
+  def image_or_youtube_url_is_present
+    errors.add(:base, "Upload either an image or add a YouTube URL") if (image.blank? && youtube_video_url.blank?) || (image.present? && youtube_video_url.present?)
+  end
 end

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -1,4 +1,6 @@
 class PromotionalFeatureItem < ApplicationRecord
+  VALID_YOUTUBE_URL_FORMAT = /\A(?:(?:https:\/\/youtu\.be\/)(.+)|(?:https:\/\/www.youtube\.com\/watch\?v=)(.*?)(?:&|#|$).*)\Z/
+
   belongs_to :promotional_feature, inverse_of: :promotional_feature_items
   has_one :organisation, through: :promotional_feature
   has_many :links, class_name: "PromotionalFeatureLink", dependent: :destroy, inverse_of: :promotional_feature_item
@@ -7,6 +9,11 @@ class PromotionalFeatureItem < ApplicationRecord
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
   validates :title_url, uri: true, allow_blank: true
   validate :image_or_youtube_url_is_present
+  validates :youtube_video_url, format: {
+    with: VALID_YOUTUBE_URL_FORMAT,
+    message: "Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL",
+    allow_blank: true,
+  }
 
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: ->(attributes) { attributes["url"].blank? }
 

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -19,6 +19,16 @@ class PromotionalFeatureItem < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
+  def youtube_video_id
+    return if youtube_video_url.blank?
+
+    youtube_video_url =~ VALID_YOUTUBE_URL_FORMAT
+    youtube_video_id = ::Regexp.last_match(1) || ::Regexp.last_match(2)
+    raise "youtube_video_url: #{youtube_video_url} is invalid for PromotionalFeatureItem id: #{id}" if youtube_video_id.blank?
+
+    youtube_video_id
+  end
+
 private
 
   def image_or_youtube_url_is_present

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     PREVIEW_NEXT_RELEASE = "Preview next release".freeze
+    ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES = "Add youtube urls to promotional features".freeze
   end
 
   def role
@@ -89,6 +90,10 @@ class User < ApplicationRecord
 
   def can_preview_next_release?
     has_permission?(Permissions::PREVIEW_NEXT_RELEASE)
+  end
+
+  def can_add_youtube_urls_to_promotional_features?
+    has_permission?(Permissions::ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES)
   end
 
   def organisation_name

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -280,25 +280,44 @@ module PublishingApi
         {
           title: promotional_feature.title,
           items: promotional_feature.items.map do |promotional_feature_item|
-            {
-              title: promotional_feature_item.title,
-              href: promotional_feature_item.title_url,
-              summary: promotional_feature_item.summary,
-              image: {
-                url: promotional_feature_item.image_url,
-                alt_text: promotional_feature_item.image_alt_text,
-              },
-              double_width: promotional_feature_item.double_width,
-              links: promotional_feature_item.links.map do |link|
-                {
-                  title: link.text,
-                  href: link.url,
-                }
-              end,
-            }
+            if promotional_feature_item.youtube_video_id.present?
+              promotional_feature_item_youtube_hash(promotional_feature_item)
+            else
+              promotional_feature_item_image_hash(promotional_feature_item)
+            end
           end,
         }
       end
+    end
+
+    def promotional_feature_item_youtube_hash(promotional_feature_item)
+      promotional_feature_item_hash_common(promotional_feature_item).merge(
+        { youtube_video_id: promotional_feature_item.youtube_video_id },
+      )
+    end
+
+    def promotional_feature_item_image_hash(promotional_feature_item)
+      promotional_feature_item_hash_common(promotional_feature_item).merge({
+        image: {
+          url: promotional_feature_item.image_url,
+          alt_text: promotional_feature_item.image_alt_text,
+        },
+      })
+    end
+
+    def promotional_feature_item_hash_common(promotional_feature_item)
+      {
+        title: promotional_feature_item.title,
+        href: promotional_feature_item.title_url,
+        summary: promotional_feature_item.summary,
+        double_width: promotional_feature_item.double_width,
+        links: promotional_feature_item.links.map do |link|
+          {
+            title: link.text,
+            href: link.url,
+          }
+        end,
+      }.compact
     end
 
     def people_content_ids(role:)

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -4,11 +4,46 @@
 <%= form.check_box :double_width, label_text: "Display double-width?" %>
 <%= form.text_area :summary, rows: 4 %>
 
-<div class="form-group">
-  <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
-</div>
-<%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
-<%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
+<% if current_user.can_add_youtube_urls_to_promotional_features? %>
+  <div class="publishing-controls">
+    <fieldset>
+      <legend>Image or YouTube video</legend>
+
+      <p>Upload an image or input a YouTube video url for the promotional feature item</p>
+
+      <%= form.labelled_radio_button(
+        "Image",
+        :image_or_youtube_video_url,
+        "image",
+        checked: form.object.image.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "image"
+      ) %>
+
+      <div class="form-group image-fields">
+        <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
+        <%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
+        <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
+      </div>
+
+      <%= form.labelled_radio_button(
+        "YouTube video",
+        :image_or_youtube_video_url,
+        "youtube_video_url",
+        checked: form.object.youtube_video_url.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "youtube_video_url"
+      ) %>
+
+      <div class="youtube-video-url-fields form-group">
+        <%= form.text_field :youtube_video_url, label_text: "YouTube video URL" %>
+        <p class="hint add-bottom-margin">For example https://www.youtube.com/watch?v=MSmotCRFFMc</p>
+      </div>
+    </fieldset>
+  </div>
+<% else %>
+  <div class="form-group">
+    <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
+  </div>
+  <%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
+  <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
+<% end %>
 
 <div class="js-duplicate-fields">
   <legend>Feature item links</legend>

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -6,7 +6,7 @@
 
 <% if current_user.can_add_youtube_urls_to_promotional_features? %>
   <div class="publishing-controls">
-    <fieldset>
+    <fieldset class="image-and-youtube-radios">
       <legend>Image or YouTube video</legend>
 
       <p>Upload an image or input a YouTube video url for the promotional feature item</p>

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -3,6 +3,12 @@
     <%= image_tag promotional_feature_item.image.s300.url, alt: promotional_feature_item.image_alt_text %>
   <% end %>
 
+  <% if promotional_feature_item.youtube_video_url.present? %>
+    <p>
+      <%= link_to promotional_feature_item.youtube_video_url, promotional_feature_item.youtube_video_url %>
+    </p>
+  <% end %>
+
   <% if promotional_feature_item.title.present? %>
     <p><%= link_to_unless promotional_feature_item.title_url.blank?, promotional_feature_item.title, promotional_feature_item.title_url %></p>
   <% end %>

--- a/app/views/admin/promotional_feature_items/edit.html.erb
+++ b/app/views/admin/promotional_feature_items/edit.html.erb
@@ -1,3 +1,5 @@
+<%= initialise_script "GOVUK.adminPromotionalFeatureItemsForm", selector: ".promotional_feature_item" %>
+
 <% page_title "Feature item for #{@promotional_feature.title}" %>
 <h1>Editing feature item for <%= @promotional_feature.title %></h1>
 <p class="warning">Warning: changes will appear instantly on the live site.</p>

--- a/app/views/admin/promotional_feature_items/new.html.erb
+++ b/app/views/admin/promotional_feature_items/new.html.erb
@@ -1,3 +1,5 @@
+<%= initialise_script "GOVUK.adminPromotionalFeatureItemsForm", selector: ".promotional_feature_item" %>
+
 <% page_title "Feature item for #{@promotional_feature.title}" %>
 <h1>New feature item for <%= @promotional_feature.title %></h1>
 <p class="warning">Warning: newly created feature items will appear instantly on the live site.</p>

--- a/app/views/admin/promotional_features/new.html.erb
+++ b/app/views/admin/promotional_features/new.html.erb
@@ -1,3 +1,5 @@
+<%= initialise_script "GOVUK.adminPromotionalFeatureItemsForm", selector: ".promotional_feature_item" %>
+
 <% page_title "New promotional feature for #{@organisation.name}" %>
 <h1>New Promotional feature block</h1>
 <p class="warning">Warning: newly created feature blocks will appear instantly on the live site.</p>

--- a/features/executive-office-promotional-features.feature
+++ b/features/executive-office-promotional-features.feature
@@ -4,8 +4,13 @@ Feature: Promotional features for executive offices
     Given I am an admin
     And the executive office organisation "Number 32 - The Cheese Office" exists
 
-  Scenario: Add a promotional feature to an executive office
-    When I add a new promotional feature with a single item
+  Scenario: Add a promotional feature with an image to an executive office
+    When I add a new promotional feature with a single item which has an image
+    Then I should see the promotional feature on the organisation's page
+
+  Scenario: Add a promotional feature with a youtube url to an executive office
+    And I have the "Add youtube urls to promotional features" permission
+    When I add a new promotional feature with a single item which has a YouTube URL
     Then I should see the promotional feature on the organisation's page
 
   Scenario: Deleting a promotional feature

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -17,7 +17,7 @@ When(/^I view the promotional feature$/) do
   visit admin_organisation_promotional_feature_url(@executive_office, @promotional_feature)
 end
 
-When(/^I add a new promotional feature with a single item$/) do
+When(/^I add a new promotional feature with a single item which has an image$/) do
   visit admin_organisation_path(@executive_office)
   click_link "Promotional features"
   click_link "New promotional feature"
@@ -30,6 +30,24 @@ When(/^I add a new promotional feature with a single item$/) do
     fill_in "Item title url (optional)",    with: "http://big-cheese.co"
     attach_file :image, Rails.root.join("test/fixtures/big-cheese.960x640.jpg")
     fill_in "Image description (alt text)", with: "The Big Cheese"
+  end
+
+  click_button "Save"
+end
+
+When(/^I add a new promotional feature with a single item which has a YouTube URL$/) do
+  visit admin_organisation_path(@executive_office)
+  click_link "Promotional features"
+  click_link "New promotional feature"
+
+  fill_in "Feature title", with: "Big Cheese"
+
+  within "form.promotional_feature_item" do
+    fill_in "Summary",                      with: "The Big Cheese is coming."
+    fill_in "Item title (optional)",        with: "The Big Cheese"
+    fill_in "Item title url (optional)",    with: "http://big-cheese.co"
+    choose "YouTube video"
+    fill_in "YouTube video URL", with: "https://www.youtube.com/watch?v=fFmDQn9Lbl4"
   end
 
   click_button "Save"
@@ -76,7 +94,8 @@ Then(/^I should see the promotional feature on the organisation's page$/) do
     within record_css_selector(item) do
       expect(page).to have_content(item.summary)
       expect(page).to have_link(item.title, href: item.title_url)
-      expect(page).to have_selector("img[src='#{item.image.s300.url}'][alt='#{item.image_alt_text}']")
+      expect(page).to have_selector("img[src='#{item.image.s300.url}'][alt='#{item.image_alt_text}']") if item.image.present?
+      expect(page).to have_selector("a[href='#{item.youtube_video_url}']") if item.youtube_video_url.present?
     end
   end
 end

--- a/spec/javascripts/admin_legacy/views/promotional_feature_items/_form.spec.js
+++ b/spec/javascripts/admin_legacy/views/promotional_feature_items/_form.spec.js
@@ -1,0 +1,123 @@
+describe('GOVUK.Modules.adminPromotionalFeaturesForm', function () {
+  var form
+
+  beforeEach(function () {
+    form = document.createElement('form')
+    form.classList.add('promotional_feature_item')
+    document.body.append(form)
+  })
+
+  afterEach(function () {
+    form.remove()
+  })
+
+  it('hides the image and youtube fields on init when no radios are checked', function () {
+    form.innerHTML = uncheckedRadioFields()
+    GOVUK.adminPromotionalFeatureItemsForm.init({
+      selector: '.promotional_feature_item'
+    })
+
+    var imageFields = form.querySelector('.image-fields')
+    var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+    expect(imageFields.hidden).toBe(true)
+    expect(youtubeFields.hidden).toBe(true)
+  })
+
+  it('hides the youtube fields on init when the image radio is checked', function () {
+    form.innerHTML = checkedImageRadioFields()
+    GOVUK.adminPromotionalFeatureItemsForm.init({
+      selector: '.promotional_feature_item'
+    })
+
+    var imageFields = form.querySelector('.image-fields')
+    var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+    expect(imageFields.hidden).toBe(false)
+    expect(youtubeFields.hidden).toBe(true)
+  })
+
+  it('hides the image fields on init when the youtube_video_url radio is checked', function () {
+    form.innerHTML = checkedYoutubeVideoUrlRadioFields()
+    GOVUK.adminPromotionalFeatureItemsForm.init({
+      selector: '.promotional_feature_item'
+    })
+
+    var imageFields = form.querySelector('.image-fields')
+    var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+    expect(imageFields.hidden).toBe(true)
+    expect(youtubeFields.hidden).toBe(false)
+  })
+
+  it('hides the youtube fields when the image radio is checked', function () {
+    form.innerHTML = uncheckedRadioFields()
+    GOVUK.adminPromotionalFeatureItemsForm.init({
+      selector: '.promotional_feature_item'
+    })
+
+    var imageRadio = form.querySelector('#promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_image')
+    imageRadio.dispatchEvent(new Event('change'))
+
+    var imageFields = form.querySelector('.image-fields')
+    var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+    expect(imageFields.hidden).toBe(false)
+    expect(youtubeFields.hidden).toBe(true)
+  })
+
+  it('hides the image fields when the youtube_video_url radio is checked', function () {
+    form.innerHTML = uncheckedRadioFields()
+    GOVUK.adminPromotionalFeatureItemsForm.init({
+      selector: '.promotional_feature_item'
+    })
+
+    var youtubeRadio = form.querySelector('#promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_youtube_video_url')
+    youtubeRadio.dispatchEvent(new Event('change'))
+
+    var imageFields = form.querySelector('.image-fields')
+    var youtubeFields = form.querySelector('.youtube-video-url-fields')
+
+    expect(imageFields.hidden).toBe(true)
+    expect(youtubeFields.hidden).toBe(false)
+  })
+
+  function uncheckedRadioFields () {
+    return (
+      '<fieldset class="image-and-youtube-radios">' +
+        '<input type="radio" value="image" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_image">' +
+        '<div class="image-fields">' +
+        '</div>' +
+        '<input type="radio" value="youtube_video_url" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_youtube_video_url">' +
+        '<div class="youtube-video-url-fields">' +
+        '</div>' +
+      '</fieldset>'
+    )
+  }
+
+  function checkedImageRadioFields () {
+    return (
+      '<fieldset class="image-and-youtube-radios">' +
+        '<input type="radio" value="image" checked="checked" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_image">' +
+        '<div class="image-fields">' +
+        '</div>' +
+        '<input type="radio" value="youtube_video_url" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_youtube_video_url">' +
+        '<div class="youtube-video-url-fields">' +
+        '</div>' +
+      '</fieldset class="image-and-youtube-radios">'
+    )
+  }
+
+  function checkedYoutubeVideoUrlRadioFields () {
+    return (
+      '<fieldset class="image-and-youtube-radios">' +
+        '<input type="radio" value="image" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_image">' +
+        '<div class="image-fields">' +
+        '</div>' +
+        '<input type="radio" value="youtube_video_url" checked="checked" name="promotional_feature[promotional_feature_items_attributes][0][image_or_youtube_video_url]" id="promotional_feature_promotional_feature_items_attributes_0_image_or_youtube_video_url_youtube_video_url">' +
+        '<div class="youtube-video-url-fields">' +
+        '</div>' +
+      '</fieldset>'
+    )
+  }
+})

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -4,5 +4,11 @@ FactoryBot.define do
     summary { "Summary text" }
     image { image_fixture_file }
     image_alt_text { "Image alt text" }
+
+    trait(:with_youtube_video_url) do
+      image { nil }
+      image_alt_text { nil }
+      youtube_video_url { "https://www.youtube.com/watch?v=fFmDQn9Lbl4" }
+    end
   end
 end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -181,24 +181,44 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
   end
 
   test "presents an eligible organisation with promotional features" do
-    promotional_feature = create(:promotional_feature)
+    promotional_feature1 = create(:promotional_feature)
+    promotional_feature_item1 = create(:promotional_feature_item, promotional_feature: promotional_feature1)
+    promotional_feature2 = create(:promotional_feature)
+    promotional_feature_item2 = create(:promotional_feature_item, :with_youtube_video_url, promotional_feature: promotional_feature2)
+
     organisation = create(
       :organisation,
       name: "Organisation of Things",
       organisation_type: OrganisationType.executive_office,
-      promotional_features: [promotional_feature],
+      promotional_features: [
+        promotional_feature1,
+        promotional_feature2,
+      ],
     )
     presented_item = present(organisation)
 
-    assert_equal(
-      [
-        {
-          title: promotional_feature.title,
-          items: [],
-        },
-      ],
-      presented_item.content[:details][:ordered_promotional_features],
-    )
+    expected_output = [
+      {
+        title: promotional_feature1.title,
+        items: [
+          summary: promotional_feature_item1.summary,
+          image: { url: promotional_feature_item1.image.url, alt_text: promotional_feature_item1.image_alt_text },
+          double_width: promotional_feature_item1.double_width,
+          links: promotional_feature_item2.links,
+        ],
+      },
+      {
+        title: promotional_feature2.title,
+        items: [
+          summary: promotional_feature_item2.summary,
+          youtube_video_id: promotional_feature_item2.youtube_video_id,
+          double_width: promotional_feature_item2.double_width,
+          links: promotional_feature_item2.links,
+        ],
+      },
+    ]
+
+    assert_equal(expected_output, presented_item.content[:details][:ordered_promotional_features])
   end
 
   test "does not present an ineligible organisation with promotional features" do

--- a/test/unit/promotional_feature_item_test.rb
+++ b/test/unit/promotional_feature_item_test.rb
@@ -62,6 +62,20 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
     assert_equal promotional_feature_item.errors[:youtube_video_url], ["Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL"]
   end
 
+  VALID_YOUTUBE_URLS.each do |url|
+    test "#youtube_video_id returns the youtube_video_id for `#{url}`" do
+      assert_equal build(:promotional_feature_item, youtube_video_url: url).youtube_video_id, "fFmDQn9Lbl4"
+    end
+  end
+
+  test "#youtube_video_id raises an exception when an youtube_video_id cannot be parsed form the youtube_video_url" do
+    promotional_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
+
+    assert_raises "youtube_video_url: #{promotional_feature_item.youtube_video_url} is invalid for PromotionalFeatureItem id: #{promotional_feature_item.id}" do
+      promotional_feature_item.youtube_video_id
+    end
+  end
+
 private
 
   def string_of_length(length)

--- a/test/unit/promotional_feature_item_test.rb
+++ b/test/unit/promotional_feature_item_test.rb
@@ -26,6 +26,24 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
     assert_equal "Example link", item.links.first.text
   end
 
+  test "validates that an image or youtube_video_url is present on save" do
+    feature_item_with_image = build(:promotional_feature_item)
+    feature_item_with_youtube_url = build(:promotional_feature_item, image: nil, youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4")
+    invalid_feature_item = build(:promotional_feature_item, image: nil, youtube_video_url: nil)
+
+    assert feature_item_with_image.valid?
+    assert feature_item_with_youtube_url.valid?
+    assert_not invalid_feature_item.valid?
+    assert_equal invalid_feature_item.errors.full_messages, ["Upload either an image or add a YouTube URL"]
+  end
+
+  test "validates that either an image and youtube_video_url can be provided" do
+    invalid_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4")
+
+    assert_not invalid_feature_item.valid?
+    assert_equal invalid_feature_item.errors.full_messages, ["Upload either an image or add a YouTube URL"]
+  end
+
 private
 
   def string_of_length(length)

--- a/test/unit/promotional_feature_item_test.rb
+++ b/test/unit/promotional_feature_item_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class PromotionalFeatureItemTest < ActiveSupport::TestCase
+  VALID_YOUTUBE_URLS = [
+    "https://youtu.be/fFmDQn9Lbl4",
+    "https://www.youtube.com/watch?v=fFmDQn9Lbl4",
+  ].freeze
+
   test "invalid without a summary" do
     assert_not build(:promotional_feature_item, summary: nil).valid?
   end
@@ -42,6 +47,19 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
     assert_not invalid_feature_item.valid?
     assert_equal invalid_feature_item.errors.full_messages, ["Upload either an image or add a YouTube URL"]
+  end
+
+  VALID_YOUTUBE_URLS.each do |url|
+    test "validates that a youtube_video_url of `#{url}` is valid" do
+      assert build(:promotional_feature_item, image: nil, youtube_video_url: url).valid?
+    end
+  end
+
+  test "validates that a youtube_video_url of `https://www.gov.uk/government/organisations/government-digital-service` is invalid" do
+    promotional_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
+
+    assert_not promotional_feature_item.valid?
+    assert_equal promotional_feature_item.errors[:youtube_video_url], ["Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL"]
   end
 
 private

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -145,6 +145,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_preview_next_release?
   end
 
+  test "cannot add youtube urls to promotional features by default" do
+    user = build(:user)
+    assert_not user.can_add_youtube_urls_to_promotional_features?
+  end
+
+  test "can add youtube urls to promotional features" do
+    user = build(:user, permissions: [User::Permissions::ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES])
+    assert user.can_add_youtube_urls_to_promotional_features?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description

We're adding the ability for users to add a link to a youtube video in place or an image for promotional features.  This will allow us to use an embedded youtube video in place of an image. There's quite a lot of context in the Trello card (https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features) which is def worth reading.

This PR does the following:

1. Adds the `Add youtube urls to promotional features` permission so we can feature flag until the frontend work is done on Collections
2. Adds radio buttons which allow the user to choose between uploading an image or providing a Youtube URL
3. Adds a validation to check that an image or Youtube URL is present on a PromotionalFeatureItem (previously they could save without an image, but it would blow up with a 500 when published to the Publishing API)
4. Validates that the Youtube URL provided is valid
5. Pushes the Youtube video ID downstream to the Publishing API (not the whole URL)
6. Adds a JS module which hides the image fields when the youtube radio is selected and hides the youtube input when the image radio is selected.

## Screenshots

### With permission

<img width="912" alt="image" src="https://user-images.githubusercontent.com/42515961/210525062-34a6dd9e-7866-4d98-8e2e-1d8c798291f2.png">

### Without permission

<img width="908" alt="image" src="https://user-images.githubusercontent.com/42515961/210525265-a4ad01b9-ea78-46f9-953c-f83de878d461.png">

## Related PRs 

Collections - https://github.com/alphagov/collections/pull/3116
Publishing API ContentSchema changes - https://github.com/alphagov/publishing-api/pull/2237


## Trello card 

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
