### PR TITLE
Fix check to hide markdown field for lead images

### DIFF
--- a/app/views/admin/editions/_image_template.html.erb
+++ b/app/views/admin/editions/_image_template.html.erb
@@ -58,7 +58,7 @@
         } %>
       <% end %>
 
-      <% if edition.image_disallowed_in_body_text?(index) %>
+      <% if edition.image_disallowed_in_body_text?(index + 1) %>
         <p class="govuk-body">This image is shown automatically, and is not available for use inline in the body.</p>
       <% elsif image.persisted? %>
         <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the check to hide markdown field for lead images

## Why
image_disallowed_in_body_text expects the user's base 1 image index.
Passing through the base 0 index was resulting in markdown for the lead image being displayed even when it shouldn't.