### PR TITLE
Switch rendering app for the historical accounts index page

### DIFF
--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -26,7 +26,7 @@ module PublishingApi
         },
         document_type: "historic_appointments",
         public_updated_at: Time.zone.now,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "historic_appointments",
       )
 

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
     expected_hash = {
       base_path: "/government/history/past-prime-ministers",
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       schema_name: "historic_appointments",
       document_type: "historic_appointments",
       title: "Past Prime Ministers",


### PR DESCRIPTION
Trello: https://trello.com/c/LSd8y4zg/421-render-past-prime-ministers-index-page-in-collections

Dependant on: https://github.com/alphagov/collections/pull/3197

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
