### PR TITLE
Switch rendering of individual past prime minister pages to collections

### DIFF
--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
         },
         document_type: "historic_appointment",
         public_updated_at: historical_account.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "historic_appointment",
       )
 

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
     expected_hash = {
       base_path: public_path,
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       schema_name: "historic_appointment",
       document_type: "historic_appointment",
       title: "Some Person",


### PR DESCRIPTION
We have now moved the rendering code into collections, so we can switch the rendering app here and republish the pages.

Dependent on [PR to add the rendering code into collections](https://github.com/alphagov/collections/pull/3191)

[Trello](https://trello.com/c/YJ4RzyVl/424-render-individual-past-prime-ministers-pages-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
