### PR TITLE
Update govspeak syntax for images

### DIFF
--- a/app/controllers/admin/preview_controller.rb
+++ b/app/controllers/admin/preview_controller.rb
@@ -1,10 +1,12 @@
 class Admin::PreviewController < Admin::BaseController
   before_action :find_attachments
   before_action :limit_attachment_access!
+  include GovspeakHelper
 
   def preview
     if Govspeak::HtmlValidator.new(params[:body]).valid?
-      @images = Image.find(params.fetch(:image_ids, []))
+      images = Image.find(params.fetch(:image_ids, []))
+      @images = images_setup(images)
       @alternative_format_contact_email = alternative_format_contact_email
       render layout: false
     else

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -25,9 +25,26 @@ module GovspeakHelper
 
   def bare_govspeak_edition_to_html(edition)
     images = edition.respond_to?(:images) ? edition.images : []
+    images = images_setup(images)
+
     allowed_elements = edition.allows_inline_attachments? ? %w[details] : []
     partially_processed_govspeak = edition_body_with_attachments_and_alt_format_information(edition)
     bare_govspeak_to_html(partially_processed_govspeak, images, allowed_elements:)
+  end
+
+  def images_setup(images)
+    images.map do |image|
+      {
+        id: image.image_data.carrierwave_image,
+        image_data_id: image.image_data_id,
+        edition_id: image.edition_id,
+        alt_text: image.alt_text,
+        url: image.url,
+        caption: image.caption,
+        created_at: image.created_at,
+        updated_at: image.updated_at,
+      }
+    end
   end
 
   def bare_govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -90,9 +90,9 @@
     },
   } do %>
     <p class='govuk-body'>First upload your image(s), then:</p>
-    <pre class='govspeak-help__pre'>!!<em>n</em></pre>
+    <pre class='govspeak-help__pre'>[Image:filename]</pre>
     <p class='govuk-body'>eg for the first image:</p>
-    <pre class='govspeak-help__pre'>!!1</pre>
+    <pre class='govspeak-help__pre'>[Image:example.jpg]</pre>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {

--- a/app/views/admin/editions/_image_template.html.erb
+++ b/app/views/admin/editions/_image_template.html.erb
@@ -67,7 +67,7 @@
             bold: true,
           },
           name: "readonly",
-          value: "!!#{index + 1}",
+          value: "[Image:#{image.image_data.carrierwave_image}]",
           readonly: true,
         } %>
       <% end %>

--- a/app/views/admin/editions/_legacy_govspeak_help.html.erb
+++ b/app/views/admin/editions/_legacy_govspeak_help.html.erb
@@ -108,9 +108,9 @@
   <h3><a data-toggle="collapse" href="#govspeak-images" aria-expanded="false">Images</a></h3>
   <div class="collapse" id="govspeak-images">
     <p>First upload your image(s), then:</p>
-    <pre>!!<em>n</em></pre>
+    <pre>[Image:filename]</pre>
     <p>eg for the first image:</p>
-    <pre>!!1</pre>
+    <pre>[Image:example.jpg]</pre>
   </div>
 
   <h3><a data-toggle="collapse" href="#govspeak-video-links" aria-expanded="false">Video links</a></h3>

--- a/app/views/admin/editions/_legacy_image_fields.html.erb
+++ b/app/views/admin/editions/_legacy_image_fields.html.erb
@@ -25,7 +25,7 @@
             <p>This image is shown automatically, and is not available for use inline in the body.</p>
           <% else %>
             <p>Markdown to use:
-              <input type="text" readonly="readonly" value="!!<%= i %>" />
+              <input type="text" readonly="readonly" value="[Image:<%= images_fields.object.image_data.carrierwave_image %>]" />
             </p>
           <% end %>
         </div>

--- a/app/views/admin/editions/_legacy_image_fields_case_studies.html.erb
+++ b/app/views/admin/editions/_legacy_image_fields_case_studies.html.erb
@@ -47,7 +47,7 @@
                   <p>This image is shown automatically, and is not available for use inline in the body.</p>
                 <% else %>
                   <p>Markdown to use:
