### PR TITLE
Remove design system wip when applicable

### DIFF
--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
+<div class="app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "edition[create_foreign_language_only]",
     id: "edition_create_foreign_language_only",

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -10,7 +10,6 @@ Feature: Filtering documents by author in admin
     Then I should see the publication "My Publication"
     And I should not see the publication "Another Publication"
 
-  @design-system-wip
   Scenario: Viewing only publications written by me
     Given I am a writer
     And there is a user called "Janice"

--- a/features/admin-statistical-data-sets.feature
+++ b/features/admin-statistical-data-sets.feature
@@ -3,7 +3,6 @@ Feature: Adding stastical data set references to a publication
   In order to reference relevant stastics
   I want to be able to add those references to a publication
 
-  @design-system-wip
   Scenario: Creating a new draft publication that references statistical data sets
     Given I am an editor
     And a published statistical data set "Historical Beard Lengths"

--- a/features/admin-world-locations.feature
+++ b/features/admin-world-locations.feature
@@ -3,7 +3,6 @@ Feature: Tagging world locations to publications
   In order to show which location a publication is about
   I want to be able to tag world locations to publications
 
-  @design-system-wip
   Scenario: The publication is about a country
     Given I am an editor
     And a world location "British Antarctic Territory" exists

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -1,6 +1,5 @@
 Feature: Consultations
 
-  @design-system-wip
   Scenario: Creating a new draft consultation
     Given I am a writer
     When I draft a new "English" language consultation "Beard Length Review"
@@ -20,7 +19,7 @@ Feature: Consultations
     And I publish the consultation "Beard Length Review"
     Then I should see the consultation "Beard Length Review" in the list of published documents
 
-  @disable-sidekiq-test-mode @design-system-wip
+  @disable-sidekiq-test-mode
   Scenario: Adding an outcome to a closed consultation
     Given I am an editor
     And a closed consultation exists
@@ -28,7 +27,7 @@ Feature: Consultations
     And I save and publish the amended consultation
     Then I can see that the consultation has been published
 
-  @disable-sidekiq-test-mode @design-system-wip
+  @disable-sidekiq-test-mode
   Scenario: Adding public feedback to a closed consultation
     Given I am an editor
     And a closed consultation exists
@@ -44,24 +43,23 @@ Feature: Consultations
     And I mark the consultation as offsite
     Then the consultation can be associated with topical events
 
-  @javascript @design-system-wip
+  @javascript
   Scenario: Creating a new draft consultation in another language
     Given I am a writer
     When I draft a new "Cymraeg" language consultation "Beard Length Review"
     Then I can see the primary locale for consultation "Beard Length Review" is "cy"
 
-  @design-system-wip
   Scenario: Adding and reordering a responses attachments
     Given I am an writer
     And a closed consultation exists
     When I add an outcome to the consultation
     And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example **Govspeak body**"
     Then the consultation response should have 2 attachments
-    When I set the order of attachments to:
+    When I set the order of the responses attachments to:
       | title                    | order |
       | Beard Length Graphs 2012 | 0     |
       | Outcome attachment title | 1     |
-    Then the attachments should be in the following order:
+    Then the responses attachments should be in the following order:
       | title                    |
       | Beard Length Graphs 2012 |
       | Outcome attachment title |

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -1,4 +1,3 @@
-@design-system-wip
 Feature: Grouping documents into a collection
   As an organisation,
   I want to present regularly published documents as collection

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -46,7 +46,6 @@ Feature: Managing attachments on editions
     When I try and upload an attachment but there are validation errors
     Then I should be able to submit the attachment without re-uploading the file
 
-  @design-system-wip
   Scenario: Attempting to publish attachment which is still being uploaded to the asset manager
     Given I am an editor
     And a published publication "Standard Beard Lengths" with a PDF attachment

--- a/features/fatalities.feature
+++ b/features/fatalities.feature
@@ -38,7 +38,6 @@ Feature: Fatalities
     When I create a new field of operation called "New Field" with description "Description"
     Then I am able to associate fatality notices with "New Field"
 
-  @design-system-wip
   Scenario: Writer manages casualty entries for a fatality shown on the field of operation page
     Given there is a fatality notice titled "Death of Joe" in the field "Iraq"
     When I add a casualty to the fatality notice

