### PR TITLE
Break out history pagination into a separate controller

### DIFF
--- a/app/controllers/admin/edition_audit_trail_controller.rb
+++ b/app/controllers/admin/edition_audit_trail_controller.rb
@@ -3,13 +3,6 @@ class Admin::EditionAuditTrailController < Admin::EditionsController
 
   def index
     @edition = Edition.find_by(id: params[:edition_id]) || Edition.find(params[:id])
-
-    if preview_design_system?(next_release: false) || (preview_design_system?(next_release: true) && params[:editing].blank?)
-      @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
-
-      render(html: Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: params[:editing]).render_in(view_context))
-    else
-      @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
-    end
+    @document_history = Document::PaginatedHistory.new(@edition.document, params[:page])
   end
 end

--- a/app/controllers/admin/edition_document_history_controller.rb
+++ b/app/controllers/admin/edition_document_history_controller.rb
@@ -1,0 +1,10 @@
+class Admin::EditionDocumentHistoryController < Admin::EditionsController
+  layout nil
+
+  def index
+    @edition = Edition.find_by(id: params[:edition_id]) || Edition.find(params[:id])
+    @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
+
+    render(html: Admin::Editions::DocumentHistoryTabComponent.new(edition: @edition, document_history: @document_history, editing: params[:editing]).render_in(view_context))
+  end
+end

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -18,10 +18,10 @@ module Admin::AuditTrailHelper
     html << absolute_time(entry.created_at, class: "created_at")
   end
 
-  def paginated_audit_trail_url(page, editing = nil)
+  def paginated_audit_trail_url(page)
     url_for(
       params.to_unsafe_hash
-            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page), editing:)
+            .merge(controller: "admin/edition_audit_trail", action: "index", page: (page <= 1 ? nil : page))
             .symbolize_keys,
     )
   end

--- a/app/helpers/admin/document_history_helper.rb
+++ b/app/helpers/admin/document_history_helper.rb
@@ -1,0 +1,9 @@
+module Admin::DocumentHistoryHelper
+  def paginated_document_history_url(page:, editing: nil)
+    url_for(
+      params.to_unsafe_hash
+            .merge(controller: "admin/edition_document_history", action: "index", page: (page <= 1 ? nil : page), editing:)
+            .symbolize_keys,
+    )
+  end
+end

--- a/app/views/kaminari/history/_next_page.html.erb
+++ b/app/views/kaminari/history/_next_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page + 1, editing) } %>
+<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page + 1, editing:) } %>

--- a/app/views/kaminari/history/_prev_page.html.erb
+++ b/app/views/kaminari/history/_prev_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-view-document-history-tab__newer-pagination-link", data: {'remote-pagination' => paginated_audit_trail_url(current_page - 1) } %>
+<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-view-document-history-tab__newer-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page - 1, editing:) } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,7 +245,8 @@ Whitehall::Application.routes.draw do
             post :force_schedule, to: "edition_workflow#force_schedule"
             get :confirm_unschedule, to: "edition_workflow#confirm_unschedule"
             post :unschedule, to: "edition_workflow#unschedule"
-            get  :audit_trail, to: "edition_audit_trail#index"
+            get :audit_trail, to: "edition_audit_trail#index"
+            get :document_history, to: "edition_document_history#index"
             patch :update_bypass_id
             get :history, to: "editions#history"
             get :confirm_destroy


### PR DESCRIPTION
## Description 

Currently, the EditionAuditTrailController handles pagination for the Bootstrap and GOV.UK Design System implementation of paginated history.

These being combined into one endpoint has caused a few subtle bugs. It's far better to just break them out into separate endpoints.

This adds an endpoint which handles paginating the GOV.UK Design System implementation and updates the DocumentHistoryTabComponent paginator to call it instead of the EditionAuditTrailController.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
