### PR TITLE
Allow outstanding Models to define their own routes

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,9 +2,11 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def append_url_options(path, options = {})
-    if options[:format] && options[:locale]
+    locale = normalise_locale(options[:locale])
+
+    if options[:format] && options[:locale] && locale != I18n.default_locale
       path = "#{path}.#{options[:locale]}.#{options[:format]}"
-    elsif options[:locale] && options[:locale] != I18n.default_locale
+    elsif options[:locale] && locale != I18n.default_locale
       path = "#{path}.#{options[:locale]}"
     elsif options[:format]
       path = "#{path}.#{options[:format]}"
@@ -20,5 +22,18 @@ class ApplicationRecord < ActiveRecord::Base
     path = "#{path}##{options[:anchor]}" if options[:anchor]
 
     path
+  end
+
+private
+
+  def normalise_locale(locale)
+    case locale
+    when Struct
+      locale.code
+    when String
+      locale.to_sym
+    when Symbol
+      locale
+    end
   end
 end

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -24,4 +24,16 @@ class OperationalField < ApplicationRecord
   def published_fatality_notices
     fatality_notices.published
   end
+
+  def base_path
+    "/government/fields-of-operation/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -94,6 +94,18 @@ class Person < ApplicationRecord
     ministerial_roles.map(&:slug).include?("prime-minister")
   end
 
+  def base_path
+    "/government/people/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
+
 private
 
   def name_as_words(*elements)

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -60,6 +60,18 @@ class PolicyGroup < ApplicationRecord
     true
   end
 
+  def base_path
+    "/government/groups/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
+
   extend FriendlyId
   friendly_id
 
@@ -68,11 +80,7 @@ class PolicyGroup < ApplicationRecord
   end
 
   searchable title: :name,
-             link: :search_link,
+             link: :public_path,
              content: :summary_or_name,
              description: :summary
-
-  def search_link
-    Whitehall.url_maker.policy_group_path(slug)
-  end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -157,6 +157,18 @@ class Role < ApplicationRecord
     Govspeak::Document.new(responsibilities).to_text
   end
 
+  def base_path
+    "/government/ministers/#{slug}" if type == "MinisterialRole"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
+
 private
 
   def prevent_destruction_unless_destroyable

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -79,13 +79,9 @@ class WorldwideOrganisation < ApplicationRecord
   include Searchable
   searchable title: :name,
              description: :summary,
-             link: :search_link,
+             link: :public_path,
              content: :summary,
              format: "worldwide_organisation"
-
-  def search_link
-    Whitehall.url_maker.worldwide_organisation_path(slug)
-  end
 
   def display_name
     name
@@ -121,5 +117,13 @@ class WorldwideOrganisation < ApplicationRecord
 
   def base_path
     "/world/organisations/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 end

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -20,7 +20,7 @@ class EmbassyPresenter < SimpleDelegator
     elsif organisation
       link_to(
         organisation.name,
-        worldwide_organisation_path(organisation.slug),
+        organisation.public_path,
         class: "govuk-link",
       )
     end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -19,6 +19,6 @@ class PersonPresenter < Whitehall::Decorators::Decorator
   end
 
   def path
-    context.person_path model
+    model.public_path
   end
 end

--- a/app/presenters/role_presenter.rb
+++ b/app/presenters/role_presenter.rb
@@ -19,7 +19,7 @@ class RolePresenter < Whitehall::Decorators::Decorator
 
   def path
     if ministerial?
-      context.ministerial_role_path model
+      model.public_path
     end
   end
 

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -21,7 +21,7 @@
             <tr>
               <td class="locale">
                 <%= link_to locale.native_language_name, edit_admin_person_translation_path(@person, locale.code) %>
-                (<%= link_to "view", Plek.website_root + person_path(@person, locale: locale) %>)
+                (<%= link_to "view", @person.public_url(locale: locale.code) %>)
               </td>
               <td class="actions">
                 <%= button_to 'Delete', admin_person_translation_path(@person, locale.code),

