### PR TITLE
Add additional tracking to worldwide tags

### DIFF
--- a/app/controllers/admin/edition_world_tags_controller.rb
+++ b/app/controllers/admin/edition_world_tags_controller.rb
@@ -7,6 +7,7 @@ class Admin::EditionWorldTagsController < Admin::BaseController
   def edit
     @world_taxonomy = Taxonomy::WorldTaxonomy.new
     @tag_form = WorldTaxonomyTagForm.load(@edition.content_id)
+    @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
     render_design_system("edit", "edit_legacy", next_release: true)
   end
 

--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -1,6 +1,12 @@
 <% content_for :page_title, "#{@edition.title}: Worldwide tags" %>
 <% content_for :context, @edition.title %>
 <% content_for :title, "Worldwide tags" %>
+<% content_for :head do %>
+  <% custom_track_dimensions(@edition, @edition_taxons).each do |key, value| %>
+    <meta name="custom-dimension:<%= key %>" content="<%= value %>">
+  <% end %>
+<% end %>
+
 <%= render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <div class="govuk-grid-row">

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -9,7 +9,9 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
     @publishing_api_endpoint = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT
     @organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
     @edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [@organisation])
+    stub_taxonomy_with_all_taxons
     stub_taxonomy_with_world_taxons
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
   end
 
   test "should return an error on a version conflict" do


### PR DESCRIPTION
## Description 

This adds in custom dimension tracking that is being collected on the other edit taxons page.

<img width="726" alt="image" src="https://user-images.githubusercontent.com/42515961/216329363-6d8601a9-b217-4d0c-a9fc-0ee52ef92755.png">

## Trello card

https://trello.com/c/3r7X14SB/96-tracking-to-be-added-to-wordwide-tagging-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
