### PR TITLE
Use inset prompts for broken links and edition history sections on the sidebar

### DIFF
--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -35,13 +35,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   BrokenLinksReport.prototype.setupPolling = function (refreshLink) {
-    refreshLink.hidden = true
+    refreshLink.parentElement.remove()
 
     var retries = 10
     var retry = function () {
       retries -= 1
       if (retries === 0) {
-        refreshLink.hidden = false
+        this.module.addChild(refreshLink.parentElement)
         return
       }
 
@@ -59,7 +59,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (json.inProgress) {
           retry()
         } else {
-          this.replaceContentsAndCopyClasses(json.html)
+          this.replaceContents(json.html)
           this.init()
         }
       }.bind(this))

--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -28,7 +28,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }).then(function (response) { return response.json() })
         .catch(function () { location.reload() })
         .then(function (json) {
-          this.replaceContentsAndCopyClasses(json.html)
+          this.replaceContents(json.html)
           this.init()
         }.bind(this))
     }.bind(this))
@@ -66,9 +66,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       .catch(function () { retry() })
   }
 
-  BrokenLinksReport.prototype.replaceContentsAndCopyClasses = function (html) {
+  BrokenLinksReport.prototype.replaceContents = function (html) {
     this.module.innerHTML = html
-    this.module.classList = this.module.firstChild.classList
     this.module.firstChild.outerHTML = this.module.firstChild.innerHTML
   }
 

--- a/app/assets/stylesheets/admin/views/_edition-summary.scss
+++ b/app/assets/stylesheets/admin/views/_edition-summary.scss
@@ -49,11 +49,6 @@
   margin-bottom: 0;
 }
 
-.app-view-edition-summary__sidebar-info + .app-view-edition-summary__sidebar-info {
-  border-top: 2px solid $govuk-border-colour;
-  padding-top: govuk-spacing(6);
-}
-
 .app-view-edition-summary__broken-links-report {
   overflow-wrap: break-word;
   word-break: break-word;

--- a/app/views/admin/editions/show/_sidebar_history_state.html.erb
+++ b/app/views/admin/editions/show/_sidebar_history_state.html.erb
@@ -2,19 +2,21 @@
 
 <% if edition.superseded? %>
   <% if edition.is_latest_edition? %>
-    <div class="app-view-edition-summary__sidebar-info">
-      <p class="govuk-body">
-        This edition has been superseded, you can still create a
-        new draft edition for this document.
-      </p>
+    <%= render "components/inset_prompt", {
+      description: capture do %>
+        <p class="govuk-body">
+          This edition has been superseded, you can still create a
+          new draft edition for this document.
+        </p>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Create new edition to edit",
-        title: "Create new edition to edit",
-        href: revise_admin_edition_path(edition),
-        secondary_solid: true
-      } %>
-    </div>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Create new edition to edit",
+          title: "Create new edition to edit",
+          href: revise_admin_edition_path(edition),
+          secondary_quiet: true
+        } %>
+      <% end
+    } %>
   <% else %>
     <%= render "components/inset_prompt", {
       title: "This edition has been superseded",
@@ -29,31 +31,35 @@
     } %>
   <% end %>
 <% elsif edition.pre_publication? && document.live_edition.present? %>
-  <div class="app-view-edition-summary__sidebar-info">
-    <p class="govuk-body">
-      This is a new draft of a document that has already been published.
-    </p>
-
-    <p class="govuk-body">
-      <%= link_to "Go to published edition", admin_edition_path(document.live_edition), class: "govuk-link" %>
-    </p>
-
-    <% if edition.previous_edition.present? %>
+  <%= render "components/inset_prompt", {
+    description: capture do %>
       <p class="govuk-body">
-        <%= link_to "See what’s changed", diff_admin_edition_path(edition, audit_trail_entry_id: edition.previous_edition.id), class: "govuk-link" %>
+        This is a new draft of a document that has already been published.
       </p>
-  <% end %>
-</div>
+
+      <p class="govuk-body">
+        <%= link_to "Go to published edition", admin_edition_path(document.live_edition), class: "govuk-link" %>
+      </p>
+
+      <% if edition.previous_edition.present? %>
+        <p class="govuk-body">
+          <%= link_to "See what’s changed", diff_admin_edition_path(edition, audit_trail_entry_id: edition.previous_edition.id), class: "govuk-link" %>
+        </p>
+      <% end %>
+    <% end
+  } %>
 <% elsif !edition.is_latest_edition? %>
   <% if can?(:see, document.latest_edition) %>
