### PR TITLE
Add pagination component

### DIFF
--- a/app/views/components/_pagination.html.erb
+++ b/app/views/components/_pagination.html.erb
@@ -1,0 +1,60 @@
+<%
+  id ||= "pagination-#{SecureRandom.hex(4)}"
+  aria_label ||= "results"
+  items ||= []
+  previous_href ||= false
+  next_href ||= false
+%>
+
+<nav id="<% id %>" class="app-c-pagination govuk-pagination" role="navigation" aria-label="<%= aria_label %>">
+  <% if previous_href %>
+    <div class="govuk-pagination__prev">
+      <a class="govuk-link govuk-pagination__link" href="<%= previous_href %>" rel="prev">
+        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+        </svg>
+        <span class="govuk-pagination__link-title">Previous</span>
+      </a>
+    </div>
+  <% end %>
+
+  <ul class="govuk-pagination__list">
+    <% items.each_with_index do | item, index | %>
+      <%
+        item_label = item[:label] ? item[:label] : index + 1
+        item_aria_label = item[:label] ? item[:label] : "Page #{item_label}"
+        item_aria_label = item[:aria_label].present? ? item[:aria_label] : item_aria_label
+        list_item_classes = ["govuk-pagination__item"]
+        list_item_classes << "govuk-pagination__item--current" if item[:current]
+        list_item_classes << "govuk-pagination__item--ellipses" if item[:ellipses]
+      %>
+
+      <%= tag.li class: list_item_classes do %>
+        <% if item[:ellipses] %>
+          &ctdot;
+        <% else %>
+          <%= tag.a(
+            item_label,
+            class: "govuk-link govuk-pagination__link",
+            href: item[:href],
+            aria: {
+              label: item_aria_label,
+              current: item[:current] ? "page" : nil,
+            }
+          ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <% if next_href %>
+    <div class="govuk-pagination__next">
+      <a class="govuk-link govuk-pagination__link" href="<%= next_href %>" rel="next">
+        <span class="govuk-pagination__link-title">Next</span>
+        <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+        </svg>
+      </a>
+    </div>
+  <% end %>
+</nav>

--- a/app/views/components/docs/pagination.yml
+++ b/app/views/components/docs/pagination.yml
@@ -1,0 +1,111 @@
+name: Pagination
+description: |
+  Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that’s divided into multiple website pages.
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form select elements
+  - have correctly associated labels
+
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      previous_href: /page/1
+      next_href: /page/3
+      items:
+        - href: /page/1
+        - href: /page/2
+          current: true
+        - href: /page/3
+  without_previous_or_next_links:
+    data:
+      items:
+        - href: /page/1
+        - href: /page/2
+        - href: /page/3
+  with_selected_item:
+    data:
+      items:
+        - href: /page/1
+          current: true
+        - href: /page/2
+        - href: /page/3
+  without_previous_link:
+    data:
+      next_href: /page/3
+      items:
+        - label: 1
+          href: /page/1
+          current: true
+        - label: 2
+          href: /page/2
+        - label: 3
+          href: /page/3
+  without_next_link:
+    data:
+      previous_href: /page/2
+      items:
+        - href: /page/1
+        - href: /page/2
+        - href: /page/3
+          current: true
+  with_labels:
+    data:
+      previous_href: /page/1
+      next_href: /page/3
+      items:
+        - label: 1.1
+          href: /page/1
+        - label: 1.2
+          href: /page/2
+          current: true
+        - label: 1.3
+          href: /page/3
+  with_custom_aria_label:
+    data:
+      aria_label: Search results
+      previous_href: /page/1
+      next_href: /page/3
+      items:
+        - href: /page/1
+        - href: /page/2
+          current: true
+        - href: /page/3
+  with_custom_aria_label_for_element:
+    data:
+      aria_label: Search results with aria labels
+      previous_href: /page/1.1
+      next_href: /page/3.1
+      items:
+        - href: /page/1.1
+          aria_label: Page 1.1
+        - href: /page/2.1
+          current: true
+          aria_label: Page 2.1
+        - href: /page/3.1
+          aria_label: Page 3.1
+  with_ellipses_items:
+    data:
+      previous_href: /page/1
+      next_href: /page/3
+      items:
+        - label: 1
+          href: /page/1
+        - ellipses: true
+        - label: 20
+          href: /page/20
+        - label: 21
+          href: /page/21
+          current: true
+        - label: 22
+          href: /page/22
+        - ellipses: true
+        - label: 100
+          href: /page/100

--- a/test/views/components/pagination_test.rb
+++ b/test/views/components/pagination_test.rb
@@ -1,0 +1,242 @@
+require "test_helper"
+
+class PaginationTest < ActionView::TestCase
+  test "should render component" do
+    render("components/pagination")
+
+    assert_select ".app-c-pagination", count: 1
+  end
+
+  test "should render component with only items" do
+    list_items = [
+      {
+        href: "/page/1",
+      },
+      {
+        href: "/page/2",
+      },
+      {
+        href: "/page/3",
+      },
+    ]
+
+    render("components/pagination", {
+      items: list_items,
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__prev", count: 0
+    assert_select ".govuk-pagination__next", count: 0
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".govuk-pagination__item .govuk-pagination__link" do |elements|
+      list_items.each_with_index do |item, index|
+        assert_equal elements[index].text, (index + 1).to_s
+        assert_equal elements[index].attr("aria-label"), "Page #{index + 1}"
+        assert_equal elements[index].attr("href"), item[:href]
+      end
+    end
+  end
+
+  test "should render component with current page" do
+    render("components/pagination", {
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          href: "/page/2",
+          current: true,
+        },
+        {
+          href: "/page/3",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".govuk-pagination__item--current", count: 1
+    assert_select ".govuk-pagination__item--current", text: "2"
+    assert_select ".govuk-pagination__item--current .govuk-pagination__link" do |current_link|
+      assert_equal current_link.first.attr("aria-current"), "page"
+    end
+  end
+
+  test "should render component with previous and next links" do
+    render("components/pagination", {
+      previous_href: "/page/1",
+      next_href: "/page/3",
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          href: "/page/2",
+        },
+        {
+          href: "/page/3",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".govuk-pagination__prev", count: 1
+    assert_select ".govuk-pagination__next", count: 1
+  end
+
+  test "should render component with only previous links" do
+    render("components/pagination", {
+      previous_href: "/page/1",
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          href: "/page/2",
+        },
+        {
+          href: "/page/3",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".govuk-pagination__prev", count: 1
+    assert_select ".govuk-pagination__next", count: 0
+  end
+
+  test "should render component with only next links" do
+    render("components/pagination", {
+      next_href: "/page/3",
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          href: "/page/2",
+        },
+        {
+          href: "/page/3",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".govuk-pagination__prev", count: 0
+    assert_select ".govuk-pagination__next", count: 1
+  end
+
+  test "should render component with custom labels" do
+    list_items = [
+      {
+        label: "This is page 1.1",
+        href: "/page/1.1",
+      },
+      {
+        label: "This is page 1.2",
+        href: "/page/1.2",
+      },
+      {
+        label: "This is page 1.2",
+        href: "/page/1.2",
+      },
+    ]
+
+    render("components/pagination", {
+      items: list_items,
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select(".govuk-pagination__item .govuk-pagination__link") do |elements|
+      list_items.each_with_index do |item, index|
+        assert_equal elements[index].text, item[:label]
+        assert_equal elements[index].attr("aria-label"), item[:label]
+        assert_equal elements[index].attr("href"), item[:href]
+      end
+    end
+  end
+
+  test "should render component with custom aria label for pagination component" do
+    render("components/pagination", {
+      aria_label: "some pagination thing",
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          href: "/page/2",
+        },
+        {
+          href: "/page/3",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select ".app-c-pagination" do |component|
+      assert_equal component.first.attr("aria-label"), "some pagination thing"
+    end
+  end
+
+  test "should render component with custom aria labels for each item" do
+    list_items = [
+      {
+        href: "/page/1.1",
+        aria_label: "Page 1.1",
+      },
+      {
+        href: "/page/2.1",
+        current: true,
+        aria_label: "Page 2.1",
+      },
+      {
+        href: "/page/3.1",
+        aria_label: "Page 3.1",
+      },
+    ]
+
+    render("components/pagination", {
+      items: list_items,
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__prev", count: 0
+    assert_select ".govuk-pagination__next", count: 0
+    assert_select ".govuk-pagination__item", count: 3
+    assert_select(".govuk-pagination__item .govuk-pagination__link") do |elements|
+      list_items.each_with_index do |item, index|
+        assert_equal elements[index].text, (index + 1).to_s
+        assert_equal elements[index].attr("aria-label"), item[:aria_label]
+        assert_equal elements[index].attr("href"), item[:href]
+      end
+    end
+  end
+
+  test "should render component with ellipses items" do
+    render("components/pagination", {
+      items: [
+        {
+          href: "/page/1",
+        },
+        {
+          ellipses: true,
+        },
+        {
+          href: "/page/20",
+        },
+        {
+          href: "/page/21",
+        },
+      ],
+    })
+
+    assert_select ".app-c-pagination", count: 1
+    assert_select ".govuk-pagination__item", count: 4
+    assert_select ".govuk-pagination__item.govuk-pagination__item--ellipses", count: 1
+  end
+end


### PR DESCRIPTION
This ports the pagination component from the GOVUK Design System - https://design-system.service.gov.uk/components/pagination/

We need this component for listing pages where pagination is required.

https://trello.com/c/SF2D6O7S/47-create-pagination-component

![screenshot-whitehall-admin dev gov uk-2023 03 02-17_14_51](https://user-images.githubusercontent.com/4599889/222502750-eba2e896-f7d4-4ec1-873a-97dab441fd8a.png)