--- a/features/force-publishing-editions.feature
+++ b/features/force-publishing-editions.feature
@@ -3,7 +3,7 @@ Feature: Force Publishing editions
   Background:
     Given I am an editor
 
-  @not-quite-as-fake-search @design-system-wip
+  @not-quite-as-fake-search
   Scenario: Force-publishing a submitted edition
     Given I draft a new publication "Ban Beards"
     When I force publish the publication "Ban Beards"

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -1,4 +1,3 @@
-@design-system-wip
 Feature: New Tagging Workflow
   In order to get more publishers tagging to the new taxonomy
   Whitehall Needs to alter it's tagging workflow to remove editing
@@ -20,7 +19,7 @@ Feature: New Tagging Workflow
     Then I should be on the legacy tagging page
     And I should be able to update the legacy tags
 
-  Scenario: Publication that supports the new taxonomy with the Preview design system permission
+  Scenario: Publication that supports the new taxonomy
     Given I am a writer
     When I start editing a draft document which can be tagged to the new taxonomy
     And I continue to the tagging page

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -18,7 +18,6 @@ Feature: News articles
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
     Then the news article "A thing happened in X" should have been created
 
-  @design-system-wip
   Scenario: Create a news article of type 'World news story', then changing its locale from en
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
     Then the news article "A thing happened in X" should have been created

--- a/features/policy-groups.feature
+++ b/features/policy-groups.feature
@@ -20,7 +20,7 @@ Feature: Policy groups
   Background:
     Given I am an editor
 
-  @disable-sidekiq-test-mode @design-system-wip
+  @disable-sidekiq-test-mode
   Scenario:
     Given a policy group "Panel" exists
     Then I should be able to add attachments to the policy group "Panel"

--- a/features/speeches.feature
+++ b/features/speeches.feature
@@ -11,7 +11,6 @@ Feature: Speeches
     When I edit the speech "Outlaw Moustaches" changing the title to "Ban Moustaches"
     Then I should see the speech "Ban Moustaches" in the list of draft documents
 
-  @design-system-wip
   Scenario: Trying to save a speech that has been changed by another user
     Given I am a writer
     And a draft speech "Outlaw Moustaches" exists

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -1,6 +1,10 @@
 When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/) do |title, location_name|
   begin_drafting_publication(title)
-  select location_name, from: "Select the world locations this publication is about"
+  if using_design_system?
+    select location_name, from: "World locations"
+  else
+    select location_name, from: "Select the world locations this publication is about"
+  end
   click_button "Save and continue"
   click_button "Update tags"
   add_external_attachment

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -12,13 +12,27 @@ When(/^I draft a new "(.*?)" language consultation "(.*?)"$/) do |locale, title|
   begin_drafting_document document_options
   fill_in "Link URL", with: "http://participate.com"
   fill_in "Email", with: "participate@gov.uk"
-  select_date 1.day.ago.to_s, from: "Opening Date"
-  select_date 6.days.from_now.to_s, from: "Closing Date"
 
-  within record_css_selector(Nation.find_by_name!("Wales")) do
-    check "Wales"
-    fill_in "URL of corresponding content", with: "http://www.visitwales.co.uk/"
+  if using_design_system?
+    within "#edition_opening_at" do
+      fill_in_datetime_field(1.day.ago.to_s)
+    end
+
+    within "#edition_closing_at" do
+      fill_in_datetime_field(6.days.from_now.to_s)
+    end
+
+    check "Does not apply to Wales"
+    fill_in "edition[nation_inapplicabilities_attributes][2][alternative_url]", with: "http://www.visitwales.co.uk/"
+  else
+    select_date 1.day.ago.to_s, from: "Opening Date"
+    select_date 6.days.from_now.to_s, from: "Closing Date"
+    within record_css_selector(Nation.find_by_name!("Wales")) do
+      check "Wales"
+      fill_in "URL of corresponding content", with: "http://www.visitwales.co.uk/"
+    end
   end
+
   check "Scotland"
   click_button "Save"
 end
@@ -85,4 +99,21 @@ end
 
 Then(/^the consultation response should have (\d+) attachments$/) do |expected_number_of_attachments|
   expect(expected_number_of_attachments.to_i).to eq(Response.last.attachments.count)
