### PR TITLE
Add Document History pagination links to bottom

### DIFF
--- a/app/assets/javascripts/admin/modules/document-history-paginator.js
+++ b/app/assets/javascripts/admin/modules/document-history-paginator.js
@@ -7,24 +7,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   DocumentHistoryPaginator.prototype.init = function () {
-    var fetch = window.fetch
-    if (!fetch) { return }
+    if (!window.fetch) { return }
 
     this.setupEventListeners()
   }
 
   DocumentHistoryPaginator.prototype.setupEventListeners = function () {
-    var module = this.module
-    var newerLink = module.querySelector('.app-view-document-history-tab__newer-pagination-link')
-    var olderLink = module.querySelector('.app-view-document-history-tab__older-pagination-link')
+    var _this = this
 
-    if (newerLink) {
-      this.addLinkEventListener(newerLink)
-    }
+    var linkSelectors = [
+      '.app-view-document-history-tab__newer-pagination-link',
+      '.app-view-document-history-tab__older-pagination-link'
+    ]
 
-    if (olderLink) {
-      this.addLinkEventListener(olderLink)
-    }
+    this.module.querySelectorAll(linkSelectors.join()).forEach(function (link) {
+      _this.addLinkEventListener(link)
+    })
   }
 
   DocumentHistoryPaginator.prototype.addLinkEventListener = function (link) {

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -4,10 +4,10 @@
   <p class="govuk-body">To add an internal note, save your changes.</p>
 <% end %>
 
-<p class="govuk-body"><%= link_to("Add internal note", new_admin_edition_editorial_remark_path(edition), class: "govuk-body govuk-link") %></p>
+<p class="govuk-body"><%= link_to("Add internal note", new_admin_edition_editorial_remark_path(edition), class: "govuk-body govuk-link govuk-link--no-visited-state") %></p>
 
 <%= render "govuk_publishing_components/components/inset_text", {
-  text: sanitize("History and notes have been merged. #{tag.a('Read more about the change', href: admin_whats_new_path)}")
+  text: sanitize("History and notes have been merged. #{link_to('Read more about the change', admin_whats_new_path, class: "govuk-link")}")
 } %>
 
 <%= paginate(@document_history, theme: 'history', editing:) %>

--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -49,3 +49,5 @@
     } %>
   </div>
 <% end %>
+
+<%= paginate(@document_history, theme: 'history', editing:) %>

--- a/app/views/kaminari/history/_next_page.html.erb
+++ b/app/views/kaminari/history/_next_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page + 1, editing:) } %>
+<%= link_to_next_page @document_history, 'Older', class: "govuk-body govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0 app-view-document-history-tab__older-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page + 1, editing:) } %>

--- a/app/views/kaminari/history/_prev_page.html.erb
+++ b/app/views/kaminari/history/_prev_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link app-view-document-history-tab__newer-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page - 1, editing:) } %>
+<%= link_to_previous_page @document_history, 'Newer', class: "govuk-body govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0 app-view-document-history-tab__newer-pagination-link", data: {'remote-pagination' => paginated_document_history_url(page: current_page - 1, editing:) } %>

--- a/features/admin-history-pagination.feature
+++ b/features/admin-history-pagination.feature
@@ -1,4 +1,4 @@
-Feature: Viewing a documents history
+Feature: Viewing a document's history
 
   Background:
     Given I am a writer
@@ -9,10 +9,10 @@ Feature: Viewing a documents history
     When "Stubble to be Outlawed" has two pages of history
     Then I can see the first ten items in the History tab
 
-    When I click the "Older" link
+    When I click the "Older" history link
     Then I can see the second page of history
 
-    When I click the "Newer" link
+    When I click the "Newer" history link
     Then I can see the first ten items in the History tab
 
   @javascript @design-system-only
@@ -21,10 +21,10 @@ Feature: Viewing a documents history
     When "Stubble to be Outlawed" has two pages of history
     Then I can see the first ten items in the History tab
 
-    When I click the "Older" link
+    When I click the "Older" history link
     Then I can see the second page of history
     And the History tab is still showing
 
-    When I click the "Newer" link
+    When I click the "Newer" history link
     Then I can see the first ten items in the History tab
     And the History tab is still showing

--- a/features/step_definitions/admin_history_pagination_steps.rb
+++ b/features/step_definitions/admin_history_pagination_steps.rb
@@ -19,8 +19,11 @@ Then(/^I can see the first ten items in the History tab$/) do
   expect(all(".app-view-editions-editorial-remark__list-item").count).to eq 10
 end
 
-When(/^I click the "([^"]*)" link$/) do |link|
-  click_link link
+When(/^I click the "([^"]*)" history link$/) do |link|
+  within "#history_tab" do
+    # Randomly click one of the two matching links
+    all("a", text: link, count: 2).sample.click
+  end
 end
 
 Then(/^I can see the second page of history$/) do

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -42,7 +42,7 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
   test "it renders pagination links based on the pagination attribute" do
     render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline))
 
-    assert_selector ".app-view-document-history-tab__pagination-link", text: "Older"
+    assert_selector ".app-view-document-history-tab__pagination-link", text: "Older", count: 2
   end
 
   test "it renders the timeline entries in the correct sections for, future, current and previous editions" do


### PR DESCRIPTION
This PR adds 'Newer' and 'Older' links to the bottom of the Document History tab. They already existed at the top of the tab, so this duplicates them and updates JavaScript & tests accordingly.

I've also tweaked a couple of styling quirks that I discovered along the way (see the 2nd commit on this PR).

| Before | After |
| --- | --- |
| <img width="360" alt="Before" src="https://user-images.githubusercontent.com/7735945/216036369-cb4b427b-efa4-4636-88fc-9d4803d2a0e0.png"> | <img width="360" alt="After" src="https://user-images.githubusercontent.com/7735945/216036411-4798e7fb-ceaa-46d5-82dd-eb10c7d35127.png"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
