### PR TITLE
Reintroduce and fix the basics for models knowing their own routes

### DIFF
--- a/app/helpers/admin/get_involved_helper.rb
+++ b/app/helpers/admin/get_involved_helper.rb
@@ -5,4 +5,8 @@ module Admin::GetInvolvedHelper
       "Take part pages" => admin_take_part_pages_path,
     )
   end
+
+  def get_involved_url
+    "#{Plek.website_root}/government/get-involved?#{cachebust_url_options.to_query}"
+  end
 end

--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -13,7 +13,11 @@ module Admin::UrlOptionsHelper
 
   def show_url_with_public_and_cachebusted_options(model, url_options = {})
     options = public_and_cachebusted_url_options.merge(url_options)
-    send("#{model.class.to_s.underscore}_url", model, options)
+    if model.respond_to?(:public_url)
+      model.public_url(options)
+    else
+      send("#{model.class.to_s.underscore}_url", model, options)
+    end
   end
 
   def view_on_website_link_for(model, options = {})

--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -22,7 +22,7 @@ module LogoHelper
            else
              organisation_logo_name(organisation)
            end
-    linked_logo = link_to_if(options[:linked], logo, organisation_path(organisation))
+    linked_logo = link_to_if(options[:linked], logo, organisation.public_path)
     if organisation.custom_logo_selected?
       linked_logo
     else

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -74,7 +74,7 @@ module OrganisationHelper
   def superseding_organisations_text(organisation)
     if organisation.superseding_organisations.any?
       organisation_links = organisation.superseding_organisations.map do |org|
-        link_to(org.name, organisation_path(org))
+        link_to(org.name, org.public_path)
       end
       organisation_links.to_sentence.html_safe
     end
@@ -134,7 +134,7 @@ module OrganisationHelper
 
   def organisation_relationship_html(organisation)
     prefix = needs_definite_article?(organisation.name) ? "the " : ""
-    (prefix + link_to(organisation.name, organisation_path(organisation), class: "brand__color"))
+    (prefix + link_to(organisation.name, organisation.public_path, class: "brand__color"))
   end
 
   def needs_definite_article?(phrase)

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -2,7 +2,8 @@ module PublicDocumentRoutesHelper
   include ActionDispatch::Routing::PolymorphicRoutes
 
   def document_path(edition, options = {})
-    document_url(edition, options.merge(only_path: true))
+    options = locale_options(edition, options)
+    edition.public_path(options)
   end
 
   def public_document_path(edition, options = {})
@@ -12,33 +13,19 @@ module PublicDocumentRoutesHelper
   def document_url(edition, options = {}, _builder_options = {})
     return edition.url if edition.is_a?(RummagerDocumentPresenter)
 
-    if edition.non_english_edition?
-      options[:locale] = edition.primary_locale
-    elsif edition.translatable?
-      options[:locale] ||= best_locale_for_edition(edition)
-    else
-      options.delete(:locale)
-    end
+    options = locale_options(edition, options)
 
-    case edition
-    when CorporateInformationPage
-      build_url_for_corporate_information_page(edition, options)
-    else
-      polymorphic_url(edition.path_name, options.reverse_merge(id: edition.document))
-    end
+    edition.public_url(options)
   end
 
-  def public_document_url(edition, options = {}, builder_options = {})
-    document_url(
-      edition,
-      { host: Whitehall.public_host, protocol: Whitehall.public_protocol }.merge(options),
-      builder_options,
-    )
+  def public_document_url(edition, options = {})
+    options = locale_options(edition, options)
+    edition.public_url(options)
   end
 
   def preview_document_url(edition, options = {})
     if edition.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-      options[:host] = URI(Plek.external_url_for("draft-origin")).host
+      options[:draft] = true
     else
       options[:preview] = edition.document.latest_edition_id
       options[:cachebust] = Time.zone.now.getutc.to_i
@@ -57,129 +44,18 @@ module PublicDocumentRoutesHelper
     "#{preview_document_url(edition)}?#{params}"
   end
 
-  def organisation_url(slug_or_organisation, options = {})
-    organisation_or_court = case slug_or_organisation
-                            when String
-                              Organisation.find_by(slug: slug_or_organisation)
-                            when Organisation
-                              slug_or_organisation
-                            else
-                              raise ArgumentError, "Must provide a slug or Organisation"
-                            end
-
-    if organisation_or_court.nil?
-      logger.warn "Generating a URL for a missing organisation: #{slug_or_organisation}"
-      return super(slug_or_organisation, options)
-    end
-
-    if organisation_or_court.court_or_hmcts_tribunal?
-      court_url(organisation_or_court, options)
-    else
-      super(organisation_or_court, options)
-    end
-  end
-
-  def organisation_path(organisation_or_court_or_slug, options = {})
-    organisation_url(organisation_or_court_or_slug, options.merge(only_path: true))
-  end
-
-  def organisation_preview_url(organisation, options = {})
-    polymorphic_url(organisation, options.merge(host: URI(Plek.external_url_for("draft-origin")).host))
-  end
-
-  def get_involved_path(options = {})
-    append_url_options("/government/get-involved", options)
-  end
-
-  def get_involved_url(options = {})
-    Plek.website_root + get_involved_path(options)
-  end
-
-  def take_part_page_path(object, options = {})
-    slug = case object
-           when String
-             object
-           when TakePartPage
-             object.slug
-           else
-             raise ArgumentError, "Must provide a slug or TakePartPage"
-           end
-
-    append_url_options("/government/get-involved/take-part/#{slug}", options)
-  end
-
-  def take_part_page_url(object, options = {})
-    Plek.website_root + take_part_page_path(object, options)
-  end
-
-  def topical_event_path(object, options = {})
-    slug = case object
-           when String
-             object
-           when TopicalEvent
-             object.slug
-           else
-             raise ArgumentError, "Must provide a slug or TopicalEvent"
-           end
-
-    append_url_options("/government/topical-events/#{slug}", options)
-  end
-
-  def topical_event_url(object, options = {})
-    Plek.website_root + topical_event_path(object, options)
-  end
-
-  def topical_event_about_pages_path(object, options = {})
-    slug = case object
-           when String
-             object
-           when TopicalEvent
-             object.slug
-           when TopicalEventAboutPage
-             object.topical_event.slug
-           else
-             raise ArgumentError, "Must provide a slug, TopicalEvent or TopicalEventAboutPage"
-           end
-
-    append_url_options("/government/topical-events/#{slug}/about", options)
-  end
-
-  def world_location_path(object, options = {})
-    slug = world_location_slug(object)
-
-    append_url_options("/world/#{slug}", options)
-  end
-
-  def world_location_url(object, options = {})
-    Plek.new.website_root + world_location_path(object, options)
-  end
-
-  def world_location_news_index_path(object, options = {})
-    slug = world_location_slug(object)
-
-    append_url_options("/world/#{slug}/news", options)
-  end
-
-  def world_location_news_index_url(object, options = {})
-    Plek.new.website_root + world_location_news_index_path(object, options)
-  end
-
 private
 
-  def build_url_for_corporate_information_page(edition, options)
-    org = edition.owning_organisation
-
-    decorator = CorporateInfoPageDecorator.new(edition)
-    url = polymorphic_url([org, decorator], options)
-
-    # About pages are actually shown on the CIP index for an Organisation.
-    # We generate a unique path for them anyway, but this is always redirected.
-    case org
-    when Organisation
-      url.gsub("/about/about", "/about")
-    when WorldwideOrganisation
-      url.gsub("/about/about", "")
+  def locale_options(edition, options)
+    if edition.non_english_edition?
+      options[:locale] = edition.primary_locale
+    elsif edition.translatable?
+      options[:locale] ||= best_locale_for_edition(edition)
+    else
+      options.delete(:locale)
     end
+
+    options
   end
 
   def best_locale_for_edition(edition)
@@ -201,38 +77,6 @@ private
 
     def to_model
       self
-    end
-  end
-
-  def append_url_options(path, options = {})
-    if options[:format] && options[:locale]
-      path = "#{path}.#{options[:locale]}.#{options[:format]}"
-    elsif options[:locale] && options[:locale] != I18n.default_locale
-      path = "#{path}.#{options[:locale]}"
-    elsif options[:format]
-      path = "#{path}.#{options[:format]}"
-    end
-
-    if options[:cachebust]
-      query_params = {
-        cachebust: options[:cachebust],
-      }
-      path = "#{path}?#{query_params.to_query}"
-    end
-
-    path
-  end
-
-  def world_location_slug(object)
-    case object
-    when String
-      object
-    when WorldLocation
-      object.slug
-    when WorldLocationNews
-      object.world_location.slug
-    else
-      raise ArgumentError, "Must provide a slug, WorldLocation or WorldLocationNews"
     end
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -21,6 +21,10 @@ class Announcement < Edition
   def presenter
     AnnouncementPresenter
   end
+
+  def base_path
+    "/government/news/#{slug}"
+  end
 end
 
 require_relative "news_article"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,24 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def append_url_options(path, options = {})
+    if options[:format] && options[:locale]
+      path = "#{path}.#{options[:locale]}.#{options[:format]}"
+    elsif options[:locale] && options[:locale] != I18n.default_locale
+      path = "#{path}.#{options[:locale]}"
+    elsif options[:format]
+      path = "#{path}.#{options[:format]}"
+    end
+
+    if options[:cachebust]
+      query_params = {
+        cachebust: options[:cachebust],
+      }
+      path = "#{path}?#{query_params.to_query}"
+    end
+
+    path = "#{path}##{options[:anchor]}" if options[:anchor]
+
+    path
+  end
 end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -23,4 +23,8 @@ class CaseStudy < Edition
   def translatable?
     !non_english_edition?
   end
+
+  def base_path
+    "/government/case-studies/#{slug}"
+  end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -176,6 +176,10 @@ class Consultation < Publicationesque
     title
   end
 
+  def base_path
+    "/government/consultations/#{slug}"
+  end
+
 private
 
   def validate_closes_after_opens

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -174,6 +174,16 @@ class CorporateInformationPage < Edition
     attachments.any? { |a| a.is_a?(FileAttachment) }
   end
 
+  def base_path
+    if worldwide_organisation.present?
+      url = edition_worldwide_organisation.worldwide_organisation.base_path.to_s + "/about/#{slug}"
+      url.gsub("/about/about", "")
+    elsif organisation.present?
+      url = edition_organisation.organisation.base_path.to_s + "/about/#{slug}"
+      url.gsub("/about/about", "/about")
+    end
+  end
+
 private
 
   def string_for_slug

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -124,6 +124,10 @@ class DetailedGuide < Edition
     newly_created ? false : all_nation_applicability
   end
 
+  def base_path
+    "/guidance/#{slug}"
+  end
+
 private
 
   def date_for_government

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -25,7 +25,7 @@ class DocumentCollection < Edition
   end
 
   def search_link
-    Whitehall.url_maker.public_document_path(self)
+    base_path
   end
 
   def indexable_content
@@ -47,6 +47,10 @@ class DocumentCollection < Edition
 
   def locale_can_be_changed?
     true