--- a/app/views/admin/worldwide_organisations_translations/index.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/index.html.erb
@@ -22,7 +22,7 @@
             <% @worldwide_organisation.non_english_translated_locales.each do |locale| %>
               <tr>
                 <td class="locale">
-                  <%= link_to locale.native_language_name, edit_admin_worldwide_organisation_translation_path(@worldwide_organisation, locale.code) %> (<%= link_to "view", worldwide_organisation_path(@worldwide_organisation, locale: locale) %>)
+                  <%= link_to locale.native_language_name, edit_admin_worldwide_organisation_translation_path(@worldwide_organisation, locale.code) %> (<%= link_to "view", @worldwide_organisation.public_path(locale: locale.code) %>)
                 </td>
                 <td class="actions">
                   <%= button_to 'Delete',

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -6,6 +6,6 @@
       heading_level: 3,
       margin_bottom: 1
     } %>
-    <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug), class: "govuk-link") %>
+    <%= link_to(organisation.name, organisation.public_path, class: "govuk-link") %>
   </li>
 <% end %>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -98,7 +98,7 @@
           } %>
 
           <% if @prime_minister.present? %>
-            <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, url_for(@prime_minister), class: "govuk-link" %>.</p>
+            <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, @prime_minister.public_url, class: "govuk-link" %>.</p>
           <% end %>
 
           <p class="govuk-body govuk-!-margin-bottom-8">

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -16,7 +16,7 @@
     <% unless hide_image %>
       <% if person.image %>
         <div class="app-person__image-holder">
-          <%= link_to person.image, person, class: "aspect-ratio-3:2", tabindex: '-1', aria: { hidden: true } %>
+          <%= link_to person.image, person.public_path, class: "aspect-ratio-3:2", tabindex: '-1', aria: { hidden: true } %>
         </div>
       <% else %>
         <div class="blank-person">

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -8,7 +8,7 @@
     <%= render "govuk_publishing_components/components/organisation_logo", {
       organisation: {
         name: translated_organisation_logo_name(organisation),
-        url: link_to_organisation ? worldwide_organisation_path(organisation) : nil,
+        url: link_to_organisation ? organisation.public_path : nil,
         crest: "single-identity",
       },
       heading_level: 1,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,6 @@ Whitehall::Application.routes.draw do
     end
     get "/how-government-works" => "home#how_government_works", as: "how_government_works"
     get "/ministers(.:locale)", as: "ministerial_roles", to: "ministerial_roles#index", constraints: { locale: valid_locales_regex }
-    get "/ministers/:id(.:locale)", as: "ministerial_role", to: "ministerial_roles#show", constraints: { locale: valid_locales_regex }
     resources :operational_fields, path: "fields-of-operation", only: %i[index show]
     get "/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview" => "csv_preview#show", as: :csv_preview
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,6 @@ Whitehall::Application.routes.draw do
     get "/consultations/:consultation_id/public-feedback/:id", as: "consultation_public_feedback_html_attachment", to: rack_404
     get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
-    get "/people/:id(.:locale)", as: "person", constraints: { locale: valid_locales_regex }, to: rack_404
     get "/groups/:id", as: "policy_group", to: rack_404
     get "/publications/:publication_id/:id", as: "publication_html_attachment", to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,6 @@ Whitehall::Application.routes.draw do
     get "/consultations/:consultation_id/public-feedback/:id", as: "consultation_public_feedback_html_attachment", to: rack_404
     get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
-    get "/groups/:id", as: "policy_group", to: rack_404
     get "/publications/:publication_id/:id", as: "publication_html_attachment", to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
     get "/statistics/announcements/:id", as: "statistics_announcement", to: rack_404

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -41,7 +41,7 @@ When(/^I reorder the offices to highlight my new office$/) do
 end
 
 Then(/^I see the offices in my specified order including the new one under the main office on the home page of the worldwide organisation$/) do
-  visit worldwide_organisation_path(@the_organisation)
+  visit @the_organisation.public_path
 
   contact_headings = all(".contact-section .gem-c-heading").map(&:text)
 
@@ -64,7 +64,7 @@ When(/^I decide that one of the offices no longer belongs on the home page$/) do
 end
 
 Then(/^that office is no longer visible on the home page of the worldwide organisation$/) do
-  visit worldwide_organisation_path(@the_organisation)
+  visit @the_organisation.public_path
 
   within ".contact-section:first-of-type" do
     expect(page).to_not have_selector("h2", text: @the_removed_office.title)

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -31,7 +31,7 @@ end
 Then(/^I should see the corporate information on the public worldwide organisation page$/) do
   worldwide_organisation = WorldwideOrganisation.last
   info_page = worldwide_organisation.corporate_information_pages.last
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
   expect(page).to have_content(info_page.title)
   click_link info_page.title
   expect(page).to have_content(info_page.body)
@@ -61,7 +61,7 @@ end
 
 Then(/^I should be able to read the translated "([^"]*)" corporate information page for the worldwide organisation "([^"]*)" on the site$/) do |corp_page, worldwide_org|
   worldwide_organisation = WorldwideOrganisation.find_by(name: worldwide_org)
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
 
   click_link corp_page
   click_link "Français"

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -87,7 +87,7 @@ Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
 end
 
 Then(/^I should see him listed as "([^"]*)" on the worldwide organisation page$/) do |role_name|
