### PR TITLE
Add youtube video alt text

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -72,6 +72,7 @@ private
       :title_url,
       :image_cache,
       :youtube_video_url,
+      :youtube_video_alt_text,
       :image_or_youtube_video_url,
       links_attributes: %i[url text _destroy id],
     )
@@ -85,6 +86,7 @@ private
       promotional_feature_item_params["image_alt_text"] = nil
     else
       promotional_feature_item_params["youtube_video_url"] = nil
+      promotional_feature_item_params["youtube_video_alt_text"] = nil
     end
   end
 end

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -87,6 +87,7 @@ private
         :title_url,
         :image_cache,
         :youtube_video_url,
+        :youtube_video_alt_text,
         :image_or_youtube_video_url,
         { links_attributes: %i[url text _destroy] },
       ],
@@ -103,6 +104,7 @@ private
       first_promotional_feature_item_params["image_alt_text"] = nil
     else
       first_promotional_feature_item_params["youtube_video_url"] = nil
+      first_promotional_feature_item_params["youtube_video_alt_text"] = nil
     end
   end
 

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -14,6 +14,7 @@ class PromotionalFeatureItem < ApplicationRecord
     message: "Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL",
     allow_blank: true,
   }
+  validates :youtube_video_alt_text, presence: true, if: -> { youtube_video_url.present? }
 
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: ->(attributes) { attributes["url"].blank? }
 

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -291,9 +291,12 @@ module PublishingApi
     end
 
     def promotional_feature_item_youtube_hash(promotional_feature_item)
-      promotional_feature_item_hash_common(promotional_feature_item).merge(
-        { youtube_video_id: promotional_feature_item.youtube_video_id },
-      )
+      promotional_feature_item_hash_common(promotional_feature_item).merge({
+        youtube_video: {
+          id: promotional_feature_item.youtube_video_id,
+          alt_text: promotional_feature_item.youtube_video_alt_text,
+        },
+      })
     end
 
     def promotional_feature_item_image_hash(promotional_feature_item)

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -33,6 +33,8 @@
       <div class="youtube-video-url-fields form-group">
         <%= form.text_field :youtube_video_url, label_text: "YouTube video URL" %>
         <p class="hint add-bottom-margin">For example https://www.youtube.com/watch?v=MSmotCRFFMc</p>
+
+        <%= form.text_field :youtube_video_alt_text, label_text: "YouTube video description (alt text)" %>
       </div>
     </fieldset>
   </div>

--- a/db/migrate/20230111131609_add_youtube_video_alt_text_to_promotional_feature_items.rb
+++ b/db/migrate/20230111131609_add_youtube_video_alt_text_to_promotional_feature_items.rb
@@ -1,0 +1,5 @@
+class AddYoutubeVideoAltTextToPromotionalFeatureItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :promotional_feature_items, :youtube_video_alt_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_10_161456) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_11_131609) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -744,6 +744,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_161456) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "youtube_video_url"
+    t.string "youtube_video_alt_text"
     t.index ["promotional_feature_id"], name: "index_promotional_feature_items_on_promotional_feature_id"
   end
 

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -48,6 +48,7 @@ When(/^I add a new promotional feature with a single item which has a YouTube UR
     fill_in "Item title url (optional)",    with: "http://big-cheese.co"
     choose "YouTube video"
     fill_in "YouTube video URL", with: "https://www.youtube.com/watch?v=fFmDQn9Lbl4"
+    fill_in "YouTube video description (alt text)", with: "Description of video."
   end
 
   click_button "Save"

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       image { nil }
       image_alt_text { nil }
       youtube_video_url { "https://www.youtube.com/watch?v=fFmDQn9Lbl4" }
+      youtube_video_alt_text { "YouTube alt text." }
     end
   end
 end

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -105,6 +105,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
                   promotional_feature_item: {
                     summary: "Updated summary",
                     youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4",
+                    youtube_video_alt_text: "YouTube alt text.",
                     image_or_youtube_video_url: "youtube_video_url",
                     links_attributes: { "0" => { url: link.url, text: link.text, id: link.id, _destroy: false } },
                   } }

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -210,7 +210,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         title: promotional_feature2.title,
         items: [
           summary: promotional_feature_item2.summary,
-          youtube_video_id: promotional_feature_item2.youtube_video_id,
+          youtube_video: { id: promotional_feature_item2.youtube_video_id, alt_text: promotional_feature_item2.youtube_video_alt_text },
           links: promotional_feature_item2.links,
         ],
       },

--- a/test/unit/promotional_feature_item_test.rb
+++ b/test/unit/promotional_feature_item_test.rb
@@ -33,7 +33,7 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   test "validates that an image or youtube_video_url is present on save" do
     feature_item_with_image = build(:promotional_feature_item)
-    feature_item_with_youtube_url = build(:promotional_feature_item, image: nil, youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4")
+    feature_item_with_youtube_url = build(:promotional_feature_item, :with_youtube_video_url)
     invalid_feature_item = build(:promotional_feature_item, image: nil, youtube_video_url: nil)
 
     assert feature_item_with_image.valid?
@@ -43,7 +43,7 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
   end
 
   test "validates that either an image and youtube_video_url can be provided" do
-    invalid_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4")
+    invalid_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.youtube.com/watch?v=fFmDQn9Lbl4", youtube_video_alt_text: "Alt text.")
 
     assert_not invalid_feature_item.valid?
     assert_equal invalid_feature_item.errors.full_messages, ["Upload either an image or add a YouTube URL"]
@@ -51,12 +51,12 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   VALID_YOUTUBE_URLS.each do |url|
     test "validates that a youtube_video_url of `#{url}` is valid" do
-      assert build(:promotional_feature_item, image: nil, youtube_video_url: url).valid?
+      assert build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: url).valid?
     end
   end
 
   test "validates that a youtube_video_url of `https://www.gov.uk/government/organisations/government-digital-service` is invalid" do
-    promotional_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
+    promotional_feature_item = build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
 
     assert_not promotional_feature_item.valid?
     assert_equal promotional_feature_item.errors[:youtube_video_url], ["Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL"]
@@ -64,7 +64,7 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   VALID_YOUTUBE_URLS.each do |url|
     test "#youtube_video_id returns the youtube_video_id for `#{url}`" do
-      assert_equal build(:promotional_feature_item, youtube_video_url: url).youtube_video_id, "fFmDQn9Lbl4"
+      assert_equal build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: url).youtube_video_id, "fFmDQn9Lbl4"
     end
   end
 


### PR DESCRIPTION
## Description 

We recently add the ability for a promotional feature item to take a YouTube video id in place of an image. Upon review it became apparent that needs accompanying alt_text field in case the video is unable to be embedded on the Frontend.

Publishing API pr - https://github.com/alphagov/publishing-api/pull/2251

## Screenshot

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/42515961/211837422-c897f045-cebd-41e3-850e-4839e66324d5.png">


## Trello card 

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
