### PR TITLE
Add permission for previewing images update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
     GDS_ADMIN = "GDS Admin".freeze
     PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
     PREVIEW_NEXT_RELEASE = "Preview next release".freeze
+    PREVIEW_IMAGES_UPDATE = "Preview images update".freeze
   end
 
   def role
@@ -89,6 +90,10 @@ class User < ApplicationRecord
 
   def can_preview_next_release?
     has_permission?(Permissions::PREVIEW_NEXT_RELEASE)
+  end
+
+  def can_preview_images_update?
+    has_permission?(Permissions::PREVIEW_IMAGES_UPDATE)
   end
 
   def organisation_name

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -145,6 +145,16 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_preview_next_release?
   end
 
+  test "cannot preview the upcoming images workflow update" do
+    user = build(:user)
+    assert_not user.can_preview_images_update?
+  end
+
+  test "can preview the upcoming images workflow update" do
+    user = build(:user, permissions: [User::Permissions::PREVIEW_IMAGES_UPDATE])
+    assert user.can_preview_images_update?
+  end
+
   test "can handle fatalities if our organisation is set to handle them" do
     not_allowed = build(:user, organisation: build(:organisation, handles_fatalities: false))
     assert_not not_allowed.can_handle_fatalities?


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/O3m1clkD/1055-user-permissions-for-new-flow)

## What
This PR adds a feature flag for the upcoming work on images workflow. 

## Why
To enable development to continue on this epic, without affecting everyday functionality of Whitehall.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