-  visit worldwide_organisation_path(WorldwideOrganisation.last)
+  visit WorldwideOrganisation.last.public_path
   person = Person.last
   role = Role.find_by!(name: role_name)
 

--- a/features/step_definitions/social_media_steps.rb
+++ b/features/step_definitions/social_media_steps.rb
@@ -43,34 +43,31 @@ When(/^I edit a "([^"]*)" social media link "([^"]*)" with the title "([^"]+)" i
 end
 
 Then(/^the "([^"]*)" social link should be shown on the public website for the (worldwide organisation|organisation)$/) do |social_service, social_container|
-  if social_container == "worldwide organisation"
-    social_container = WorldwideOrganisation.last
-    visit worldwide_organisation_path(social_container)
-  else
-    social_container = Organisation.last
-    visit social_container.public_path
-  end
+  social_container = if social_container == "worldwide organisation"
+                       WorldwideOrganisation.last
+                     else
+                       Organisation.last
+                     end
+  visit social_container.public_path
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: social_service)
 end
 
 Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public website for the (worldwide organisation|organisation)$/) do |social_service, title, social_container|
-  if social_container == "worldwide organisation"
-    social_container = WorldwideOrganisation.last
-    visit worldwide_organisation_path(social_container)
-  else
-    social_container = Organisation.last
-    visit social_container.public_path
-  end
+  social_container = if social_container == "worldwide organisation"
+                       WorldwideOrganisation.last
+                     else
+                       Organisation.last
+                     end
+  visit social_container.public_path
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title)
 end
 
 Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public website with locale "([^"]*)" for the (worldwide organisation|organisation)$/) do |social_service, title, locale, social_container|
-  if social_container == "worldwide organisation"
-    social_container = WorldwideOrganisation.last
-    visit worldwide_organisation_path(social_container, locale:)
-  else
-    social_container = Organisation.last
-    visit social_container.public_path(locale:)
-  end
+  social_container = if social_container == "worldwide organisation"
+                       WorldwideOrganisation.last
+                     else
+                       Organisation.last
+                     end
+  visit social_container.public_path(locale:)
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title)
 end

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -16,7 +16,7 @@ Given(/^a worldwide organisation that is translated exists$/) do
 end
 
 When(/^I visit the world organisation that is translated$/) do
-  visit worldwide_organisation_path(WorldwideOrganisation.last, locale: "fr")
+  visit WorldwideOrganisation.last.public_path(locale: "fr")
 end
 
 Then(/^I should see the translation of that world organisation$/) do

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -25,7 +25,7 @@ end
 
 Then(/^I should see the(?: updated)? worldwide organisation information on the public website$/) do
   worldwide_organisation = WorldwideOrganisation.last
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
   expect(page).to have_title(worldwide_organisation.name)
 end
 
@@ -75,7 +75,7 @@ When(/^I delete the worldwide organisation$/) do
 end
 
 Then(/^the worldwide organisation should not be visible from the public website$/) do
