### PR TITLE
Introduce locale as keyword argument in append_url_options

### DIFF
--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -13,8 +13,14 @@ module Admin::UrlOptionsHelper
 
   def show_url_with_public_and_cachebusted_options(model, url_options = {})
     options = public_and_cachebusted_url_options.merge(url_options)
+    locale = options[:locale] || :en # FIXME
     if model.respond_to?(:public_url)
-      model.public_url(options)
+      # FIXME: remove and always call with locale
+      begin
+        model.public_url(options, locale:)
+      rescue StandardError
+        model.public_url(options)
+      end
     else
       send("#{model.class.to_s.underscore}_url", model, options)
     end

--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -22,7 +22,7 @@ module LogoHelper
            else
              organisation_logo_name(organisation)
            end
-    linked_logo = link_to_if(options[:linked], logo, organisation.public_path)
+    linked_logo = link_to_if(options[:linked], logo, organisation.public_path(locale: I18n.default_locale))
     if organisation.custom_logo_selected?
       linked_logo
     else

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -243,7 +243,7 @@ module OrganisationHelper
           ),
         },
         {
-          text: link_to("[gov.uk]", organisation.public_path, class: "govuk-link #{font_weight_bold}".strip) +
+          text: link_to("[gov.uk]", organisation.public_path(locale: I18n.default_locale), class: "govuk-link #{font_weight_bold}".strip) +
             (link_to("[current site]", organisation.url, class: "govuk-link #{font_weight_bold}".strip) if organisation.govuk_status != "live"),
         },
       ]

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -74,7 +74,7 @@ module OrganisationHelper
   def superseding_organisations_text(organisation)
     if organisation.superseding_organisations.any?
       organisation_links = organisation.superseding_organisations.map do |org|
-        link_to(org.name, org.public_path)
+        link_to(org.name, org.public_path(locale: I18n.default_locale))
       end
       organisation_links.to_sentence.html_safe
     end
@@ -134,7 +134,7 @@ module OrganisationHelper
 
   def organisation_relationship_html(organisation)
     prefix = needs_definite_article?(organisation.name) ? "the " : ""
-    (prefix + link_to(organisation.name, organisation.public_path, class: "brand__color"))
+    (prefix + link_to(organisation.name, organisation.public_path(locale: I18n.default_locale), class: "brand__color"))
   end
 
   def needs_definite_article?(phrase)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,13 +1,13 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  def append_url_options(path, options = {})
-    locale = normalise_locale(options[:locale])
+  def append_url_options(path, options = {}, locale:)
+    locale_symbol = normalise_locale(locale)
 
