### PR TITLE
Revert "Rename dit colours and crest following rename"

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -147,10 +147,10 @@ class OrganisationBrandColour
     title: "Civil Service",
     class_name: "civil-service",
   )
-  DepartmentForBusinessAndTrade = create!(
+  DepartmentForInternationalTrade = create!(
     id: 29,
-    title: "Department for Business and Trade",
-    class_name: "department-for-business-and-trade",
+    title: "Department for International Trade",
+    class_name: "department-for-international-trade",
   )
   ForeignCommonwealthDevelopmentOffice = create!(
     id: 30,

--- a/app/models/organisation_logo_type.rb
+++ b/app/models/organisation_logo_type.rb
@@ -49,7 +49,7 @@ class OrganisationLogoType
   CustomLogo = create!(
     id: 14, title: "Use custom logo for organisations exempt from the single identity", class_name: "custom",
   )
-  DepartmentForBusinessAndTrade = create!(
-    id: 15, title: "Department for Business and Trade", class_name: "dbt",
+  DepartmentInternationalTrade = create!(
+    id: 15, title: "Department for International Trade", class_name: "dit",
   )
 end


### PR DESCRIPTION
We need to revert the change made to rename the organisation brand for Department for International Trade (DIT) to Department for Business & Trade (DBT), since changes further downstream have not been made and this change blocks the DBT organisation page being updated (as the brand isn't permitted by the content schema, so Publishing API returns a 500 error).

In order to release this change again, we'll need to update (at a minimum):
- content schemas to permit this organisation brand
- govuk-frontend to include the new brand, including updating this in govuk_publishing_components and then in all our frontend apps
- renaming the CSS classes in Whitehall (and possibly other rendering apps)
- renaming the organisation crest files in Whitehall (and possibly other rendering apps)
- republishing all existing organisation pages that use the existing brand name to trigger link expansion to update the brand new in content items for any documents that need to brand information

Reverts alphagov/whitehall#7397