### PR TITLE
Update styling for document history tab

### DIFF
--- a/app/assets/stylesheets/admin/views/_audit-trail.scss
+++ b/app/assets/stylesheets/admin/views/_audit-trail.scss
@@ -83,3 +83,7 @@ $state-success-text: govuk-colour("green");
     }
   }
 }
+
+.app-view-editions-audit-trail-entry__list-item-datetime {
+  color: $govuk-secondary-text-colour;
+}

--- a/app/assets/stylesheets/admin/views/_editorial-remarks.scss
+++ b/app/assets/stylesheets/admin/views/_editorial-remarks.scss
@@ -1,4 +1,3 @@
-.app-view-editions-editorial-remark__list-item {
-  background-color: govuk-colour("light-grey");
-  padding: govuk-spacing(4);
+.app-view-editions-editorial-remark__list-item-datetime {
+  color: $govuk-secondary-text-colour;
 }

--- a/app/components/admin/editions/audit_trail_entry_component.html.erb
+++ b/app/components/admin/editions/audit_trail_entry_component.html.erb
@@ -1,8 +1,13 @@
-<li class="app-view-editions-audit-trail-entry__list-item govuk-!-margin-bottom-4">
+<div class="app-view-editions-audit-trail-entry__list-item govuk-!-margin-bottom-4">
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-0"><%= action %></h4>
+
   <% if compare_with_previous_version? %>
-    <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: entry.version.item_id), class: "govuk-link" %>
+    <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+      <%= link_to "[Compare with previous version]", diff_admin_edition_path(@edition, audit_trail_entry_id: entry.version.item_id), class: "govuk-link" %>
+    </p>
   <% end %>
-  <%= action %> <%= actor %>
-  <br>
-  <%= time %>
-</li>
+
+  <p class="app-view-editions-audit-trail-entry__list-item-datetime govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+    <%= time %> by <%= actor %>
+  </p>
+</div>

--- a/app/components/admin/editions/audit_trail_entry_component.rb
+++ b/app/components/admin/editions/audit_trail_entry_component.rb
@@ -13,7 +13,7 @@ class Admin::Editions::AuditTrailEntryComponent < ViewComponent::Base
 private
 
   def action
-    "#{entry.action.capitalize} by "
+    "Document #{entry.action}"
   end
 
   def actor

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -14,36 +14,38 @@
 
 <% if entries_on_newer_editions.present? %>
   <div class="app-view-editions__newer-edition-entries">
-    <h3 class="govuk-heading-m">On newer editions</h3>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">On newer editions</h3>
 
-    <ul class="gem-c-list govuk-list">
-      <% entries_on_newer_editions.each do |entry| %>
-        <%= render_entry(entry) %>
-      <% end %>
-    </ul>
+    <%= render "govuk_publishing_components/components/list", {
+      margin_bottom: entries_on_previous_editions.present? ? 8 : 0,
+      items: entries_on_newer_editions.map do |entry|
+        render_entry(entry)
+      end
+    } %>
   </div>
 <% end %>
 
 <% if entries_on_current_edition.present? %>
   <div class="app-view-editions__current-edition-entries">
-    <h3 class="govuk-heading-m">On this edition</h3>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">On this edition</h3>
 
-    <ul class="gem-c-list govuk-list">
-      <% entries_on_current_edition.each do |entry| %>
-        <%= render_entry(entry) %>
-      <% end %>
-    </ul>
+    <%= render "govuk_publishing_components/components/list", {
+      margin_bottom: entries_on_previous_editions.present? ? 8 : 0,
+      items: entries_on_current_edition.map do |entry|
+        render_entry(entry)
+      end
+    } %>
   </div>
 <% end %>
 
 <% if entries_on_previous_editions.present? %>
   <div class="app-view-editions__previous-edition-entries">
-    <h3 class="govuk-heading-m">On previous editions</h3>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">On previous editions</h3>
 
-    <ul class="gem-c-list govuk-list">
-      <% entries_on_previous_editions.each do |entry| %>
-        <%= render_entry(entry) %>
-      <% end %>
-    </ul>
+    <%= render "govuk_publishing_components/components/list", {
+      items: entries_on_previous_editions.map do |entry|
+        render_entry(entry)
+      end
+    } %>
   </div>
 <% end %>

--- a/app/components/admin/editions/editorial_remark_component.html.erb
+++ b/app/components/admin/editions/editorial_remark_component.html.erb
@@ -1,4 +1,11 @@
-<li class="app-view-editions-editorial-remark__list-item govuk-!-margin-bottom-4">
-  <p><%= editorial_remark.body %></p>
-  <%= actor %> <%= time %>
-</li>
+<div class="app-view-editions-editorial-remark__list-item govuk-!-margin-bottom-4">
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-1">Internal note</h4>
+
+  <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+    <%= editorial_remark.body %>
+  </p>
+
+  <p class="app-view-editions-editorial-remark__list-item-datetime govuk-body govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+    <%= time %> by <%= actor %>
+  </p>
+</div>

--- a/test/components/admin/editions/audit_trail_entry_component_test.rb
+++ b/test/components/admin/editions/audit_trail_entry_component_test.rb
@@ -13,9 +13,10 @@ class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
 
     render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition:))
 
-    assert_equal page.text, "\n  Created by  #{actor.name}\n  \n   1 January 2020 11:11am\n\n"
-    assert_equal page.find("li a").text, actor.name
-    assert_equal page.find("li a")[:href], "/government/admin/authors/#{actor.id}"
+    assert_equal page.find("h4").text, "Document created"
+    assert_equal page.all("p")[0].text.strip, "1 January 2020 11:11am by #{actor.name}"
+    assert_equal page.find("p a").text, actor.name
+    assert_equal page.find("p a")[:href], "/government/admin/authors/#{actor.id}"
   end
 
   test "it constructs output based on the entry when an actor is absent" do