-    <div class="app-view-edition-summary__sidebar-info">
-      <p class="govuk-body">
-        This document has a new draft. You are currently viewing the edition that is published on the website.
-      </p>
-      <p class="govuk-body">
-        <%= link_to "Go to draft", admin_edition_path(document.latest_edition), class: "govuk-link" %>
-      </p>
-    </div>
+    <%= render "components/inset_prompt", {
+      description: capture do %>
+        <p class="govuk-body">
+          This document has a new draft. You are currently viewing the edition that is published on the website.
+        </p>
+        <p class="govuk-body">
+          <%= link_to "Go to draft", admin_edition_path(document.latest_edition), class: "govuk-link" %>
+        </p>
+      <% end
+    } %>
   <% else %>
     <%= render "components/inset_prompt", {
       description: "This isn’t the most recent edition of this document – you are

--- a/app/views/admin/link_check_reports/_form.html.erb
+++ b/app/views/admin/link_check_reports/_form.html.erb
@@ -1,7 +1,10 @@
+<% secondary_solid ||= false %>
+<% secondary_quiet ||= false %>
 <%= form_tag admin_edition_link_check_reports_path(reportable), class: 'js-broken-links-form' do %>
   <%= render "govuk_publishing_components/components/button", {
     text: button_text,
-    margin_bottom: margin_bottom,
-    secondary_solid: true
+    margin_bottom: 0,
+    secondary_solid: secondary_solid,
+    secondary_quiet: secondary_quiet
   } %>
 <% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,18 +1,26 @@
-<div data-module="broken-links-report" class="<%= "app-view-edition-summary__sidebar-info" unless report.broken_links.any? || report.caution_links.any?%>">
+<div data-module="broken-links-report">
   <% if report.new_record? %>
-    <p class="govuk-body">Check this document for broken links. The report will take a few moments to complete.</p>
-    <%= render partial: 'admin/link_check_reports/form', locals: {
-      reportable: report.link_reportable,
-      button_text: 'Check for broken links',
-      margin_bottom: 6
+    <%= render "components/inset_prompt", {
+      description: capture do %>
+        <p class="govuk-body">Check this document for broken links. The report will take a few moments to complete.</p>
+        <%= render partial: 'admin/link_check_reports/form', locals: {
+          reportable: report.link_reportable,
+          button_text: 'Check for broken links',
+          secondary_quiet: true
+        } %>
+      <% end
     } %>
   <% elsif report.in_progress? %>
-    <p class="govuk-body">Broken link report in progress.</p>
-    <p class="govuk-body">
-      <%= link_to "Check progress",
-        admin_edition_link_check_report_path(report.link_reportable, report),
-        class: 'govuk-link js-broken-links-refresh' %>
-    </p>
+    <%= render "components/inset_prompt", {
+      description: capture do %>
+        <p class="govuk-body">Broken link report in progress.</p>
+        <p class="govuk-body">
+          <%= link_to "Check progress",
+            admin_edition_link_check_report_path(report.link_reportable, report),
+            class: 'govuk-link js-broken-links-refresh' %>
+        </p>
+      <% end
+    } %>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
     <%= render "components/inset_prompt", {
       title: t("broken_links.title"),
@@ -48,25 +56,28 @@
         <% end %>
         <%= render partial: 'admin/link_check_reports/form', locals: {
           reportable: report.link_reportable,
-          button_text: 'Check again',
-          margin_bottom: 0
+          button_text: 'Check again'
         } %>
       <% end,
       error: true
     } %>
   <% else %>
-    <p class="govuk-body">
-      This document contains no broken links.
-    </p>
-    <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
-      <p class="govuk-body">
-        It contains links to draft documents that weren't checked.
-      </p>
-    <% end %>
-    <%= render partial: 'admin/link_check_reports/form', locals: {
-      reportable: report.link_reportable,
-      button_text: 'Check again',
-      margin_bottom: 6
+    <%= render "components/inset_prompt", {
+      description: capture do %>
+        <p class="govuk-body">
+          This document contains no broken links.
+        </p>
+        <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
+          <p class="govuk-body">
+            It contains links to draft documents that weren't checked.
+          </p>
+        <% end %>
+        <%= render partial: 'admin/link_check_reports/form', locals: {
+          reportable: report.link_reportable,
+          button_text: 'Check again',
+          secondary_quiet: true
+        } %>
+      <% end
     } %>
   <% end %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Use inset prompts for broken links and edition history sections on the sidebar

# Why
As part of the styling adjustments in advance of release 1.5

## Screenshots
### After

<img width="1452" alt="Screenshot 2023-01-31 at 21 28 10" src="https://user-images.githubusercontent.com/9594455/215889308-465fb0cb-cf53-4280-a54b-5a8faaf3d389.png">

### Before

<img width="1452" alt="Screenshot 2023-01-31 at 21 12 56" src="https://user-images.githubusercontent.com/9594455/215889334-8b2ca237-3870-47cd-afc6-b454c19acca1.png">
