### PR TITLE
Move the worldwide tagging page to the GOV.UK Design System.

### DIFF
--- a/app/controllers/admin/edition_world_tags_controller.rb
+++ b/app/controllers/admin/edition_world_tags_controller.rb
@@ -2,10 +2,12 @@ class Admin::EditionWorldTagsController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
+  layout :get_layout
 
   def edit
     @world_taxonomy = Taxonomy::WorldTaxonomy.new
     @tag_form = WorldTaxonomyTagForm.load(@edition.content_id)
+    render_design_system("edit", "edit_legacy", next_release: false)
   end
 
   def update
@@ -23,6 +25,14 @@ class Admin::EditionWorldTagsController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    if preview_design_system?(next_release: false)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def enforce_permissions!
     unless @edition.can_be_tagged_to_worldwide_taxonomy?

--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -1,12 +1,13 @@
-<% page_title "Edit topics: " + @edition.title %>
+<% content_for :page_title, "#{@edition.title}: Worldwide tags" %>
+<% content_for :context, @edition.title %>
+<% content_for :title, "Worldwide tags" %>
 
-<div class="row">
-  <h1><%= @edition.title %></h1>
-</div>
-<div class="row">
-  <div class="col-md-12">
-    <h2>Worldwide</h2>
-    <hr>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Selected topics",
+      margin_bottom: 2,
+    } %>
 
     <%= form_for(
       @tag_form,
@@ -16,34 +17,24 @@
     ) do |form| %>
       <%= form.hidden_field :previous_version %>
 
-      <div class="form-group"
-        data-module="taxonomy-tree-checkboxes"
-        data-content-id="<%= @edition.content_id %>"
-        data-content-format="<%= @edition.content_store_document_type %>"
-        data-content-public-path="<%= public_document_path(@edition) %>">
+      <%= render partial: "/components/miller-columns", locals: {
+        id: "taxonomy_tag_form[taxons]",
+        searchable: true,
+        items: @world_taxonomy.all_world_taxons_transformed(@tag_form.selected_taxons),
+      } %>
 
-        <%= render(
-          partial: "/admin/shared/tagging/taxonomy",
-          locals: {
-            selected_taxons: @tag_form.selected_taxons,
-            level_one_taxons: @world_taxonomy.all_world_taxons
-          }
-        ) %>
-      </div>
+      <%= render "govuk_publishing_components/components/details", {
+        title: "Changes are applied to a live page as soon as you update the tags"
+      } do %>
+        If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
+      <% end %>
 
-      <h2>Selected topics</h2>
-      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
-      </div>
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save topic changes",
+        } %>
 
-      <p class="warning">
-        Warning: topic changes to published content appear instantly on the live site.
-      </p>
-
-      <div class="publishing-controls well">
-        <%= form.form_actions(
-          buttons: { save: 'Save topic changes' },
-          cancel: admin_edition_path(@edition)
-        ) %>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/edition_world_tags/edit_legacy.html.erb
+++ b/app/views/admin/edition_world_tags/edit_legacy.html.erb
@@ -1,0 +1,50 @@
+<% page_title "Edit topics: " + @edition.title %>
+
+<div class="row">
+  <h1><%= @edition.title %></h1>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <h2>Worldwide</h2>
+    <hr>
+
+    <%= form_for(
+      @tag_form,
+      url: admin_edition_world_tags_path(@edition),
+      method: :put,
+      as: :taxonomy_tag_form
+    ) do |form| %>
+      <%= form.hidden_field :previous_version %>
+
+      <div class="form-group"
+        data-module="taxonomy-tree-checkboxes"
+        data-content-id="<%= @edition.content_id %>"
+        data-content-format="<%= @edition.content_store_document_type %>"
+        data-content-public-path="<%= public_document_path(@edition) %>">
+
+        <%= render(
+          partial: "/admin/shared/tagging/taxonomy",
+          locals: {
+            selected_taxons: @tag_form.selected_taxons,
+            level_one_taxons: @world_taxonomy.all_world_taxons
+          }
+        ) %>
+      </div>
+
+      <h2>Selected topics</h2>
+      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
+      </div>
+
+      <p class="warning">
+        Warning: topic changes to published content appear instantly on the live site.
+      </p>
+
+      <div class="publishing-controls well">
+        <%= form.form_actions(
+          buttons: { save: 'Save topic changes' },
+          cancel: admin_edition_path(@edition)
+        ) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/taxonomy/world_taxonomy.rb
+++ b/lib/taxonomy/world_taxonomy.rb
@@ -9,11 +9,26 @@ module Taxonomy
       @all_world_taxons ||= sorted_world_taxons
     end
 
