### PR TITLE
Ensure Autoselect passes blank value to controller if none selected

### DIFF
--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -37,6 +37,8 @@
 
   <% if select.any? %>
     <% if select[:multiple] %>
+      <%= hidden_field_tag "#{name}[]", [""] %>
+
       <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.",
                    class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
     <% end %>


### PR DESCRIPTION
## Description 

At the moment, when multiple is set to true on the autocomplete a blank value is not passed to the controller.

This means that it's not possible to set the fields from a value to nil on the object.

There's 2 ways to handle this

1. pass a blank hidden field which is overwritten when a value is present on the field
2. construct the blank params in the controller

Passing a hidden field is the component itself seems like the easiest and robust solution for extensibility.

## Before


https://user-images.githubusercontent.com/42515961/220346380-b0866373-9494-4238-9074-961442959178.mov

## After 


https://user-images.githubusercontent.com/42515961/220346629-7819cca3-b007-4140-b63e-252c6a4b6b4b.mov



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
