### PR TITLE
Prepare 1.5 release 

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,10 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force the 'next release' of Design System to be shown to everybody.
+    # This will be tidied up alongside the removal of now-defunct Bootstrap code for affected features.
+    return true if next_release
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -120,7 +120,7 @@ class Admin::EditionsController < Admin::BaseController
       flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: false)
       @information = updater.failure_reason unless preview_design_system?(next_release: false)
       build_edition_dependencies
-      fetch_version_and_remark_trails
+      fetch_version_and_remark_trails(next_release: false)
       construct_similar_slug_warning_error
       render_design_system(:edit, :edit_legacy, next_release: false)
     end

--- a/app/helpers/admin/miller_columns_helper.rb
+++ b/app/helpers/admin/miller_columns_helper.rb
@@ -1,0 +1,12 @@
+module Admin::MillerColumnsHelper
+  def check_item?(item)
+    item[:checked].present? &&
+      item[:checked] ||
+      item[:items].any? do |child|
+        child[:checked] ||
+          child[:items].any? do |grandchild|
+            grandchild[:checked]
+          end
+      end
+  end
+end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -16,7 +16,7 @@
             { field: "Type of document", value: edition_type(@edition) },
             { field: "Status", value: status_text.join(' ') },
             { field: "Change type", value: @edition.minor_change? ? 'Minor' : 'Major' },
-            { field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) },
+            *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
           ]
         }
       %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -71,6 +71,7 @@
           } %>
         <% end %>
       <% end %>
+
       <% if @edition.has_enabled_shareable_preview? %>
         <%= render "govuk_publishing_components/components/details", {
           title: "Share document preview"

--- a/app/views/components/_miller-columns-list.html.erb
+++ b/app/views/components/_miller-columns-list.html.erb
@@ -3,7 +3,7 @@
     <li>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input" type="checkbox" name="<%= name %>" value="<%= item[:value] %>" id="<%= id %>-<%= index %>"
-          <% if item[:checked].present? && item[:checked] %> checked <% end %>
+          <% if check_item?(item) %> checked <% end %>
         >
         <label class="govuk-label govuk-checkboxes__label" for="<%= id %>-<%= index %>">
           <%= item[:label] %>

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -7,11 +7,7 @@ When(/^the attachment has been uploaded to the asset-manager$/) do
 end
 
 When(/^I start editing the attachments from the .*? page$/) do
-  if using_design_system?
-    click_on "Add attachment"
-  else
-    click_on "Modify attachments"
-  end
+  click_on "Add attachment"
 end
 
 When(/^I upload a file attachment with the title "(.*?)" and the file "(.*?)"$/) do |title, fixture_file_name|

--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -13,7 +13,7 @@ Given(/^a document that has gone through many changes$/) do
 end
 
 When(/^I visit the document to see the audit trail$/) do
-  visit admin_publication_path(@the_publication)
+  visit edit_admin_publication_path(@the_publication)
 end
 
 Then(/^I can traverse the audit trail with newer and older navigation$/) do

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -160,12 +160,7 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
 
   visit admin_document_collection_path(@document_collection)
 
-  if using_design_system?
-    click_on "Create new edition"
-  else
-    click_on "Create new edition to edit"
-  end
-
+  click_on "Create new edition"
   fill_in_change_note_if_required
   click_button "Save and continue"
   click_button "Update tags"

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -10,11 +10,7 @@ end
 
 Then(/^I can see the slug has been updated to "([^"]*)"$/) do |new_slug|
   visit admin_edition_path(@edition)
-  if using_design_system?
-    click_button "Create new edition"
-  else
-    click_button "Create new edition to edit"
-  end
+  click_button "Create new edition"
   expect(find("#edition_slug").value).to eq new_slug
 end
 

--- a/features/step_definitions/editorial_remarks.rb
+++ b/features/step_definitions/editorial_remarks.rb
@@ -48,21 +48,12 @@ When(/^I add an editorial remark "([^"]*)" to the document "([^"]*)"$/) do |rema
   @remark_text = remark_text
 
   visit admin_edition_path(@edition)
-  if using_design_system?
-    click_link "Add internal note"
-  else
-    click_link "Add new remark"
-  end
-
+  click_link "Add internal note"
   fill_in "Internal note", with: @remark_text
   click_button "Submit internal note"
 end
 
 Then(/^my editorial remark should be visible with the document$/) do
   ensure_path admin_edition_path(@edition)
-  if using_design_system?
-    expect(page).to have_selector(".app-view-editions-editorial-remark__list-item", text: @remark_text)
-  else
-    expect(page).to have_selector(".editorial_remark .body", text: @remark_text)
-  end
+  expect(page).to have_selector(".app-view-editions-editorial-remark__list-item", text: @remark_text)
 end

--- a/features/step_definitions/force_publishing_steps.rb
+++ b/features/step_definitions/force_publishing_steps.rb
@@ -3,12 +3,8 @@ When(/^another editor retrospectively approves the "([^"]*)" publication$/) do |
   login_as user
   visit admin_editions_path(state: :published)
   click_link publication_title
