### PR TITLE
Render uploaded images with details in their tab

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition-images.scss
+++ b/app/assets/stylesheets/admin/views/_edition-images.scss
@@ -1,0 +1,12 @@
+.app-view-edition-images__section-break {
+  margin-bottom: govuk-spacing(5);
+}
+
+.app-view-edition-images__image {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.app-view-edition-images__details {
+  padding-left: govuk-spacing(6);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/audit-trail";
 @import "./admin/views/document-history-tab";
 @import "./admin/views/edit-edition";
+@import "./admin/views/edition-images";
 @import "./admin/views/edition-summary";
 @import "./admin/views/edition-translation";
 @import "./admin/views/editions-edition";

--- a/app/views/admin/edition_images/_uploaded_images.html.erb
+++ b/app/views/admin/edition_images/_uploaded_images.html.erb
@@ -38,3 +38,25 @@
     margin_top: 0
   } %>
 </div>
+
+<% if edition.images %>
+  <ul class="govuk-list">
+    <% edition.images.each_with_index do |image, index| %>
+      <li class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <% if image.url.present? %>
+            <img src="<%= image.url %>" alt="Image <%= index + 1 %>" class="app-view-edition-images__image">
+          <% end %>
+        </div>
+        <ul class="app-view-edition-images__details govuk-grid-column-two-thirds govuk-list govuk-list--bullet">
+          <li><strong>Caption: </strong><%= image.caption.blank? ? "None" : image.caption %></li>
+          <% if image.alt_text %><li><strong>Alt text: </strong><%= image.alt_text.blank? ? "None" : image.alt_text %></li><% end %>
+          <li><strong>Markdown code: </strong><span>[Image:&nbsp;<%=image.image_data.carrierwave_image %>]</span></li>
+        </ul>
+      </li>
+      <% if image != edition.images.last %>
+        <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--m govuk-section-break--visible"></li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -13,3 +13,10 @@ Feature: Images tab on edit edition
     And I start drafting a new publication "Standard Beard Lengths"
     When I am on the edit page for publication "Standard Beard Lengths"
     Then the page should not have an images tab
+
+  Scenario: Images are listed on the images tab
+    Given I am a writer
+    And I have the "Preview images update" permission
+    And a draft document with images exists
+    When I visit the images tab of the the document with images
+    Then I should see a list of the images

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -1,3 +1,16 @@
+Given("a draft document with images exists") do
+  images = [build(:image), build(:image)]
+  @edition = create(:draft_publication, body: "!!2", images:)
+end
+
+When("I visit the images tab of the the document with images") do
+  visit admin_edition_images_path(@edition)
+end
+
+Then("I should see a list of the images") do
+  expect(page).to have_selector(".app-view-edition-images__details", count: 2)
+end
+
 When(/^I select an image for the (?:detailed guide|publication)$/) do
   within ".images" do
     attach_file "File", jpg_image


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
[Renders the images attached to an edition in the new images tab and adds a new CSS file to style the layout.
](https://trello.com/c/cb3oyumy/1135-add-display-uploaded-images-functionality-to-images-tab)
# Screenshots

![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/218156942-8b00d677-1945-4cdd-bc04-585a947e254d.png)

![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/9594455/218156959-2437660e-6378-455f-a012-2aed495911d2.png)
