### PR TITLE
Corrects locale in URL for document preview

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -282,7 +282,7 @@ module Admin::EditionsHelper
     end
 
     links + edition.non_english_translated_locales.map do |locale|
-      [preview_document_url(edition, locale:),
+      [preview_document_url(edition, locale: locale.code),
        "Language: #{locale.native_and_english_language_name}"]
     end
   end


### PR DESCRIPTION
[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5187936)

When the user wishes to preview a document in a language other than English they select the language from the "Preview on website" dropdown and click on the required language (see screenshot below). This opens the document in a preview window but the document is displayed here in the default language (English). See [this example](https://whitehall-admin.publishing.service.gov.uk/government/admin/publications/1410112) in Whitehall production.

The cause of this is a badly formed URL in the dropdown which is `.../format-of-registers-for-titles-in-wales-pg58.#<struct Locale code=:cy>` in the example above rather than the correct URL of `.../format-of-registers-for-titles-in-wales-pg58.cy`.

This change renders the URL in the correct form. 

![Screenshot 2023-01-20 at 15 19 55](https://user-images.githubusercontent.com/6080548/213734298-e4de21d4-f6eb-4453-b081-ac7090ed71a4.png)
