### PR TITLE
Add tracking to Edition Summary page

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -42,6 +42,12 @@ private
       actions << form_with(url: revise_admin_edition_path(@edition.id), method: :post) do
         render("govuk_publishing_components/components/button", {
           text: "Create new edition",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Create new edition",
+          },
         })
       end
     end
@@ -52,6 +58,12 @@ private
       actions << form_with(url: submit_admin_edition_path(@edition, lock_version: @edition.lock_version), method: :post) do
         render("govuk_publishing_components/components/button", {
           text: "Submit for 2nd eyes",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Submit for 2nd eyes",
+          },
         })
       end
     end
@@ -63,6 +75,12 @@ private
         text: "Edit draft",
         href: @url_maker.edit_admin_edition_path(@edition),
         secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Edit draft",
+        },
       })
     end
   end
@@ -74,6 +92,12 @@ private
         title: "Unschedule this edition to allow changes or prevent automatic publication on #{l @edition.scheduled_publication, format: :long}",
         href: confirm_unschedule_admin_edition_path(@edition, lock_version: @edition.lock_version),
         secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Unschedule",
+        },
       })
     end
   end
@@ -85,6 +109,12 @@ private
           text: "Schedule",
           title: "Schedule #{@edition.title} for publication on #{l @edition.scheduled_publication, format: :long}",
           secondary_quiet: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Schedule",
+          },
         })
       end
     elsif @force_scheduler.can_perform? && @enforcer.can?(:force_publish)
@@ -93,6 +123,12 @@ private
         title: "Schedule #{@edition.title} for publication on #{l @edition.scheduled_publication, format: :long}",
         href: confirm_force_schedule_admin_edition_path(@edition, lock_version: @edition.lock_version),
         secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Force schedule",
+        },
       })
     end
   end
@@ -103,6 +139,12 @@ private
         render("govuk_publishing_components/components/button", {
           text: "Publish",
           title: "Publish #{@edition.title}",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Publish",
+          },
         })
       end
     elsif @force_publisher.can_perform? && @enforcer.can?(:force_publish)
@@ -111,6 +153,12 @@ private
         title: "Publish #{@edition.title}",
         href: confirm_force_publish_admin_edition_path(@edition, lock_version: @edition.lock_version),
         secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Force publish",
+        },
       })
     end
   end
@@ -121,6 +169,12 @@ private
         render("govuk_publishing_components/components/button", {
           text: "Reject",
           destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Reject",
+          },
         })
       end
     end
@@ -132,6 +186,12 @@ private
         "Discard draft",
         confirm_destroy_admin_edition_path(@edition),
         class: "govuk-link gem-link--destructive",
+        data: {
+          module: "gem-track-click",
+          "track-category": "button-clicked",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Discard draft",
+        },
       )
     end
   end
@@ -142,6 +202,12 @@ private
         text: "Unwithdraw",
         href: confirm_unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version),
         secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Unwithdraw",
+        },
       })
     end
   end
@@ -153,6 +219,12 @@ private
           text: "Withdraw or unpublish",
           href: confirm_unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version),
           destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "button-pressed",
+            "track-action": "#{dasherized_class_name}-button",
+            "track-label": "Withdraw or unpublish",
+          },
         })
       elsif @edition.unpublishing.present? && @edition.unpublishing.explanation.present?
         actions << link_to(
@@ -166,7 +238,17 @@ private
 
   def add_view_action
     if @edition.publicly_visible?
-      actions << link_to("View on website (opens in new tab)", @url_maker.public_document_url(@edition), class: "govuk-link", target: "_blank", rel: "noopener")
+      actions << link_to("View on website (opens in new tab)",
+                         @url_maker.public_document_url(@edition),
+                         class: "govuk-link",
+                         target: "_blank",
+                         rel: "noopener",
+                         data: {
+                           module: "gem-track-click",
+                           track_category: "external-link-clicked",
+                           track_action: @url_maker.public_document_url(@edition),
+                           track_label: "View on website",
+                         })
     end
   end
 
@@ -179,5 +261,9 @@ private
         track_label: "View data about page",
       })
     end
+  end
+
+  def dasherized_class_name
+    @dasherized_class_name ||= @edition.model_name.singular.dasherize
   end
 end

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, "#{@edition.title} - #{@edition.format_name}" %>
 <% content_for :title, @edition.title %>
+<% content_for :head do %>
+  <% custom_track_dimensions(@edition, @edition_taxons).each do |key, value| %>
+    <meta name="custom-dimension:<%= key %>" content="<%= value %>">
+  <% end %>
+<% end %>
+
+<%= render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -39,7 +39,18 @@
         font_size: "l",
         margin_bottom: 3,
       } %>
