### PR TITLE
Adds required modules to allow miller-columns to render correctly

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,12 @@
 //= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics
 
+// support ES6 (promises, functions, etc. - see docs)
+//= require core-js-bundle/index.js
+
+// support ES6 custom elements
+//= require @webcomponents/custom-elements/custom-elements.min.js
+
 //= require jquery
 //= require bootstrap
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     }
   },
   "dependencies": {
+    "@webcomponents/custom-elements": "^1.5.1",
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
+    "core-js-bundle": "^3.27.2",
     "jquery": "3.6.3",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@webcomponents/custom-elements@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.5.1.tgz#48029f6c62b94a4b49be061ca1dae04ab9681ace"
+  integrity sha512-6T/XT3S1UHDlRWFSxRXdeSoYWczEl78sygNPS7jDyHVrfZcF/pUtWGYgxF4uviH59iPVw1eOWbhubm8CqO0MpA==
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -378,6 +383,11 @@ cookie@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+core-js-bundle@^3.27.2:
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.27.2.tgz#86dab89f859f372aec40876e6910e82557e602da"
+  integrity sha512-tFneTtwettzFntMIv4+p+E7SB0pgSWeuLSad9gp27MvSRxckGOGlx5EFIvS8JXODqVeaYKWqUAwQhyDZ8VqLnA==
 
 core-util-is@~1.0.0:
   version "1.0.3"


### PR DESCRIPTION
[Trello](https://trello.com/c/Run0Mkiq/1094-add-a-polyfill-for-custom-elements)

We have found that the newly-added miller columns on Whitehall are currently very broken in IE11 (nothing displays at all). This is due to lack of support for custom elements (this component uses a `miller-columns` element). The solution that has been used on Content Publisher is to use the [@webcomponents/custom-elements](https://www.npmjs.com/package/@webcomponents/custom-elements) polyfill. 

These changes implement that in Whitehall as well. 

During the process it became clear that even with this there were still some problems due to the use of the `Reflect` JS Object. In Content Publisher this is remedied with the [core-js-bundle](https://www.npmjs.com/package/core-js-bundle) module. That has also been added here as the quickest tried and tested method.

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/6080548/214620204-68fc005d-f24f-48c4-b3ed-1e5fc77eb75e.png)|![after](https://user-images.githubusercontent.com/6080548/214620307-8a6a7ef1-30b3-4c98-b980-8597411007be.png)|