-  expect { visit worldwide_organisation_path(@worldwide_organisation) }
+  expect { visit @worldwide_organisation.public_path }
     .to raise_error(ActiveRecord::RecordNotFound)
 end
 
@@ -107,7 +107,7 @@ end
 
 Then(/^the "([^"]*)" office details should be shown on the public website$/) do |description|
   worldwide_org = WorldwideOrganisation.last
-  visit worldwide_organisation_path(worldwide_org)
+  visit worldwide_org.public_path
   worldwide_office = worldwide_org.offices.joins(contact: :translations).where(contact_translations: { title: description }).first
 
   within record_css_selector(worldwide_office) do
@@ -158,14 +158,14 @@ end
 Then(/^the "([^"]*)" should be shown as the main office on the public website$/) do |contact_title|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: contact_title }).first
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
   within record_css_selector(worldwide_office) do
     expect(page).to have_content(contact_title)
   end
 end
 
 Then(/^I should see his name on the worldwide organisation page$/) do
-  visit worldwide_organisation_path(WorldwideOrganisation.last)
+  visit WorldwideOrganisation.last.public_path
   person = Person.last
 
   within record_css_selector(person) do
@@ -174,7 +174,7 @@ Then(/^I should see his name on the worldwide organisation page$/) do
 end
 
 Then(/^I should not see his name on the worldwide organisation page$/) do
-  visit worldwide_organisation_path(WorldwideOrganisation.last)
+  visit WorldwideOrganisation.last.public_path
   person = Person.last
 
   within record_css_selector(person) do
@@ -193,7 +193,7 @@ end
 Then(/^I should see the default access information on the public "([^"]*)" office page$/) do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
   within record_css_selector(worldwide_office) do
     click_link "Access and opening times"
   end
@@ -239,7 +239,7 @@ end
 Then(/^I should see the custom access information on the public "([^"]*)" office page$/) do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit worldwide_organisation_path(worldwide_organisation)
+  visit worldwide_organisation.public_path
   within record_css_selector(worldwide_office) do
     click_link "Access and opening times"
   end
