### PR TITLE
Allow emails to be intercepted in non-production environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development do
 end
 
 group :test do
+  gem "climate_control"
   gem "database_cleaner-active_record"
   gem "equivalent-xml"
   gem "factory_bot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     carrierwave-i18n (0.2.0)
     childprocess (4.1.0)
     chronic (0.10.2)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
@@ -754,6 +755,7 @@ DEPENDENCIES
   carrierwave
   carrierwave-i18n
   chronic
+  climate_control
   cucumber
   cucumber-rails
   dalli

--- a/config/initializers/mail_recipient_interceptor.rb
+++ b/config/initializers/mail_recipient_interceptor.rb
@@ -1,0 +1,5 @@
+require "mail_recipient_interceptor"
+
+if ENV.fetch("EMAIL_ADDRESS_OVERRIDE", nil)
+  ActionMailer::Base.register_interceptor(MailRecipientInterceptor)
+end

--- a/lib/mail_recipient_interceptor.rb
+++ b/lib/mail_recipient_interceptor.rb
@@ -1,0 +1,8 @@
+class MailRecipientInterceptor
+  def self.delivering_email(message)
+    body_prefix = "Intended recipient(s): #{message.to.join(', ')}\n\n"
+
+    message.body = body_prefix + message.body.raw_source
+    message.to = ENV["EMAIL_ADDRESS_OVERRIDE"]
+  end
+end

--- a/test/lib/mail_recipient_interceptor_test.rb
+++ b/test/lib/mail_recipient_interceptor_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class MailRecipientInterceptorTest < ActiveSupport::TestCase
+  setup do
+    @mail = Mail.new(
+      to: "original-recipient@example.com",
+      body: "Hello from Whitehall",
+    )
+
+    ClimateControl.modify(EMAIL_ADDRESS_OVERRIDE: "intercepted@example.com") do
+      MailRecipientInterceptor.delivering_email(@mail)
+    end
+  end
+
+  test "intercepts emails and sends to the address specified by the EMAIL_ADDRESS_OVERRIDE env var" do
+    assert_equal ["intercepted@example.com"], @mail.to
+  end
+
+  test "intercepts emails and prefixes the original recipient to the body" do
+    assert_equal "Intended recipient(s): original-recipient@example.com\n\nHello from Whitehall", @mail.body.to_s
+  end
+end


### PR DESCRIPTION
We don't want emails sent in non-production environments to be delivered to end users. For example, email notifications sent in integration and staging should not be delivered in case they're mistaken as production notifications.

Therefore, the GOV.UK Notify accounts used by Whitehall in integration and staging have been configured to reject emails being sent to recipients who aren't on a pre-defined 'allow list' of addresses.

This commit adds a Mail Recipient Interceptor, which will intercept emails before Rails attempts to deliver them and update the recipient. This can be used in integration and staging by setting the environment variable `EMAIL_ADDRESS_OVERRIDE` to an email address that is known to be on the GOV.UK Notify 'allow list'.

This setup was _heavily inspired_ by the Content Publisher app, which also implements an interceptor:

- [lib/mail_recipient_interceptor.rb][1]
- [config/initializers/mail_recipient_interceptor.rb][2]

[1]: https://github.com/alphagov/content-publisher/blob/efc7cc8156d153d458472e5dd1f81992241c0b87/lib/mail_recipient_interceptor.rb
[2]: https://github.com/alphagov/content-publisher/blob/efc7cc8156d153d458472e5dd1f81992241c0b87/config/initializers/mail_recipient_interceptor.rb

---

Trello: https://trello.com/c/FIzGBARz/1020-allow-devs-to-see-whitehall-emails-sent-in-integration-staging-environments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
