### PR TITLE
Rename dit colours and crest following rename

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -147,10 +147,10 @@ class OrganisationBrandColour
     title: "Civil Service",
     class_name: "civil-service",
   )
-  DepartmentForInternationalTrade = create!(
+  DepartmentForBusinessAndTrade = create!(
     id: 29,
-    title: "Department for International Trade",
-    class_name: "department-for-international-trade",
+    title: "Department for Business and Trade",
+    class_name: "department-for-business-and-trade",
   )
   ForeignCommonwealthDevelopmentOffice = create!(
     id: 30,

--- a/app/models/organisation_logo_type.rb
+++ b/app/models/organisation_logo_type.rb
@@ -49,7 +49,7 @@ class OrganisationLogoType
   CustomLogo = create!(
     id: 14, title: "Use custom logo for organisations exempt from the single identity", class_name: "custom",
   )
-  DepartmentInternationalTrade = create!(
-    id: 15, title: "Department for International Trade", class_name: "dit",
+  DepartmentForBusinessAndTrade = create!(
+    id: 15, title: "Department for Business and Trade", class_name: "dbt",
   )
 end


### PR DESCRIPTION
Rename the organisation colours and crest name for Department of International Trade now it is called Department for Business and Trade
Before:
![Brand colour and crest](https://user-images.githubusercontent.com/17481621/222711361-f661def8-7c4e-4b8e-853d-e9400353a472.png)
lack.com/files-pri/T8GT9416G-F04SXTJ9YQG/brand_colour_and_crest.png)

After:
![image](https://user-images.githubusercontent.com/17481621/222711302-0baf7e3e-246a-46a4-a2b3-ca1090e81ec6.png)

