### PR TITLE
Fix for remove-role-appointment-for-speech migration

### DIFF
--- a/db/migrate/20230118130656_remove_role_appointment_for_speech.rb
+++ b/db/migrate/20230118130656_remove_role_appointment_for_speech.rb
@@ -7,8 +7,10 @@
 
 class RemoveRoleAppointmentForSpeech < ActiveRecord::Migration[7.0]
   def change
-    speech = Speech.find(1_216_085)
-    speech.role_appointment_id = nil
-    speech.save!(validate: false)
+    speech = Speech.find_by(id: 1_216_085)
+    if speech
+      speech.role_appointment_id = nil
+      speech.save!(validate: false)
+    end
   end
 end


### PR DESCRIPTION
This is to update changes made in https://github.com/alphagov/whitehall/pull/7262

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
