### PR TITLE
Add images tab

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -1,4 +1,28 @@
 class Admin::EditionImagesController < Admin::BaseController
-  def index
+  before_action :find_edition
+  before_action :redirect_unless_user_can_preview_images_update
+  before_action :enforce_permissions!
+  layout "design_system"
+
+  def index; end
+
+private
+
+  def find_edition
+    edition = Edition.find(params[:edition_id])
+    @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def redirect_unless_user_can_preview_images_update
+    redirect_to edit_admin_edition_path(@edition) unless current_user.can_preview_images_update?
+  end
+
+  def enforce_permissions!
+    case action_name
+    when "index"
+      enforce_permission!(:see, @edition)
+    else
+      raise Whitehall::Authority::Errors::InvalidAction, action_name
+    end
   end
 end

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -1,0 +1,4 @@
+class Admin::EditionImagesController < Admin::BaseController
+  def index
+  end
+end

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
-      items: secondary_navigation_tabs_items(attachment.attachable, request.path)
+      items: secondary_navigation_tabs_items(current_user, attachment.attachable, request.path)
     } %>
 
     <p class="govuk-body">Note: <%= attachment_note(attachment.attachable_model_name) %></p>

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
-      items: secondary_navigation_tabs_items(@edition, request.path)
+      items: secondary_navigation_tabs_items(current_user, @edition, request.path)
     } %>
 
     <%= render "form", edition: @edition %>

--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -1,0 +1,27 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Upload an image",
+  font_size: "l",
+} %>
+
+<%= form_tag admin_edition_images_path(@edition.document) do %>
+  <%= render "govuk_publishing_components/components/file_upload", {
+    name: "edition[images_attributes][image_data_attributes][file]",
+    id: "edition_images_image_data_file",
+    hint: "Images can be JPEG, PNG, SVG or GIF files.",
+  } %>
+
+   <%= render "govuk_publishing_components/components/details", {
+      title: "You must use an SVG for charts and diagrams",
+    } do %>
+      SVGs allow users to magnify images without losing quality.
+      Find out <%= link_to "how to create an SVG file (opens in new tab)",
+      "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos#creating-an-svg-file",
+      class: "govuk-link",
+      target: "_blank" %>.
+    <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Upload",
+    margin_bottom: 10
+  } %>
+<% end %>

--- a/app/views/admin/edition_images/_uploaded_images.html.erb
+++ b/app/views/admin/edition_images/_uploaded_images.html.erb
@@ -1,0 +1,40 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Uploaded images",
+  font_size: "l",
+} %>
+<div>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Lead image",
+    font_size: "m",
+    padding: true
+  } %>
+
+  <%= render "govuk_publishing_components/components/details", {
+        title: "Using a lead image",
+      } do %>
+    <p class="govuk-body">Using a lead image is optional. To use a lead image either select the
+    default image for your organisation or upload an image and select it as
+    the lead image.</p>
+    <p class="govuk-body">The lead image appears at the top of the document. It cannot be used
+    in the document body.</p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Use default image",
+    secondary_solid: true,
+    margin_bottom: 4
+  } %>
+</div>
+
+<div>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Images available to use in document",
+    font_size: "m",
+    padding: true
+  } %>
+
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "Use the 'Insert image' button in the document tab to add images to body copy.",
+    margin_top: 0
+  } %>
+</div>

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::EditionImages#index</h1>
+<p>Find me in app/views/admin/edition_images/index.html.erb</p>

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -4,6 +4,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(current_user, @edition, request.path)
+    } %>
+
     <%= render "image_upload", edition: @edition %>
     <%= render "uploaded_images", edition: @edition %>
   </div>

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -1,2 +1,11 @@
-<h1>Admin::EditionImages#index</h1>
-<p>Find me in app/views/admin/edition_images/index.html.erb</p>
+<% content_for :context, "#{@edition.title}" %>
+<% content_for :page_title, "Images for #{@edition.format_name}" %>
+<% content_for :title, "Images for #{@edition.format_name}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "image_upload", edition: @edition %>
+    <%= render "uploaded_images", edition: @edition %>
+  </div>
+</div>
+

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -73,10 +73,12 @@
 
 <%= render 'first_published_at', form: form, edition: edition %>
 
-<% if form.object.allows_image_attachments? %>
-  <% if edition.type == "CaseStudy" %>
-    <%= render partial: "image_fields_case_studies", locals: { form: form, edition: form.object } %>
-  <% else %>
-    <%= render partial: "image_fields", locals: { form: form, edition: form.object } %>
+<% unless current_user.can_preview_images_update? %> 
+  <% if form.object.allows_image_attachments? %>
+    <% if edition.type == "CaseStudy" %>
+      <%= render partial: "image_fields_case_studies", locals: { form: form, edition: form.object } %>
+    <% else %>
+      <%= render partial: "image_fields", locals: { form: form, edition: form.object } %> 
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -26,7 +26,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "components/secondary_navigation", {
         aria_label: "Document navigation tabs",
-        items: secondary_navigation_tabs_items(@edition, request.path)
+        items: secondary_navigation_tabs_items(current_user, @edition, request.path)
       } %>
 
       <%= render "form", edition: @edition %>

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
-      items: secondary_navigation_tabs_items(@edition, request.path)
+      items: secondary_navigation_tabs_items(current_user, @edition, request.path)
     } %>
 
     <%= render "form", edition: @edition %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,6 +270,7 @@ Whitehall::Application.routes.draw do
             post :upload_zip, on: :collection
             get :set_titles, on: :member
           end