-    if options[:format] && options[:locale] && locale != I18n.default_locale
-      path = "#{path}.#{options[:locale]}.#{options[:format]}"
-    elsif options[:locale] && locale != I18n.default_locale
-      path = "#{path}.#{options[:locale]}"
+    if options[:format] && locale_symbol != I18n.default_locale
+      path = "#{path}.#{locale_symbol}.#{options[:format]}"
+    elsif locale_symbol != I18n.default_locale
+      path = "#{path}.#{locale_symbol}"
     elsif options[:format]
       path = "#{path}.#{options[:format]}"
     end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -693,15 +693,13 @@ EXISTS (
     "/government/generic-editions/#{url_slug}"
   end
 
-  def public_path(options = {})
+  def public_path(options = {}, locale:)
     return if base_path.nil?
-
-    locale = options[:locale] || "en"
 
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
+  def public_url(options = {}, locale:)
     return if base_path.nil?
 
     website_root = if options[:draft]
@@ -710,7 +708,7 @@ EXISTS (
                      Plek.website_root
                    end
 
-    website_root + public_path(options)
+    website_root + public_path(options, locale:)
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -696,7 +696,9 @@ EXISTS (
   def public_path(options = {})
     return if base_path.nil?
 
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -86,9 +86,7 @@ class HistoricalAccount < ApplicationRecord
   end
 
   def public_path(options = {})
-    locale = options[:locale] || "en"
-
-    append_url_options(base_path, options, locale:) if previous_prime_minister?
+    append_url_options(base_path, options, locale: :en) if previous_prime_minister?
   end
 
   def public_url(options = {})

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -86,7 +86,9 @@ class HistoricalAccount < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options) if previous_prime_minister?
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:) if previous_prime_minister?
   end
 
   def public_url(options = {})

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -30,7 +30,9 @@ class OperationalField < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -29,13 +29,11 @@ class OperationalField < ApplicationRecord
     "/government/fields-of-operation/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -535,20 +535,18 @@ class Organisation < ApplicationRecord
     end
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
+  def public_url(options = {}, locale:)
     website_root = if options[:draft]
                      Plek.external_url_for("draft-origin")
                    else
                      Plek.website_root
                    end
 
-    website_root + public_path(options)
+    website_root + public_path(options, locale:)
   end
 
 private

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -536,7 +536,9 @@ class Organisation < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -99,7 +99,9 @@ class Person < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -98,14 +98,12 @@ class Person < ApplicationRecord
     "/government/people/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
   def previous_dates_in_office_for_role(role)

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -65,9 +65,7 @@ class PolicyGroup < ApplicationRecord
   end
 
   def public_path(options = {})
-    locale = options[:locale] || "en"
-
-    append_url_options(base_path, options, locale:)
+    append_url_options(base_path, options, locale: I18n.default_locale)
   end
 
   def public_url(options = {})

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -65,7 +65,9 @@ class PolicyGroup < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -161,14 +161,12 @@ class Role < ApplicationRecord
     "/government/ministers/#{slug}" if type == "MinisterialRole"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
 private

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -162,7 +162,9 @@ class Role < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -109,7 +109,11 @@ module Searchable
     # Build the payload to pass to the search index
     def search_index
       SEARCH_FIELDS.each_with_object({}) do |name, result|
-        value = searchable_options[name].call(self)
+        value = begin
+          searchable_options[name].call(self)
+        rescue StandardError
+          searchable_options[name].call(self, locale: I18n.default_locale)
+        end
         key = KEY_MAPPING[name] || name.to_s
         result[key] = value unless value.nil?
       end

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -51,14 +51,12 @@ class TakePartPage < ApplicationRecord
     "/government/get-involved/take-part/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
 protected

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -52,7 +52,9 @@ class TakePartPage < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -189,14 +189,12 @@ class TopicalEvent < ApplicationRecord
     "/government/topical-events/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
 private

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -190,7 +190,9 @@ class TopicalEvent < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/topical_event_about_page.rb
+++ b/app/models/topical_event_about_page.rb
@@ -29,13 +29,11 @@ class TopicalEventAboutPage < ApplicationRecord
     "/government/topical-events/#{topical_event.slug}/about"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 end

--- a/app/models/topical_event_about_page.rb
+++ b/app/models/topical_event_about_page.rb
@@ -30,7 +30,9 @@ class TopicalEventAboutPage < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -56,11 +56,11 @@ class Unpublishing < ApplicationRecord
   end
 
   def document_path
-    edition.public_path.gsub(edition.slug, slug)
+    edition.public_path(locale: I18n.default_locale).gsub(edition.slug, slug)
   end
 
   def document_url
-    edition.public_url.gsub(edition.slug, slug)
+    edition.public_url(locale: I18n.default_locale).gsub(edition.slug, slug)
   end
 
   # Because the edition may have been deleted, we need to find it unscoped to

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -79,14 +79,12 @@ class WorldLocation < ApplicationRecord
     "/world/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
   extend FriendlyId

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -80,7 +80,9 @@ class WorldLocation < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -42,7 +42,7 @@ class WorldLocationNews < ApplicationRecord
     if world_location.world_location?
       public_path(locale: I18n.default_locale)
     elsif world_location.international_delegation?
-      world_location.public_path
+      world_location.public_path(locale: I18n.default_locale)
     end
   end
 

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -77,7 +77,9 @@ class WorldLocationNews < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -40,7 +40,7 @@ class WorldLocationNews < ApplicationRecord
 
   def search_link
     if world_location.world_location?
-      public_path
+      public_path(locale: I18n.default_locale)
     elsif world_location.international_delegation?
       world_location.public_path
     end
@@ -76,14 +76,14 @@ class WorldLocationNews < ApplicationRecord
     "/world/#{slug}/news"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
+  def public_path(options = {}, locale:)
+    # locale = options[:locale] || "en"
 
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 
   extend FriendlyId

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -120,7 +120,9 @@ class WorldwideOrganisation < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    locale = options[:locale] || "en"
+
+    append_url_options(base_path, options, locale:)
   end
 
   def public_url(options = {})

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -119,13 +119,11 @@ class WorldwideOrganisation < ApplicationRecord
     "/world/organisations/#{slug}"
   end
 
-  def public_path(options = {})
-    locale = options[:locale] || "en"
-
+  def public_path(options = {}, locale:)
     append_url_options(base_path, options, locale:)
   end
 
-  def public_url(options = {})
-    Plek.website_root + public_path(options)
+  def public_url(options = {}, locale:)
+    Plek.website_root + public_path(options, locale:)
   end
 end

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -5,7 +5,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       title: model.name,
       format: model.display_type,
       updated_at: model.updated_at,
-      web_url: model.public_url,
+      web_url: model.public_url(locale: I18n.default_locale),
       analytics_identifier: model.analytics_identifier,
       details: {
         slug: model.slug,
@@ -13,7 +13,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       },
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),
-        web_url: model.public_url(anchor: "organisations"),
+        web_url: model.public_url({ anchor: "organisations" }, locale: I18n.default_locale),
       },
       content_id: model.content_id,
     }

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -28,7 +28,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
   def sponsor_as_json(sponsor)
     {
       title: sponsor.name,
-      web_url: sponsor.public_url,
+      web_url: sponsor.public_url(locale: I18n.default_locale),
       details: {
         acronym: sponsor.acronym || "",
       },

--- a/app/presenters/document_export_presenter.rb
+++ b/app/presenters/document_export_presenter.rb
@@ -215,7 +215,7 @@ private
         edition = Whitehall::AdminLinkLookup.find_edition(link)
         {
           whitehall_admin_url: link,
-          public_url: edition ? edition.public_url : nil,
+          public_url: edition ? edition.public_url(locale: I18n.default_locale) : nil,
           content_id: edition&.content_id,
         }
       end

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -36,7 +36,7 @@ class DocumentListExportPresenter
 
   def row_data
     [
-      public_url,
+      edition.public_url(locale: I18n.default_locale),
       admin_url,
       edition.title,
       lead_organisations,
@@ -58,8 +58,6 @@ class DocumentListExportPresenter
       edition.summary,
     ]
   end
-
-  delegate :public_url, to: :edition
 
   def admin_url
     Whitehall.url_maker.admin_edition_url(edition)

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -20,7 +20,7 @@ class EmbassyPresenter < SimpleDelegator
     elsif organisation
       link_to(
         organisation.name,
-        organisation.public_path,
+        organisation.public_path(locale: I18n.default_locale),
         class: "govuk-link",
       )
     end

--- a/app/presenters/feature_presenter.rb
+++ b/app/presenters/feature_presenter.rb
@@ -54,7 +54,7 @@ FeaturePresenter = Struct.new(:feature) do
       edition.public_path(locale: feature.locale)
     else
       ::I18n.with_locale ENGLISH_LOCALE_CODE do
-        edition.public_path
+        edition.public_path(locale: I18n.locale)
       end
     end
   end

--- a/app/presenters/feature_presenter.rb
+++ b/app/presenters/feature_presenter.rb
@@ -47,7 +47,7 @@ FeaturePresenter = Struct.new(:feature) do
 
   def public_path
     if topical_event
-      topical_event.public_path
+      topical_event.public_path(locale: I18n.default_locale)
     elsif offsite_link
       offsite_link.url
     elsif edition.translatable?

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -19,6 +19,6 @@ class PersonPresenter < Whitehall::Decorators::Decorator
   end
 
   def path
-    model.public_path
+    model.public_path(locale: I18n.default_locale)
   end
 end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -171,7 +171,7 @@ module PublishingApi
         if about_page.present?
           cips << {
             title: I18n.t("corporate_information_page.type.title.about"),
-            href: about_page.public_path,
+            href: about_page.public_path(locale: I18n.default_locale),
           }
         end
       end
@@ -186,14 +186,14 @@ module PublishingApi
       item.corporate_information_pages.published.by_menu_heading(:our_information).each do |cip|
         cips << {
           title: cip.title,
-          href: cip.public_path,
+          href: cip.public_path(locale: I18n.default_locale),
         }
       end
 
       item.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |cip|
         cips << {
           title: cip.title,
-          href: cip.public_path,
+          href: cip.public_path(locale: I18n.default_locale),
         }
       end
 
@@ -259,7 +259,7 @@ module PublishingApi
       page.extend(UseSlugAsParam)
       link_to(
         t_corporate_information_page_type_link_text(page),
-        page.public_path,
+        page.public_path(locale: I18n.default_locale),
         class: "govuk-link brand__color",
       )
     end

--- a/app/presenters/role_presenter.rb
+++ b/app/presenters/role_presenter.rb
@@ -19,7 +19,7 @@ class RolePresenter < Whitehall::Decorators::Decorator
 
   def path
     if ministerial?
-      model.public_path
+      model.public_path(locale: I18n.default_locale)
     end
   end
 

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -3,7 +3,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdates
     visible_edition = attachment_data.visible_edition_for(nil)
     return [] if visible_edition.blank?
 
-    parent_document_url = visible_edition.public_url
+    parent_document_url = visible_edition.public_url(locale: I18n.default_locale)
 
     Enumerator.new do |enum|
       enum.yield AssetManager::AttachmentUpdater::Update.new(

--- a/app/services/author_notifier_service.rb
+++ b/app/services/author_notifier_service.rb
@@ -35,6 +35,6 @@ class AuthorNotifierService
   end
 
   def public_document_url
-    edition.public_url
+    edition.public_url(locale: I18n.default_locale)
   end
 end

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -36,7 +36,7 @@ class LinkCheckerApiService
     converted = links.map do |link|
       edition = Whitehall::AdminLinkLookup.find_edition(link)
       if edition
-        edition.public_url if edition.published?
+        edition.public_url(locale: I18n.default_locale) if edition.published?
       else
         link
       end

--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -54,7 +54,7 @@ private
   end
 
   def public_url(edition)
-    edition.public_url(host: public_host, protocol: "https")
+    edition.public_url({ host: public_host, protocol: "https" }, locale: I18n.default_locale)
   end
 
   def admin_url(edition)

--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -41,7 +41,7 @@ module ServiceListeners
       destination = if edition.unpublishing.redirect?
                       Addressable::URI.parse(edition.unpublishing.alternative_url).path
                     else
-                      edition.public_path
+                      edition.public_path(locale: I18n.default_locale)
                     end
 
       current_html_attachments.each do |html_attachment|
@@ -132,7 +132,7 @@ module ServiceListeners
       content_ids_to_remove.each do |content_id|
         PublishingApiRedirectWorker.new.perform(
           content_id,
-          edition.public_path,
+          edition.public_path(locale: I18n.default_locale),
           I18n.default_locale.to_s,
         )
       end

--- a/app/views/admin/edition_workflow/confirm_approve_retrospectively.html.erb
+++ b/app/views/admin/edition_workflow/confirm_approve_retrospectively.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag approve_retrospectively_admin_edition_path(@edition, lock_version: @edition.lock_version) do %>
       <p class="govuk-body">Are you sure you want to retrospectively approve this document?</p>
-      <p class="govuk-body govuk-!-margin-bottom-7">This edition was force published and has not yet been reviewed by a second pair of eyes. <%= link_to "View this on the website (opens in new tab)", preview_document_url(@edition), class: "govuk-link", target: '_blank' %> and check everything thoroughly.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">This edition was force published and has not yet been reviewed by a second pair of eyes. <%= link_to "View this on the website (opens in new tab)", preview_document_url(@edition, locale: I18n.default_locale), class: "govuk-link", target: '_blank' %> and check everything thoroughly.</p>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -41,7 +41,7 @@
       } %>
       <p class="govuk-body">
         <%= link_to("Preview on website #{"- English" if @edition.translatable? && @edition.available_in_multiple_languages?} (opens in new tab)".strip,
-        preview_document_url(@edition),
+        preview_document_url(@edition, locale: I18n.default_locale),
         class: "govuk-link",
         target: "_blank",
         data: {

--- a/app/views/admin/editions/show/_main_notices.html.erb
+++ b/app/views/admin/editions/show/_main_notices.html.erb
@@ -10,7 +10,7 @@
     title: "This edition was force published and has not yet been reviewed by a second pair of eyes",
     description: capture do %>
       <% if can?(:approve, edition) %>
-        <p class="govuk-body"><%= link_to "View this on the website", preview_document_url(edition), class: "govuk-link", target: '_blank' %> and check everything thoroughly.</p>
+        <p class="govuk-body"><%= link_to "View this on the website", preview_document_url(edition, locale: I18n.default_locale), class: "govuk-link", target: '_blank' %> and check everything thoroughly.</p>
         <%= render "govuk_publishing_components/components/button", {
             text: "Approve",
             href: confirm_approve_retrospectively_admin_edition_path(@edition, lock_version: @edition.lock_version),

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -20,7 +20,7 @@
           <tr>
             <td class="locale">
               <%= link_to locale.native_language_name, edit_admin_organisation_translation_path(@organisation, locale.code) %>
-              (<%= link_to "view", @organisation.public_url(draft: true, locale: locale.code) %>)
+              (<%= link_to "view", @organisation.public_url({draft: true}, locale: locale.code) %>)
             </td>
             <td class="actions">
               <%= button_to 'Delete',

--- a/app/views/admin/organisations/_legacy_organisation_row.html.erb
+++ b/app/views/admin/organisations/_legacy_organisation_row.html.erb
@@ -11,7 +11,7 @@
   <td><%= organisation.organisation_type.name %></td>
   <td><%= organisation.govuk_status %></td>
   <td>
-    <%= link_to '[gov.uk]', organisation.public_path %>
+    <%= link_to '[gov.uk]', organisation.public_path(locale: I18n.default_locale) %>
     <% if organisation.govuk_status != 'live' %>
       <%= link_to '[current site]', organisation.url %>
     <% end %>

--- a/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_legacy_organisations_name_list.html.erb
@@ -1,7 +1,7 @@
 <ul class="organisations-name-list">
   <% organisations.each do |organisation| %>
     <%= content_tag_for(:li, organisation, class: 'organisation') do %>
-      <%= link_to organisation.name, organisation.public_path %>
+      <%= link_to organisation.name, organisation.public_path(locale: I18n.default_locale) %>
     <% end %>
   <% end %>
 </ul>

--- a/app/views/admin/organisations/_organisations_name_list.html.erb
+++ b/app/views/admin/organisations/_organisations_name_list.html.erb
@@ -1,5 +1,5 @@
 <%= render "govuk_publishing_components/components/list", {
   items: organisations.map do |organisation|
-    link_to organisation.name, organisation.public_path, class: "govuk-link"
+    link_to organisation.name, organisation.public_path(locale: I18n.default_locale), class: "govuk-link"
   end
 } %>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -5,7 +5,7 @@
     <h1>
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
-    <p><%= link_to "View on website", @world_location_news.public_url({locale: params[:locale]}.merge(cachebust_url_options)) %></p>
+    <p><%= link_to "View on website", @world_location_news.public_url(cachebust_url_options, locale: params[:locale]) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location_news) %>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
     <p>
-    <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %>
+    <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options, locale: :en) %>
   </div>
 
   <section class="world-location-details">

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -6,7 +6,7 @@
     <h1>
       <span class="name"><%= @world_location_news.name %></span>
     </h1>
-    <p><%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %></p>
+    <p><%= link_to "View on website", @world_location_news.public_url(cachebust_url_options, locale: :en) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location_news) %>

--- a/app/views/corporate_information_pages/index.html.erb
+++ b/app/views/corporate_information_pages/index.html.erb
@@ -21,7 +21,7 @@
 
       <div class="govuk-grid-column-two-thirds">
         <%= content_tag :p, class: 'govuk-body homepage-link' do %>
-          <%= link_to "#{@organisation.name} homepage", @organisation.public_path, class: "govuk-link" %>
+          <%= link_to "#{@organisation.name} homepage", @organisation.public_path(locale: I18n.default_locale), class: "govuk-link" %>
         <% end %>
         <aside class="organisation-top-tasks">
           <%= render partial: 'shared/available_languages', locals: {object: @organisation, linkable: [:about, @organisation]} %>

--- a/app/views/corporate_information_pages/show.html.erb
+++ b/app/views/corporate_information_pages/show.html.erb
@@ -19,7 +19,7 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render 'shared/available_languages', object: @corporate_information_page %>
         <%= content_tag :p, class: 'govuk-body homepage-link' do %>
-          <%= link_to "#{@organisation.name} homepage", @organisation.public_path, class: "govuk-link" %>
+          <%= link_to "#{@organisation.name} homepage", @organisation.public_path(locale: I18n.default_locale), class: "govuk-link" %>
         <% end %>
         <%= render "govuk_publishing_components/components/title", {
           title: @corporate_information_page.title,

--- a/app/views/csv_preview/show.html.erb
+++ b/app/views/csv_preview/show.html.erb
@@ -8,7 +8,7 @@
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: {
           name: organisation_logo_name(organisation),
-          url: organisation.public_path,
+          url: organisation.public_path(locale: I18n.default_locale),
           brand: organisation.organisation_brand_colour ? organisation.organisation_brand_colour.class_name : nil,
           crest: organisation.organisation_logo_type.class_name,
         }

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -6,6 +6,6 @@
       heading_level: 3,
       margin_bottom: 1
     } %>
-    <%= link_to(organisation.name, organisation.public_path, class: "govuk-link") %>
+    <%= link_to(organisation.name, organisation.public_path(locale: I18n.default_locale), class: "govuk-link") %>
   </li>
 <% end %>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -98,7 +98,7 @@
           } %>
 
           <% if @prime_minister.present? %>
