### PR TITLE
Adds support for RTL languages on Foreign language only consultations

### DIFF
--- a/app/assets/javascripts/admin/views/locale-switcher.js
+++ b/app/assets/javascripts/admin/views/locale-switcher.js
@@ -1,10 +1,20 @@
+/* This module is used where only certain elements within a form are required to update the value of their `dir` attribute in response to a change in a `select` element.
+** By default it will affect this change on `input` and `textarea` elements but can be extended to other elements as below.
+** Usage:
+** - Add to the form with `data-module="LocaleSwitcher"`
+** - Add collection of RTL languages on the form element with `data-rtl-locales=<array of LTR languages>`
+** - Wrap the language selector with the class `js-locale-switcher-selector`
+** - Wrap fields to display RTL languages with `js-locale-switcher-field`
+** - Add to any custom elements the class `js-locale-switcher-custom`
+*/
+
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
   function LocaleSwitcher (module) {
     this.module = module
-    this.rightToLeftLocales = module.dataset.rtlLocales.split(' ')
+    this.rightToLeftLocales = JSON.parse(module.dataset.rtlLocales)
   }
 
   LocaleSwitcher.prototype.init = function () {
@@ -14,24 +24,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   LocaleSwitcher.prototype.setupLocaleSwitching = function () {
     var form = this.module
     var rightToLeftLocales = this.rightToLeftLocales
-    var select = form.querySelector('#attachment_locale')
-    var title = form.querySelector('.app-view-attachments__form-title input')
-    var body = form.querySelector('.app-view-attachments__form-body .app-c-govspeak-editor__textarea textarea')
-    var preview = form.querySelector('.app-view-attachments__form-body .app-c-govspeak-editor__preview')
+    var select = form.querySelector('.js-locale-switcher-selector')
+    var localeFields = form.querySelectorAll('.js-locale-switcher-field input, .js-locale-switcher-field textarea, .js-locale-switcher-custom')
 
     if (!select) {
       return
     }
 
-    select.addEventListener('change', function () {
-      if (rightToLeftLocales.indexOf(this.value) > -1) {
-        title.setAttribute('dir', 'rtl')
-        body.setAttribute('dir', 'rtl')
-        preview.setAttribute('dir', 'rtl')
+    select.addEventListener('change', function (event) {
+      var value = event.target.value
+
+      if (rightToLeftLocales.indexOf(value) > -1) {
+        localeFields.forEach(function (field) {
+          field.setAttribute('dir', 'rtl')
+        })
       } else {
-        title.removeAttribute('dir')
-        body.removeAttribute('dir')
-        preview.removeAttribute('dir')
+        localeFields.forEach(function (field) {
+          field.removeAttribute('dir')
+        })
       }
     })
   }

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -126,7 +126,7 @@ module Admin::EditionsHelper
 
   def standard_edition_form(edition, information = nil, preview_design_system: false)
     if preview_design_system
-      form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm" } do |form|
+      form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
         concat render("standard_fields", form:, edition:)
         yield(form)
         concat render("access_limiting_fields", form:, edition:)

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", :"data-module" => "LocaleSwitcher", :"data-rtl-locales" => Locale.right_to_left.collect(&:to_param) }, multipart: true do |form| %>
-  <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title">
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
+  <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Title (required)"
@@ -41,9 +41,8 @@
         } %>
       </div>
 
-      <div class="govuk-!-margin-bottom-8 app-view-attachments__form-body">
+      <div class="govuk-!-margin-bottom-8 app-view-attachments__form-body js-locale-switcher-field">
         <%= render "components/govspeak-editor", {
-          form: form,
           label: {
             heading_size: "l",
             text: "Body (required)"
@@ -53,6 +52,7 @@
           id: "attachment_govspeak_content_body",
           value: form.object.govspeak_content.body,
           error_items: errors_for(attachment.errors, :"govspeak_content.body"),
+          right_to_left: form.object.rtl_locale?,
           data_attributes: {
             image_ids: @edition && @edition.images.any? ? @edition.images.map { |img| img[:id] } : [],
             attachment_ids: @edition && @edition.allows_attachments? ? @edition.attachments.map(&:id) : [],

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -9,7 +9,7 @@
       }
     end)
   %>
-  <div class="govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-bottom-8 js-locale-switcher-selector">
     <%= render "govuk_publishing_components/components/select", {
       id: "attachment_locale",
       label: "Display language",

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
+<div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field js-locale-switcher-selector <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "edition[create_foreign_language_only]",
     id: "edition_create_foreign_language_only",

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -10,7 +10,7 @@
     </div>
   <% end %>
 
-  <div class="govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Title (required)",
@@ -21,24 +21,30 @@
       value: edition.title,
       hint: "Title text should be 65 characters or fewer",
       error_items: errors_for(edition.errors, :title),
+      right_to_left: form.object.translation_rtl?,
+      right_to_left_help: false
     } %>
   </div>
 
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: "Summary" + "#{' (required)' if form.object.summary_required?}",
-      heading_size: "l",
-    },
-    name: "edition[summary]",
-    id: "edition_summary",
-    value: edition.summary,
-    rows: 4,
-    hint: "Summary text should be 160 characters or fewer.",
-    error_items: errors_for(edition.errors, :summary),
-    margin_bottom: 8,
-  } %>
+  <div class="js-locale-switcher-field">
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Summary" + "#{' (required)' if form.object.summary_required?}",
+        heading_size: "l",
+      },
+      name: "edition[summary]",
+      id: "edition_summary",
+      value: edition.summary,
+      rows: 4,
+      hint: "Summary text should be 160 characters or fewer.",
+      error_items: errors_for(edition.errors, :summary),
+      right_to_left: form.object.translation_rtl?,
+      right_to_left_help: false,
+      margin_bottom: 8,
+    } %>
+  </div>
 