-  if using_design_system?
-    click_link "Approve"
-    click_button "Approve"
-  else
-    click_button "Looks good"
-  end
+  click_link "Approve"
+  click_button "Approve"
 end
 
 Then(/^the "([^"]*)" publication should not be flagged as force-published any more$/) do |publication_title|

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -76,17 +76,9 @@ end
 
 Then("I subsequently change the primary locale") do
   visit admin_edition_path(@news_article)
-
-  if using_design_system?
-    click_button "Create new edition"
-    select "Deutsch (German)", from: "edition[primary_locale]"
-    choose "No – it’s a minor edit that does not change the meaning"
-  else
-    click_button "Create new edition to edit"
-    select "Deutsch (German)", from: "edition[primary_locale]"
-    choose "edition_minor_change_true"
-  end
-
+  click_button "Create new edition"
+  select "Deutsch (German)", from: "edition[primary_locale]"
+  choose "No – it’s a minor edit that does not change the meaning"
   click_button "Save"
 end
 

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -23,11 +23,7 @@ Then(/^I should see a link to the preview version of the publication "([^"]*)"$/
   visit admin_edition_path(publication)
   expected_preview_url = "https://draft-origin.test.gov.uk/government/publications/#{publication.slug}"
 
-  if using_design_system?
-    expect(expected_preview_url).to eq(find("a[target='_blank']")[:href])
-  else
-    expect(expected_preview_url).to eq(find("a.preview_version")[:href])
-  end
+  expect(expected_preview_url).to eq(find("a[target='_blank']")[:href])
 end
 
 Then(/^I should see that it was rejected by "([^"]*)"$/) do |rejected_by|

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -143,13 +143,7 @@ end
 Then(/^I should see a link to the public version of the publication "([^"]*)"$/) do |publication_title|
   publication = Publication.published.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  if using_design_system?
-    expect(find("a.govuk-link[target='_blank']")[:href]).to eq(
-      "#{Whitehall.public_protocol}://#{Whitehall.public_host}/government/publications/#{publication.document.slug}",
-    )
-  else
-    expect(find("a.public_version")[:href]).to eq(
-      "#{Whitehall.public_protocol}://#{Whitehall.public_host}/government/publications/#{publication.document.slug}",
-    )
-  end
+  expect(find("a.govuk-link[target='_blank']")[:href]).to eq(
+    "#{Whitehall.public_protocol}://#{Whitehall.public_host}/government/publications/#{publication.document.slug}",
+  )
 end

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -26,21 +26,12 @@ private
   end
 
   def assert_selected_specialist_sectors_are_displayed
-    if using_design_system?
-      expect(page).to have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Wells")
-      expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Fields")
-      expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
+    expect(page).to have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Wells")
+    expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Fields")
+    expect(page).to have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
 
-      expect(page).to_not have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Fields")
-      expect(page).to_not have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Wells")
-    else
-      expect(page).to have_selector(".primary-specialist-sector li", text: "Oil and Gas: Wells")
-      expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Fields")
-      expect(page).to have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Offshore")
-
-      expect(page).to_not have_selector(".primary-specialist-sector li", text: "Oil and Gas: Fields")
-      expect(page).to_not have_selector(".secondary-specialist-sectors li", text: "Oil and Gas: Wells")
-    end
+    expect(page).to_not have_selector(".app-view-edition-summary__primary-specialist-sector li", text: "Oil and Gas: Fields")
+    expect(page).to_not have_selector(".app-view-edition-summary__secondary-specialist-sectors li", text: "Oil and Gas: Wells")
   end
 end
 

--- a/features/support/attachment_helper.rb
+++ b/features/support/attachment_helper.rb
@@ -33,11 +33,7 @@ module AttachmentHelper
 
   def add_external_attachment
     location = current_url
