### PR TITLE
Fix bug with conditional Publication subtype guidance

### DIFF
--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -27,9 +27,9 @@
         <% end %>
       <optgroup/>
     </select>
-
-    <% if edition.publication_type_id.present? %>
-      <%= render "subtype_format_advice", guidance: JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
-    <% end %>
   </div>
+
+  <% if edition.publication_type_id.present? %>
+    <%= render "subtype_format_advice", guidance: JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>
+  <% end %>
 </div>


### PR DESCRIPTION
## Description

At the moment the JS blows up when trying to delete the previous subtypeDiv. This occurs due to the subtypeFormatAdvice div not being a direct child of the subtypeDiv.

This moves the div outside of the form group div to mirror the implementation for Speeches and News Articles.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
