### PR TITLE
Add upload image to the images tab

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -22,6 +22,21 @@ class Admin::EditionImagesController < Admin::BaseController
     end
   end
 
+  def create
+    @new_image = @edition.images.build
+    @new_image.build_image_data(image_params["image_data"])
+
+    if @new_image.save
+      redirect_to edit_admin_edition_image_path(@edition, @new_image.id)
+    else
+      # Removes @new_image from the edition, otherwise the index page will attempt to render it and error
+      @edition.images.delete(@new_image)
+      render :index
+    end
+  end
+
+  def edit; end
+
 private
 
   def image
@@ -46,10 +61,14 @@ private
     case action_name
     when "index"
       enforce_permission!(:see, @edition)
-    when "edit", "update", "destroy", "confirm_destroy"
+    when "edit", "update", "destroy", "confirm_destroy", "create"
       enforce_permission!(:update, @edition)
     else
       raise Whitehall::Authority::Errors::InvalidAction, action_name
     end
+  end
+
+  def image_params
+    params.fetch(:image, {}).permit(image_data: [:file])
   end
 end

--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -11,6 +11,7 @@
     name: "image[image_data][file]",
     id: "edition_images_image_data_file",
     hint: "Images can be JPEG, PNG, SVG or GIF files.",
+    error_items: @new_image.present? ? errors_for(@new_image.errors, :"image_data.file") : nil,
   } %>
 
    <%= render "govuk_publishing_components/components/details", {

--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -3,9 +3,12 @@
   font_size: "l",
 } %>
 
-<%= form_tag admin_edition_images_path(@edition.document) do %>
+<%= form_tag(
+  admin_edition_images_path(@edition),
+  multipart: true,
+) do %>
   <%= render "govuk_publishing_components/components/file_upload", {
-    name: "edition[images_attributes][image_data_attributes][file]",
+    name: "image[image_data][file]",
     id: "edition_images_image_data_file",
     hint: "Images can be JPEG, PNG, SVG or GIF files.",
   } %>

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :context, "#{@edition.title}" %>
 <% content_for :page_title, "Images for #{@edition.format_name}" %>
 <% content_for :title, "Images for #{@edition.format_name}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @new_image, parent_class: "edition_images")) if @new_image.present? %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,7 @@ Whitehall::Application.routes.draw do
             post :upload_zip, on: :collection
             get :set_titles, on: :member
           end
-          resources :images, controller: "edition_images", only: %i[destroy edit update index] do
+          resources :images, controller: "edition_images", only: %i[create destroy edit update index] do
             get :confirm_destroy, on: :member
           end
         end

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -1,28 +1,27 @@
 @design-system-only
 Feature: Images tab on edit edition
 
-  Scenario: Accessing the images tab with correct permissions
+  Background:
     Given I am a writer
+
+  Scenario: Images tab is hidden by default
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    Then the page should not have an images tab
+
+  Scenario: Accessing the images tab with correct permissions
     And I have the "Preview images update" permission
     And I start drafting a new publication "Standard Beard Lengths"
     When I am on the edit page for publication "Standard Beard Lengths"
     Then I can navigate to the images tab
 
-  Scenario: Images tab is hidden by default
-    Given I am a writer
-    And I start drafting a new publication "Standard Beard Lengths"
-    When I am on the edit page for publication "Standard Beard Lengths"
-    Then the page should not have an images tab
-
   Scenario: Images are listed on the images tab
-    Given I am a writer
     And I have the "Preview images update" permission
     And a draft document with images exists
     When I visit the images tab of the document with images
     Then I should see a list with 2 images
 
   Scenario: Images can be deleted from the images tab
-    Given I am a writer
     And I have the "Preview images update" permission
     And a draft document with images exists
     When I visit the images tab of the document with images
@@ -33,7 +32,6 @@ Feature: Images tab on edit edition
     And I should see a list with 1 image
 
   Scenario: Images details can be updated from the images tab
-    Given I am a writer
     And I have the "Preview images update" permission
     And a draft document with images exists
     When I visit the images tab of the document with images
@@ -43,7 +41,6 @@ Feature: Images tab on edit edition
     Then I should see the updated image details
     
   Scenario: Image uploaded with no cropping required
-    Given I am a writer
     And I have the "Preview images update" permission
     And I start drafting a new publication "Standard Beard Lengths"
     When I am on the edit page for publication "Standard Beard Lengths"
@@ -51,3 +48,19 @@ Feature: Images tab on edit edition
     And I upload a 960x640 image
     And I update the image details and save
     Then the publication "Standard Beard Lengths" should have 1 image attachment
+
+  Scenario: Small image uploaded
+    And I have the "Preview images update" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    And I navigate to the images tab
+    And I upload a 64x96 image
+    Then I should get the error message "Image data file must be 960px wide and 640px tall, but is 64px wide and 96px tall"
+
+  Scenario: No file uploaded
+    And I have the "Preview images update" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    And I navigate to the images tab
+    And I click upload without attaching a file
+    Then I should get the error message "Image data file can't be blank"

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -41,3 +41,13 @@ Feature: Images tab on edit edition
     And I update the image details and save
     Then I should see a updated banner
     Then I should see the updated image details
+    
+  Scenario: Image uploaded with no cropping required
+    Given I am a writer
+    And I have the "Preview images update" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    And I navigate to the images tab
+    And I upload a 960x640 image
+    And I update the image details and save
+    Then the publication "Standard Beard Lengths" should have 1 image attachment

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -58,3 +58,26 @@ end
 Then "I should see the updated image details" do
   expect(page).to have_content("Test caption")
 end
+
+And(/^I navigate to the images tab$/) do
+  find("li.app-c-secondary-navigation__list-item a", text: "Images").click
+end
+
+And(/^I upload a (\d+)x(\d+) image$/) do |width, height|
+  within "input.gem-c-file-upload" do
+    if width == 960 && height == 640
+      attach_file jpg_image
+    elsif width == 64 && height == 96
+      attach_file Rails.root.join("test/fixtures/horrible-image.64x96.jpg")
+    end
+  end
+  click_on "Upload"
+end
+
+And(/^I click the "Save and continue" button on the preview page$/) do
+  click_on "Save and continue"
+end
+
+Then(/^the publication "(.*?)" should have (\d+) image attachments?$/) do |title, expected_number_of_images|
+  expect(expected_number_of_images.to_i).to eq(Edition.find_by(title:).images.count)
+end

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -78,6 +78,14 @@ And(/^I click the "Save and continue" button on the preview page$/) do
   click_on "Save and continue"
 end
 
+And(/^I click upload without attaching a file$/) do
+  click_on "Upload"
+end
+
 Then(/^the publication "(.*?)" should have (\d+) image attachments?$/) do |title, expected_number_of_images|
   expect(expected_number_of_images.to_i).to eq(Edition.find_by(title:).images.count)
+end
+
+Then(/^I should get the error message "(.*?)"$/) do |error_message|
+  expect(page).to have_content(error_message)
 end


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/C7Aby79t/1137-add-image-upload-functionality-to-images-tab)

## What
- Adds the ability to upload images via the images tab. 
- Adds error handling of image uploads to the index page.

**NOTE:** The error handling mirrors existing error handling for images, but this needs refreshing. The error messages do not represent those in the Figma designs, and when uploading a file which is the wrong file type the error message does not accurately describe the issue to the user (it gives a "file cannot be blank" error). I will write up a separate ticket for this work as it was getting quite involved and blocking the ticket from progressing.

## Why
This is part of the images update epic

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