-    if using_design_system?
-      click_link "Add attachment"
-    else
-      click_link "Modify attachments"
-    end
+    click_link "Add attachment"
     create_external_attachment("http://www.example.com/example", "Example doc")
     visit location
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -59,11 +59,7 @@ module DocumentHelper
 
   def begin_new_draft_document(title)
     visit_edition_admin title
-    if using_design_system?
-      click_button "Create new edition"
-    else
-      click_button "Create new edition to edit"
-    end
+    click_button "Create new edition"
   end
 
   def begin_drafting_news_article(options)

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -101,8 +101,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
-    @current_user.permissions << "Preview next release"
-
     create(:html_attachment, title: "An HTML attachment", attachable: @edition)
     create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)
     attachment_data = create(:attachment_data, uploaded_to_asset_manager_at: nil)

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -15,15 +15,6 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
     assert_select "#{record_css_selector(edition)} .body", text: "edition-body"
   end
 
-  view_test "should render the edition title and body to give context to the person rejecting with preview next release flag" do
-    @logged_in_user.permissions << "Preview next release"
-    edition = create(:submitted_publication, title: "edition-title", body: "edition-body")
-    get :new, params: { edition_id: edition }
-
-    assert_select "#{record_css_selector(edition)} .title", text: "edition-title"
-    assert_select "#{record_css_selector(edition)} .body", text: "edition-body"
-  end
-
   view_test "should render the editorial remark form for a statistical data set" do
     StatisticalDataSet.stubs(access_limited_by_default?: false)
     edition = create(:draft_statistical_data_set, title: "edition-title", body: "edition-body")

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -34,16 +34,6 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     get :edit, params: { id: fact_check_request }
 
     assert_response :success
-    assert_template "admin/fact_check_requests/edit_legacy"
-  end
-
-  test "users with a valid.to_param and the preview design system flag should be able to access the publication" do
-    @current_user.permissions << "Preview design system"
-    fact_check_request = create(:fact_check_request)
-
-    get :edit, params: { id: fact_check_request }
-
-    assert_response :success
     assert_template "admin/fact_check_requests/edit"
   end
 
@@ -88,7 +78,10 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     get :edit, params: { id: fact_check_request }
 
-    assert_select "#fact_check_request_instructions", text: /Please concentrate on the content/
+    assert_select ".govuk-grid-column-one-third" do
+      assert_select "h2", text: "Extra instructions"
+      assert_select ".govuk-body", text: /Please concentrate on the content/
+    end
   end
 
   view_test "should not display the extra instructions section" do
@@ -96,7 +89,9 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     get :edit, params: { id: fact_check_request }
 
-    refute_select "#fact_check_request_instructions"
+    assert_select ".govuk-grid-column-one-third" do
+      refute_select "h2", text: "Extra instructions"
+    end
   end
 
   test "save the fact checkers comment" do
@@ -169,7 +164,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
-    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
+    assert_select ".apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end
 end
 
@@ -276,7 +271,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     edition = create(:deleted_publication)
     post :create, params: { edition_id: edition.id, fact_check_request: @attributes }
 
-    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
+    assert_select ".apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end
 
 private

--- a/test/functional/admin/generic_editions_controller_tests/audit_trail_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/audit_trail_test.rb
@@ -4,19 +4,17 @@ class Admin::GenericEditionsController::AuditTrailTest < ActionController::TestC
   include TaxonomyHelper
   tests Admin::GenericEditionsController
 
-  %i[show edit].each do |action|
-    view_test "should show who created the document and when on #{action}" do
-      login_as(create(:gds_editor, name: "Tom", email: "tom@example.com"))
+  view_test "should show who created the document and when on edit" do
+    login_as(create(:gds_editor, name: "Tom", email: "tom@example.com"))
 
-      draft_edition = create(:draft_edition)
-      stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
+    draft_edition = create(:draft_edition)
+    stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
 
-      request.env["HTTPS"] = "on"
-      get action, params: { id: draft_edition }
+    request.env["HTTPS"] = "on"
+    get :edit, params: { id: draft_edition }
 
-      assert_select "#history", text: /Created by Tom/ do
-        assert_select "img[src^='https']"
-      end
+    assert_select "#history", text: /Created by Tom/ do
+      assert_select "img[src^='https']"
     end
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -17,8 +17,8 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: draft_edition }
 
