### PR TITLE
Remove `double_width` field

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -70,7 +70,6 @@ private
       :image_alt_text,
       :title,
       :title_url,
-      :double_width,
       :image_cache,
       :youtube_video_url,
       :image_or_youtube_video_url,

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -85,7 +85,6 @@ private
         :image_alt_text,
         :title,
         :title_url,
-        :double_width,
         :image_cache,
         :youtube_video_url,
         :image_or_youtube_video_url,

--- a/app/models/promotional_feature.rb
+++ b/app/models/promotional_feature.rb
@@ -13,14 +13,10 @@ class PromotionalFeature < ApplicationRecord
   end
 
   def has_reached_item_limit?
-    items.count == 3 || has_one_small_and_one_large_item?
+    items.count == 3
   end
 
 private
-
-  def has_one_small_and_one_large_item?
-    items.count == 2 && items.one?(&:double_width?)
-  end
 
   def set_ordering
     self.ordering = (organisation.promotional_features.maximum(:ordering) || 0) + 1

--- a/app/presenters/promotional_feature_item_presenter.rb
+++ b/app/presenters/promotional_feature_item_presenter.rb
@@ -1,12 +1,8 @@
 class PromotionalFeatureItemPresenter < Whitehall::Decorators::Decorator
   delegate_instance_methods_of PromotionalFeatureItem
 
-  def css_classes
-    ["feature", ("large" if double_width?)].compact.join(" ")
-  end
-
   def image_url
-    double_width? ? image.s630.url : image.s300.url
+    image.s300.url
   end
 
   def display_image
@@ -25,12 +21,8 @@ class PromotionalFeatureItemPresenter < Whitehall::Decorators::Decorator
     context.image_tag(image_url, alt: image_alt_text)
   end
 
-  def link_list_class
-    "dash-list" unless double_width?
-  end
-
   def width
-    double_width? ? 2 : 1
+    1
   end
 
   def summary

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -310,7 +310,6 @@ module PublishingApi
         title: promotional_feature_item.title,
         href: promotional_feature_item.title_url,
         summary: promotional_feature_item.summary,
-        double_width: promotional_feature_item.double_width,
         links: promotional_feature_item.links.map do |link|
           {
             title: link.text,

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -1,7 +1,6 @@
 
 <%= form.text_field :title, label_text: 'Item title (optional)' %>
 <%= form.text_field :title_url, label_text: 'Item title url (optional)' %>
-<%= form.check_box :double_width, label_text: "Display double-width?" %>
 <%= form.text_area :summary, rows: 4 %>
 
 <% if current_user.can_add_youtube_urls_to_promotional_features? %>

--- a/db/migrate/20230110161456_remove_double_width_from_promotional_feature_items.rb
+++ b/db/migrate/20230110161456_remove_double_width_from_promotional_feature_items.rb
@@ -1,0 +1,5 @@
+class RemoveDoubleWidthFromPromotionalFeatureItems < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :promotional_feature_items, :double_width, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_28_103350) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_10_161456) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -741,7 +741,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_28_103350) do
     t.string "image_alt_text"
     t.string "title"
     t.string "title_url"
-    t.boolean "double_width", default: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "youtube_video_url"

--- a/test/unit/presenters/promotional_feature_item_presenter_test.rb
+++ b/test/unit/presenters/promotional_feature_item_presenter_test.rb
@@ -12,19 +12,9 @@ class PromotionalFeatureItemPresenterTest < ActionView::TestCase
     end
   end
 
-  test '#css_classes returns "large" for double-width items' do
-    assert_equal "feature", item_presenter.css_classes
-    assert_equal "feature large", item_presenter(double_width: true).css_classes
-  end
-
   test "#image_url returns 300px width images for single-width items" do
     item = item_presenter
     assert_equal item.image.s300.url, item.image_url
-  end
-
-  test "#image_url returns 630px width image path for double-width items" do
-    item = item_presenter(double_width: true)
-    assert_equal item.image.s630.url, item.image_url
   end
 
   test "#display_image returns a normal image tag if no link" do
@@ -43,14 +33,8 @@ class PromotionalFeatureItemPresenterTest < ActionView::TestCase
     assert_equal "", item.display_image
   end
 
-  test '#link_list_class returns "dash-list" for single-width items' do
-    assert_equal "dash-list", item_presenter.link_list_class
-    assert_nil item_presenter(double_width: true).link_list_class
-  end
-
   test "#width returns the width as an integer" do
     assert_equal 1, item_presenter.width
-    assert_equal 2, item_presenter(double_width: true).width
   end
 
   test "#title returns nil if feature item has no title" do

--- a/test/unit/presenters/promotional_feature_presenter_test.rb
+++ b/test/unit/presenters/promotional_feature_presenter_test.rb
@@ -9,13 +9,11 @@ class PromotionalFeaturePresenterTest < ActionView::TestCase
     assert_equal 0, feature_presenter.width
     assert_equal 1, feature_presenter([build(:promotional_feature_item)]).width
     assert_equal 2, feature_presenter([build(:promotional_feature_item), build(:promotional_feature_item)]).width
-    assert_equal 3, feature_presenter([build(:promotional_feature_item), build(:promotional_feature_item, double_width: true)]).width
   end
 
   test "#width_class returns the appropriate class based on the feature's width" do
     assert_equal "features-1", feature_presenter([build(:promotional_feature_item)]).width_class
     assert_equal "features-2", feature_presenter([build(:promotional_feature_item), build(:promotional_feature_item)]).width_class
-    assert_equal "features-3", feature_presenter([build(:promotional_feature_item), build(:promotional_feature_item, double_width: true)]).width_class
   end
 
   test "can be initialized with the position" do

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -203,7 +203,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         items: [
           summary: promotional_feature_item1.summary,
           image: { url: promotional_feature_item1.image.url, alt_text: promotional_feature_item1.image_alt_text },
-          double_width: promotional_feature_item1.double_width,
           links: promotional_feature_item2.links,
         ],
       },
@@ -212,7 +211,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         items: [
           summary: promotional_feature_item2.summary,
           youtube_video_id: promotional_feature_item2.youtube_video_id,
-          double_width: promotional_feature_item2.double_width,
           links: promotional_feature_item2.links,
         ],
       },

--- a/test/unit/promotional_feature_test.rb
+++ b/test/unit/promotional_feature_test.rb
@@ -12,14 +12,6 @@ class PromotionalFeatureTest < ActiveSupport::TestCase
     assert feature.has_reached_item_limit?
   end
 
-  test "A feature with one normal item and one double-width item has reached its limit" do
-    feature = create(:promotional_feature)
-    create(:promotional_feature_item, promotional_feature: feature, double_width: true)
-    assert_not feature.has_reached_item_limit?
-    create(:promotional_feature_item, promotional_feature: feature)
-    assert feature.has_reached_item_limit?
-  end
-
   test "it sets the ordering value before_save when ordering is blank" do
     organisation = create(:executive_office)
     feature1 = create(:promotional_feature, organisation:)


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/CXft2Mlr/1013-remove-unused-double-width-field-from-promotional-features)

## What
This PR removes all reference to `double_width` and adds a migration to remove the `double_width` column from the `promotional_feature_items` table.

## Why
`double_width` is no longer used in the frontend and so is redundant

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