+    def all_world_taxons_transformed(selected_taxon_content_ids = [])
+      transform_taxon(all_world_taxons, selected_taxon_content_ids)
+    end
+
   private
 
     def sorted_world_taxons
       world_taxon_branches.sort_by do |world_taxon|
         [world_taxon.children.count.zero? ? 0 : 1, world_taxon.name]
+      end
+    end
+
+    def transform_taxon(taxons, selected_taxon_content_ids)
+      taxons.map do |taxon|
+        {
+          label: taxon.name,
+          value: taxon.content_id,
+          items: (transform_taxon(taxon.children, selected_taxon_content_ids) if taxon.children),
+          checked: selected_taxon_content_ids.include?(taxon.content_id),
+        }
       end
     end
 

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -65,6 +65,27 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
     refute_select "input[value='#{world_grandchild_taxon_content_id}'][checked='checked']"
   end
 
+  view_test "should render design system layout when permission is applied" do
+    login_as(:departmental_editor_with_preview_design_system)
+    stub_publishing_api_links_with_taxons(@edition.content_id, [world_child_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select ".govuk-caption-xl", @edition[:title]
+    assert_select "h1", "Worldwide tags"
+  end
+
+  view_test "should render miller columns when user has design system layout" do
+    login_as(:departmental_editor_with_preview_design_system)
+    stub_publishing_api_links_with_taxons(@edition.content_id, [world_child_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select "h2", "Selected topics"
+    assert_select "miller-columns", count: 1
+    assert_select "miller-columns-selected", count: 1
+  end
+
   test "should also post taxons tagged to the topic and world taxonomies" do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
 

--- a/test/unit/taxonomy/world_taxonomy_test.rb
+++ b/test/unit/taxonomy/world_taxonomy_test.rb
@@ -19,4 +19,16 @@ class Taxonomy::WorldTaxonomyTest < ActiveSupport::TestCase
     assert_equal ["Birth, death and marriage abroad", "News and events", "Australia", "France"],
                  subject.all_world_taxons.map(&:name)
   end
+
+  test "#ordered_taxons_transformed are checked for preselected" do
+    redis_cache_has_world_taxons(
+      [
+        build(:taxon_hash, content_id: "france", title: "France", children: [child_taxon]),
+        build(:taxon_hash, content_id: "australia", title: "Australia", children: [child_taxon, child_taxon]),
+        build(:taxon_hash, content_id: "news", title: "News and events"),
+        build(:taxon_hash, content_id: "birth", title: "Birth, death and marriage abroad"),
+      ],
+    )
+    assert_equal([false, true, false, false], subject.all_world_taxons_transformed(%w[news]).map { |t| t[:checked] })
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

[Move the worldwide tagging page to the GOV.UK Design System.
](https://trello.com/c/IHhCfM7i/1011-move-the-worldwide-tagging-page-to-the-design-system)

## Why

This is part of a Whitehall transition work to move from bootstrap to GOVUK design system.

## Screenshots
|Before|After|
|-|-|
|![whitehall-admin dev gov uk_government_admin_editions_1374086_world_tags_edit(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/210376025-13c47c9b-4b31-47cd-8066-be7523469d62.png) ![whitehall-admin dev gov uk_government_admin_editions_1374086_world_tags_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/210382244-6fdb3680-825d-4864-a66b-bfa37476d61e.png)|![whitehall-admin dev gov uk_government_admin_editions_1374086_world_tags_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/210376009-f22a6f9c-5d5f-4add-9397-d535dfa3d4b0.png) ![whitehall-admin dev gov uk_government_admin_editions_1374086_world_tags_edit(iPad Pro)](https://user-images.githubusercontent.com/9594455/210382294-3e9c7c83-bae0-4200-8d33-96090b42c29e.png)|