-    assert_select ".edition-sidebar" do
-      assert_select "a[href=?]", confirm_destroy_admin_edition_path(draft_edition), text: "Discard draft"
+    assert_select ".app-view-edition-summary__sidebar-actions" do
+      assert_select "a[href=?]", confirm_destroy_admin_edition_path(draft_edition), text: "Delete draft"
     end
   end
 
@@ -28,8 +28,8 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: submitted_edition }
 
-    assert_select ".edition-sidebar" do
-      assert_select "a[href=?]", confirm_destroy_admin_edition_path(submitted_edition), text: "Discard draft"
+    assert_select ".app-view-edition-summary__sidebar-actions" do
+      assert_select "a[href=?]", confirm_destroy_admin_edition_path(submitted_edition), text: "Delete draft"
     end
   end
 
@@ -39,7 +39,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: published_edition }
 
-    refute_select ".edition-sidebar input[name='_method'][type='hidden'][value='delete']"
+    refute_select ".app-view-edition-summary__sidebar-actions input[name='_method'][type='hidden'][value='delete']"
   end
 
   view_test "show does not display the delete button for superseded editions" do

--- a/test/functional/admin/generic_editions_controller_tests/force_publishing_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/force_publishing_documents_test.rb
@@ -37,7 +37,7 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    assert_select ".force_published"
+    assert_select ".govuk-body", text: "Please have an editor other than the original publisher review the document to clear this warning."
   end
 
   view_test "show should not display the approve_retrospectively form for the creator" do
@@ -47,7 +47,7 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    refute_select ".force_published form input"
+    refute_select ".govuk-button", text: "Approve"
   end
 
   view_test "show should display the approve_retrospectively form for a departmental editor who wasn't the creator" do
@@ -58,6 +58,6 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
 
     login_as(create(:departmental_editor, name: "Another Editor"))
     get :show, params: { id: edition }
-    assert_select ".force_published form input"
+    assert_select ".govuk-button", text: "Approve"
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_document_on_public_site_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_document_on_public_site_test.rb
@@ -13,7 +13,7 @@ class Admin::GenericEditionsController::LinkingToDocumentOnPublicSiteTest < Acti
     stub_publishing_api_expanded_links_with_taxons(published_edition.content_id, [])
 
     get :show, params: { id: published_edition }
-    assert_select link_to_public_version_selector, count: 1
+    assert_select link_to_public_version_selector(published_edition), count: 1
   end
 
   view_test "should not link to public version when not published" do
@@ -21,6 +21,6 @@ class Admin::GenericEditionsController::LinkingToDocumentOnPublicSiteTest < Acti
     stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
 
     get :show, params: { id: draft_edition }
-    refute_select link_to_public_version_selector
+    refute_select link_to_public_version_selector(draft_edition)
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_preview_of_document_on_public_site_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_preview_of_document_on_public_site_test.rb
@@ -13,6 +13,6 @@ class Admin::GenericEditionsController::LinkingToPreviewOfDocumentOnPublicSiteTe
     stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
 
     get :show, params: { id: draft_edition }
-    assert_select link_to_preview_version_selector
+    assert_select link_to_preview_version_selector(draft_edition)
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
@@ -33,7 +33,7 @@ class Admin::GenericEditionsController::RejectingDocumentsTest < ActionControlle
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    assert_select ".rejected_by", text: current_user.name
+    assert_select ".app-c-inset-prompt__body a", text: current_user.name
   end
 
   view_test "should not show the editorial remarks section" do
@@ -50,10 +50,10 @@ class Admin::GenericEditionsController::RejectingDocumentsTest < ActionControlle
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    assert_select ".editorial_remark" do
-      assert_select ".body", text: /editorial-remark-body/
-      assert_select ".actor", text: current_user.name
-      assert_select "time.created_at[datetime='#{remark.created_at.iso8601}']"
+    assert_select "#history_tab" do
+      assert_select ".app-view-editions-editorial-remark__list-item", text: /editorial-remark-body/
+      assert_select ".app-view-editions-editorial-remark__list-item a", text: current_user.name
+      assert_select "time.datetime[datetime='#{remark.created_at.iso8601}']"
     end
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
@@ -42,7 +42,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
 
     get :show, params: { id: new_draft }
 
-    assert_select ".alert a", href: Whitehall.url_maker.admin_edition_path(original_edition)
+    assert_select ".app-c-inset-prompt a", text: "Go to published edition", href: Whitehall.url_maker.admin_edition_path(original_edition)
   end
 
   view_test "show for a published edition links to a new draft" do
@@ -52,6 +52,6 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
 
     get :show, params: { id: original_edition }
 
