### PR TITLE
Document collection rake task

### DIFF
--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -14,6 +14,7 @@ class DraftDocumentCollectionBuilder
     ActiveRecord::Base.transaction do
       dc = initialise_document_collection
       add_groups_to_document_collection(dc)
+      add_documents_to_groups(dc)
     end
   end
 
@@ -47,8 +48,34 @@ private
     document_collection.groups.replace(groups)
   end
 
+  def add_documents_to_groups(document_collection)
+    document_collection.groups.each do |group|
+      add_documents_to_group(group)
+    end
+  end
+
+  def add_documents_to_group(group)
+    specialist_topic_groups.each do |topic_group|
+      next if topic_group[:name] != group.heading
+
+      topic_group[:content_ids].each do |content_id|
+        if whitehall_document(content_id).present?
+
+          DocumentCollectionGroupMembership.find_or_create_by!(
+            document_id: whitehall_document(content_id).id,
+            document_collection_group_id: group.id,
+          )
+        end
+      end
+    end
+  end
+
   def specialist_topic_groups
     specialist_topic.dig(:details, :groups)
+  end
+
+  def whitehall_document(content_id)
+    Document.find_by(content_id:)
   end
 
   def user

--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -59,10 +59,9 @@ private
       next if topic_group[:name] != group.heading
 
       topic_group[:content_ids].each do |content_id|
-        if whitehall_document(content_id).present?
-
+        if permissable_whitehall_document(content_id).present?
           DocumentCollectionGroupMembership.find_or_create_by!(
-            document_id: whitehall_document(content_id).id,
+            document_id: permissable_whitehall_document(content_id).id,
             document_collection_group_id: group.id,
           )
         else
@@ -76,8 +75,12 @@ private
     specialist_topic.dig(:details, :groups)
   end
 
-  def whitehall_document(content_id)
-    Document.find_by(content_id:)
+  def permissable_whitehall_document(content_id)
+    document = Document.find_by(content_id:)
+
+    return if document&.document_type == "DocumentCollection"
+
+    document
   end
 
   # only govuk pages can be tagged to a specialist topic. So we can safely

--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -13,6 +13,7 @@ class DraftDocumentCollectionBuilder
 
     ActiveRecord::Base.transaction do
       dc = initialise_document_collection
+      confirm_valid_for_conversion(dc)
       add_groups_to_document_collection(dc)
       add_documents_to_groups(dc)
     end
@@ -21,6 +22,23 @@ class DraftDocumentCollectionBuilder
 private
 
   attr_reader :specialist_topic, :assignee_email_address
