### PR TITLE
Present historical accounts for past prime ministers to Publishing API

### DIFF
--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -73,7 +73,23 @@ class HistoricalAccount < ApplicationRecord
          .join(", ")
   end
 
+  def base_path
+    "/government/history/past-prime-ministers/#{person.slug}" if previous_prime_minister?
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options) if previous_prime_minister?
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options) if previous_prime_minister?
+  end
+
 private
+
+  def previous_prime_minister?
+    roles.map(&:slug).include?("prime-minister")
+  end
 
   def roles_support_historical_accounts
     unless roles.all?(&:supports_historical_accounts?)

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -1,4 +1,6 @@
 class HistoricalAccount < ApplicationRecord
+  include PublishesToPublishingApi
+
   belongs_to :person, inverse_of: :historical_accounts
   has_many   :historical_account_roles
   has_many   :roles, through: :historical_account_roles
@@ -83,6 +85,10 @@ class HistoricalAccount < ApplicationRecord
 
   def public_url(options = {})
     Plek.website_root + public_path(options) if previous_prime_minister?
+  end
+
+  def can_publish_to_publishing_api?
+    super && previous_prime_minister?
   end
 
 private

--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -1,0 +1,47 @@
+module PublishingApi
+  class HistoricalAccountPresenter
+    attr_accessor :historical_account, :update_type
+
+    def initialize(historical_account, update_type: nil)
+      self.historical_account = historical_account
+      self.update_type = update_type || "major"
+    end
+
+    delegate :content_id, to: :historical_account
+
+    def content
+      content = BaseItemPresenter.new(
+        historical_account,
+        title: historical_account.person.name, # TODO
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        description: historical_account.summary,
+        details: {
+          body: Whitehall::GovspeakRenderer.new.govspeak_to_html(historical_account.body),
+          born: historical_account.born,
+          died: historical_account.died,
+          interesting_facts: historical_account.interesting_facts,
+          major_acts: historical_account.major_acts,
+          political_party: historical_account.political_membership,
+          previous_dates_in_office: historical_account.previous_dates_in_office,
+        },
+        document_type: "historic_appointment",
+        public_updated_at: historical_account.updated_at,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "historic_appointment",
+      )
+
+      content.merge!(PayloadBuilder::PolymorphicPath.for(historical_account))
+    end
+
+    def links
+      {
+        person: [
+          historical_account.person.content_id,
+        ],
+      }
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -46,6 +46,8 @@ module PublishingApiPresenters
         PublishingApi::ContactPresenter
       when OperationalField
         PublishingApi::OperationalFieldPresenter
+      when HistoricalAccount
+        PublishingApi::HistoricalAccountPresenter
       else
         raise UndefinedPresenterError, "Could not find presenter class for: #{model.inspect}"
       end

--- a/db/migrate/20230119093902_add_content_id_to_historical_accounts.rb
+++ b/db/migrate/20230119093902_add_content_id_to_historical_accounts.rb
@@ -1,0 +1,9 @@
+class AddContentIdToHistoricalAccounts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :historical_accounts, :content_id, :string
+
+    HistoricalAccount.all.each do |historical_account|
+      historical_account.update(content_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_18_130656) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_19_093902) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -513,6 +513,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_130656) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "political_party_ids"
+    t.string "content_id"
     t.index ["person_id"], name: "index_historical_accounts_on_person_id"
   end
 

--- a/test/factories/historical_accounts.rb
+++ b/test/factories/historical_accounts.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :historical_account do
     association :person
+    content_id { SecureRandom.uuid }
     summary { "Some summary text" }
     body { "Some body text" }
     political_parties { [PoliticalParty::Labour] }

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -30,5 +30,6 @@ FactoryBot.define do
     name { "Prime Minister" }
     slug { "prime-minister" }
     role_type { "minister" }
+    supports_historical_accounts { true }
   end
 end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -25,4 +25,10 @@ FactoryBot.define do
       role.role_appointments = [FactoryBot.create(:role_appointment, :ended)]
     end
   end
+
+  factory :prime_minister_role, class: MinisterialRole do
+    name { "Prime Minister" }
+    slug { "prime-minister" }
+    role_type { "minister" }
+  end
 end

--- a/test/unit/historical_account_test.rb
+++ b/test/unit/historical_account_test.rb
@@ -1,6 +1,8 @@
 require_relative "../test_helper"
 
 class HistoricalAccountTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   test "is invalid without a summary, body, political party or person" do
     %w[summary body person political_parties].each do |attribute|
       assert_not build(:historical_account, attribute => nil).valid?
