### PR TITLE
Store temporary reference between document collections and specialist topics

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -53,6 +53,10 @@ class DocumentCollection < Edition
     "/government/collections/#{slug}"
   end
 
+  def specialist_topic_conversion?
+    mapped_specialist_topic_content_id.present?
+  end
+
 private
 
   def string_for_slug

--- a/db/migrate/20230307101416_add_mapped_specialist_topic_content_id_to_edition.rb
+++ b/db/migrate/20230307101416_add_mapped_specialist_topic_content_id_to_edition.rb
@@ -1,0 +1,5 @@
+class AddMappedSpecialistTopicContentIdToEdition < ActiveRecord::Migration[7.0]
+  def change
+    add_column :editions, :mapped_specialist_topic_content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_162401) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_101416) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -335,6 +335,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_162401) do
     t.boolean "all_nation_applicability", default: true
     t.string "image_display_option"
     t.string "auth_bypass_id", null: false
+    t.string "mapped_specialist_topic_content_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -148,4 +148,9 @@ class DocumentCollectionTest < ActiveSupport::TestCase
 
     assert_equal doc_collection.content_ids, [doc.content_id, non_whitehall_link.content_id]
   end
+
+  test "#specialist_topic_conversion? returns true if mapped_specialist_topic_content_id is present" do
+    doc = create(:document_collection, mapped_specialist_topic_content_id: "123")
+    assert doc.specialist_topic_conversion?
+  end
 end


### PR DESCRIPTION
We will soon be converting some specialist topics into document collections.
This will be done via a [rake task](https://github.com/alphagov/whitehall/pull/7409) to create a draft document collection.

Storing a reference to the source topic will make it possible to check if a topic
has already been converted, and avoid accidentally creating duplicates.

This is a temporary association, once the conversions have all been completed,
the column can be removed again.

https://trello.com/c/Y8Pf7xFO/1590-rake-task-to-create-a-document-collection-from-a-specialist-topic-m
