### PR TITLE
Use 'Internal note' instead of 'Editorial remark' on new page

### DIFF
--- a/app/views/admin/editorial_remarks/new.html.erb
+++ b/app/views/admin/editorial_remarks/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "New editorial remark" %>
-<% content_for :title, "New editorial remark" %>
+<% content_for :page_title, "New internal note" %>
+<% content_for :title, "New internal note" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @editorial_remark)) %>
 
 <div class="govuk-grid-row">
@@ -13,7 +13,7 @@
     <%= form_for [:admin, @edition, @editorial_remark], url: admin_edition_editorial_remarks_path(@edition) do |feedback_form| %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: "Remark",
+          text: "Internal note",
           bold: true,
         },
         name: "editorial_remark[body]",
@@ -24,7 +24,7 @@
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
-            text: "Submit remark"
+            text: "Submit internal note"
           } %>
         <% end %>
 

--- a/features/admin-editorial-remarks.feature
+++ b/features/admin-editorial-remarks.feature
@@ -3,7 +3,6 @@ Feature: Creating and viewing editorial remarks
   Background:
     Given I am a writer
 
-  @design-system-wip
   Scenario: Adding an editorial remark
     When I add an editorial remark "Try using a spellchecker" to the document "Badddly Rittin"
     Then my editorial remark should be visible with the document

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -50,7 +50,7 @@ When(/^I add an editorial remark "([^"]*)" to the document "([^"]*)"$/) do |rema
   visit admin_edition_path(@edition)
   click_link "Add new remark"
   fill_in "Remark", with: @remark_text
-  click_button "Submit remark"
+  click_button "Submit internal note"
 end
 
 Then(/^my editorial remark should be visible with the document$/) do

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -48,12 +48,21 @@ When(/^I add an editorial remark "([^"]*)" to the document "([^"]*)"$/) do |rema
   @remark_text = remark_text
 
   visit admin_edition_path(@edition)
-  click_link "Add new remark"
-  fill_in "Remark", with: @remark_text
+  if using_design_system?
+    click_link "Add internal note"
+  else
+    click_link "Add new remark"
+  end
+
+  fill_in "Internal note", with: @remark_text
   click_button "Submit internal note"
 end
 
 Then(/^my editorial remark should be visible with the document$/) do
   ensure_path admin_edition_path(@edition)
-  expect(page).to have_selector(".editorial_remark .body", text: @remark_text)
+  if using_design_system?
+    expect(page).to have_selector(".app-view-editions-editorial-remark__list-item", text: @remark_text)
+  else
+    expect(page).to have_selector(".editorial_remark .body", text: @remark_text)
+  end
 end


### PR DESCRIPTION
## Description

We're updating the UI to use Internal note rather than editorial remark throughout the UI. This page was missed.

While updating the feature spec i noticed it was marked as @design-system-wip so i've ensured the test passes with and without Bootstrap.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
