### PR TITLE
Make the historical account presenter work

### DIFF
--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -54,16 +54,14 @@ module PublishingApi
         .distinct(&:person)
         .order(:started_at)
         .map(&:person)
+        .select { |person| person.historical_accounts.present? }
 
       person_to_present = historical_account.person
 
       return [] unless all_appointees.include?(person_to_present)
 
       neighbouring_role_holders(all_appointees, person_to_present).map do |person|
-        {
-          "title" => person.name,
-          "base_path" => person.historical_accounts.present? ? person.historical_accounts.for_role(role.id).first.public_path : HistoricalAccountsIndexPresenter.base_path,
-        }
+        person.historical_accounts.for_role(role.id).first.content_id
       end
     end
 

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -63,12 +63,7 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
       person: [
         historical_account.person.content_id,
       ],
-      ordered_related_items: [
-        {
-          "title" => "Some Other Person",
-          "base_path" => "/government/history/past-prime-ministers/some-other-person",
-        },
-      ],
+      ordered_related_items: [person2.historical_accounts.first.content_id],
     }
 
     PublishingApi::HistoricalAccountPresenter.new(historical_account2)
@@ -102,9 +97,11 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
 
     historical_accounts_in_descending_order.each_with_index do |historical_account, index|
       links = PublishingApi::HistoricalAccountPresenter.new(historical_account).links
-      actual_names_of_related_people = links[:ordered_related_items].map { |person_hash| person_hash["title"] }
-      expected_names_of_related_people = expected_indices_of_surrounding_prime_ministers[index].map { |i| "Prime Minister #{i}" }
-      assert_equal expected_names_of_related_people, actual_names_of_related_people
+      actual_content_ids_of_related_people = links[:ordered_related_items]
+      expected_content_ids_of_related_people = expected_indices_of_surrounding_prime_ministers[index].map do |i|
+        historical_accounts_in_descending_order[i].content_id
+      end
+      assert_equal expected_content_ids_of_related_people, actual_content_ids_of_related_people
     end
   end
 end


### PR DESCRIPTION
Things weren't being added to the content item because links need content id's not urls

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
