### PR TITLE
Add "position: sticky" to the miller columns

### DIFF
--- a/app/assets/stylesheets/components/_miller-columns.scss
+++ b/app/assets/stylesheets/components/_miller-columns.scss
@@ -3,3 +3,8 @@
 .app-c-miller-columns__search {
   margin-bottom: govuk-spacing(6);
 }
+
+.miller-columns__column {
+  position: sticky;
+  top: 0;
+}


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

In longer lists the children of the item of a miller column element are sometimes not visible when you click on it. Using `position: sticky` ensures that they are displayed on screen when possible.

## Before
https://user-images.githubusercontent.com/9594455/210401714-a8fb1fac-4ca6-47f4-a03c-e8eab3247347.mov

## After
https://user-images.githubusercontent.com/9594455/210401729-a4d0af56-b8ac-44bf-a691-dbded31348ff.mov

https://trello.com/c/YJ8n9Hc9/1097-add-position-sticky-to-miller-columns
