### PR TITLE
Make ruby tests a reusable workflow

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -1,48 +1,21 @@
-name: CI
+name: Run Minitest
 
 on:
-  workflow_dispatch: {}
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
-  pull_request:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        required: false
+        type: string
+      publishingApiRef:
+        description: 'The branch, tag or SHA to checkout Publishing API'
+        required: false
+        default: 'deployed-to-production'
+        type: string
 
 jobs:
-  security-analysis:
-    name: Security Analysis
-    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
-
-  lint-scss:
-    name: Lint SCSS
-    uses: alphagov/govuk-infrastructure/.github/workflows/stylelint.yml@main
-    with:
-      files: "app/assets/stylesheets/"
-
-  lint-javascript:
-    name: Lint JavaScript
-    uses: alphagov/govuk-infrastructure/.github/workflows/standardx.yml@main
-    with:
-      files: "'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'"
-
-  lint-ruby:
-    name: Lint Ruby
-    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
-
-  test-javascript:
-    name: Test JavaScript
-    uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main
-    with:
-      useWithRails: true
-
-  test-ruby:
-    name: Test Ruby
-    uses: ./.github/workflows/minitest.yml
-
-  integration-tests:
-    name: Integration tests
+  run-minitest:
+    name: Run Minitest
     runs-on: ubuntu-latest
     steps:
       - name: Setup MySQL
@@ -59,6 +32,16 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          repository: alphagov/whitehall
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout Publishing API (for Content Schemas)
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/publishing-api
+          ref: ${{ inputs.publishingApiRef }}
+          path: vendor/publishing-api
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -77,8 +60,9 @@ jobs:
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
         run: bundle exec rails db:setup
 
-      - name: Run cucumber
+      - name: Run Minitest
         env:
           RAILS_ENV: test
+          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
-        run: bundle exec rails cucumber
+        run: bundle exec rake test


### PR DESCRIPTION
This application depends on the Content Schemas. Making the tests
reusable allows Publishing API to run the tests when the Content Schemas
are updated.