+  end
+
+  def base_path
+    "/government/collections/#{slug}"
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -319,7 +319,7 @@ EXISTS (
   end
 
   def search_link
-    Whitehall.url_maker.public_document_path(self)
+    base_path
   end
 
   def search_format_types
@@ -686,6 +686,29 @@ EXISTS (
   # TODO: this can be removed once rails/rails#44770 is released.
   def attribute_names
     @attributes.keys
+  end
+
+  def base_path
+    url_slug = slug || id.to_param
+    "/government/generic-editions/#{url_slug}"
+  end
+
+  def public_path(options = {})
+    return if base_path.nil?
+
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    return if base_path.nil?
+
+    website_root = if options[:draft]
+                     Plek.external_url_for("draft-origin")
+                   else
+                     Plek.website_root
+                   end
+
+    website_root + public_path(options)
   end
 
 private

--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -39,4 +39,8 @@ class FatalityNotice < Announcement
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
+
+  def base_path
+    "/government/fatalities/#{slug}"
+  end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -417,10 +417,6 @@ class Organisation < ApplicationRecord
     end
   end
 
-  def base_path
-    Whitehall.url_maker.organisation_path(self)
-  end
-
   def search_link
     base_path
   end
@@ -529,6 +525,28 @@ class Organisation < ApplicationRecord
       promotional_feature = promotional_features.find(id)
       promotional_feature.update!(ordering: promotional_features_orderings[ordering.to_i - 1])
     end
+  end
+
+  def base_path
+    if court_or_hmcts_tribunal?
+      "/courts-tribunals/#{slug}"
+    else
+      "/government/organisations/#{slug}"
+    end
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    website_root = if options[:draft]
+                     Plek.external_url_for("draft-origin")
+                   else
+                     Plek.website_root
+                   end
+
+    website_root + public_path(options)
   end
 
 private

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -157,6 +157,12 @@ class Publication < Publicationesque
     end
   end
 
+  def base_path
+    return "/government/statistics/#{slug}" if statistics? || national_statistic?
+
+    "/government/publications/#{slug}"
+  end
+
 private
 
   def attachment_required_before_moving_out_of_draft

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -59,6 +59,10 @@ class Speech < Announcement
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
+  def base_path
+    "/government/speeches/#{slug}"
+  end
+
 private
 
   def date_for_government

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -25,4 +25,8 @@ class StatisticalDataSet < Publicationesque
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
+
+  def base_path
+    "/government/statistical-data-sets/#{slug}"
+  end
 end

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -66,7 +66,7 @@ class StatisticsAnnouncement < ApplicationRecord
   include Searchable
   searchable  only: :without_published_publication,
               title: :title,
-              link: :public_path,
+              link: :base_path,
               description: :summary,
               display_date: :display_date,
               display_type: :display_type,
@@ -142,12 +142,11 @@ class StatisticsAnnouncement < ApplicationRecord
     PublicationType.find_by_id(publication_type_id)
   end
 
-  def public_path
+  def base_path
     Whitehall.url_maker.statistics_announcement_path(self)
   end
 
-  alias_method :base_path, :public_path
-  alias_method :search_link, :public_path
+  alias_method :search_link, :base_path
 
   def organisations_slugs
     organisations.map(&:slug)
@@ -234,7 +233,7 @@ private
   end
 
   def redirect_not_circular
-    if redirect_url.present? && (public_path == redirect_url)
+    if redirect_url.present? && (base_path == redirect_url)
       errors.add(:redirect_url, "cannot redirect to itself")
     end
   end

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -213,7 +213,7 @@ private
   end
 
   def publication_url
-    Whitehall.url_maker.public_document_path(publication)
+    publication.base_path
   end
 
   def last_major_change

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -21,15 +21,11 @@ class TakePartPage < ApplicationRecord
 
   include Searchable
   searchable title: :title,
-             link: :search_link,
+             link: :public_path,
              content: :body_without_markup,
              description: :summary,
              format: "take_part",
              ordering: :ordering
-
-  def search_link
-    Whitehall.url_maker.take_part_page_path(slug)
-  end
 
   def body_without_markup
     Govspeak::Document.new(body).to_text
@@ -49,6 +45,18 @@ class TakePartPage < ApplicationRecord
       end
       TakePartPage.where("id NOT IN (?)", ids_in_new_ordering).update_all(ordering: ids_in_new_ordering.size + 1)
     end
+  end
+
+  def base_path
+    "/government/get-involved/take-part/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 
 protected

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -102,10 +102,6 @@ class TopicalEvent < ApplicationRecord
     end
   end
 
-  def base_path
-    Whitehall.url_maker.topical_event_path(slug)
-  end
-
   def search_link
     base_path
   end
@@ -187,6 +183,18 @@ class TopicalEvent < ApplicationRecord
 
   def to_s
     name
+  end
+
+  def base_path
+    "/government/topical-events/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 
 private

--- a/app/models/topical_event_about_page.rb
+++ b/app/models/topical_event_about_page.rb
@@ -18,10 +18,22 @@ class TopicalEventAboutPage < ApplicationRecord
              description: :summary
 
   def search_link
-    Whitehall.url_maker.topical_event_about_pages_path(topical_event.slug)
+    base_path
   end
 
   def indexable_content
     Govspeak::Document.new(body).to_text
+  end
+
+  def base_path
+    "/government/topical-events/#{topical_event.slug}/about"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 end

--- a/app/models/topical_event_featuring.rb
+++ b/app/models/topical_event_featuring.rb
@@ -37,7 +37,7 @@ class TopicalEventFeaturing < ApplicationRecord
     if offsite?
       offsite_link.url
     else
-      Whitehall.url_maker.public_document_path(edition)
+      edition.base_path
     end
   end
 

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -56,11 +56,11 @@ class Unpublishing < ApplicationRecord
   end
 
   def document_path
-    Whitehall.url_maker.public_document_path(edition, id: slug)
+    edition.public_path.gsub(edition.slug, slug)
   end
 
   def document_url
-    Whitehall.url_maker.public_document_url(edition, id: slug)
+    edition.public_url.gsub(edition.slug, slug)
   end
 
   # Because the edition may have been deleted, we need to find it unscoped to

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -75,6 +75,18 @@ class WorldLocation < ApplicationRecord
   validates_with SafeHtmlValidator
   validates :name, :world_location_type, presence: true
 
+  def base_path
+    "/world/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
+
   extend FriendlyId
   friendly_id
 end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -40,9 +40,9 @@ class WorldLocationNews < ApplicationRecord
 
   def search_link
     if world_location.world_location?
-      Whitehall.url_maker.world_location_news_index_path(world_location)
+      public_path
     elsif world_location.international_delegation?
-      Whitehall.url_maker.world_location_path(world_location)
+      world_location.public_path
     end
   end
 
@@ -70,6 +70,18 @@ class WorldLocationNews < ApplicationRecord
 
     world_location
       .worldwide_organisations
+  end
+
+  def base_path
+    "/world/#{slug}/news"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 
   extend FriendlyId

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -118,4 +118,8 @@ class WorldwideOrganisation < ApplicationRecord
   def office_staff_roles
     roles.occupied.where(type: OFFICE_ROLES.map(&:name))
   end
+
+  def base_path
+    "/world/organisations/#{slug}"
+  end
 end

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -5,7 +5,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       title: model.name,
       format: model.display_type,
       updated_at: model.updated_at,
-      web_url: Whitehall.url_maker.world_location_url(model),
+      web_url: model.public_url,
       analytics_identifier: model.analytics_identifier,
       details: {
         slug: model.slug,
@@ -13,7 +13,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       },
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),
-        web_url: Whitehall.url_maker.world_location_url(model, anchor: "organisations"),
+        web_url: model.public_url(anchor: "organisations"),
       },
       content_id: model.content_id,
     }

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -28,7 +28,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
   def sponsor_as_json(sponsor)
     {
       title: sponsor.name,
-      web_url: Whitehall.url_maker.organisation_url(sponsor),
+      web_url: sponsor.public_url,
       details: {
         acronym: sponsor.acronym || "",
       },

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -140,7 +140,7 @@ private
 
   def present_translations(edition)
     edition.translations.map do |translation|
-      base_path = Whitehall.url_maker.public_document_path(edition, locale: translation.locale)
+      base_path = edition.public_path(locale: translation.locale)
       translation.as_json(except: :edition_id).merge(base_path:)
     end
   end
@@ -215,7 +215,7 @@ private
         edition = Whitehall::AdminLinkLookup.find_edition(link)
         {
           whitehall_admin_url: link,
-          public_url: edition ? Whitehall.url_maker.public_document_url(edition) : nil,
+          public_url: edition ? edition.public_url : nil,
           content_id: edition&.content_id,
         }
       end

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -59,9 +59,7 @@ class DocumentListExportPresenter
     ]
   end
 
-  def public_url
-    Whitehall.url_maker.public_document_url(edition)
-  end
+  delegate :public_url, to: :edition
 
   def admin_url
     Whitehall.url_maker.admin_edition_url(edition)

--- a/app/presenters/feature_presenter.rb
+++ b/app/presenters/feature_presenter.rb
@@ -47,14 +47,14 @@ FeaturePresenter = Struct.new(:feature) do
 
   def public_path
     if topical_event
-      Whitehall.url_maker.topical_event_path(topical_event)
+      topical_event.public_path
     elsif offsite_link
       offsite_link.url
     elsif edition.translatable?
-      Whitehall.url_maker.public_document_path(edition, locale: feature.locale)
+      edition.public_path(locale: feature.locale)
     else
       ::I18n.with_locale ENGLISH_LOCALE_CODE do
-        Whitehall.url_maker.public_document_path(edition)
+        edition.public_path
       end
     end
   end

