### PR TITLE
Update historic account images for past prime ministers without individual pages

### DIFF
--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -37,7 +37,10 @@ module PublishingApi
       people_to_present.map do |person|
         { title: person.name,
           dates_in_office: person.previous_dates_in_office_for_role(role),
-          image_url: person.image_url }
+          image: {
+            url: person.image_url,
+            alt_text: person.name,
+          } }
       end
     end
 

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -74,7 +74,10 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
             },
 
           ],
-          image_url: person_without_historic_account.image_url,
+          image: {
+            url: person_without_historic_account.image_url,
+            alt_text: "A Person without a historic account yet",
+          },
         },
       ],
     }


### PR DESCRIPTION
This standardises the way we present images for past pms without historic accounts to be the same as that for those with historic accounts (which is added via link expansion). This allows us:

* to add alt text to the images
* to simplify the frontend code that handles this data, since the structure of this data will be the same between the two types of past prime ministers.

Depends on the [schema PR](https://github.com/alphagov/publishing-api/pull/2304)

[Trello](https://trello.com/c/LSd8y4zg/421-render-past-prime-ministers-index-page-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