@@ -262,7 +262,7 @@ Then(/^when viewing the worldwide organisation "([^"]*)" with the locale "([^"]*
   worldwide_organisation = WorldwideOrganisation.find_by!(name:)
   translation = table.rows_hash
 
-  visit worldwide_organisation_path(worldwide_organisation, locale:)
+  visit worldwide_organisation.public_path(locale:)
 
   expect(page).to have_selector(".worldwide-org-summary", text: translation["summary"])
   expect(page).to have_selector(".worldwide-org-description", text: translation["description"])

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -31,7 +31,7 @@ module NavigationHelpers
 
   def visit_worldwide_organisation_page(name)
     worldwide_organisation = WorldwideOrganisation.find_by!(name:)
-    visit worldwide_organisation_path(worldwide_organisation)
+    visit worldwide_organisation.public_path
   end
 
   def public_path_for(edition)

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -60,7 +60,7 @@ module DataHygiene
       when Organisation
         new_slug.public_path
       when WorldwideOrganisation
-        Whitehall.url_maker.worldwide_organisation_path(new_slug)
+        new_slug.public_path
       end
     end
   end

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -75,7 +75,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
     get :index, params: { person_id: person }
 
     edit_translation_path = edit_admin_person_translation_path(person, "fr")
-    view_person_path = person_path(person, locale: "fr")
+    view_person_path = person.public_path(locale: "fr")
     assert_select "a[href=?]", edit_translation_path, text: "Français"
     assert_select "a[href=?]", Plek.website_root + view_person_path, text: "view"
   end

--- a/test/functional/admin/worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_translations_controller_test.rb
@@ -43,7 +43,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
     get :index, params: { worldwide_organisation_id: worldwide_organisation }
     edit_translation_path = edit_admin_worldwide_organisation_translation_path(worldwide_organisation, "fr")
-    view_worldwide_organisation_path = worldwide_organisation_path(worldwide_organisation, locale: "fr")
+    view_worldwide_organisation_path = worldwide_organisation.public_path(locale: "fr")
     assert_select "a[href=?]", edit_translation_path, text: "Français"
     assert_select "a[href=?]", view_worldwide_organisation_path, text: "view"
   end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -27,7 +27,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
 
     get :show, params: { organisation: nil, worldwide_organisation_id: worldwide_organisation, id: corporate_information_page.slug }
 
-    assert_select "a[href=?]", worldwide_organisation_path(worldwide_organisation)
+    assert_select "a[href=?]", worldwide_organisation.public_path
     assert_select "a[href=?]", world_location.public_path
   end
 

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -202,7 +202,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     get :index
 
     assert_select_prefix_object(person, "by-organisation-#{org.slug}") do
-      assert_select "a[href=?]", person_path(person), text: "John Doe"
+      assert_select "a[href=?]", person.public_path, text: "John Doe"
       assert_minister_role_links_to_their_role(ministerial_role)
     end
   end

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -224,6 +224,6 @@ class MinisterialRolesControllerTest < ActionController::TestCase
 private
 
   def assert_minister_role_links_to_their_role(role)
-    assert_select ".app-person__roles a[href='#{ministerial_role_path(role)}']", text: role.name
+    assert_select ".app-person__roles a[href='#{role.public_path}']", text: role.name
   end
 end

--- a/test/functional/operational_fields_controller_test.rb
+++ b/test/functional/operational_fields_controller_test.rb
@@ -73,9 +73,9 @@ class OperationalFieldsControllerTest < ActionController::TestCase
 
   view_test "index displays a rudimentary index of fields (for url hackers)" do
     fields = [
-      stub_record(:operational_field),
-      stub_record(:operational_field),
-      stub_record(:operational_field),
+      stub_record(:operational_field, slug: "test-1"),
+      stub_record(:operational_field, slug: "test-2"),
+      stub_record(:operational_field, slug: "test-3"),
     ]
     OperationalField.stubs(:all).returns(fields)
 
@@ -84,7 +84,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
     assert_select "ul.govuk-list" do
       fields.each do |field|
         assert_select_object field do
-          assert_select "a[href=?]", operational_field_path(field)
+          assert_select "a[href=?]", field.public_path
         end
       end
     end

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -44,36 +44,36 @@ class RoutingLocaleTest < ActionDispatch::IntegrationTest
   test "#show with no locale" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}",
-                 worldwide_organisation_path(worldwide_organisation)
+                 worldwide_organisation.public_path
   end
 
   test "#show with english locale doesn't includes the locale in the path" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}",
-                 worldwide_organisation_path(worldwide_organisation, locale: "en")
+                 worldwide_organisation.public_path(locale: "en")
   end
 
   test "#show with non-english locale includes the locale in the path" do
     worldwide_organisation = I18n.with_locale(:dr) { create(:worldwide_organisation) }
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.dr",
-                 worldwide_organisation_path(worldwide_organisation, locale: "dr")
+                 worldwide_organisation.public_path(locale: "dr")
   end
 
   test "#show with a format includes it in the path" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.json",
-                 worldwide_organisation_path(worldwide_organisation, format: "json")
+                 worldwide_organisation.public_path(format: "json")
   end
 
   test "#show with a english locale and a format includes the format in the path" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.json",
-                 worldwide_organisation_path(worldwide_organisation, locale: "en", format: "json")
+                 worldwide_organisation.public_path(locale: "en", format: "json")
   end
 
   test "#show with a non-english locale and a format includes the locale and format in the path" do
     worldwide_organisation = I18n.with_locale(:cy) { create(:worldwide_organisation) }
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.cy.json",
-                 worldwide_organisation_path(worldwide_organisation, locale: "cy", format: "json")
+                 worldwide_organisation.public_path(locale: "cy", format: "json")
   end
 end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -18,6 +18,26 @@ class PersonTest < ActiveSupport::TestCase
     assert_not person.valid?
   end
 