--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       edition = feature.document.live_edition
       {
         title: edition.title,
-        href: Whitehall.url_maker.public_document_path(edition),
+        href: edition.public_path,
         image: {
           url: feature.image.url,
           alt_text: feature.alt_text,
@@ -35,7 +35,7 @@ module PublishingApi
       topical_event = feature.topical_event
       {
         title: topical_event.name,
-        href: Whitehall.url_maker.polymorphic_path(topical_event),
+        href: topical_event.public_path,
         image: {
           url: feature.image.url,
           alt_text: feature.alt_text,

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -171,7 +171,7 @@ module PublishingApi
         if about_page.present?
           cips << {
             title: I18n.t("corporate_information_page.type.title.about"),
-            href: Whitehall.url_maker.public_document_path(about_page),
+            href: about_page.public_path,
           }
         end
       end
@@ -186,14 +186,14 @@ module PublishingApi
       item.corporate_information_pages.published.by_menu_heading(:our_information).each do |cip|
         cips << {
           title: cip.title,
-          href: Whitehall.url_maker.public_document_path(cip),
+          href: cip.public_path,
         }
       end
 
       item.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |cip|
         cips << {
           title: cip.title,
-          href: Whitehall.url_maker.public_document_path(cip),
+          href: cip.public_path,
         }
       end
 
@@ -259,7 +259,7 @@ module PublishingApi
       page.extend(UseSlugAsParam)
       link_to(
         t_corporate_information_page_type_link_text(page),
-        Whitehall.url_maker.public_document_path(page),
+        page.public_path,
         class: "govuk-link brand__color",
       )
     end

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -22,7 +22,7 @@ module PublishingApi
 
       def base_path
         @base_path ||= if item.respond_to?(:public_path)
-                         item.public_path
+                         item.public_path(locale: I18n.locale)
                        else
                          Whitehall.url_maker.polymorphic_path(item)
                        end

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -21,7 +21,11 @@ module PublishingApi
     private
 
       def base_path
-        @base_path ||= Whitehall.url_maker.polymorphic_path(item)
+        @base_path ||= if item.respond_to?(:public_path)
+                         item.public_path
+                       else
+                         Whitehall.url_maker.polymorphic_path(item)
+                       end
       end
     end
   end

--- a/app/presenters/publishing_api/payload_builder/public_document_path.rb
+++ b/app/presenters/publishing_api/payload_builder/public_document_path.rb
@@ -18,7 +18,7 @@ module PublishingApi
     private
 
       def base_path
-        @base_path ||= Whitehall.url_maker.public_document_path(item, locale: I18n.locale)
+        @base_path ||= item.public_path(locale: I18n.locale)
       end
     end
   end

--- a/app/presenters/publishing_api/topical_event_about_page_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_about_page_presenter.rb
@@ -39,7 +39,7 @@ module PublishingApi
     end
 
     def base_path
-      Whitehall.url_maker.topical_event_about_pages_path(item.topical_event)
+      item.base_path
     end
 
     def details

--- a/app/presenters/publishing_api/world_location_news_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_presenter.rb
@@ -64,9 +64,9 @@ module PublishingApi
 
     def path_for_news_page
       if world_location.world_location?
-        Whitehall.url_maker.world_location_news_index_path(world_location, locale: I18n.locale)
+        world_location_news.public_path(locale: I18n.locale)
       elsif world_location.international_delegation?
-        Whitehall.url_maker.world_location_path(world_location, locale: I18n.locale)
+        world_location.public_path(locale: I18n.locale)
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -3,7 +3,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdates
     visible_edition = attachment_data.visible_edition_for(nil)
     return [] if visible_edition.blank?
 
-    parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
+    parent_document_url = visible_edition.public_url
 
     Enumerator.new do |enum|
       enum.yield AssetManager::AttachmentUpdater::Update.new(

--- a/app/services/author_notifier_service.rb
+++ b/app/services/author_notifier_service.rb
@@ -35,6 +35,6 @@ class AuthorNotifierService
   end
 
   def public_document_url
-    Whitehall.url_maker.public_document_url(edition)
+    edition.public_url
   end
 end

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -36,7 +36,7 @@ class LinkCheckerApiService
     converted = links.map do |link|
       edition = Whitehall::AdminLinkLookup.find_edition(link)
       if edition
-        Whitehall.url_maker.public_document_url(edition) if edition.published?
+        edition.public_url if edition.published?
       else
         link
       end

--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -54,7 +54,7 @@ private
   end
 
   def public_url(edition)
-    Whitehall.url_maker.public_document_url(edition, host: public_host, protocol: "https")
+    edition.public_url(host: public_host, protocol: "https")
   end
 
   def admin_url(edition)

--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -41,7 +41,7 @@ module ServiceListeners
       destination = if edition.unpublishing.redirect?
                       Addressable::URI.parse(edition.unpublishing.alternative_url).path
                     else
-                      Whitehall.url_maker.public_document_path(edition)
+                      edition.public_path
                     end
 
       current_html_attachments.each do |html_attachment|
@@ -132,7 +132,7 @@ module ServiceListeners
       content_ids_to_remove.each do |content_id|
         PublishingApiRedirectWorker.new.perform(
           content_id,
-          Whitehall.url_maker.public_document_path(edition),
+          edition.public_path,
           I18n.default_locale.to_s,
         )
       end

--- a/app/views/admin/get_involved/index.html.erb
+++ b/app/views/admin/get_involved/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="get-involved-header">
   <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_url(public_and_cachebusted_url_options) %>
+  <%= link_to "View on website", get_involved_url %>
 </div>
 <section class="get-involved">
   <%= get_involved_tab_navigation %>

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -20,7 +20,7 @@
           <tr>
             <td class="locale">
               <%= link_to locale.native_language_name, edit_admin_organisation_translation_path(@organisation, locale.code) %>
-              (<%= link_to "view", organisation_preview_url(@organisation, locale: locale) %>)
+              (<%= link_to "view", @organisation.public_url(draft: true, locale: locale.code) %>)
             </td>
             <td class="actions">
               <%= button_to 'Delete',

--- a/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
@@ -1,7 +1,7 @@
 <ul class="organisations-name-list">
   <% organisations.each do |organisation| %>
     <%= content_tag_for(:li, organisation, class: 'organisation') do %>
-      <%= link_to organisation.name, organisation_path(organisation) %>
+      <%= link_to organisation.name, organisation.public_path %>
     <% end %>
   <% end %>
 </ul>

--- a/app/views/admin/organisations/_organisation_row.html.erb
+++ b/app/views/admin/organisations/_organisation_row.html.erb
@@ -11,7 +11,7 @@
   <td><%= organisation.organisation_type.name %></td>
   <td><%= organisation.govuk_status %></td>
   <td>
-    <%= link_to '[gov.uk]', organisation_path(organisation) %>
+    <%= link_to '[gov.uk]', organisation.public_path %>
     <% if organisation.govuk_status != 'live' %>
       <%= link_to '[current site]', organisation.url %>
     <% end %>

--- a/app/views/admin/organisations/_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_organisations_name_list.html.erb
@@ -1,5 +1,5 @@
 <%= render "govuk_publishing_components/components/list", {
   items: organisations.map do |organisation|
-    link_to organisation.name, organisation_path(organisation), class: "govuk-link"
+    link_to organisation.name, organisation.public_path, class: "govuk-link"
   end
 } %>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -15,7 +15,7 @@
         data-module="taxonomy-tree-checkboxes"
         data-content-id="<%= @statistics_announcement.content_id %>"
         data-content-format="statistics_announcement"
-        data-content-public-path="<%= @statistics_announcement.public_path %>">
+        data-content-public-path="<%= @statistics_announcement.base_path %>">
 
         <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.ordered_taxons } %>
 

--- a/app/views/admin/take_part_pages/index.html.erb
+++ b/app/views/admin/take_part_pages/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="get-involved-header">
   <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_url(public_and_cachebusted_url_options) %>
+  <%= link_to "View on website", get_involved_url %>
 </div>
 
 <section class="get-involved">

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -5,7 +5,7 @@
     <h1>
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
-    <p><%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location_news, {locale: params[:locale]}.merge(cachebust_url_options)) %></p>
+    <p><%= link_to "View on website", @world_location_news.public_url({locale: params[:locale]}.merge(cachebust_url_options)) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location_news) %>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
     <p>
-    <%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location_news, cachebust_url_options) %>
+    <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %>
   </div>
 
   <section class="world-location-details">

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -6,7 +6,7 @@
     <h1>
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
-    <p><%= link_to "View on website", Whitehall.url_maker.world_location_news_index_url(@world_location_news, cachebust_url_options) %></p>
+    <p><%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location_news) %>
@@ -23,7 +23,7 @@
           <% @world_location_news.non_english_translated_locales.each do |locale| %>
             <tr>
               <td class="locale">
-                <%= link_to locale.native_language_name, edit_admin_world_location_news_translation_path(@world_location_news, locale.code) %> (<%= link_to "view", Whitehall.url_maker.world_location_news_index_url(@world_location_news, locale: locale.code) %>)
+                <%= link_to locale.native_language_name, edit_admin_world_location_news_translation_path(@world_location_news, locale.code) %> (<%= link_to "view", @world_location_news.public_url(locale: locale.code) %>)
               </td>
               <td class="actions">
                 <%= button_to 'Delete',

--- a/app/views/corporate_information_pages/_header.html.erb
+++ b/app/views/corporate_information_pages/_header.html.erb
@@ -16,7 +16,7 @@
         <%= t("organisation.support.part_of") %>
         <%=
           organisation.parent_organisations.map { |parent_org|
-            link_to parent_org.name, organisation_path(parent_org), class: "govuk-link"
+            link_to parent_org.name, parent_org.public_path, class: "govuk-link"
           }.to_sentence.html_safe
         %>
       </p>
@@ -25,7 +25,7 @@
         <%= t("organisation.support.administered_by") %>
         <%=
           organisation.parent_organisations.map { |parent_org|
-            link_to parent_org.name, organisation_path(parent_org), class: "govuk-link"
+            link_to parent_org.name, parent_org.public_path, class: "govuk-link"
           }.to_sentence.html_safe
         %>
       </p>

--- a/app/views/corporate_information_pages/index.html.erb
+++ b/app/views/corporate_information_pages/index.html.erb
@@ -21,7 +21,7 @@
 
       <div class="govuk-grid-column-two-thirds">
         <%= content_tag :p, class: 'govuk-body homepage-link' do %>
-          <%= link_to "#{@organisation.name} homepage", organisation_path(@organisation), class: "govuk-link" %>
+          <%= link_to "#{@organisation.name} homepage", @organisation.public_path, class: "govuk-link" %>
         <% end %>
         <aside class="organisation-top-tasks">
           <%= render partial: 'shared/available_languages', locals: {object: @organisation, linkable: [:about, @organisation]} %>

--- a/app/views/corporate_information_pages/show.html.erb
+++ b/app/views/corporate_information_pages/show.html.erb
@@ -19,7 +19,7 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render 'shared/available_languages', object: @corporate_information_page %>
         <%= content_tag :p, class: 'govuk-body homepage-link' do %>
-          <%= link_to "#{@organisation.name} homepage", organisation_path(@organisation), class: "govuk-link" %>
+          <%= link_to "#{@organisation.name} homepage", @organisation.public_path, class: "govuk-link" %>
         <% end %>
         <%= render "govuk_publishing_components/components/title", {
           title: @corporate_information_page.title,

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -8,7 +8,7 @@
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: {
           name: organisation_logo_name(organisation),
-          url: organisation_path(organisation),
+          url: organisation.public_path,
           brand: organisation.organisation_brand_colour ? organisation.organisation_brand_colour.class_name : nil,
           crest: organisation.organisation_logo_type.class_name,
         }

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -85,7 +85,7 @@
           <%= render "govuk_publishing_components/components/organisation_logo", {
             organisation: {
               name: sanitize(format_with_html_line_breaks(organisation.logo_formatted_name)),
-              url: organisation_path(organisation),
+              url: organisation.public_path,
               brand: organisation[:slug],
               crest: organisation.organisation_crest,
             },

--- a/app/views/world_locations/_list.html.erb
+++ b/app/views/world_locations/_list.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/list", {
   items: world_locations.map do |world_location|
     if world_location.active?
-      link_to world_location.name, world_location_path(world_location), class: 'location-link govuk-link'
+      link_to world_location.name, world_location.public_path, class: 'location-link govuk-link'
     else
       world_location.name
     end

--- a/app/views/world_locations/_world_location.html.erb
+++ b/app/views/world_locations/_world_location.html.erb
@@ -1,7 +1,7 @@
 <% options ||= {} %>
 <%= content_tag_for(:li, world_location, options) do %>
   <% if world_location.active? %>
-    <%= link_to world_location.name, world_location_path(world_location), class: 'location-link govuk-link' %>
+    <%= link_to world_location.name, world_location.public_path, class: 'location-link govuk-link' %>
   <% else %>
     <span class="location-link"><%= world_location.name %></span>
   <% end %>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -26,10 +26,10 @@
         <dl>
           <% if world_locations.any? %>
             <dt><%= t('worldwide_organisation.location') %>:</dt>
-            <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l, class: "govuk-link") }.to_sentence.html_safe %></dd>
+            <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l.public_path, class: "govuk-link") }.to_sentence.html_safe %></dd>
           <% end %>
           <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-          <dd lang="en"><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
+          <dd lang="en"><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o.public_path, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
         </dl>
       </div>
     </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -254,13 +254,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "98d4e188042dbc97e4ef433f643ac633014de04f80a1d574fcfa68677aaeeeca",
