### PR TITLE
Do not raise `GdsApi::HTTPUnprocessableEntity` for Worldwide Organisations

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -40,7 +40,9 @@ module Whitehall
         end
       end
     rescue GdsApi::HTTPUnprocessableEntity => e
-      if e.message =~ /conflicts with content_id/
+      if model_instance.instance_of?(WorldwideOrganisation) && e.message =~ /conflicts with content_id/
+        nil
+      elsif e.message =~ /conflicts with content_id/
         raise UnpublishableInstanceError, e.message
       else
         raise


### PR DESCRIPTION
We know there is an issue with Worldwide Organisations having the same base path as one of their Corporate Information Pages. This leads to `GdsApi::HTTPUnprocessableEntity` being raised when the Worldwide Organisation itself is published again.

There is currently no user facing impact as the content item is not being used for anything on these pages.

This is tracked on a Trello card looked after by Publishing Platform (see https://trello.com/c/qYYHTFW0). When rendering is moved out of Whitehall, this issue will need to be fixed.

However, in the meantime, we are sending approximately 46 events each day to Sentry. This both uses our allowance of events and is a nuisance in Slack.

This will stop an error being raised solely for the known scenario covered by the aforementioned Trello card, which should reduce some of the noise in Slack.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