-    assert_select ".alert a", href: Whitehall.url_maker.admin_edition_path(new_draft)
+    assert_select ".app-c-inset-prompt a", text: "Go to draft", href: Whitehall.url_maker.admin_edition_path(new_draft)
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/translation_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/translation_test.rb
@@ -49,9 +49,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
 
     get :show, params: { id: edition }
 
-    assert_select "form[action=?]", admin_edition_translation_path(edition, "fr") do
-      assert_select "input[type='submit'][value=?]", "Delete"
-    end
+    assert_select ".govuk-table__row .govuk-table__cell:last-child a", text: "Delete"
   end
 
   view_test "show displays the language of the translation on published editions" do
@@ -65,9 +63,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
 
     get :show, params: { id: edition }
 
-    assert_select "#translations" do
-      assert_select "td", text: "French"
-    end
+    assert_select ".govuk-table__cell", text: "Français (French)"
   end
 
   view_test "show omits the link to edit an existing translation unless the edition is editable" do
@@ -105,9 +101,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
       get :show, params: { id: edition }
     end
 
-    assert_select "#translations" do
-      refute_select "td", text: "english-title"
-      assert_select "td", text: "french-title"
-    end
+    refute_select ".govuk-table__row .govuk-table__cell:nth-child(2)", text: "english-title"
+    assert_select ".govuk-table__row .govuk-table__cell:nth-child(2)", text: "french-title"
   end
 end

--- a/test/functional/admin/legacy_case_studies_controller_test.rb
+++ b/test/functional/admin/legacy_case_studies_controller_test.rb
@@ -32,16 +32,6 @@ class Admin::LegacyCaseStudiesControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "GET :show renders a side nav bar with notes, history and fact checking" do
-    edition = create(:draft_case_study)
-    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-    get :show, params: { id: edition }
-
-    assert_select ".nav-tabs a", text: "Notes 0"
-    assert_select ".nav-tabs a", text: "History 1"
-  end
-
   view_test "GET :edit renders a side nav bar with notes, history and fact checking" do
     edition = create(:draft_case_study)
 

--- a/test/functional/admin/legacy_consultations_controller_test.rb
+++ b/test/functional/admin/legacy_consultations_controller_test.rb
@@ -107,14 +107,6 @@ class Admin::LegacyConsultationsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "show renders the summary" do
-    draft_consultation = create(:draft_consultation, summary: "a-simple-summary")
-    stub_publishing_api_expanded_links_with_taxons(draft_consultation.content_id, [])
-
-    get :show, params: { id: draft_consultation }
-    assert_select ".page-header .lead", text: "a-simple-summary"
-  end
-
   view_test "edit displays consultation fields" do
     response_form = create(:consultation_response_form)
     participation = create(:consultation_participation, consultation_response_form: response_form)

--- a/test/functional/admin/legacy_detailed_guides_controller_test.rb
+++ b/test/functional/admin/legacy_detailed_guides_controller_test.rb
@@ -29,62 +29,6 @@ class Admin::LegacyDetailedGuidesControllerTest < ActionController::TestCase
   legacy_should_allow_overriding_of_first_published_at_for :detailed_guide
   legacy_should_allow_access_limiting_of :detailed_guide
 
-  view_test "user needs associated with a detailed guide" do
-    content_id_a = SecureRandom.uuid
-    content_id_b = SecureRandom.uuid
-
-    detailed_guide = create(:detailed_guide)
-    stub_publishing_api_has_links(
-      {
-        content_id: detailed_guide.document.content_id,
-        links: {
-          meets_user_needs: [content_id_a, content_id_b],
-        },
-      },
-    )
-    stub_publishing_api_has_expanded_links(
-      {
-        content_id: detailed_guide.document.content_id,
-        expanded_links: {
-          taxons: [],
-          meets_user_needs: [
-            {
-              content_id: content_id_a,
-              details: {
-                role: "x",
-                goal: "y",
-                benefit: "z",
-              },
-            },
-            {
-              content_id: content_id_b,
-              details: {
-                role: "c",
-                goal: "d",
-                benefit: "e",
-              },
-            },
-          ],
-        },
-        version: 1,
-      },
-    )
-
-    get :show, params: { id: detailed_guide.id }
-
-    assert_select "#user-needs-section" do |_section|
-      assert_select "#user-need-id-#{content_id_a}" do
-        assert_select ".description", text: "As a x,\n    I need to y,\n    So that z"
-        assert_select ".maslow-url[href*='#{content_id_a}']"
-      end
-
-      assert_select "#user-need-id-#{content_id_b}" do
-        assert_select ".description", text: "As a c,\n    I need to d,\n    So that e"
-        assert_select ".maslow-url[href*='#{content_id_b}']"
-      end
-    end
-  end
-
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/legacy_document_collections_controller_test.rb
+++ b/test/functional/admin/legacy_document_collections_controller_test.rb
@@ -14,21 +14,6 @@ class Admin::LegacyDocumentCollectionsControllerTest < ActionController::TestCas
   legacy_should_be_an_admin_controller
   legacy_should_allow_organisations_for :document_collection
 
