### PR TITLE
Remove static routes for deprecated finders

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -34,26 +34,11 @@ class PublishStaticPages
         base_path: "/government/get-involved",
       },
       {
-        content_id: "b13317e9-3753-47b2-95da-c173071e621d",
-        title: "All publications",
-        document_type: "finder",
-        description: "Find publications from across government including policy papers, consultations, statistics, research, transparency data and Freedom of Information responses.",
-        base_path: "/government/publications",
-      },
-      {
         content_id: "a34e9bb6-f4af-4e4f-a21c-8127e3d2edbf",
         title: "Statistics",
         document_type: "finder",
         description: "Find statistics publications from across government, including statistical releases, live data tables, and National Statistics.",
         base_path: "/government/statistics",
-        locales: Locale.non_english.map(&:code),
-      },
-      {
-        content_id: "88936763-df8a-441f-8b96-9ea0dc0758a1",
-        title: "Government announcements",
-        document_type: "finder",
-        description: "Find news articles, speeches and statements from government organisations",
-        base_path: "/government/announcements",
         locales: Locale.non_english.map(&:code),
       },
       {


### PR DESCRIPTION
These finders were removed in https://github.com/alphagov/whitehall/pull/6950 and the content items are now published by Short URL Manager.

This means we won't want Whitehall publishing these routes again next time the `publish_static_routes` rake task is run.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
