### PR TITLE
Change `accessible-autocomplete` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "dependencies": {
-    "accessible-autocomplete": "kevindew/accessible-autocomplete",
+    "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
     "jquery": "3.6.3",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,9 +93,9 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-accessible-autocomplete@kevindew/accessible-autocomplete:
+accessible-autocomplete@alphagov/accessible-autocomplete-multiselect:
   version "1.6.2"
-  resolved "https://codeload.github.com/kevindew/accessible-autocomplete/tar.gz/62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
+  resolved "https://codeload.github.com/alphagov/accessible-autocomplete-multiselect/tar.gz/62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
   dependencies:
     preact "^8.3.1"
 


### PR DESCRIPTION
Change the dependency from kevindew's personal account to the `alphagov` organisation.

https://trello.com/c/iNuMxfk4/893-adopt-kevins-fork-of-accessible-autocomplete

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
