### PR TITLE
Add helper method for logging in preview design system users

### DIFF
--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
     email
     uid
     permissions { [User::Permissions::SIGNIN] }
+
+    trait(:with_preview_design_system) do
+      permissions { [User::Permissions::SIGNIN, User::Permissions::PREVIEW_DESIGN_SYSTEM] }
+    end
   end
 
   factory :disabled_user, parent: :user do
@@ -27,14 +31,45 @@ FactoryBot.define do
 
   factory :vip_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::VIP_EDITOR] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::VIP_EDITOR,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :departmental_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::DEPARTMENTAL_EDITOR] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::GDS_EDITOR,
+          User::Permissions::DEPARTMENTAL_EDITOR,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :managing_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::MANAGING_EDITOR] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::MANAGING_EDITOR,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :scheduled_publishing_robot, parent: :user do
@@ -45,26 +80,79 @@ FactoryBot.define do
 
   factory :gds_admin, parent: :user do
     permissions do
-      [User::Permissions::SIGNIN,
-       User::Permissions::GDS_EDITOR,
-       User::Permissions::GDS_ADMIN]
+      [
+        User::Permissions::SIGNIN,
+        User::Permissions::GDS_EDITOR,
+        User::Permissions::GDS_ADMIN,
+      ]
+    end
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::GDS_EDITOR,
+          User::Permissions::GDS_ADMIN,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
     end
   end
 
   factory :gds_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::GDS_EDITOR] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::GDS_EDITOR,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :world_editor, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::WORLD_EDITOR] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::WORLD_EDITOR,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :world_writer, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::WORLD_WRITER] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::WORLD_WRITER,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :export_data_user, parent: :user do
     permissions { [User::Permissions::SIGNIN, User::Permissions::EXPORT_DATA] }
+
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::EXPORT_DATA,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
+    end
   end
 
   factory :gds_team_user, parent: :user do
@@ -78,16 +166,17 @@ FactoryBot.define do
         User::Permissions::FORCE_PUBLISH_ANYTHING,
       ]
     end
-  end
 
-  factory :departmental_editor_with_preview_design_system, parent: :user do
-    permissions do
-      [
-        User::Permissions::SIGNIN,
-        User::Permissions::GDS_EDITOR,
-        User::Permissions::DEPARTMENTAL_EDITOR,
-        User::Permissions::PREVIEW_DESIGN_SYSTEM,
-      ]
+    trait(:with_preview_design_system) do
+      permissions do
+        [
+          User::Permissions::SIGNIN,
+          User::Permissions::DEPARTMENTAL_EDITOR,
+          User::Permissions::GDS_EDITOR,
+          User::Permissions::FORCE_PUBLISH_ANYTHING,
+          User::Permissions::PREVIEW_DESIGN_SYSTEM,
+        ]
+      end
     end
   end
 end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -205,7 +205,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   end
 
   view_test "should render design system layout when permission is applied" do
-    login_as(:departmental_editor_with_preview_design_system)
+    login_as_preview_design_system_user(:departmental_editor)
     stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
 
     get :edit, params: { edition_id: @edition }
@@ -215,7 +215,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   end
 
   view_test "should render miller columns when user has design system layout" do
-    login_as(:departmental_editor_with_preview_design_system)
+    login_as_preview_design_system_user(:departmental_editor)
     stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
 
     get :edit, params: { edition_id: @edition }

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -68,7 +68,7 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
   end
 
   view_test "should render design system layout when permission is applied" do
-    login_as(:departmental_editor_with_preview_design_system)
+    login_as_preview_design_system_user(:departmental_editor)
     stub_publishing_api_links_with_taxons(@edition.content_id, [world_child_taxon_content_id])
 
     get :edit, params: { edition_id: @edition }
@@ -78,7 +78,7 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
   end
 
   view_test "should render miller columns when user has design system layout" do
-    login_as(:departmental_editor_with_preview_design_system)
+    login_as_preview_design_system_user(:departmental_editor)
     stub_publishing_api_links_with_taxons(@edition.content_id, [world_child_taxon_content_id])
 
     get :edit, params: { edition_id: @edition }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -244,6 +244,10 @@ class ActionController::TestCase
     login_as(create(:user, name: "user-name", email: "user@example.com"))
   end
 
+  def login_as_preview_design_system_user(role)
+    login_as(create(role, :with_preview_design_system, name: "user-name", email: "user@example.com"))
+  end
+
   def assert_login_required
     assert_redirected_to login_path
   end


### PR DESCRIPTION
## Description

While we're porting over the pages to the GOV.UK Design System, we need to ensure that we are testing the GOV.UK Design System and Bootstrap implementations.

In order to do this we've come up with the strategy of duplicating the relevant controller specs. One will be appended with `legacy` and will continue to test the Bootstrap implementation. 

The other will add the `Preview design system` to the users in the tests and test the new implementation.

In order to make this as easy as possible, this adds the ` login_as_preview_design_system_user` helper method.

This takes a role (`:writer`, `:departmental_editor` etc.), creates a user with the `Preview design system` permission and logs the user in.

As it passes the user into the `login_as` method, it assigns the created user to `@current_user` and returns the user.

## Trello card

https://trello.com/c/A2x1Asps/23-listing-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
