### PR TITLE
Add page to allow image details to be edited

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition-images.scss
+++ b/app/assets/stylesheets/admin/views/_edition-images.scss
@@ -1,4 +1,5 @@
 .app-view-edition-images__section-break {
+  margin-top: 0;
   margin-bottom: govuk-spacing(5);
 }
 
@@ -13,4 +14,5 @@
 
 .app-view-edition-images__actions {
   margin-top: govuk-spacing(2);
+  margin-bottom: 0;
 }

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -14,6 +14,14 @@ class Admin::EditionImagesController < Admin::BaseController
     redirect_to admin_edition_images_path(@edition), notice: "#{filename} has been deleted"
   end
 
+  def update
+    if image.update(params.require(:image).permit(:caption, :alt_text))
+      redirect_to admin_edition_images_path(@edition), notice: "#{image.image_data.carrierwave_image} details updated"
+    else
+      render :edit
+    end
+  end
+
 private
 
   def image
@@ -38,7 +46,7 @@ private
     case action_name
     when "index"
       enforce_permission!(:see, @edition)
-    when "destroy", "confirm_destroy"
+    when "edit", "update", "destroy", "confirm_destroy"
       enforce_permission!(:update, @edition)
     else
       raise Whitehall::Authority::Errors::InvalidAction, action_name

--- a/app/views/admin/edition_images/_image_information.html.erb
+++ b/app/views/admin/edition_images/_image_information.html.erb
@@ -1,0 +1,11 @@
+<section class="govuk-grid-column-one-third">
+  <img src="<%= image.url %>" alt="Image preview" class="app-view-edition-images__image govuk-!-margin-bottom-4">
+  <h2 class="govuk-heading-m">Image information</h2>
+  <ul class="govuk-list">
+    <li><strong>Width: </strong>960px</li>
+    <li><strong>Height: </strong>640px</li>
+    <li><strong>Format: </strong><%= image.image_data.file.content_type %></li>
+    <li><strong>File size: </strong><%= number_to_human_size image.image_data.file.size %></li>
+    <li><strong>File name: </strong><%= image.image_data.file.file.filename %></li>
+  </ul>
+</section>

--- a/app/views/admin/edition_images/_uploaded_images.html.erb
+++ b/app/views/admin/edition_images/_uploaded_images.html.erb
@@ -53,12 +53,13 @@
           <% if image.alt_text %><li><strong>Alt text: </strong><%= image.alt_text.blank? ? "None" : image.alt_text %></li><% end %>
           <li><strong>Markdown code: </strong><span>[Image:&nbsp;<%=image.image_data.carrierwave_image %>]</span></li>
         </ul>
-        <div class="app-view-edition-images__actions govuk-grid-column-full">
+        <div class="app-view-edition-images__actions govuk-grid-column-full govuk-button-group">
+          <%= link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link") %>
           <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive") %>
         </div>
       </li>
       <% if image != edition.images.last %>