-  <div class="govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
     <%= render "components/govspeak-editor", {
       label: {
         text: "Body" + "#{' (required)' if form.object.body_required?}",
@@ -49,6 +55,7 @@
       value: edition.body,
       rows: 20,
       error_items: errors_for(edition.errors, :body),
+      right_to_left: form.object.translation_rtl?,
       data_attributes: {
         image_ids: edition.images.map { |img| img[:id] }.to_json,
         attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -8,7 +8,7 @@
   value ||= nil
   error_items ||= nil
   rows ||= 12
-  form ||= nil
+  right_to_left ||= false
 
   track_preview_toggle ||= false
   track_category ||= false
@@ -33,7 +33,6 @@
   classes = "app-c-govspeak-editor govuk-form-group"
   classes << " govuk-form-group--error" if error_items
 
-  right_to_left = form ? form.object.rtl_locale? : nil
   dir = right_to_left ? "rtl" : nil
 %>
 
@@ -70,11 +69,12 @@
       data: textarea_data_attributes,
       margin_bottom: 0,
       describedby: hint_id,
-      right_to_left: right_to_left
+      right_to_left: right_to_left,
+      right_to_left_help: false
     } %>
   </div>
 
-  <%= tag.div class: "app-c-govspeak-editor__preview", 'aria-live': "polite", id: preview_id, dir: dir do %>
-    <p class="govuk-body">Generating preview, please wait.</p>
+  <%= tag.div class: "app-c-govspeak-editor__preview js-locale-switcher-custom", 'aria-live': "polite", id: preview_id, dir: dir do %>
+    <p class="govuk-body" dir="ltr">Generating preview, please wait.</p>
   <% end %>
 <% end %>

--- a/spec/javascripts/admin/modules/locale-switcher.spec.js
+++ b/spec/javascripts/admin/modules/locale-switcher.spec.js
@@ -4,25 +4,28 @@ describe('GOVUK.Modules.LocaleSwitcher', function () {
   beforeEach(function () {
     form = document.createElement('form')
     form.setAttribute('data-module', 'LocaleSwitcher')
-    form.setAttribute('data-rtl-locales', 'ar dr fa he pa-pk ps ur yi')
+    form.setAttribute('data-rtl-locales', '["ar", "dr", "fa", "he", "pa-pk", "ps", "ur", "yi"]')
 
     form.innerHTML = `
       <form>
-        <div class="app-view-attachments__form-title">
-          <input id="attachment_title">
+        <div class="js-locale-switcher-selector">
+          <select>
+            <option value="">All languages</option>
+            <option value="ar">العربيَّة</option>
+            <option value="en">English</option>
+          </select>
         </div>
 
-        <select id="attachment_locale">
-          <option value="">All languages</option>
-          <option value="ar">العربيَّة</option>
-          <option value="en">English</option>
-        </select>
+        <div class="js-locale-switcher-field">
+          <input id="input"></input>
+        </div>
 
-        <div class="app-view-attachments__form-body">
-          <div class="app-c-govspeak-editor__textarea">
-            <textarea></textarea>
-          </div>
-          <div class="app-c-govspeak-editor__preview"></div>
+        <div class="js-locale-switcher-field">
+          <textarea id="textarea"></textarea>
+        </div>
+
+        <div>
+          <div id="customElement" class="js-locale-switcher-custom"></div>
         </div>
       </form>
     `
@@ -32,23 +35,23 @@ describe('GOVUK.Modules.LocaleSwitcher', function () {
   })
 
   it('should add the correct value for the `dir` attribute on the appropriate elements when the laguage select element is changed', function () {
-    var select = form.querySelector('#attachment_locale')
-    var title = form.querySelector('.app-view-attachments__form-title input')
-    var body = form.querySelector('.app-view-attachments__form-body .app-c-govspeak-editor__textarea textarea')
-    var preview = form.querySelector('.app-view-attachments__form-body .app-c-govspeak-editor__preview')
+    var select = form.querySelector('.js-locale-switcher-selector')
+    var input = form.querySelector('#input')
+    var textarea = form.querySelector('#textarea')
+    var customElement = form.querySelector('#customElement')
 
     select.value = 'ar'
     select.dispatchEvent(new Event('change'))
 
-    expect(title.getAttribute('dir')).toEqual('rtl')
-    expect(body.getAttribute('dir')).toEqual('rtl')
-    expect(preview.getAttribute('dir')).toEqual('rtl')
+    expect(input.getAttribute('dir')).toEqual('rtl')
+    expect(textarea.getAttribute('dir')).toEqual('rtl')
+    expect(customElement.getAttribute('dir')).toEqual('rtl')
 
     select.value = 'en'
     select.dispatchEvent(new Event('change'))
 
-    expect(title.getAttribute('dir')).toBeNull()
-    expect(body.getAttribute('dir')).toBeNull()
-    expect(preview.getAttribute('dir')).toBeNull()
+    expect(input.getAttribute('dir')).toBeNull()
+    expect(textarea.getAttribute('dir')).toBeNull()
+    expect(customElement.getAttribute('dir')).toBeNull()
   })
 })


### PR DESCRIPTION
[Trello](https://trello.com/c/aCuYoaQX/72-add-rtl-support-for-foreign-language-only-consultations)

These changes add support for right-to-left languages to the Foreign language only consultation page, for example [this page](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/consultations/661078/edit). When a consultation document is being edited or created the user has the option to select “Foreign language only consultation” and choose a language for the document. Where the language selected is a RTL language the appropriate attribute should be updated in the relevant fields.

![Screenshot 2023-02-10 at 10 31 28](https://user-images.githubusercontent.com/6080548/218071160-d47c6de7-3a5b-4117-a80a-4da6dae14f8e.png)

The work here
- Adds the correct value to the `dir` attribute when the page is loaded
- Updates the existing `LocaleSwitcher` module so that it can be used more widely than the page on which it is currently used. 
- Adds that module to this page so that the changes are made dynamically
- Updates the attachment page to use the more generic module.