### PR TITLE
Remove ability to run broken links report from Edit Edition page

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -6,7 +6,7 @@
   link_check_report ||= nil
 %>
 
-<%= render('admin/link_check_reports/link_check_report', report: link_check_report) if link_check_report %>
+<%= render('admin/link_check_reports/link_check_report', report: link_check_report, render_broken_links_button: false) if link_check_report %>
 
 <div class="govspeak-help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,3 +1,5 @@
+<% render_broken_links_button ||= true %>
+
 <div data-module="broken-links-report">
   <% if report.new_record? %>
     <%= render "components/inset_prompt", {
@@ -54,10 +56,12 @@
         <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
           <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
         <% end %>
-        <%= render partial: 'admin/link_check_reports/form', locals: {
-          reportable: report.link_reportable,
-          button_text: 'Check again'
-        } %>
+        <% if render_broken_links_button %>
+          <%= render partial: 'admin/link_check_reports/form', locals: {
+            reportable: report.link_reportable,
+            button_text: 'Check again'
+          } %>
+        <% end %>
       <% end,
       error: true
     } %>


### PR DESCRIPTION
## Description

In Bootstrap you can only run the broken links report from the Edition Summary page.

Currently, in the GOV.UK Design System we always allow this.

This adds in a bit of functionality to hide the run report buttons if a
`render_broken_links_button: false` is passed into the partial.

## Trello card

https://trello.com/c/KLzIk1bW/70-broken-link-checker-on-edit-page


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
