### PR TITLE
Only present past dates of relevant role in historical accounts index presenter

### DIFF
--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -37,7 +37,7 @@ module PublishingApi
       people_to_present.map do |person|
         { title: person.name,
           dates_in_office:
-            person.role_appointments.historic.map do |appointment|
+            person.role_appointments.where(role_id: role.id).historic.map do |appointment|
               {
                 start_year: appointment.started_at.year,
                 end_year: appointment.ended_at.year,

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -52,6 +52,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
     person_without_historic_account = create(:person, forename: "A", surname: "Person without a historic account yet", image: File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")))
     create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1960), ended_at: Date.civil(1970))
     create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1990), ended_at: Date.civil(2000))
+    create(:historic_role_appointment, person: person_without_historic_account, role: create(:role), started_at: Date.civil(1970), ended_at: Date.civil(1980))
     create(:role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(2001), ended_at: nil)
 
     expected_links = {


### PR DESCRIPTION
On the past prime ministers page, we display their dates in role. 

For past prime ministers without historic appointments, in the content item we were presenting their dates in role for any historic role they held (for example, dates when they were chancellors). This fixes that. 

Note that since we're not yet using this content item, this isn't affecting the data displaying on the website, which is still accurate.

[Trello](https://trello.com/c/0NcK4ojz/420-populate-content-item-for-past-prime-ministers-index)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
