### PR TITLE
Ensure prime ministers can only be edited by VIP Editors or GDS Admins

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -90,6 +90,10 @@ class Person < ApplicationRecord
     [name, role_name, organisation].compact.join(" – ")
   end
 
+  def current_or_previous_prime_minister?
+    ministerial_roles.map(&:slug).include?("prime-minister")
+  end
+
 private
 
   def name_as_words(*elements)

--- a/lib/whitehall/authority/rules/person_rules.rb
+++ b/lib/whitehall/authority/rules/person_rules.rb
@@ -1,7 +1,7 @@
 module Whitehall::Authority::Rules
   PersonRules = Struct.new(:actor, :subject) do
     def can?(action)
-      if subject.slug == "boris-johnson"
+      if subject.current_or_previous_prime_minister?
         actor.vip_editor? || actor.gds_admin?
       elsif action == :perform_administrative_tasks
         actor.gds_admin?

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -4,6 +4,9 @@ FactoryBot.define do
   end
 
   factory :pm, parent: :person do
-    slug { "boris-johnson" }
+    after :create do |person, _evaluator|
+      role = create(:ministerial_role, slug: "prime-minister")
+      create(:ministerial_role_appointment, person:, role:)
+    end
   end
 end

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -135,35 +135,35 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   test "GET on :edit denied if not a vip-editor" do
-    create(:pm)
+    pm = create(:pm)
 
     login_as :writer
-    get :edit, params: { id: "boris-johnson" }
+    get :edit, params: { id: pm.slug }
     assert_response :forbidden
   end
 
   test "PUT on :update denied if not a vip-editor" do
-    create(:pm)
+    pm = create(:pm)
 
     login_as :writer
-    put :update, params: { id: "boris-johnson" }
+    put :update, params: { id: pm.slug }
     assert_response :forbidden
   end
 
   test "DELETE on :destroy denied if not a vip-editor" do
-    create(:pm)
+    pm = create(:pm)
 
     login_as :writer
-    delete :destroy, params: { id: "boris-johnson" }
+    delete :destroy, params: { id: pm.slug }
     assert_response :forbidden
   end
 
   %i[vip_editor gds_admin].each do |permission|
     test "GET on :edit allowed if a #{permission}" do
-      create(:pm)
+      pm = create(:pm)
 
       login_as :vip_editor
-      get :edit, params: { id: "boris-johnson" }
+      get :edit, params: { id: pm.slug }
       assert_response :success
     end
 
@@ -171,20 +171,10 @@ class Admin::PeopleControllerTest < ActionController::TestCase
       pm = create(:pm)
 
       login_as :vip_editor
-      put :update, params: { id: "boris-johnson", person: { title: "", forename: "Aronnax", surname: "", letters: "" } }
+      put :update, params: { id: pm.slug, person: { title: "", forename: "Aronnax", surname: "", letters: "" } }
 
       assert_redirected_to admin_person_url(pm)
       assert_equal %("Aronnax" saved.), flash[:notice]
-    end
-
-    test "DELETE on :destroy allowed if a #{permission}" do
-      create(:pm, forename: "Nemo")
-
-      login_as :vip_editor
-      delete :destroy, params: { id: "boris-johnson" }
-      assert_response :redirect
-
-      assert_equal %("Nemo" destroyed.), flash[:notice]
     end
   end
 

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -188,4 +188,18 @@ class PersonTest < ActiveSupport::TestCase
       assert_equal Time.zone.now, role_appointment.reload.updated_at
     end
   end
+
+  test "#current_or_previous_prime_minister returns true when the persons ministerial_roles includes Prime Minister" do
+    person = build(:person)
+    prime_minister_role = build(:ministerial_role, slug: "prime-minister")
+    person.stubs(:ministerial_roles).returns([prime_minister_role])
+
+    assert_equal true, person.current_or_previous_prime_minister?
+  end
+
+  test "#current_or_previous_prime_minister returns false when the persons ministerial_roles does not include Prime Minister" do
+    person = build(:person)
+
+    assert_equal false, person.current_or_previous_prime_minister?
+  end
 end


### PR DESCRIPTION
## Description

Currently, we've got a check in place that only VIP Editors and GDS Admins can edit a specific previous PMs page. This was hardcoded. It's been decided that this should be extended to all previous PMs.

## Trello card

https://trello.com/c/BHgHcbrv/992-update-rule-for-vip-editor-on-pms-person-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
