### PR TITLE
Ensure Edit Edition's styling is consistent

### DIFF
--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -9,8 +9,10 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
-    <%= render 'world_location_fields', form: form, edition: edition %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
+      <%= render 'world_location_fields', form: form, edition: edition %>
+      <%= render 'organisation_fields', form: form, edition: edition %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/consultations/_date_fields.html.erb
+++ b/app/views/admin/consultations/_date_fields.html.erb
@@ -1,73 +1,77 @@
-<%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Opening date (required)",
-  heading_size: "s",
-  id: "edition_opening_at",
-} do %>
-  <%= render "components/datetime_fields", {
-      field_name: "opening_at",
-      prefix: "edition",
-      error_items: errors_for(edition.errors, :opening_at),
-      date_hint: "For example, 01 August 2022",
-      time_hint: "For example, 09:30 or 19:30",
-      year: {
-        value: edition.opening_at&.year,
-        start_year: 1997,
-        end_year: Date.today.year + 5,
-        id: "edition_opening_at_1i",
-      },
-      month: {
-        value: edition.opening_at&.month,
-        id: "edition_opening_at_2i",
-      },
-      day: {
-        value: edition.opening_at&.day,
-        id: "edition_opening_at_3i",
-      },
-      hour: {
-        value: edition.opening_at&.hour,
-        id: "edition_opening_at_4i",
-      },
-      minute: {
-        value: edition.opening_at&.min,
-        id: "edition_opening_at_5i",
-      },
-    }
-  %>
-<% end %>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Opening date (required)",
+    heading_size: "l",
+    id: "edition_opening_at",
+  } do %>
+    <%= render "components/datetime_fields", {
+        field_name: "opening_at",
+        prefix: "edition",
+        error_items: errors_for(edition.errors, :opening_at),
+        date_hint: "For example, 01 August 2022",
+        time_hint: "For example, 09:30 or 19:30",
+        year: {
+          value: edition.opening_at&.year,
+          start_year: 1997,
+          end_year: Date.today.year + 5,
+          id: "edition_opening_at_1i",
+        },
+        month: {
+          value: edition.opening_at&.month,
+          id: "edition_opening_at_2i",
+        },
+        day: {
+          value: edition.opening_at&.day,
+          id: "edition_opening_at_3i",
+        },
+        hour: {
+          value: edition.opening_at&.hour,
+          id: "edition_opening_at_4i",
+        },
+        minute: {
+          value: edition.opening_at&.min,
+          id: "edition_opening_at_5i",
+        },
+      }
+    %>
+  <% end %>
+</div>
 
-<%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Closing date (required)",
-  heading_size: "s",
-  id: "edition_closing_at",
-} do %>
-  <%= render "components/datetime_fields", {
-      field_name: "closing_at",
-      prefix: "edition",
-      error_items: errors_for(edition.errors, :closing_at),
-      date_hint: "For example, 01 August 2022",
-      time_hint: "For example, 09:30 or 19:30",
-      year: {
-        value: edition.closing_at&.year,
-        start_year: 1997,
-        end_year: Date.today.year + 5,
-        id: "edition_closing_at_1i",
-      },
-      month: {
-        value: edition.closing_at&.month,
-        id: "edition_closing_at_2i",
-      },
-      day: {
-        value: edition.closing_at&.day,
-        id: "edition_closing_at_3i",
-      },
-      hour: {
-        value: edition.closing_at&.hour,
-        id: "edition_closing_at_4i",
-      },
-      minute: {
-        value: edition.closing_at&.min,
-        id: "edition_closing_at_5i",
-      },
-    }
-  %>
-<% end %>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Closing date (required)",
+    heading_size: "l",
+    id: "edition_closing_at",
+  } do %>
+    <%= render "components/datetime_fields", {
+        field_name: "closing_at",
+        prefix: "edition",
+        error_items: errors_for(edition.errors, :closing_at),
+        date_hint: "For example, 01 August 2022",
+        time_hint: "For example, 09:30 or 19:30",
+        year: {
+          value: edition.closing_at&.year,
+          start_year: 1997,
+          end_year: Date.today.year + 5,
+          id: "edition_closing_at_1i",
+        },
+        month: {
+          value: edition.closing_at&.month,
+          id: "edition_closing_at_2i",
+        },
+        day: {
+          value: edition.closing_at&.day,
+          id: "edition_closing_at_3i",
+        },
+        hour: {
+          value: edition.closing_at&.hour,
+          id: "edition_closing_at_4i",
+        },
+        minute: {
+          value: edition.closing_at&.min,
+          id: "edition_closing_at_5i",
+        },
+      }
+    %>
+  <% end %>
+</div>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -5,40 +5,42 @@
 </div>
 
 <%= standard_edition_form(edition, @information, preview_design_system: true) do |form| %>
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: ""
-  } do %>
-    <%= form.hidden_field :external, value: "0" %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: ""
+    } do %>
+      <%= form.hidden_field :external, value: "0" %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[external]",
-      heading: "Held on another website",
-      heading_level: 3,
-      heading_size: "l",
-      no_hint_text: true,
-      error_items: errors_for(edition.errors, :external),
-      items: [
-        {
-          label: "This #{edition.class.name.humanize.downcase} is held on another website",
-          value: 1,
-          checked: edition.external,
-          bold: true,
-          conditional: render("govuk_publishing_components/components/input", {
-            label: {
-              text: "External link URL",
-              bold: true,
-            },
-            name: "edition[external_url]",
-            id: "edition_external_url",
-            value: edition.external_url,
-            error_items: errors_for(edition.errors, :external_url)
-          })
-        }
-      ]
-    } %>
-  <% end %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[external]",
+        heading: "Held on another website",
+        heading_level: 3,
+        heading_size: "l",
+        no_hint_text: true,
+        error_items: errors_for(edition.errors, :external),
+        items: [
+          {
+            label: "This #{edition.class.name.humanize.downcase} is held on another website",
+            value: 1,
+            checked: edition.external,
+            bold: true,
+            conditional: render("govuk_publishing_components/components/input", {
+              label: {
+                text: "External link URL",
+                bold: true,
+              },
+              name: "edition[external_url]",
+              id: "edition_external_url",
+              value: edition.external_url,
+              error_items: errors_for(edition.errors, :external_url)
+            })
+          }
+        ]
+      } %>
+    <% end %>
+  </div>
 
