### PR TITLE
Populate content item for past prime ministers index

### DIFF
--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -11,6 +11,8 @@ class HistoricalAccount < ApplicationRecord
   validates :born, :died, length: { maximum: 256 }
   validate :roles_support_historical_accounts
   validate :validate_correct_political_party
+  after_save :republish_prime_ministers_index_page_to_publishing_api
+  after_destroy :republish_prime_ministers_index_page_to_publishing_api
 
   serialize :political_party_ids, Array
 
@@ -38,6 +40,10 @@ class HistoricalAccount < ApplicationRecord
 
   def role
     roles.first
+  end
+
+  def republish_prime_ministers_index_page_to_publishing_api
+    PublishPrimeMinistersIndexPage.new.publish unless role.slug != "prime-minister"
   end
 
   def appointment_info_array

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -69,13 +69,17 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api
+  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
 
   def republish_organisation_to_publishing_api
     organisations.each do |organisation|
       Whitehall::PublishingApi.republish_async(organisation)
     end
+  end
+
+  def republish_prime_ministers_index_page_to_publishing_api
+    PublishPrimeMinistersIndexPage.new.publish unless current? || role.slug != "prime-minister"
   end
 
   def self.between(start_time, end_time)

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -79,7 +79,7 @@ class RoleAppointment < ApplicationRecord
   end
 
   def republish_prime_ministers_index_page_to_publishing_api
-    PublishPrimeMinistersIndexPage.new.publish unless current? || role.slug != "prime-minister"
+    PublishPrimeMinistersIndexPage.new.publish unless current? || role.slug != "prime-minister" || has_historical_account?
   end
 
   def self.between(start_time, end_time)

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -63,6 +63,7 @@ class RoleAppointment < ApplicationRecord
   scope :for_ministerial_roles, -> { includes(role: :organisations).merge(Role.ministerial).references(:roles) }
   scope :alphabetical_by_person, -> { includes(:person).order("people.surname", "people.forename") }
   scope :ascending_start_date, -> { order("started_at DESC") }
+  scope :historic, -> { where.not(CURRENT_CONDITION) }
 
   after_create :set_order
   after_create :make_other_current_appointments_non_current

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -19,7 +19,9 @@ module PublishingApi
 
       content.merge!(
         base_path:,
-        details: {},
+        details: {
+          appointments_without_historical_accounts:,
+        },
         document_type: "historic_appointments",
         public_updated_at: Time.zone.now,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
@@ -27,6 +29,22 @@ module PublishingApi
       )
 
       content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def appointments_without_historical_accounts
+      role = Role.friendly.find("prime-minister")
+      people_to_present = (role.role_appointments.historic.map(&:person) - HistoricalAccount.all.map(&:person)).uniq
+      people_to_present.map do |person|
+        { title: person.name,
+          dates_in_office:
+            person.role_appointments.historic.map do |appointment|
+              {
+                start_year: appointment.started_at.year,
+                end_year: appointment.ended_at.year,
+              }
+            end,
+          image_url: person.image_url }
+      end
     end
 
     def base_path

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -1,0 +1,42 @@
+module PublishingApi
+  class HistoricalAccountsIndexPresenter
+    attr_accessor :update_type
+
+    def initialize(update_type: nil)
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      "a258e45a-acbe-4d70-ad2c-a2a20761536a"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: "Past Prime Ministers",
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        base_path:,
+        details: {},
+        document_type: "historic_appointments",
+        public_updated_at: Time.zone.now,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "historic_appointments",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def base_path
+      "/government/history/past-prime-ministers"
+    end
+
+    def links
+      {
+        historical_accounts: HistoricalAccount.all.map(&:content_id),
+      }
+    end
+  end
+end

--- a/lib/publish_prime_ministers_index_page.rb
+++ b/lib/publish_prime_ministers_index_page.rb
@@ -1,0 +1,9 @@
+class PublishPrimeMinistersIndexPage
+  def publish
+    payload = PublishingApi::HistoricalAccountsIndexPresenter.new
+
+    Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
+    Services.publishing_api.publish(payload.content_id, nil)
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -68,6 +68,11 @@ namespace :publishing_api do
       document = Document.find_by!(slug: args[:slug])
       PublishingApiDocumentRepublishingWorker.new.perform(document.id)
     end
+
+    desc "Republish the past prime ministers index page to Publishing API"
+    task republish_past_prime_ministers: :environment do
+      PublishPrimeMinistersIndexPage.new.publish
+    end
   end
 
   namespace :patch_links do

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -22,33 +22,6 @@ namespace :publishing_api do
     end
   end
 
-  desc "Publish past holders of some of the Great Offices of State"
-  task publish_past_post_holders: :environment do
-    publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
-      logger: Logger.new($stdout),
-      publishing_api: Services.publishing_api,
-    )
-
-    [
-      {
-        base_path: "/government/history/past-prime-ministers",
-        content_id: "a258e45a-acbe-4d70-ad2c-a2a20761536a",
-        title: "Past Prime Ministers",
-      },
-    ].each do |route|
-      publisher.publish(
-        {
-          format: "special_route",
-          publishing_app: "whitehall",
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-          update_type: "major",
-          type: "exact",
-          public_updated_at: Time.zone.now.iso8601,
-        }.merge(route),
-      )
-    end
-  end
-
   desc "Publish redirect routes (eg /government/world)"
   task publish_redirect_routes: :environment do
     RedirectRoute.all.each do |route|

