### PR TITLE
Fix featured topical event page summary

### DIFF
--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -40,7 +40,7 @@ module PublishingApi
           url: feature.image.url,
           alt_text: feature.alt_text,
         },
-        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
+        summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.summary),
         public_updated_at: topical_event.start_date,
         document_type: nil, # We don't want a type for topical events
       }

--- a/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/featured_documents_presenter_test.rb
@@ -64,7 +64,7 @@ class PublishingApi::FeaturedDocumentsPresenterTest < ActiveSupport::TestCase
             href: "/government/topical-events/topical_event_1#{locale[:suffix]}",
             image: { url: feature.image.url,
                      alt_text: feature.alt_text },
-            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
+            summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.summary),
             public_updated_at: topical_event.start_date,
             document_type: nil },
         ]


### PR DESCRIPTION
The long document body was being published instead of the short summary affecting the page layout.

https://govuk.zendesk.com/agent/tickets/5213668

| Before | After |
| --- | ----------- |
| <img width="334" alt="Screenshot 2023-02-21 at 13 55 54" src="https://user-images.githubusercontent.com/38078064/220371333-9f441578-d8e9-40a4-98c2-fc2449efac6d.png"> | <img width="667" alt="Screenshot 2023-02-21 at 14 21 38" src="https://user-images.githubusercontent.com/38078064/220371405-420ebe7e-d535-4b62-b752-67a0d4415f82.png"> |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
