### PR TITLE
Add govuk-form-group to datetime component

### DIFF
--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -42,7 +42,7 @@
  minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
  minute_label_id = "minute-#{SecureRandom.hex(4)}"
 
- root_classes = %w[app-c-datetime-fields]
+ root_classes = %w[app-c-datetime-fields govuk-form-group]
  root_classes << "govuk-form-group--error" if error_items.present?
  data_attributes ||= {}
 %>


### PR DESCRIPTION
## Description

I missed adding this when i first created the component. It handles adding margin.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
