### PR TITLE
Implement presenter for 'How Government Works' page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -194,6 +194,7 @@ class Organisation < ApplicationRecord
   before_destroy { |r| throw :abort unless r.destroyable? }
   after_save :ensure_analytics_identifier
   after_save :update_organisations_index_page
+  after_save :republish_how_government_works_page_to_publishing_api
   after_destroy :update_organisations_index_page
 
   after_save do
@@ -222,6 +223,10 @@ class Organisation < ApplicationRecord
       documents = Document.live.where(editions: { alternative_format_provider_id: self })
       documents.find_each { |d| Whitehall::PublishingApi.republish_document_async(d, bulk: true) }
     end
+  end
+
+  def republish_how_government_works_page_to_publishing_api
+    PublishHowGovernmentWorksPage.new.publish
   end
 
   def update_organisations_index_page

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -69,8 +69,7 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_create :republish_how_government_works_page_to_publishing_api
-  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
+  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
 
   def republish_organisation_to_publishing_api
@@ -80,7 +79,7 @@ class RoleAppointment < ApplicationRecord
   end
 
   def republish_how_government_works_page_to_publishing_api
-    PublishHowGovernmentWorksPage.new.publish if current? && role.slug == "prime-minister"
+    PublishHowGovernmentWorksPage.new.publish if ministerial?
   end
 
   def republish_prime_ministers_index_page_to_publishing_api
@@ -174,7 +173,7 @@ private
   end
 
   def set_order
-    update!(order: person.role_appointments.count)
+    update_column(:order, person.role_appointments.count)
   end
 
   def prevent_destruction_unless_destroyable

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -69,6 +69,7 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
+  after_create :republish_how_government_works_page_to_publishing_api
   after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
 
@@ -76,6 +77,10 @@ class RoleAppointment < ApplicationRecord
     organisations.each do |organisation|
       Whitehall::PublishingApi.republish_async(organisation)
     end
+  end
+
+  def republish_how_government_works_page_to_publishing_api
+    PublishHowGovernmentWorksPage.new.publish if current? && role.slug == "prime-minister"
   end
 
   def republish_prime_ministers_index_page_to_publishing_api

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -4,7 +4,7 @@ class SitewideSetting < ApplicationRecord
   validates :key, uniqueness: { case_sensitive: false } # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates_with SafeHtmlValidator
 
-  after_save :republish_ministers_if_reshuffle
+  after_save :republish_downstream_if_reshuffle
 
   def human_status
     on ? "On" : "Off"
@@ -14,12 +14,14 @@ class SitewideSetting < ApplicationRecord
     key.humanize
   end
 
-  def republish_ministers_if_reshuffle
+  def republish_downstream_if_reshuffle
     return unless key == "minister_reshuffle_mode"
 
     payload = PublishingApi::MinistersIndexPresenter.new
 
     Services.publishing_api.put_content(payload.content_id, payload.content)
     Services.publishing_api.publish(payload.content_id, nil, locale: "en")
+
+    PublishHowGovernmentWorksPage.new.publish
   end
 end

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -20,10 +20,10 @@ module PublishingApi
       content.merge!(
         base_path:,
         description: "About the UK system of government. Understand who runs government, and how government is run.",
-        document_type: "special_route",
+        document_type: "how_government_works",
         public_updated_at: Time.zone.now,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "special_route",
+        schema_name: "how_government_works",
       )
 
       content.merge!(PayloadBuilder::Routes.for(base_path))

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -32,5 +32,11 @@ module PublishingApi
     def base_path
       "/government/how-government-works"
     end
+
+    def links
+      {
+        current_prime_minister: [MinisterialRole.find_by(slug: "prime-minister")&.current_person&.content_id],
+      }
+    end
   end
 end

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -1,0 +1,36 @@
+module PublishingApi
+  class HowGovernmentWorksPresenter
+    attr_accessor :update_type
+
+    def initialize(update_type: nil)
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      "f56cfe74-8e5c-432d-bfcf-fd2521c5919c"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: "How government works",
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        base_path:,
+        description: "About the UK system of government. Understand who runs government, and how government is run.",
+        document_type: "special_route",
+        public_updated_at: Time.zone.now,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "special_route",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def base_path
+      "/government/how-government-works"
+    end
+  end
+end

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "how_government_works",
         details: {
+          department_counts:,
           ministerial_role_counts:,
         },
       )
