### PR TITLE
Update what's new content for release 1.5

### DIFF
--- a/app/components/admin/editions/document_history_tab_component.html.erb
+++ b/app/components/admin/editions/document_history_tab_component.html.erb
@@ -7,7 +7,7 @@
 <p class="govuk-body"><%= link_to("Add internal note", new_admin_edition_editorial_remark_path(edition), class: "govuk-body govuk-link govuk-link--no-visited-state") %></p>
 
 <%= render "govuk_publishing_components/components/inset_text", {
-  text: sanitize("History and notes have been merged. #{link_to('Read more about the change', admin_whats_new_path, class: "govuk-link")}")
+  text: sanitize("History and notes have been merged. #{link_to('Read more about the change', admin_whats_new_path, class: "govuk-link")}.")
 } %>
 
 <%= paginate(@document_history, theme: 'history', editing:) %>

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "What's new",
-    message: sanitize("Attachments page and comparing previous editions move to the GOV.UK Design System -
+    message: sanitize("Edition summary page moves to the GOV.UK Design System and changes to history and notes -
       #{
         link_to(
           "read more about the changes",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,11 +1,11 @@
 en:
   admin:
     whats_new:
-      show_banner: false
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 22 December 2022
+      last_updated: Last updated 2 February 2023
       introduction:
         heading: Moving to the Design System
         body_govspeak: |
@@ -22,6 +22,22 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: Document history and notes have been merged
+            area: Creating and updating documents
+            type: change
+            date: 2 February 2023
+            body_govspeak: |
+              History and notes have been merged into a single history tab on the edition summary page. Internal notes will be shown alongside a document’s history.
+              
+              ‘Remarks’ or ‘editorial remarks’ are now known as ‘internal notes’.
+          - heading: Edition summary page and worldwide tagging move to the Design System
+            area: Creating and updating documents
+            type: improvement
+            date: 2 February 2023
+            body_govspeak: |
+              The edition summary page (where you can do things like previewing, history and notes, submitting for 2i or publishing) and worldwide tagging have moved to use the GOV.UK Design System.
+              
+              Some of the buttons and actions, such as ‘create new edition’ or ‘view on website’, have moved to the sidebar.
           - heading: Attachments page, comparing previous editions and other pages move to the Design System
             area: Creating and updating documents
             type: improvement

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -34,7 +34,7 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
   test "it renders a inset component which links to the whats new page" do
     render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @first_edition, document_history: @timeline))
 
-    assert_selector ".gem-c-inset-text", text: "History and notes have been merged. Read more about the change"
+    assert_selector ".gem-c-inset-text", text: "History and notes have been merged. Read more about the change."
     assert_equal page.all(".gem-c-inset-text a")[0].text, "Read more about the change"
     assert_equal page.all(".gem-c-inset-text a")[0][:href], admin_whats_new_path
   end


### PR DESCRIPTION
This PR updates the following things for release 1.5:

- the what's new phase banner content
- the what's new page
- the inset message in history and notes

https://trello.com/c/4OTFgUtl

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