+      "fingerprint": "ca449e74829c897de6b6b4c217afd5ab6f85cd738afd8079ba6ab25660f5de30",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/worldwide_organisations/_header.html.erb",
       "line": 29,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).world_locations.map do\n link_to(l.name, l, :class => \"govuk-link\")\n end.to_sentence",
+      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).world_locations.map do\n link_to(l.name, l.public_path, :class => \"govuk-link\")\n end.to_sentence",
       "render_path": [
         {
           "type": "controller",
@@ -470,13 +470,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "f77ca1269299a6304017454456ff5d3a70c3434d8a643dae59f61b245da12fdb",
+      "fingerprint": "498c073dc7b4366a2817a1840933e5c409984ebded95ce90de0c784928d05a29",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/worldwide_organisations/_header.html.erb",
       "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).sponsoring_organisations.map do\n link_to(o.name, o, :class => \"sponsoring-organisation govuk-link\")\n end.to_sentence",
+      "code": "(Organisation.friendly.find(params[:organisation_id]) or if params.key?(:worldwide_organisation_id) then\n  WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])\nelse\n  raise(ActiveRecord::RecordNotFound)\nend).sponsoring_organisations.map do\n link_to(o.name, o.public_path, :class => \"sponsoring-organisation govuk-link\")\n end.to_sentence",
       "render_path": [
         {
           "type": "controller",
@@ -512,6 +512,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-12-14 15:00:41 +0000",
+  "updated": "2022-12-19 10:53:50 +0000",
   "brakeman_version": "5.4.0"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,28 +102,17 @@ Whitehall::Application.routes.draw do
     # End of public facing routes still rendered by Whitehall
 
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
-    get "/case-studies/:id(.:locale)", as: "case_study", constraints: { locale: valid_locales_regex }, to: rack_404
-    get "/collections/:id(.:locale)", as: "document_collection", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/consultations/:consultation_id/:id", as: "consultation_html_attachment", to: rack_404
     get "/consultations/:consultation_id/outcome/:id", as: "consultation_outcome_html_attachment", to: rack_404
     get "/consultations/:consultation_id/public-feedback/:id", as: "consultation_public_feedback_html_attachment", to: rack_404
-    get "/consultations/:id(.:locale)", as: "consultation", constraints: { locale: valid_locales_regex }, to: rack_404
-    get "/consultations/open", as: "open_consultation", to: rack_404
-    get "/consultations/closed", as: "closed_consultation", to: rack_404
-    get "/consultations/upcoming", as: "upcoming_consultation", to: rack_404
     get "/latest", as: "latest", to: rack_404
-    get "/news/:id(.:locale)", as: "news_article", constraints: { locale: valid_locales_regex }, to: rack_404
-    get "/organisations/:id(.:locale)", as: "organisation", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/organisations", as: "organisations", to: rack_404
     get "/people/:id(.:locale)", as: "person", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/groups/:id", as: "policy_group", to: rack_404
-    get "/publications/:id(.:locale)", as: "publication", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/publications/:publication_id/:id", as: "publication_html_attachment", to: rack_404
-    get "/speeches/:id(.:locale)", as: "speech", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
     get "/statistics/announcements/:id", as: "statistics_announcement", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
-    get "/statistics/:id(.:locale)", as: "statistic", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/statistics/:statistics_id/:id", as: "statistic_html_attachment", to: rack_404
 
     resources :organisations, only: [] do
@@ -384,9 +373,6 @@ Whitehall::Application.routes.draw do
 
     get "/placeholder" => "placeholder#show", as: :placeholder
   end
-
-  # TODO: the organisations controller has been removed but this route is still required to get the relevant helper methods. This can be removed once new helpers have been created.
-  get "/courts-tribunals/:id(.:locale)", as: "court", courts_only: true, constraints: { locale: valid_locales_regex }, to: rack_404
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(

--- a/db/data_migration/20141204114251_convert_unpublishing_reasons_and_urls.rb
+++ b/db/data_migration/20141204114251_convert_unpublishing_reasons_and_urls.rb
@@ -6,7 +6,7 @@ Unpublishing.where('alternative_url like "https://whitehall-admin%"').each do |u
   original_url.match('government/admin/[\w-]+/(\d+)$') do |m|
     # linked edition can be deleted, nothing we can do about that.
     edition = Edition.unscoped.find(m[1])
-    new_url = Whitehall.url_maker.public_document_url(edition)
+    new_url = edition.public_url
   end
 
   # otherwise it's a frontend URL, just substitute gov.uk

--- a/db/data_migration/20150615092751_replace_policy_admin_links.rb
+++ b/db/data_migration/20150615092751_replace_policy_admin_links.rb
@@ -5,7 +5,7 @@ puts "Building ID/slug to URL mapping"
 policies_and_supporting_pages = Edition.unscoped.where(type: %w[Policy SupportingPage])
 
 id_to_url_mapping = policies_and_supporting_pages.inject({}) do |hash, edition|
-  url = Whitehall.url_maker.public_document_url(edition, {}, include_deleted_documents: true)
+  url = edition.public_url({}, include_deleted_documents: true)
 
   id = edition.id.to_s
   slug = edition.slug

--- a/db/data_migration/20160623092908_correct_document_content_ids.rb
+++ b/db/data_migration/20160623092908_correct_document_content_ids.rb
@@ -39,7 +39,7 @@ end
 # correct IDs from the content store and set them accordingly:
 slugs_to_fix.each do |slug|
   document = Document.find_by(slug:)
-  base_path = Whitehall.url_maker.public_document_path(document.live_edition)
+  base_path = document.live_edition.public_path
   correct_content_id = Services.publishing_api.lookup_content_id(base_path:)
   if correct_content_id.blank?
     raise ArgumentError, "no content id found for #{base_path}"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -46,11 +46,11 @@ end
 
 Then(/^I should only see the news article on the French version of the public "([^"]*)" location page$/) do |world_location_name|
   world_location = WorldLocation.find_by!(name: world_location_name)
-  visit world_location_path(world_location, locale: :fr)
+  visit world_location.public_path(locale: :fr)
   within record_css_selector(@news_article) do
     expect(page).to have_content(@news_article.title)
   end
-  visit world_location_path(world_location)
+  visit world_location.public_path
   expect(page).to_not have_selector(record_css_selector(@news_article))
 end
 

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -371,7 +371,7 @@ Given(/^a closed organisation with documents which has been superseded by anothe
 end
 
 When(/^I view the organisation$/) do
-  visit organisation_path(@organisation)
+  visit @organisation.public_path
 end
 
 Then(/^I can see that the organisation is closed$/) do

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -21,7 +21,7 @@ end
 Then(/^I should see a link to the preview version of the publication "([^"]*)"$/) do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  expected_preview_url = "http://draft-origin.test.gov.uk/government/publications/#{publication.slug}"
+  expected_preview_url = "https://draft-origin.test.gov.uk/government/publications/#{publication.slug}"
 
   if using_design_system?
     expect(expected_preview_url).to eq(find("a[target='_blank']")[:href])

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -105,7 +105,7 @@ Then(/^I should not be able to add any further feature items$/) do
 end
 
 Then(/^I should see the promotional feature on the executive office page$/) do
-  visit organisation_path(@executive_office)
+  visit @executive_office.public_path
 
   within record_css_selector(@executive_office) do
     within "section.features" do

--- a/features/step_definitions/social_media_steps.rb
+++ b/features/step_definitions/social_media_steps.rb
@@ -48,7 +48,7 @@ Then(/^the "([^"]*)" social link should be shown on the public website for the (
     visit worldwide_organisation_path(social_container)
   else
     social_container = Organisation.last
-    visit organisation_path(social_container)
+    visit social_container.public_path
   end
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: social_service)
 end
@@ -59,7 +59,7 @@ Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public 
     visit worldwide_organisation_path(social_container)
   else
     social_container = Organisation.last
-    visit organisation_path(social_container)
+    visit social_container.public_path
   end
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title)
 end
@@ -70,7 +70,7 @@ Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public 
     visit worldwide_organisation_path(social_container, locale:)
   else
     social_container = Organisation.last
-    visit organisation_path(social_container, locale:)
+    visit social_container.public_path(locale:)
   end
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title)
 end

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -15,7 +15,7 @@ When(/^I unpublish the duplicate, marking it as consolidated into the other page
   click_on "Withdraw or unpublish"
   choose "Unpublish: consolidated into another GOV.UK page"
   within ".js-unpublish-withdraw-form__consolidated" do
-    fill_in "consolidated_alternative_url", with: Whitehall.url_maker.publication_url(@existing_edition.document)
+    fill_in "consolidated_alternative_url", with: @existing_edition.public_url
     click_button "Unpublish"
   end
 end
@@ -68,7 +68,7 @@ end
 
 Then(/^the unpublishing should redirect to the existing edition$/) do
   unpublishing = @duplicate_edition.unpublishing
-  path = publication_path(@existing_edition.document)
+  path = @existing_edition.public_path
   expect(unpublishing.alternative_url.end_with?(path)).to be(true)
 end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -56,7 +56,7 @@ end
 Then(/^I should see the worldwide organisation "([^"]*)" on the "([^"]*)" world location page$/) do |worldwide_organisation_name, location_name|
   location = WorldLocation.find_by(name: location_name)
   worldwide_organisation = WorldwideOrganisation.find_by(name: worldwide_organisation_name)
-  visit world_location_path(location)
+  visit location.public_path
   within record_css_selector(worldwide_organisation) do
     expect(page).to have_content(worldwide_organisation_name)
   end

--- a/features/support/corporate_information_page_helper.rb
+++ b/features/support/corporate_information_page_helper.rb
@@ -19,7 +19,7 @@ module CorporateInformationPageHelper
   end
 
   def check_attachment_appears_on_corporate_information_page(attachment, page)
-    visit organisation_path(page.organisation)
+    visit page.organisation.public_path
     click_link page.title
 
     expect(page).to have_selector(".attachment-details .title", text: attachment.title)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -21,7 +21,7 @@ module NavigationHelpers
 
   def visit_organisation(name)
     organisation = Organisation.find_by!(name:)
-    visit organisation_path(organisation)
+    visit organisation.public_path
   end
 
   def visit_organisation_about_page(name)

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -47,7 +47,7 @@ module TopicalEventsHelper
       title: name,
     }
 
-    base_path = topical_event_path(TopicalEvent.find_by!(name:))
+    base_path = TopicalEvent.find_by!(name:).base_path
 
     stub_content_store_has_item(base_path, content_item)
   end

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -58,7 +58,7 @@ module DataHygiene
     def new_base_path
       case organisation
       when Organisation
-        Whitehall.url_maker.organisation_path(new_slug)
+        new_slug.public_path
       when WorldwideOrganisation
         Whitehall.url_maker.worldwide_organisation_path(new_slug)
       end

--- a/lib/govspeak/admin_link_replacer.rb
+++ b/lib/govspeak/admin_link_replacer.rb
@@ -21,7 +21,7 @@ module Govspeak
       edition = Whitehall::AdminLinkLookup.find_edition(anchor["href"])
 
       if edition.present? && edition.linkable?
-        public_url = Whitehall.url_maker.public_document_url(edition)
+        public_url = edition.public_url
         new_html = convert_link(anchor, public_url)
       else
         new_html = anchor.inner_text

--- a/lib/publish_organisations_index_page.rb
+++ b/lib/publish_organisations_index_page.rb
@@ -51,7 +51,7 @@ private
     presented_organisations.send(organisation_type_key).map do |organisation|
       {
         title: organisation.name,
-        href: Whitehall.url_maker.polymorphic_path(organisation),
+        href: organisation.public_path,
         brand: organisation.organisation_brand,
         logo: organisation_logo(organisation),
         separate_website: organisation.exempt?,
@@ -120,7 +120,7 @@ private
   def summary_organisation(organisation)
     {
       title: organisation.name,
-      href: Whitehall.url_maker.polymorphic_path(organisation),
+      href: organisation.public_path,
     }
   end
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -26,7 +26,7 @@ namespace :export do
             document.slug,
             document.display_type,
             document.latest_edition.state,
-            document.live? ? Whitehall.url_maker.public_document_url(edition) : nil,
+            document.live? ? edition.public_url : nil,
             edition.id,
             edition.title,
             edition.state,
@@ -68,7 +68,7 @@ namespace :export do
         org.published_editions.each do |edition|
           csv << [
             org.display_name,
-            Whitehall.url_maker.public_document_url(edition),
+            edition.public_url,
             Whitehall.url_maker.admin_edition_url(edition),
             edition.title,
             edition.display_type,

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -122,14 +122,14 @@ module Whitehall
     def self.schedule_async(edition)
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
-        base_path = Whitehall.url_maker.public_document_path(edition, locale:)
+        base_path = edition.public_path(locale:)
         PublishingApiScheduleWorker.perform_async(base_path, publish_timestamp)
       end
     end
 
     def self.unschedule_async(edition)
       locales_for(edition).each do |locale|
-        base_path = Whitehall.url_maker.public_document_path(edition, locale:)
+        base_path = edition.public_path(locale:)
         PublishingApiUnscheduleWorker.perform_async(base_path)
       end
     end

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -44,7 +44,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation, translated_into: [:fr])
     get :index, params: { organisation_id: organisation }
     edit_translation_path = edit_admin_organisation_translation_path(organisation, "fr")
-    view_organisation_url = routes_helper.organisation_preview_url(organisation, locale: "fr")
+    view_organisation_url = organisation.public_url(draft: true, locale: "fr")
     assert_select "a[href=?]", edit_translation_path, text: "Français"
     assert_select "a[href=?]", view_organisation_url, text: "view"
   end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -28,7 +28,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     get :show, params: { organisation: nil, worldwide_organisation_id: worldwide_organisation, id: corporate_information_page.slug }
 
     assert_select "a[href=?]", worldwide_organisation_path(worldwide_organisation)
-    assert_select "a[href=?]", world_location_path(world_location)
+    assert_select "a[href=?]", world_location.public_path
   end
 
   view_test "should show links to the alternate languages for a translated organisation" do

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -426,8 +426,8 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     get :show, params: params
 
-    assert_select "a[href=?]", organisation_path(organisation1)
-    assert_select "a[href=?]", organisation_path(organisation2)
+    assert_select "a[href=?]", organisation1.public_path
+    assert_select "a[href=?]", organisation2.public_path
   end
 
   view_test "renders CSV column headings" do

--- a/test/functional/document_collections_controller_test.rb
+++ b/test/functional/document_collections_controller_test.rb
@@ -2,9 +2,11 @@ require "test_helper"
 
 class DocumentCollectionControllerRedirectsTest < ActionDispatch::IntegrationTest
   test "old route (eg. /government/organisations/?/series/?) should redirect to this show action" do
+    document_collection = build(:document_collection, document: build(:document, slug: "firing_notice"))
+
     get "/government/organisations/ministry-of-defence/series/firing-notice"
 
     assert response.redirect?
-    assert response.location = document_collection_url(id: "firing-notice")
+    assert response.location = document_collection.public_url
   end
 end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -44,8 +44,8 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     get :show, params: { id: organisation.id }
 
-    assert_select "a[href='#{world_location_path(location1)}']"
-    assert_select "a[href='#{world_location_path(location2)}']"
+    assert_select "a[href='#{location1.public_path}']"
+    assert_select "a[href='#{location2.public_path}']"
   end
 
   test "show redirects to the api worldwide organisation endpoint when json is requested" do

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -38,7 +38,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
           visit admin_news_article_path(edition)
           force_publish_document
 
-          parent_document_url = Whitehall.url_maker.public_document_url(edition)
+          parent_document_url = edition.public_url
 
           Services.asset_manager.expects(:update_asset)
             .at_least_once

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -13,8 +13,8 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:attachment) { build(:file_attachment, attachable:, file:) }
     let(:attachable) { edition }
     let(:asset_id) { "asset-id" }
-    let(:redirect_path) { Whitehall.url_maker.public_document_path(edition) }
-    let(:redirect_url) { Whitehall.url_maker.public_document_url(edition) }
+    let(:redirect_path) { edition.public_path }
+    let(:redirect_url) { edition.public_url }
     let(:topic_taxon) { build(:taxon_hash) }
 
     before do

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -76,14 +76,4 @@ class RoutingLocaleTest < ActionDispatch::IntegrationTest
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.cy.json",
                  worldwide_organisation_path(worldwide_organisation, locale: "cy", format: "json")
   end
-
-  test "#show for a non-localised resource" do
-    topical_event = create(:topical_event)
-    assert_equal "/government/topical-events/#{topical_event.slug}", topical_event_path(topical_event)
-  end
-
-  test "#show for a non-localised resource with a format" do
-    topical_event = create(:topical_event)
-    assert_equal "/government/topical-events/#{topical_event.slug}.json", topical_event_path(topical_event, format: "json")
-  end
 end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -57,25 +57,25 @@ class RoutingTest < ActionDispatch::IntegrationTest
   test "redirects organisation groups index URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/groups"
-    assert_redirected_to organisation_path(organisation)
+    assert_redirected_to organisation.public_path
   end
 
   test "redirects organisation groups show URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/groups/some-group"
-    assert_redirected_to organisation_path(organisation)
+    assert_redirected_to organisation.public_path
   end
 
   test "redirects organisation chiefs-of-staff URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/chiefs-of-staff"
-    assert_redirected_to organisation_path(organisation)
+    assert_redirected_to organisation.public_path
   end
 
   test "redirects organisation consultations URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/consultations"
-    assert_redirected_to organisation_path(organisation)
+    assert_redirected_to organisation.public_path
   end
 
   test "redirects organisation series URL to publications page" do

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -18,7 +18,7 @@ class SchedulingTest < ActiveSupport::TestCase
 
   test "scheduling a first-edition publishes a publish intent" do
     Sidekiq::Testing.inline! do
-      path = Whitehall.url_maker.public_document_path(@submitted_edition)
+      path = @submitted_edition.public_path
       schedule(@submitted_edition)
       assert_publishing_api_put_intent(
         path,
@@ -44,7 +44,7 @@ class SchedulingTest < ActiveSupport::TestCase
         user = create(:user)
       end
 
-      path = Whitehall.url_maker.public_document_path(new_draft)
+      path = new_draft.public_path
 
       acting_as(user) { schedule(new_draft) }
 
@@ -60,8 +60,8 @@ class SchedulingTest < ActiveSupport::TestCase
         @submitted_edition.save!
       end
 
-      english_path = Whitehall.url_maker.public_document_path(@submitted_edition)
-      french_path  = Whitehall.url_maker.public_document_path(@submitted_edition, locale: :fr)
+      english_path = @submitted_edition.public_path
+      french_path  = @submitted_edition.public_path(locale: :fr)
       publish_time = @submitted_edition.scheduled_publication.as_json
 
       schedule(@submitted_edition)
@@ -77,7 +77,7 @@ class SchedulingTest < ActiveSupport::TestCase
       SecureRandom.stubs(uuid: gone_uuid)
       scheduled_edition = create(:scheduled_case_study)
       unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-      base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
+      base_path         = scheduled_edition.public_path
 
       destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
       unscheduler.perform!
@@ -92,7 +92,7 @@ class SchedulingTest < ActiveSupport::TestCase
       scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
 
       unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-      base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
+      base_path         = scheduled_edition.public_path
 
       destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
 

--- a/test/support/generic_edition.rb
+++ b/test/support/generic_edition.rb
@@ -10,14 +10,3 @@ class GenericEdition < Edition
     self.class.translatable
   end
 end
-
-module PublicDocumentRoutesHelper
-  def generic_edition_path(options = {})
-    "/government/generic-editions/#{options[:id].to_param}"
-  end
-
-  def generic_edition_url(options = {})
-    host = options[:host] || ""
-    host + generic_edition_path(options)
-  end
-end

--- a/test/unit/application_record_test.rb
+++ b/test/unit/application_record_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class ApplicationRecordTest < ActiveSupport::TestCase
+  test "append_url_options adds locale" do
+    assert_equal "/government/foo.cy", Edition.new.append_url_options("/government/foo", locale: "cy")
+  end
+
+  test "append_url_options adds format" do
+    assert_equal "/government/foo.atom", Edition.new.append_url_options("/government/foo", format: "atom")
+  end
+
+  test "append_url_options adds locale and format when both present" do
+    assert_equal "/government/foo.cy.atom", Edition.new.append_url_options("/government/foo", format: "atom", locale: "cy")
+  end
+
+  test "append_url_options adds cachebust string when present" do
+    assert_equal "/government/foo?cachebust=123", Edition.new.append_url_options("/government/foo", cachebust: "123")
+  end
+
+  test "append_url_options adds anchor string when present" do
+    assert_equal "/government/foo#heading", Edition.new.append_url_options("/government/foo", anchor: "heading")
+  end
+
+  test "append_url_options adds cachebust string, format, locale and anchor when all present" do
+    assert_equal "/government/foo.cy.atom?cachebust=123#heading", Edition.new.append_url_options("/government/foo", cachebust: "123", format: "atom", locale: "cy", anchor: "heading")
+  end
+end

--- a/test/unit/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/govspeak/admin_link_replacer_test.rb
@@ -4,7 +4,7 @@ module Govspeak
   class AdminLinkReplacerTest < ActiveSupport::TestCase
     test "rewrites admin links for published editions" do
       speech     = create(:published_speech)
-      public_url = Whitehall.url_maker.public_document_url(speech)
+      public_url = speech.public_url
       fragment   = govspeak_to_nokogiri_fragment("this and [that](/government/admin/speeches/#{speech.id}) yeah?")
 
       AdminLinkReplacer.new(fragment).replace!
@@ -26,7 +26,7 @@ module Govspeak
     test "rewrites admin links to published corporate information pages" do
       cip        = create(:published_corporate_information_page)
       admin_path = Whitehall.url_maker.polymorphic_path([:admin, cip.organisation, cip])
-      public_url = Whitehall.url_maker.public_document_url(cip)
+      public_url = cip.public_url
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to an [info page](#{admin_path})")
 
       AdminLinkReplacer.new(fragment).replace!
@@ -38,7 +38,7 @@ module Govspeak
       world_org  = create(:worldwide_organisation)
       cip        = create(:published_corporate_information_page, organisation: nil, worldwide_organisation: world_org)
       admin_path = Whitehall.url_maker.polymorphic_path([:admin, world_org, cip])
-      public_url = Whitehall.url_maker.public_document_url(cip)
+      public_url = cip.public_url
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to a [world info page](#{admin_path})")
 
       AdminLinkReplacer.new(fragment).replace!

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -65,7 +65,7 @@ class GovspeakHelperTest < ActionView::TestCase
   test "should rewrite admin links for editions" do
     speech = create(:published_speech)
     admin_path = admin_speech_path(speech)
-    public_url = Whitehall.url_maker.public_document_url(speech)
+    public_url = speech.public_url
 
     govspeak = "this and [that](#{admin_path}) yeah?"
     html = govspeak_to_html(govspeak)

--- a/test/unit/helpers/localised_url_path_helper_test.rb
+++ b/test/unit/helpers/localised_url_path_helper_test.rb
@@ -1,14 +1,6 @@
 require "test_helper"
 
 class LocalisedUrlPathHelperTest < ActiveSupport::TestCase
-  test "should call original news_article_path with locale set" do
-    controller = FakeController.new(locale: "fr")
-    object = stub("news article")
-    object.stubs(:available_in_locale?).with("fr").returns(true)
-    controller.expects(:news_article_path_was_called).with(object, { locale: "fr" })
-    controller.news_article_path(object)
-  end
-
   test "should not generate paths including locale with en locale set" do
     controller = FakeController.new(locale: "en")
     object = stub("news article")
@@ -32,23 +24,6 @@ class LocalisedUrlPathHelperTest < ActiveSupport::TestCase
     object.stubs(:available_in_locale?).with("fr").returns(true)
     controller.expects(:worldwide_organisation_corporate_information_page_path_was_called).with(parent, object, { locale: "fr" })
     controller.worldwide_organisation_corporate_information_page_path(parent, object)
-  end
-
-  test "if locale is not provided to path helper, and it is not set in params, should fall back to I18n.locale" do
-    controller = FakeController.new
-    object = stub("news article")
-
-    object.expects(:available_in_locale?).with(:fr).returns(true)
-    I18n.with_locale :fr do
-      controller.expects(:news_article_path_was_called).with(object, { locale: :fr })
-      controller.news_article_path(object)
-    end
-
-    object.expects(:available_in_locale?).never
-    I18n.with_locale :en do
-      controller.expects(:news_article_path_was_called).with(object, {})
-      controller.news_article_path(object)
-    end
   end
 
   module FakeRouting

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -3,39 +3,39 @@ require "test_helper"
 class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
   test "uses the document to generate the route" do
     publication = create(:publication)
-    assert_equal publication_path(publication.document), public_document_path(publication)
+    assert_equal publication.public_path, public_document_path(publication)
   end
 
   test "respects additional path options" do
     publication = create(:publication)
-    assert_equal publication_path(publication.document, anchor: "additional"), public_document_path(publication, anchor: "additional")
+    assert_equal publication.public_path(anchor: "additional"), public_document_path(publication, anchor: "additional")
   end
 
-  test "returns the publication_path for Publication instances" do
+  test "returns the public_path for Publication instances" do
     publication = create(:publication)
-    assert_equal publication_path(publication.document), public_document_path(publication)
+    assert_equal publication.public_path, public_document_path(publication)
   end
 
-  test "returns the news_article_path for NewsArticle instances" do
+  test "returns the public_path for NewsArticle instances" do
     news_article = create(:news_article)
-    assert_equal news_article_path(news_article.document), public_document_path(news_article)
+    assert_equal news_article.public_path, public_document_path(news_article)
   end
 
-  test "returns the statistic_path for Publications which are Statistics or NationalStatistics" do
+  test "returns the public_path for Publications which are Statistics or NationalStatistics" do
     statistics = create(:publication, :statistics)
-    assert_equal statistic_path(statistics.document), public_document_path(statistics)
+    assert_equal statistics.public_path, public_document_path(statistics)
     national_statistics = create(:publication, :national_statistics)
-    assert_equal statistic_path(national_statistics.document), public_document_path(national_statistics)
+    assert_equal national_statistics.public_path, public_document_path(national_statistics)
   end
 
-  test "returns the speech_path for Speech instances" do
+  test "returns the public_path for Speech instances" do
     speech = create(:speech)
-    assert_equal speech_path(speech.document), public_document_path(speech)
+    assert_equal speech.public_path, public_document_path(speech)
   end
 
-  test "returns the consultation_path for Consultation instances" do
+  test "returns the public_path for Consultation instances" do
     consultation = create(:consultation)
-    assert_equal consultation_path(consultation.document), public_document_path(consultation)
+    assert_equal consultation.public_path, public_document_path(consultation)
   end
 
   test "returns the statistical_data_set_path for StatisticalDataSet instances" do
@@ -73,37 +73,35 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
     assert_equal "/world/organisations/#{org.slug}.fr", public_document_path(cip, locale: :fr)
   end
 
-  test "returns the document URL using Whitehall public_host and protocol" do
-    Whitehall.stubs(public_host: "some.host")
-    Whitehall.stubs(public_protocol: "http")
+  test "returns the document URL always using the correct public site URL and protocol" do
     edition = create(:published_publication)
     uri = Addressable::URI.parse(public_document_url(edition))
-    assert_equal "some.host", uri.host
-    assert_equal "http", uri.scheme
+    assert_equal "www.test.gov.uk", uri.host
+    assert_equal "https", uri.scheme
     assert_equal public_document_path(edition), uri.path
   end
 
   test "generates an appropriate path for non-English editions" do
     publication = create(:publication, primary_locale: "fr")
-    assert_equal publication_path(publication.document, locale: "fr"), public_document_path(publication)
+    assert_equal publication.public_path(locale: "fr"), public_document_path(publication)
   end
 
   test "generates an appropriate url for non-English editions" do
     publication = create(:publication, primary_locale: "fr")
-    assert_equal Whitehall.url_maker.publication_url(publication.document, locale: "fr"), public_document_url(publication)
+    assert_equal publication.public_url(locale: "fr"), public_document_url(publication)
   end
 
   test "When in a foreign locale, it generates a route to the foreign version if available" do
     publication = create(:publication, :translated, translated_into: [:fr])
     I18n.with_locale(:fr) do
-      assert_equal Whitehall.url_maker.publication_url(publication.document, locale: "fr"), public_document_url(publication)
+      assert_equal publication.public_url(locale: "fr"), public_document_url(publication)
     end
   end
 
   test "When in a foreign locale, it generates a route to the english version if no foreign version is available" do
     publication = create(:publication)
     I18n.with_locale(:fr) do
-      assert_equal Whitehall.url_maker.publication_url(publication.document, locale: "en"), public_document_url(publication)
+      assert_equal publication.public_url, public_document_url(publication)
     end
   end
 
@@ -122,237 +120,19 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
   test "Creates a preview URL with cachebust and edition parameters" do
     edition = create(:corporate_information_page)
     preview_url = preview_document_url(edition)
-    assert_equal "http://draft-origin.test.gov.uk/government/organisations/#{edition.organisation.slug}/about/publication-scheme", preview_url
+    assert_equal "https://draft-origin.test.gov.uk/government/organisations/#{edition.organisation.slug}/about/publication-scheme", preview_url
   end
 
   test "Creates a preview URL without parameters for edition formats that have migrated" do
     edition = create(:draft_case_study)
     preview_url = preview_document_url(edition)
-    assert_equal "http://draft-origin.test.gov.uk/government/case-studies/#{edition.slug}", preview_url
+    assert_equal "https://draft-origin.test.gov.uk/government/case-studies/#{edition.slug}", preview_url
   end
 
   test "Creates a preview URL with auth bypass token" do
     edition = create(:draft_case_study)
     token = edition.auth_bypass_token
     preview_url_with_auth_bypass_token = preview_document_url_with_auth_bypass_token(edition)
-    assert_equal "http://draft-origin.test.gov.uk/government/case-studies/case-study-title?token=#{token}&utm_campaign=govuk_publishing&utm_medium=preview&utm_source=share", preview_url_with_auth_bypass_token
-  end
-
-  test "organisations have the correct path generated" do
-    org = create(:organisation)
-
-    assert_equal "/government/organisations/#{org.slug}", organisation_path(org)
-    assert_equal "http://test.host/government/organisations/#{org.slug}", organisation_url(org)
-  end
-
-  test "courts have the correct path generated" do
-    court = create(:court)
-
-    assert_equal "/courts-tribunals/#{court.slug}", organisation_path(court)
-    assert_equal "http://test.host/courts-tribunals/#{court.slug}", organisation_url(court)
-  end
-
-  test "HMCTS tribunals have the correct path generated" do
-    tribunal = create(:hmcts_tribunal)
-
-    assert_equal "/courts-tribunals/#{tribunal.slug}", organisation_path(tribunal)
-    assert_equal "http://test.host/courts-tribunals/#{tribunal.slug}", organisation_url(tribunal)
-  end
-
-  test "organisation_path still works with slugs" do
-    court = create(:court)
-    org = create(:organisation)
-
-    assert_equal "/courts-tribunals/#{court.slug}", organisation_path(court.slug)
-    assert_equal "/government/organisations/#{org.slug}", organisation_path(org.slug)
-  end
-
-  test "organisation_path naively uses the slug in the path if the organisation is missing" do
-    assert_equal "/government/organisations/foobar", organisation_path("foobar")
-    assert_equal "http://test.host/government/organisations/foobar", organisation_url("foobar")
-  end
-
-  test "append_url_options adds locale" do
-    assert_equal "/government/foo.cy", append_url_options("/government/foo", locale: "cy")
-  end
-
-  test "append_url_options adds format" do
-    assert_equal "/government/foo.atom", append_url_options("/government/foo", format: "atom")
-  end
-
-  test "append_url_options adds locale and format when both present" do
-    assert_equal "/government/foo.cy.atom", append_url_options("/government/foo", format: "atom", locale: "cy")
-  end
-
-  test "append_url_options adds cachebust string when present" do
-    assert_equal "/government/foo?cachebust=123", append_url_options("/government/foo", cachebust: "123")
-  end
-
-  test "append_url_options adds cachebust string, format and locale when all present" do
-    assert_equal "/government/foo.cy.atom?cachebust=123", append_url_options("/government/foo", cachebust: "123", format: "atom", locale: "cy")
-  end
-
-  test "get_involved_path returns the path" do
-    assert_equal "/government/get-involved", get_involved_path
-  end
-
-  test "get_involved_url returns the url" do
-    assert_equal "https://www.test.gov.uk/government/get-involved", get_involved_url
-  end
-
-  test "get_involved_path returns the path and appends options" do
-    assert_equal "/government/get-involved?cachebust=123", get_involved_path(cachebust: "123")
-  end
-
-  test "get_involved_url returns the url and appends options" do
-    assert_equal "https://www.test.gov.uk/government/get-involved?cachebust=123", get_involved_url(cachebust: "123")
-  end
-
-  test "take_part_page_path returns the correct path for a slug" do
-    assert_equal "/government/get-involved/take-part/foo", take_part_page_path("foo")
-  end
-
-  test "take_part_page_path returns the correct path for a slug with options" do
-    assert_equal "/government/get-involved/take-part/foo?cachebust=123", take_part_page_path("foo", cachebust: "123")
-  end
-
-  test "take_part_page_path returns the correct path for a TakePart object" do
-    object = create(:take_part_page, slug: "foo")
-    assert_equal "/government/get-involved/take-part/foo", take_part_page_path(object)
-  end
-
-  test "take_part_page_path returns the correct path for a TakePart object with options" do
-    object = create(:take_part_page, slug: "foo")
-    assert_equal "/government/get-involved/take-part/foo?cachebust=123", take_part_page_path(object, cachebust: "123")
-  end
-
-  test "take_part_page_url returns the correct path for a slug" do
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", take_part_page_url("foo")
-  end
-
-  test "take_part_page_url returns the correct path for a slug with options" do
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", take_part_page_url("foo", cachebust: "123")
-  end
-
-  test "take_part_page_url returns the correct path for a TakePart object" do
-    object = create(:take_part_page, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", take_part_page_url(object)
-  end
-
-  test "take_part_page_url returns the correct path for a TakePart object with options" do
-    object = create(:take_part_page, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", take_part_page_url(object, cachebust: "123")
-  end
-
-  test "topical_event_path returns the correct path for a TopicalEvent object" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo", topical_event_path(object)
-  end
-
-  test "topical_event_path returns the correct path for a TopicalEvent object with options" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo?cachebust=123", topical_event_path(object, cachebust: "123")
-  end
-
-  test "topical_event_url returns the correct path for a slug" do
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo", topical_event_url("foo")
-  end
-
-  test "topical_event_url returns the correct path for a slug with options" do
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", topical_event_url("foo", cachebust: "123")
-  end
-
-  test "topical_event_url returns the correct path for a TopicalEvent object" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo", topical_event_url(object)
-  end
-
-  test "topical_event_url returns the correct path for a TopicalEvent object with options" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", topical_event_url(object, cachebust: "123")
-  end
-
-  test "topical_event_about_pages_path returns the correct path for a TopicalEvent object" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo/about", topical_event_about_pages_path(object)
-  end
-
-  test "topical_event_about_pages_path returns the correct path for a TopicalEventAboutPage object" do
-    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
-    assert_equal "/government/topical-events/foo/about", topical_event_about_pages_path(object.topical_event_about_page)
-  end
-
-  test "topical_event_about_pages_path returns the correct path for a TopicalEvent object with options" do
-    object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo/about?cachebust=123", topical_event_about_pages_path(object, cachebust: "123")
-  end
-
-  test "topical_event_about_pages_path returns the correct path for a TopicalEventAboutPage object with options" do
-    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
-    assert_equal "/government/topical-events/foo/about?cachebust=123", topical_event_about_pages_path(object.topical_event_about_page, cachebust: "123")
-  end
-
-  test "world_location_path returns the correct path for a slug" do
-    assert_equal "/world/foo", world_location_path("foo")
-  end
-
-  test "world_location_path returns the correct path for a slug with options" do
-    assert_equal "/world/foo?cachebust=123", world_location_path("foo", cachebust: "123")
-  end
-
-  test "world_location_path returns the correct path for a WorldLocation object" do
-    object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo", world_location_path(object)
-  end
-
-  test "world_location_path returns the correct path for a WorldLocation object with options" do
-    object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo?cachebust=123", world_location_path(object, cachebust: "123")
-  end
-
-  test "world_location_path returns the correct path for a WorldLocationNews object" do
-    object = create(:world_location_news, world_location: build(:world_location, slug: "foo"))
-    assert_equal "/world/foo", world_location_path(object)
-  end
-
-  test "world_location_path returns the correct path for a WorldLocationNews object with options" do
-    object = create(:world_location_news, world_location: build(:world_location, slug: "foo"))
-    assert_equal "/world/foo?cachebust=123", world_location_path(object, cachebust: "123")
-  end
-
-  test "world_location_url returns the url and appends options" do
-    assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", world_location_url("foo", cachebust: "123")
-  end
-
-  test "world_location_news_index_path returns the correct path for a slug" do
-    assert_equal "/world/foo/news", world_location_news_index_path("foo")
-  end
-
-  test "world_location_news_index_path returns the correct path for a slug with options" do
-    assert_equal "/world/foo/news?cachebust=123", world_location_news_index_path("foo", cachebust: "123")
-  end
-
-  test "world_location_news_index_path returns the correct path for a WorldLocation object" do
-    object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo/news", world_location_news_index_path(object)
-  end
-
-  test "world_location_news_index_path returns the correct path for a WorldLocation object with options" do
-    object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo/news?cachebust=123", world_location_news_index_path(object, cachebust: "123")
-  end
-
-  test "world_location_news_index_path returns the correct path for a WorldLocationNews object" do
-    object = create(:world_location_news, world_location: build(:world_location, slug: "foo"))
-    assert_equal "/world/foo/news", world_location_news_index_path(object)
-  end
-
-  test "world_location_news_index_path returns the correct path for a WorldLocationNews object with options" do
-    object = create(:world_location_news, world_location: build(:world_location, slug: "foo"))
-    assert_equal "/world/foo/news?cachebust=123", world_location_news_index_path(object, cachebust: "123")
-  end
-
-  test "world_location_news_index_url returns the url and appends options" do
-    assert_equal "https://www.test.gov.uk/world/foo/news?cachebust=123", world_location_news_index_url("foo", cachebust: "123")
+    assert_equal "https://draft-origin.test.gov.uk/government/case-studies/case-study-title?token=#{token}&utm_campaign=govuk_publishing&utm_medium=preview&utm_source=share", preview_url_with_auth_bypass_token
   end
 end

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -25,4 +25,9 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
   test "corporate information pages cannot be previously published" do
     assert_not build(:corporate_information_page).previously_published
   end
+
+  test "base path is nil when neither organisation or worldwide organisation is present" do
+    corporate_information_page = create(:corporate_information_page, organisation: nil, worldwide_organisation: nil)
+    assert_nil corporate_information_page.base_path
+  end
 end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1104,4 +1104,25 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal 4, promotional_feature2.reload.ordering
     assert_equal 5, promotional_feature1.reload.ordering
   end
+
+  test "organisations have the correct path generated" do
+    org = create(:organisation)
+
+    assert_equal "/government/organisations/#{org.slug}", org.public_path
+    assert_equal "https://www.test.gov.uk/government/organisations/#{org.slug}", org.public_url
+  end
+
+  test "courts have the correct path generated" do
+    court = create(:court)
+
+    assert_equal "/courts-tribunals/#{court.slug}", court.public_path
+    assert_equal "https://www.test.gov.uk/courts-tribunals/#{court.slug}", court.public_url
+  end
+
+  test "HMCTS tribunals have the correct path generated" do
+    tribunal = create(:hmcts_tribunal)
+
+    assert_equal "/courts-tribunals/#{tribunal.slug}", tribunal.public_path
+    assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url
+  end
 end

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -68,7 +68,7 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url as web_url" do
-    assert_equal Whitehall.url_maker.world_location_url(@location), @presenter.as_json[:web_url]
+    assert_equal @location.public_url, @presenter.as_json[:web_url]
   end
 
   test "json includes request-relative api organisations url as organisations id" do
@@ -76,6 +76,6 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url (anchored on organisations) organisations web_url" do
-    assert_equal Whitehall.url_maker.world_location_url(@location, anchor: "organisations"), @presenter.as_json[:organisations][:web_url]
+    assert_equal @location.public_url(anchor: "organisations"), @presenter.as_json[:organisations][:web_url]
   end
 end

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -87,7 +87,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public organisations url for sponsor in sponsors array as web_url" do
-    assert_equal Whitehall.url_maker.organisation_url(@main_sponsor), @presenter.as_json[:sponsors].first[:web_url]
+    assert_equal @main_sponsor.public_url, @presenter.as_json[:sponsors].first[:web_url]
   end
 
   test "json includes office contact title in offices as title" do

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -78,7 +78,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
     expected_whitehall_admin_links = [{
       whitehall_admin_url: "/government/admin/news/2",
-      public_url: "www.test.gov.uk/government/generic-editions/some-article",
+      public_url: "https://www.test.gov.uk/government/generic-editions/some-article",
       content_id: linked_edition.content_id,
     }]
 
@@ -99,7 +99,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
     expected_whitehall_admin_links = [{
       whitehall_admin_url: "/government/admin/news/2",
-      public_url: "www.test.gov.uk/government/generic-editions/some-article",
+      public_url: "https://www.test.gov.uk/government/generic-editions/some-article",
       content_id: linked_edition.content_id,
     }]
 

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -8,7 +8,7 @@ class FeaturePresenterTest < PresenterTestCase
     f = stub_record(:feature, topical_event: te, document: nil)
     fp = FeaturePresenter.new(f)
 
-    assert_equal topical_event_path(te), fp.public_path
+    assert_equal te.public_path, fp.public_path
   end
 
   test "#public_path doesn't localize links to topical events" do
@@ -17,7 +17,7 @@ class FeaturePresenterTest < PresenterTestCase
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
 
-    assert_equal topical_event_path(te), fp.public_path
+    assert_equal te.public_path, fp.public_path
   end
 
   test "#public_path generates a localized link to the edition" do
@@ -28,7 +28,7 @@ class FeaturePresenterTest < PresenterTestCase
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
 
-    assert_equal case_study_path(d.slug, locale: "ar"), fp.public_path
+    assert_equal cs.public_path(locale: "ar"), fp.public_path
   end
 
   test "#public_path generates an unlocalized link to the edition if it's not a localizable type" do
@@ -39,7 +39,7 @@ class FeaturePresenterTest < PresenterTestCase
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
 
-    assert_equal consultation_path(d.slug), fp.public_path
+    assert_equal p.public_path, fp.public_path
   end
 
   test "#public_path respects the locale of the feature when generating localized edition links" do
@@ -51,7 +51,7 @@ class FeaturePresenterTest < PresenterTestCase
     fp = FeaturePresenter.new(f)
 
     ::I18n.with_locale "fr" do
-      assert_equal case_study_path(d.slug, locale: "ar"), fp.public_path
+      assert_equal cs.public_path(locale: "ar"), fp.public_path
     end
   end
 
@@ -64,7 +64,7 @@ class FeaturePresenterTest < PresenterTestCase
     fp = FeaturePresenter.new(f)
 
     ::I18n.with_locale "fr" do
-      assert_equal consultation_path(d.slug), fp.public_path
+      assert_equal p.public_path, fp.public_path
       assert_no_match(/locale=fr/, fp.public_path)
       assert_no_match(/\.fr/, fp.public_path)
     end

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       summary: "The summary",
       body: "Some content",
     )
-    public_path = Whitehall.url_maker.public_document_path(case_study)
+    public_path = case_study.public_path
     expected_content = {
       base_path: public_path,
       title: "Case study title",

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -37,7 +37,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     detailed_guide.topical_event_memberships.create!(topical_event_id: topical_event.id)
 
-    public_path = Whitehall.url_maker.public_document_path(detailed_guide)
+    public_path = detailed_guide.public_path
     expected_content = {
       base_path: public_path,
       title: "Some detailed guide",

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -32,7 +32,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the base_path" do
-    assert_equal "/government/fatalities/fatality-notice-title", @presented_content[:base_path]
+    assert_equal "/government/fatalities/fatality-notice-title.de", @presented_content[:base_path]
   end
 
   test "it presents updated_at if public_timestamp is nil" do

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -18,7 +18,7 @@ module PublishingApi
         secondary_specialist_sector_tags: ["oil-and-gas/licensing"],
       )
 
-      public_path = Whitehall.url_maker.public_document_path(edition)
+      public_path = edition.public_path
 
       expected_hash = {
         base_path: public_path,

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -312,4 +312,33 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
 
     assert organisation_political
   end
+
+  test "presents the correct routes for an organisation with a translation" do
+    organisation = create(
+      :organisation,
+      translated_into: %i[en cy],
+    )
+
+    I18n.with_locale(:en) do
+      presented_item = present(organisation)
+
+      assert_equal organisation.base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: organisation.base_path, type: "exact" },
+        { path: "#{organisation.base_path}.atom", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
+    I18n.with_locale(:cy) do
+      presented_item = present(organisation)
+
+      assert_equal "#{organisation.base_path}.cy", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{organisation.base_path}.cy", type: "exact" },
+        { path: "#{organisation.base_path}.cy.atom", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -37,7 +37,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     minister = create(:person)
     create(:ministerial_role_appointment, role:, person: minister)
 
-    public_path = Whitehall.url_maker.organisation_path(organisation)
+    public_path = organisation.public_path
     public_atom_path = "#{public_path}.atom"
 
     expected_hash = {

--- a/test/unit/presenters/publishing_api/payload_builder/public_document_path_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/public_document_path_test.rb
@@ -3,18 +3,16 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class PublicDocumentPathTest < ActiveSupport::TestCase
-      test "returns political details for the item" do
-        dummy_item = Object.new
-        Whitehall.url_maker.expects(:public_document_path)
-          .with(dummy_item, locale: I18n.locale)
-          .returns("/government/pub/doc/path")
+      test "returns path for the document" do
+        document = create(:document, slug: "some-news")
+        edition = create(:edition, document:)
 
         expected_hash = {
-          base_path: "/government/pub/doc/path",
-          routes: [{ path: "/government/pub/doc/path", type: "exact" }],
+          base_path: "/government/generic-editions/some-news",
+          routes: [{ path: "/government/generic-editions/some-news", type: "exact" }],
         }
 
-        assert_equal PublicDocumentPath.for(dummy_item), expected_hash
+        assert_equal PublicDocumentPath.for(edition), expected_hash
       end
     end
   end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       statistical_data_sets: [statistical_data_set],
     )
 
-    public_path = Whitehall.url_maker.public_document_path(publication)
+    public_path = publication.public_path
     expected_content = {
       base_path: public_path,
       title: "Publication title",

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -7,7 +7,7 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
 
   test "presents a Services and Information page ready for adding to the publishing API" do
     organisation = create(:organisation, name: "Organisation of Things")
-    public_path = "#{Whitehall.url_maker.organisation_path(organisation)}/services-information"
+    public_path = "#{organisation.public_path}/services-information"
 
     expected_hash = {
       base_path: public_path,

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -31,7 +31,7 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the base_path" do
-    assert_equal "/government/statistical-data-sets/statistical-data-set-title", @presented_content[:base_path]
+    assert_equal "/government/statistical-data-sets/statistical-data-set-title.de", @presented_content[:base_path]
   end
 
   test "it presents updated_at if public_timestamp is nil" do

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -11,7 +11,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
     image_url = take_part_page.image_url(:s300)
 
     expected_hash = {
-      base_path: take_part_page.search_link,
+      base_path: "/government/get-involved/take-part/#{take_part_page.slug}",
       title: "A take part page title",
       description: "Summary text",
       schema_name: "take_part",
@@ -21,7 +21,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
       publishing_app: "whitehall",
       rendering_app: "government-frontend",
       routes: [
-        { path: take_part_page.search_link, type: "exact" },
+        { path: "/government/get-involved/take-part/#{take_part_page.slug}", type: "exact" },
       ],
       redirects: [],
       details: {

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -9,7 +9,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
     let(:edition) { FactoryBot.create(:published_edition) }
-    let(:parent_document_url) { Whitehall.url_maker.public_document_url(edition) }
+    let(:parent_document_url) { edition.public_url }
     let(:update_worker) { mock("asset-manager-update-worker") }
 
     around do |test|

--- a/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
@@ -9,7 +9,7 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
     let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
-    let(:redirect_url) { Whitehall.url_maker.public_document_url(unpublished_edition) }
+    let(:redirect_url) { unpublished_edition.public_url }
     let(:unpublished) { true }
     let(:update_worker) { mock("asset-manager-update-asset-worker") }
 

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -53,7 +53,7 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
 
   test "converts a Whitehall admin URL to its public URL" do
     speech = create(:published_speech)
-    expected_url = Whitehall.url_maker.public_document_url(speech)
+    expected_url = speech.public_url
 
     edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
 
@@ -68,7 +68,7 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
 
   test "doesn't check the links of unpublished Whitehall admin URLs" do
     speech = create(:draft_speech)
-    expected_url = Whitehall.url_maker.public_document_url(speech)
+    expected_url = speech.public_url
 
     edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
 

--- a/test/unit/services/link_reporter_csv_service_test.rb
+++ b/test/unit/services/link_reporter_csv_service_test.rb
@@ -36,11 +36,11 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     detailed_guide = create(
       :published_detailed_guide,
       lead_organisations: [hmrc],
-      body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good](https://www.test.gov.uk/good-link)\n[broken link](https://www.test.gov.uk/bad-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/bad-link", status: "broken")
     create(:link_checker_api_report_completed, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link])
 
     LinkReporterCsvService.new(reports_dir:, organisation: hmrc).generate
@@ -58,19 +58,19 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     detailed_guide = create(
       :published_detailed_guide,
       lead_organisations: [hmrc],
-      body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good](https://www.test.gov.uk/good-link)\n[broken link](https://www.test.gov.uk/bad-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
     publication = create(
       :published_publication,
       lead_organisations: [hmrc],
-      body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)",
+      body: "[A broken page](https://www.test.gov.uk/another-bad-link)\n[A good link](https://www.test.gov.uk/another-good-link)",
     )
 
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
-    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
-    another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/bad-link", status: "broken")
+    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
+    another_good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-good-link", status: "ok")
 
     create(:link_checker_api_report_completed, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link])
     create(:link_checker_api_report_completed, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link])
@@ -78,19 +78,19 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     LinkReporterCsvService.new(reports_dir:, organisation: hmrc).generate
     hmrc_csv = CSV.read(reports_dir_pathname.join("hm-revenue-customs_links_report.csv"))
     assert_equal 3, hmrc_csv.size
-    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+    assert_equal [detailed_guide.public_url,
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
                   detailed_guide.public_timestamp.to_s,
                   "DetailedGuide",
                   "2",
-                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"],
+                  "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
-    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+    assert_equal [publication.public_url,
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
                   publication.public_timestamp.to_s,
                   "Publication",
                   "1",
-                  "https://www.gov.uk/another-bad-link"],
+                  "https://www.test.gov.uk/another-bad-link"],
                  hmrc_csv[2]
   end
 
@@ -100,25 +100,25 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     detailed_guide = create(
       :published_detailed_guide,
       lead_organisations: [hmrc],
-      body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good](https://www.test.gov.uk/good-link)\n[broken link](https://www.test.gov.uk/bad-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
     publication = create(
       :published_publication,
       lead_organisations: [hmrc],
-      body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)",
+      body: "[A broken page](https://www.test.gov.uk/another-bad-link)\n[A good link](https://www.test.gov.uk/another-good-link)",
     )
     news_article = create(
       :news_article_world_news_story,
       :withdrawn,
       worldwide_organisations: [embassy_paris],
-      body: "[Good link](https://www.gov.uk/good-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good link](https://www.test.gov.uk/good-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
 
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
-    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
-    another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/bad-link", status: "broken")
+    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
+    another_good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-good-link", status: "ok")
 
     create(:link_checker_api_report, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link], status: "completed")
     create(:link_checker_api_report, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link], status: "completed")
@@ -135,31 +135,31 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     detailed_guide = create(
       :published_detailed_guide,
       lead_organisations: [hmrc],
-      body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good](https://www.test.gov.uk/good-link)\n[broken link](https://www.test.gov.uk/bad-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
     publication = create(
       :published_publication,
       lead_organisations: [hmrc],
-      body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)",
+      body: "[A broken page](https://www.test.gov.uk/another-bad-link)\n[A good link](https://www.test.gov.uk/another-good-link)",
     )
 
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
 
     create(:link_checker_api_report_completed, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link])
 
     LinkReporterCsvService.new(reports_dir:, organisation: hmrc).generate
     hmrc_csv = CSV.read(reports_dir_pathname.join("hm-revenue-customs_links_report.csv"))
     assert_equal 2, hmrc_csv.size
-    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+    assert_equal ["https://www.test.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
                   detailed_guide.public_timestamp.to_s,
                   "DetailedGuide",
                   "2",
-                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"],
+                  "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
-    assert_not_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+    assert_not_equal [publication.public_url,
                       "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
                       publication.public_timestamp.to_s,
                       "Publication",
@@ -172,12 +172,12 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     speech = create(
       :published_speech,
       person_override: "The Queen",
-      body: "[Good link](https://www.gov.uk/good-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good link](https://www.test.gov.uk/good-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
       role_appointment: nil,
       create_default_organisation: false,
     )
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
 
     create(:link_checker_api_report_completed, batch_id: 1, link_reportable: speech, links: [missing_link, good_link])
 
@@ -189,12 +189,12 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     assert File.exist?(csv_test_file_path)
     assert_equal 2, csv.size
     assert_equal ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"], csv[0]
-    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.speech_path(speech.slug)}",
+    assert_equal [speech.public_url,
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
                   speech.public_timestamp.to_s,
                   "Speech",
                   "1",
-                  "https://www.gov.uk/missing-link"],
+                  "https://www.test.gov.uk/missing-link"],
                  csv[1]
   end
 
@@ -205,19 +205,19 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     detailed_guide = create(
       :published_detailed_guide,
       lead_organisations: [hmrc],
-      body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)",
+      body: "[Good](https://www.test.gov.uk/good-link)\n[broken link](https://www.test.gov.uk/bad-link)\n[Missing page](https://www.test.gov.uk/missing-link)",
     )
     publication = create(
       :published_publication,
       lead_organisations: [not_hmrc],
-      body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)",
+      body: "[A broken page](https://www.test.gov.uk/another-bad-link)\n[A good link](https://www.test.gov.uk/another-good-link)",
     )
 
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
-    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
-    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
-    another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/bad-link", status: "broken")
+    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/good-link", status: "ok")
+    another_good_link = create(:link_checker_api_report_link, uri: "https://www.test.gov.uk/another-good-link", status: "ok")
 
     create(:link_checker_api_report, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link], status: "completed")
     create(:link_checker_api_report, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link], status: "completed")

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -33,7 +33,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
 
   test "when unpublished, it cannot redirect to itself" do
     announcement = build(:unpublished_statistics_announcement, slug: "dummy")
-    announcement.redirect_url = announcement.public_path
+    announcement.redirect_url = announcement.base_path
     assert_not announcement.valid?
 
     assert_match %r{cannot redirect to itself}, announcement.errors[:redirect_url].first
@@ -54,7 +54,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     expected_indexed_content = {
       "content_id" => announcement.content_id,
       "title" => announcement.title,
-      "link" => announcement.public_path,
+      "link" => announcement.base_path,
       "format" => "statistics_announcement",
       "description" => announcement.summary,
       "organisations" => announcement.organisations.map(&:slug),

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -198,5 +198,25 @@ class TakePartPageTest < ActiveSupport::TestCase
     )
   end
 
+  test "public_path returns the correct path" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "/government/get-involved/take-part/foo", object.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "/government/get-involved/take-part/foo?cachebust=123", object.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path for a TakePart object" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", object.public_url
+  end
+
+  test "public_url returns the correct path for a TakePart object with options" do
+    object = create(:take_part_page, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", object.public_url(cachebust: "123")
+  end
+
   should_not_accept_footnotes_in :body
 end

--- a/test/unit/topical_event_about_page_test.rb
+++ b/test/unit/topical_event_about_page_test.rb
@@ -8,5 +8,20 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
     assert_equal "/government/topical-events/#{event.slug}/about", page.search_index["link"]
   end
 
+  test "public_path returns the correct path" do
+    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
+    assert_equal "/government/topical-events/foo/about", object.topical_event_about_page.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
+    assert_equal "/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path with options" do
+    object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_url(cachebust: "123")
+  end
+
   should_not_accept_footnotes_in :body
 end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -234,4 +234,24 @@ class TopicalEventTest < ActiveSupport::TestCase
 
     topical_event.save!
   end
+
+  test "public_path returns the correct path" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo", object.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "/government/topical-events/foo?cachebust=123", object.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo", object.public_url
+  end
+
+  test "public_url returns the correct path with options" do
+    object = create(:topical_event, slug: "foo")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", object.public_url(cachebust: "123")
+  end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -152,7 +152,7 @@ class UnpublishingTest < ActiveSupport::TestCase
 
   test "#document_path returns the URL path for the unpublished edition" do
     edition = create(:detailed_guide, :draft)
-    original_path = Whitehall.url_maker.public_document_path(edition)
+    original_path = edition.public_path
     unpublishing = create(
       :unpublishing,
       edition:,
@@ -176,7 +176,7 @@ class UnpublishingTest < ActiveSupport::TestCase
 
   test "#document_url returns the URL for the unpublished edition" do
     edition = create(:detailed_guide, :draft)
-    original_url = Whitehall.url_maker.public_document_url(edition)
+    original_url = edition.public_url
     unpublishing = create(
       :unpublishing,
       edition:,

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -199,8 +199,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       edition.save!
     end
 
-    english_path = Whitehall.url_maker.public_document_path(edition)
-    french_path  = Whitehall.url_maker.public_document_path(edition, locale: :fr)
+    english_path = edition.public_path
+    french_path  = edition.public_path(locale: :fr)
 
     Whitehall::PublishingApi.schedule_async(edition)
 
@@ -224,8 +224,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       updated_edition.save!
     end
 
-    english_path = Whitehall.url_maker.public_document_path(updated_edition)
-    spanish_path = Whitehall.url_maker.public_document_path(updated_edition, locale: :es)
+    english_path = updated_edition.public_path
+    spanish_path = updated_edition.public_path(locale: :es)
 
     Whitehall::PublishingApi.schedule_async(updated_edition)
 
@@ -247,8 +247,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       edition.save!(validate: false)
     end
 
-    english_path = Whitehall.url_maker.public_document_path(edition)
-    german_path = Whitehall.url_maker.public_document_path(edition, locale: :de)
+    english_path = edition.public_path
+    german_path = edition.public_path(locale: :de)
 
     Whitehall::PublishingApi.unschedule_async(edition)
 
@@ -265,8 +265,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       updated_edition.save!(validate: false)
     end
 
-    english_path = Whitehall.url_maker.public_document_path(updated_edition)
-    german_path = Whitehall.url_maker.public_document_path(updated_edition, locale: :de)
+    english_path = updated_edition.public_path
+    german_path = updated_edition.public_path(locale: :de)
 
     Whitehall::PublishingApi.unschedule_async(updated_edition)
 

--- a/test/unit/world_location_news_test.rb
+++ b/test/unit/world_location_news_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class WorldLocationNewsTest < ActiveSupport::TestCase
+  test "public_path returns the correct path" do
+    world_location = build(:world_location, slug: "foo")
+    world_location_news = create(:world_location_news, world_location:)
+    assert_equal "/world/foo/news", world_location_news.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    world_location = build(:world_location, slug: "foo")
+    world_location_news = create(:world_location_news, world_location:)
+    assert_equal "/world/foo/news?cachebust=123", world_location_news.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path" do
+    world_location = build(:world_location, slug: "foo")
+    world_location_news = create(:world_location_news, world_location:)
+    assert_equal "https://www.test.gov.uk/world/foo/news", world_location_news.public_url
+  end
+
+  test "public_url returns the correct path with options" do
+    world_location = build(:world_location, slug: "foo")
+    world_location_news = create(:world_location_news, world_location:)
+    assert_equal "https://www.test.gov.uk/world/foo/news?cachebust=123", world_location_news.public_url(cachebust: "123")
+  end
+end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -103,4 +103,19 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert geographic.include?(world_location)
     assert_not geographic.include?(international_delegation)
   end
+
+  test "public_path returns the correct path" do
+    object = create(:world_location, slug: "foo")
+    assert_equal "/world/foo", object.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    object = create(:world_location, slug: "foo")
+    assert_equal "/world/foo?cachebust=123", object.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the url and appends options" do
+    object = create(:world_location, slug: "foo")
+    assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", object.public_url(cachebust: "123")
+  end
 end


### PR DESCRIPTION
This reintroduces the code for starting to migrate models to know their own routes, which was removed in https://github.com/alphagov/whitehall/pull/7183 as it caused an incident.

A test has been added to cover the scenario in the incident and the bug fixed.  Additionally this revealed a somewhat related issue with statistical announcements, which is also fixed here.

[Trello card](https://trello.com/c/86Gc4TqZ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
