### PR TITLE
Post 1.5 review fixes 

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -20,8 +20,8 @@ class Admin::Editions::Show::SidebarActionsComponent < ViewComponent::Base
     unless @actions
       @actions = []
       add_create_action
-      add_submit_action
       add_edit_action
+      add_submit_action
       add_unschedule_action
       add_schedule_action
       add_publish_action
@@ -108,7 +108,6 @@ private
         render("govuk_publishing_components/components/button", {
           text: "Schedule",
           title: "Schedule #{@edition.title} for publication on #{l @edition.scheduled_publication, format: :long}",
-          secondary_quiet: true,
           data_attributes: {
             module: "gem-track-click",
             "track-category": "button-pressed",

--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -183,14 +183,14 @@ private
   def add_destroy_action
     if @edition.can_delete? && @edition.unpublishing.nil?
       actions << link_to(
-        "Discard draft",
+        "Delete draft",
         confirm_destroy_admin_edition_path(@edition),
         class: "govuk-link gem-link--destructive",
         data: {
           module: "gem-track-click",
           "track-category": "button-clicked",
           "track-action": "#{dasherized_class_name}-button",
-          "track-label": "Discard draft",
+          "track-label": "Delete draft",
         },
       )
     end

--- a/app/concerns/historic_content_concern.rb
+++ b/app/concerns/historic_content_concern.rb
@@ -6,7 +6,7 @@ module HistoricContentConcern
     # to redirect with a nice message rather than just "permission denied".
     if @edition.historic? && !can?(:modify, @edition)
       redirect_to [:admin, @edition],
-                  alert: %(This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.)
+                  alert: %(This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode" class="govuk-link">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.)
     end
   end
 end

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -63,7 +63,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
       MailNotifications.edition_rejected(user, @edition, admin_edition_url(@edition)).deliver_now
     end
     redirect_to new_admin_edition_editorial_remark_path(@edition),
-                notice: "Document rejected; please explain why in an editorial remark"
+                notice: "Document rejected; please explain why in an #{preview_design_system?(next_release: true) ? 'internal note' : 'editorial remark'}"
   end
 
   def publish

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
     return unless attachment
 
     name = attachment.name_for_link
-    html_class = options[:class]
+    html_class = options.delete(:class)
     link_to name, attachment.url(options), class: html_class
   end
 

--- a/app/models/document/paginated_timeline.rb
+++ b/app/models/document/paginated_timeline.rb
@@ -102,7 +102,7 @@ private
   private_constant :RawEntry
 
   def document_versions
-    @document.edition_versions
+    @document.edition_versions.where.not(state: "superseded")
   end
 
   def document_remarks

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -13,10 +13,10 @@
         render "govuk_publishing_components/components/summary_list", {
           borderless: true,
           items: [
+            { field: "Type of document", value: edition_type(@edition) },
             { field: "Status", value: status_text.join(' ') },
             { field: "Change type", value: @edition.minor_change? ? 'Minor' : 'Major' },
             { field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) },
-            { field: "Type of document", value: edition_type(@edition) },
           ]
         }
       %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -58,7 +58,7 @@
           <%= render "govuk_publishing_components/components/list", {
             items: @edition.non_english_translated_locales.map do |locale|
               (link_to("Preview on website - #{locale.native_and_english_language_name}",
-                      public_document_url(@edition, locale:),
+                      preview_document_url(@edition, locale: locale.code),
                       class: 'govuk-link',
                       target: '_blank',
                       data: {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -157,10 +157,12 @@
       margin_bottom: 3,
     } %>
 
-    <p class="govuk-body">
-      <%= link_to(@edition.has_legacy_tags? ? "Change specialist topic tags" : "Add specialist topic tags",
-                  edit_admin_edition_legacy_associations_path(@edition.id), class: 'govuk-link') %>
-    </p>
+    <% if @edition.editable? %>
+      <p class="govuk-body">
+        <%= link_to(@edition.has_legacy_tags? ? "Change specialist topic tags" : "Add specialist topic tags",
+                    edit_admin_edition_legacy_associations_path(@edition.id), class: 'govuk-link') %>
+      </p>
+    <% end %>
 
     <% if @edition.has_legacy_tags? %>
       <% if @edition.has_primary_sector? %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -1,7 +1,7 @@
 <div class="app-view-edition-summary__main">
   <section class="app-view-edition-summary__section page-header">
     <div class="app-view-edition-summary__document-summary">
-      <p class="govuk-body lead"><%= @edition.summary %></p>
+      <p class="govuk-body-lead"><%= @edition.summary %></p>
     </div>
 
     <div>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -99,7 +99,7 @@
     <% end %>
   </section>
 
-  <% if @edition.change_note_required? && @edition.change_note %>
+  <% if @edition.change_note_required? %>
     <section class="app-view-edition-summary__section">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Public change note",
@@ -107,8 +107,15 @@
         font_size: "l",
         margin_bottom: 3,
       } %>
-      <p class="govuk-body">
-        <%= @edition.change_note %>
+
+      <p class="govuk-body-lead">
+        <% if @edition.minor_change? %>
+          Minor change
+        <% elsif @edition.change_note.blank? %>
+          No change note
+        <% else %>
+          <%= @edition.change_note %>
+        <% end %>
       </p>
     </section>
   <% end %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -257,7 +257,7 @@
             {
               text: "Filename"
             },
-            @edition.published? ? {
+            @edition.editable? ? {
               text: "Actions"
             } : nil
           ].compact,
@@ -265,7 +265,7 @@
             [
               { text: attachment[:title] },
               { text: link_to_attachment(attachment, preview: !@edition.published?, full_url: true, class: "govuk-link") },
-              @edition.published? ? { text: link_to("Edit", edit_admin_edition_attachment_path(@edition.id, attachment[:id]), class: "govuk-link") } : nil,
+              @edition.editable? ? { text: link_to("Edit", edit_admin_edition_attachment_path(@edition.id, attachment[:id]), class: "govuk-link") } : nil,
             ].compact
           end
         } %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -144,7 +144,7 @@
 
   <section class="app-view-edition-summary__section">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Specialist Topic tags",
+      text: "Specialist topic tags",
       heading_level: 2,
       font_size: "l",
       margin_bottom: 3,

--- a/app/views/admin/editions/show/_main_notices.html.erb
+++ b/app/views/admin/editions/show/_main_notices.html.erb
@@ -1,6 +1,6 @@
 <% if edition.rejected? %>
   <%= render "/components/inset_prompt", {
-    description: sanitize("Rejected by #{linked_author(edition.rejected_by, class: "govuk-link")}. See History and Notes."),
+    description: sanitize("Rejected by #{linked_author(edition.rejected_by, class: "govuk-link")} - check the internal note in the document history for the reason."),
     error: true
   } %>
 <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -42,7 +42,7 @@
       <% if flash["alert"].present? %>
         <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-danger" data-track-label="<%= flash["alert"] %>">
           <%= render "govuk_publishing_components/components/error_alert", {
-            message: flash["alert"]
+            message: flash["alert"].html_safe
           } %>
         </div>
       <% end %>

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -129,6 +129,6 @@ end
 
 Then(/^I should not be able to discard the draft resulting from the unpublishing$/) do
   visit admin_edition_path(Edition.last)
-
-  expect(page).not_to have_button("Discard draft")
+  button_text = using_design_system? ? "Delete draft" : "Discard draft"
+  expect(page).not_to have_button(button_text)
 end

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -11,7 +11,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "li", count: 3
     assert_selector "button", text: "Submit for 2nd eyes"
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for published edition" do
@@ -32,7 +32,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 2
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for rejected edition" do
@@ -42,7 +42,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 3
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
     assert_selector "button", text: "Submit for 2nd eyes"
   end
 
@@ -93,7 +93,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "button", text: "Submit for 2nd eyes"
     assert_selector "a", text: "Force publish"
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for draft edition with a scheduled date as managing editor" do
@@ -105,7 +105,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "button", text: "Submit for 2nd eyes"
     assert_selector "a", text: "Force schedule"
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for published edition as managing editor" do
@@ -129,7 +129,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "button", text: "Publish"
     assert_selector "button", text: "Reject"
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for submitted edition with a scheduled date as managing editor" do
@@ -141,7 +141,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "button", text: "Schedule"
     assert_selector "button", text: "Reject"
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
   end
 
   test "actions for rejected edition as managing editor" do
@@ -151,7 +151,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 3
     assert_selector "a", text: "Edit draft"
-    assert_selector "a", text: "Discard draft"
+    assert_selector "a", text: "Delete draft"
     assert_selector "button", text: "Submit for 2nd eyes"
   end
 

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -136,7 +136,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     stub_publishing_api_expanded_links_with_taxons(draft_consultation.content_id, [])
 
     get :show, params: { id: draft_consultation }
-    assert_select ".page-header .lead", text: "a-simple-summary"
+    assert_select ".page-header .govuk-body-lead", text: "a-simple-summary"
   end
 
   view_test "edit displays consultation fields" do

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -24,7 +24,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     get :show, params: { id: collection }
 
     assert_select "h1", "collection-title"
-    assert_select ".page-header .lead", "the summary"
+    assert_select ".page-header .govuk-body-lead", "the summary"
   end
 
   view_test "GET #new renders document collection form" do

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -30,7 +30,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
 
     get :show, params: { id: draft_fatality_notice }
 
-    assert_select ".page-header .lead", text: "a-simple-summary"
+    assert_select ".page-header .govuk-body-lead", text: "a-simple-summary"
   end
 
   view_test "when creating allows assignment to operational field" do

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -48,7 +48,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
 
     get :show, params: { id: draft_news_article }
 
-    assert_select ".app-view-edition-summary__document-summary .govuk-body", text: "a-simple-summary"
+    assert_select ".app-view-edition-summary__document-summary .govuk-body-lead", text: "a-simple-summary"
   end
 
 private


### PR DESCRIPTION
## Description 

JP did a review of the 1.5 release here https://docs.google.com/document/d/1d4kWINFNT5hRuU1YorQjaobKO33c4N42FOQKk0BoYO8/edit#heading=h.gim55hybr76h

It's largely made up of minor fixes. This PR works through them with 1 fix per commit. It'll be easiest to review per commit. I'll squash them down into something more sensible after review.

**Adding pagination to the bottom of the history tab and moving broken links & the go to draft/published section being moved to inset text is out of scope for this PR (items 14 & 15 in the doc)**

## Changes

Numbers correspond to the document numbers

1. Use `Delete draft` instead of `Discard draft`

|Before|After|
|------------|------------|
|<img width="596" alt="image" src="https://user-images.githubusercontent.com/42515961/215741642-bfd7c3a2-a1e1-4b66-860b-cf67bf1366be.png">|<img width="513" alt="image" src="https://user-images.githubusercontent.com/42515961/215734175-e4a16cfa-979a-412c-9478-15544b9a79dc.png">|

2. Apply `govuk-body-lead` class to summary text

|Before|After|
|------------|------------|
|<img width="675" alt="image" src="https://user-images.githubusercontent.com/42515961/215741471-a783072a-6f81-4259-b5cf-c74bbfb381d8.png">|<img width="642" alt="image" src="https://user-images.githubusercontent.com/42515961/215734419-c17d8857-73ab-4df7-a95f-5ee4936c6997.png">|

3. Lowercase `Topics` 

|Before|After|
|------------|------------|
|<img width="611" alt="image" src="https://user-images.githubusercontent.com/42515961/215741421-62836a40-5656-4739-b3cb-ff9a5eed4cb6.png">|<img width="633" alt="image" src="https://user-images.githubusercontent.com/42515961/215734574-229d0365-5990-4d51-b4f0-90b0692c0b84.png">|

4. Remove `class="govuk-link"` from query string for link to attachments in the attachment section

|Before|After|
|------------|------------|
|<img width="1642" alt="image" src="https://user-images.githubusercontent.com/42515961/215741348-37d22fcc-1a29-48d6-8ebd-c501d79cf28a.png">|<img width="1262" alt="image" src="https://user-images.githubusercontent.com/42515961/215734975-e6808a53-f5c8-4fcf-8b81-ed94d02860e9.png">|

5. Fix the links for preview translations

|Before|After|
|------------|------------|
|<img width="1667" alt="image" src="https://user-images.githubusercontent.com/42515961/215741246-7457c5db-f86e-45c2-a3e4-fb821ee77841.png">|<img width="1586" alt="image" src="https://user-images.githubusercontent.com/42515961/215735181-d9852aff-ae12-4831-b458-edd1873bb6c4.png">|

6. Update success message for rejecting a doc to say internal note not editorial remarks

|Before|After|
|------------|------------|
|<img width="1013" alt="image" src="https://user-images.githubusercontent.com/42515961/215741025-068d04b1-d3ed-4693-8938-b49dce7939ae.png">|<img width="980" alt="image" src="https://user-images.githubusercontent.com/42515961/215735843-4a5d9b5f-4b3e-4fca-bd91-fc8303e42ad5.png">|

7. Rejected inset text mentions history and notes. It should say `Rejected by [user] - check the internal note in the document history for the reason`

|Before|After|
|------------|------------|
|<img width="630" alt="image" src="https://user-images.githubusercontent.com/42515961/215740807-46e6e19c-e9cf-4d19-b0fa-419f9a1139f1.png">|<img width="653" alt="image" src="https://user-images.githubusercontent.com/42515961/215735709-0a2e7898-368d-488a-aff1-112b2a2e31e1.png">|

8. Change not section not showing for minor changes. It should render and say minor change

|Before|After|
|------------|------------|
|<img width="649" alt="image" src="https://user-images.githubusercontent.com/42515961/215740741-57316e7b-6ef9-4680-b199-8ad4655dade4.png">|<img width="619" alt="image" src="https://user-images.githubusercontent.com/42515961/215736014-5f29eb9f-87a3-47da-a81b-adbf1653399e.png">|

9. Remove edit links for attachments of non-draft applications

|Before|After|
|------------|------------|
|<img width="667" alt="image" src="https://user-images.githubusercontent.com/42515961/215742108-fc591fc5-b113-422a-8a3d-786361cf8dd8.png">|<img width="658" alt="image" src="https://user-images.githubusercontent.com/42515961/215738420-32925e4c-1bda-4666-9084-afc13f50a2fa.png">|

10. Don't allow editing of specialist topics for non-draft editions

|Before|After|
|------------|------------|
|<img width="634" alt="image" src="https://user-images.githubusercontent.com/42515961/215740557-3c998a3a-d305-45f2-853d-d4dfad5efa2c.png">|<img width="606" alt="image" src="https://user-images.githubusercontent.com/42515961/215738462-1cd35ff0-1adc-4967-8ebe-fc15b2b395cf.png">|


11.  Superseded actions shouldn't show on previous docs

|Before|After|
|------------|------------|
|<img width="437" alt="image" src="https://user-images.githubusercontent.com/42515961/215740504-40f02bfc-1fc9-4059-98a1-330cc01021a2.png">|<img width="709" alt="image" src="https://user-images.githubusercontent.com/42515961/215738534-86645ab4-88dc-4d66-a8c6-10398639e58d.png">|


13. Revert ordering of metadata

|Before|After|
|------------|------------|
|<img width="640" alt="image" src="https://user-images.githubusercontent.com/42515961/215740370-15da6c3e-6a65-439d-bad6-dc167e508795.png">|<img width="668" alt="image" src="https://user-images.githubusercontent.com/42515961/215738660-5d412b5e-58df-4f91-80e7-dbc7eac1bb3c.png">|


16a. make ‘schedule’ a primary action button when in submitted state for someone else's document

|Before|After|
|------------|------------|
|<img width="385" alt="image" src="https://user-images.githubusercontent.com/42515961/215740281-40368654-ff55-4730-82a7-6d13049b09dc.png">|<img width="465" alt="image" src="https://user-images.githubusercontent.com/42515961/215739101-5f4e998f-6997-484e-bdb5-39c8a8e7dcd0.png">|

16b.  Reorder sidebar action buttons to be consistent (edit draft always being the first)

|Before|After|
|------------|------------|
|<img width="500" alt="image" src="https://user-images.githubusercontent.com/42515961/215740014-4b919026-f3f0-4200-ad71-daa73863a480.png">|<img width="543" alt="image" src="https://user-images.githubusercontent.com/42515961/215739184-3304d59c-1577-4d23-bfdd-82b9da5c57ff.png">|

17.  Links in error validation messages showing as HTML

|Before|After|
|------------|------------|
|<img width="954" alt="image" src="https://user-images.githubusercontent.com/42515961/215739958-9d7f248b-87c9-4fb8-9433-a9d6047e41a0.png">|<img width="931" alt="image" src="https://user-images.githubusercontent.com/42515961/215739561-e312de1a-fc8d-4020-84f0-c248e9f63b6a.png">|

## Trello card

https://trello.com/c/ALQzQdNT/1114-fixes-for-15-review-doc

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