+end
+
+When(/^I set the order of the responses attachments to:$/) do |attachment_order|
+  attachment_order.hashes.each do |attachment_info|
+    attachment = Attachment.find_by(title: attachment_info[:title])
+    fill_in "ordering[#{attachment.id}]", with: attachment_info[:order]
+  end
+  click_on "Save attachment order"
+end
+
+Then(/^the responses attachments should be in the following order:$/) do |attachment_list|
+  attachment_ids = all(".existing-attachments > li").map { |element| element[:id] }
+
+  attachment_list.hashes.each_with_index do |attachment_info, index|
+    attachment = Attachment.find_by(title: attachment_info[:title])
+    expect("attachment_#{attachment.id}").to eq(attachment_ids[index])
+  end
 end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -159,7 +159,13 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   expect(@document_collection).to be_present
 
   visit admin_document_collection_path(@document_collection)
-  click_on "Create new edition to edit"
+
+  if using_design_system?
+    click_on "Create new edition"
+  else
+    click_on "Create new edition to edit"
+  end
+
   fill_in_change_note_if_required
   click_button "Save and continue"
   click_button "Update tags"

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -209,8 +209,14 @@ Then("{edition} should no longer be listed on the public site") do |edition|
 end
 
 Then(/^I should see the conflict between the (publication|policy|news article|consultation|speech) titles "([^"]*)" and "([^"]*)"$/) do |_document_type, new_title, latest_title|
-  expect(new_title).to eq(find(".conflicting.new #edition_title").value)
-  expect(page).to have_selector(".conflicting.latest .document .title", text: latest_title)
+  if using_design_system?
+    expect(new_title).to eq(find(".gem-c-title__context").text)
+    expect(page).to have_selector(".conflict h2", text: latest_title)
+  else
+    expect(new_title).to eq(find(".conflicting.new #edition_title").value)
+    expect(page).to have_selector(".conflicting.latest .document .title", text: latest_title)
+
+  end
 end
 
 Then(/^my attempt to publish "([^"]*)" should fail$/) do |title|

--- a/features/step_definitions/fatalities_steps.rb
+++ b/features/step_definitions/fatalities_steps.rb
@@ -20,7 +20,13 @@ When(/^I link the minister "([^"]*)" to the fatality notice$/) do |minister_name
   create(:ministerial_role_appointment, person: @person)
   begin_new_draft_document FatalityNotice.last.title
   select minister_name, from: "Ministers"
-  choose "edition_minor_change_true"
+
+  if using_design_system?
+    choose "No – it’s a minor edit that does not change the meaning"
+  else
+    choose "edition_minor_change_true"
+  end
+
   click_button "Save"
   publish(force: true)
 end
@@ -46,7 +52,13 @@ end
 When(/^I add a casualty to the fatality notice$/) do
   begin_new_draft_document FatalityNotice.last.title
   fill_in "Personal details", with: "Causualty"
-  choose "edition_minor_change_true"
+
+  if using_design_system?
+    choose "No – it’s a minor edit that does not change the meaning"
+  else
+    choose "edition_minor_change_true"
+  end
+
   click_button "Save"
 end
 

