### PR TITLE
Update filter label for organisation

### DIFF
--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -26,11 +26,7 @@
 
     <% if filter_by.include?(:organisation) %>
       <div id="organisation_filter">
-        <% if filter_by.include?(:author) %>
-          <%= label_tag :organisation, 'or organisation' %>
-        <% else %>
-          <%= label_tag :organisation, 'organisation' %>
-        <% end %>
+        <%= label_tag :organisation, 'Organisation' %>
         <%= select_tag  :organisation, admin_organisation_filter_options(current_user, @filter.options[:organisation]), class: 'chzn-select form-control' %>
       </div>
     <% end %>


### PR DESCRIPTION
This is always an "and" query between authors and organisations. There is also nothing in the UI to stop users from selecting both options.

Therefore updating the filter label to remove the word "or".

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