-        <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--m govuk-section-break--visible"></li>
+        <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--visible"></li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -1,0 +1,60 @@
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Add image details" %>
+<% content_for :title, "Add image details" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag [:admin, :edition, :image], id: image, method: :patch do %>
+      <p class="govuk-body-lead">You can leave any image detail blank if you do not need it.</p>
+
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Caption",
+          heading_size: "l",
+        },
+        name: "image[caption]",
+        id: "image_caption",
+        value: image.caption,
+        rows: 5,
+        hint: tag.p("Name a person in a photo. The caption appears next to the image.", class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0"),
+        margin_bottom: 4,
+      } %>
+
+      <% if image.alt_text.blank? %>
+        <h2 class="govuk-heading-l">Alt text</h2>
+
+        <p class="govuk-body">If you need to give an alt text description, write it in the body copy below the image so it’s available to everyone.</p>
+
+        <p class="govuk-body">You do not need to provide an alt text description for decorative images.</p>
+      <% else %>
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Alt text",
+            heading_size: "l",
+          },
+          name: "image[alt_text]",
+          id: "image_alt_text",
+          value: image.alt_text,
+          rows: 5,
+          hint: tag.p("You should write the alt text description in the body copy below the image so it’s available to everyone.", class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0"),
+          margin_bottom: 4,
+        } %>
+      <% end %>
+
+      <p class="govuk-body"><a href="https://www.gov.uk/guidance/content-design/images" class="govuk-link" target="_blank">How to use alt text (opens in new tab)</a></p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+
+        <%= link_to("Cancel", admin_edition_images_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+
+  <%= render "image_information" %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,7 @@ Whitehall::Application.routes.draw do
             post :upload_zip, on: :collection
             get :set_titles, on: :member
           end
-          resources :images, controller: "edition_images", only: %i[destroy index] do
+          resources :images, controller: "edition_images", only: %i[destroy edit update index] do
             get :confirm_destroy, on: :member
           end
         end

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -29,5 +29,15 @@ Feature: Images tab on edit edition
     Then I should see a list with 2 images
     When I click to delete an image
     And I confirm the deletion
-    Then I should see a success banner
+    Then I should see a successfully deleted banner
     And I should see a list with 1 image
+
+  Scenario: Images details can be updated from the images tab
+    Given I am a writer
+    And I have the "Preview images update" permission
+    And a draft document with images exists
+    When I visit the images tab of the document with images
+    And I click to edit the details of an image
+    And I update the image details and save
+    Then I should see a updated banner
+    Then I should see the updated image details

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -34,10 +34,27 @@ When("I click to delete an image") do
   first("a", text: "Delete image").click
 end
 
+When("I click to edit the details of an image") do
+  first("a", text: "Edit details").click
+end
+
 When("I confirm the deletion") do
   find("button", text: "Delete image").click
 end
 
-Then "I should see a success banner" do
+When("I update the image details and save") do
+  fill_in "image[caption]", with: "Test caption"
+  find("button", text: "Save").click
+end
+
+Then "I should see a successfully deleted banner" do
   expect(page).to have_content("has been deleted")
+end
+
+Then "I should see a updated banner" do
+  expect(page).to have_content("details updated")
+end
+
+Then "I should see the updated image details" do
+  expect(page).to have_content("Test caption")
 end

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -18,4 +18,24 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     get admin_edition_images_path(edition.id)
     assert_equal 403, status
   end
+
+  test "edit page displays alt text input for images with alt text" do
+    images = [build(:image)]
+    edition = create(:draft_publication, images:)
+    user = create(:gds_editor)
+    user.permissions << "Preview images update"
+    login_as user
+    get edit_admin_edition_image_path(edition, images[0])
+    assert_select "#image_alt_text"
+  end
+
+  test "edit page does not display alt text input where it is blank" do
+    images = [build(:image, alt_text: "")]
+    edition = create(:draft_publication, images:)
+    user = create(:gds_editor)
+    user.permissions << "Preview images update"
+    login_as user
+    get edit_admin_edition_image_path(edition, images[0])
+    assert_select "#image_alt_text", count: 0
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Add a page to edit image details with fields for caption and alt text and image information.

# Trello cards
[Existing images](https://trello.com/c/QeifKsuT/1060-edit-details)
[New images](https://trello.com/c/tBzITHVi/1059-image-details-part-2-of-uploading-an-image)

# Screenshots
## Edit page
![whitehall-admin dev gov uk_government_admin_editions_1370963_images_445034_edit(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/219083734-bd2fda2a-bb7f-4ae6-8e30-d60e99909af4.png)

## Edit page with alt text
![whitehall-admin dev gov uk_government_admin_editions_1370963_images_445034_edit(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/219083714-3e9fd50f-d39a-486d-88d2-f7c08a493d93.png)

## Index page
![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/219083677-a3170f9b-bf69-4201-b1c5-f89d1b87f862.png)

## Success banner
![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro) (2)](https://user-images.githubusercontent.com/9594455/219083602-148fa9f7-0774-48d1-b074-53c36afb2d80.png)

## Mobile
![whitehall-admin dev gov uk_government_admin_editions_1370963_images_445034_edit(iPhone 12 Pro) (2)](https://user-images.githubusercontent.com/9594455/219083623-98e4c138-ea10-4499-8b1a-3e38b3251571.png)
