### PR TITLE
Ensure the edition summary page has design system layout for preview next release

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -196,7 +196,8 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy diff]
-    design_system_actions += %w[edit update new create show] if preview_design_system?(next_release: false)
+    design_system_actions += %w[show] if preview_design_system?(next_release: true)
+    design_system_actions += %w[edit update new create] if preview_design_system?(next_release: false)
     if design_system_actions.include?(action_name)
       "design_system"
     else


### PR DESCRIPTION
## Description

When i moved the 1.5 pages behind the preview next release flag i missed updating the get_layout method to render the design system layout for the show action

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