--- a/test/unit/historical_account_test.rb
+++ b/test/unit/historical_account_test.rb
@@ -114,5 +114,47 @@ class HistoricalAccountTest < ActiveSupport::TestCase
     test "public_url returns nil" do
       assert_nil object.public_url
     end
+
+    test "does not republish the past prime ministers page on create" do
+      PublishPrimeMinistersIndexPage.any_instance.expects(:publish).never
+
+      object.save!
+    end
+  end
+
+  context "for a person who was a prime minister" do
+    setup do
+      @pm_role = create(:prime_minister_role)
+    end
+
+    test "republishes the past prime ministers page on create" do
+      PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+      create(:historical_account, roles: [@pm_role])
+    end
+
+    test "republishes the past prime ministers page on update" do
+      account = create(:historical_account, roles: [@pm_role])
+
+      PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+      account.update!(roles: [@pm_role, create(:historic_role)])
+    end
+
+    test "republishes the past prime ministers page on update removing the prime minister role" do
+      account = create(:historical_account, roles: [@pm_role])
+
+      PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+      account.update!(born: "2000")
+    end
+
+    test "republishes the past prime ministers page on destroy" do
+      account = create(:historical_account, roles: [@pm_role])
+
+      PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+      account.destroy!
+    end
   end
 end

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCase
+  test "presents a valid content item" do
+    person = create(:person, forename: "Some", surname: "Person")
+    role = create(:prime_minister_role)
+    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    historical_account = create(:historical_account,
+                                person:,
+                                born: "1900",
+                                died: "1975",
+                                interesting_facts: "They were a very interesting person",
+                                major_acts: "Significant legislation changes",
+                                roles: [role])
+
+    expected_hash = {
+      base_path: "/government/history/past-prime-ministers",
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      schema_name: "historic_appointments",
+      document_type: "historic_appointments",
+      title: "Past Prime Ministers",
+      locale: "en",
+      routes: [
+        {
+          path: "/government/history/past-prime-ministers",
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: historical_account.updated_at,
+      details: {},
+    }
+
+    expected_links = {
+      historical_accounts: [historical_account.content_id],
+    }
+
+    presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
+
+    assert_equal expected_hash, presenter.content
+    assert_hash_includes presenter.links, expected_links
+    assert_valid_against_publisher_schema(presenter.content, "historic_appointments")
+  end
+end

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCase
   setup do
-    @role = create(:prime_minister_role)
     person = create(:person, forename: "Some", surname: "Person")
+    @role = create(:prime_minister_role)
     create(:historic_role_appointment, person:, role: @role, started_at: Date.civil(1950), ended_at: Date.civil(1960))
     @historical_account = create(:historical_account,
                                  person:,

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -1,18 +1,20 @@
 require "test_helper"
 
 class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCase
-  test "presents a valid content item" do
+  setup do
+    @role = create(:prime_minister_role)
     person = create(:person, forename: "Some", surname: "Person")
-    role = create(:prime_minister_role)
-    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
-    historical_account = create(:historical_account,
-                                person:,
-                                born: "1900",
-                                died: "1975",
-                                interesting_facts: "They were a very interesting person",
-                                major_acts: "Significant legislation changes",
-                                roles: [role])
+    create(:historic_role_appointment, person:, role: @role, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    @historical_account = create(:historical_account,
+                                 person:,
+                                 born: "1900",
+                                 died: "1975",
+                                 interesting_facts: "They were a very interesting person",
+                                 major_acts: "Significant legislation changes",
+                                 roles: [@role])
+  end
 
+  test "presents a valid content item" do
     expected_hash = {
       base_path: "/government/history/past-prime-ministers",
       publishing_app: "whitehall",
@@ -29,18 +31,68 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
       ],
       update_type: "major",
       redirects: [],
-      public_updated_at: historical_account.updated_at,
-      details: {},
+      public_updated_at: @historical_account.updated_at,
+      details: {
+        appointments_without_historical_accounts: [],
+      },
     }
 
     expected_links = {
-      historical_accounts: [historical_account.content_id],
+      historical_accounts: [@historical_account.content_id],
     }
 
     presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
 
     assert_equal expected_hash, presenter.content
-    assert_hash_includes presenter.links, expected_links
+    assert presenter.links, expected_links
     assert_valid_against_publisher_schema(presenter.content, "historic_appointments")
+  end
+
+  test "when a historic role appointment does not yet have a historic account created, presents these in the details hash" do
+    person_without_historic_account = create(:person, forename: "A", surname: "Person without a historic account yet", image: File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")))
+    create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1960), ended_at: Date.civil(1970))
+    create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1990), ended_at: Date.civil(2000))
+    create(:role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(2001), ended_at: nil)
+
+    expected_links = {
+      historical_accounts: [@historical_account.content_id],
+    }
+
+    expected_details = {
+      appointments_without_historical_accounts: [
+        {
+          title: "A Person without a historic account yet",
+          dates_in_office: [
+            {
+              start_year: 1960,
+              end_year: 1970,
+            },
+            {
+              start_year: 1990,
+              end_year: 2000,
+            },
+
+          ],
+          image_url: person_without_historic_account.image_url,
+        },
+      ],
+    }
+
+    presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
+
+    assert_equal presenter.links, expected_links
+    assert_equal expected_details, presenter.content[:details]
+    assert_valid_against_publisher_schema(presenter.content, "historic_appointments")
+  end
+
+  test "when a role appointment is current, does not present these in the details hash" do
+    person_without_historic_account = create(:person, forename: "A", surname: "Person without a historic account yet")
+    create(:role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(2001), ended_at: nil)
+
+    expected_details = { appointments_without_historical_accounts: [] }
+
+    actual_details = PublishingApi::HistoricalAccountsIndexPresenter.new.content[:details]
+
+    assert_equal expected_details, actual_details
   end
 end

