### PR TITLE
Update destroy edition flash message

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -176,7 +176,7 @@ class Admin::EditionsController < Admin::BaseController
   def destroy
     edition_deleter = Whitehall.edition_services.deleter(@edition)
     if edition_deleter.perform!
-      redirect_to admin_editions_path, notice: "The document '#{@edition.title}' has been deleted"
+      redirect_to admin_editions_path, notice: "The draft of '#{@edition.title}' has been deleted"
     else
       redirect_to admin_edition_path(@edition), alert: edition_deleter.failure_reason
     end

--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -67,7 +67,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   test "destroy displays a notice indicating the edition has been deleted" do
     draft_edition = create(:draft_edition, title: "edition-title")
     delete :destroy, params: { id: draft_edition }
-    assert_equal "The document 'edition-title' has been deleted", flash[:notice]
+    assert_equal "The draft of 'edition-title' has been deleted", flash[:notice]
   end
 
   test "destroy notifies the publishing API of the deleted document" do


### PR DESCRIPTION
## Description

At the moment, the flash can be quite alarming and potentially misleading. This commit updates the flash message from:

```
The document {title} has been deleted
```

to:

```
The draft of {title} has been deleted
```

As laid out in the Trello card.


## Trello card

https://trello.com/b/0n3p84mY/govuk-publishing-service-publisher-experience-team-doing


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
