### PR TITLE
Fix the this attachment is accesible checkbox

### DIFF
--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -16,7 +16,7 @@
     error_items: errors_for(attachment_data_fields.object.errors, :file),
   } %>
 
-  <% form.hidden_field :accessible, value: "0" %>
+  <%= form.hidden_field :accessible, value: "0" %>
 
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "attachment[accessible]",


### PR DESCRIPTION
There was a missing `=` meaning that the this attachment is accessible checkbox could not be unchecked.