@@ -74,4 +76,43 @@ class HistoricalAccountTest < ActiveSupport::TestCase
   end
 
   should_not_accept_footnotes_in(:body)
+
+  context "for a previous prime minister" do
+    let(:object) do
+      build(:historical_account,
+            roles: [create(:prime_minister_role)],
+            person: create(:person, slug: "foo"))
+    end
+
+    test "public_path returns the correct path" do
+      assert_equal "/government/history/past-prime-ministers/foo", object.public_path
+    end
+
+    test "public_path returns the correct path with options" do
+      assert_equal "/government/history/past-prime-ministers/foo?cachebust=123", object.public_path(cachebust: "123")
+    end
+
+    test "public_url returns the correct path" do
+      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo", object.public_url
+    end
+
+    test "public_url returns the correct path with options" do
+      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo?cachebust=123", object.public_url(cachebust: "123")
+    end
+  end
+
+  context "for a person who was not a prime minister" do
+    let(:object) do
+      build(:historical_account,
+            roles: [create(:historic_role, slug: "chancellor")])
+    end
+
+    test "public_path returns nil" do
+      assert_nil object.public_path
+    end
+
+    test "public_url returns nil" do
+      assert_nil object.public_url
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
+  test "presents a valid content item" do
+    person = create(:person, forename: "Some", surname: "Person")
+    role = create(:prime_minister_role)
+    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    historical_account = create(:historical_account,
+                                person:,
+                                born: "1900",
+                                died: "1975",
+                                interesting_facts: "They were a very interesting person",
+                                major_acts: "Significant legislation changes",
+                                roles: [role])
+
+    public_path = "/government/history/past-prime-ministers/some-person"
+
+    expected_hash = {
+      base_path: public_path,
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      schema_name: "historic_appointment",
+      document_type: "historic_appointment",
+      title: "Some Person",
+      description: "Some summary text",
+      locale: "en",
+      routes: [
+        {
+          path: public_path,
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: historical_account.updated_at,
+      details: {
+        body: Whitehall::GovspeakRenderer.new.govspeak_to_html("Some body text"),
+        born: "1900",
+        died: "1975",
+        interesting_facts: "They were a very interesting person",
+        major_acts: "Significant legislation changes",
+        political_party: "Labour",
+        previous_dates_in_office: "1950 to 1960",
+      },
+    }
+
+    expected_links = {
+      person: [
+        historical_account.person.content_id,
+      ],
+    }
+
+    presenter = PublishingApi::HistoricalAccountPresenter.new(historical_account)
+
+    assert_equal expected_hash, presenter.content
+    assert_hash_includes presenter.links, expected_links
+    assert_valid_against_publisher_schema(presenter.content, "historic_appointment")
+  end
+end


### PR DESCRIPTION
This will be used to put the content of Historical Accounts (i.e. profile pages for past prime ministers) into Publishing API to enable us to serve the content from an application outside of Whitehall.

The associated person page is added as a link so we can access their image.

Example of a content item generated by the presenter:
```
{
	"analytics_identifier": null,
	"base_path": "/government/history/past-prime-ministers/edward-heath",
	"content_id": "84351af1-4dba-4c25-a6a4-cf1c97b2bdf2",
	"document_type": "historic_appointment",
	"first_published_at": "2023-01-19T13:33:29.000+00:00",
	"locale": "en",
	"phase": "live",
	"public_updated_at": "2023-01-19T13:46:58.000+00:00",
	"publishing_app": "whitehall",
	"publishing_scheduled_at": null,
	"rendering_app": "whitehall-frontend",
	"scheduled_publishing_delay_seconds": null,
	"schema_name": "historic_appointment",
	"title": "Sir Edward Heath",
	"updated_at": "2023-01-19T13:46:59.356Z",
	"withdrawn_notice": {},
	"publishing_request_id": "23769-1674136018.470-10.1.1.50-5840",
	"links": {
		"person": [{
			"content_id": "85372f34-c0f1-11e4-8223-005056011aef",
			"title": "Sir Edward Heath",
			"locale": "en",
			"api_path": "/api/content/government/people/edward-heath",
			"base_path": "/government/people/edward-heath",
			"document_type": "person",
			"public_updated_at": "2019-11-07T14:59:05Z",
			"schema_name": "person",
			"withdrawn": false,
			"details": {
				"body": "<p>Sir  Edward Heath served as Prime Minister between 1970 to 1974. Read more about the life and achievements of Sir  Edward Heath in our <a href=\"/government/history/past-prime-ministers/edward-heath\">past Prime Ministers</a> section.</p>\n",
				"image": {
					"url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/970/s465_Edward-Heath.jpg",
					"alt_text": "Sir Edward Heath"
				}
			},
			"links": {},
			"api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/people/edward-heath",
			"web_url": "https://www.integration.publishing.service.gov.uk/government/people/edward-heath"
		}],
		"available_translations": [{
			"title": "Sir Edward Heath",
			"public_updated_at": "2023-01-19T13:46:58Z",
			"document_type": "historic_appointment",
			"schema_name": "historic_appointment",
			"base_path": "/government/history/past-prime-ministers/edward-heath",
			"api_path": "/api/content/government/history/past-prime-ministers/edward-heath",
			"withdrawn": false,
			"content_id": "84351af1-4dba-4c25-a6a4-cf1c97b2bdf2",
			"locale": "en",
			"api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/history/past-prime-ministers/edward-heath",
			"web_url": "https://www.integration.publishing.service.gov.uk/government/history/past-prime-ministers/edward-heath",
			"links": {}
		}]
	},
	"description": "Sir Edward Heath was Prime Minister during a time of industrial upheaval and economic decline during which he led Britain into the European Community. test2",
	"details": {
		"body": "<div class=\"govspeak\"><p>Edward ‘Ted’ Heath was born in Kent to working class parents, in contrast to many previous Conservative leaders and Prime Ministers. He was grammar school educated before going to Balliol College, Oxford, where he was awarded an organ scholarship in his first term. He received a second class degree in Philosophy, Politics and Economics and travelled widely in Europe during his holidays, especially in Spain and Germany. It was during these travels that he first witnessed the horrors of fascism and dictatorship that were sweeping across Europe.</p>\n\n<p>Heath served in the Second World War, reaching the rank of Lieutenant Colonel before briefly entering the Civil Service. He was elected to Parliament in 1950 and rose rapidly to become Government Chief Whip to <a rel=\"external\" href=\"https://www.gov.uk/government/history/past-prime-ministers/anthony-eden\" class=\"govuk-link\">Anthony Eden</a> before backing <a rel=\"external\" href=\"https://www.gov.uk/government/history/past-prime-ministers/harold-macmillan\" class=\"govuk-link\">Harold Macmillan</a>‘s attempt to lead the UK into the European Community.</p>\n\n<p>He was elected leader of the Conservative Party in 1965, and so began his long-lasting rivalry with Harold Wilson, leader of the Labour Party and Prime Minister.</p>\n\n<p>Heath won the 1970 election, and served his only term as Prime Minister during a time of strong industrial change and economic decline. He was elected on a manifesto to turn around the nation’s fortunes and pursued a number of policies that would later become identified with ‘Thatcherism’. Unemployment continued to rise which, combined with the strength of the trade unions, forced a famous U-turn on the government’s economic policy.</p>\n\n<p>It was from this point that the trade unions sensed they could seize the initiative. Heath’s attempts to weaken their power had failed, and when their pay demands were not met, they went out on strike. Particularly crippling were the miners’ strikes of 1972 and 1974, the second of which led to the 3-day week, when electricity was limited to 3 consecutive days’ use.</p>\n\n<p>Heath also worked to create a lasting peace in Northern Ireland.</p>\n\n<p>Heath continued to serve in the House of Commons until 2001, becoming the Father of the House. Along with Harold Macmillan, he was an outspoken critic of <a rel=\"external\" href=\"https://www.gov.uk/government/history/past-prime-ministers/margaret-thatcher\" class=\"govuk-link\">Margaret Thatcher</a>. Outside of politics he maintained lifelong passions for conducting and playing music, as well as sailing, notably winning the Admiral’s Cup while Prime Minister.</p>\n\n<p><br></p>\n</div>",
		"born": "9 July 1916, Broadstairs, Kent",
		"died": "17 July 2005, Salisbury, Wiltshire",
		"major_acts": "Industrial relations Act 1971 (repealed 1974): controversial legislation to curb union power.",
		"political_party": "Conservative",
		"interesting_facts": "Arundells, Heath's home in Salisbury is open to the public.",
		"previous_dates_in_office": "1970 to 1974"
	}
}
```

The rendering app will remain as Whitehall until the frontend has been built for this page.

Not to be merged until https://github.com/alphagov/publishing-api/pull/2263 is deployed.

After merging, the following rake task will need to be run to republish all existing content of this type:
```
publishing_api:bulk_republish:document_type[HistoricalAccount]
```

This content can also be included as a link on the 'Past Prime Ministers' index page.

[Trello card](https://trello.com/c/ArbqIwFp/423-populate-content-items-for-past-prime-ministers-individual-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