-      <p class="govuk-body"><%= link_to("Preview on website #{"- English" if @edition.translatable? && @edition.available_in_multiple_languages?} (opens in new tab)".strip, preview_document_url(@edition), class: "govuk-link", target: "_blank") if @edition.available_in_english? %></p>
+      <p class="govuk-body">
+        <%= link_to("Preview on website #{"- English" if @edition.translatable? && @edition.available_in_multiple_languages?} (opens in new tab)".strip,
+        preview_document_url(@edition),
+        class: "govuk-link",
+        target: "_blank",
+        data: {
+          module: "gem-track-click",
+          "track-category": "button-clicked",
+          "track-action": "#{@edition.model_name.singular.dasherize}-button",
+          "track-label": "Preview on website",
+        }) if @edition.available_in_english? %>
+      </p>
       <% if @edition.translatable? && @edition.available_in_multiple_languages? %>
         <%= render "govuk_publishing_components/components/details", {
           title: "Preview translated pages"
@@ -47,7 +58,15 @@
           <%= render "govuk_publishing_components/components/list", {
             items: @edition.non_english_translated_locales.map do |locale|
               (link_to("Preview on website - #{locale.native_and_english_language_name}",
-                      public_document_url(@edition, locale:), class: 'govuk-link', target: '_blank') + "")
+                      public_document_url(@edition, locale:),
+                      class: 'govuk-link',
+                      target: '_blank',
+                      data: {
+                        module: "gem-track-click",
+                        "track-category": "button-clicked",
+                        "track-action": "#{@edition.model_name.singular.dasherize}-button",
+                        "track-label": "Preview on website - #{locale.native_and_english_language_name}",
+                      }) + "")
             end
           } %>
         <% end %>
@@ -211,7 +230,14 @@
       <% if @edition.editable? %>
         <p class="govuk-body">
           <%= link_to("#{@edition.attachments.any? ? "Modify" : "Add"} attachments",
-                      admin_edition_attachments_path(@edition.id), class: 'govuk-link') %>
+                      admin_edition_attachments_path(@edition.id),
+                      class: 'govuk-link',
+                      data: {
+                        module: "gem-track-click",
+                        "track-category": "button-clicked",
+                        "track-action": "#{@edition.model_name.singular.dasherize}-button",
+                        "track-label": "Modify attachments",
+                      }) %>
         </p>
       <% end %>
 

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -40,9 +40,11 @@
       <% end %>
 
       <% if flash["alert"].present? %>
-        <%= render "govuk_publishing_components/components/error_alert", {
-          message: flash["alert"]
-        } %>
+        <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-danger" data-track-label="<%= flash["alert"] %>">
+          <%= render "govuk_publishing_components/components/error_alert", {
+            message: flash["alert"]
+          } %>
+        </div>
       <% end %>
 
       <%= yield(:error_summary) %>


### PR DESCRIPTION
## Description

A bunch of analytics need to be added to the Edition Summary page which are laid out in this document https://docs.google.com/document/d/1-tokztelmox6hi7pCCmJgrt41-BO2eUiGQoG_UJDzV8/edit#

This adds in the following:

1. custom-dimension:1 The Edition's public path (/government/admin/model_name/slug)
2. custom-dimension:2 - The Edition type
3. custom-dimension:3 - The taxonomy linked to the Edition
4. custom-dimension:4 - The documents content_id
5. custom-dimension:5 - The Edition subtype
6. auto tracking for flash alerts 
7.  tracking of all the buttons and links in the edition sidebar
8. tracking for the preview links


## Screenshots

### Default page tracking

<img width="716" alt="image" src="https://user-images.githubusercontent.com/42515961/214565774-4de1471d-d6f2-4f6f-a6bf-48453db73e9b.png">

### Event from alert flash 

<img width="724" alt="image" src="https://user-images.githubusercontent.com/42515961/214565866-087c4230-15bd-4604-aeb4-3e592dd16096.png">


### Events from preview link click

<img width="738" alt="image" src="https://user-images.githubusercontent.com/42515961/214586736-0e984f19-e8fe-418d-b37a-29c32f8c157c.png">


<img width="727" alt="image" src="https://user-images.githubusercontent.com/42515961/214566228-be4f05d4-20d6-41e9-b87c-f21c9b8c04d2.png">

### Events from clicking preview translation

<img width="710" alt="image" src="https://user-images.githubusercontent.com/42515961/214808271-d9c6e9a3-9e71-4614-9189-979f27e1bb19.png">

<img width="730" alt="image" src="https://user-images.githubusercontent.com/42515961/214808298-273f5d08-9fa1-41e8-9af0-81890c894ada.png">


### Event from edit draft 

<img width="715" alt="image" src="https://user-images.githubusercontent.com/42515961/214586849-4e4dd133-7da7-41a3-a1e7-7676990a3857.png">


### Event form 2i

<img width="725" alt="image" src="https://user-images.githubusercontent.com/42515961/214586945-9ac69463-0167-475f-b5e8-d0d22a076e0a.png">


## Guidance for review

I added tracking for all the buttons since it's weird some were being tracked and not others. Should i take it out?


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
