### PR TITLE
Use edition.format_name in email notifications

### DIFF
--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -1,5 +1,3 @@
-require "zip"
-
 class MailNotifications < ApplicationMailer
   include ActionView::RecordIdentifier
   include ActionView::Helpers::TextHelper

--- a/app/models/fact_check_request.rb
+++ b/app/models/fact_check_request.rb
@@ -22,6 +22,6 @@ class FactCheckRequest < ApplicationRecord
   delegate :title, to: :edition, prefix: true
 
   def edition_type
-    edition.type.downcase
+    edition.format_name
   end
 end

--- a/app/views/mail_notifications/edition_rejected.text.erb
+++ b/app/views/mail_notifications/edition_rejected.text.erb
@@ -1,6 +1,6 @@
 Hi,
 
-The <%= @edition.class.model_name.human.downcase %> '<%= @edition.title %>' was rejected by <%= @edition.rejected_by.name %>.  You can make changes to this <%= @edition.class.model_name.human.downcase %>, and view the editorial remarks by visiting the following URL: <%= @admin_url %>.
+The <%= @edition.format_name %> '<%= @edition.title %>' was rejected by <%= @edition.rejected_by.name %>.  You can make changes to this <%= @edition.format_name %>, and view the editorial remarks by visiting the following URL: <%= @admin_url %>.
 
 All the best,
 


### PR DESCRIPTION
There were a few places where we just downcased the edition type instead of using its #format_name method.

This resulted in multi-word edition types from rendering incorrectly in emails.

For example, 'detailed guide' was being rendered as 'detailedguide'.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
