### PR TITLE
Turn on GA4 for related navigation

### DIFF
--- a/app/views/historic_appointments/show.html.erb
+++ b/app/views/historic_appointments/show.html.erb
@@ -68,6 +68,7 @@
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/related_navigation", {
       content_item: previous_appointments_list,
+      ga4_tracking: true
     } %>
 
     <p class="govuk-body">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Turn on GA4 tracking for the related navigation component.

Example pages:

- this page, I think: https://www.gov.uk/government/news/carole-souter-appointed-interim-chair-of-historic-royal-palaces

## Why
Part of implementing analytics using GA4.

## Visual changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer