### PR TITLE
Add guidance for images tab on Case Studies, Speeches and Fatality Notices

### DIFF
--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -52,5 +52,23 @@
 </div>
 
 <% if form.object.allows_image_attachments? %>
-  <%= render "image_fields", form: form, edition: form.object %>
+  <% if current_user.can_preview_images_update? %>
+    <%= render "govuk_publishing_components/components/heading", {
+          text: "Images",
+          heading_level: 3,
+          font_size: "l",
+          margin_bottom: 3
+      } %>
+      <p class="govuk-body">
+        <% if edition.new_record? %>
+          To add images you must save the document first. After saving, use the 
+          new tabs at the top of the page to upload, edit and delete images and 
+          attachments.
+        <% else %>
+          Use the tabs at the top of the page to upload, edit and delete images.
+        <% end %>
+      </p>
+  <% else %>
+    <%= render "image_fields", form: form, edition: form.object %>
+  <% end %>
 <% end %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -93,7 +93,27 @@
 
 <%= render 'first_published_at', form: form, edition: edition %>
 
-<% unless current_user.can_preview_images_update? %> 
+<% if current_user.can_preview_images_update? %>
+  <% if %w(CaseStudy Speech FatalityNotice).include?(edition.type) %>
+    <div class="govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/heading", {
+          text: "Images",
+          heading_level: 3,
+          font_size: "l",
+          margin_bottom: 3
+      } %>
+      <p class="govuk-body">
+        <% if edition.new_record? %>
+          To add images you must save the document first. After saving, use the 
+          new tabs at the top of the page to upload, edit and delete images and 
+          attachments.
+        <% else %>
+          Use the tabs at the top of the page to upload, edit and delete images.
+        <% end %>
+      </p>
+    </div>
+  <% end %>
+<% else %>
   <% if form.object.allows_image_attachments? %>
     <% if edition.type == "CaseStudy" %>
       <%= render partial: "image_fields_case_studies", locals: { form: form, edition: form.object } %>


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/yPr3zr4h/1147-add-guidance-for-images-to-the-edit-form)

## What
Adds guidance for using the new images tab on Case Studies, Speeches and Fatality Notices for users who have the `Preview images update` permission.

## Why
These content types only support image attachments - not file attachments - and hence do not benefit from the recent [additions to guidance](https://github.com/alphagov/whitehall/pull/7332) for content types which support both image and file attachments.

## Screenshots
### Case Studies
![whitehall-admin dev gov uk_government_admin_case-studies_new(iPad Pro)](https://user-images.githubusercontent.com/94846816/222402891-db5757c2-3862-44b7-906b-d199aa51cf5c.png)
![whitehall-admin dev gov uk_government_admin_case-studies_1408687_edit(iPad Pro)](https://user-images.githubusercontent.com/94846816/222402995-09dca34a-5f1b-4b6d-88e5-9e1395a80b89.png)

### Fatality Notices
![whitehall-admin dev gov uk_government_admin_fatalities_new(iPad Pro)](https://user-images.githubusercontent.com/94846816/222402675-93397979-4f5c-4ae4-8aad-58d3c8c38cca.png)
![whitehall-admin dev gov uk_government_admin_fatalities_1408686_edit(iPad Pro)](https://user-images.githubusercontent.com/94846816/222402829-97519d64-dedc-4c30-93b8-09acf54d2ce8.png)

### Speeches
![whitehall-admin dev gov uk_government_admin_speeches_new(iPad Pro) (1)](https://user-images.githubusercontent.com/94846816/222402013-a57e0487-d744-4feb-9875-5233464ce6a5.png)
![whitehall-admin dev gov uk_government_admin_speeches_1408685_edit(iPad Pro)](https://user-images.githubusercontent.com/94846816/222402592-da8af7c6-23a6-4e58-b281-c3770448c1af.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
