### PR TITLE
Fix document history pagination bug

### DIFF
--- a/app/components/admin/editions/document_history_tab_component.rb
+++ b/app/components/admin/editions/document_history_tab_component.rb
@@ -3,7 +3,7 @@
 class Admin::Editions::DocumentHistoryTabComponent < ViewComponent::Base
   attr_reader :edition, :document_history, :editing
 
-  def initialize(edition:, document_history:, editing: false)
+  def initialize(edition:, document_history:, editing: nil)
     @edition = edition
     @document_history = document_history
     @editing = editing

--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
   def index
     @edition = Edition.find_by(id: params[:edition_id]) || Edition.find(params[:id])
 
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: false) || (preview_design_system?(next_release: true) && params[:editing].blank?)
       @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
 
       render(html: Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: params[:editing]).render_in(view_context))

--- a/app/views/kaminari/history/_next_page.html.erb
+++ b/app/views/kaminari/history/_next_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1) } %>
+<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1, editing) } %>


### PR DESCRIPTION
## Description

Currently, the EditionAuditTrailController#index action is hit under 3 from 3 different pages.

1. edit edition
2. edit edition translation
3. edition summary

These pages are going out in the following releases

Release 1.5

1. edition summary

Release 1.6

1. edition edition
2. edit edition translation

Due to these pages going out in different releases, we need a mechanism
to flag the new behaviour to the edition summary page, but not the two
edit pages.

Fortunately the editing="true" query string param is passed through to
the endpoint for the two edit pages so we can use that to ensure
the old flow is retained until the new pages go out in 1.6.


## Screenshots 
With preview next release flag on

### Before

<img width="413" alt="image" src="https://user-images.githubusercontent.com/42515961/215088008-4c322139-06d1-40ee-b535-87963125d374.png">


### After

<img width="532" alt="image" src="https://user-images.githubusercontent.com/42515961/215087898-a04a6698-31d6-49c3-ac9e-f72fbd8488ec.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
