### PR TITLE
Remove constraint and comment on Mailer version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem "jbuilder"
 gem "jquery-ui-rails"
 gem "kaminari"
 gem "link_header"
-gem "mail", "~> 2.8.0" # TODO: remove once https://www.github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mime-types"
 gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,7 +792,6 @@ DEPENDENCIES
   kaminari
   launchy
   link_header
-  mail (~> 2.8.0)
   mail-notify
   maxitest
   mechanize


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

This has been resolved so we can remove the comment and use the latest stable release.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