-  <div class="js-external-url-set">
+  <div class="govuk-!-margin-bottom-8">
     <%= render "govuk_publishing_components/components/fieldset", {
       legend_text: "Ways to respond",
       heading_level: 3,
@@ -46,30 +48,33 @@
     } do %>
       <% consultation_participation = edition.consultation_participation || edition.build_consultation_participation %>
       <%= hidden_field_tag "edition[consultation_participation_attributes][id]", consultation_participation.id %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Link URL",
-          bold: true,
         },
         name: "edition[consultation_participation_attributes][link_url]",
         id: "edition_consultation_participation_link_url",
+        heading_size: "m",
         value: consultation_participation.link_url,
         error_items: errors_for(consultation_participation.errors, :link_url),
       } %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Email",
-          bold: true,
         },
         name: "edition[consultation_participation_attributes][email]",
         id: "edition_consultation_participation_email",
+        heading_size: "m",
         value: consultation_participation.email,
         error_items: errors_for(consultation_participation.errors, :email),
       } %>
+
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: "Postal address",
-          bold: true,
+          heading_size: "m",
         },
         name: "edition[consultation_participation_attributes][postal_address]",
         id: "edition_consultation_participation_postal_address",
@@ -77,18 +82,21 @@
         error_items: errors_for(consultation_participation.errors, :postal_address),
         rows: 4,
       } %>
+
       <% consultation_response_form = consultation_participation.consultation_response_form || consultation_participation.build_consultation_response_form %>
       <% consultation_response_form_data = consultation_response_form.consultation_response_form_data || consultation_response_form.build_consultation_response_form_data %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Downloadable response form title",
-          bold: true,
         },
         name: "edition[consultation_participation_attributes][consultation_response_form_attributes][title]",
         id: "edition_consultation_participation_consultation_response_form_title",
+        heading_size: "m",
         value: consultation_response_form.title,
         error_items: errors_for(consultation_response_form.errors, :title),
       } %>
+
       <% if consultation_response_form.consultation_response_form_data.try(:persisted?) %>
         <div class="attachment">
           <p class="govuk-body">Current data: <%= link_to File.basename(consultation_response_form.consultation_response_form_data.file.path), consultation_response_form.consultation_response_form_data.file.url, class: "govuk-link" %></p>
@@ -101,6 +109,7 @@
             heading: "Actions:",
             name: "edition[consultation_participation_attributes][consultation_response_form_attributes][attachment_action]",
             id: "edition_consultation_participation_consultation_response_form_attachment_action",
+            heading_size: "m",
             error_items: errors_for(consultation_response_form.errors, :attachment_action),
             items: [
               {
@@ -134,7 +143,7 @@
         <%= render "govuk_publishing_components/components/file_upload", {
           label: {
             text: "File",
-            bold: true,
+            heading_size: "m",
           },
           name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
           id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
@@ -149,10 +158,8 @@
     <% end %>
   </div>
 
-  <div class="js-external-url-set">
-    <%= render 'html_version_fields', form: form, edition: edition %>
-    <%= render 'inline_attachments_info', form: form, edition: edition %>
-  </div>
+  <%= render 'html_version_fields', form: form, edition: edition %>
+  <%= render 'inline_attachments_info', form: form, edition: edition %>
 
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
@@ -160,32 +167,34 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <div class="js-external-url-set">
+    <div class="govuk-!-margin-bottom-4">
       <%= render 'appointment_fields', form: form, edition: edition %>
+      <%= render 'topical_event_fields', form: form, edition: edition %>
+      <%= render 'nation_fields', form: form, edition: edition %>
+      <%= render 'organisation_fields', form: form, edition: edition %>
     </div>
-
-    <%= render 'topical_event_fields', form: form, edition: edition %>
-    <%= render 'nation_fields', form: form, edition: edition %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
   <% end %>
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Consultation principles",
-    heading_level: 3,
-    heading_size: "l"
-  } do %>
-    <%= form.hidden_field :read_consultation_principles, value: "0" %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[read_consultation_principles]",
-      id: "edition_read_consultation_principles",
-      error_items: errors_for(edition.errors, :read_consultation_principles),
-      items: [
-        {
-          label: sanitize("We have considered the #{tag.a("consultation principles", href: 'https://www.gov.uk/government/publications/consultation-principles-guidance', class: 'govuk-link')}"),
-          value: 1,
-          checked: edition.read_consultation_principles,
-        }
-      ]
-    } %>
-  <% end %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "Consultation principles",
+      heading_level: 3,
+      heading_size: "l"
+    } do %>
+      <%= form.hidden_field :read_consultation_principles, value: "0" %>
+
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[read_consultation_principles]",
+        id: "edition_read_consultation_principles",
+        error_items: errors_for(edition.errors, :read_consultation_principles),
+        items: [
+          {
+            label: sanitize("We have considered the #{tag.a("consultation principles", href: 'https://www.gov.uk/government/publications/consultation-principles-guidance', class: 'govuk-link')}"),
+            value: 1,
+            checked: edition.read_consultation_principles,
+          }
+        ]
+      } %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -11,25 +11,29 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
-    <%= render "topical_event_fields", form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'organisation_fields', form: form, edition: edition %>
+      <%= render "topical_event_fields", form: form, edition: edition %>
 
