### PR TITLE
Move Edit Edition and Translation pages into the next release

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,10 +42,6 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
-    # Temporarily force the 'next release' of Design System to be shown to everybody.
-    # This will be tidied up alongside the removal of now-defunct Bootstrap code for affected features.
-    return true if next_release
-
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
 

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -3,11 +3,11 @@ class Admin::EditionTranslationsController < Admin::BaseController
   layout :get_layout
 
   def new
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new", next_release: true)
   end
 
   def edit
-    render_design_system("edit", "edit_legacy", next_release: false)
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
@@ -16,7 +16,7 @@ class Admin::EditionTranslationsController < Admin::BaseController
       save_draft_translation if send_downstream?
       redirect_to update_redirect_path, notice: notice_message("saved")
     else
-      render_design_system("edit", "edit_legacy", next_release: false)
+      render_design_system("edit", "edit_legacy", next_release: true)
     end
   end
 
@@ -26,7 +26,7 @@ private
 
   def get_layout
     design_system_actions = %w[edit update new confirm_destroy]
-    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"
@@ -54,7 +54,7 @@ private
   end
 
   def load_translated_models
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1)
     else
       @document_remarks = Document::PaginatedRemarks.new(@edition.document, params[:remarks_page])

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -90,10 +90,10 @@ class Admin::EditionsController < Admin::BaseController
       updater.perform!
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
-      flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: false)
-      @information = updater.failure_reason unless preview_design_system?(next_release: false)
+      flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: true)
+      @information = updater.failure_reason unless preview_design_system?(next_release: true)
       build_edition_dependencies
-      render_design_system(:new, :new_legacy, next_release: false)
+      render_design_system(:new, :new_legacy, next_release: true)
     end
   end
 
@@ -115,19 +115,19 @@ class Admin::EditionsController < Admin::BaseController
 
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
-      flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: false)
-      @information = updater.failure_reason unless preview_design_system?(next_release: false)
+      flash.now[:alert] = "There are some problems with the document" unless preview_design_system?(next_release: true)
+      @information = updater.failure_reason unless preview_design_system?(next_release: true)
       build_edition_dependencies
       fetch_version_and_remark_trails
       construct_similar_slug_warning_error
-      render_design_system(:edit, :edit_legacy, next_release: false)
+      render_design_system(:edit, :edit_legacy, next_release: true)
     end
   rescue ActiveRecord::StaleObjectError
     flash.now[:alert] = "This document has been saved since you opened it"
     @conflicting_edition = Edition.find(params[:id])
     @edition.lock_version = @conflicting_edition.lock_version
     build_edition_dependencies
-    render_design_system(:edit, :edit_legacy, next_release: false)
+    render_design_system(:edit, :edit_legacy, next_release: true)
   end
 
   def revise
@@ -194,7 +194,7 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy diff show]
-    design_system_actions += %w[edit update new create] if preview_design_system?(next_release: false)
+    design_system_actions += %w[edit update new create] if preview_design_system?(next_release: true)
     if design_system_actions.include?(action_name)
       "design_system"
     else
@@ -335,7 +335,7 @@ private
 
   def build_national_exclusion_params
     design_system_controllers = %w[consultations detailed_guides publications]
-    return unless design_system_controllers.include?(controller_name) && preview_design_system?(next_release: false)
+    return unless design_system_controllers.include?(controller_name) && preview_design_system?(next_release: true)
 
     exclusion_params = edition_params["all_nation_applicability"]
     return if exclusion_params.blank? || edition_params["nation_inapplicabilities_attributes"].blank?
@@ -437,7 +437,7 @@ private
     return if edition_params.empty?
 
     edition_params[:title].strip! if edition_params[:title]
-    edition_params.delete(:primary_locale) if edition_params[:primary_locale].blank? || (preview_design_system?(next_release: false) && edition_params[:create_foreign_language_only].blank?)
+    edition_params.delete(:primary_locale) if edition_params[:primary_locale].blank? || (preview_design_system?(next_release: true) && edition_params[:create_foreign_language_only].blank?)
     edition_params.delete(:create_foreign_language_only)
     edition_params[:external_url] = nil if edition_params[:external] == "0"
     edition_params[:change_note] = nil if edition_params[:minor_change] == "true"


### PR DESCRIPTION
## Description

This moves the Edit Edition and Edit Translation pages into behind the "Preview next release" so that users with the permission are able to view them in the Design System,

It also removes the override from the "BaseController#preview_design_system` method which allows all users to view the pages flagged as in the next release. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