@@ -25,7 +26,8 @@ class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
 
     render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition:))
 
-    assert_equal page.text, "\n  Created by  User (removed)\n  \n   1 January 2020 11:11am\n\n"
+    assert_equal page.find("h4").text, "Document created"
+    assert_equal page.all("p")[0].text.strip, "1 January 2020 11:11am by User (removed)"
   end
 
   test "it links to the diff page is the action is published and the edition passed in is different to the versions" do
@@ -38,10 +40,12 @@ class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
 
     render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition: newer_edition))
 
-    assert_equal page.text, "\n    [Compare with previous version]\n  Published by  #{actor.name}\n  \n   1 January 2020 11:11am\n\n"
-    assert_equal page.all("li a")[0].text, "[Compare with previous version]"
-    assert_equal page.all("li a")[0][:href], diff_admin_edition_path(newer_edition, audit_trail_entry_id: version.item_id)
-    assert_equal page.all("li a")[1].text, actor.name
-    assert_equal page.all("li a")[1][:href], admin_author_path(actor)
+    assert_equal page.find("h4").text, "Document published"
+    assert_equal page.all("p")[0].text.strip, "[Compare with previous version]"
+    assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by #{actor.name}"
+    assert_equal page.all("p a")[0].text, "[Compare with previous version]"
+    assert_equal page.all("p a")[0][:href], diff_admin_edition_path(newer_edition, audit_trail_entry_id: version.item_id)
+    assert_equal page.all("p a")[1].text, actor.name
+    assert_equal page.all("p a")[1][:href], admin_author_path(actor)
   end
 end

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -49,16 +49,16 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
     render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @second_edition, document_history: @timeline))
 
     assert_selector ".app-view-editions__newer-edition-entries h3", text: "On newer editions"
-    assert_selector ".app-view-editions__newer-edition-entries li.app-view-editions-audit-trail-entry__list-item", count: 2
-    assert_selector ".app-view-editions__newer-edition-entries li.app-view-editions-editorial-remark__list-item", count: 1
+    assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 2
+    assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-editorial-remark__list-item", count: 1
 
     assert_selector ".app-view-editions__current-edition-entries h3", text: "On this edition"
-    assert_selector ".app-view-editions__current-edition-entries li.app-view-editions-audit-trail-entry__list-item", count: 4
-    assert_selector ".app-view-editions__current-edition-entries li.app-view-editions-editorial-remark__list-item", count: 1
+    assert_selector ".app-view-editions__current-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 4
+    assert_selector ".app-view-editions__current-edition-entries div.app-view-editions-editorial-remark__list-item", count: 1
 
     assert_selector ".app-view-editions__previous-edition-entries h3", text: "On previous editions"
-    assert_selector ".app-view-editions__previous-edition-entries li.app-view-editions-audit-trail-entry__list-item", count: 2
-    assert_selector ".app-view-editions__previous-edition-entries li.app-view-editions-editorial-remark__list-item", count: 0
+    assert_selector ".app-view-editions__previous-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 2
+    assert_selector ".app-view-editions__previous-edition-entries div.app-view-editions-editorial-remark__list-item", count: 0
   end
 
   def seed_document_event_history

--- a/test/components/admin/editions/editorial_remark_component_test.rb
+++ b/test/components/admin/editions/editorial_remark_component_test.rb
@@ -8,9 +8,9 @@ class Admin::Editions::EditorialRemarkComponentTest < ViewComponent::TestCase
     author = editorial_remark.author
     render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
 
-    assert_equal page.text.strip, "#{editorial_remark.body}\n  #{author.name}  1 January 2020 11:11am"
-    assert_equal page.find("li a").text, author.name
-    assert_equal page.find("li a")[:href], "/government/admin/authors/#{author.id}"
+    assert_equal page.find("h4").text, "Internal note"
+    assert_equal page.all("p")[0].text.strip, editorial_remark.body
+    assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by #{author.name}"
   end
 
   test "it constructs output based on the editorial remark when an author is absent" do
@@ -18,6 +18,8 @@ class Admin::Editions::EditorialRemarkComponentTest < ViewComponent::TestCase
 
     render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
 
-    assert_equal page.text.strip, "#{editorial_remark.body}\n  User (removed)  1 January 2020 11:11am"
+    assert_equal page.find("h4").text, "Internal note"
+    assert_equal page.all("p")[0].text.strip, editorial_remark.body
+    assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by User (removed)"
   end
 end


### PR DESCRIPTION
## Description

After some discussion with Nikin there are a few styling changes we can make to improve the history tab that is rendered ont the edition summary, edit and edit translation pages.

This PR does the following: 

Uses the GOV.UK Publishing list component in place of custom HTML in the document tab component

And for the audit entry component and editorial remark component:

1. Replaces list tag with a div (the output of this is being passed
into the GOV.UK List component as an item)
2. Makes the document action a H4
3. Updates the ordering of the author and datetime
4. Applies govuk-body-s to the author and datetime
5. Applies $govuk-secondary-text-colour to the datetime (hint text)

## Screenshots

### Before

<img width="434" alt="image" src="https://user-images.githubusercontent.com/42515961/211602077-21ae6728-b401-41d7-8ec4-a181e0eb2cb3.png">

### After 

<img width="509" alt="image" src="https://user-images.githubusercontent.com/42515961/212028888-56129d97-2234-4b67-9896-2bccac91f510.png">

## Trello card 

https://trello.com/c/o03t3EYI/1046-fix-styling-of-history-component-based-on-design-feedback

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