+
+  def confirm_valid_for_conversion(edition)
+    message = "Specialist topic has already been converted and published"
+
+    confirm_latest_edition(edition, message)
+    confirm_draft(edition, message)
+  end
+
+  def confirm_latest_edition(edition, message)
+    parent_document = edition.document
+
+    raise message unless parent_document.latest_edition.id == edition.id
+  end
+
+  def confirm_draft(edition, message)
+    raise message if edition.document.live?
+  end
 
   def initialise_document_collection
     DocumentCollection.find_or_create_by!(

--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -1,0 +1,42 @@
+class DraftDocumentCollectionBuilder
+  def initialize(specialist_topic, assignee_email_address)
+    @specialist_topic = specialist_topic
+    @assignee_email_address = assignee_email_address
+  end
+
+  def self.call(*args)
+    new(*args).perform!
+  end
+
+  def perform!
+    raise "No user could be found for that email address" unless user
+
+    initialise_document_collection
+  end
+
+private
+
+  attr_reader :specialist_topic, :assignee_email_address
+
+  def initialise_document_collection
+    DocumentCollection.find_or_create_by!(
+      mapped_specialist_topic_content_id: specialist_topic[:content_id],
+    ) do |document_collection|
+      document_collection.title = "Specialist topic import: #{specialist_topic[:title]}"
+      document_collection.summary = specialist_topic[:description]
+      document_collection.body = ""
+      document_collection.creator = user
+      document_collection.lead_organisations = [gds]
+      document_collection.previously_published = false
+      document_collection.state = "draft"
+    end
+  end
+
+  def user
+    @user ||= User.find_by(email: assignee_email_address)
+  end
+
+  def gds
+    @gds ||= Organisation.find_by(name: "Government Digital Service")
+  end
+end

--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -1,11 +1,9 @@
 class DraftDocumentCollectionBuilder
+  attr_reader :message
+
   def initialize(specialist_topic, assignee_email_address)
     @specialist_topic = specialist_topic
     @assignee_email_address = assignee_email_address
-  end
-
-  def self.call(*args)
-    new(*args).perform!
   end
 
   def perform!
@@ -16,6 +14,7 @@ class DraftDocumentCollectionBuilder
       confirm_valid_for_conversion(dc)
       add_groups_to_document_collection(dc)
       add_documents_to_groups(dc)
+      @message = build_completion_message(dc)
     end
   end
 
@@ -138,5 +137,16 @@ private
 
   def content_item(content_id)
     Services.publishing_api.get_content(content_id).to_h.deep_symbolize_keys
+  end
+
+  def build_completion_message(collection)
+    format = "%d-%m-%Y at %H:%M:%S"
+    created = collection.created_at
+    updated = collection.updated_at
+
+    creation_message = "#{collection.title} was created #{created.strftime(format)}"
+    updated_message =  "#{collection.title} has been updated"
+
+    created == updated ? creation_message : updated_message
   end
 end

--- a/app/services/specialist_topic_fetcher.rb
+++ b/app/services/specialist_topic_fetcher.rb
@@ -1,0 +1,56 @@
+class SpecialistTopicFetcher
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def self.call(*args)
+    new(*args).permitted_specialist_topic
+  end
+
+  def permitted_specialist_topic
+    validate!
+    specialist_topic_content_item
+  end
+
+private
+
+  attr_reader :base_path
+
+  def validate!
+    @errors = []
+    @errors << "Not a level two topic" unless level_two_specialist_topic?
+    @errors << "Not a curated topic" unless curated_specialist_topic?
+
+    if @errors.any?
+      raise @errors.first
+    end
+  end
+
+  def level_two_specialist_topic?
+    specialist_topic_links.dig(:links, :parent).present?
+  end
+
+  def specialist_topic_links
+    Services.publishing_api.get_links(specialist_topic_content_id).to_h.deep_symbolize_keys
+  end
+
+  def specialist_topic_content_id
+    content_id = Services.publishing_api.lookup_content_id(base_path:)
+
+    raise "No specialist topic with that base path" unless content_id
+
+    content_id
+  end
+
+  def curated_specialist_topic?
+    specialist_topic_groups.present?
+  end
+
+  def specialist_topic_groups
+    specialist_topic_content_item.dig(:details, :groups)
+  end
+
+  def specialist_topic_content_item
+    Services.publishing_api.get_content(specialist_topic_content_id).to_h.deep_symbolize_keys
+  end
+end

--- a/lib/tasks/draft_document_collection_writer.rake
+++ b/lib/tasks/draft_document_collection_writer.rake
@@ -1,0 +1,16 @@
+require_relative "../../app/validators/gov_uk_url_validator"
+
+desc "Create a draft document collection in the whitehall database, from a given specialist topic"
+task :create_draft_document_collection, %i[specialist_topic_base_path assignee_email_address] => :environment do |_task, args|
+  message = "Error! A specialist topic base_path and valid email address are required"
+  raise message unless args[:specialist_topic_base_path].present? && args[:assignee_email_address].present?
+
+  puts "Fetching specialist topic at #{args[:specialist_topic_base_path]}"
+  topic = SpecialistTopicFetcher.call(args[:specialist_topic_base_path])
+
+  puts "Creating draft document collection"
+  builder = DraftDocumentCollectionBuilder.new(topic, args[:assignee_email_address])
+  builder.perform!
+
+  puts builder.message
+end

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -3,6 +3,7 @@ module SpecialistTopicHelper
     stub_publishing_api_has_lookups({
       specialist_topic_base_path => specialist_topic_content_id,
       non_whitehall_document_base_path => non_whitehall_document_content_id,
+      document_collection_base_path => document_collection_content_id,
     })
 
     stub_publishing_api_has_links({
@@ -12,6 +13,7 @@ module SpecialistTopicHelper
 
     stub_publishing_api_has_item(specialist_topic_content_item)
     stub_publishing_api_has_item(non_whitehall_document_content_item)
+    stub_publishing_api_has_item(document_collection_content_item)
   end
 
   def stub_level_one_specialist_topic
@@ -76,6 +78,22 @@ module SpecialistTopicHelper
       "publishing_app": "publisher" }
   end
 
+  def document_collection_content_id
+    "10e436e5-26e0-4462-913f-9a497f7e793e"
+  end
+
+  def document_collection_base_path
+    "/government/collections/i_am_document_collection"
+  end
+
+  def document_collection_content_item
+    { "title": "I am a document collection",
+      "base_path": document_collection_base_path,
+      "content_id": document_collection_content_id,
+      "document_type": "document_collection",
+      "publishing_app": "whitehall" }
+  end
+
   def specialist_topic_content_item
     {
       "base_path": specialist_topic_base_path,
@@ -95,6 +113,10 @@ module SpecialistTopicHelper
           {
             "name": "Payments",
             "content_ids": [non_whitehall_document_content_id],
+          },
+          {
+            "name": "Report changes",
+            "content_ids": [document_collection_content_id],
           },
         ],
         "internal_name": "Benefits / Child Benefit",

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -16,6 +16,16 @@ module SpecialistTopicHelper
     stub_publishing_api_has_item(document_collection_content_item)
   end
 
+  def stub_valid_specialist_topic_with_unpublished_links
+    stub_publishing_api_has_lookups({
+      specialist_topic_with_unpublished_links_base_path => specialist_topic_with_unpublished_links_content_id,
+      unpublished_non_whitehall_document_base_path => unpublished_non_whitehall_document_content_id,
+    })
+
+    stub_publishing_api_has_item(specialist_topic_with_unpublished_links_content_item)
+    stub_publishing_api_has_item(unpublished_non_whitehall_document_content_item)
+  end
+
   def stub_level_one_specialist_topic
     stub_publishing_api_has_lookups({
       specialist_topic_base_path => specialist_topic_content_id,
@@ -161,5 +171,76 @@ module SpecialistTopicHelper
     specialist_topic_content_item[:base_path] = uncurated_specialist_topic_base_path
     specialist_topic_content_item[:content_id] = uncurated_specialist_topic_content_id
     specialist_topic_content_item.merge(details: {})
+  end
+
+  def specialist_topic_with_unpublished_links_base_path
+    "/topic/benefits-credits/tax"
+  end
+
+  def specialist_topic_with_unpublished_links_content_id
+    "e2644b6d-abcd-47e3-89b7-bf69be25465b"
+  end
+
+  def specialist_topic_with_unpublished_links_content_item
+    specialist_topic_content_item.deep_merge(
+      content_id: specialist_topic_with_unpublished_links_content_id,
+      base_path: specialist_topic_with_unpublished_links_base_path,
+      details: {
+        groups: [
+          {
+            name: "foo",
+            content_ids: [
+              unpublished_non_whitehall_document_content_id,
+            ],
+          },
+          {
+            name: "bar",
+            content_ids: [
+              unpublished_document_content_id,
+            ],
+          },
+        ],
+      },
+    )
+  end
+
+  def unpublished_non_whitehall_document_content_id
+    "f9528877-2f3a-402a-9e38-cffb94ad7386"
+  end
+
+  def unpublished_non_whitehall_document_base_path
+    "/i-am-a-redirect"
+  end
+
+  def unpublished_non_whitehall_document_content_item
+    {
+      content_id: unpublished_non_whitehall_document_content_id,
+      base_path: unpublished_non_whitehall_document_base_path,
+      unpublishing: {
+        type: "redirect",
+        redirects: [
+          {
+            path: "/qualify-tax-credits",
+            type: "prefix",
+            destination: "/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries",
+          },
+        ],
+      },
+    }
+  end
+
+  def unpublished_document_content_id
+    "b32c8ee2-4bec-42d7-81e8-b03cb536ffb8"
+  end
+
+  def unpublished_document_base_path
+    "/government/publications/guidance"
+  end
+
+  def unpublished_document_content_item
+    unpublished_non_whitehall_document_content_item.deep_merge(
+      content_id: unpublished_document_content_id,
+      base_path: unpublished_document_base_path,
+    )
   end
 end

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -1,0 +1,117 @@
+module SpecialistTopicHelper
+  def stub_valid_specialist_topic
+    stub_publishing_api_has_lookups({
+      specialist_topic_base_path => specialist_topic_content_id,
+    })
+
+    stub_publishing_api_has_links({
+      "content_id" => specialist_topic_content_id,
+      "links" => level_two_topic_links,
+    })
+
+    stub_publishing_api_has_item(specialist_topic_content_item)
+  end
+
+  def stub_level_one_specialist_topic
+    stub_publishing_api_has_lookups({
+      specialist_topic_base_path => specialist_topic_content_id,
+    })
+
+    stub_publishing_api_has_links({
+      "content_id" => specialist_topic_content_id,
+      "links" => {},
+    })
+
+    stub_publishing_api_has_item(specialist_topic_content_item.deep_merge("links" => {}))
+  end
+
+  def stub_uncurated_specialist_topic
+    stub_publishing_api_has_lookups({
+      specialist_topic_base_path => specialist_topic_content_id,
+    })
+
+    stub_publishing_api_has_links({
+      "content_id" => specialist_topic_content_id,
+      "links" => level_two_topic_links,
+    })
+
+    stub_publishing_api_has_item(specialist_topic_content_item.deep_merge("details" => {}))
+  end
+
+  def specialist_topic_base_path
+    "/topic/benefits-credits/child-benefit"
+  end
+
+  def specialist_topic_content_id
+    "cc9eb8ab-7701-43a7-a66d-bdc5046224c0"
+  end
+
+  def specialist_topic_title
+    "Child Benefit"
+  end
+
+  def specialist_topic_description
+    "List of information about Child Benefit."
+  end
+
+  def specialist_topic_content_item
+    {
+      "base_path": specialist_topic_base_path,
+      "content_id": specialist_topic_content_id,
+      "document_type": "topic",
+      "first_published_at": "2015-08-11T15:09:55.000+00:00",
+      "schema_name": "topic",
+      "title": specialist_topic_title,
+      "links": level_two_topic_links,
+      "description": specialist_topic_description,
+      "details": {
+        "groups": [
+          {
+            "name": "How to claim",
+            "content_ids": %w[],
+          },
+        ],
+        "internal_name": "Benefits / Child Benefit",
+      },
+    }
+  end
+
+  def level_two_topic_links
+    {
+      "parent": [
+        {
+          "content_id": "4505d908-89f2-4322-956b-29ac243c608b",
+          "title": "Benefits",
+        },
+      ],
+    }
+  end
+
+  def level_one_specialist_topic_base_path
+    "/topic/benefits-credits"
+  end
+
+  def level_one_specialist_topic_content_id
+    "5fe781fb-7631-11e4-a3cb-005056011aef"
+  end
+
+  def level_one_specialist_topic_content_item
+    specialist_topic_content_item[:base_path] = level_one_specialist_topic_base_path
+    specialist_topic_content_item[:content_id] = level_one_specialist_topic_content_id
+    specialist_topic_content_item.merge(links: {})
+  end
+
+  def uncurated_specialist_topic_base_path
+    "/topic/i-am-an-a-to-z"
+  end
+
+  def uncurated_specialist_topic_content_id
+    "e2644b6d-2c90-47e3-89b7-bf69be25465b"
+  end
+
+  def uncurated_specialist_topic_content_item
+    specialist_topic_content_item[:base_path] = uncurated_specialist_topic_base_path
+    specialist_topic_content_item[:content_id] = uncurated_specialist_topic_content_id
+    specialist_topic_content_item.merge(details: {})
+  end
+end

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -2,6 +2,7 @@ module SpecialistTopicHelper
   def stub_valid_specialist_topic
     stub_publishing_api_has_lookups({
       specialist_topic_base_path => specialist_topic_content_id,
+      non_whitehall_document_base_path => non_whitehall_document_content_id,
     })
 
     stub_publishing_api_has_links({
@@ -10,6 +11,7 @@ module SpecialistTopicHelper
     })
 
     stub_publishing_api_has_item(specialist_topic_content_item)
+    stub_publishing_api_has_item(non_whitehall_document_content_item)
   end
 
   def stub_level_one_specialist_topic
@@ -58,6 +60,22 @@ module SpecialistTopicHelper
     "aed2cee3-7ca8-4f00-ab17-9193fff516ae"
   end
 
+  def non_whitehall_document_content_id
+    "0e1de8f1-9909-4e45-a6a3-bffe95470275"
+  end
+
+  def non_whitehall_document_base_path
+    "/i-am-not-a-whitehall-document"
+  end
+
+  def non_whitehall_document_content_item
+    { "title": "I am not a whitehall document",
+      "base_path": non_whitehall_document_base_path,
+      "content_id": non_whitehall_document_content_id,
+      "document_type": "guide",
+      "publishing_app": "publisher" }
+  end
+
   def specialist_topic_content_item
     {
       "base_path": specialist_topic_base_path,
@@ -73,6 +91,10 @@ module SpecialistTopicHelper
           {
             "name": "How to claim",
             "content_ids": [whitehall_document_content_id],
+          },
+          {
+            "name": "Payments",
+            "content_ids": [non_whitehall_document_content_id],
           },
         ],
         "internal_name": "Benefits / Child Benefit",

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -54,6 +54,10 @@ module SpecialistTopicHelper
     "List of information about Child Benefit."
   end
 
+  def whitehall_document_content_id
+    "aed2cee3-7ca8-4f00-ab17-9193fff516ae"
+  end
+
   def specialist_topic_content_item
     {
       "base_path": specialist_topic_base_path,
@@ -68,7 +72,7 @@ module SpecialistTopicHelper
         "groups": [
           {
             "name": "How to claim",
-            "content_ids": %w[],
+            "content_ids": [whitehall_document_content_id],
           },
         ],
         "internal_name": "Benefits / Child Benefit",

--- a/test/unit/services/draft_document_collection_builder_test.rb
+++ b/test/unit/services/draft_document_collection_builder_test.rb
@@ -67,6 +67,12 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
     assert_not_requested stub_publishing_api_has_item(unpublished_document_content_item)
   end
 
+  test "#perform! will not update a document collection that has been published" do
+    create(:published_document_collection, mapped_specialist_topic_content_id: specialist_topic_content_id)
+    exception = assert_raises(Exception) { DraftDocumentCollectionBuilder.call(specialist_topic_content_item, assignee_email_address) }
+    assert_equal("Specialist topic has already been converted and published", exception.message)
+  end
+
   test "#perform! fails unless a user is present" do
     exception = assert_raises(Exception) { DraftDocumentCollectionBuilder.call(specialist_topic_content_item, "no-one@email.co.uk") }
     assert_equal("No user could be found for that email address", exception.message)

--- a/test/unit/services/draft_document_collection_builder_test.rb
+++ b/test/unit/services/draft_document_collection_builder_test.rb
@@ -18,6 +18,12 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
     assert_equal specialist_topic_content_item[:content_id], DocumentCollection.last.mapped_specialist_topic_content_id
     assert_equal DocumentCollection.last.title, "Specialist topic import: #{specialist_topic_title}"
     assert_equal specialist_topic_description, DocumentCollection.last.summary
+
+    # Adds groups
+    specialist_topic_group_names = specialist_topic_content_item[:details][:groups].map { |group| group[:name] }
+    document_collection_group_names = DocumentCollection.last.groups.map(&:heading)
+
+    assert_equal specialist_topic_group_names, document_collection_group_names
   end
 
   test "#perform! fails unless a user is present" do

--- a/test/unit/services/draft_document_collection_builder_test.rb
+++ b/test/unit/services/draft_document_collection_builder_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
+  include SpecialistTopicHelper
+
+  setup do
+    create(:user, email: assignee_email_address)
+    create(:organisation, name: "Government Digital Service")
+  end
+
+  test "#perform! builds basic document collection" do
+    stub_valid_specialist_topic
+
+    DraftDocumentCollectionBuilder.call(specialist_topic_content_item, assignee_email_address)
+
+    # Adds basic attributes
+    assert_equal 1, DocumentCollection.count
+    assert_equal specialist_topic_content_item[:content_id], DocumentCollection.last.mapped_specialist_topic_content_id
+    assert_equal DocumentCollection.last.title, "Specialist topic import: #{specialist_topic_title}"
+    assert_equal specialist_topic_description, DocumentCollection.last.summary
+  end
+
+  test "#perform! fails unless a user is present" do
+    exception = assert_raises(Exception) { DraftDocumentCollectionBuilder.call(specialist_topic_content_item, "no-one@email.co.uk") }
+    assert_equal("No user could be found for that email address", exception.message)
+  end
+
+  def assignee_email_address
+    "my_email@email.com"
+  end
+end

--- a/test/unit/services/draft_document_collection_builder_test.rb
+++ b/test/unit/services/draft_document_collection_builder_test.rb
@@ -6,8 +6,12 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
   setup do
     create(:user, email: assignee_email_address)
     create(:organisation, name: "Government Digital Service")
+
     document = create(:document, content_id: whitehall_document_content_id, document_type: "DetailedGuide")
     create(:published_detailed_guide, document_id: document.id, type: "DetailedGuide")
+
+    collection = create(:document, content_id: document_collection_content_id, document_type: "DocumentCollection")
+    create(:published_document_collection, document_id: collection.id, type: "DocumentCollection")
   end
 
   test "#perform! builds basic document collection" do
@@ -15,7 +19,7 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
     DraftDocumentCollectionBuilder.call(specialist_topic_content_item, assignee_email_address)
 
     # Adds basic attributes
-    assert_equal 1, DocumentCollection.count
+    assert_equal 2, DocumentCollection.count
     assert_equal specialist_topic_content_item[:content_id], DocumentCollection.last.mapped_specialist_topic_content_id
     assert_equal DocumentCollection.last.title, "Specialist topic import: #{specialist_topic_title}"
     assert_equal specialist_topic_description, DocumentCollection.last.summary
@@ -37,6 +41,11 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
     non_whitehall_document_member = document_collection_group_memberships.second
     non_whitehall_link = DocumentCollectionNonWhitehallLink.find_by(base_path: non_whitehall_document_content_item[:base_path])
     assert_equal non_whitehall_document_member.non_whitehall_link_id, non_whitehall_link.id
+
+    # Document collections
+    document_collection_member = document_collection_group_memberships.third
+    document_collection_link = DocumentCollectionNonWhitehallLink.find_by(base_path: document_collection_content_item[:base_path])
+    assert_equal document_collection_member.non_whitehall_link_id, document_collection_link.id
   end
 
   test "#perform! fails unless a user is present" do

--- a/test/unit/services/draft_document_collection_builder_test.rb
+++ b/test/unit/services/draft_document_collection_builder_test.rb
@@ -32,6 +32,11 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
     # Documents that already exist in the Whitehall database
     whitehall_document_member = document_collection_group_memberships.first
     assert_equal whitehall_document_member.document.content_id, whitehall_document_content_id
+
+    # Documents that were not published by Whitehall
+    non_whitehall_document_member = document_collection_group_memberships.second
+    non_whitehall_link = DocumentCollectionNonWhitehallLink.find_by(base_path: non_whitehall_document_content_item[:base_path])
+    assert_equal non_whitehall_document_member.non_whitehall_link_id, non_whitehall_link.id
   end
 
   test "#perform! fails unless a user is present" do

--- a/test/unit/services/specialist_topic_fetcher_test.rb
+++ b/test/unit/services/specialist_topic_fetcher_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SpecialistTopicFetcherTest < ActiveSupport::TestCase
+  include SpecialistTopicHelper
+
+  test "#permitted_specialist_topic returns a content item for level two curated topics" do
+    stub_valid_specialist_topic
+    assert_equal SpecialistTopicFetcher.call(specialist_topic_base_path), specialist_topic_content_item
+  end
+
+  test "#permitted_specialist_topic raises an error for level one topics" do
+    stub_level_one_specialist_topic
+
+    exception = assert_raises(Exception) { SpecialistTopicFetcher.call(specialist_topic_base_path) }
+    assert_equal("Not a level two topic", exception.message)
+  end
+
+  test "#permitted_specialist_topic raises an error for uncurated topics" do
+    stub_uncurated_specialist_topic
+
+    exception = assert_raises(Exception) { SpecialistTopicFetcher.call(specialist_topic_base_path) }
+    assert_equal("Not a curated topic", exception.message)
+  end
+
+  test "#permitted_specialist_topic raises an error if no topic exists" do
+    stub_publishing_api_has_lookups(specialist_topic_base_path => nil)
+
+    exception = assert_raises(Exception) { SpecialistTopicFetcher.call(specialist_topic_base_path) }
+    assert_equal("No specialist topic with that base path", exception.message)
+  end
+end

--- a/test/unit/tasks/draft_document_collection_writer_test.rb
+++ b/test/unit/tasks/draft_document_collection_writer_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class DraftDocumentCollectionWriteRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include SpecialistTopicHelper
+
+  teardown do
+    task.reenable
+  end
+
+  describe "Create draft document collection" do
+    let(:task) { Rake::Task["create_draft_document_collection"] }
+
+    test "it raises an error if args are missing" do
+      assert_raise { task.invoke("my_email@email.com") }
+      assert_raise { task.invoke(stub_valid_specialist_topic) }
+    end
+
+    test "it builds a draft document collection in the Whitehall database" do
+      stub_valid_specialist_topic
+      create(:user, email: "my_email@email.com")
+      create(:organisation, name: "Government Digital Service")
+      create(:document, content_id: whitehall_document_content_id, document_type: "detailed_guide")
+      create(:edition, :published, type: "DetailedGuide", document_id: Document.last.id)
+
+      task.invoke(specialist_topic_base_path, "my_email@email.com")
+
+      assert_equal 1, DocumentCollection.count
+    end
+
+    test "will update an existing draft document collection" do
+      create(:user, email: "my_email@email.com")
+      create(:organisation, name: "Government Digital Service")
+      create(:document, content_id: whitehall_document_content_id, document_type: "detailed_guide")
+      create(:edition, :published, type: "DetailedGuide", document_id: Document.last.id)
+
+      stub_valid_specialist_topic
+
+      task.invoke(specialist_topic_base_path, "my_email@email.com")
+      task.reenable
+
+      new_document_content_id = "abc436e5-1234-4462-913f-9a497f7e793e"
+      create(:document, content_id: new_document_content_id, document_type: "detailed_guide")
+      create(:edition, :published, type: "DetailedGuide", document_id: Document.last.id)
+      stub_publishing_api_has_item(
+        specialist_topic_content_item
+        .deep_merge(
+          {
+            "details": {
+              "groups": [
+                "name": "Foo",
+                "content_ids": [new_document_content_id],
+              ],
+            },
+          },
+        ),
+      )
+
+      Timecop.travel 1.minute.from_now
+      task.invoke(specialist_topic_base_path, "my_email@email.com")
+
+      assert_equal 1, DocumentCollection.count
+    end
+
+    test "does not write a draft document collection if any operation fails" do
+      create(:user, email: "my_email@email.com")
+      create(:organisation, name: "Government Digital Service")
+
+      unknown_document_content_id = "10e436e5-1234-4462-913f-9a497f7e793e"
+      stub_publishing_api_has_item({
+        content_id: unknown_document_content_id,
+        base_path: "/i-have-not-been-stubbed",
+      })
+
+      stub_publishing_api_has_lookups(specialist_topic_base_path => specialist_topic_content_id)
+
+      stub_publishing_api_has_item({
+        "base_path": specialist_topic_base_path,
+        "content_id": specialist_topic_content_id,
+        "description": "something",
+        "details": {
+          "groups": [
+            "name": "Foo",
+            "content_ids": [unknown_document_content_id],
+          ],
+        },
+      })
+
+      stub_publishing_api_has_links({
+        "content_id" => specialist_topic_content_id,
+        "links" => level_two_topic_links,
+      })
+
+      assert_raise { task.invoke(specialist_topic_base_path, "my_email@email.com") }
+      assert_equal 0, DocumentCollection.count
+    end
+  end
+end


### PR DESCRIPTION
A temporary rake task to convert a level two curated specialist topic into a document collection. 

Running this task will create a draft document collection in the Whitehall database, it will not publish the document to the draft stack. 

Editions cannot be published unless they are tagged to the topic taxonomy. It has been decided that the responsibility for tagging will sit with the department, to encourage engagement and improved tagging curation. Once the draft document has been created, content designers on navigation and presentation will edit and improve the pages via the Whitehall UI before assigning them to the owning organisation so that the tagging and publishing can be done by them.

See commit messages for implementation details.

https://trello.com/c/Y8Pf7xFO/1590-rake-task-to-create-a-document-collection-from-a-specialist-topic-m

Related work: https://github.com/alphagov/whitehall/pull/7408

![DocumentCollectionTables](https://user-images.githubusercontent.com/17908089/224375714-323792cc-ff01-4475-b1e8-58c729db48d1.jpg)

