### PR TITLE
Add subtype tracking to design system pages

### DIFF
--- a/app/views/admin/attachments/new.html.erb
+++ b/app/views/admin/attachments/new.html.erb
@@ -2,6 +2,10 @@
 <% content_for :title, "Add #{attachment.readable_type} attachment" %>
 <% content_for :context, "Attachments for #{attachment.attachable_model_name}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: attachment, parent_class: "attachment")) %>
+<% render "admin/tracking/subtype_tracking", 
+      document_type: attachment.attachable_model_name.titleize.delete(' '), 
+      document: attachable
+%>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">

--- a/app/views/admin/bulk_uploads/new.html.erb
+++ b/app/views/admin/bulk_uploads/new.html.erb
@@ -2,6 +2,7 @@
 <% content_for :title, "Bulk upload" %>
 <% content_for :context, "Attachments for #{@edition.format_name}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @zip_file, parent_class: "zip_file")) %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -3,6 +3,7 @@
 <% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
 <% content_for :title_margin_bottom, 6 %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing, noun: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explanation")) %>
+<% render "admin/tracking/subtype_tracking", document_type: @unpublishing.edition.type, document: @unpublishing.edition %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">

--- a/app/views/admin/edition_workflow/confirm_force_publish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_force_publish.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_title, "Force publish: #{@edition.title}" %>
 <% content_for :title, "Force publish" %>
 <% content_for :title_margin_bottom, 6 %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -2,6 +2,7 @@
 <% content_for :title, "Withdraw or unpublish" %>
 <% content_for :context, @edition.title %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing, verb: "withdraw or unpublish", noun: @edition.format_name)) %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <%
   unpublish_reasons = {

--- a/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
@@ -2,6 +2,7 @@
 <% content_for :title, "Are you sure you want to unwithdraw?" %>
 <% content_for :context, @edition.title %>
 <% content_for :title_margin_bottom, 6 %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/editions/confirm_destroy.html.erb
+++ b/app/views/admin/editions/confirm_destroy.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_title, "Delete draft" %>
 <% content_for :title, "Delete draft" %>
 <% content_for :title_margin_bottom, 6 %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">

--- a/app/views/admin/tracking/_subtype_tracking.html.erb
+++ b/app/views/admin/tracking/_subtype_tracking.html.erb
@@ -1,0 +1,9 @@
+<% if document_type == "Publication" || document_type == "NewsArticle" %>
+  <% content_for :head do %>
+    <meta name="custom-dimension:5" content="<%= document.display_type %>">
+  <% end %>
+<% elsif document_type == "Speech" %>
+  <% content_for :head do %>
+    <meta name="custom-dimension:5" content="<%= document.speech_type.singular_name %>">
+  <% end %>
+<% end %>


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/kaEUP9us/1038-add-custom-dimension-sub-type-tracking-to-pages-events-already-moved-to-design-system)

## What
Add document subtype tracking to pages which have been moved to the design system. Tracking is added to publications, news articles and speeches on the following pages:
- Edit withdrawal message
- Confirm unwithdraw
- Bulk uploads
- Add HTML attachment
- Add file attachment
- Add external attachment
- Confirm unpublish
- Confirm destroy
- Confirm force publish

## Why
This was requested by the performance analysis team to enable a more granular view of data associated with publications, news articles and speeches.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