-            <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, @prime_minister.public_url, class: "govuk-link" %>.</p>
+            <p class="govuk-body">The Prime Minister is <%= link_to @prime_minister.name, @prime_minister.public_url(locale: I18n.default_locale), class: "govuk-link" %>.</p>
           <% end %>
 
           <p class="govuk-body govuk-!-margin-bottom-8">

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -85,7 +85,7 @@
           <%= render "govuk_publishing_components/components/organisation_logo", {
             organisation: {
               name: sanitize(format_with_html_line_breaks(organisation.logo_formatted_name)),
-              url: organisation.public_path,
+              url: organisation.public_path(locale: I18n.default_locale),
               brand: organisation[:slug],
               crest: organisation.organisation_crest,
             },

--- a/app/views/operational_fields/show.html.erb
+++ b/app/views/operational_fields/show.html.erb
@@ -55,7 +55,7 @@
                         <% if fatality_notice.fatality_notice_casualties.any? %>
                           <% fatality_notice.fatality_notice_casualties.each do |casualty| %>
                             <%= content_tag_for :li, casualty, class: 'govuk-list--bullet' do %>
-                              <%= link_to casualty.personal_details, public_document_url(fatality_notice), class: "govuk-link" %>
+                              <%= link_to casualty.personal_details, public_document_url(fatality_notice, locale: I18n.default_locale), class: "govuk-link" %>
                             <% end %>
                           <% end %>
                         <% else %>

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -16,7 +16,7 @@
     <% unless hide_image %>
       <% if person.image %>
         <div class="app-person__image-holder">
-          <%= link_to person.image, person.public_path, class: "aspect-ratio-3:2", tabindex: '-1', aria: { hidden: true } %>
+          <%= link_to person.image, person.public_path(locale: I18n.default_locale), class: "aspect-ratio-3:2", tabindex: '-1', aria: { hidden: true } %>
         </div>
       <% else %>
         <div class="blank-person">

--- a/app/views/world_locations/_list.html.erb
+++ b/app/views/world_locations/_list.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/list", {
   items: world_locations.map do |world_location|
     if world_location.active?
-      link_to world_location.name, world_location.public_path, class: 'location-link govuk-link'
+      link_to world_location.name, world_location.public_path(locale: I18n.default_locale), class: 'location-link govuk-link'
     else
       world_location.name
     end

--- a/app/views/world_locations/_world_location.html.erb
+++ b/app/views/world_locations/_world_location.html.erb
@@ -1,7 +1,7 @@
 <% options ||= {} %>
 <%= content_tag_for(:li, world_location, options) do %>
   <% if world_location.active? %>
-    <%= link_to world_location.name, world_location.public_path, class: 'location-link govuk-link' %>
+    <%= link_to world_location.name, world_location.public_path(locale: I18n.default_locale), class: 'location-link govuk-link' %>
   <% else %>
     <span class="location-link"><%= world_location.name %></span>
   <% end %>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -26,7 +26,7 @@
         <dl>
           <% if world_locations.any? %>
             <dt><%= t('worldwide_organisation.location') %>:</dt>
-            <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l.public_path, class: "govuk-link") }.to_sentence.html_safe %></dd>
+            <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l.public_path(locale: I18n.default_locale), class: "govuk-link") }.to_sentence.html_safe %></dd>
           <% end %>
           <dt><%= t('worldwide_organisation.part_of') %>:</dt>
           <dd lang="en"><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o.public_path(locale: I18n.default_locale), class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -8,7 +8,7 @@
     <%= render "govuk_publishing_components/components/organisation_logo", {
       organisation: {
         name: translated_organisation_logo_name(organisation),
-        url: link_to_organisation ? organisation.public_path : nil,
+        url: link_to_organisation ? organisation.public_path(locale: I18n.default_locale) : nil,
         crest: "single-identity",
       },
       heading_level: 1,
@@ -29,7 +29,7 @@
             <dd class="js-hide-other-links"><%= world_locations.map {|l| link_to(l.name, l.public_path, class: "govuk-link") }.to_sentence.html_safe %></dd>
           <% end %>
           <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-          <dd lang="en"><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o.public_path, class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
+          <dd lang="en"><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o.public_path(locale: I18n.default_locale), class: "sponsoring-organisation govuk-link") }.to_sentence.html_safe %></dd>
         </dl>
       </div>
     </div>

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -41,7 +41,7 @@ When(/^I reorder the offices to highlight my new office$/) do
 end
 
 Then(/^I see the offices in my specified order including the new one under the main office on the home page of the worldwide organisation$/) do