@@ -39,6 +40,14 @@ module PublishingApi
     def links
       {
         current_prime_minister: [MinisterialRole.find_by(slug: "prime-minister")&.current_person&.content_id],
+      }
+    end
+
+    def department_counts
+      {
+        ministerial_departments: Organisation.listable.ministerial_departments.count,
+        non_ministerial_departments: Organisation.listable.non_ministerial_departments.count,
+        agencies_and_public_bodies: Organisation.listable.select { |o| o.type.agency_or_public_body? }.count,
       }
     end
 

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -24,6 +24,9 @@ module PublishingApi
         public_updated_at: Time.zone.now,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "how_government_works",
+        details: {
+          ministerial_role_counts:,
+        },
       )
 
       content.merge!(PayloadBuilder::Routes.for(base_path))
@@ -37,6 +40,29 @@ module PublishingApi
       {
         current_prime_minister: [MinisterialRole.find_by(slug: "prime-minister")&.current_person&.content_id],
       }
+    end
+
+    def ministerial_role_counts
+      {
+        prime_minister:,
+        cabinet_ministers:,
+        other_ministers: total_ministers - cabinet_ministers - prime_minister,
+        total_ministers:,
+      }
+    end
+
+  private
+
+    def prime_minister
+      1
+    end
+
+    def cabinet_ministers
+      MinisterialRole.cabinet.occupied.where(cabinet_member: true).map(&:current_role_appointment).map(&:person).uniq.count
+    end
+
+    def total_ministers
+      MinisterialRole.occupied.map(&:current_role_appointment).map(&:person).uniq.count
     end
   end
 end

--- a/lib/publish_how_government_works_page.rb
+++ b/lib/publish_how_government_works_page.rb
@@ -1,0 +1,8 @@
+class PublishHowGovernmentWorksPage
+  def publish
+    payload = PublishingApi::HowGovernmentWorksPresenter.new
+
+    Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.publish(payload.content_id, nil)
+  end
+end

