### PR TITLE
Add JS for Speeches to the EditionForm module

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -74,20 +74,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
     var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
     var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
-    var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+    var locationDiv = form.querySelector('.js-app-view-edit-edition__speech-location-field')
     var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
     var authoredArticleId = '6'
 
     select.addEventListener('change', function (event) {
       if (event.currentTarget.value === authoredArticleId) {
-        locationDiv.classList.add('govuk-visually-hidden')
+        locationDiv.classList.add('app-view-edit-edition__speech-location--hidden')
         deliveredByLabel.textContent = 'Writer (required)'
         hasProfileRadioLabel.textContent = 'Writer has a profile on GOV.UK'
         noProfileRadioLabel.textContent = 'Writer does not have a profile on GOV.UK'
         deliveredOnLabel.textContent = 'Written on (required)'
         locationInput.value = ''
       } else {
-        locationDiv.classList.remove('govuk-visually-hidden')
+        locationDiv.classList.remove('app-view-edit-edition__speech-location--hidden')
         deliveredByLabel.textContent = 'Speaker (required)'
         hasProfileRadioLabel.textContent = 'Speaker has a profile on GOV.UK'
         noProfileRadioLabel.textContent = 'Speaker does not have a profile on GOV.UK'

--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -9,6 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   EditionForm.prototype.init = function () {
     this.setupSubtypeFormatAdviceEventListener()
     this.setupWorldNewsStoryVisibilityToggle()
+    this.setupSpeechSubtypeEventListeners()
   }
 
   EditionForm.prototype.setupSubtypeFormatAdviceEventListener = function () {
@@ -58,6 +59,39 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         localeSelect.value = ''
       } else {
         container.classList.remove('app-view-edit-edition__locale-field--hidden')
+      }
+    })
+  }
+
+  EditionForm.prototype.setupSpeechSubtypeEventListeners = function () {
+    var form = this.module
+
+    var select = form.querySelector('#edition_speech_type_id')
+
+    if (!select) { return }
+
+    var deliveredByLabel = form.querySelector('#edition_role_appointment .govuk-fieldset__heading')
+    var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
+    var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
+    var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
+    var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+    var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
+    var authoredArticleId = '6'
+
+    select.addEventListener('change', function (event) {
+      if (event.currentTarget.value === authoredArticleId) {
+        locationDiv.classList.add('govuk-visually-hidden')
+        deliveredByLabel.textContent = 'Writer (required)'
+        hasProfileRadioLabel.textContent = 'Writer has a profile on GOV.UK'
+        noProfileRadioLabel.textContent = 'Writer does not have a profile on GOV.UK'
+        deliveredOnLabel.textContent = 'Written on (required)'
+        locationInput.value = ''
+      } else {
+        locationDiv.classList.remove('govuk-visually-hidden')
+        deliveredByLabel.textContent = 'Speaker (required)'
+        hasProfileRadioLabel.textContent = 'Speaker has a profile on GOV.UK'
+        noProfileRadioLabel.textContent = 'Speaker does not have a profile on GOV.UK'
+        deliveredOnLabel.textContent = 'Delivered on (required)'
       }
     })
   }

--- a/app/assets/stylesheets/admin/views/_edit-edition.scss
+++ b/app/assets/stylesheets/admin/views/_edit-edition.scss
@@ -21,6 +21,7 @@
   margin-bottom: 0;
 }
 
-.app-view-edit-edition__locale-field--hidden {
+.app-view-edit-edition__locale-field--hidden,
+.app-view-edit-edition__speech-location--hidden {
   display: none;
 }

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -125,7 +125,6 @@ module Admin::EditionsHelper
   end
 
   def standard_edition_form(edition, information = nil, preview_design_system: false)
-    initialise_script "GOVUK.adminEditionsForm", selector: ".js-edition-form", right_to_left_locales: Locale.right_to_left.collect(&:to_param)
     if preview_design_system
       form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm" } do |form|
         concat render("standard_fields", form:, edition:)
@@ -135,6 +134,8 @@ module Admin::EditionsHelper
         concat standard_edition_publishing_controls(form, edition)
       end
     else
+      initialise_script "GOVUK.adminEditionsForm", selector: ".js-edition-form", right_to_left_locales: Locale.right_to_left.collect(&:to_param)
+
       form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition) } do |form|
         concat edition_information(information) if information
         concat form.errors

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -39,6 +39,10 @@ class Speech < Announcement
     self.speech_type_id = speech_type.id if speech_type
   end
 