-  visit @the_organisation.public_path
+  visit @the_organisation.public_path(locale: :en)
 
   contact_headings = all(".contact-section .gem-c-heading").map(&:text)
 
@@ -64,7 +64,7 @@ When(/^I decide that one of the offices no longer belongs on the home page$/) do
 end
 
 Then(/^that office is no longer visible on the home page of the worldwide organisation$/) do
-  visit @the_organisation.public_path
+  visit @the_organisation.public_path(locale: :en)
 
   within ".contact-section:first-of-type" do
     expect(page).to_not have_selector("h2", text: @the_removed_office.title)

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -31,7 +31,7 @@ end
 Then(/^I should see the corporate information on the public worldwide organisation page$/) do
   worldwide_organisation = WorldwideOrganisation.last
   info_page = worldwide_organisation.corporate_information_pages.last
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
   expect(page).to have_content(info_page.title)
   click_link info_page.title
   expect(page).to have_content(info_page.body)
@@ -61,7 +61,7 @@ end
 
 Then(/^I should be able to read the translated "([^"]*)" corporate information page for the worldwide organisation "([^"]*)" on the site$/) do |corp_page, worldwide_org|
   worldwide_organisation = WorldwideOrganisation.find_by(name: worldwide_org)
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
 
   click_link corp_page
   click_link "Français"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -50,7 +50,7 @@ Then(/^I should only see the news article on the French version of the public "(
   within record_css_selector(@news_article) do
     expect(page).to have_content(@news_article.title)
   end
-  visit world_location.public_path
+  visit world_location.public_path(locale: :en)
   expect(page).to_not have_selector(record_css_selector(@news_article))
 end
 

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -87,7 +87,7 @@ Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
 end
 
 Then(/^I should see him listed as "([^"]*)" on the worldwide organisation page$/) do |role_name|
-  visit WorldwideOrganisation.last.public_path
+  visit WorldwideOrganisation.last.public_path(locale: :en)
   person = Person.last
   role = Role.find_by!(name: role_name)
 

--- a/features/step_definitions/social_media_steps.rb
+++ b/features/step_definitions/social_media_steps.rb
@@ -48,7 +48,7 @@ Then(/^the "([^"]*)" social link should be shown on the public website for the (
                      else
                        Organisation.last
                      end
-  visit social_container.public_path
+  visit social_container.public_path(locale: :en)
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: social_service)
 end
 
@@ -58,7 +58,7 @@ Then(/^the "([^"]*)" social link called "([^"]+)" should be shown on the public 
                      else
                        Organisation.last
                      end
-  visit social_container.public_path
+  visit social_container.public_path(locale: :en)
   expect(page).to have_selector(".gem-c-share-links .gem-c-share-links__link[data-track-action=\"#{social_service.parameterize}\"]", text: title)
 end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -56,7 +56,7 @@ end
 Then(/^I should see the worldwide organisation "([^"]*)" on the "([^"]*)" world location page$/) do |worldwide_organisation_name, location_name|
   location = WorldLocation.find_by(name: location_name)
   worldwide_organisation = WorldwideOrganisation.find_by(name: worldwide_organisation_name)
-  visit location.public_path
+  visit location.public_path(locale: :en)
   within record_css_selector(worldwide_organisation) do
     expect(page).to have_content(worldwide_organisation_name)
   end

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -25,7 +25,7 @@ end
 
 Then(/^I should see the(?: updated)? worldwide organisation information on the public website$/) do
   worldwide_organisation = WorldwideOrganisation.last
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
   expect(page).to have_title(worldwide_organisation.name)
 end
 
@@ -75,7 +75,7 @@ When(/^I delete the worldwide organisation$/) do
 end
 
 Then(/^the worldwide organisation should not be visible from the public website$/) do
-  expect { visit @worldwide_organisation.public_path }
+  expect { visit @worldwide_organisation.public_path(locale: :en) }
     .to raise_error(ActiveRecord::RecordNotFound)
 end
 
@@ -107,7 +107,7 @@ end
 
 Then(/^the "([^"]*)" office details should be shown on the public website$/) do |description|
   worldwide_org = WorldwideOrganisation.last
-  visit worldwide_org.public_path
+  visit worldwide_org.public_path(locale: :en)
   worldwide_office = worldwide_org.offices.joins(contact: :translations).where(contact_translations: { title: description }).first
 
   within record_css_selector(worldwide_office) do
@@ -158,14 +158,14 @@ end
 Then(/^the "([^"]*)" should be shown as the main office on the public website$/) do |contact_title|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: contact_title }).first
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
   within record_css_selector(worldwide_office) do
     expect(page).to have_content(contact_title)
   end
 end
 
 Then(/^I should see his name on the worldwide organisation page$/) do
-  visit WorldwideOrganisation.last.public_path
+  visit WorldwideOrganisation.last.public_path(locale: :en)
   person = Person.last
 
   within record_css_selector(person) do
@@ -174,7 +174,7 @@ Then(/^I should see his name on the worldwide organisation page$/) do
 end
 
 Then(/^I should not see his name on the worldwide organisation page$/) do
-  visit WorldwideOrganisation.last.public_path
+  visit WorldwideOrganisation.last.public_path(locale: :en)
   person = Person.last
 
   within record_css_selector(person) do
@@ -193,7 +193,7 @@ end
 Then(/^I should see the default access information on the public "([^"]*)" office page$/) do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
   within record_css_selector(worldwide_office) do
     click_link "Access and opening times"
   end
@@ -239,7 +239,7 @@ end
 Then(/^I should see the custom access information on the public "([^"]*)" office page$/) do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit worldwide_organisation.public_path
+  visit worldwide_organisation.public_path(locale: :en)
   within record_css_selector(worldwide_office) do
     click_link "Access and opening times"
   end

--- a/lib/govspeak/admin_link_replacer.rb
+++ b/lib/govspeak/admin_link_replacer.rb
@@ -21,7 +21,7 @@ module Govspeak
       edition = Whitehall::AdminLinkLookup.find_edition(anchor["href"])
 
       if edition.present? && edition.linkable?
-        public_url = edition.public_url
+        public_url = edition.public_url(locale: I18n.default_locale)
         new_html = convert_link(anchor, public_url)
       else
         new_html = anchor.inner_text