--- a/lib/publish_how_government_works_page.rb
+++ b/lib/publish_how_government_works_page.rb
@@ -3,6 +3,7 @@ class PublishHowGovernmentWorksPage
     payload = PublishingApi::HowGovernmentWorksPresenter.new
 
     Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
     Services.publishing_api.publish(payload.content_id, nil)
   end
 end

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -17,14 +17,6 @@ class PublishStaticPages
   def pages
     [
       {
-        content_id: "f56cfe74-8e5c-432d-bfcf-fd2521c5919c",
-        title: "How government works",
-        document_type: "special_route",
-        description: "About the UK system of government. Understand who runs government, and how government is run.",
-        indexable_content: TemplateContent.new("home/how_government_works").indexable_content,
-        base_path: "/government/how-government-works",
-      },
-      {
         content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
         title: "Get involved",
         document_type: "get_involved",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -73,6 +73,11 @@ namespace :publishing_api do
     task republish_past_prime_ministers: :environment do
       PublishPrimeMinistersIndexPage.new.publish
     end
+
+    desc "Republish the how government works page to Publishing API"
+    task republish_how_government_works: :environment do
+      PublishHowGovernmentWorksPage.new.publish
+    end
   end
 
   namespace :patch_links do

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -61,6 +61,10 @@ FactoryBot.define do
     organisation_type_key { :sub_organisation }
   end
 
+  factory :executive_agency, parent: :organisation do
+    organisation_type_key { :executive_agency }
+  end
+
   factory :executive_office, parent: :organisation do
     organisation_type_key { :executive_office }
   end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -10,6 +10,11 @@ FactoryBot.define do
     role_type { "minister" }
   end
 
+  factory :non_ministerial_role_without_organisations, class: Role, traits: [:translated] do
+    sequence(:name) { |index| "role-name-#{index}" }
+    type { "permanent_secretary" }
+  end
+
   factory :historic_role, parent: :ministerial_role do
     supports_historical_accounts { true }
   end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1125,4 +1125,18 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal "/courts-tribunals/#{tribunal.slug}", tribunal.public_path
     assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url
   end
+
+  test "should send the how government works page to publishing api when an organisation is created" do
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    create(:organisation)
+  end
+
+  test "should send the how government works page to publishing api when an organisation is updated" do
+    organisation = create(:organisation)
+
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    organisation.update!(name: "New department name")
+  end
 end

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -11,6 +11,10 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     create(:role_appointment, person: create(:person), role: create(:ministerial_role))
     create(:role_appointment, person: create(:person), role: create(:ministerial_role))
     create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+
+    create(:ministerial_department)
+    create(:non_ministerial_department)
+    create(:executive_agency)
   end
 
   test "presents a valid content item" do
@@ -33,6 +37,11 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       redirects: [],
       public_updated_at: Time.zone.now,
       details: {
+        department_counts: {
+          ministerial_departments: 6,
+          non_ministerial_departments: 1,
+          agencies_and_public_bodies: 1,
+        },
         ministerial_role_counts: {
           prime_minister: 1,
           cabinet_ministers: 2,

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -6,8 +6,8 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       base_path: "/government/how-government-works",
       publishing_app: "whitehall",
       rendering_app: "whitehall-frontend",
-      schema_name: "special_route",
-      document_type: "special_route",
+      schema_name: "how_government_works",
+      document_type: "how_government_works",
       title: "How government works",
       description: "About the UK system of government. Understand who runs government, and how government is run.",
       locale: "en",
@@ -25,6 +25,6 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::HowGovernmentWorksPresenter.new
 
     assert_equal expected_hash, presenter.content
-    assert_valid_against_publisher_schema(presenter.content, "special_route")
+    assert_valid_against_publisher_schema(presenter.content, "how_government_works")
   end
 end

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -1,6 +1,12 @@
 require "test_helper"
 
 class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
+  setup do
+    @current_pm = create(:person)
+    pm_role = create(:prime_minister_role)
+    create(:role_appointment, person: @current_pm, role: pm_role)
+  end
+
   test "presents a valid content item" do
     expected_hash = {
       base_path: "/government/how-government-works",
@@ -22,9 +28,18 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       public_updated_at: Time.zone.now,
     }
 
+    expected_links = {
+      current_prime_minister: [
+        @current_pm.content_id,
+      ],
+    }
+
     presenter = PublishingApi::HowGovernmentWorksPresenter.new
 
     assert_equal expected_hash, presenter.content
     assert_valid_against_publisher_schema(presenter.content, "how_government_works")
+
+    assert_equal expected_links, presenter.links
+    assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
   end
 end

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -5,6 +5,12 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     @current_pm = create(:person)
     pm_role = create(:prime_minister_role)
     create(:role_appointment, person: @current_pm, role: pm_role)
+
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
   end
 
   test "presents a valid content item" do
@@ -26,6 +32,14 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       update_type: "major",
       redirects: [],
       public_updated_at: Time.zone.now,
+      details: {
+        ministerial_role_counts: {
+          prime_minister: 1,
+          cabinet_ministers: 2,
+          other_ministers: 3,
+          total_ministers: 6,
+        },
+      },
     }
 
     expected_links = {

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
+  test "presents a valid content item" do
+    expected_hash = {
+      base_path: "/government/how-government-works",
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      schema_name: "special_route",
+      document_type: "special_route",
+      title: "How government works",
+      description: "About the UK system of government. Understand who runs government, and how government is run.",
+      locale: "en",
+      routes: [
+        {
+          path: "/government/how-government-works",
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: Time.zone.now,
+    }
+
+    presenter = PublishingApi::HowGovernmentWorksPresenter.new
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_publisher_schema(presenter.content, "special_route")
+  end
+end

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   setup do
     @current_pm = create(:person)
     pm_role = create(:prime_minister_role)
@@ -17,52 +19,96 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     create(:executive_agency)
   end
 
-  test "presents a valid content item" do
-    expected_hash = {
-      base_path: "/government/how-government-works",
-      publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
-      schema_name: "how_government_works",
-      document_type: "how_government_works",
-      title: "How government works",
-      description: "About the UK system of government. Understand who runs government, and how government is run.",
-      locale: "en",
-      routes: [
-        {
-          path: "/government/how-government-works",
-          type: "exact",
+  context "when a ministerial reshuffle is not taking place" do
+    test "presents a valid content item" do
+      expected_hash = {
+        base_path: "/government/how-government-works",
+        publishing_app: "whitehall",
+        rendering_app: "whitehall-frontend",
+        schema_name: "how_government_works",
+        document_type: "how_government_works",
+        title: "How government works",
+        description: "About the UK system of government. Understand who runs government, and how government is run.",
+        locale: "en",
+        routes: [
+          {
+            path: "/government/how-government-works",
+            type: "exact",
+          },
+        ],
+        update_type: "major",
+        redirects: [],
+        public_updated_at: Time.zone.now,
+        details: {
+          department_counts: {
+            ministerial_departments: 6,
+            non_ministerial_departments: 1,
+            agencies_and_public_bodies: 1,
+          },
+          ministerial_role_counts: {
+            prime_minister: 1,
+            cabinet_ministers: 2,
+            other_ministers: 3,
+            total_ministers: 6,
+          },
+          reshuffle_in_progress: false,
         },
-      ],
-      update_type: "major",
-      redirects: [],
-      public_updated_at: Time.zone.now,
-      details: {
-        department_counts: {
-          ministerial_departments: 6,
-          non_ministerial_departments: 1,
-          agencies_and_public_bodies: 1,
+      }
+
+      expected_links = {
+        current_prime_minister: [
+          @current_pm.content_id,
+        ],
+      }
+
+      presenter = PublishingApi::HowGovernmentWorksPresenter.new
+
+      assert_equal expected_hash, presenter.content
+      assert_valid_against_publisher_schema(presenter.content, "how_government_works")
+
+      assert_equal expected_links, presenter.links
+      assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
+    end
+  end
+
+  context "when a ministerial reshuffle is taking place" do
+    setup do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+    end
+
+    test "presents a valid content item without any details or links" do
+      expected_hash = {
+        base_path: "/government/how-government-works",
+        publishing_app: "whitehall",
+        rendering_app: "whitehall-frontend",
+        schema_name: "how_government_works",
+        document_type: "how_government_works",
+        title: "How government works",
+        description: "About the UK system of government. Understand who runs government, and how government is run.",
+        locale: "en",
+        routes: [
+          {
+            path: "/government/how-government-works",
+            type: "exact",
+          },
+        ],
+        update_type: "major",
+        redirects: [],
+        public_updated_at: Time.zone.now,
+        details: {
+          reshuffle_in_progress: true,
         },
-        ministerial_role_counts: {
-          prime_minister: 1,
-          cabinet_ministers: 2,
-          other_ministers: 3,
-          total_ministers: 6,
-        },
-      },
-    }
+      }
 
-    expected_links = {
-      current_prime_minister: [
-        @current_pm.content_id,
-      ],
-    }
+      expected_links = {}
 
-    presenter = PublishingApi::HowGovernmentWorksPresenter.new
+      presenter = PublishingApi::HowGovernmentWorksPresenter.new
 
-    assert_equal expected_hash, presenter.content
-    assert_valid_against_publisher_schema(presenter.content, "how_government_works")
+      assert_equal expected_hash, presenter.content
+      assert_valid_against_publisher_schema(presenter.content, "how_government_works")
 
-    assert_equal expected_links, presenter.links
-    assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
+      assert_equal expected_links, presenter.links
+      assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
+    end
   end
 end

--- a/test/unit/publish_how_government_works_page_test.rb
+++ b/test/unit/publish_how_government_works_page_test.rb
@@ -5,6 +5,7 @@ class PublishHowGovernmentWorksPageTest < ActiveSupport::TestCase
     expected_content = presenter.content
 
     Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content)
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
     Services.publishing_api.expects(:publish).with(presenter.content_id, nil)
 
     PublishHowGovernmentWorksPage.new.publish

--- a/test/unit/publish_how_government_works_page_test.rb
+++ b/test/unit/publish_how_government_works_page_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+class PublishHowGovernmentWorksPageTest < ActiveSupport::TestCase
+  test "sends the page to publishing api" do
+    presenter = PublishingApi::HowGovernmentWorksPresenter.new
+    expected_content = presenter.content
+
+    Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, nil)
+
+    PublishHowGovernmentWorksPage.new.publish
+  end
+end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -483,4 +483,20 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     create(:role_appointment, person: create(:person), role:)
   end
+
+  test "should send the how government works page to publishing api when someone is appointed to a ministerial role" do
+    role = create(:ministerial_role)
+
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    create(:role_appointment, person: create(:person), role:)
+  end
+
+  test "should not send the how government works page to publishing api when someone is appointed to a non-ministerial role" do
+    role = create(:non_ministerial_role_without_organisations)
+
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish).never
+
+    create(:role_appointment, person: create(:person), role:)
+  end
 end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -475,4 +475,12 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
   end
+
+  test "should send the how government works page to publishing api when the role created is a current prime minister" do
+    role = create(:prime_minister_role)
+
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    create(:role_appointment, person: create(:person), role:)
+  end
 end

--- a/test/unit/sitewide_setting_test.rb
+++ b/test/unit/sitewide_setting_test.rb
@@ -1,7 +1,17 @@
 require "test_helper"
 
 class SitewideSettingTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should send the how government works page to publishing api when reshuffle mode is switched on" do
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+  end
+
+  test "should send the how government works page to publishing api when reshuffle mode is switched off" do
+    setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+
+    PublishHowGovernmentWorksPage.any_instance.expects(:publish)
+
+    setting.update!(on: false)
+  end
 end


### PR DESCRIPTION
This content into the presenter for the 'How Government Works' page, which will allow us to render it outside of Whitehall.

The page gets republished when:
- the relevant rake task is run
- a new prime minister is appointed
- a ministerial role appointment is created or updated
- an organisation is created or updated
- reshuffle mode is switched on or off

Depends on: https://github.com/alphagov/publishing-api/pull/2303

[Trello card](https://trello.com/c/ckwRKhIR)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
