### PR TITLE
Updates `input` and `textarea` elements on edit translations page for `dir` attribute

### DIFF
--- a/app/models/edition/translatable.rb
+++ b/app/models/edition/translatable.rb
@@ -52,6 +52,10 @@ module Edition::Translatable
     Locale.find_by_code(primary_locale).rtl?
   end
 
+  def translation_rtl?
+    Locale.new(translation_locale.code).rtl?
+  end
+
   def primary_language_name
     Locale.find_by_code(primary_locale).english_language_name
   end

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -18,6 +18,8 @@
           heading_size: "l",
           value: @translated_edition.title,
           error_items: errors_for(form.object.errors, :title),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false
         } %>
 
         <h3 class="app-view-edition-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English title content:</h3>
@@ -34,6 +36,8 @@
         value: @translated_edition.summary,
         rows: 2,
         error_items: errors_for(form.object.errors, :summary),
+        right_to_left: form.object.translation_rtl?,
+        right_to_left_help: false
       } %>
 
       <h3 class="app-view-edition-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English summary content:</h3>
@@ -49,6 +53,8 @@
         value: @translated_edition.body,
         rows: 20,
         error_items: errors_for(form.object.errors, :body),
+        right_to_left: form.object.translation_rtl?,
+        right_to_left_help: false
       } %>
 
       <h3 class="app-view-edition-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English body content:</h3>


### PR DESCRIPTION
[Trello](https://trello.com/c/peLddSGk/69-add-rtl-to-translations)

This PR adds a value for the `dir` attribute in the title, summary and body fields of the Edit Translation page. This ensures that the language displays correctly where it is a right-to-left displaying language.

It roughly follows the way the definition for `rtl_locale?` is done on the attachments page but could do with some checking from a ruby perspective. Otherwise it adds the values using the newly-updated input and textarea components.

|LTR language|RTL language|
|-|-|
|![Screenshot 2023-02-03 at 12 42 03](https://user-images.githubusercontent.com/6080548/216608418-dfd854ab-8351-4835-bc5c-079a47d2d1e2.png)|![Screenshot 2023-02-03 at 12 47 11](https://user-images.githubusercontent.com/6080548/216608450-0e95d049-d7d0-4394-ba6f-59dba4c5b527.png)|
