### PR TITLE
Fix Attachments not appearing in Markdown preview

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -35,6 +35,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.append('image_ids[]', imageIds[index])
     }
 
+    var attachmentIds = this.getAttachmentIds()
+    for (var i = 0; i < attachmentIds.length; i++) {
+      data.append('attachment_ids[]', attachmentIds[i])
+    }
+
     return data
   }
 
@@ -79,6 +84,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     imagesIds = imagesIds ? JSON.parse(imagesIds) : []
 
     return imagesIds.filter(function (id) { return id })
+  }
+
+  GovspeakEditor.prototype.getAttachmentIds = function () {
+    var attachmentIds = this.module.getAttribute('data-attachment-ids')
+    attachmentIds = attachmentIds ? JSON.parse(attachmentIds) : []
+
+    return attachmentIds.filter(function (id) { return id })
   }
 
   GovspeakEditor.prototype.alternativeFormatProviderId = function () {

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -55,6 +55,7 @@
           error_items: errors_for(attachment.errors, :"govspeak_content.body"),
           data_attributes: {
             image_ids: @edition && @edition.images.any? ? @edition.images.map { |img| img[:id] } : [],
+            attachment_ids: @edition && @edition.allows_attachments? ? @edition.attachments.map(&:id) : [],
             alternative_format_provider_id: @edition && @edition.alternative_format_provider_id ? @edition.alternative_format_provider_id : current_user.organisation.try(:id),
           }
         } %>

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -43,6 +43,7 @@
     error_items: errors_for(form.object.errors, :body),
     data_attributes: {
       image_ids: edition.images.map { |img| img[:id] }.to_json,
+      attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
       alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
     }
   } %>

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -29,6 +29,7 @@
         error_items: errors_for(@unpublishing.errors, :explanation),
         data_attributes: {
           image_ids: @unpublishing.edition.images.map { |img| img[:id] }.to_json,
+          attachment_ids: @unpublishing.edition.allows_attachments? ? @unpublishing.edition.attachments.map(&:id) : [],
           alternative_format_provider_id: (@unpublishing.edition.alternative_format_provider_id || current_user.organisation.try(:id)),
         }
       } %>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -34,6 +34,7 @@
     error_items: errors_for(@unpublishing.errors, :explanation),
     data_attributes: {
       image_ids: @edition.images.map { |img| img[:id] }.to_json,
+      attachment_ids: @edition.allows_attachments? ? @edition.attachments.map(&:id) : [],
       alternative_format_provider_id: (@edition.alternative_format_provider_id || current_user.organisation.try(:id)),
     }
   })
@@ -160,6 +161,7 @@
           error_items: errors_for(@unpublishing.errors, :explanation),
           data_attributes: {
             image_ids: @edition.images.map { |img| img[:id] }.to_json,
+            attachment_ids: @edition.allows_attachments? ? @edition.attachments.map(&:id) : [],
             alternative_format_provider_id: (@edition.alternative_format_provider_id || current_user.organisation.try(:id)),
           }
         } %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -44,6 +44,7 @@
     error_items: errors_for(edition.errors, :body),
     data_attributes: {
       image_ids: edition.images.map { |img| img[:id] }.to_json,
+      attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
       alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
     }
   } %>

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -8,8 +8,6 @@
   value ||= nil
   error_items ||= nil
   rows ||= 12
-  image_ids ||= []
-  alternative_format_provider_id ||= nil
   form ||= nil
 
   track_preview_toggle ||= false

--- a/app/views/components/docs/govspeak-editor.yml
+++ b/app/views/components/docs/govspeak-editor.yml
@@ -56,7 +56,7 @@ examples:
 
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 
-  with_image_ids_and_alternative_format_provider_id:
+  with_attachments_and_alternative_format_provider_id:
     data:
       label:
         text: "Document content body"
@@ -68,7 +68,15 @@ examples:
           - 1
           - 2
           - 3
+        attachment_ids:
+          - 3
+          - 4
+          - 5
       value: |
         ## What is Lorem Ipsum?
 
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+
+        This is an attachment: !@1
+
+        This is an image: !!1

--- a/spec/javascripts/components/govspeak-editor.spec.js
+++ b/spec/javascripts/components/govspeak-editor.spec.js
@@ -4,6 +4,7 @@ describe('GOVUK.Modules.GovspekEditor', function () {
   beforeEach(function () {
     component = document.createElement('div')
     component.setAttribute('data-image-ids', JSON.stringify([1, 2, 3, 4]))
+    component.setAttribute('data-attachment-ids', JSON.stringify([5, 6, 7, 8]))
     component.setAttribute('data-alternative-format-provider-id', 11)
 
     // Preview Button
@@ -204,7 +205,11 @@ describe('GOVUK.Modules.GovspekEditor', function () {
       ['image_ids[]', '1'],
       ['image_ids[]', '2'],
       ['image_ids[]', '3'],
-      ['image_ids[]', '4']
+      ['image_ids[]', '4'],
+      ['attachment_ids[]', '5'],
+      ['attachment_ids[]', '6'],
+      ['attachment_ids[]', '7'],
+      ['attachment_ids[]', '8']
     ])
   })
 })


### PR DESCRIPTION
## What

Send attachment IDs in the payload for the preview API.

## Why

We want to display attachments, and to do this we need the IDs sent to the API.

https://trello.com/c/LSbxhFrY/1073-attachments-dont-appear-in-markdown-preview

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
