### PR TITLE
Add additional fields to fields of operation presenter

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -2,6 +2,8 @@ module PublishingApi
   class OperationalFieldPresenter
     attr_reader :update_type
 
+    MINISTRY_OF_DEFENCE_CONTENT_ID = "d994e55c-48c9-4795-b872-58d8ec98af12".freeze
+
     def initialize(operational_field, _options = {})
       @operational_field = operational_field
       @update_type = "major"
@@ -29,6 +31,7 @@ module PublishingApi
     def links
       {
         fatality_notices: operational_field.published_fatality_notices.order("first_published_at desc").map(&:content_id),
+        primary_publishing_organisation: [MINISTRY_OF_DEFENCE_CONTENT_ID],
       }
     end
 

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -1,10 +1,9 @@
 module PublishingApi
   class OperationalFieldPresenter
-    attr_reader :links, :update_type
+    attr_reader :update_type
 
     def initialize(operational_field, _options = {})
       @operational_field = operational_field
-      @links = {}
       @update_type = "major"
     end
 
@@ -25,6 +24,12 @@ module PublishingApi
           update_type:,
         )
       end
+    end
+
+    def links
+      {
+        fatality_notices: operational_field.published_fatality_notices.order("first_published_at desc").map(&:content_id),
+      }
     end
 
   private

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
           locale: "en",
           publishing_app: "whitehall",
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-          schema_name: "placeholder",
+          schema_name: "field_of_operation",
           title: operational_field.name,
           update_type:,
         )

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -54,7 +54,9 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
   test "it presents the expected links" do
     expected_links = {
       fatality_notices: @fatality_notices_for_operational_field.map(&:content_id),
+      primary_publishing_organisation: [PublishingApi::OperationalFieldPresenter::MINISTRY_OF_DEFENCE_CONTENT_ID],
     }
+
     assert_equal expected_links, @links
     assert_valid_against_links_schema({ links: @links }, "field_of_operation")
   end

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid placeholder content item" do
-    assert_valid_against_publisher_schema @presented_content, "placeholder"
+    assert_valid_against_publisher_schema @presented_content, "field_of_operation"
   end
 
   test "it delegates the content id" do

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -12,47 +12,31 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
     @presented_content = @presented_operational_field.content
   end
 
-  test "it presents a valid placeholder content item" do
+  test "presents an operational field" do
+    expected_hash = {
+      title: "Operational Field name",
+      locale: "en",
+      publishing_app: "whitehall",
+      update_type: "major",
+      base_path: "/government/fields-of-operation/operational-field-name",
+      details: {},
+      document_type: "field_of_operation",
+      rendering_app: "whitehall-frontend",
+      schema_name: "field_of_operation",
+      description: "Operational Field description",
+      routes: [
+        {
+          path: "/government/fields-of-operation/operational-field-name",
+          type: "exact",
+        },
+      ],
+    }
+
+    assert_equal expected_hash, @presented_content
     assert_valid_against_publisher_schema @presented_content, "field_of_operation"
   end
 
   test "it delegates the content id" do
     assert_equal @operational_field.content_id, @presented_operational_field.content_id
-  end
-
-  test "it presents the name as title" do
-    assert_equal "Operational Field name", @presented_content[:title]
-  end
-
-  test "it presents the description" do
-    assert_equal "Operational Field description", @presented_content[:description]
-  end
-
-  test "it presents the base_path" do
-    assert_equal "/government/fields-of-operation/operational-field-name", @presented_content[:base_path]
-  end
-
-  test "it presents the publishing_app as whitehall" do
-    assert_equal "whitehall", @presented_content[:publishing_app]
-  end
-
-  test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal "whitehall-frontend", @presented_content[:rendering_app]
-  end
-
-  test "it presents the schema_name as placeholder" do
-    assert_equal "placeholder", @presented_content[:schema_name]
-  end
-
-  test "it presents the document type as field_of_operation" do
-    assert_equal "field_of_operation", @presented_content[:document_type]
-  end
-
-  test "it presents the global process wide locale as the locale of the operational_field" do
-    assert_equal "en", @presented_content[:locale]
-  end
-
-  test "it presents empty details" do
-    assert_empty @presented_content[:details]
   end
 end


### PR DESCRIPTION
As part of moving the rendering of these pages (example: [https://www.gov.uk/government/fields-of-operation/iraq](https://www.gov.uk/government/fields-of-operation/iraq)) out of whitehall, we need to add items to the presenter for it, and use the new schema (dependent PR - see [here](https://github.com/alphagov/publishing-api/pull/2299)).

A lot of the content on these pages actually comes from individual fatality notices, so these are added as links here, and will be expanded as part of link expansion in publishing api.

[Trello ](https://trello.com/c/4UszwKWR/471-update-content-item-for-field-of-operation-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
