### PR TITLE
Change dates in office on Historic Appointments to be an array

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -106,6 +106,15 @@ class Person < ApplicationRecord
     Plek.website_root + public_path(options)
   end
 
+  def previous_dates_in_office_for_role(role)
+    role_appointments.where(role:).historic.map do |appointment|
+      {
+        start_year: appointment.started_at.year,
+        end_year: appointment.ended_at.year,
+      }
+    end
+  end
+
 private
 
   def name_as_words(*elements)

--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -21,11 +21,11 @@ module PublishingApi
         details: {
           body: Whitehall::GovspeakRenderer.new.govspeak_to_html(historical_account.body),
           born: historical_account.born,
+          dates_in_office: historical_account.person.previous_dates_in_office_for_role(historical_account.role),
           died: historical_account.died,
           interesting_facts: historical_account.interesting_facts,
           major_acts: historical_account.major_acts,
           political_party: historical_account.political_membership,
-          previous_dates_in_office: historical_account.previous_dates_in_office,
         },
         document_type: "historic_appointment",
         public_updated_at: historical_account.updated_at,

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -36,13 +36,7 @@ module PublishingApi
       people_to_present = (role.role_appointments.historic.map(&:person) - HistoricalAccount.all.map(&:person)).uniq
       people_to_present.map do |person|
         { title: person.name,
-          dates_in_office:
-            person.role_appointments.where(role_id: role.id).historic.map do |appointment|
-              {
-                start_year: appointment.started_at.year,
-                end_year: appointment.ended_at.year,
-              }
-            end,
+          dates_in_office: person.previous_dates_in_office_for_role(role),
           image_url: person.image_url }
       end
     end

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -5,6 +5,8 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
     person = create(:person, forename: "Some", surname: "Person")
     role = create(:prime_minister_role)
     create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    create(:historic_role_appointment, person:, role: create(:role), started_at: Date.civil(1960), ended_at: Date.civil(1965))
+    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1965), ended_at: Date.civil(1970))
     historical_account = create(:historical_account,
                                 person:,
                                 born: "1900",
@@ -36,11 +38,20 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
       details: {
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html("Some body text"),
         born: "1900",
+        dates_in_office: [
+          {
+            start_year: 1950,
+            end_year: 1960,
+          },
+          {
+            start_year: 1965,
+            end_year: 1970,
+          },
+        ],
         died: "1975",
         interesting_facts: "They were a very interesting person",
         major_acts: "Significant legislation changes",
         political_party: "Labour",
-        previous_dates_in_office: "1950 to 1960",
       },
     }
 


### PR DESCRIPTION
We are currently including a string for dates of historic appointments, such as `2010 to 2015`. This won't allow us to cleanly group the appointments by year in the frontend.

Therefore updating this to use an array, in the same way the Historic Apppointments format already does.

Additionally, the field name has been updated to match the other format, to remove inconsistency.

Depends on https://github.com/alphagov/publishing-api/pull/2290.

[Trello card](https://trello.com/c/lBL9cgVC)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
