### PR TITLE
Fix HTML attachment validation errors

### DIFF
--- a/app/models/govspeak_content.rb
+++ b/app/models/govspeak_content.rb
@@ -2,7 +2,7 @@ class GovspeakContent < ApplicationRecord
   belongs_to :html_attachment, inverse_of: :govspeak_content
 
   validates :body, :html_attachment, presence: true
-  validates_with SafeHtmlValidator
+  validates_with SafeHtmlValidator, attribute: :body
 
   before_save :reset_computed_html, if: :body_or_numbering_scheme_changed?
   after_save :queue_html_compute_job, if: :saved_change_to_body_or_numbering_scheme?

--- a/test/unit/govspeak_content_test.rb
+++ b/test/unit/govspeak_content_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class GovspeakContentTest < ActiveSupport::TestCase
+  def setup
+    Whitehall.stubs(:skip_safe_html_validation).returns(false)
+  end
+
   test "queues a job to compute the HTML on creation" do
     govspeak_content = create(:html_attachment).govspeak_content
 
@@ -141,6 +145,17 @@ class GovspeakContentTest < ActiveSupport::TestCase
     post_updated_at = govspeak_content.reload.updated_at
 
     assert_equal pre_updated_at, post_updated_at
+  end
+
+  test "validate user input for HTML safety, but not the computed HTML output" do
+    govspeak_content = create(:html_attachment).govspeak_content
+
+    bad_html = '<script>alert("hax!")</script>'
+    govspeak_content.body = bad_html
+    govspeak_content.computed_body_html = bad_html
+
+    assert_equal false, govspeak_content.valid?
+    assert_equal %i[body], govspeak_content.errors.group_by_attribute.keys
   end
 
 private


### PR DESCRIPTION
The SafeHtmlValidator checks values for unsafe HTML.

This PR changes the way HTML attachments are validated. Previously, the SafeHtmlValidator was run on both the Govspeak input as well as the generated HTML output.

However, it's possible (and perfectly valid) for generated HTML output to contain HTML that would be considered unsafe if entered by a user. When Govspeak is converted to HTML, it's possible for govuk_publishing_components to be included – for example, when adding a [button] to a document – or indeed any other HTML that might be added in post-processing.

This commit changes the validation rule so it only applies to Govspeak input provided by the user. Govspeak HTML output is no longer validated. This is safe to do because Govspeak post-processing is trusted code. For more information, see alphagov/govspeak#237 which established this as safe behaviour.

[button]: https://github.com/alphagov/govspeak#button

---

Trello: https://trello.com/c/2Nvlja0w

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
