### PR TITLE
[14/02/2023] Remove release 1.5 what's new banner

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     whats_new:
-      show_banner: true
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.


### PR DESCRIPTION
This PR:

- removes the release 1.5 what's new phase banner
- removes the inset text for merging history and notes
- removes the related test for merging history and notes

Merge and release on 14 February 2023.

https://trello.com/c/W1dVQV4w/4-remove-15-whats-new-banner-and-inset-text-for-history

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
