### PR TITLE
Delete role appointment for speech

### DIFF
--- a/db/migrate/20230118130656_remove_role_appointment_for_speech.rb
+++ b/db/migrate/20230118130656_remove_role_appointment_for_speech.rb
@@ -1,0 +1,14 @@
+# Zendesk ticket https://govuk.zendesk.com/agent/tickets/5182511
+# Need to unlink the speech from the role appointment.
+# This speech in published state is already linked to person's new role.
+# Because the speech is superseded and would raise the validation
+# "cannot be modified when edition is in the superseded state"
+# it must be saved without running the validations.
+
+class RemoveRoleAppointmentForSpeech < ActiveRecord::Migration[7.0]
+  def change
+    speech = Speech.find(1_216_085)
+    speech.role_appointment_id = nil
+    speech.save!(validate: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_11_131609) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_18_130656) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"


### PR DESCRIPTION
So the duplicated role can be removed as requested in https://govuk.zendesk.com/agent/tickets/5182511

As a result, role appointment can be deleted and consequently, so can duplicated role.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
