### PR TITLE
Ensure new broken links report cannot be generated from edit page

### DIFF
--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -54,7 +54,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   BrokenLinksReport.prototype.poll = function (href, retry) {
-    fetch(href + '.json').then(function (response) { return response.json() })
+    if (href.includes('?')) {
+      href = href.split('?').join('.json?')
+    } else {
+      href = href + '.json'
+    }
+
+    fetch(href).then(function (response) { return response.json() })
       .then(function (json) {
         if (json.inProgress) {
           retry()

--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -46,7 +46,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       setTimeout(function () {
-        this.poll(refreshLink.href, retry)
+        this.poll(refreshLink.dataset.jsonHref, retry)
       }.bind(this), 2000)
     }.bind(this)
 
@@ -54,12 +54,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   BrokenLinksReport.prototype.poll = function (href, retry) {
-    if (href.includes('?')) {
-      href = href.split('?').join('.json?')
-    } else {
-      href = href + '.json'
-    }
-
     fetch(href).then(function (response) { return response.json() })
       .then(function (json) {
         if (json.inProgress) {

--- a/app/controllers/admin/link_check_reports_controller.rb
+++ b/app/controllers/admin/link_check_reports_controller.rb
@@ -17,6 +17,8 @@ class Admin::LinkCheckReportsController < Admin::BaseController
 
   def show
     @report = LinkCheckerApiReport.find(params[:id])
+    @allow_new_report = params[:allow_new_report] || false
+
     respond_to do |format|
       format.js
       format.html { redirect_to [:admin, @reportable] }

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -6,7 +6,7 @@
   link_check_report ||= nil
 %>
 
-<%= render('admin/link_check_reports/link_check_report', report: link_check_report, render_broken_links_button: false) if link_check_report %>
+<%= render('admin/link_check_reports/link_check_report', report: link_check_report, allow_new_report: false) if link_check_report %>
 
 <div class="govspeak-help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -4,7 +4,8 @@
   <%= render(
         partial: 'admin/link_check_reports/link_check_report',
         locals: {
-          report: (@edition.link_check_reports.last || @edition.link_check_reports.build)
+          report: (@edition.link_check_reports.last || @edition.link_check_reports.build),
+          allow_new_report: true,
         }
       ) if show_link_check_report?(@edition)
   %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -15,9 +15,7 @@
       description: capture do %>
         <p class="govuk-body">Broken link report in progress.</p>
         <p class="govuk-body">
-          <%= link_to "Check progress",
-            admin_edition_link_check_report_path(report.link_reportable, report, allow_new_report: allow_new_report.present? ? true : nil),
-            class: 'govuk-link js-broken-links-refresh' %>
+          <%= link_to "Check progress", "", class: 'govuk-link js-broken-links-refresh', data: { json_href: url_for(admin_edition_link_check_report_path(report.link_reportable, report, format: :json, allow_new_report: allow_new_report.present? ? true : nil)) } %>
         </p>
       <% end
     } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,5 +1,3 @@
-<% render_broken_links_button ||= true %>
-
 <div data-module="broken-links-report">
   <% if report.new_record? %>
     <%= render "components/inset_prompt", {
@@ -18,7 +16,7 @@
         <p class="govuk-body">Broken link report in progress.</p>
         <p class="govuk-body">
           <%= link_to "Check progress",
-            admin_edition_link_check_report_path(report.link_reportable, report),
+            admin_edition_link_check_report_path(report.link_reportable, report, allow_new_report: allow_new_report.present? ? true : nil),
             class: 'govuk-link js-broken-links-refresh' %>
         </p>
       <% end
@@ -56,7 +54,7 @@
         <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
           <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
         <% end %>
-        <% if render_broken_links_button %>
+        <% if allow_new_report %>
           <%= render partial: 'admin/link_check_reports/form', locals: {
             reportable: report.link_reportable,
             button_text: 'Check again'
@@ -76,11 +74,13 @@
             It contains links to draft documents that weren't checked.
           </p>
         <% end %>
-        <%= render partial: 'admin/link_check_reports/form', locals: {
-          reportable: report.link_reportable,
-          button_text: 'Check again',
-          secondary_quiet: true
-        } %>
+        <% if allow_new_report %>
+          <%= render partial: 'admin/link_check_reports/form', locals: {
+            reportable: report.link_reportable,
+            button_text: 'Check again',
+            secondary_quiet: true
+          } %>
+        <% end %>
       <% end
     } %>
   <% end %>

--- a/app/views/admin/link_check_reports/show.json.jbuilder
+++ b/app/views/admin/link_check_reports/show.json.jbuilder
@@ -1,2 +1,2 @@
-json.html render partial: "link_check_report", locals: { report: @report }, formats: [:html]
+json.html render partial: "link_check_report", locals: { report: @report, allow_new_report: @allow_new_report }, formats: [:html]
 json.in_progress @report.in_progress?


### PR DESCRIPTION
## Description 

At the moment, if a broken links report is pending when the edit page is loaded, the JS module is loaded and starts polling the LinkCheckReportsController#show endpoint.

Once the report is completed it inserts the html output from the `_link_check_report` partial into the innerHTML of the link reports div.

This causes the button to appear on the edit page when it shouldn't be.

To work around this we can pass`allow_new_report` through as a param in the query string to the show endpoint and pass it into the partial.

## Trello card

https://trello.com/c/KLzIk1bW/70-broken-link-checker-on-edit-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
