### PR TITLE
Add tests to check presented routes for translated content

### DIFF
--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -333,6 +333,33 @@ module PublishingApi::CorporateInformationPagePresenterTest
     test "validity" do
       assert_valid_against_publisher_schema presented_content, "corporate_information_page"
     end
+
+    test "presents the correct routes for a corporate information page with a translation" do
+      corporate_information_page = create(
+        :corporate_information_page,
+        translated_into: %i[en cy],
+      )
+
+      I18n.with_locale(:en) do
+        presented_item = PublishingApi::CorporateInformationPagePresenter.new(corporate_information_page)
+
+        assert_equal corporate_information_page.base_path, presented_item.content[:base_path]
+
+        assert_equal [
+          { path: corporate_information_page.base_path, type: "exact" },
+        ], presented_item.content[:routes]
+      end
+
+      I18n.with_locale(:cy) do
+        presented_item = PublishingApi::CorporateInformationPagePresenter.new(corporate_information_page)
+
+        assert_equal "#{corporate_information_page.base_path}.cy", presented_item.content[:base_path]
+
+        assert_equal [
+          { path: "#{corporate_information_page.base_path}.cy", type: "exact" },
+        ], presented_item.content[:routes]
+      end
+    end
   end
 
   class ComplaintsProcedureCorporateInformationPage < TestCase

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -71,5 +71,32 @@ module PublishingApi
       presented_item = present(edition, update_type: update_type_override)
       assert_equal update_type_override, presented_item.update_type
     end
+
+    test "presents the correct routes for an edition with a translation" do
+      news_article = create(
+        :news_article,
+        translated_into: %i[en cy],
+      )
+
+      I18n.with_locale(:en) do
+        presented_item = present(news_article)
+
+        assert_equal news_article.base_path, presented_item.content[:base_path]
+
+        assert_equal [
+          { path: news_article.base_path, type: "exact" },
+        ], presented_item.content[:routes]
+      end
+
+      I18n.with_locale(:cy) do
+        presented_item = present(news_article)
+
+        assert_equal "#{news_article.base_path}.cy", presented_item.content[:base_path]
+
+        assert_equal [
+          { path: "#{news_article.base_path}.cy", type: "exact" },
+        ], presented_item.content[:routes]
+      end
+    end
   end
 end

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -74,4 +74,37 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
 
     assert_valid_against_publisher_schema(presented_item.content, "person")
   end
+
+  test "presents the correct routes for a person with a translation" do
+    person = create(
+      :person,
+      translated_into: {
+        cy: {
+          biography: "Some text",
+        },
+      },
+    )
+
+    expected_base_path = Whitehall.url_maker.person_path(person)
+
+    I18n.with_locale(:en) do
+      presented_item = PublishingApi::PersonPresenter.new(person)
+
+      assert_equal expected_base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: expected_base_path, type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
+    I18n.with_locale(:cy) do
+      presented_item = PublishingApi::PersonPresenter.new(person)
+
+      assert_equal "#{expected_base_path}.cy", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{expected_base_path}.cy", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -153,4 +153,33 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
 
     assert_equal expected_hash, presented_item.content
   end
+
+  test "presents the correct routes for a role with a translation" do
+    role = create(
+      :role,
+      translated_into: [:cy],
+    )
+
+    expected_base_path = Whitehall.url_maker.ministerial_role_path(role)
+
+    I18n.with_locale(:en) do
+      presented_item = PublishingApi::RolePresenter.new(role)
+
+      assert_equal expected_base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: expected_base_path, type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
+    I18n.with_locale(:cy) do
+      presented_item = PublishingApi::RolePresenter.new(role)
+
+      assert_equal "#{expected_base_path}.cy", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{expected_base_path}.cy", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -93,12 +93,27 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
     assert_equal "", presented_content.dig(:details, :mission_statement)
   end
 
-  test "it builds localised base paths correctly" do
+  test "presents the correct routes for a world location news with a translation" do
+    expected_base_path = "/world/aardistan/news"
+
+    I18n.with_locale(:en) do
+      presented_item = present(@world_location_news)
+
+      assert_equal expected_base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: expected_base_path, type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
     I18n.with_locale(:fr) do
       presented_item = present(@world_location_news)
-      base_path = presented_item.content[:base_path]
 
-      assert_equal "/world/aardistan/news.fr", base_path
+      assert_equal "#{expected_base_path}.fr", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{expected_base_path}.fr", type: "exact" },
+      ], presented_item.content[:routes]
     end
   end
 

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -33,4 +33,32 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
 
     assert_valid_against_publisher_schema(presented_item.content, "world_location")
   end
+
+  test "presents the correct routes for an international delegation with a translation" do
+    world_location = create(:international_delegation,
+                            name: "UK Delegation to Narnia",
+                            translated_into: [:cy])
+
+    expected_base_path = "/world/uk-delegation-to-narnia"
+
+    I18n.with_locale(:en) do
+      presented_item = present(world_location)
+
+      assert_equal expected_base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: expected_base_path, type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
+    I18n.with_locale(:cy) do
+      presented_item = present(world_location)
+
+      assert_equal "#{expected_base_path}.cy", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{expected_base_path}.cy", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -95,4 +95,31 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
     assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
   end
+
+  test "presents the correct routes for a worldwide organisation with a translation" do
+    worldwide_organisation = create(
+      :worldwide_organisation,
+      translated_into: %i[en cy],
+    )
+
+    I18n.with_locale(:en) do
+      presented_item = present(worldwide_organisation)
+
+      assert_equal worldwide_organisation.base_path, presented_item.content[:base_path]
+
+      assert_equal [
+        { path: worldwide_organisation.base_path, type: "exact" },
+      ], presented_item.content[:routes]
+    end
+
+    I18n.with_locale(:cy) do
+      presented_item = present(worldwide_organisation)
+
+      assert_equal "#{worldwide_organisation.base_path}.cy", presented_item.content[:base_path]
+
+      assert_equal [
+        { path: "#{worldwide_organisation.base_path}.cy", type: "exact" },
+      ], presented_item.content[:routes]
+    end
+  end
 end


### PR DESCRIPTION
During a recent incident, we saw either the Welsh translation of an organisation page appear on the English content item and/or the Welsh page unpublished and redirected to the English page.
    
After the incident we [added a test for organisation pages](https://github.com/alphagov/whitehall/pull/7198/commits/fa08dbd2277ac09dcc42e44c162a148f3201f85e) to ensure the correct base path and routes were being presented to Publishing API for translated organisations.
    
This adds the same tests for all other content types that can be translated.

[Trello card](https://trello.com/c/6pOYnfkp)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
