### PR TITLE
Add Datetime fields Publishing Component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/all_components";
 
 @import "./components/autocomplete";
+@import "./components/datetime-fields";
 @import "./components/govspeak-editor";
 @import "./components/inset-prompt";
 @import "./components/miller-columns";

--- a/app/assets/stylesheets/components/_datetime-fields.scss
+++ b/app/assets/stylesheets/components/_datetime-fields.scss
@@ -1,0 +1,22 @@
+.app-c-datetime-fields__date-time-wrapper {
+  display: inline-flex;
+}
+
+.app-c-datetime-fields__date-time {
+  margin-right: govuk-spacing(2);
+}
+
+.app-c-datetime-fields__date-time-input {
+  max-width: 4.5em;
+  min-width: 4.5em;
+}
+
+.app-c-datetime-fields__date-time-input--large {
+  max-width: 7.5em;
+  min-width: 7.5em;
+}
+
+.app-c-datetime-fields__time-separator {
+  margin: govuk-spacing(6) + 5 govuk-spacing(2) 0 0;
+  margin-bottom: 0;
+}

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -1,0 +1,190 @@
+<%
+ prefix = prefix
+ field_name = field_name
+
+ error_items = error_items ||= nil
+
+ heading_level = heading_level ||= nil
+ heading_size = heading_size ||= nil
+
+ date_hint = date_hint ||= nil
+ date_hint_id = "date-hint-#{SecureRandom.hex(4)}"
+
+ time_hint = time_hint ||= nil
+ time_hint_id = "time-hint-#{SecureRandom.hex(4)}"
+
+ year ||= {}
+ year_value = year[:value]
+ start_year = year[:start_year]
+ end_year = year[:end_year]
+ year_select_id = year[:id] || "select-year-#{SecureRandom.hex(4)}"
+ year_label_id = "year-#{SecureRandom.hex(4)}"
+
+ month ||= {}
+ month_value = month[:value]
+ month_select_id = month[:id] || "select-month-#{SecureRandom.hex(4)}"
+ month_label_id = "month-#{SecureRandom.hex(4)}"
+
+ day ||= {}
+ day_value = day[:value]
+ day_select_id = day[:id] || "select-day-#{SecureRandom.hex(4)}"
+ day_label_id = "day-#{SecureRandom.hex(4)}"
+
+ hour ||= {}
+ hour_value = hour[:value]
+ hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
+ hour_label_id = "hour-#{SecureRandom.hex(4)}"
+
+ minute ||= {}
+ minute_value = minute[:value]
+ minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
+ minute_label_id = "minute-#{SecureRandom.hex(4)}"
+
+ root_classes = %w[app-c-datetime-fields]
+ root_classes << "govuk-form-group--error" if error_items.present?
+ data_attributes ||= {}
+%>
+
+<%= tag.div class: root_classes, data: data_attributes do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Date",
+    heading_level: heading_level || 3,
+    font_size: heading_size || "m",
+    padding: true,
+  } %>
+
+  <% if date_hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      text: date_hint,
+      id: date_hint_id
+    } %>
+  <% end %>
+
+  <% if error_items.present? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      items: error_items,
+    } %>
+  <% end %>
+
+  <div class="govuk-!-margin-bottom-3 app-c-datetime-fields__date-time-wrapper">
+    <div class="app-c-datetime-fields__date-time">
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Day",
+        html_for: year_select_id,
+        id: day_label_id,
+      } %>
+
+      <%= select_day day_value,
+        {
+          include_blank: true,
+          prefix: prefix,
+          field_name: "#{field_name}(3i)"
+        },
+        {
+          id: year_select_id,
+          class: "govuk-select app-c-datetime-fields__date-time-input",
+          "aria-describedby": "#{day_label_id} #{date_hint_id if date_hint.present?}".strip
+        } %>
+    </div>
+
+    <div class="app-c-datetime-fields__date-time app-c-datetime-fields__date-time--large">
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Month",
+        html_for: month_select_id,
+        id: month_label_id,
+      } %>
+
+      <%= select_month month_value,
+        {
+          include_blank: true,
+          prefix: prefix,
+          field_name: "#{field_name}(2i)"
+        },
+        {
+          id: month_select_id,
+          class: "govuk-select app-c-datetime-fields__date-time-input--large",
+          "aria-describedby": "#{month_label_id} #{date_hint_id if date_hint.present?}".strip
+        } %>
+    </div>
+
+    <div class="app-c-datetime-fields__date-time">
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Year",
+        html_for: day_select_id,
+        id: year_label_id,
+      } %>
+
+      <%= select_year year_value,
+        {
+          include_blank: true,
+          start_year: start_year,
+          end_year: end_year,
+          prefix: prefix,
+          field_name: "#{field_name}(1i)"
+        },
+        {
+          id: day_select_id,
+          class: "govuk-select app-c-datetime-fields__date-time-input",
+          "aria-describedby": "#{year_label_id} #{date_hint_id if date_hint.present?}".strip
+        } %>
+    </div>
+  </div>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Time",
+    heading_level: heading_level || 3,
+    font_size: heading_size || "m",
+    padding: true,
+  } %>
+
+  <% if time_hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      text: time_hint,
+      id: time_hint_id
+    } %>
+  <% end %>
+
+  <div class="app-c-datetime-fields__date-time-wrapper">
+    <div class="app-c-datetime-fields__date-time">
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Hour",
+        html_for: hour_select_id,
+        id: hour_label_id,
+      } %>
+
+      <%= select_hour hour_value,
+        {
+          include_blank: true,
+          prefix: prefix,
+          field_name: "#{field_name}(4i)"
+        },
+        {
+          id: hour_select_id,
+          class: "govuk-select app-c-datetime-fields__date-time-input",
+          "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip
+        } %>
+    </div>
+
+    <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
+
+    <div class="app-c-datetime-fields__date-time">
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Minute",
+        html_for: minute_select_id,
+        id: minute_label_id,
+      } %>
+
+      <%= select_minute minute_value,
+        {
+          include_blank: true,
+          prefix: prefix,
+          field_name: "#{field_name}(5i)"
+        },
+        {
+          id: minute_select_id,
+          class: "govuk-select app-c-datetime-fields__date-time-input",
+          "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip
+        } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/components/docs/datetime_fields.yml
+++ b/app/views/components/docs/datetime_fields.yml
@@ -1,0 +1,86 @@
+name: Datetime fields
+description: Use the datetime fields component to help users enter a datetime for a specific event.
+body: |
+  This differs from the [Date fields][] component in a few notable ways:
+    1. In addition, to day, month and year, it also takes hour and minute
+    2. It generates select fields in place of inputs
+    3. As this uses the `ActionView::Helpers::DateHelper` helpers you must
+    provide a prefix and field_name to constuct the fields
+     - the prefix must be the downcased and underscored model name
+     - the field_name is the attribute for the model
+
+  [Date fields]: https://design-system.service.gov.uk/components/date-input/
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form select elements
+  - have correctly associated labels
+examples:
+  default:
+    data:
+      prefix: edition
+      field_name: first_published_at
+  with_heading_level_and_size:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      heading_level: 1
+      heading_size: l
+  with_hint_text:
+    data:
+      prefix: edition
+      date_hint: For example, 01 August 2022
+      time_hint: For example, 09:30 or 19:30
+  with_custom_ids:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      year:
+        id: edition_first_published_year
+      month:
+        id: edition_first_published_month
+      day:
+        id: edition_first_published_day
+      hour:
+        id: edition_first_published_hour
+      minute:
+        id: edition_first_published_minute
+  with_values:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      year:
+        value: 2022
+      month:
+        value: 1
+      day:
+        value: 1
+      hour:
+        value: 9
+      minute:
+        value: 30
+  with_start_and_end_year:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      year:
+        start_year: 2000
+        end_year: 2025
+  with_error_items:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      error_items:
+      - text: Descriptive error 1
+      - text: Descriptive error 2
+  with_data_attributes:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      data_attributes:
+        tracking: GTM-123AB


### PR DESCRIPTION
## Description

At the moment, we've got a fairly complex `datetime-fields` partial that we use to render the DateTime fields for editions.

In it's current implementation, it's coupled to editions which isn't ideal as we've got a need for DateTime inputs for a variety of objects.

Due to this, it makes sense to create a Datetime fields  Publishing Component. This should be model agnostic so it can be reused throughout Whitehall.


## Trello card 

https://trello.com/c/TLp8zlHT/899-add-publishing-component-for-datetime-fields

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