-                    <input type="text" readonly="readonly" value="!!<%= i %>" />
+                    <input type="text" readonly="readonly" value="[Image:<%= images_fields.object.image_data.carrierwave_image %>]" />
                   </p>
                 <% end %>
               </div>

--- a/test/functional/admin/preview_controller_test.rb
+++ b/test/functional/admin/preview_controller_test.rb
@@ -12,8 +12,16 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     assert_select ".document .body h1", "gov speak"
   end
 
-  view_test "renders attached images if image_ids provided" do
+  view_test "renders attached images if image_ids provided using !!number as a markdown" do
     edition = create(:publication, body: "!!1")
+    image = create(:image, edition:)
+
+    post :preview, params: { body: edition.body, image_ids: edition.images.map(&:id) }
+    assert_select ".document .body figure.image.embedded img[src=?]", image.url
+  end
+
+  view_test "renders attached images if image_ids provided using filename as a markdown" do
+    edition = create(:publication, body: "[Image:minister-of-funk.960x640.jpg]")
     image = create(:image, edition:)
 
     post :preview, params: { body: edition.body, image_ids: edition.images.map(&:id) }

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -295,9 +295,18 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".attachment.embedded"
   end
 
-  test "embeds image urls" do
+  test "embeds image urls when using !!number as a markdown" do
     edition = build(:published_news_article, body: "!!1")
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")])
+    image_data = create(:image_data, id: 1)
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
+    html = govspeak_edition_to_html(edition)
+    assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
+  end
+
+  test "embeds image urls when using filename as a markdown" do
+    edition = build(:published_news_article, body: "[Image:minister-of-funk.960x640.jpg]")
+    image_data = create(:image_data, id: 1)
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
     html = govspeak_edition_to_html(edition)
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end

--- a/test/unit/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/whitehall/govspeak_renderer_test.rb
@@ -8,9 +8,20 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
                            render_govspeak(edition)
   end
 
-  test "interpolates images into rendered HTML" do
-    image = OpenStruct.new(alt_text: "My Alt", url: "http://example.com/image.jpg")
+  test "interpolates images into rendered HTML when using !!number as a markdown" do
+    image_data = create(:image_data, id: 1)
+    image = OpenStruct.new(alt_text: "My Alt", url: "http://example.com/image.jpg", image_data: ImageData.find(image_data.id))
     edition = build(:edition, body: "Some content with an image.\n\n!!1")
+    edition.stubs(:images).returns([image])
+
+    assert_equivalent_html govspeak_with_image_html(image),
+                           render_govspeak(edition)
+  end
+
+  test "interpolates images into rendered HTML when using filename as a markdown" do
+    image_data = create(:image_data, id: 1)
+    image = OpenStruct.new(alt_text: "My Alt", url: "http://example.com/image.jpg", image_data: ImageData.find(image_data.id))
+    edition = build(:edition, body: "Some content with an image.\n\n[Image:minister-of-funk.960x640.jpg]")
     edition.stubs(:images).returns([image])
 
     assert_equivalent_html govspeak_with_image_html(image),


### PR DESCRIPTION
[Trello card](https://trello.com/c/9oMxpTMN/991-update-govspeak-markdown-syntax)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

New syntax in Bootstrap design:
<img width="764" alt="Screenshot 2022-12-30 at 11 35 09" src="https://user-images.githubusercontent.com/4563521/210066207-36c020bd-c179-4206-adfa-2822b295aeaf.png">
<img width="929" alt="Screenshot 2022-12-30 at 11 35 51" src="https://user-images.githubusercontent.com/4563521/210066229-5fd05500-0602-4f3e-bcf2-88a9c7984c23.png">

New syntax in the new Design System:
<img width="810" alt="Screenshot 2022-12-30 at 11 39 12" src="https://user-images.githubusercontent.com/4563521/210066465-7021f0a9-4508-43eb-9c00-1d0e10933cbf.png">
<img width="1373" alt="Screenshot 2022-12-30 at 11 39 21" src="https://user-images.githubusercontent.com/4563521/210066476-51095eaa-0be9-497d-a86c-47ffcadb6f4d.png">

