### PR TITLE
Show World Taxons on the Edition Summary page

### DIFF
--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -13,7 +13,7 @@ class EditionTaxonsFetcher
 
   def fetch_world_taxons
     taxons.select do |taxon|
-      visible?(taxon) && world_taxon?(taxon.content_id)
+      world_taxon?(taxon.content_id)
     end
   end
 


### PR DESCRIPTION
## Description

For some reasons the World Taxons stored in Redis all have
`@visible_to_departmental_editors=false` as an attribute.

This is causing then not to show the Edition Summary page. I've spoken to various people with good knowledge in the area and as far as we can tell there is no reason for this.

This removes checking that this is set to true before rendering them on the summary page.

## Screenshot

Before 

<img width="594" alt="image" src="https://user-images.githubusercontent.com/42515961/216571684-4865e16d-a1ea-4244-9834-5a50735ee231.png">


After 

<img width="552" alt="image" src="https://user-images.githubusercontent.com/42515961/216568135-c161cda9-8efc-45f6-a086-30e19a46ae81.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
