### PR TITLE
Remove the ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES permission

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -81,7 +81,7 @@ private
   def clean_image_or_youtube_video_url_param
     feature_item_type = promotional_feature_item_params.delete(:image_or_youtube_video_url)
 
-    if feature_item_type == "youtube_video_url" && current_user.can_add_youtube_urls_to_promotional_features?
+    if feature_item_type == "youtube_video_url"
       promotional_feature_item_params["image"] = nil
       promotional_feature_item_params["image_alt_text"] = nil
     else

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -99,7 +99,7 @@ private
 
     feature_item_type = first_promotional_feature_item_params.delete(:image_or_youtube_video_url)
 
-    if feature_item_type == "youtube_video_url" && current_user.can_add_youtube_urls_to_promotional_features?
+    if feature_item_type == "youtube_video_url"
       first_promotional_feature_item_params["image"] = nil
       first_promotional_feature_item_params["image_alt_text"] = nil
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,6 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     PREVIEW_NEXT_RELEASE = "Preview next release".freeze
-    ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES = "Add youtube urls to promotional features".freeze
   end
 
   def role
@@ -90,10 +89,6 @@ class User < ApplicationRecord
 
   def can_preview_next_release?
     has_permission?(Permissions::PREVIEW_NEXT_RELEASE)
-  end
-
-  def can_add_youtube_urls_to_promotional_features?
-    has_permission?(Permissions::ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES)
   end
 
   def organisation_name

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -3,48 +3,40 @@
 <%= form.text_field :title_url, label_text: 'Item title url (optional)' %>
 <%= form.text_area :summary, rows: 4 %>
 
-<% if current_user.can_add_youtube_urls_to_promotional_features? %>
-  <div class="publishing-controls">
-    <fieldset class="image-and-youtube-radios">
-      <legend>Image or YouTube video</legend>
+<div class="publishing-controls">
+  <fieldset class="image-and-youtube-radios">
+    <legend>Image or YouTube video</legend>
 
-      <p>Upload an image or input a YouTube video url for the promotional feature item</p>
+    <p>Upload an image or input a YouTube video url for the promotional feature item</p>
 
-      <%= form.labelled_radio_button(
-        "Image",
-        :image_or_youtube_video_url,
-        "image",
-        checked: form.object.image.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "image"
-      ) %>
+    <%= form.labelled_radio_button(
+      "Image",
+      :image_or_youtube_video_url,
+      "image",
+      checked: form.object.image.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "image"
+    ) %>
 
-      <div class="form-group image-fields">
-        <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
-        <%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
-        <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
-      </div>
+    <div class="form-group image-fields">
+      <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
+      <%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
+      <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
+    </div>
 
-      <%= form.labelled_radio_button(
-        "YouTube video",
-        :image_or_youtube_video_url,
-        "youtube_video_url",
-        checked: form.object.youtube_video_url.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "youtube_video_url"
-      ) %>
+    <%= form.labelled_radio_button(
+      "YouTube video",
+      :image_or_youtube_video_url,
+      "youtube_video_url",
+      checked: form.object.youtube_video_url.present? || params.dig("promotional_feature", "promotional_feature_items_attributes", "0", "image_or_youtube_video_url") == "youtube_video_url"
+    ) %>
 
-      <div class="youtube-video-url-fields form-group">
-        <%= form.text_field :youtube_video_url, label_text: "YouTube video URL" %>
-        <p class="hint add-bottom-margin">For example https://www.youtube.com/watch?v=MSmotCRFFMc</p>
+    <div class="youtube-video-url-fields form-group">
+      <%= form.text_field :youtube_video_url, label_text: "YouTube video URL" %>
+      <p class="hint add-bottom-margin">For example https://www.youtube.com/watch?v=MSmotCRFFMc</p>
 
-        <%= form.text_field :youtube_video_alt_text, label_text: "YouTube video description (alt text)" %>
-      </div>
-    </fieldset>
-  </div>
-<% else %>
-  <div class="form-group">
-    <%= image_tag(form.object.image.url(:s300)) if form.object.image_url %>
-  </div>
-  <%= form.upload :image, label_text: 'Item image (must be 960px by 640px)' %>
-  <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
-<% end %>
+      <%= form.text_field :youtube_video_alt_text, label_text: "YouTube video description (alt text)" %>
+    </div>
+  </fieldset>
+</div>
 
 <div class="js-duplicate-fields">
   <legend>Feature item links</legend>

--- a/features/executive-office-promotional-features.feature
+++ b/features/executive-office-promotional-features.feature
@@ -9,7 +9,6 @@ Feature: Promotional features for executive offices
     Then I should see the promotional feature on the organisation's page
 
   Scenario: Add a promotional feature with a youtube url to an executive office
-    And I have the "Add youtube urls to promotional features" permission
     When I add a new promotional feature with a single item which has a YouTube URL
     Then I should see the promotional feature on the organisation's page
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -145,16 +145,6 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_preview_next_release?
   end
 
-  test "cannot add youtube urls to promotional features by default" do
-    user = build(:user)
-    assert_not user.can_add_youtube_urls_to_promotional_features?
-  end
-
-  test "can add youtube urls to promotional features" do
-    user = build(:user, permissions: [User::Permissions::ADD_YOUTUBE_URLS_TO_PROMOTIONAL_FEATURES])
-    assert user.can_add_youtube_urls_to_promotional_features?
-  end
-
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
## Description

This was a temporary permission in place for testing on the frontend.

Now we're going live with the feature it can be removed

## Trello card

https://trello.com/c/vka5wHuD/73-remove-feature-flag-for-youtube-id-adding-in-whitehall-to-allow-number-10-to-upload-videos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
