### PR TITLE
Prevent javascript execution in IE11

### DIFF
--- a/app/assets/javascripts/admin/modules/document-history-paginator.js
+++ b/app/assets/javascripts/admin/modules/document-history-paginator.js
@@ -7,8 +7,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   DocumentHistoryPaginator.prototype.init = function () {
-    if (!window.fetch) { return }
-
     this.setupLinkEventListeners()
     this.setupFormChangeListener()
   }

--- a/app/assets/javascripts/admin/stop-scripts-nomodule.js
+++ b/app/assets/javascripts/admin/stop-scripts-nomodule.js
@@ -1,0 +1,11 @@
+// In browsers that do not support ES6 modules
+if (!('noModule' in HTMLScriptElement.prototype)) {
+  // Remove any JavaScript reliant style changes.
+  document.body.classList.remove('js-enabled')
+
+  // Prevent the GOV.UK Frontend from being initialised.
+  document.addEventListener('DOMContentLoaded', function (e) {
+    e.stopImmediatePropagation()
+    e.stopPropagation()
+  }, true)
+}

--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -7,7 +7,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   BrokenLinksReport.prototype.init = function () {
-    if (!fetch) return
     var button = this.module.querySelector('button')
     var authenticityTokenField = this.module.querySelector('[name="authenticity_token"]')
     if (button && authenticityTokenField) this.setupEventListener(button, authenticityTokenField.value)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,5 @@
+//= require admin/stop-scripts-nomodule
+
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,12 +4,6 @@
 //= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics
 
-// support ES6 (promises, functions, etc. - see docs)
-//= require core-js-bundle/index.js
-
-// support ES6 custom elements
-//= require @webcomponents/custom-elements/custom-elements.min.js
-
 //= require jquery
 //= require bootstrap
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     }
   },
   "dependencies": {
-    "@webcomponents/custom-elements": "^1.5.1",
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
-    "core-js-bundle": "^3.28.0",
     "jquery": "3.6.3",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,11 +85,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@webcomponents/custom-elements@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.5.1.tgz#48029f6c62b94a4b49be061ca1dae04ab9681ace"
-  integrity sha512-6T/XT3S1UHDlRWFSxRXdeSoYWczEl78sygNPS7jDyHVrfZcF/pUtWGYgxF4uviH59iPVw1eOWbhubm8CqO0MpA==
-
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -383,11 +378,6 @@ cookie@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-core-js-bundle@^3.28.0:
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.28.0.tgz#c250161c3aefc17d0d0594f8f219496959fafc6b"
-  integrity sha512-3xuC5gFOnP4iaFwVBJAS2vuQsAdHzRKkbSOuNIU3LZ9o+XVNk2usBo68m5Q0uUQ3Ag0HHadETf8azJttTFW8oA==
 
 core-util-is@~1.0.0:
   version "1.0.3"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
[Stop the DOMContentLoaded event from propagating on design system pages in IE11.](https://trello.com/c/57MY6jrJ/1098-prevent-javascript-from-executing-in-ie-11)
Remove the modules added to support miller columns on IE11.
Remove `fetch` feature detection as modules are not executed on IE11.

# Why
This is used to start the GOV.UK Frontend an in turn all of the JavasScript modules. By preventing the rest of the javascript from being executed it does not need to be tailored for IE11.
[For further details see the document detailing Whitehall IE11 support.](https://docs.google.com/document/d/158UOS4tjh7FLLHNfrc14PdRz_dObUePH7yuSrYFRSCc/edit?usp=sharing)