+          resources :images, controller: "edition_images", only: %i[index]
         end
 
         get "/editions/:id" => "editions#show"

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -1,0 +1,15 @@
+@design-system-only
+Feature: Images tab on edit edition
+
+  Scenario: Accessing the images tab with correct permissions
+    Given I am a writer
+    And I have the "Preview images update" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    Then I can navigate to the images tab
+
+  Scenario: Images tab is hidden by default
+    Given I am a writer
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    Then the page should not have an images tab

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -7,3 +7,12 @@ When(/^I select an image for the (?:detailed guide|publication)$/) do
     fill_in "Alt text", with: "minister of funk", match: :first
   end
 end
+
+Then(/^the page should not have an images tab$/) do
+  expect(page).to_not have_link("li.app-c-secondary-navigation__list-item a", text: "Images")
+end
+
+Then(/^I can navigate to the images tab$/) do
+  find("li.app-c-secondary-navigation__list-item a", text: "Images").click
+  expect(page).to have_content("Upload an image")
+end

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
+end

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -1,4 +1,21 @@
 require "test_helper"
 
 class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
+  test "redirects users without the 'Preview images update' permission" do
+    edition = create(:draft_publication)
+    login_as create(:gds_editor)
+    get admin_edition_images_path(edition.id)
+    assert_equal 302, status
+    follow_redirect!
+    assert_equal "/government/admin/publications/#{edition.id}/edit", path
+  end
+
+  test "forbids unauthorised users from viewing the images index endpoint" do
+    edition = create(:draft_publication)
+    user = create(:world_editor)
+    user.permissions << "Preview images update"
+    login_as user
+    get admin_edition_images_path(edition.id)
+    assert_equal 403, status
+  end
 end

--- a/test/unit/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/helpers/admin/tabbed_nav_helper_test.rb
@@ -4,6 +4,10 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
   include Rails.application.routes.url_helpers
   include Admin::EditionRoutesHelper
 
+  setup do
+    @current_user = build(:gds_editor)
+  end
+
   test "#secondary_navigation_tabs_items for persisted consultations with no attachments" do
     consultation = build_stubbed(:consultation)
 
@@ -30,7 +34,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
       },
     ]
 
-    assert_equal expected_output, secondary_navigation_tabs_items(consultation, admin_consultation_public_feedback_path(consultation))
+    assert_equal expected_output, secondary_navigation_tabs_items(@current_user, consultation, admin_consultation_public_feedback_path(consultation))
   end
 
   test "#secondary_navigation_tabs_items for persisted consultations with attachments" do
@@ -60,7 +64,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
       },
     ]
 
-    assert_equal expected_output, secondary_navigation_tabs_items(consultation, admin_consultation_outcome_path(consultation))
+    assert_equal expected_output, secondary_navigation_tabs_items(@current_user, consultation, admin_consultation_outcome_path(consultation))
   end
 
   test "#secondary_navigation_tabs_items for persisted document collections" do
@@ -79,7 +83,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
       },
     ]
 
-    assert_equal expected_output, secondary_navigation_tabs_items(document_collection, admin_document_collection_groups_path(document_collection))
+    assert_equal expected_output, secondary_navigation_tabs_items(@current_user, document_collection, admin_document_collection_groups_path(document_collection))
   end
 
   test "#secondary_navigation_tabs_items for persisted editions which do not allow attachments" do
@@ -94,7 +98,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         },
       ]
 
-      assert_equal expected_output, secondary_navigation_tabs_items(edition, edit_admin_edition_path(edition))
+      assert_equal expected_output, secondary_navigation_tabs_items(@current_user, edition, edit_admin_edition_path(edition))
     end
   end
 
@@ -120,7 +124,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         },
       ]
 
-      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+      assert_equal expected_output, secondary_navigation_tabs_items(@current_user, edition, tab_url_for_edition(edition))
     end
   end
 
@@ -148,7 +152,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         },
       ]
 
-      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+      assert_equal expected_output, secondary_navigation_tabs_items(@current_user, edition, tab_url_for_edition(edition))
     end
   end
 
@@ -169,7 +173,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         },
       ]
 
-      assert_equal expected_output, secondary_navigation_tabs_items(edition, tab_url_for_edition(edition))
+      assert_equal expected_output, secondary_navigation_tabs_items(@current_user, edition, tab_url_for_edition(edition))
     end
   end
 
@@ -189,7 +193,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
       },
     ]
 
-    assert_equal expected_output, secondary_navigation_tabs_items(policy_group, edit_admin_policy_group_path(policy_group))
+    assert_equal expected_output, secondary_navigation_tabs_items(@current_user, policy_group, edit_admin_policy_group_path(policy_group))
   end
 
   test "#secondary_navigation_tabs_items for policy groups with attachments" do
@@ -209,6 +213,6 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
       },
     ]
 
-    assert_equal expected_output, secondary_navigation_tabs_items(policy_group, admin_policy_group_attachments_path(policy_group))
+    assert_equal expected_output, secondary_navigation_tabs_items(@current_user, policy_group, admin_policy_group_attachments_path(policy_group))
   end
 end


### PR DESCRIPTION
Trello ticket [link 1](https://trello.com/c/0M9vyh5i/1106-create-separate-images-page), [link 2](https://trello.com/c/AvguABf6/1056-new-image-tab), [link 3](https://trello.com/c/koVf63dk/1118-create-separate-images-page)

## What
This PR creates a separate resource for images, adding a controller and an index endpoint. It then uses this endpoint when creating a tab for adding/removing/editing images on the edit edition page, which is hidden behind a feature flag. 

**NOTE:** None of the UI is functional at the moment, this is just a backbone for the upcoming update to images workflow.

## Why
This is required for the upcoming work on updating the images workflow.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
