### PR TITLE
Remove ASSET_HOST env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -87,10 +87,6 @@ module Whitehall
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/assets/whitehall"
 
-    # allow overriding the asset host with an enironment variable, useful for
-    # when router is proxying to this app but asset proxying isn't set up.
-    config.asset_host = ENV["ASSET_HOST"]
-
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"
     end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This env var is no longer in active use since the introduction of Static proxy [1] and usage of it will soon have problems with the Content Security Policy [2].

[1]: https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_proxy/static_proxy.rb
[2]: https://github.com/alphagov/govuk_app_config/pull/274

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