+  test "public_path returns the correct path for person" do
+    person = create(:person, forename: " forename ", surname: " surname ")
+    assert_equal "/government/people/forename-surname", person.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    person = create(:person, forename: " forename ", surname: " surname ")
+    assert_equal "/government/people/forename-surname?cachebust=123", person.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path for a Person object" do
+    person = create(:person, forename: " forename ", surname: " surname ")
+    assert_equal "https://www.test.gov.uk/government/people/forename-surname", person.public_url
+  end
+
+  test "public_url returns the correct path for a TakePart object with options" do
+    person = create(:person, forename: " forename ", surname: " surname ")
+    assert_equal "https://www.test.gov.uk/government/people/forename-surname?cachebust=123", person.public_url(cachebust: "123")
+  end
+
   test "should be valid if legacy image isn't 960x640px" do
     person = build(
       :person,

--- a/test/unit/presenters/person_presenter_test.rb
+++ b/test/unit/presenters/person_presenter_test.rb
@@ -7,10 +7,6 @@ class PersonPresenterTest < ActionView::TestCase
     @presenter = PersonPresenter.new(@person, @view_context)
   end
 
-  test "path is generated using person_path" do
-    assert_equal person_path(@person), @presenter.path
-  end
-
   test "link links name to path" do
     @presenter.stubs(:path).returns("http://example.com/person/a-person")
     assert_select_within_html @presenter.link, 'a[href="http://example.com/person/a-person"]', text: @person.name

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       biography: "Sir Winston Churchill was a Prime Minister.",
     )
 
-    public_path = Whitehall.url_maker.person_path(person)
+    public_path = person.public_path
 
     expected_hash = {
       base_path: public_path,
@@ -85,7 +85,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       },
     )
 
-    expected_base_path = Whitehall.url_maker.person_path(person)
+    expected_base_path = person.public_path
 
     I18n.with_locale(:en) do
       presented_item = PublishingApi::PersonPresenter.new(person)

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -160,7 +160,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       translated_into: [:cy],
     )
 
-    expected_base_path = Whitehall.url_maker.ministerial_role_path(role)
+    expected_base_path = role.public_path
 
     I18n.with_locale(:en) do
       presented_item = PublishingApi::RolePresenter.new(role)

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -14,7 +14,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            :with_world_location,
                            name: "Locationia Embassy",
                            analytics_identifier: "WO123")
-    public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)
+    public_path = worldwide_org.public_path
 
     expected_hash = {
       base_path: public_path,

--- a/test/unit/presenters/role_presenter_test.rb
+++ b/test/unit/presenters/role_presenter_test.rb
@@ -7,11 +7,6 @@ class RolePresenterTest < ActionView::TestCase
     @presenter = RolePresenter.new(@role, @view_context)
   end
 
-  test "path is the ministerial_role_path if role is ministerial" do
-    @role.stubs(:ministerial?).returns(true)
-    assert_equal ministerial_role_path(@role), @presenter.path
-  end
-
   test "path is nil if appointed role is not ministerial" do
     @role.stubs(:ministerial?).returns(false)
     assert_nil @presenter.path

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -196,9 +196,28 @@ class RoleTest < ActiveSupport::TestCase
     assert_not_includes Role.occupied, vacant
   end
 
+  test "public_path returns the correct path for ministerial role" do
+    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
+    assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
+  end
+
+  test "public_path returns the correct path with options" do
+    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
+    assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
+  end
+
+  test "public_url returns the correct path for a Ministerial role" do
+    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
+    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
+  end
+
+  test "public_url returns the correct path for a Ministerial Role with options" do
+    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
+    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
+  end
+
   test "has removeable translations" do
     stub_any_publishing_api_call
-
     role = create(:role, translated_into: %i[fr es])
     role.remove_translations_for(:fr)
     assert_not role.translated_locales.include?(:fr)


### PR DESCRIPTION
Allow outstanding Models to define their own routes

This change allows certain models to move away from the use of UrlMaker, which is necessary to migrate
rendering of these Models outside of Whitehall, without leaving unnecessary routes behind just to take 
advantage of Rails routing helpers. 

Both Worldwide Organisations and Operational Fields are still rendered by Whitehall, so I've left the route intact. 
In the case of those two Models this PR will simply make migrating the rendering later on, easier. 

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
