### PR TITLE
Dockerfile cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,11 @@
 .dockerignore
 .git
+.github
 .gitignore
 Dockerfile
 Jenkinsfile
 Procfile
 README.md
-CONTRIBUTING.md
-adr
 asset-manager-tmp
 attachment-cache
 bulk-upload-zip-file-tmp
@@ -19,6 +18,7 @@ incoming-uploads
 infected-uploads
 log
 node_modules
+script/cucumber
 spec
 test
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,36 +2,30 @@ ARG ruby_version=3.1.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
+
 FROM $builder_image AS builder
 
-ENV ASSETS_PREFIX=/assets/whitehall \
-    JWT_AUTH_SECRET=unused_yet_required
+ENV JWT_AUTH_SECRET=unused_yet_required
 
 WORKDIR $APP_HOME
-COPY Gemfile Gemfile.lock .ruby-version ./
-# TODO: remove chmod workaround once https://github.com/mikel/mail/issues/1489 is fixed.
-RUN bundle install && chmod -R o+r "${BUNDLE_PATH}"
+COPY Gemfile* .ruby-version ./
+RUN bundle install
 COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
-COPY . ./
-RUN bundle exec bootsnap precompile --gemfile .
-RUN bundle exec rails assets:precompile && rm -fr log
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
-
-ENV ASSETS_PREFIX=/assets/whitehall \
-    GOVUK_APP_NAME=whitehall \
-    GOVUK_UPLOADS_ROOT=/uploads
-
 RUN install_packages imagemagick unzip
 
+ENV GOVUK_APP_NAME=whitehall
+
 WORKDIR $APP_HOME
-COPY --from=builder /usr/bin/node* /usr/bin/
-COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
-COPY --from=builder $BUNDLE_PATH/ $BUNDLE_PATH/
-COPY --from=builder $BOOTSNAP_CACHE_DIR/ $BOOTSNAP_CACHE_DIR/
-COPY --from=builder $APP_HOME ./
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
 CMD ["puma"]


### PR DESCRIPTION
- Omit Node.js binaries and modules from the output image since these are only needed for `rails assets:precompile`.
- Parameterise Ruby version.
- Clean up paths slightly.
- Remove unnecessary use of `bundle exec`.
- Update .dockerignore.

Tested: app boots successfully with `docker run`.

Rollout: depends on https://github.com/alphagov/govuk-helm-charts/pull/860