### PR TITLE
Update link anchor to open 'Fact checking' tab

### DIFF
--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -22,7 +22,7 @@ class MailNotifications < ApplicationMailer
   def fact_check_response(request, url_options)
     @fact_check_request = request
     @url_options = url_options
-    @comment_url = admin_edition_url(request.edition, url_options.merge(anchor: dom_id(request)))
+    @comment_url = admin_edition_url(request.edition, url_options.merge(anchor: "fact_checking_tab"))
 
     to_address = request.requestor.email
     subject = "Fact check comment added by #{request.email_address}: #{request.edition_title}"

--- a/test/functional/notifications_fact_check_request_response_test.rb
+++ b/test/functional/notifications_fact_check_request_response_test.rb
@@ -15,10 +15,6 @@ class NotificationsFactCheckRequestTest < ActionMailer::TestCase
     @mail = MailNotifications.fact_check_request(@request, host: "example.com")
   end
 
-  teardown do
-    Fog::Mock.reset
-  end
-
   test "email should be sent to the fact checker email address" do
     assert_equal ["fact-checker@example.com"], @mail.to
   end
@@ -63,13 +59,13 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
   include Admin::EditionRoutesHelper
 
   setup do
-    @publication = build(:publication, title: "<publication-title>")
-    @requestor = build(
+    @publication = create(:publication, title: "<publication-title>")
+    @requestor = create(
       :fact_check_requestor,
       name: "<requestor-name>",
       email: "fact-check-requestor@example.com",
     )
-    @request = build(
+    @request = create(
       :fact_check_request,
       email_address: "fact-checker@example.com",
       edition: @publication,
@@ -87,7 +83,7 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
   end
 
   test "email body should contain a link to the comment on the edition page" do
-    url = admin_edition_url(@request.edition, anchor: dom_id(@request), host: "example.com")
+    url = admin_edition_url(@request.edition, anchor: "fact_checking_tab", host: "example.com")
     assert_match Regexp.new(url), @mail.body.to_s
   end
 


### PR DESCRIPTION
The fact check response email contains a link that publishers can click to see the comment left by the reviewer.

However the link anchor has changed following a move to the GOV.UK Design System, which resulted in element IDs changing on the page.

This new link will automatically show and jump to the 'Fact checking' tab so users can see the comment.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
