### PR TITLE
Fix bug with edit edition page using wrong history pagination

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -101,7 +101,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def edit
     @edition.open_for_editing_as(current_user)
-    fetch_version_and_remark_trails
+    fetch_version_and_remark_trails(next_release: false)
     render_design_system(:edit, :edit_legacy, next_release: false)
   end
 
@@ -205,8 +205,8 @@ private
     end
   end
 
-  def fetch_version_and_remark_trails
-    if preview_design_system?(next_release: true)
+  def fetch_version_and_remark_trails(next_release: true)
+    if preview_design_system?(next_release:)
       @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
     else
       @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])


### PR DESCRIPTION
## Description 

At the moment, the legacy edit page doesn't set the history variables in the controller correctly as it's being passed the new merged history object.

We should only be passing the new merged history for the page when to the edit page when the "Preview design system" permission is present on the user.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
