### PR TITLE
Adds option to date-time component to render date only

### DIFF
--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -1,6 +1,8 @@
 <%
  prefix = prefix
  field_name = field_name
+ date_only ||= false
+ date_heading ||= nil
 
  error_items = error_items ||= nil
 
@@ -46,12 +48,14 @@
 %>
 
 <%= tag.div class: root_classes, data: data_attributes do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Date",
-    heading_level: heading_level || 3,
-    font_size: heading_size || "m",
-    padding: true,
-  } %>
+  <% unless date_only && !date_heading %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: date_heading || "Date",
+      heading_level: heading_level || 3,
+      font_size: heading_size || "m",
+      padding: true,
+    } %>
+  <% end %>
 
   <% if date_hint %>
     <%= render "govuk_publishing_components/components/hint", {
@@ -66,7 +70,7 @@
     } %>
   <% end %>
 
-  <div class="govuk-!-margin-bottom-3 app-c-datetime-fields__date-time-wrapper">
+  <div class="app-c-datetime-fields__date-time-wrapper">
     <div class="app-c-datetime-fields__date-time">
       <%= render "govuk_publishing_components/components/label", {
         text: "Day",
@@ -130,61 +134,65 @@
     </div>
   </div>
 
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Time",
-    heading_level: heading_level || 3,
-    font_size: heading_size || "m",
-    padding: true,
-  } %>
+  <% unless date_only %>
+    <div class="govuk-!-margin-top-3">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Time",
+        heading_level: heading_level || 3,
+        font_size: heading_size || "m",
+        padding: true,
+      } %>
+    </div>
 
-  <% if time_hint %>
-    <%= render "govuk_publishing_components/components/hint", {
-      text: time_hint,
-      id: time_hint_id
-    } %>
+    <% if time_hint %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: time_hint,
+        id: time_hint_id
+      } %>
+    <% end %>
+
+    <div class="app-c-datetime-fields__date-time-wrapper">
+      <div class="app-c-datetime-fields__date-time">
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Hour",
+          html_for: hour_select_id,
+          id: hour_label_id,
+        } %>
+
+        <%= select_hour hour_value,
+          {
+            include_blank: true,
+            prefix: prefix,
+            field_name: "#{field_name}(4i)"
+          },
+          {
+            id: hour_select_id,
+            class: "govuk-select app-c-datetime-fields__date-time-input",
+            "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip
+          } %>
+      </div>
+
+      <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
+
+      <div class="app-c-datetime-fields__date-time">
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Minute",
+          html_for: minute_select_id,
+          id: minute_label_id,
+        } %>
+
+        <%= select_minute minute_value,
+          {
+            include_blank: true,
+            prefix: prefix,
+            field_name: "#{field_name}(5i)"
+          },
+          {
+            id: minute_select_id,
+            class: "govuk-select app-c-datetime-fields__date-time-input",
+            "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip
+          } %>
+      </div>
+    </div>
   <% end %>
-
-  <div class="app-c-datetime-fields__date-time-wrapper">
-    <div class="app-c-datetime-fields__date-time">
-      <%= render "govuk_publishing_components/components/label", {
-        text: "Hour",
-        html_for: hour_select_id,
-        id: hour_label_id,
-      } %>
-
-      <%= select_hour hour_value,
-        {
-          include_blank: true,
-          prefix: prefix,
-          field_name: "#{field_name}(4i)"
-        },
-        {
-          id: hour_select_id,
-          class: "govuk-select app-c-datetime-fields__date-time-input",
-          "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip
-        } %>
-    </div>
-
-    <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
-
-    <div class="app-c-datetime-fields__date-time">
-      <%= render "govuk_publishing_components/components/label", {
-        text: "Minute",
-        html_for: minute_select_id,
-        id: minute_label_id,
-      } %>
-
-      <%= select_minute minute_value,
-        {
-          include_blank: true,
-          prefix: prefix,
-          field_name: "#{field_name}(5i)"
-        },
-        {
-          id: minute_select_id,
-          class: "govuk-select app-c-datetime-fields__date-time-input",
-          "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip
-        } %>
-    </div>
-  </div>
 <% end %>

--- a/app/views/components/docs/datetime_fields.yml
+++ b/app/views/components/docs/datetime_fields.yml
@@ -84,3 +84,11 @@ examples:
       field_name: first_published_at
       data_attributes:
         tracking: GTM-123AB
+  with_date_only_option:
+    description: |
+      This is used to render the component to display only the date input fields.
+    data:
+      prefix: edition
+      field_name: first_published_at
+      date_heading: "An optional heading for the date fields"
+      date_only: true


### PR DESCRIPTION
[Trello](https://trello.com/c/YNK1v6ta/27-create-a-new-publishing-component-to-use-select-elements-for-a-date-inputs)

- Updates view
- Updates documentation
- Updates spacing for consistency

These changes add an option to the Datetime fields component to allow the user to choose to render the date fields only. 

This option defaults to false so that it is compatible with existing uses of the component.

When set to true it removes the time fields and the “Date” heading, which becomes superfluous in this use case. 

It also applies a small change to the vertical spacing between the date and time fields for consistency when only one of these is displayed. This applies in particular when error messages are included.

![Screenshot 2023-02-24 at 12 44 19](https://user-images.githubusercontent.com/6080548/221182184-9b9f6726-33de-499e-a9c1-dc11109d113f.png)