--- a/features/step_definitions/new_tagging_workflow_steps.rb
+++ b/features/step_definitions/new_tagging_workflow_steps.rb
@@ -3,8 +3,13 @@ When(/^I start editing a draft document which can be tagged to the new taxonomy$
   begin_drafting_publication("The Pub")
   stub_taxonomy_data
   stub_patch_links
-  within(".lead-organisations") do
-    select("Taxon Org", from: "Organisation 1")
+
+  if using_design_system?
+    select("Taxon Org", from: "Lead organisation 1")
+  else
+    within(".lead-organisations") do
+      select("Taxon Org", from: "Organisation 1")
+    end
   end
 end
 
@@ -24,8 +29,13 @@ When(/^I start editing a draft document which cannot be tagged to the new taxono
   stub_specialist_sectors
   create(:organisation, content_id: "otherzzz-zzzz-zzzz-zzzz-zzzz0000zzzz", name: "Non Taxon Org")
   begin_drafting_publication("The Pub")
-  within(".lead-organisations") do
-    select("Non Taxon Org", from: "Organisation 1")
+
+  if using_design_system?
+    select("Taxon Org", from: "Lead organisation 1")
+  else
+    within(".lead-organisations") do
+      select("Taxon Org", from: "Organisation 1")
+    end
   end
 end
 

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -76,9 +76,17 @@ end
 
 Then("I subsequently change the primary locale") do
   visit admin_edition_path(@news_article)
-  click_button "Create new edition to edit"
-  select "Deutsch (German)", from: "edition[primary_locale]"
-  choose "edition_minor_change_true"
+
+  if using_design_system?
+    click_button "Create new edition"
+    select "Deutsch (German)", from: "edition[primary_locale]"
+    choose "No – it’s a minor edit that does not change the meaning"
+  else
+    click_button "Create new edition to edit"
+    select "Deutsch (German)", from: "edition[primary_locale]"
+    choose "edition_minor_change_true"
+  end
+
   click_button "Save"
 end
 

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -37,7 +37,13 @@ end
 
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
-  select data_set_name, from: "Related statistical data sets"
+
+  if using_design_system?
+    select data_set_name, from: "Statistical data sets"
+  else
+    select data_set_name, from: "Related statistical data sets"
+  end
+
   click_button "Save and continue"
   click_button "Update tags"
   add_external_attachment

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -26,12 +26,21 @@ private
   end
 
   def assert_selected_specialist_sectors_are_displayed
-    expect(page).to have_selector(".primary-specialist-sector li", text: "Oil and Gas: Wells")
-    expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Fields")
-    expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
+    if using_design_system?
+      expect(page).to have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Wells")
+      expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Fields")
+      expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
 
-    expect(page).to_not have_selector(".primary-specialist-sector li", text: "Oil and Gas: Fields")
-    expect(page).to_not have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Wells")
+      expect(page).to_not have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Fields")
+      expect(page).to_not have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Wells")
+    else
+      expect(page).to have_selector(".primary-specialist-sector li", text: "Oil and Gas: Wells")
+      expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Fields")
+      expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
+
+      expect(page).to_not have_selector(".primary-specialist-sector li", text: "Oil and Gas: Fields")
+      expect(page).to_not have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Wells")
+    end
   end
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -59,7 +59,11 @@ module DocumentHelper
 
   def begin_new_draft_document(title)
     visit_edition_admin title
-    click_button "Create new edition to edit"
+    if using_design_system?
+      click_button "Create new edition"
+    else
+      click_button "Create new edition to edit"
+    end
   end
 
   def begin_drafting_news_article(options)
@@ -98,9 +102,7 @@ module DocumentHelper
 
     if using_design_system?
       choose "Speaker has a profile on GOV.UK"
-      within_conditional_reveal "Speaker has a profile on GOV.UK" do
-        select "Colonel Mustard, Attorney General"
-      end
+      select "Colonel Mustard, Attorney General"
 
       within_fieldset "Delivered on" do
         select_date 1.day.ago.to_s, base_dom_id: "edition_delivered_on"
@@ -194,6 +196,16 @@ module DocumentHelper
   def preview_document_path(edition, options = {})
     query = { preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i }
     document_path(edition, options.merge(query))
+  end
+
+  def fill_in_datetime_field(date)
+    date = Time.zone.parse(date)
+
+    select date.year, from: "Year"
+    select date.strftime("%B"), from: "Month"
+    select date.day, from: "Day"
+    select date.strftime("%H"), from: "Hour"
+    select date.strftime("%M"), from: "Minute"
   end
 end
 


### PR DESCRIPTION
## Description

Quite a few of our feature tests are flagged with @design-system-wip. This removes the tag and updates the tests to pass wherever possible.

There are still a few tests that will have to stay as @design-system-wip for now while we port over the edit edition page.

Still to port:

1. admin audit trail feature -will be unblocked by the async pagination pr
2. broken links features - unblocked by Daniels work on broken links
3. detailed guide add another image feature - unblocked by image work
4.  Creating authored articles  feature spec - will be unblocked by adding the required JS for speeches (still needs to be carded up)

## Guidance for review

I've grouped tests from each feature files specs into a commit for ease of review. I'll squash them pre merge


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
