### PR TITLE
Fix typo: change lowercase "g" for uppercase

### DIFF
--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -38,7 +38,7 @@
           error_message: errors_for_input(edition.errors, :change_note),
           value: edition.change_note,
           hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
-                link_to("guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link")).html_safe
+                link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link")).html_safe
         })
       },
       {


### PR DESCRIPTION
Fixes a typo in the 'change notes' section of the Design System edition 'edit' page.

| Before | After |
| --- | --- |
| <img width="409" alt="Lowercase" src="https://user-images.githubusercontent.com/7735945/211805365-1eb85f5b-aa57-4f77-8ef0-34f03606253d.png"> | <img width="412" alt="Uppercase" src="https://user-images.githubusercontent.com/7735945/211805385-d4443e75-d275-42e4-a994-6fe9c5495b22.png"> |

<img width="806" alt="Lowercase _g_" src="https://user-images.githubusercontent.com/7735945/211804978-bfadfd7b-320a-43f4-bbb5-268d12e76a4f.png">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