+  def authored_article?
+    speech_type == SpeechType::AuthoredArticle
+  end
+
   def display_type
     if speech_type.statement_to_parliament?
       I18n.t("document.type.statement_to_parliament", count: 1)

--- a/app/views/admin/speeches/_additional_significant_fields.html.erb
+++ b/app/views/admin/speeches/_additional_significant_fields.html.erb
@@ -1,12 +1,14 @@
 <%= render 'delivered_by_fields', form: form, edition: edition %>
 <%= render 'delivered_on_fields', form: form, edition: edition %>
 
-<%= render "govuk_publishing_components/components/input", {
-  label: {
-    text: "Location",
-    bold: true,
-  },
-  name: "edition[location]",
-  id: "edition_location",
-  value: edition.location
-} %>
+<div class="js-app-view-edition-form__speech-location <%= "govuk-visually-hidden" if edition.authored_article? %>">
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Location",
+      bold: true,
+    },
+    name: "edition[location]",
+    id: "edition_location",
+    value: edition.location
+  } %>
+</div>

--- a/app/views/admin/speeches/_additional_significant_fields.html.erb
+++ b/app/views/admin/speeches/_additional_significant_fields.html.erb
@@ -1,5 +1,5 @@
-<%= render partial: 'delivered_by_fields', locals: { form: form, edition: edition } %>
-<%= render partial: 'delivered_on_fields', locals: { form: form, edition: edition } %>
+<%= render 'delivered_by_fields', form: form, edition: edition %>
+<%= render 'delivered_on_fields', form: form, edition: edition %>
 
 <%= render "govuk_publishing_components/components/input", {
   label: {

--- a/app/views/admin/speeches/_additional_significant_fields.html.erb
+++ b/app/views/admin/speeches/_additional_significant_fields.html.erb
@@ -1,7 +1,7 @@
 <%= render 'delivered_by_fields', form: form, edition: edition %>
 <%= render 'delivered_on_fields', form: form, edition: edition %>
 
-<div class="js-app-view-edition-form__speech-location <%= "govuk-visually-hidden" if edition.authored_article? %>">
+<div class="js-app-view-edit-edition__speech-location-field <%= "app-view-edit-edition__speech-location-field--hidden" if edition.authored_article? %>">
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Location",

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -1,19 +1,19 @@
 <%= render "govuk_publishing_components/components/radio", {
   name: "speaker_radios",
   id: "edition_role_appointment",
-  heading: "Speaker (required)",
+  heading: edition.authored_article? ? "Writer (required)" : "Speaker (required)",
   heading_size: "s",
   error_items: errors_for(edition.errors, :role_appointment),
   items: [
     {
       value: "yes",
-      text: "Speaker has a profile on GOV.UK",
+      text: "#{edition.authored_article? ? "Writer" : 'Speaker'} has a profile on GOV.UK",
       checked: edition.role_appointment_id.present?,
       conditional: render("speaker_select_field", form:, edition:)
     },
     {
       value: "no",
-      text: "Speaker does not have a profile on GOV.UK",
+      text: "#{edition.authored_article? ? "Writer" : 'Speaker'} does not have a profile on GOV.UK",
       checked: edition.person_override.present?,
       conditional: render("govuk_publishing_components/components/input", {
         name: "edition[person_override]",

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -7,12 +7,14 @@
   items: [
     {
       value: "yes",
+      id: "edition_role_appointment_speaker_on_govuk",
       text: "#{edition.authored_article? ? "Writer" : 'Speaker'} has a profile on GOV.UK",
       checked: edition.role_appointment_id.present?,
       conditional: render("speaker_select_field", form:, edition:)
     },
     {
       value: "no",
+      id: "edition_role_appointment_speaker_not_on_govuk",
       text: "#{edition.authored_article? ? "Writer" : 'Speaker'} does not have a profile on GOV.UK",
       checked: edition.person_override.present?,
       conditional: render("govuk_publishing_components/components/input", {

--- a/app/views/admin/speeches/_delivered_on_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_on_fields.html.erb
@@ -1,5 +1,5 @@
 <%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Delivered on (required)",
+  legend_text: edition.authored_article? ? "Written on (required)" : "Delivered on (required)",
   heading_size: "l",
   id: "edition_delivered_on",
 } do %>

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -1,5 +1,3 @@
-<% initialise_script "GOVUK.AdminSpeechesForm", el: '.js-edition-form', speech_type_label_data: speech_type_label_data %>
-
 <div class="format-advice">
   <p class="govuk-body"><strong>Use this format for:</strong> Public speeches by ministers or other named spokespeople, ministerial statements to Parliament and bylined articles.</p>
   <p class="govuk-body">Do <em>not</em> use for: statements <em>not</em> made to Parliament (use the “news article” format for those).</p>

--- a/features/speeches.feature
+++ b/features/speeches.feature
@@ -32,7 +32,7 @@ Feature: Speeches
     When I visit the list of speeches awaiting review
     Then I should see that "Legalise beards" is listed on the page
 
-  @javascript @design-system-wip
+  @javascript
   Scenario: Creating authored articles (originally published externally)
     Given I am an editor
     When I draft a new authored article "Colonel Mustard talks about beards to The Times"

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -65,11 +65,22 @@ When(/^I draft a new authored article "([^"]*)"$/) do |title|
 end
 
 Then(/^I should be able to choose who wrote the article$/) do
-  select "Colonel Mustard, Attorney General", from: "Writer"
+  if using_design_system?
+    choose "Writer has a profile on GOV.UK"
+    select "Colonel Mustard, Attorney General", from: "edition[role_appointment_id]"
+  else
+    select "Colonel Mustard, Attorney General", from: "Writer"
+  end
 end
 
 Then(/^I should be able to choose the date it was written on$/) do
-  select_date 1.day.ago.to_s, from: "Written on"
+  if using_design_system?
+    within "#edition_delivered_on" do
+      fill_in_datetime_field(1.day.ago.to_s)
+    end
+  else
+    select_date 1.day.ago.to_s, from: "Written on"
+  end
 end
 
 Then(/^I cannot choose a location for the article$/) do

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -93,7 +93,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
       var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
       var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
-      var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+      var locationDiv = form.querySelector('.js-app-view-edit-edition__speech-location-field')
       var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
 
       select.value = '6'
@@ -104,7 +104,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(hasProfileRadioLabel.textContent).toEqual('Writer has a profile on GOV.UK')
       expect(noProfileRadioLabel.textContent).toEqual('Writer does not have a profile on GOV.UK')
       expect(deliveredOnLabel.textContent).toEqual('Written on (required)')
-      expect(locationDiv.classList[1]).toEqual('govuk-visually-hidden')
+      expect(locationDiv.classList[1]).toEqual('app-view-edit-edition__speech-location--hidden')
       expect(locationInput.value).toEqual('')
     })
 
@@ -114,7 +114,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
       var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
       var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
-      var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+      var locationDiv = form.querySelector('.js-app-view-edit-edition__speech-location-field')
       var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
 
       select.value = '6'
@@ -129,7 +129,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(noProfileRadioLabel.textContent).toEqual('Speaker does not have a profile on GOV.UK')
       expect(deliveredOnLabel.textContent).toEqual('Delivered on (required)')
       expect(locationDiv.classList.length).toEqual(1)
-      expect(locationDiv.classList[0]).toEqual('js-app-view-edition-form__speech-location')
+      expect(locationDiv.classList[0]).toEqual('js-app-view-edit-edition__speech-location-field')
     })
   })
 
@@ -198,7 +198,7 @@ describe('GOVUK.Modules.EditionForm', function () {
         '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on (required)</legend>' +
       '</fieldset>' +
 
-      '<div class="js-app-view-edition-form__speech-location">' +
+      '<div class="js-app-view-edit-edition__speech-location-field">' +
         '<input name="edition[location]" type="text">' +
       '</div>'
     )

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -4,90 +4,203 @@ describe('GOVUK.Modules.EditionForm', function () {
   beforeEach(function () {
     form = document.createElement('form')
     form.setAttribute('data-module', 'EditionForm')
-
-    form.innerHTML = `
-    <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">
-      <div class="govuk-form-group gem-c-select">
-        <label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>
-        <select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">
-          <option value=""></option>
-          <option value="1">News story</option>
-          <option value="2">Press release</option>
-          <option value="3">Government response</option>
-          <option value="4">World news story</option></select>
-      </div>
-    </div>
-
-    <div class="app-view-edit-edition__locale-field app-view-edit-edition__locale-field--hidden">
-      <input type="checkbox" name="edition[create_foreign_language_only]" id="edition_create_foreign_language_only-0" value="0" checked="checked">
-
-      <select name="edition[primary_locale]" id="edition_primary_locale" class="govuk-select gem-c-select__select--full-width">
-        <option value=""></option>
-        <option value="ar">العربيَّة (Arabic)</option>
-        <option value="az">Azeri (Azeri)</option>
-        <option value="be">Беларуская (Belarusian)</option>
-      </select>
-    </div>
-    `
-    var editionForm = new GOVUK.Modules.EditionForm(form)
-    editionForm.init()
   })
 
-  it('should render subtype guidance based when the subtype format select changes value', function () {
-    var select = form.querySelector('#edition_news_article_type_id')
+  describe('#setupSubtypeFormatAdviceEventListener', function () {
+    beforeEach(function () {
+      form.innerHTML = subtypeFields() + localeFields()
+      var editionForm = new GOVUK.Modules.EditionForm(form)
+      editionForm.init()
+    })
 
-    select.value = '1'
-    select.dispatchEvent(new Event('change'))
-    var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
+    it('should render subtype guidance based when the subtype format select changes value', function () {
+      var select = form.querySelector('#edition_news_article_type_id')
 
-    expect(subtypeAdvice.innerHTML).toBe('<strong>Use this subformat for…</strong> <p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>')
+      select.value = '1'
+      select.dispatchEvent(new Event('change'))
+      var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
+
+      expect(subtypeAdvice.innerHTML).toBe('<strong>Use this subformat for…</strong> <p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>')
+    })
+
+    it('should remove subtype guidance when the subtype format select is unselected', function () {
+      var select = form.querySelector('#edition_news_article_type_id')
+
+      select.value = '1'
+      select.dispatchEvent(new Event('change'))
+      select.value = '0'
+      select.dispatchEvent(new Event('change'))
+
+      var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
+      expect(subtypeAdvice).toBe(null)
+    })
   })
 
-  it('should remove subtype guidance when the subtype format select is unselected', function () {
-    var select = form.querySelector('#edition_news_article_type_id')
+  describe('#setupSubtypeFormatAdviceEventListener', function () {
+    beforeEach(function () {
+      form.innerHTML = subtypeFields() + localeFields()
+      var editionForm = new GOVUK.Modules.EditionForm(form)
+      editionForm.init()
+    })
 
-    select.value = '1'
-    select.dispatchEvent(new Event('change'))
-    select.value = '0'
-    select.dispatchEvent(new Event('change'))
+    it('should hide the locale fields when a NewsArticle is not a WorldNewsStory', function () {
+      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
 
-    var subtypeAdvice = form.querySelector('.js-app-view-edition-form__subtype-format-advice')
-    expect(subtypeAdvice).toBe(null)
+      expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
+    })
+
+    it('should render the locale fields when the WorldNewsStory is selected', function () {
+      var select = form.querySelector('#edition_news_article_type_id')
+
+      select.value = '4'
+      select.dispatchEvent(new Event('change'))
+
+      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+
+      expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
+    })
+
+    it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {
+      var select = form.querySelector('#edition_news_article_type_id')
+      var localeCheckbox = form.querySelector('#edition_create_foreign_language_only-0')
+      var localeSelect = form.querySelector('#edition_primary_locale')
+
+      select.value = '4'
+      select.dispatchEvent(new Event('change'))
+
+      localeCheckbox.checked = true
+      localeCheckbox.value = '1'
+      localeSelect.value = 'ar'
+      select.value = '1'
+      select.dispatchEvent(new Event('change'))
+
+      expect(localeCheckbox.value).toEqual('0')
+      expect(localeCheckbox.checked).toEqual(false)
+      expect(localeSelect.value).toEqual('')
+    })
   })
 
-  it('should hide the locale fields when a NewsArticle is not a WorldNewsStory', function () {
-    var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+  describe('#setupSubtypeFormatAdviceEventListener', function () {
+    beforeEach(function () {
+      form.innerHTML = speechFields()
+      var editionForm = new GOVUK.Modules.EditionForm(form)
+      editionForm.init()
+    })
 
-    expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
+    it('updates the labels of speaker fields to `writer` and hides and resets the location field when authored_article is selected ', function () {
+      var select = form.querySelector('#edition_speech_type_id')
+      var deliveredByLabel = form.querySelector('#edition_role_appointment .govuk-fieldset__heading')
+      var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
+      var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
+      var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
+      var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+      var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
+
+      select.value = '6'
+      locationInput.value = 'To be deleted.'
+      select.dispatchEvent(new Event('change'))
+
+      expect(deliveredByLabel.textContent).toEqual('Writer (required)')
+      expect(hasProfileRadioLabel.textContent).toEqual('Writer has a profile on GOV.UK')
+      expect(noProfileRadioLabel.textContent).toEqual('Writer does not have a profile on GOV.UK')
+      expect(deliveredOnLabel.textContent).toEqual('Written on (required)')
+      expect(locationDiv.classList[1]).toEqual('govuk-visually-hidden')
+      expect(locationInput.value).toEqual('')
+    })
+
+    it('updates the labels of speaker fields to `speaker` and shows the location field when the authored_article is deselected ', function () {
+      var select = form.querySelector('#edition_speech_type_id')
+      var deliveredByLabel = form.querySelector('#edition_role_appointment .govuk-fieldset__heading')
+      var hasProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_on_govuk"]')
+      var noProfileRadioLabel = form.querySelector('#edition_role_appointment label[for="edition_role_appointment_speaker_not_on_govuk"]')
+      var deliveredOnLabel = form.querySelector('#edition_delivered_on .govuk-fieldset__legend')
+      var locationDiv = form.querySelector('.js-app-view-edition-form__speech-location')
+      var locationInput = locationDiv.querySelector('input[name="edition[location]"]')
+
+      select.value = '6'
+      locationInput.value = 'To be deleted.'
+      select.dispatchEvent(new Event('change'))
+
+      select.value = '1'
+      select.dispatchEvent(new Event('change'))
+
+      expect(deliveredByLabel.textContent).toEqual('Speaker (required)')
+      expect(hasProfileRadioLabel.textContent).toEqual('Speaker has a profile on GOV.UK')
+      expect(noProfileRadioLabel.textContent).toEqual('Speaker does not have a profile on GOV.UK')
+      expect(deliveredOnLabel.textContent).toEqual('Delivered on (required)')
+      expect(locationDiv.classList.length).toEqual(1)
+      expect(locationDiv.classList[0]).toEqual('js-app-view-edition-form__speech-location')
+    })
   })
 
-  it('should render the locale fields when the WorldNewsStory is selected', function () {
-    var select = form.querySelector('#edition_news_article_type_id')
+  function subtypeFields () {
+    return (
+      '<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">' +
+        '<div class="govuk-form-group gem-c-select">' +
+          '<label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>' +
+          '<select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">' +
+            '<option value=""></option>' +
+            '<option value="1">News story</option>' +
+            '<option value="2">Press release</option>' +
+            '<option value="3">Government response</option>' +
+            '<option value="4">World news story</option></select>' +
+        '</div>' +
+      '</div>'
+    )
+  }
 
-    select.value = '4'
-    select.dispatchEvent(new Event('change'))
+  function localeFields () {
+    return (
+      '<div class="app-view-edit-edition__locale-field app-view-edit-edition__locale-field--hidden">' +
+        '<input type="checkbox" name="edition[create_foreign_language_only]" id="edition_create_foreign_language_only-0" value="0" checked="checked">' +
 
-    var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+        '<select name="edition[primary_locale]" id="edition_primary_locale" class="govuk-select gem-c-select__select--full-width">' +
+          '<option value=""></option>' +
+          '<option value="ar">العربيَّة (Arabic)</option>' +
+          '<option value="az">Azeri (Azeri)</option>' +
+          '<option value="be">Беларуская (Belarusian)</option>' +
+        '</select>' +
+      '</div>'
+    )
+  }
 
-    expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
-  })
+  function speechFields () {
+    return (
+      '<div>' +
+        '<div class="govuk-form-group gem-c-select">' +
+          '<label class="govuk-label govuk-label--s" for="edition_speech_type_id">Speech type</label>' +
+          '<select name="edition[speech_type_id]" id="edition_speech_type_id" class="govuk-select gem-c-select__select--full-width">' +
+            '<option value=""></option>' +
+            '<option value="1">Transcript</option>' +
+            '<option value="2">Draft text</option>' +
+            '<option value="3">Speaking notes</option>' +
+            '<option value="4">Written statement to Parliament</option>' +
+            '<option value="5">Oral statement to Parliament</option>' +
+            '<option value="6">Authored article</option>' +
+          '</select>' +
+        '</div>' +
+      '</div>' +
 
-  it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {
-    var select = form.querySelector('#edition_news_article_type_id')
-    var localeCheckbox = form.querySelector('#edition_create_foreign_language_only-0')
-    var localeSelect = form.querySelector('#edition_primary_locale')
+      '<div id="edition_role_appointment">' +
+        '<fieldset class="govuk-fieldset">' +
+           '<legend class="govuk-fieldset__legend">' +
+              '<h2 class="govuk-fieldset__heading">Speaker (required)</h2>' +
+           '</legend>' +
+             '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_on_govuk">' +
+             '<label for="edition_role_appointment_speaker_on_govuk">Speaker has a profile on GOV.UK</label>' +
+             '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_not_on_govuk">' +
+             '<label for="edition_role_appointment_speaker_not_on_govuk">Speaker does not have a profile on GOV.UK</label>' +
+           '</div>' +
+        '</fieldset>' +
+      '</div>' +
 
-    select.value = '4'
-    select.dispatchEvent(new Event('change'))
+      '<fieldset class="govuk-fieldset" id="edition_delivered_on">' +
+        '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on (required)</legend>' +
+      '</fieldset>' +
 
-    localeCheckbox.checked = true
-    localeCheckbox.value = '1'
-    localeSelect.value = 'ar'
-    select.value = '1'
-    select.dispatchEvent(new Event('change'))
-
-    expect(localeCheckbox.value).toEqual('0')
-    expect(localeCheckbox.checked).toEqual(false)
-    expect(localeSelect.value).toEqual('')
-  })
+      '<div class="js-app-view-edition-form__speech-location">' +
+        '<input name="edition[location]" type="text">' +
+      '</div>'
+    )
+  }
 })


### PR DESCRIPTION
## Description

When a user creates a speech, one of the possible subtypes is `Authored article`. Unlike the other speeches, this is written not spoken. 

Due to this, when an `Authored article` is selected the following needs to happen:

1. The location field needs to be hidden and the value reset
2. Any reference to `Speaker` in labels needs to be updated to `Writer`

Then when the subtype moves from `Authored edition` to another subtype the reverse needs to the occur: 

1. the location field needs to be displayed
2. Any reference to `Writer` needs to be updated to `Speaker`

This PR adds the speech form to displays the correct fields/values on page load and adds a JS module which does the above dynamically.

## Screenshots

### With authored article subtype

<img width="652" alt="image" src="https://user-images.githubusercontent.com/42515961/212667716-c14f6cb3-7bc8-44bc-a52a-a2e781cccacb.png">

<img width="677" alt="image" src="https://user-images.githubusercontent.com/42515961/212667770-7996f2e6-c9b1-4384-a756-3c47ac516fd8.png">


### With any other subtype

<img width="612" alt="image" src="https://user-images.githubusercontent.com/42515961/212668448-7a1fbbeb-2152-4a69-9562-e6340ca55d54.png">


<img width="745" alt="image" src="https://user-images.githubusercontent.com/42515961/212668488-27df6a8a-7ba0-4201-b5d3-7623f5ebd78e.png">

## Trello card

https://trello.com/c/KOGs7sJq/1072-add-javascript-for-authoredarticles-to-hide-show-fields-subtype-of-speech

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
