### PR TITLE
Fix bug with history pagination on edit translation page

### DIFF
--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -2,7 +2,8 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
   layout nil
 
   def index
-    @edition = Edition.find(params[:id])
+    @edition = Edition.find_by(id: params[:edition_id]) || Edition.find(params[:id])
+
     if preview_design_system?(next_release: false)
       @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
 


### PR DESCRIPTION
## Description 

At the moment, this is broken in the Bootstrap and GOV.UK Design System implementation.

It looks like it's not ever worked in Bootstrap. This is due to the controller attempting to find the edition by params[:id].

For translations this is the locale, so it blows up. This handles this by using params[:edition_id] if present.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