-    <% cache_if edition.related_detailed_guide_ids.empty?, "#{taggable_detailed_guides_cache_digest}-design-system" do %>
-      <%= render "components/autocomplete", {
-        id: "edition_related_detailed_guide_ids",
-        name: "edition[related_detailed_guide_ids][]",
-        error_items: errors_for(edition.errors, :related_detailed_guide_ids),
-        label: {
-          text: "Related guides",
-          bold: true,
-        },
-        select: {
-          options: [""] + taggable_detailed_guides_container,
-          multiple: true,
-          selected: edition.related_detailed_guide_ids,
-        },
-      } %>
-    <% end %>
+      <% cache_if edition.related_detailed_guide_ids.empty?, "#{taggable_detailed_guides_cache_digest}-design-system" do %>
+        <%= render "components/autocomplete", {
+          id: "edition_related_detailed_guide_ids",
+          name: "edition[related_detailed_guide_ids][]",
+          error_items: errors_for(edition.errors, :related_detailed_guide_ids),
+          label: {
+            text: "Related guides",
+            heading_size: "m",
+          },
+          select: {
+            options: [""] + taggable_detailed_guides_container,
+            multiple: true,
+            selected: edition.related_detailed_guide_ids,
+          },
+        } %>
+      <% end %>
+
+      <%= render 'nation_fields', form: form, edition: edition %>        
+    </div>
   <% end %>
 
   <%= render 'inline_attachments_info', form: form, edition: edition %>
@@ -42,7 +46,7 @@
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Related mainstream content url",
-        bold: true,
+        heading_size: "m",
       },
       hint: "Link to the top-level URL for mainstream content - not a specific chapter.",
       name: "edition[related_mainstream_content_url]",
@@ -53,7 +57,7 @@
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Additional related mainstream content url",
-        bold: true,
+        heading_size: "m",
       },
       name: "edition[additional_related_mainstream_content_url]",
       id: "edition_additional_related_mainstream_content_url",
@@ -61,6 +65,4 @@
       error_items: errors_for(edition.errors, :additional_related_mainstream_content_url),
     } %>
   <% end %>
-
-  <%= render 'nation_fields', form: form, edition: edition %>
 <% end %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -9,7 +9,9 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
-    <%= render "topical_event_fields", form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'organisation_fields', form: form, edition: edition %>
+      <%= render "topical_event_fields", form: form, edition: edition %>        
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -1,20 +1,22 @@
-<%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Access limiting",
-  heading_level: 3,
-  heading_size: "l"
-} do %>
-  <%= form.hidden_field :access_limited, value: "0" %>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Access limiting",
+    heading_level: 3,
+    heading_size: "l"
+  } do %>
+    <%= form.hidden_field :access_limited, value: "0" %>
 
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    name: "edition[access_limited]",
-    id: "edition_access_limited",
-    error_items: errors_for(edition.errors, :access_limited),
-    items: [
-      {
-        label: "Limit access to producing organisations prior to publication",
-        value: 1,
-        checked: edition.access_limited,
-      }
-    ]
-  } %>
-<% end %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "edition[access_limited]",
+      id: "edition_access_limited",
+      error_items: errors_for(edition.errors, :access_limited),
+      items: [
+        {
+          label: "Limit access to producing organisations prior to publication",
+          value: 1,
+          checked: edition.access_limited,
+        }
+      ]
+    } %>
+  <% end %>  
+</div>

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -4,7 +4,7 @@
     name: "edition[role_appointment_ids][]",
     label: {
       text: "Ministers",
-      bold: true,
+      heading_size: "m",
     },
     select: {
       options: [""] + taggable_ministerial_role_appointments_container,

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -30,36 +30,40 @@
 %>
 
 <% if edition.published_major_version.nil? %>
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Document status (required)",
-    heading_size: "l",
-    id: "edition_first_published_at"
-  } do %>
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "edition[previously_published]",
-      id: "edition_previously_published",
-      error_items: errors_for(edition.errors, :previously_published),
-      items: [
-        {
-          value: false,
-          text: "This document has never been published before.",
-          checked: edition.previously_published == false
-        },
-        {
-          value: true,
-          text: "This document has previously been published on another website.",
-          checked: edition.previously_published,
-          conditional: first_published_at_fields
-        }
-      ]
-    } %>
+  <div class="govuk-!-margin-bottom-4">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "Document status (required)",
+      heading_size: "l",
+      id: "edition_first_published_at"
+    } do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "edition[previously_published]",
+        id: "edition_previously_published",
+        error_items: errors_for(edition.errors, :previously_published),
+        items: [
+          {
+            value: false,
+            text: "This document has never been published before.",
+            checked: edition.previously_published == false
+          },
+          {
+            value: true,
+            text: "This document has previously been published on another website.",
+            checked: edition.previously_published,
+            conditional: first_published_at_fields
+          }
+        ]
+      } %>
+  </div>
   <% end %>
 <% else %>
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "First published (required)",
-    heading_size: "l",
-    hint: "For example, 31 3 2000",
-  } do %>
-    <%= first_published_at_fields %>
-  <% end %>
+  <div class="govuk-!-margin-bottom-4">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "First published (required)",
+      heading_size: "l",
+      hint: "For example, 31 3 2000",
+    } do %>
+      <%= first_published_at_fields %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/admin/editions/_html_version_fields.html.erb
+++ b/app/views/admin/editions/_html_version_fields.html.erb
@@ -1,12 +1,14 @@
-<h3 class="govuk-heading-l">HTML attachment</h3>
+<div class="govuk-!-margin-bottom-8">
+  <h3 class="govuk-heading-l">HTML attachment</h3>
 
-<p class="govuk-body">
-  <% if @edition.persisted? %>
-    You can create and edit HTML attachments in the
-    <%= link_to 'same tab as the other attachments', admin_edition_attachments_path(@edition), class: "govuk-link" %>.
-  <% else %>
-    If you’d like to add an HTML attachment to this document, please save
-    it first. You’ll then find a new tab at the top of the page that you
-    can use to create, edit and delete attachments.
-  <% end %>
-</p>
+  <p class="govuk-body">
+    <% if @edition.persisted? %>
+      You can create and edit HTML attachments in the
+      <%= link_to 'same tab as the other attachments', admin_edition_attachments_path(@edition), class: "govuk-link" %>.
+    <% else %>
+      If you’d like to add an HTML attachment to this document, please save
+      it first. You’ll then find a new tab at the top of the page that you
+      can use to create, edit and delete attachments.
+    <% end %>
+  </p>
+</div>

--- a/app/views/admin/editions/_image_fields_case_studies.html.erb
+++ b/app/views/admin/editions/_image_fields_case_studies.html.erb
@@ -2,6 +2,7 @@
   heading: "Images",
   name: "edition[image_display_option]",
   id: "edition_image_display_option",
+  heading_size: "l",
   items: [
     {
       value: "no_image",

--- a/app/views/admin/editions/_inline_attachments_info.html.erb
+++ b/app/views/admin/editions/_inline_attachments_info.html.erb
@@ -1,39 +1,41 @@
-<%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Attachments",
-  heading_size: "l",
-  id: "edition_alternative_format_provider",
-  error_message: errors_for_input(edition.errors, :alternative_format_provider)
-} do %>
-  <% if edition.new_record? %>
-    <p class="govuk-body">
-      If you’d like to add an attachment to this document, please save
-      it first. You’ll then find a new tab at the top of the page that you
-      can use to upload, edit and delete attachments.
-    </p>
-  <% elsif edition.allows_inline_attachments? %>
-    <%= render 'admin/attachments/markdown_codes', attachable: edition %>
-  <% end %>
-  <% if edition.respond_to?(:alternative_format_provider) %>
-    <div class="govuk-form-group gem-c-select">
-      <label class="govuk-label govuk-!-font-weight-bold" for="alternative_format_provider_id">
-        Email address for ordering attachment files in an alternative format <%= "(required)" if edition.alternative_format_provider_required? %>
-      </label>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Attachments",
+    heading_size: "l",
+    id: "edition_alternative_format_provider",
+    error_message: errors_for_input(edition.errors, :alternative_format_provider)
+  } do %>
+    <% if edition.new_record? %>
+      <p class="govuk-body">
+        If you’d like to add an attachment to this document, please save
+        it first. You’ll then find a new tab at the top of the page that you
+        can use to upload, edit and delete attachments.
+      </p>
+    <% elsif edition.allows_inline_attachments? %>
+      <%= render 'admin/attachments/markdown_codes', attachable: edition %>
+    <% end %>
+    <% if edition.respond_to?(:alternative_format_provider) %>
+      <div class="govuk-form-group gem-c-select">
+        <label class="govuk-label govuk-label--m govuk-!-font-weight-bold" for="alternative_format_provider_id">
+          Email address for ordering attachment files in an alternative format <%= "(required)" if edition.alternative_format_provider_required? %>
+        </label>
 
-      <div id="alternative-format-provider-hint" class="gem-c-hint govuk-hint govuk-!-margin-bottom-3">
-        If the email address you need isn’t here, it should be added to the relevant Department or Agency
+        <div id="alternative-format-provider-hint" class="gem-c-hint govuk-hint govuk-!-margin-bottom-3">
+          If the email address you need isn’t here, it should be added to the relevant Department or Agency
+        </div>
+
+        <select name="edition[alternative_format_provider_id]" id="edition_alternative_format_provider_id" class="govuk-select" aria-describedby="alternative-format-provider-hint">
+          <option></option>
+          <% taggable_alternative_format_providers_container.each do |name, id| %>
+            <option
+              value="<%= id %>"
+              <%="disabled='disabled'" if name.end_with?('(-)') %>
+              <%="selected" if (id == edition.alternative_format_provider_id || id == current_user.organisation.try(:id)) %>>
+              <%= name %>
+            </option>
+          <% end %>
+        </select>
       </div>
-
-      <select name="edition[alternative_format_provider_id]" id="edition_alternative_format_provider_id" class="govuk-select" aria-describedby="alternative-format-provider-hint">
-        <option></option>
-        <% taggable_alternative_format_providers_container.each do |name, id| %>
-          <option
-            value="<%= id %>"
-            <%="disabled='disabled'" if name.end_with?('(-)') %>
-            <%="selected" if (id == edition.alternative_format_provider_id || id == current_user.organisation.try(:id)) %>>
-            <%= name %>
-          </option>
-        <% end %>
-      </select>
-    </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
+<div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "edition[create_foreign_language_only]",
     id: "edition_create_foreign_language_only",
@@ -15,7 +15,7 @@
           id: "edition_primary_locale",
           name: "edition[primary_locale]",
           label: "Document language",
-          heading_size: "s",
+          heading_size: "m",
           full_width: true,
           allow_blank: true,
           errors: errors_for(edition.errors, :primary_locale),

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -11,7 +11,7 @@
   name: "edition[all_nation_applicability][]",
   id: "edition_nation_inapplicabilities",
   heading: "Excluded nations",
-  heading_size: "l",
+  heading_size: "m",
   error: errors_for_input(edition.errors, :nation_inapplicabilities),
   no_hint_text: true,
   items: [

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -2,7 +2,7 @@
   id: "edition_operational_field_id",
   label: "Field of operation (required)",
   name: "edition[operational_field_id]",
-  heading_size: "s",
+  heading_size: "l",
   error_message: errors_for_input(edition.errors, :operational_field_id),
   options: ([nil] + OperationalField.all).map do |operation|
     {

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -2,38 +2,35 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Organisations",
     heading_level: 3,
-    heading_size: "l",
+    heading_size: "m",
     id: "edition_organisations",
     error_message: errors_for_input(edition.errors, :organisations)
     } do %>
-
-    <h4 class="govuk-heading-m">Lead organisations</h4>
-
-    <% 0.upto(3) do |index| %>
-      <% lead_organisation_id = lead_organisation_id_at_index(edition, index) %>
-      <% cache_if lead_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
-        <%= render "govuk_publishing_components/components/select", {
-            id: "edition_lead_organisation_ids_#{index + 1}",
-            name: "edition[lead_organisation_ids][]",
-            label: "Lead organisation #{index + 1}",
-            heading_size: "s",
-            data: {
-                module: 'track-select-click',
-                track_category: 'leadOrgSelection',
-                track_label: request.path
-            },
-            options: ([""] + taggable_organisations_container).map do |name, id|
-            {
-              text: name,
-              value: id,
-              selected: id == lead_organisation_id
-            }
-           end
-        } %>
+    <div class="govuk-!-margin-bottom-8">
+      <% 0.upto(3) do |index| %>
+        <% lead_organisation_id = lead_organisation_id_at_index(edition, index) %>
+        <% cache_if lead_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
+          <%= render "govuk_publishing_components/components/select", {
+              id: "edition_lead_organisation_ids_#{index + 1}",
+              name: "edition[lead_organisation_ids][]",
+              label: "Lead organisation #{index + 1}",
+              heading_size: "s",
+              data: {
+                  module: 'track-select-click',
+                  track_category: 'leadOrgSelection',
+                  track_label: request.path
+              },
+              options: ([""] + taggable_organisations_container).map do |name, id|
+              {
+                text: name,
+                value: id,
+                selected: id == lead_organisation_id
+              }
+             end
+          } %>
+        <% end %>
       <% end %>
-    <% end %>
-
-    <h4 class="govuk-heading-m">Supporting organisations</h4>
+    </div>
 
     <% 0.upto(5) do |index| %>
       <% supporting_organisation_id = supporting_organisation_id_at_index(edition, index) %>

--- a/app/views/admin/editions/_scheduled_publication_fields.html.erb
+++ b/app/views/admin/editions/_scheduled_publication_fields.html.erb
@@ -1,44 +1,46 @@
-<%= hidden_field_tag :scheduled_publication_active, 0, id: "" %>
+<div class="govuk-!-margin-bottom-8">
+  <%= hidden_field_tag :scheduled_publication_active, 0, id: "" %>
 
-<%= render "govuk_publishing_components/components/checkboxes", {
-  name: "scheduled_publication_active",
-  id: "scheduled_publication_active",
-  heading: "Scheduled publication",
-  heading_size: 'l',
-  error_items: errors_for(edition.errors, :scheduled_publication_active),
-  no_hint_text: true,
-  items: [
-    {
-      label: "Schedule for publication",
-      value: 1,
-      checked: edition.scheduled_publication.present?,
-      conditional: render("components/datetime_fields", {
-            field_name: "scheduled_publication",
-            prefix: "edition",
-            error_items: errors_for(edition.errors, :scheduled_publication),
-            date_hint: "For example, 01 August 2022",
-            time_hint: "For example, 09:30 or 19:30",
-            year: {
-              value: edition.scheduled_publication&.year || Time.zone.today.year,
-              id: "edition_scheduled_publication_1i",
-            },
-            month: {
-              value: edition.scheduled_publication&.month || Time.zone.today.month,
-              id: "edition_scheduled_publication_2i",
-            },
-            day: {
-              value: edition.scheduled_publication&.day || Time.zone.today.day,
-              id: "edition_scheduled_publication_3i",
-            },
-            hour: {
-              value: edition.scheduled_publication&.hour || 9,
-              id: "edition_scheduled_publication_4i",
-            },
-            minute: {
-              value: edition.scheduled_publication&.min || 30,
-              id: "edition_scheduled_publication_5i",
-            },
-          })
-    }
-  ]
-} %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "scheduled_publication_active",
+    id: "scheduled_publication_active",
+    heading: "Scheduled publication",
+    heading_size: 'l',
+    error_items: errors_for(edition.errors, :scheduled_publication_active),
+    no_hint_text: true,
+    items: [
+      {
+        label: "Schedule for publication",
+        value: 1,
+        checked: edition.scheduled_publication.present?,
+        conditional: render("components/datetime_fields", {
+              field_name: "scheduled_publication",
+              prefix: "edition",
+              error_items: errors_for(edition.errors, :scheduled_publication),
+              date_hint: "For example, 01 August 2022",
+              time_hint: "For example, 09:30 or 19:30",
+              year: {
+                value: edition.scheduled_publication&.year || Time.zone.today.year,
+                id: "edition_scheduled_publication_1i",
+              },
+              month: {
+                value: edition.scheduled_publication&.month || Time.zone.today.month,
+                id: "edition_scheduled_publication_2i",
+              },
+              day: {
+                value: edition.scheduled_publication&.day || Time.zone.today.day,
+                id: "edition_scheduled_publication_3i",
+              },
+              hour: {
+                value: edition.scheduled_publication&.hour || 9,
+                id: "edition_scheduled_publication_4i",
+              },
+              minute: {
+                value: edition.scheduled_publication&.min || 30,
+                id: "edition_scheduled_publication_5i",
+              },
+            })
+      }
+    ]
+  } %>
+</div>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -4,25 +4,30 @@
   <%= form.hidden_field :lock_version %>
 
   <% if edition.document&.slug.present? %>
-    <label for="edition_slug" class="gem-c-label govuk-label govuk-!-font-weight-bold">Slug (read only)</label>
-    <input disabled="disabled" class="gem-c-input govuk-input govuk-body govuk-!-margin-bottom-4" id="edition_slug" name="edition[slug]" readonly="readonly" spellcheck="false" type="text" value=<%= edition.slug %>>
+    <div class="govuk-!-margin-bottom-8">
+      <label for="edition_slug" class="gem-c-label govuk-label govuk-label--l govuk-!-font-weight-bold">Slug (read only)</label>
+      <input disabled="disabled" class="gem-c-input govuk-input govuk-body" id="edition_slug" name="edition[slug]" readonly="readonly" spellcheck="false" type="text" value=<%= edition.slug %>>
+    </div>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "Title (required)",
-      bold: true
-    },
-    name: "edition[title]",
-    id: "edition_title",
-    value: edition.title,
-    hint: "Title text should be 65 characters or fewer",
-    error_items: errors_for(edition.errors, :title),
-  } %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Title (required)",
+      },
+      name: "edition[title]",
+      id: "edition_title",
+      heading_size: "l",
+      value: edition.title,
+      hint: "Title text should be 65 characters or fewer",
+      error_items: errors_for(edition.errors, :title),
+    } %>
+  </div>
+
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
       text: "Summary" + "#{' (required)' if form.object.summary_required?}",
-       bold: true
+      heading_size: "l",
     },
     name: "edition[summary]",
     id: "edition_summary",
@@ -30,44 +35,52 @@
     rows: 4,
     hint: "Summary text should be 160 characters or fewer.",
     error_items: errors_for(edition.errors, :summary),
+    margin_bottom: 8,
   } %>
 
-  <%= render "components/govspeak-editor", {
-    label: {
-      text: "Body" + "#{' (required)' if form.object.body_required?}",
-        bold: true
-    },
-    name: "edition[body]",
-    id: "edition_body",
-    value: edition.body,
-    rows: 20,
-    error_items: errors_for(edition.errors, :body),
-    data_attributes: {
-      image_ids: edition.images.map { |img| img[:id] }.to_json,
-      attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
-      alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
-    }
-  } %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "components/govspeak-editor", {
+      label: {
+        text: "Body" + "#{' (required)' if form.object.body_required?}",
+        heading_size: "l",
+      },
+      name: "edition[body]",
+      id: "edition_body",
+      value: edition.body,
+      rows: 20,
+      error_items: errors_for(edition.errors, :body),
+      data_attributes: {
+        image_ids: edition.images.map { |img| img[:id] }.to_json,
+        attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
+        alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+      }
+    } %>
+  </div>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
   <% if edition.document && edition.document.live? && can?(:mark_political, edition) %>
-    <%= form.hidden_field :political, value: "0" %>
+    <div class="govuk-!-margin-bottom-8">
+      <%= form.hidden_field :political, value: "0" %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[political]",
-      id: "edition_political",
-      error: errors_for_input(edition.errors, :political),
-      items: [
-        {
-          label: "Associate with government of the time (currently set to #{edition.government&.name}).",
-          value: "1",
-          checked: edition.political
-        }
-      ]
-    } %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[political]",
+        id: "edition_political",
+        heading: "Political",
+        heading_size: "l",
+        no_hint_text: true,
+        error: errors_for_input(edition.errors, :political),
+        items: [
+          {
+            label: "Associate with government of the time (currently set to #{edition.government&.name}).",
+            value: "1",
+            checked: edition.political
+          }
+        ]
+      } %>
 
-    <p class="govuk-body"><%= link_to "Read the history mode guidance", 'https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode', class: "govuk-link" %> for more information as to what this means.</p>
+      <p class="govuk-body"><%= link_to "Read the history mode guidance", 'https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode', class: "govuk-link" %> for more information as to what this means.</p>
+    </div>
   <% end %>
 </div>
 

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -4,7 +4,7 @@
     name: "edition[statistical_data_set_document_ids][]",
     label: {
       text: "Statistical data sets",
-      bold: true,
+      heading_size: "m",
     },
     select: {
       options: [""] + taggable_statistical_data_sets_container,

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -4,7 +4,7 @@
     name: "edition[topical_event_ids][]",
     label: {
       text: "Topical events",
-      bold: true,
+      heading_size: "m",
     },
     select: {
       options: [""] + TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -6,7 +6,7 @@
     name: "edition[world_location_ids][]",
     label: {
       text: "World locations" + "#{' (required)' if required}",
-      bold: true,
+      heading_size: "m",
     },
     select: {
       options: taggable_world_locations_container,

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -6,7 +6,7 @@
     name: "edition[worldwide_organisation_ids][]",
     label: {
       text:  "Worldwide organisations" + "#{' (required)' if required}",
-      bold: true,
+      heading_size: "m",
     },
     select: {
       options: [""] + taggable_worldwide_organisations_container,

--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -10,9 +10,11 @@
   } do %>
     <p class="govuk-body">You'll be able to specialist sectors later.</p>
 
-    <%= render 'organisation_fields', form: form, edition: edition %>
-    <%= render 'appointment_fields', form: form, edition: edition %>
-    <%= render 'operational_field_fields', form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'organisation_fields', form: form, edition: edition %>
+      <%= render 'appointment_fields', form: form, edition: edition %>
+      <%= render 'operational_field_fields', form: form, edition: edition %>
+    </div>
   <% end %>
 
   <%= render "govuk_publishing_components/components/fieldset", {
@@ -23,7 +25,7 @@
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
         text: "Introduction (required)",
-        bold: true,
+        heading_size: "m",
         value: edition.roll_call_introduction,
       },
       name: "edition[roll_call_introduction]",

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -12,10 +12,12 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'appointment_fields', form: form, edition: edition %>
-    <%= render 'topical_event_fields', form: form, edition: edition %>
-    <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
-    <%= render 'world_location_fields', form: form, edition: edition %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'appointment_fields', form: form, edition: edition %>
+      <%= render 'topical_event_fields', form: form, edition: edition %>
+      <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
+      <%= render 'world_location_fields', form: form, edition: edition %>
+      <%= render 'organisation_fields', form: form, edition: edition %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -3,7 +3,7 @@
     name: "edition[news_article_type_id]",
     id: "edition_news_article_type_id",
     label: "News article type",
-    heading_size: "s",
+    heading_size: "l",
     full_width: true,
     value: edition.news_article_type_id,
     error_message: errors_for_input(edition.errors, :news_article_type_id),

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -12,13 +12,15 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <p class="govuk-body">You'll be able to select Topics and Specialist Sectors later.</p>
+    <div class="govuk-!-margin-bottom-4">
+      <p class="govuk-body">You'll be able to select Topics and Specialist Sectors later.</p>
 
-    <%= render 'appointment_fields', form: form, edition: edition %>
-    <%= render 'statistical_data_set_fields', form: form, edition: edition %>
-    <%= render 'topical_event_fields', form: form, edition: edition %>
-    <%= render 'world_location_fields', form: form, edition: edition %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
-    <%= render 'nation_fields', form: form, edition: edition %>
+      <%= render 'appointment_fields', form: form, edition: edition %>
+      <%= render 'statistical_data_set_fields', form: form, edition: edition %>
+      <%= render 'topical_event_fields', form: form, edition: edition %>
+      <%= render 'world_location_fields', form: form, edition: edition %>
+      <%= render 'organisation_fields', form: form, edition: edition %>
+      <%= render 'nation_fields', form: form, edition: edition %>        
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
-  <div class="govuk-form-group <%= "govuk-form-group--error" if errors_for_input(edition.errors, :publication_type_id).present? %>">
-    <label class="gem-c-label govuk-label govuk-!-font-weight-bold" for="edition_publication_type_id">
+  <div class="govuk-!-margin-bottom-8 govuk-form-group <%= "govuk-form-group--error" if errors_for_input(edition.errors, :publication_type_id).present? %>">
+    <label class="gem-c-label govuk-label govuk-label--l govuk-!-font-weight-bold" for="edition_publication_type_id">
       Publication type
     </label>
     <% if errors_for_input(edition.errors, :publication_type_id).present? %>

--- a/app/views/admin/speeches/_additional_significant_fields.html.erb
+++ b/app/views/admin/speeches/_additional_significant_fields.html.erb
@@ -1,11 +1,11 @@
 <%= render 'delivered_by_fields', form: form, edition: edition %>
 <%= render 'delivered_on_fields', form: form, edition: edition %>
 
-<div class="js-app-view-edit-edition__speech-location-field <%= "app-view-edit-edition__speech-location-field--hidden" if edition.authored_article? %>">
+<div class="js-app-view-edit-edition__speech-location-field <%= "app-view-edit-edition__speech-location-field--hidden" if edition.authored_article? %> govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Location",
-      bold: true,
+      heading_size: "l",
     },
     name: "edition[location]",
     id: "edition_location",

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -1,28 +1,30 @@
-<%= render "govuk_publishing_components/components/radio", {
-  name: "speaker_radios",
-  id: "edition_role_appointment",
-  heading: edition.authored_article? ? "Writer (required)" : "Speaker (required)",
-  heading_size: "s",
-  error_items: errors_for(edition.errors, :role_appointment),
-  items: [
-    {
-      value: "yes",
-      id: "edition_role_appointment_speaker_on_govuk",
-      text: "#{edition.authored_article? ? "Writer" : 'Speaker'} has a profile on GOV.UK",
-      checked: edition.role_appointment_id.present?,
-      conditional: render("speaker_select_field", form:, edition:)
-    },
-    {
-      value: "no",
-      id: "edition_role_appointment_speaker_not_on_govuk",
-      text: "#{edition.authored_article? ? "Writer" : 'Speaker'} does not have a profile on GOV.UK",
-      checked: edition.person_override.present?,
-      conditional: render("govuk_publishing_components/components/input", {
-        name: "edition[person_override]",
-        id: "edition_person_override",
-        value: edition.person_override,
-        error_items: errors_for(edition.errors, :person_override),
-      })
-    }
-  ]
-} %>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "speaker_radios",
+    id: "edition_role_appointment",
+    heading: edition.authored_article? ? "Writer (required)" : "Speaker (required)",
+    heading_size: "l",
+    error_items: errors_for(edition.errors, :role_appointment),
+    items: [
+      {
+        value: "yes",
+        id: "edition_role_appointment_speaker_on_govuk",
+        text: "#{edition.authored_article? ? "Writer" : 'Speaker'} has a profile on GOV.UK",
+        checked: edition.role_appointment_id.present?,
+        conditional: render("speaker_select_field", form:, edition:)
+      },
+      {
+        value: "no",
+        id: "edition_role_appointment_speaker_not_on_govuk",
+        text: "#{edition.authored_article? ? "Writer" : 'Speaker'} does not have a profile on GOV.UK",
+        checked: edition.person_override.present?,
+        conditional: render("govuk_publishing_components/components/input", {
+          name: "edition[person_override]",
+          id: "edition_person_override",
+          value: edition.person_override,
+          error_items: errors_for(edition.errors, :person_override),
+        })
+      }
+    ]
+  } %>  
+</div>

--- a/app/views/admin/speeches/_delivered_on_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_on_fields.html.erb
@@ -1,34 +1,36 @@
-<%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: edition.authored_article? ? "Written on (required)" : "Delivered on (required)",
-  heading_size: "l",
-  id: "edition_delivered_on",
-} do %>
-  <%= render "components/datetime_fields", {
-      field_name: "delivered_on",
-      prefix: "edition",
-      error_items: errors_for(edition.errors, :delivered_on),
-      date_hint: "For example, 01 August 2022",
-      time_hint: "For example, 09:30 or 19:30",
-      year: {
-        value: edition.delivered_on&.year,
-        id: "edition_delivered_on_1i",
-      },
-      month: {
-        value: edition.delivered_on&.month,
-        id: "edition_delivered_on_2i",
-      },
-      day: {
-        value: edition.delivered_on&.day,
-        id: "edition_delivered_on_3i",
-      },
-      hour: {
-        value: edition.delivered_on&.hour,
-        id: "edition_delivered_on_4i",
-      },
-      minute: {
-        value: edition.delivered_on&.min,
-        id: "edition_delivered_on_5i",
-      },
-    }
-  %>
-<% end %>
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: edition.authored_article? ? "Written on (required)" : "Delivered on (required)",
+    heading_size: "l",
+    id: "edition_delivered_on",
+  } do %>
+    <%= render "components/datetime_fields", {
+        field_name: "delivered_on",
+        prefix: "edition",
+        error_items: errors_for(edition.errors, :delivered_on),
+        date_hint: "For example, 01 August 2022",
+        time_hint: "For example, 09:30 or 19:30",
+        year: {
+          value: edition.delivered_on&.year,
+          id: "edition_delivered_on_1i",
+        },
+        month: {
+          value: edition.delivered_on&.month,
+          id: "edition_delivered_on_2i",
+        },
+        day: {
+          value: edition.delivered_on&.day,
+          id: "edition_delivered_on_3i",
+        },
+        hour: {
+          value: edition.delivered_on&.hour,
+          id: "edition_delivered_on_4i",
+        },
+        minute: {
+          value: edition.delivered_on&.min,
+          id: "edition_delivered_on_5i",
+        },
+      }
+    %>
+  <% end %>
+</div>

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -10,8 +10,10 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'topical_event_fields', form: form, edition: edition %>
-    <%= render 'world_location_fields', form: form, edition: edition %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'topical_event_fields', form: form, edition: edition %>
+      <%= render 'world_location_fields', form: form, edition: edition %>
+      <%= render 'organisation_fields', form: form, edition: edition %>        
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -3,7 +3,7 @@
     name: "edition[speech_type_id]",
     id: "edition_speech_type_id",
     label: "Speech type",