--- a/lib/publish_organisations_index_page.rb
+++ b/lib/publish_organisations_index_page.rb
@@ -51,7 +51,7 @@ private
     presented_organisations.send(organisation_type_key).map do |organisation|
       {
         title: organisation.name,
-        href: organisation.public_path,
+        href: organisation.public_path(locale: I18n.default_locale),
         brand: organisation.organisation_brand,
         logo: organisation_logo(organisation),
         separate_website: organisation.exempt?,
@@ -120,7 +120,7 @@ private
   def summary_organisation(organisation)
     {
       title: organisation.name,
-      href: organisation.public_path,
+      href: organisation.public_path(locale: I18n.default_locale),
     }
   end
 

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -44,7 +44,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation, translated_into: [:fr])
     get :index, params: { organisation_id: organisation }
     edit_translation_path = edit_admin_organisation_translation_path(organisation, "fr")
-    view_organisation_url = organisation.public_url(draft: true, locale: "fr")
+    view_organisation_url = organisation.public_url({ draft: true }, locale: "fr")
     assert_select "a[href=?]", edit_translation_path, text: "Français"
     assert_select "a[href=?]", view_organisation_url, text: "view"
   end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -27,8 +27,8 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
 
     get :show, params: { organisation: nil, worldwide_organisation_id: worldwide_organisation, id: corporate_information_page.slug }
 
-    assert_select "a[href=?]", worldwide_organisation.public_path
-    assert_select "a[href=?]", world_location.public_path
+    assert_select "a[href=?]", worldwide_organisation.public_path(locale: :en)
+    assert_select "a[href=?]", world_location.public_path(locale: :en)
   end
 
   view_test "should show links to the alternate languages for a translated organisation" do

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -426,8 +426,8 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     get(:show, params:)
 
-    assert_select "a[href=?]", organisation1.public_path
-    assert_select "a[href=?]", organisation2.public_path
+    assert_select "a[href=?]", organisation1.public_path(locale: :en)
+    assert_select "a[href=?]", organisation2.public_path(locale: :en)
   end
 
   view_test "renders CSV column headings" do

--- a/test/functional/document_collections_controller_test.rb
+++ b/test/functional/document_collections_controller_test.rb
@@ -7,6 +7,6 @@ class DocumentCollectionControllerRedirectsTest < ActionDispatch::IntegrationTes
     get "/government/organisations/ministry-of-defence/series/firing-notice"
 
     assert response.redirect?
-    assert response.location = document_collection.public_url
+    assert response.location = document_collection.public_url(locale: :en)
   end
 end

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -224,6 +224,6 @@ class MinisterialRolesControllerTest < ActionController::TestCase
 private
 
   def assert_minister_role_links_to_their_role(role)
-    assert_select ".app-person__roles a[href='#{role.public_path}']", text: role.name
+    assert_select ".app-person__roles a[href='#{role.public_path(locale: :en)}']", text: role.name
   end
 end

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -202,7 +202,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     get :index
 
     assert_select_prefix_object(person, "by-organisation-#{org.slug}") do
-      assert_select "a[href=?]", person.public_path, text: "John Doe"
+      assert_select "a[href=?]", person.public_path(locale: :en), text: "John Doe"
       assert_minister_role_links_to_their_role(ministerial_role)
     end
   end

--- a/test/functional/operational_fields_controller_test.rb
+++ b/test/functional/operational_fields_controller_test.rb
@@ -84,7 +84,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
     assert_select "ul.govuk-list" do
       fields.each do |field|
         assert_select_object field do
-          assert_select "a[href=?]", field.public_path
+          assert_select "a[href=?]", field.public_path(locale: :en)
         end
       end
     end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -44,8 +44,8 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     get :show, params: { id: organisation.id }
 
-    assert_select "a[href='#{location1.public_path}']"
-    assert_select "a[href='#{location2.public_path}']"
+    assert_select "a[href='#{location1.public_path(locale: :en)}']"
+    assert_select "a[href='#{location2.public_path(locale: :en)}']"
   end
 
   test "show redirects to the api worldwide organisation endpoint when json is requested" do

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -38,7 +38,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
           visit admin_news_article_path(edition)
           force_publish_document
 
-          parent_document_url = edition.public_url
+          parent_document_url = edition.public_url(locale: :en)
 
           Services.asset_manager.expects(:update_asset)
             .at_least_once

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -13,8 +13,8 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:attachment) { build(:file_attachment, attachable:, file:) }
     let(:attachable) { edition }
     let(:asset_id) { "asset-id" }
-    let(:redirect_path) { edition.public_path }
-    let(:redirect_url) { edition.public_url }
+    let(:redirect_path) { edition.public_path(locale: :en) }
+    let(:redirect_url) { edition.public_url(locale: :en) }
     let(:topic_taxon) { build(:taxon_hash) }
 
     before do

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -41,12 +41,6 @@ class RoutingLocaleTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "#show with no locale" do
-    worldwide_organisation = create(:worldwide_organisation)
-    assert_equal "/world/organisations/#{worldwide_organisation.slug}",
-                 worldwide_organisation.public_path
-  end
-
   test "#show with english locale doesn't includes the locale in the path" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}",
@@ -59,21 +53,15 @@ class RoutingLocaleTest < ActionDispatch::IntegrationTest
                  worldwide_organisation.public_path(locale: "dr")
   end
 
-  test "#show with a format includes it in the path" do
-    worldwide_organisation = create(:worldwide_organisation)
-    assert_equal "/world/organisations/#{worldwide_organisation.slug}.json",
-                 worldwide_organisation.public_path(format: "json")
-  end
-
   test "#show with a english locale and a format includes the format in the path" do
     worldwide_organisation = create(:worldwide_organisation)
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.json",
-                 worldwide_organisation.public_path(locale: "en", format: "json")
+                 worldwide_organisation.public_path({ format: "json" }, locale: "en")
   end
 
   test "#show with a non-english locale and a format includes the locale and format in the path" do
     worldwide_organisation = I18n.with_locale(:cy) { create(:worldwide_organisation) }
     assert_equal "/world/organisations/#{worldwide_organisation.slug}.cy.json",
-                 worldwide_organisation.public_path(locale: "cy", format: "json")
+                 worldwide_organisation.public_path({ format: "json" }, locale: "cy")
   end
 end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -57,25 +57,25 @@ class RoutingTest < ActionDispatch::IntegrationTest
   test "redirects organisation groups index URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/groups"
-    assert_redirected_to organisation.public_path
+    assert_redirected_to organisation.public_path(locale: :en)
   end
 
   test "redirects organisation groups show URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/groups/some-group"
-    assert_redirected_to organisation.public_path
+    assert_redirected_to organisation.public_path(locale: :en)
   end
 
   test "redirects organisation chiefs-of-staff URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/chiefs-of-staff"
-    assert_redirected_to organisation.public_path
+    assert_redirected_to organisation.public_path(locale: :en)
   end
 
   test "redirects organisation consultations URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/consultations"
-    assert_redirected_to organisation.public_path
+    assert_redirected_to organisation.public_path(locale: :en)
   end
 
   test "redirects organisation series URL to publications page" do

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -18,7 +18,7 @@ class SchedulingTest < ActiveSupport::TestCase
 
   test "scheduling a first-edition publishes a publish intent" do
     Sidekiq::Testing.inline! do
