### PR TITLE
Add parent link to historical account presenter

### DIFF
--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -1,6 +1,7 @@
 module PublishingApi
   class HistoricalAccountPresenter
     NUMBER_OF_RELATED_LINKS = 5
+    CONTENT_ID_OF_GOVERNMENT_HISTORY_PAGE = "db95a864-874f-4f50-a483-352a5bc7ba18".freeze
 
     attr_accessor :historical_account, :update_type
 
@@ -40,10 +41,9 @@ module PublishingApi
 
     def links
       {
-        person: [
-          historical_account.person.content_id,
-        ],
+        person: [historical_account.person.content_id],
         ordered_related_items: related_pms,
+        parent: [CONTENT_ID_OF_GOVERNMENT_HISTORY_PAGE],
       }
     end
 

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -60,10 +60,9 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
     }
 
     expected_links = {
-      person: [
-        historical_account.person.content_id,
-      ],
+      person: [historical_account.person.content_id],
       ordered_related_items: [person2.historical_accounts.first.content_id],
+      parent: %w[db95a864-874f-4f50-a483-352a5bc7ba18],
     }
 
     PublishingApi::HistoricalAccountPresenter.new(historical_account2)


### PR DESCRIPTION
This will allow us to show breadcrumbs on these pages linking back to the government/history page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
