### PR TITLE
Add padding to pages for users without javascript

### DIFF
--- a/app/assets/stylesheets/admin/_layout.scss
+++ b/app/assets/stylesheets/admin/_layout.scss
@@ -1,0 +1,23 @@
+// These styles ensure that appropriate padding is added to the top of the page
+// to display the uncollapsed menu for users without javascript.
+$collapse-tabs-width: 710px;
+
+.legacy-whitehall .navbar-wrapper:after {
+  content: "";
+  display: block;
+  height: 400px;
+  margin-top: -20%;
+
+  @media (max-width: $collapse-tabs-width) {
+    height: 320px;
+  }
+
+  @media (min-width: $govuk-page-width) {
+    height: 150px;
+    margin-top: 0;
+  }
+}
+
+.js-enabled .legacy-whitehall .navbar-wrapper:after {
+  display: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $govuk-page-width: 1140px;
 @import "./components/miller-columns";
 @import "./components/secondary-navigation";
 
+@import "./admin/layout";
 @import "./admin/views/audit-trail";
 @import "./admin/views/document-history-tab";
 @import "./admin/views/edit-edition";

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,7 +17,7 @@
   <%= render "govuk_publishing_components/components/skip_link" %>
 
   <div class="legacy-whitehall">
-    <div class="environment-<%= environment %>">
+    <div class="environment-<%= environment %> navbar-wrapper">
       <%= render partial: "shared/header" %>
     </div>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/Li0EWfF2/1162-make-the-navbar-work-for-non-js-users

# What
Add padding/margin to the top of the main page container using a `:before` pseudo element. 

# Why
This ensures that the page content is visible to users who do not use JavaScript (and IE11 users) as the menus are always expanded.
Using a combination of fixed height and percentage based margin top aids with ensuring that the padding is appropriate across many screen sizes.
Using a pseudo element ensures that the styling does not clash with the `.govuk-width-container` styling.

# Video showcasing different screen widths

https://user-images.githubusercontent.com/9594455/221230042-a5af1653-4bc1-41e5-afdf-18a0c7bfbde5.mov
