### PR TITLE
Add subtype tracking for world tags

### DIFF
--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "#{@edition.title}: Worldwide tags" %>
 <% content_for :context, @edition.title %>
 <% content_for :title, "Worldwide tags" %>
+<%= render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
## Description

This adds subtype as a custom dimension to the worldwide taxonomy page's  GA `View page` tracking.  

<img width="705" alt="image" src="https://user-images.githubusercontent.com/42515961/216319300-87986cd5-632f-4d0e-b8db-33c35f44fe5a.png">

## Trello card 

https://trello.com/c/3r7X14SB/96-tracking-to-be-added-to-wordwide-tagging-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