-    heading_size: "s",
+    heading_size: "l",
     full_width: true,
     value: edition.speech_type_id,
     error_message: errors_for_input(edition.errors, :speech_type_id),

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -12,6 +12,8 @@
     heading_size: "l",
     id: "associations"
   } do %>
-    <%= render 'organisation_fields', form: form, edition: edition %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render 'organisation_fields', form: form, edition: edition %>
+    </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Description

At the moment, the Edit Edition page has inconsistent styling. Different sized labels are used for different inputs with no clear reason and there is no consistent spacing applied throughout the page.

This PR does a few things:

1. Uses a large label for top level fields
2. If a fieldset is used, it uses a medium label  for fields within it to indicate the fields belong to the fieldset
3. Applies `govuk-!-margin-bottom-8` spacing between fields

## Screenshots

### Before

<img width="639" alt="image" src="https://user-images.githubusercontent.com/42515961/217206711-f884973d-4567-4ad4-abd7-5828574ab7b4.png">

<img width="474" alt="image" src="https://user-images.githubusercontent.com/42515961/217206768-7495cc4b-a2cd-48e7-bf14-235e31a60acb.png">

<img width="598" alt="image" src="https://user-images.githubusercontent.com/42515961/217206816-4351c2e2-4fbd-4a6c-b74f-0b1a675dbbfa.png">

<img width="566" alt="image" src="https://user-images.githubusercontent.com/42515961/217206866-695e6a22-2995-4411-acc8-a2b2e9153d07.png">


### After

<img width="604" alt="image" src="https://user-images.githubusercontent.com/42515961/217206450-c722adce-5751-40bc-a489-f3987f577977.png">

<img width="617" alt="image" src="https://user-images.githubusercontent.com/42515961/217206498-812568de-099d-468f-8fe5-9dee5d2fc5d8.png">

<img width="572" alt="image" src="https://user-images.githubusercontent.com/42515961/217206549-bf807f15-2a4b-4432-bee3-037bb605ea16.png">

<img width="540" alt="image" src="https://user-images.githubusercontent.com/42515961/217206599-b50ff087-979a-4721-abcc-355d27a25dcd.png">


## Trello card

https://trello.com/c/0fFXlJp2/6-make-styling-of-edit-edition-page-consistent
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
