### PR TITLE
Ports edit consultation page to design system

### DIFF
--- a/app/controllers/admin/responses_controller.rb
+++ b/app/controllers/admin/responses_controller.rb
@@ -4,6 +4,7 @@ class Admin::ResponsesController < Admin::BaseController
   before_action :enforce_edition_permissions!
   before_action :prevent_modification_of_unmodifiable_edition
   before_action :find_response, only: %i[edit update]
+  layout :get_layout
 
   def show
     @response = response_class.find_by(edition_id: @edition) || response_class.new(published_on: Time.zone.today)
@@ -20,18 +21,29 @@ class Admin::ResponsesController < Admin::BaseController
   end
 
   def edit
-    render :edit_legacy
+    render_design_system("edit", "edit_legacy", next_release: false)
   end
 
   def update
     if @response.update(response_params)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} updated"
     else
-      render :edit_legacy
+      render_design_system("edit", "edit_legacy", next_release: false)
     end
   end
 
 private
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[edit update] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def find_consultation
     @edition = Consultation.find(params[:consultation_id])

--- a/app/views/admin/responses/_form.html.erb
+++ b/app/views/admin/responses/_form.html.erb
@@ -1,0 +1,48 @@
+<%= form_for [:admin, consultation, consultation_response], url: [:admin, consultation, consultation_response.singular_routing_symbol] do |form| %>
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Published on",
+    heading_size: "l"
+  } do %>
+    <%= render "components/datetime_fields", {
+      prefix: "consultation_#{consultation_response.singular_routing_symbol}",
+      field_name: "published_on",
+      date_only: true,
+      error_items: errors_for(consultation_response.errors, :published_on),
+      year: {
+        value: consultation_response.published_on&.year,
+        start_year: 1997,
+        end_year: Date.today.year + 5
+      },
+      month: {
+        value: consultation_response.published_on&.month
+      },
+      day: {
+        id: "consultation_#{consultation_response.singular_routing_symbol}_published_on",
+        value: consultation_response.published_on&.day
+      }
+    } %>
+  <% end %>
+
+  <%= render "components/govspeak-editor", {
+    label: {
+      heading_size: "l",
+      text: "Detail/Summary"
+    },
+    name: "consultation_#{consultation_response.singular_routing_symbol}[summary]",
+    rows: 20,
+    id: "consultation_#{consultation_response.singular_routing_symbol}_summary",
+    value: consultation_response.summary,
+    error_items: errors_for(form.object.errors, :summary),
+    data_attributes: {
+      alternative_format_provider_id: @edition && @edition.alternative_format_provider_id ? @edition.alternative_format_provider_id : current_user.organisation.try(:id)
+    }
+  } %>
+
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save"
+    } %>
+
+    <%= link_to("Cancel", "#{admin_edition_path(consultation)}/public_feedback", class: "govuk-link govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/admin/responses/edit.html.erb
+++ b/app/views/admin/responses/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "Editing #{@response.friendly_name} for: #{@edition.title}" %>
+<% content_for :title, "Editing #{@response.friendly_name} for consultation" %>
+<% content_for :context, "#{@edition.title}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response, noun: "consultation #{@response.friendly_name}")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'form', locals: { consultation: @edition, consultation_response: @response } %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "admin/editions/govspeak_help",
+    locals: { hide_inline_attachments_help: !@edition.allows_inline_attachments?, show_attachments_tab_help: true } %>
+  </div>
+</div>

--- a/test/functional/admin/legacy_responses_controller_test.rb
+++ b/test/functional/admin/legacy_responses_controller_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
-class Admin::ResponsesControllerTest < ActionController::TestCase
-  should_be_an_admin_controller
+class Admin::LegacyResponsesControllerTest < ActionController::TestCase
+  tests Admin::ResponsesController
+
+  legacy_should_be_an_admin_controller
 
   setup do
-    login_as_preview_design_system_user(:writer)
+    login_as :writer
     @consultation = create(:draft_consultation, opening_at: 2.days.ago, closing_at: 1.day.ago)
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/6x9humqo/10-move-consultation-response-edit-page-to-the-govuk-design-system)

This makes the relevant additions to the 2 pages (same view) for editing a consultation document: 
- Public feedback
- Final outcome

The changes include
- Updating the controller
- Adding a test
- Adding a view

||Bootstrap|Design System|
|-|-|-|
|**Public feedback**|![Screenshot 2023-02-22 at 16 02 21](https://user-images.githubusercontent.com/6080548/220683280-5c086d69-b8ec-46f7-b94d-0d6e6f1fc298.png)|![Screenshot 2023-02-22 at 15 55 27](https://user-images.githubusercontent.com/6080548/220680266-cdd6f83d-de4d-4e0e-99f3-a04cd2f3621f.png)|
|**Final outcome**|![Screenshot 2023-02-22 at 15 59 05](https://user-images.githubusercontent.com/6080548/220681358-d5ca80be-16f7-449d-b52b-2367954c818a.png)|![Screenshot 2023-02-22 at 15 56 45](https://user-images.githubusercontent.com/6080548/220680600-28cf0894-de47-448b-89e2-79dcdcc6edca.png)|