### PR TITLE
Remove `TODO` comment

### DIFF
--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -12,7 +12,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         historical_account,
-        title: historical_account.person.name, # TODO
+        title: historical_account.person.name,
         update_type:,
       ).base_attributes
 


### PR DESCRIPTION
This was left in by mistake as part of https://github.com/alphagov/whitehall/pull/7261.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