--- a/test/unit/publish_prime_ministers_index_page_test.rb
+++ b/test/unit/publish_prime_ministers_index_page_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+class PublishPrimeMinistersIndexPageTest < ActiveSupport::TestCase
+  setup do
+    role = create(:prime_minister_role)
+    person = create(:person, forename: "Some", surname: "Person")
+    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    create(:historical_account, person:, born: "1900", died: "1975", roles: [role])
+  end
+
+  test "sends the page to publishing api" do
+    presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
+    expected_content = presenter.content
+
+    Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content)
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, nil)
+
+    PublishPrimeMinistersIndexPage.new.publish
+  end
+end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -416,4 +416,47 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     assert_equal 1, role_appointment1.reload.order
     assert_equal 2, role_appointment2.reload.order
   end
+
+  test "should send the prime ministers index page to publishing api when the role created is a past prime minister" do
+    role = create(:prime_minister_role)
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish).at_least_once
+
+    create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+  end
+
+  test "should send the prime ministers index page to publishing api when a destroyed role is a past prime minister" do
+    role = create(:prime_minister_role)
+    past_pm_appointment = create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+    past_pm_appointment.destroy!
+  end
+
+  test "should not send the prime ministers index page to publishing api when the role created is a current prime minister" do
+    role = create(:prime_minister_role)
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish).never
+
+    create(:role_appointment, person: create(:person), role:)
+  end
+
+  test "should send the prime ministers index page to publishing api when the role updated to be a past prime minister" do
+    role = create(:prime_minister_role)
+    role_appointment = create(:role_appointment, person: create(:person), role:)
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+    role_appointment.update!(ended_at: Time.zone.now)
+  end
+
+  test "should not send the prime ministers index page to publishing api when the role created is not a prime minister" do
+    role = create(:role)
+    create(:prime_minister_role)
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish).never
+
+    create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+  end
 end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -434,6 +434,15 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     past_pm_appointment.destroy!
   end
 
+  test "should send the prime ministers index page to publishing api when the role updated to be a past prime minister" do
+    role = create(:prime_minister_role)
+    role_appointment = create(:role_appointment, person: create(:person), role:)
+
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+
+    role_appointment.update!(ended_at: Time.zone.now)
+  end
+
   test "should not send the prime ministers index page to publishing api when the role created is a current prime minister" do
     role = create(:prime_minister_role)
 
@@ -442,13 +451,20 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     create(:role_appointment, person: create(:person), role:)
   end
 
-  test "should send the prime ministers index page to publishing api when the role updated to be a past prime minister" do
+  test "should not send the prime ministers index page to publishing api when a historical account exists" do
     role = create(:prime_minister_role)
-    role_appointment = create(:role_appointment, person: create(:person), role:)
+    person = create(:person)
+    @historical_account = create(:historical_account,
+                                 person:,
+                                 born: "1900",
+                                 died: "1975",
+                                 interesting_facts: "They were a very interesting person",
+                                 major_acts: "Significant legislation changes",
+                                 roles: [role])
 
-    PublishPrimeMinistersIndexPage.any_instance.expects(:publish)
+    PublishPrimeMinistersIndexPage.any_instance.expects(:publish).never
 
-    role_appointment.update!(ended_at: Time.zone.now)
+    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
   end
 
   test "should not send the prime ministers index page to publishing api when the role created is not a prime minister" do


### PR DESCRIPTION
In preparation for moving the rendering for the [past prime ministers index page](https://www.gov.uk/government/history/past-prime-ministers) out of whitehall, we need to publish a content item for this page.

This PR adds a presenter for this page, behaviour to ensure that the page is republished when a relevant update to a model is made, and a rake task to allow us to republish the page.

Depends on [related addition to content schemas](https://github.com/alphagov/publishing-api/pull/2285) - github actions won't pass until this is merged in, but I've pointed the jenkins run at the publishing api branch, so this should be green.

[Trello](https://trello.com/c/0NcK4ojz/420-populate-content-item-for-past-prime-ministers-index)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
