### PR TITLE
add body to worldwide organisation presenter

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -19,6 +19,7 @@ module PublishingApi
       content.merge!(
         description:,
         details: {
+          body:,
           logo: {
             crest: "single-identity",
             formatted_title: item.logo_formatted_name,
@@ -46,6 +47,10 @@ module PublishingApi
 
     def description
       item.summary
+    end
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body) || ""
     end
 
     def ordered_contacts

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     trait(:with_corporate_information_pages) do
       after :create do |organisation, _evaluator|
+        FactoryBot.create(:about_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
         FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
         FactoryBot.create(:personal_information_charter_corporate_information_page, organisation: nil, worldwide_organisation: organisation)
         FactoryBot.create(:publication_scheme_corporate_information_page, organisation: nil, worldwide_organisation: organisation)

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -14,12 +14,13 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            :with_world_location,
                            name: "Locationia Embassy",
                            analytics_identifier: "WO123")
+
     public_path = worldwide_org.public_path
 
     expected_hash = {
       base_path: public_path,
       title: "Locationia Embassy",
-      description: nil,
+      description: "edition-summary",
       schema_name: "worldwide_organisation",
       document_type: "worldwide_organisation",
       locale: "en",
@@ -29,29 +30,30 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
+        body: "<div class=\"govspeak\"><p>Some stuff</p>\n</div>",
         logo: {
           crest: "single-identity",
           formatted_title: "Locationia\nEmbassy",
         },
         ordered_corporate_information_pages: [
           {
-            content_id: worldwide_org.corporate_information_pages[0].content_id,
+            content_id: worldwide_org.corporate_information_pages[1].content_id,
             title: "Complaints procedure",
           },
           {
-            content_id: worldwide_org.corporate_information_pages[3].content_id,
+            content_id: worldwide_org.corporate_information_pages[4].content_id,
             title: "Working for Locationia Embassy",
           },
           {
-            content_id: worldwide_org.corporate_information_pages[2].content_id,
+            content_id: worldwide_org.corporate_information_pages[3].content_id,
             title: "Read about the types of information we routinely publish in our Publication scheme.",
           },
           {
-            content_id: worldwide_org.corporate_information_pages[4].content_id,
+            content_id: worldwide_org.corporate_information_pages[5].content_id,
             title: "Find out about our commitment to publishing in Welsh.",
           },
           {
-            content_id: worldwide_org.corporate_information_pages[1].content_id,
+            content_id: worldwide_org.corporate_information_pages[2].content_id,
             title: "Our Personal information charter explains how we treat your personal information.",
           },
         ],
@@ -74,6 +76,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         worldwide_org.corporate_information_pages[2].content_id,
         worldwide_org.corporate_information_pages[3].content_id,
         worldwide_org.corporate_information_pages[4].content_id,
+        worldwide_org.corporate_information_pages[5].content_id,
       ],
       ordered_contacts: [
         worldwide_org.offices.first.contact.content_id,


### PR DESCRIPTION
## What
Add the body to the content item for worldwide organisations. 

## Why
This will allow us to render worldwide organisations using an app outside of Whitehall.
This is part of ongoing work to shutdown Whitehall's frontend. 

Relies on - https://github.com/alphagov/publishing-api/pull/2294

Trello - https://trello.com/c/LrXHcFUM/382-add-body-to-worldwide-organisation-presenter


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
