### PR TITLE
Add tracking to the Edit Edition page

### DIFF
--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -4,7 +4,17 @@
   <p class="govuk-body">To add an internal note, save your changes.</p>
 <% end %>
 
-<p class="govuk-body"><%= link_to("Add internal note", new_admin_edition_editorial_remark_path(edition), class: "govuk-body govuk-link govuk-link--no-visited-state") %></p>
+<p class="govuk-body">
+  <%= link_to("Add internal note",
+    new_admin_edition_editorial_remark_path(edition),
+    class: "govuk-body govuk-link govuk-link--no-visited-state",
+    data: {
+      module: "gem-track-click",
+      "track-category": "button-pressed",
+      "track-action": "#{edition.class.name.demodulize.underscore.dasherize}-button",
+      "track-label": "Add new remark",
+    }) %>
+  </p>
 
 <%= form_with url: false, method: :get, class: 'js-filter-form', data: {'remote-pagination' => document_history_admin_edition_path(edition)} do |form| %>
   <%= form.hidden_field :editing, value: editing %>

--- a/app/components/admin/error_summary_component.html.erb
+++ b/app/components/admin/error_summary_component.html.erb
@@ -1,4 +1,13 @@
-<%= render "govuk_publishing_components/components/error_summary", {
-  title: title,
-  items: error_items,
-} %>
+<% if flash["alert"].present? %>
+  <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-danger" data-track-label="<%= flash["alert"] %>">
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: title,
+      items: error_items,
+    } %>
+  </div>
+<% else %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: title,
+    items: error_items,
+  } %>
+<% end %>

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -82,7 +82,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def new
-    render_design_system(:new, :new_legacy, next_release: false)
+    render_design_system(:new, :new_legacy, next_release: true)
   end
 
   def create

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -115,7 +115,7 @@ class Admin::EditionsController < Admin::BaseController
 
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
-      flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: true)
+      flash.now[:alert] = "There are some problems with the document"
       @information = updater.failure_reason unless preview_design_system?(next_release: true)
       build_edition_dependencies
       fetch_version_and_remark_trails

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -15,16 +15,17 @@
               name: "edition[lead_organisation_ids][]",
               label: "Lead organisation #{index + 1}",
               heading_size: "s",
-              data: {
-                  module: 'track-select-click',
-                  track_category: 'leadOrgSelection',
-                  track_label: request.path
-              },
               options: ([""] + taggable_organisations_container).map do |name, id|
               {
                 text: name,
                 value: id,
-                selected: id == lead_organisation_id
+                selected: id == lead_organisation_id,
+                data_attributes: {
+                    module: 'track-select-click',
+                    track_category: 'leadOrgSelection',
+                    track_action: name,
+                    track_label: request.path
+                },
               }
              end
           } %>
@@ -40,16 +41,17 @@
           name: "edition[supporting_organisation_ids][]",
           label: "Supporting organisation #{index + 1}",
           heading_size: "s",
-          data: {
-              module: 'track-select-click',
-              track_category: 'supportingOrgSelection',
-              track_label: request.path
-          },
           options: ([""] + taggable_organisations_container).map do |name, id|
           {
             text: name,
             value: id,
-            selected: id == supporting_organisation_id
+            selected: id == supporting_organisation_id,
+            data_attributes: {
+                module: 'track-select-click',
+                track_category: 'supportingOrgSelection',
+                track_action: name,
+                track_label: request.path
+            },
           }
          end
         } %>

--- a/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
+++ b/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
@@ -1,22 +1,26 @@
 <div class="govuk-button-group">
-  <% data_attributes = {
-      module: "track-button-click",
-      "tracking-category": "form-button",
-      "tracking-action": "#{edition.class.name.demodulize.underscore.dasherize}-button",
-    }
-  %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Save",
     value: "save",
     name: "save",
-    data_attributes: data_attributes
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "form-button",
+      "track-action": "#{edition.class.name.demodulize.underscore.dasherize}-button",
+      "track-label": "Save"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: "Save and continue",
     secondary_solid: true,
-    data_attributes: data_attributes
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "form-button",
+      "track-action": "#{edition.class.name.demodulize.underscore.dasherize}-button",
+      "track-label": "Save and continue"
+    }
   } %>
 
-  <%= link_to "Cancel", admin_cancel_path(edition), class: "govuk-link govuk-link--no-visited-state", data_attributes: data_attributes %>
+  <%= link_to "Cancel", admin_cancel_path(edition), class: "govuk-link govuk-link--no-visited-state" %>
 </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -3,6 +3,7 @@
 <% content_for :context, @edition.title %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
 <% content_for :banner, render("recent_openings", edition: @edition, recent_openings: @recent_openings) %>
+<%= render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <% if @conflicting_edition %>
   <div class="govuk-grid-row">

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -39,7 +39,7 @@
         </div>
       <% end %>
 
-      <% if flash["alert"].present? %>
+      <% if flash["alert"].present? && yield(:error_summary).blank? %>
         <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-danger" data-track-label="<%= flash["alert"] %>">
           <%= render "govuk_publishing_components/components/error_alert", {
             message: flash["alert"].html_safe


### PR DESCRIPTION
## Description

This works through this document https://docs.google.com/document/d/1E-FWgS_mc-UfRjtTGoPX7Gbher_6KKL5t3jjFlJ2Kmo/edit#heading=h.ezkkr7egiwe8 and adds missing tracking on the Edit Edition page.

This does the following:

1. adds subtype tracking as a custom dimension

<img width="445" alt="image" src="https://user-images.githubusercontent.com/42515961/220592070-242f6c35-ca36-4ed8-8cfa-02106a9e066b.png">

2. Add tracking for adding an internal note

<img width="432" alt="image" src="https://user-images.githubusercontent.com/42515961/220595427-98c651ca-a72e-4cbb-b47d-d9e9e30101a6.png">


3. Add tracking to the save & save and continue buttons 

<img width="445" alt="image" src="https://user-images.githubusercontent.com/42515961/220595539-f26a432a-6a5f-450c-ad8f-27a51758a016.png">


<img width="433" alt="image" src="https://user-images.githubusercontent.com/42515961/220595615-24614fdb-4d27-44d2-9d1c-8c09763a2a31.png">


4. Ensure flash message warning is passed to GA even when flash isn't rendered

We only ever show 1 banner. This means that a flash warning isn't rendered on the page when a error summary banner is showing.

We still need the event passed so this ensures the error summary component is wrapped in a div which passes the flash warning message to GA

<img width="503" alt="image" src="https://user-images.githubusercontent.com/42515961/220592392-29cfbfe5-22db-492d-9d0a-829419c154ad.png">

5. Add tracking for lead and supporting orgs

<img width="455" alt="image" src="https://user-images.githubusercontent.com/42515961/220595800-17e7b88c-5351-4d57-bff9-4272f6b42b34.png">

<img width="416" alt="image" src="https://user-images.githubusercontent.com/42515961/220598089-7696c650-a6a3-4c44-8ec1-acefe104be56.png">


## Out of scope

### Event for adding an image 

This will now be handled in the new images workflow

### Tracking of associations 

We are going to put selecting associations into blocked for now. The accessible autocomplete is a bit of a nightmare to track due to it's niche behaviour.

We can hack around it using keyup and click event listeners on the module itself, but the behaviour is complex and niche so any changes to the accessible autocomplete would likely break it. We're going to cycle back to this when the new PA starts

## Trello card

https://trello.com/c/ya9GBOuG/42-tracking-to-be-added-to-edit-edition-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
