### PR TITLE
Updates JS reference classes to have `js-app-view` namespace

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -13,7 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   EditionForm.prototype.setupSubtypeFormatAdviceEventListener = function () {
     var form = this.module
-    var subtypeDiv = form.querySelector('.edition-form__subtype-fields')
+    var subtypeDiv = form.querySelector('.js-app-view-edition-form__subtype-fields')
 
     if (!subtypeDiv) { return }
 
@@ -21,7 +21,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     subtypeSelect.addEventListener('change', function () {
       var formatAdviceMap = JSON.parse(subtypeDiv.dataset.formatAdvice)
-      var subtypeFormatAdvice = form.querySelector('.edition-form__subtype-format-advice')
+      var subtypeFormatAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
 
       if (subtypeFormatAdvice) {
         subtypeDiv.removeChild(subtypeFormatAdvice)
@@ -31,7 +31,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (adviceText) {
         var div = document.createElement('div')
-        div.classList.add('edition-form__subtype-format-advice', 'govuk-body', 'govuk-!-margin-top-4')
+        div.classList.add('js-app-view-edition-form__subtype-format-advice', 'govuk-body', 'govuk-!-margin-top-4')
         div.innerHTML = '<strong>Use this subformat for…</strong> ' + adviceText
         subtypeDiv.append(div)
       }

--- a/app/assets/javascripts/admin/views/unpublish-display-conditions.js
+++ b/app/assets/javascripts/admin/views/unpublish-display-conditions.js
@@ -25,7 +25,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     checkbox.addEventListener('change', function (e) {
       var display = e.currentTarget.checked ? 'none' : 'block'
-      this.module.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display = display
+      this.module.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display = display
     }.bind(this))
 
     if (checkbox.checked) {
@@ -55,7 +55,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       sections.forEach(function (sectionId) {
         var display = sectionId === selectedSectionId ? 'block' : 'none'
-        this.module.querySelector('.js-unpublish-withdraw-form__' + sectionId).style.display = display
+        this.module.querySelector('.js-app-view-unpublish-withdraw-form__' + sectionId).style.display = display
       }.bind(this))
     }.bind(this)
 

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -65,7 +65,7 @@
       ],
     } %>
 
-    <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__withdrawal">
+    <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__withdrawal">
       <%= form_for @unpublishing, url: unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version), data: {
         module: "unpublish-tracking",
         "unpublish-reason-label": unpublish_reasons[:withdrawn][:label],
@@ -120,7 +120,7 @@
       <% end %>
     </div>
 
-    <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__published-in-error">
+    <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__published-in-error">
       <%= form_for @unpublishing, url: unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version), data: {
         module: "unpublish-tracking",
         "unpublish-reason-label": unpublish_reasons[:published_in_error][:label],
@@ -175,7 +175,7 @@
       <% end %>
     </div>
 
-    <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__consolidated">
+    <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__consolidated">
       <%= form_for @unpublishing, url: unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version), data: {
         module: "unpublish-tracking",
         "unpublish-reason-label": unpublish_reasons[:consolidated][:label],

--- a/app/views/admin/editions/_subtype_format_advice.html.erb
+++ b/app/views/admin/editions/_subtype_format_advice.html.erb
@@ -1,3 +1,3 @@
-<div class="edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
+<div class="app-view-edition-form__subtype-format-advice js-app-view-edition-form__subtype-format-advice govuk-body govuk-!-margin-top-4">
   <strong>Use this subformat for…</strong> <%= guidance %>
 </div>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="edition-form__subtype-fields" data-format-advice="<%= NewsArticleType::FORMAT_ADVICE %>">
+<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= NewsArticleType::FORMAT_ADVICE %>">
   <%= render "govuk_publishing_components/components/select", {
     name: "edition[news_article_type_id]",
     id: "edition_news_article_type_id",

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
+<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
   <div class="govuk-form-group <%= "govuk-form-group--error" if errors_for_input(edition.errors, :publication_type_id).present? %>">
     <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
       Publication type

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="edition-form__subtype-fields" data-format-advice="<%= SpeechType::FORMAT_ADVICE %>">
+<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= SpeechType::FORMAT_ADVICE %>">
   <%= render "govuk_publishing_components/components/select", {
     name: "edition[speech_type_id]",
     id: "edition_speech_type_id",

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -14,7 +14,7 @@ When(/^I unpublish the duplicate, marking it as consolidated into the other page
   visit admin_edition_path(@duplicate_edition)
   click_on "Withdraw or unpublish"
   choose "Unpublish: consolidated into another GOV.UK page"
-  within ".js-unpublish-withdraw-form__consolidated" do
+  within ".js-app-view-unpublish-withdraw-form__consolidated" do
     fill_in "consolidated_alternative_url", with: @existing_edition.public_url
     click_button "Unpublish"
   end
@@ -25,7 +25,7 @@ def withdraw_publication(explanation)
   visit admin_edition_path(@publication)
   click_on "Withdraw or unpublish"
   choose "Withdraw: no longer current government policy/activity"
-  within ".js-unpublish-withdraw-form__withdrawal" do
+  within ".js-app-view-unpublish-withdraw-form__withdrawal" do
     fill_in "Public explanation", with: explanation
     click_button "Withdraw"
   end

--- a/features/support/unpublishing_helpers.rb
+++ b/features/support/unpublishing_helpers.rb
@@ -3,7 +3,7 @@ module UnpublishingHelpers
     visit admin_edition_path(edition)
     click_on "Withdraw or unpublish"
     choose "Unpublish: published in error"
-    within ".js-unpublish-withdraw-form__published-in-error" do
+    within ".js-app-view-unpublish-withdraw-form__published-in-error" do
       fill_in "Public explanation", with: "This page should never have existed"
       yield if block_given?
       click_button "Unpublish"

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -6,7 +6,7 @@ describe('GOVUK.Modules.EditionForm', function () {
     form.setAttribute('data-module', 'EditionForm')
 
     form.innerHTML = `
-    <div class="edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">
+    <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">
       <div class="govuk-form-group gem-c-select">
         <label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>
         <select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">
@@ -38,7 +38,7 @@ describe('GOVUK.Modules.EditionForm', function () {
 
     select.value = '1'
     select.dispatchEvent(new Event('change'))
-    var subtypeAdvice = form.querySelector('.edition-form__subtype-format-advice')
+    var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
 
     expect(subtypeAdvice.innerHTML).toBe('<strong>Use this subformat for…</strong> <p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>')
   })
@@ -51,7 +51,7 @@ describe('GOVUK.Modules.EditionForm', function () {
     select.value = '0'
     select.dispatchEvent(new Event('change'))
 
-    var subtypeAdvice = form.querySelector('.edition-form__subtype-format-advice')
+    var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
     expect(subtypeAdvice).toBe(null)
   })
 

--- a/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
+++ b/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
@@ -26,10 +26,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
             </div>
           </fieldset>
         </div>
-        <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__withdrawal">
+        <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__withdrawal">
           this is the withdrawal section
         </div>
-        <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__published-in-error">
+        <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__published-in-error">
           this is the error section
           <div class="gem-c-checkboxes govuk-form-group">
             <div class="govuk-checkboxes__item">
@@ -41,7 +41,7 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
             This is the public explanation section
           </div>
         </div>
-        <div class="app-view-unpublish-withdrawal__form-wrapper js-unpublish-withdraw-form__consolidated">
+        <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__consolidated">
           this is the consolidated section
         </div>
       </div>
@@ -53,9 +53,9 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
   })
 
   it('should not show any section if nothing is selected', function () {
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
   })
 
   it('should only show publish in error section when selecting unpublish: published in error', function () {
@@ -63,9 +63,9 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     radio.checked = true
     radio.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
   })
 
   it('should only show consolidated section when selecting unpublish: consolidated', function () {
@@ -73,9 +73,9 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     radio.checked = true
     radio.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
   })
 
   it('should only show withdrawal section when selecting withdrawal', function () {
@@ -83,9 +83,9 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     radio.checked = true
     radio.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).toEqual('block')
   })
 
   it('should show last chosen option if user changes their selected option', function () {
@@ -93,21 +93,21 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     radio.checked = true
     radio.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).toEqual('block')
 
     var radio2 = body.querySelector('#radio-published-consolidated')
     radio2.checked = true
     radio2.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__consolidated').style.display).toEqual('block')
-    expect(body.querySelector('.js-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error').style.display).not.toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__consolidated').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal').style.display).not.toEqual('block')
   })
 
   it('should hide public explanation section when "Redirect to URL automatically?" is pre-checked', function () {
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
   })
 
   it('should show/hide public explanation section when "Redirect to URL automatically?" is unchecked/checked', function () {
@@ -115,11 +115,11 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     checkbox.checked = false
     checkbox.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('block')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('block')
 
     checkbox.checked = true
     checkbox.dispatchEvent(new Event('change'))
 
-    expect(body.querySelector('.js-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
+    expect(body.querySelector('.js-app-view-unpublish-withdraw-form__published-in-error div.app-c-govspeak-editor').style.display).toEqual('none')
   })
 })

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -38,7 +38,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
 
     assert_select "form#edit_edition" do
       assert_select "select[name*='edition[news_article_type_id']"
-      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… Unedited press releases as sent to the media, and official statements from the organisation or a minister.Do not use for: statements to Parliament. Use the “Speech” format for those."
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… Unedited press releases as sent to the media, and official statements from the organisation or a minister.Do not use for: statements to Parliament. Use the “Speech” format for those."
     end
   end
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -99,7 +99,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "form#edit_edition" do
       assert_select "select[name='edition[publication_type_id]']"
       assert_select "select[name*='edition[first_published_at']", count: 5
-      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.Read the policy papers guidance in full."
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.Read the policy papers guidance in full."
     end
   end
 

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -41,7 +41,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
       assert_select "input[name='edition[person_override]']"
       assert_select "select[name*='edition[delivered_on']", count: 5
       assert_select "input[name='edition[location]'][type='text']"
-      assert_select ".edition-form__subtype-format-advice", text: "Use this subformat for… A verbatim report of exactly what the speaker said (checked against delivery)."
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A verbatim report of exactly what the speaker said (checked against delivery)."
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -172,7 +172,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
     def unpublish_document_published_in_error
       click_link "Withdraw or unpublish"
-      within ".js-unpublish-withdraw-form__published-in-error" do
+      within ".js-app-view-unpublish-withdraw-form__published-in-error" do
         click_button "Unpublish"
       end
       assert_text "This document has been unpublished"

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -259,7 +259,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def unpublish_document_published_in_error
       click_link "Withdraw or unpublish"
-      within ".js-unpublish-withdraw-form__published-in-error" do
+      within ".js-app-view-unpublish-withdraw-form__published-in-error" do
         click_button "Unpublish"
       end
       assert_text "This document has been unpublished"
@@ -267,7 +267,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def consolidate_document
       click_link "Withdraw or unpublish"
-      within ".js-unpublish-withdraw-form__consolidated" do
+      within ".js-app-view-unpublish-withdraw-form__consolidated" do
         fill_in "consolidated_alternative_url", with: "https://www.test.gov.uk/example"
         click_button "Unpublish"
       end
@@ -276,7 +276,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     def withdraw_document
       click_link "Withdraw or unpublish"
-      within ".js-unpublish-withdraw-form__withdrawal" do
+      within ".js-app-view-unpublish-withdraw-form__withdrawal" do
         fill_in "withdrawal_explanation", with: "testing"
         click_button "Withdraw"
       end


### PR DESCRIPTION
## What

Any classes referenced by the JS should be updated to have a `js-app-view` namespace.

## Why

This will keep it consistent with our GOVUK standards and also ensure that developers are obvious the changing a class may have effects on the JS functionality.

https://trello.com/c/tUuuK8IG/842-review-js-modules
https://trello.com/c/kkAfG0WV/1044-updates-js-reference-classes-to-have-js-app-view-namespace

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