-  view_test "GET #show displays the document collection" do
-    collection = create(
-      :document_collection,
-      title: "collection-title",
-      summary: "the summary",
-    )
-
-    stub_publishing_api_expanded_links_with_taxons(collection.content_id, [])
-
-    get :show, params: { id: collection }
-
-    assert_select "h1", "collection-title"
-    assert_select ".page-header .lead", "the summary"
-  end
-
   view_test "GET #new renders document collection form" do
     get :new
 

--- a/test/functional/admin/legacy_fatality_notices_controller_test.rb
+++ b/test/functional/admin/legacy_fatality_notices_controller_test.rb
@@ -23,15 +23,6 @@ class Admin::LegacyFatalityNoticesControllerTest < ActionController::TestCase
   legacy_should_allow_scheduled_publication_of :fatality_notice
   legacy_should_allow_access_limiting_of :fatality_notice
 
-  view_test "show renders the summary" do
-    draft_fatality_notice = create(:draft_fatality_notice, summary: "a-simple-summary")
-    stub_publishing_api_expanded_links_with_taxons(draft_fatality_notice.content_id, [])
-
-    get :show, params: { id: draft_fatality_notice }
-
-    assert_select ".page-header .lead", text: "a-simple-summary"
-  end
-
   view_test "when creating allows assignment to operational field" do
     get :new
 

--- a/test/functional/admin/legacy_news_articles_controller_test.rb
+++ b/test/functional/admin/legacy_news_articles_controller_test.rb
@@ -31,15 +31,6 @@ class Admin::LegacyNewsArticlesControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "show renders the summary" do
-    draft_news_article = create(:draft_news_article, summary: "a-simple-summary")
-    stub_publishing_api_expanded_links_with_taxons(draft_news_article.content_id, [])
-
-    get :show, params: { id: draft_news_article }
-
-    assert_select ".page-header .lead", text: "a-simple-summary"
-  end
-
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -86,7 +86,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       context "when an attachment is added to the draft document" do
         before do
           visit admin_news_article_path(edition)
-          click_link "Modify attachments"
+          click_link "Add attachments"
           click_link "Upload new file attachment"
           fill_in "Title", with: "asset-title"
           attach_file "File", path_to_attachment("logo.png")
@@ -137,7 +137,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       context "when bulk uploaded to draft document" do
         before do
           visit admin_news_article_path(edition)
-          click_link "Modify attachments"
+          click_link "Add attachments"
           click_link "Bulk upload from Zip file"
           attach_file "Zip file", path_to_attachment("sample_attachment.zip")
           click_button "Upload zip"

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -66,7 +66,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       context "when draft document is discarded" do
         before do
           visit admin_news_article_path(edition)
-          click_link "Discard draft"
+          click_link "Delete draft"
           click_button "Delete"
         end
 

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -65,7 +65,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
           stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
           stub_publishing_api_has_linkables([], document_type: "topic")
           visit admin_news_article_path(edition)
-          click_button "Create new edition to edit"
+          click_button "Create new edition"
           click_link "Attachments 1"
           within row_containing(filename) do
             click_link "Edit"

--- a/test/integration/shareable_preview_generate_new_link_test.rb
+++ b/test/integration/shareable_preview_generate_new_link_test.rb
@@ -23,17 +23,21 @@ class ShareablePreviewGenerateNewLinkIntegrationTest < ActionDispatch::Integrati
       test "it revokes the previous links and generates a new one" do
         get admin_case_study_path(edition)
 
+        find(".govuk-details__summary", text: "Share document preview").click
+
         current_preview_url = all("input").first.value
         current_query_string = Rack::Utils.parse_query URI(current_preview_url).query
         current_token = current_query_string["token"]
 