-      path = @submitted_edition.public_path
+      path = @submitted_edition.public_path(locale: :en)
       schedule(@submitted_edition)
       assert_publishing_api_put_intent(
         path,
@@ -44,7 +44,7 @@ class SchedulingTest < ActiveSupport::TestCase
         user = create(:user)
       end
 
-      path = new_draft.public_path
+      path = new_draft.public_path(locale: :en)
 
       acting_as(user) { schedule(new_draft) }
 
@@ -60,7 +60,7 @@ class SchedulingTest < ActiveSupport::TestCase
         @submitted_edition.save!
       end
 
-      english_path = @submitted_edition.public_path
+      english_path = @submitted_edition.public_path(locale: :en)
       french_path  = @submitted_edition.public_path(locale: :fr)
       publish_time = @submitted_edition.scheduled_publication.as_json
 
@@ -77,7 +77,7 @@ class SchedulingTest < ActiveSupport::TestCase
       SecureRandom.stubs(uuid: gone_uuid)
       scheduled_edition = create(:scheduled_case_study)
       unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-      base_path         = scheduled_edition.public_path
+      base_path         = scheduled_edition.public_path(locale: :en)
 
       destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
       unscheduler.perform!
@@ -92,7 +92,7 @@ class SchedulingTest < ActiveSupport::TestCase
       scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
 
       unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-      base_path         = scheduled_edition.public_path
+      base_path         = scheduled_edition.public_path(locale: :en)
 
       destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
 

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -102,7 +102,7 @@ module CssSelectors
   end
 
   def link_to_preview_version_selector(document)
-    "a[href='#{preview_document_url(document)}']"
+    "a[href='#{preview_document_url(document, locale: I18n.default_locale)}']"
   end
 
   def policy_group_selector

--- a/test/unit/application_record_test.rb
+++ b/test/unit/application_record_test.rb
@@ -6,22 +6,22 @@ class ApplicationRecordTest < ActiveSupport::TestCase
   end
 
   test "append_url_options adds format" do
-    assert_equal "/government/foo.atom", Edition.new.append_url_options("/government/foo", format: "atom")
+    assert_equal "/government/foo.atom", Edition.new.append_url_options("/government/foo", { format: "atom" }, locale: "en")
   end
 
   test "append_url_options adds locale and format when both present" do
-    assert_equal "/government/foo.cy.atom", Edition.new.append_url_options("/government/foo", format: "atom", locale: "cy")
+    assert_equal "/government/foo.cy.atom", Edition.new.append_url_options("/government/foo", { format: "atom" }, locale: "cy")
   end
 
   test "append_url_options adds cachebust string when present" do
-    assert_equal "/government/foo?cachebust=123", Edition.new.append_url_options("/government/foo", cachebust: "123")
+    assert_equal "/government/foo?cachebust=123", Edition.new.append_url_options("/government/foo", { cachebust: "123" }, locale: "en")
   end
 
   test "append_url_options adds anchor string when present" do
-    assert_equal "/government/foo#heading", Edition.new.append_url_options("/government/foo", anchor: "heading")
+    assert_equal "/government/foo#heading", Edition.new.append_url_options("/government/foo", { anchor: "heading" }, locale: "en")
   end
 
   test "append_url_options adds cachebust string, format, locale and anchor when all present" do
-    assert_equal "/government/foo.cy.atom?cachebust=123#heading", Edition.new.append_url_options("/government/foo", cachebust: "123", format: "atom", locale: "cy", anchor: "heading")
+    assert_equal "/government/foo.cy.atom?cachebust=123#heading", Edition.new.append_url_options("/government/foo", { cachebust: "123", format: "atom", anchor: "heading" }, locale: "cy")
   end
 end

--- a/test/unit/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/govspeak/admin_link_replacer_test.rb
@@ -4,7 +4,7 @@ module Govspeak
   class AdminLinkReplacerTest < ActiveSupport::TestCase
     test "rewrites admin links for published editions" do
       speech     = create(:published_speech)
-      public_url = speech.public_url
+      public_url = speech.public_url(locale: :en)
       fragment   = govspeak_to_nokogiri_fragment("this and [that](/government/admin/speeches/#{speech.id}) yeah?")
 
       AdminLinkReplacer.new(fragment).replace!
@@ -26,7 +26,7 @@ module Govspeak
     test "rewrites admin links to published corporate information pages" do
       cip        = create(:published_corporate_information_page)
       admin_path = Whitehall.url_maker.polymorphic_path([:admin, cip.organisation, cip])
-      public_url = cip.public_url
+      public_url = cip.public_url(locale: :en)
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to an [info page](#{admin_path})")
 
       AdminLinkReplacer.new(fragment).replace!
@@ -38,7 +38,7 @@ module Govspeak
       world_org  = create(:worldwide_organisation)
       cip        = create(:published_corporate_information_page, organisation: nil, worldwide_organisation: world_org)
       admin_path = Whitehall.url_maker.polymorphic_path([:admin, world_org, cip])
-      public_url = cip.public_url
+      public_url = cip.public_url(locale: :en)
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to a [world info page](#{admin_path})")
 
       AdminLinkReplacer.new(fragment).replace!

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -65,7 +65,7 @@ class GovspeakHelperTest < ActionView::TestCase
   test "should rewrite admin links for editions" do
     speech = create(:published_speech)
     admin_path = admin_speech_path(speech)
-    public_url = speech.public_url
+    public_url = speech.public_url(locale: :en)
 
     govspeak = "this and [that](#{admin_path}) yeah?"
     html = govspeak_to_html(govspeak)

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -3,39 +3,39 @@ require "test_helper"
 class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
   test "uses the document to generate the route" do
     publication = create(:publication)
-    assert_equal publication.public_path, public_document_path(publication)
+    assert_equal publication.public_path(locale: :en), public_document_path(publication)
   end
 
   test "respects additional path options" do
     publication = create(:publication)
-    assert_equal publication.public_path(anchor: "additional"), public_document_path(publication, anchor: "additional")
+    assert_equal publication.public_path({ anchor: "additional" }, locale: :en), public_document_path(publication, { anchor: "additional" })
   end
 
   test "returns the public_path for Publication instances" do
     publication = create(:publication)
-    assert_equal publication.public_path, public_document_path(publication)
+    assert_equal publication.public_path(locale: :en), public_document_path(publication)
   end
 
   test "returns the public_path for NewsArticle instances" do
     news_article = create(:news_article)
-    assert_equal news_article.public_path, public_document_path(news_article)
+    assert_equal news_article.public_path(locale: :en), public_document_path(news_article)
   end
 
   test "returns the public_path for Publications which are Statistics or NationalStatistics" do
     statistics = create(:publication, :statistics)
-    assert_equal statistics.public_path, public_document_path(statistics)
+    assert_equal statistics.public_path(locale: :en), public_document_path(statistics)
     national_statistics = create(:publication, :national_statistics)
-    assert_equal national_statistics.public_path, public_document_path(national_statistics)
+    assert_equal national_statistics.public_path(locale: :en), public_document_path(national_statistics)
   end
 
   test "returns the public_path for Speech instances" do
     speech = create(:speech)
-    assert_equal speech.public_path, public_document_path(speech)
+    assert_equal speech.public_path(locale: :en), public_document_path(speech)
   end
 
   test "returns the public_path for Consultation instances" do
     consultation = create(:consultation)
-    assert_equal consultation.public_path, public_document_path(consultation)
+    assert_equal consultation.public_path(locale: :en), public_document_path(consultation)
   end
 
   test "returns the statistical_data_set_path for StatisticalDataSet instances" do
@@ -101,7 +101,7 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
   test "When in a foreign locale, it generates a route to the english version if no foreign version is available" do
     publication = create(:publication)
     I18n.with_locale(:fr) do
-      assert_equal publication.public_url, public_document_url(publication)
+      assert_equal publication.public_url(locale: :en), public_document_url(publication)
     end
   end
 
@@ -119,13 +119,13 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
 
   test "Creates a preview URL with cachebust and edition parameters" do
     edition = create(:corporate_information_page)
-    preview_url = preview_document_url(edition)
+    preview_url = preview_document_url(edition, locale: :en)
     assert_equal "https://draft-origin.test.gov.uk/government/organisations/#{edition.organisation.slug}/about/publication-scheme", preview_url
   end
 
   test "Creates a preview URL without parameters for edition formats that have migrated" do
     edition = create(:draft_case_study)
-    preview_url = preview_document_url(edition)
+    preview_url = preview_document_url(edition, locale: :en)
     assert_equal "https://draft-origin.test.gov.uk/government/case-studies/#{edition.slug}", preview_url
   end
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1108,21 +1108,21 @@ class OrganisationTest < ActiveSupport::TestCase
   test "organisations have the correct path generated" do
     org = create(:organisation)
 
-    assert_equal "/government/organisations/#{org.slug}", org.public_path
-    assert_equal "https://www.test.gov.uk/government/organisations/#{org.slug}", org.public_url
+    assert_equal "/government/organisations/#{org.slug}", org.public_path(locale: :en)
+    assert_equal "https://www.test.gov.uk/government/organisations/#{org.slug}", org.public_url(locale: :en)
   end
 
   test "courts have the correct path generated" do
     court = create(:court)
 
-    assert_equal "/courts-tribunals/#{court.slug}", court.public_path
-    assert_equal "https://www.test.gov.uk/courts-tribunals/#{court.slug}", court.public_url
+    assert_equal "/courts-tribunals/#{court.slug}", court.public_path(locale: :en)
+    assert_equal "https://www.test.gov.uk/courts-tribunals/#{court.slug}", court.public_url(locale: :en)
   end
 
   test "HMCTS tribunals have the correct path generated" do
     tribunal = create(:hmcts_tribunal)
 
-    assert_equal "/courts-tribunals/#{tribunal.slug}", tribunal.public_path
-    assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url
+    assert_equal "/courts-tribunals/#{tribunal.slug}", tribunal.public_path(locale: :en)
+    assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url(locale: :en)
   end
 end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -20,22 +20,22 @@ class PersonTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path for person" do
     person = create(:person, forename: " forename ", surname: " surname ")
-    assert_equal "/government/people/forename-surname", person.public_path
+    assert_equal "/government/people/forename-surname", person.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     person = create(:person, forename: " forename ", surname: " surname ")
-    assert_equal "/government/people/forename-surname?cachebust=123", person.public_path(cachebust: "123")
+    assert_equal "/government/people/forename-surname?cachebust=123", person.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path for a Person object" do
     person = create(:person, forename: " forename ", surname: " surname ")
-    assert_equal "https://www.test.gov.uk/government/people/forename-surname", person.public_url
+    assert_equal "https://www.test.gov.uk/government/people/forename-surname", person.public_url(locale: :en)
   end
 
   test "public_url returns the correct path for a TakePart object with options" do
     person = create(:person, forename: " forename ", surname: " surname ")
-    assert_equal "https://www.test.gov.uk/government/people/forename-surname?cachebust=123", person.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/government/people/forename-surname?cachebust=123", person.public_url({ cachebust: "123" }, locale: :en)
   end
 
   test "should be valid if legacy image isn't 960x640px" do

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -68,7 +68,7 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url as web_url" do
-    assert_equal @location.public_url, @presenter.as_json[:web_url]
+    assert_equal @location.public_url(locale: :en), @presenter.as_json[:web_url]
   end
 
   test "json includes request-relative api organisations url as organisations id" do
@@ -76,6 +76,6 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url (anchored on organisations) organisations web_url" do
-    assert_equal @location.public_url(anchor: "organisations"), @presenter.as_json[:organisations][:web_url]
+    assert_equal @location.public_url({ anchor: "organisations" }, locale: :en), @presenter.as_json[:organisations][:web_url]
   end
 end

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -87,7 +87,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public organisations url for sponsor in sponsors array as web_url" do
-    assert_equal @main_sponsor.public_url, @presenter.as_json[:sponsors].first[:web_url]
+    assert_equal @main_sponsor.public_url(locale: :en), @presenter.as_json[:sponsors].first[:web_url]
   end
 
   test "json includes office contact title in offices as title" do

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -39,7 +39,7 @@ class FeaturePresenterTest < PresenterTestCase
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
 
-    assert_equal p.public_path, fp.public_path
+    assert_equal p.public_path(locale: :en), fp.public_path
   end
 
   test "#public_path respects the locale of the feature when generating localized edition links" do
@@ -64,7 +64,7 @@ class FeaturePresenterTest < PresenterTestCase
     fp = FeaturePresenter.new(f)
 
     ::I18n.with_locale "fr" do
-      assert_equal p.public_path, fp.public_path
+      assert_equal p.public_path(locale: :en), fp.public_path
       assert_no_match(/locale=fr/, fp.public_path)
       assert_no_match(/\.fr/, fp.public_path)
     end

--- a/test/unit/presenters/feature_presenter_test.rb
+++ b/test/unit/presenters/feature_presenter_test.rb
@@ -8,7 +8,7 @@ class FeaturePresenterTest < PresenterTestCase
     f = stub_record(:feature, topical_event: te, document: nil)
     fp = FeaturePresenter.new(f)
 
-    assert_equal te.public_path, fp.public_path
+    assert_equal te.public_path(locale: :en), fp.public_path
   end
 
   test "#public_path doesn't localize links to topical events" do
@@ -17,7 +17,7 @@ class FeaturePresenterTest < PresenterTestCase
     f.stubs(:locale).returns("ar")
     fp = FeaturePresenter.new(f)
 
-    assert_equal te.public_path, fp.public_path
+    assert_equal te.public_path(locale: :en), fp.public_path
   end
 
   test "#public_path generates a localized link to the edition" do

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       summary: "The summary",
       body: "Some content",
     )
-    public_path = case_study.public_path
+    public_path = case_study.public_path(locale: :en)
     expected_content = {
       base_path: public_path,
       title: "Case study title",

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -37,7 +37,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     detailed_guide.topical_event_memberships.create!(topical_event_id: topical_event.id)
 
-    public_path = detailed_guide.public_path
+    public_path = detailed_guide.public_path(locale: I18n.default_locale)
     expected_content = {
       base_path: public_path,
       title: "Some detailed guide",

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -18,7 +18,7 @@ module PublishingApi
         secondary_specialist_sector_tags: ["oil-and-gas/licensing"],
       )
 
-      public_path = edition.public_path
+      public_path = edition.public_path(locale: :en)
 
       expected_hash = {
         base_path: public_path,

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -37,7 +37,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     minister = create(:person)
     create(:ministerial_role_appointment, role:, person: minister)
 
-    public_path = organisation.public_path
+    public_path = organisation.public_path(locale: I18n.default_locale)
     public_atom_path = "#{public_path}.atom"
 
     expected_hash = {

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       biography: "Sir Winston Churchill was a Prime Minister.",
     )
 
-    public_path = person.public_path
+    public_path = person.public_path(locale: :en)
 
     expected_hash = {
       base_path: public_path,
@@ -85,7 +85,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       },
     )
 
-    expected_base_path = person.public_path
+    expected_base_path = person.public_path(locale: :en)
 
     I18n.with_locale(:en) do
       presented_item = PublishingApi::PersonPresenter.new(person)

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       statistical_data_sets: [statistical_data_set],
     )
 
-    public_path = publication.public_path
+    public_path = publication.public_path(locale: :en)
     expected_content = {
       base_path: public_path,
       title: "Publication title",

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -160,7 +160,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       translated_into: [:cy],
     )
 
-    expected_base_path = role.public_path
+    expected_base_path = role.public_path(locale: :en)
 
     I18n.with_locale(:en) do
       presented_item = PublishingApi::RolePresenter.new(role)

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -7,7 +7,7 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
 
   test "presents a Services and Information page ready for adding to the publishing API" do
     organisation = create(:organisation, name: "Organisation of Things")
-    public_path = "#{organisation.public_path}/services-information"
+    public_path = "#{organisation.public_path(locale: :en)}/services-information"
 
     expected_hash = {
       base_path: public_path,

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -14,7 +14,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            :with_world_location,
                            name: "Locationia Embassy",
                            analytics_identifier: "WO123")
-    public_path = worldwide_org.public_path
+    public_path = worldwide_org.public_path(locale: :en)
 
     expected_hash = {
       base_path: public_path,

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -198,22 +198,22 @@ class RoleTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path for ministerial role" do
     role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
+    assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
+    assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path for a Ministerial role" do
     role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
+    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url(locale: :en)
   end
 
   test "public_url returns the correct path for a Ministerial Role with options" do
     role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url({ cachebust: "123" }, locale: :en)
   end
 
   test "has removeable translations" do

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -9,7 +9,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
     let(:edition) { FactoryBot.create(:published_edition) }
-    let(:parent_document_url) { edition.public_url }
+    let(:parent_document_url) { edition.public_url(locale: :en) }
     let(:update_worker) { mock("asset-manager-update-worker") }
 
     around do |test|

--- a/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
@@ -9,7 +9,7 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
     let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
-    let(:redirect_url) { unpublished_edition.public_url }
+    let(:redirect_url) { unpublished_edition.public_url(locale: :en) }
     let(:unpublished) { true }
     let(:update_worker) { mock("asset-manager-update-asset-worker") }
 

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -53,7 +53,7 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
 
   test "converts a Whitehall admin URL to its public URL" do
     speech = create(:published_speech)
-    expected_url = speech.public_url
+    expected_url = speech.public_url(locale: :en)
 
     edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
 
@@ -68,7 +68,7 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
 
   test "doesn't check the links of unpublished Whitehall admin URLs" do
     speech = create(:draft_speech)
-    expected_url = speech.public_url
+    expected_url = speech.public_url(locale: :en)
 
     edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
 

--- a/test/unit/services/link_reporter_csv_service_test.rb
+++ b/test/unit/services/link_reporter_csv_service_test.rb
@@ -78,14 +78,14 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     LinkReporterCsvService.new(reports_dir:, organisation: hmrc).generate
     hmrc_csv = CSV.read(reports_dir_pathname.join("hm-revenue-customs_links_report.csv"))
     assert_equal 3, hmrc_csv.size
-    assert_equal [detailed_guide.public_url,
+    assert_equal [detailed_guide.public_url(locale: :en),
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
                   detailed_guide.public_timestamp.to_s,
                   "DetailedGuide",
                   "2",
                   "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
-    assert_equal [publication.public_url,
+    assert_equal [publication.public_url(locale: :en),
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
                   publication.public_timestamp.to_s,
                   "Publication",
@@ -159,7 +159,7 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
                   "2",
                   "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
-    assert_not_equal [publication.public_url,
+    assert_not_equal [publication.public_url(locale: :en),
                       "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
                       publication.public_timestamp.to_s,
                       "Publication",
@@ -189,7 +189,7 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     assert File.exist?(csv_test_file_path)
     assert_equal 2, csv.size
     assert_equal ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"], csv[0]
-    assert_equal [speech.public_url,
+    assert_equal [speech.public_url(locale: :en),
                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
                   speech.public_timestamp.to_s,
                   "Speech",

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -200,22 +200,22 @@ class TakePartPageTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path" do
     object = create(:take_part_page, slug: "foo")
-    assert_equal "/government/get-involved/take-part/foo", object.public_path
+    assert_equal "/government/get-involved/take-part/foo", object.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     object = create(:take_part_page, slug: "foo")
-    assert_equal "/government/get-involved/take-part/foo?cachebust=123", object.public_path(cachebust: "123")
+    assert_equal "/government/get-involved/take-part/foo?cachebust=123", object.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path for a TakePart object" do
     object = create(:take_part_page, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", object.public_url
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo", object.public_url(locale: :en)
   end
 
   test "public_url returns the correct path for a TakePart object with options" do
     object = create(:take_part_page, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", object.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", object.public_url({ cachebust: "123" }, locale: :en)
   end
 
   should_not_accept_footnotes_in :body

--- a/test/unit/topical_event_about_page_test.rb
+++ b/test/unit/topical_event_about_page_test.rb
@@ -10,17 +10,17 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path" do
     object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
-    assert_equal "/government/topical-events/foo/about", object.topical_event_about_page.public_path
+    assert_equal "/government/topical-events/foo/about", object.topical_event_about_page.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
-    assert_equal "/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_path(cachebust: "123")
+    assert_equal "/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path with options" do
     object = create(:topical_event, slug: "foo", topical_event_about_page: create(:topical_event_about_page))
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo/about?cachebust=123", object.topical_event_about_page.public_url({ cachebust: "123" }, locale: :en)
   end
 
   should_not_accept_footnotes_in :body

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -237,21 +237,21 @@ class TopicalEventTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path" do
     object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo", object.public_path
+    assert_equal "/government/topical-events/foo", object.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     object = create(:topical_event, slug: "foo")
-    assert_equal "/government/topical-events/foo?cachebust=123", object.public_path(cachebust: "123")
+    assert_equal "/government/topical-events/foo?cachebust=123", object.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path" do
     object = create(:topical_event, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo", object.public_url
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo", object.public_url(locale: :en)
   end
 
   test "public_url returns the correct path with options" do
     object = create(:topical_event, slug: "foo")
-    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", object.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/government/topical-events/foo?cachebust=123", object.public_url({ cachebust: "123" }, locale: :en)
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -152,7 +152,7 @@ class UnpublishingTest < ActiveSupport::TestCase
 
   test "#document_path returns the URL path for the unpublished edition" do
     edition = create(:detailed_guide, :draft)
-    original_path = edition.public_path
+    original_path = edition.public_path(locale: :en)
     unpublishing = create(
       :unpublishing,
       edition:,
@@ -176,7 +176,7 @@ class UnpublishingTest < ActiveSupport::TestCase
 
   test "#document_url returns the URL for the unpublished edition" do
     edition = create(:detailed_guide, :draft)
-    original_url = edition.public_url
+    original_url = edition.public_url(locale: :en)
     unpublishing = create(
       :unpublishing,
       edition:,

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -199,7 +199,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       edition.save!
     end
 
-    english_path = edition.public_path
+    english_path = edition.public_path(locale: :en)
     french_path  = edition.public_path(locale: :fr)
 
     Whitehall::PublishingApi.schedule_async(edition)
@@ -224,7 +224,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       updated_edition.save!
     end
 
-    english_path = updated_edition.public_path
+    english_path = updated_edition.public_path(locale: :en)
     spanish_path = updated_edition.public_path(locale: :es)
 
     Whitehall::PublishingApi.schedule_async(updated_edition)
@@ -247,7 +247,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       edition.save!(validate: false)
     end
 
-    english_path = edition.public_path
+    english_path = edition.public_path(locale: :en)
     german_path = edition.public_path(locale: :de)
 
     Whitehall::PublishingApi.unschedule_async(edition)
@@ -265,7 +265,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       updated_edition.save!(validate: false)
     end
 
-    english_path = updated_edition.public_path
+    english_path = updated_edition.public_path(locale: :en)
     german_path = updated_edition.public_path(locale: :de)
 
     Whitehall::PublishingApi.unschedule_async(updated_edition)

--- a/test/unit/world_location_news_test.rb
+++ b/test/unit/world_location_news_test.rb
@@ -4,24 +4,24 @@ class WorldLocationNewsTest < ActiveSupport::TestCase
   test "public_path returns the correct path" do
     world_location = build(:world_location, slug: "foo")
     world_location_news = create(:world_location_news, world_location:)
-    assert_equal "/world/foo/news", world_location_news.public_path
+    assert_equal "/world/foo/news", world_location_news.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     world_location = build(:world_location, slug: "foo")
     world_location_news = create(:world_location_news, world_location:)
-    assert_equal "/world/foo/news?cachebust=123", world_location_news.public_path(cachebust: "123")
+    assert_equal "/world/foo/news?cachebust=123", world_location_news.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the correct path" do
     world_location = build(:world_location, slug: "foo")
     world_location_news = create(:world_location_news, world_location:)
-    assert_equal "https://www.test.gov.uk/world/foo/news", world_location_news.public_url
+    assert_equal "https://www.test.gov.uk/world/foo/news", world_location_news.public_url(locale: :en)
   end
 
   test "public_url returns the correct path with options" do
     world_location = build(:world_location, slug: "foo")
     world_location_news = create(:world_location_news, world_location:)
-    assert_equal "https://www.test.gov.uk/world/foo/news?cachebust=123", world_location_news.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/world/foo/news?cachebust=123", world_location_news.public_url({ cachebust: "123" }, locale: :en)
   end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -106,16 +106,16 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   test "public_path returns the correct path" do
     object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo", object.public_path
+    assert_equal "/world/foo", object.public_path(locale: :en)
   end
 
   test "public_path returns the correct path with options" do
     object = create(:world_location, slug: "foo")
-    assert_equal "/world/foo?cachebust=123", object.public_path(cachebust: "123")
+    assert_equal "/world/foo?cachebust=123", object.public_path({ cachebust: "123" }, locale: :en)
   end
 
   test "public_url returns the url and appends options" do
     object = create(:world_location, slug: "foo")
-    assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", object.public_url(cachebust: "123")
+    assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", object.public_url({ cachebust: "123" }, locale: :en)
   end
 end


### PR DESCRIPTION
Addressing an incident action (Becka will add some more detail here)

[Trello](https://trello.com/c/ZIw7d6xk/414-incident-action-make-publicpath-require-a-locale-argument-even-if-the-content-is-in-english-and-error-if-there-is-no-locale)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
