### PR TITLE
Add page to allow images to be deleted

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition-images.scss
+++ b/app/assets/stylesheets/admin/views/_edition-images.scss
@@ -10,3 +10,7 @@
 .app-view-edition-images__details {
   padding-left: govuk-spacing(6);
 }
+
+.app-view-edition-images__actions {
+  margin-top: govuk-spacing(2);
+}

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -6,7 +6,24 @@ class Admin::EditionImagesController < Admin::BaseController
 
   def index; end
 
+  def confirm_destroy; end
+
+  def destroy
+    filename = image.image_data.carrierwave_image
+    image.destroy!
+    redirect_to admin_edition_images_path(@edition), notice: "#{filename} has been deleted"
+  end
+
 private
+
+  def image
+    @image ||= find_image
+  end
+  helper_method :image
+
+  def find_image
+    @edition.images.find(params[:id]) if params[:id]
+  end
 
   def find_edition
     edition = Edition.find(params[:edition_id])
@@ -21,6 +38,8 @@ private
     case action_name
     when "index"
       enforce_permission!(:see, @edition)
+    when "destroy", "confirm_destroy"
+      enforce_permission!(:update, @edition)
     else
       raise Whitehall::Authority::Errors::InvalidAction, action_name
     end

--- a/app/views/admin/edition_images/_uploaded_images.html.erb
+++ b/app/views/admin/edition_images/_uploaded_images.html.erb
@@ -53,6 +53,9 @@
           <% if image.alt_text %><li><strong>Alt text: </strong><%= image.alt_text.blank? ? "None" : image.alt_text %></li><% end %>
           <li><strong>Markdown code: </strong><span>[Image:&nbsp;<%=image.image_data.carrierwave_image %>]</span></li>
         </ul>
+        <div class="app-view-edition-images__actions govuk-grid-column-full">
+          <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive") %>
+        </div>
       </li>
       <% if image != edition.images.last %>
         <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--m govuk-section-break--visible"></li>

--- a/app/views/admin/edition_images/confirm_destroy.html.erb
+++ b/app/views/admin/edition_images/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Delete image" %>
+<% content_for :title, "Delete image" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag [:admin, :edition, :image], id: image, method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete <%= image.image_data.carrierwave_image %>?</p>
+
+    <div class="govuk-button-group govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Delete image",
+        destructive: true,
+      } %>
+
+      <%= link_to("Cancel", admin_edition_images_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,9 @@ Whitehall::Application.routes.draw do
             post :upload_zip, on: :collection
             get :set_titles, on: :member
           end
-          resources :images, controller: "edition_images", only: %i[index]
+          resources :images, controller: "edition_images", only: %i[destroy index] do
+            get :confirm_destroy, on: :member
+          end
         end
 
         get "/editions/:id" => "editions#show"

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -18,5 +18,16 @@ Feature: Images tab on edit edition
     Given I am a writer
     And I have the "Preview images update" permission
     And a draft document with images exists
-    When I visit the images tab of the the document with images
-    Then I should see a list of the images
+    When I visit the images tab of the document with images
+    Then I should see a list with 2 images
+
+  Scenario: Images can be deleted from the images tab
+    Given I am a writer
+    And I have the "Preview images update" permission
+    And a draft document with images exists
+    When I visit the images tab of the document with images
+    Then I should see a list with 2 images
+    When I click to delete an image
+    And I confirm the deletion
+    Then I should see a success banner
+    And I should see a list with 1 image

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -3,12 +3,12 @@ Given("a draft document with images exists") do
   @edition = create(:draft_publication, body: "!!2", images:)
 end
 
-When("I visit the images tab of the the document with images") do
+When("I visit the images tab of the document with images") do
   visit admin_edition_images_path(@edition)
 end
 
-Then("I should see a list of the images") do
-  expect(page).to have_selector(".app-view-edition-images__details", count: 2)
+Then(/^I should see a list with (\d+) image/) do |count|
+  expect(page).to have_selector(".app-view-edition-images__details", count:)
 end
 
 When(/^I select an image for the (?:detailed guide|publication)$/) do
@@ -28,4 +28,16 @@ end
 Then(/^I can navigate to the images tab$/) do
   find("li.app-c-secondary-navigation__list-item a", text: "Images").click
   expect(page).to have_content("Upload an image")
+end
+
+When("I click to delete an image") do
+  first("a", text: "Delete image").click
+end
+
+When("I confirm the deletion") do
+  find("button", text: "Delete image").click
+end
+
+Then "I should see a success banner" do
+  expect(page).to have_content("has been deleted")
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
[Adds routes for destroy and confirm destroy and defines methods on the controller and a template to handle image deletion.](https://trello.com/c/b1CsjEWj/1057-deleting-an-image)

# Screenshots
![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro)](https://user-images.githubusercontent.com/9594455/218159967-74725e9a-59cc-4a0f-93b7-a2580ab9c78f.png)

![whitehall-admin dev gov uk_government_admin_editions_1370963_images_445052_confirm_destroy(iPad Pro)](https://user-images.githubusercontent.com/9594455/218159974-1e8b4e54-2e87-4b34-ba0a-387448fee0d9.png)

![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/218159982-6f14d607-8125-4ff1-88f7-531c4911f9f8.png)

![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/218159997-d55841cf-ba8a-479e-8e09-1f5606772920.png)
