### PR TITLE
Add roll call introduction to fatality notice presenter

### DIFF
--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -63,6 +63,7 @@ module PublishingApi
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
         change_history: item.change_history.as_json,
         emphasised_organisations: item.lead_organisations.map(&:content_id),
+        roll_call_introduction: item.roll_call_introduction,
       }
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -132,6 +132,10 @@ class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCas
   test "it presents first_public_at as nil for draft" do
     assert_nil @presented_details[:first_published_at]
   end
+
+  test "it presents the roll call introduction" do
+    assert_equal(@fatality_notice.roll_call_introduction, @presented_details[:roll_call_introduction])
+  end
 end
 
 class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport::TestCase


### PR DESCRIPTION
While this is not rendered on the fatality notice page, we will need it present in the fatality notice content item when rendering the fields of operation pages, which present this information for each fatality notice. Adding it in to the content item here will allow us to link to a fatality notice in the field of operation and add the roll call introduction to the expansion rules.

Additionally, we may choose to render this information on the fatality notice page in future, so having it in the content item makes sense.

[Trello](https://trello.com/c/4UszwKWR/471-update-content-item-for-field-of-operation-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