-        click_link "Generate new link"
+        click_button "Generate new link"
+
+        find(".govuk-details__summary", text: "Share document preview").click
 
         new_preview_url = all("input").first.value
         new_query_string = Rack::Utils.parse_query URI(new_preview_url).query
         new_token = new_query_string["token"]
 
-        assert_selector ".flash.notice", text: "New document preview link generated"
+        assert_selector ".gem-c-success-alert__message", text: "New document preview link generated"
         assert_not_equal current_token, new_token
       end
     end

--- a/test/support/admin_edition_controller_legacy_scheduled_publishing_test_helpers.rb
+++ b/test/support/admin_edition_controller_legacy_scheduled_publishing_test_helpers.rb
@@ -25,64 +25,6 @@ module AdminEditionControllerLegacyScheduledPublishingTestHelpers
         end
       end
 
-      view_test "GET :show with a draft scheduled edition displays the 'Force schedule', but not the 'Force publish' button" do
-        login_as :gds_editor
-        edition = create(edition_type, :draft, scheduled_publication: 1.day.from_now)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        get :show, params: { id: edition }
-
-        assert_select force_schedule_button_selector(edition), count: 1
-        refute_select force_publish_button_selector(edition)
-        assert_select ".scheduled-publication", "Scheduled publication proposed for #{I18n.localize edition.scheduled_publication, format: :long}."
-      end
-
-      view_test "should display the 'Schedule' button for a submitted scheduled edition when viewing as an editor" do
-        login_as :gds_editor
-        edition = create(edition_type, :submitted, scheduled_publication: 1.day.from_now)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        get :show, params: { id: edition }
-
-        assert_select schedule_button_selector(edition), count: 1
-        assert_select ".scheduled-publication", /Scheduled publication proposed for/
-      end
-
-      view_test "should not display the 'Schedule' button if not schedulable" do
-        edition = create(edition_type, :published)
-        redis_cache_has_world_taxons([build(:taxon_hash, content_id: "world-taxon")])
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        document_type_class.stubs(:find).with(edition.to_param).returns(edition)
-        get :show, params: { id: edition }
-        refute_select schedule_button_selector(edition)
-        refute_select force_schedule_button_selector(edition)
-      end
-
-      view_test "should display the 'Unschedule' button for a scheduled publication" do
-        edition = create(edition_type, :scheduled)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        get :show, params: { id: edition }
-        assert_select unschedule_button_selector(edition)
-      end
-
-      view_test "should indicate publishing schedule if scheduled" do
-        edition = create(edition_type, :scheduled)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        get :show, params: { id: edition }
-        assert_select ".scheduled-publication", "Scheduled for publication on #{I18n.localize edition.scheduled_publication, format: :long}."
-      end
-
-      view_test "should not indicate publishing schedule if published" do
-        edition = create(edition_type, :published, scheduled_publication: 1.day.ago)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        get :show, params: { id: edition }
-        assert_select ".scheduled-publication", count: 0
-      end
-
       test "create should not set scheduled_publication if scheduled_publication_active is not checked" do
         edition_attributes = controller_attributes_for(
           edition_type,

--- a/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
+++ b/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
@@ -34,7 +34,7 @@ module AdminEditionControllerScheduledPublishingTestHelpers
 
         assert_select force_schedule_button_selector(edition), count: 1
         refute_select force_publish_button_selector(edition)
-        assert_select ".scheduled-publication", "Scheduled publication proposed for #{I18n.localize edition.scheduled_publication, format: :long}."
+        assert_select ".app-view-edition-summary__scheduled-notice", "Scheduled publication proposed for #{I18n.localize edition.scheduled_publication, format: :long}."
       end
 
       view_test "should display the 'Schedule' button for a submitted scheduled edition when viewing as an editor" do
@@ -45,7 +45,7 @@ module AdminEditionControllerScheduledPublishingTestHelpers
         get :show, params: { id: edition }
 
         assert_select schedule_button_selector(edition), count: 1
-        assert_select ".scheduled-publication", /Scheduled publication proposed for/
+        assert_select ".app-view-edition-summary__scheduled-notice", /Scheduled publication proposed for/
       end
 
       view_test "should not display the 'Schedule' button if not schedulable" do

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -94,7 +94,7 @@ module CssSelectors
   end
 
   def force_schedule_button_selector(document)
-    "form[action='#{force_schedule_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
+    "a[href='#{confirm_force_schedule_admin_edition_path(document, lock_version: document.lock_version)}']"
   end
 
   def link_to_public_version_selector(document)

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -82,43 +82,27 @@ module CssSelectors
   end
 
   def reject_button_selector(document)
-    if current_user.can_preview_design_system?
-      "form[action='#{reject_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
-    else
-      "form[action='#{reject_admin_edition_path(document, lock_version: document.lock_version)}'] input[type=submit][value=Reject]"
-    end
+    "form[action='#{reject_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
   end
 
   def schedule_button_selector(document)
-    if current_user.can_preview_design_system?
-      "form[action='#{schedule_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
-    else
-      "form[action='#{schedule_admin_edition_path(document, lock_version: document.lock_version)}'] input[type=submit][value=Schedule]"
-    end
+    "form[action='#{schedule_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
   end
 
   def unschedule_button_selector(document)
-    if current_user.can_preview_design_system?
-      "a[href='#{confirm_unschedule_admin_edition_path(document, lock_version: document.lock_version)}']"
-    else
-      "form[action='#{unschedule_admin_edition_path(document, lock_version: document.lock_version)}'] input[type=submit][value=Unschedule]"
-    end
+    "a[href='#{confirm_unschedule_admin_edition_path(document, lock_version: document.lock_version)}']"
   end
 
   def force_schedule_button_selector(document)
-    if current_user.can_preview_design_system?
-      "form[action='#{force_schedule_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
-    else
-      "form[action='#{force_schedule_admin_edition_path(document, lock_version: document.lock_version)}'] input[type=submit][value='Force schedule']"
-    end
+    "form[action='#{force_schedule_admin_edition_path(document, lock_version: document.lock_version)}'] button[type=submit]"
   end
 
-  def link_to_public_version_selector
-    ".public_version"
+  def link_to_public_version_selector(document)
+    "a[href='#{public_document_url(document)}']"
   end
 
-  def link_to_preview_version_selector
-    ".preview_version"
+  def link_to_preview_version_selector(document)
+    "a[href='#{preview_document_url(document)}']"
   end
 
   def policy_group_selector

--- a/test/unit/helpers/admin/miller_columns_helper_test.rb
+++ b/test/unit/helpers/admin/miller_columns_helper_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class Admin::MillerColumnsHelperTest < ActionView::TestCase
+  test "#check_item? returns true if item's checked is true" do
+    checked_parent = {
+      label: "Parent",
+      value: "1",
+      checked: true,
+      items: [
+        {
+          label: "Child",
+          value: "2",
+          checked: false,
+          items: [
+            label: "Grandchild",
+            value: "3",
+            items: [],
+            checked: false,
+          ],
+        },
+      ],
+    }
+
+    assert check_item?(checked_parent)
+  end
+
+  test "#check_item? returns true if item's child's checked is true" do
+    checked_child = {
+      label: "Parent",
+      value: "1",
+      checked: false,
+      items: [
+        {
+          label: "Child",
+          value: "2",
+          checked: true,
+          items: [
+            label: "Grandchild",
+            value: "3",
+            items: [],
+            checked: false,
+          ],
+        },
+      ],
+    }
+
+    assert check_item?(checked_child)
+  end
+
+  test "#check_item? returns true if item's grandchild's checked is true" do
+    checked_grandchild = {
+      label: "Parent",
+      value: "1",
+      checked: false,
+      items: [
+        {
+          label: "Child",
+          value: "2",
+          checked: false,
+          items: [
+            label: "Grandchild",
+            value: "3",
+            items: [],
+            checked: true,
+          ],
+
+        },
+      ],
+    }
+
+    assert check_item?(checked_grandchild)
+  end
+
+  test "#check_item? returns false if item and children and not checked" do
+    unchecked_item = {
+      label: "Parent",
+      value: "1",
+      checked: false,
+      items: [
+        {
+          label: "Child",
+          value: "2",
+          checked: false,
+          items: [
+            label: "Grandchild",
+            value: "3",
+            items: [],
+            checked: false,
+          ],
+        },
+      ],
+    }
+
+    assert_not check_item?(unchecked_item)
+  end
+end


### PR DESCRIPTION
**Merging this will trigger the 1.5 release. Do not merge until comms has gone out**

## Description

This PR does two things:

1. Temporarily forces the 'next release' of Design System to be shown to everybody
2. Fixes all the tests that fail as a result of it

A follow up PR will come after the release that will clean up all the old code.

## Trello card

https://trello.com/c/2fLcyBrE/1-prepare-15-release-force-permissions-and-fix-tests

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
