### PR TITLE
Replacing uglifier gem with terser for es6-friendly JS compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem "sidekiq-scheduler"
 gem "slimmer"
 gem "sprockets-rails"
 gem "transitions", require: ["transitions", "active_record/transitions"]
-gem "uglifier"
 gem "validates_email_format_of"
 gem "view_component"
 gem "whenever", require: false
@@ -102,3 +101,5 @@ group :cucumber, :test do
   gem "govuk_test"
   gem "launchy"
 end
+
+gem "terser", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -694,6 +694,8 @@ GEM
       tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    terser (1.1.14)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     tilt (2.1.0)
     timecop (0.9.6)
@@ -704,8 +706,6 @@ GEM
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -828,9 +828,9 @@ DEPENDENCIES
   simplecov
   slimmer
   sprockets-rails
+  terser (~> 1.1)
   timecop
   transitions
-  uglifier
   validates_email_format_of
   view_component
   webmock

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -97,4 +97,9 @@ Whitehall::Application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Uncomment if you want to diagnose Javascript compression/mangling issues
+  # config.assets.js_compressor = :terser
+  # or
+  # config.assets.js_compressor = Terser.new(mangle: false)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,8 @@ Whitehall::Application.configure do
   config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # Can just use `:terser` for default settings
+  config.assets.js_compressor = Terser.new(mangle: false)
 
   # Rather than use a CSS compressor, use the SASS style to perform compression
   config.sass.style = :compressed

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -68,6 +68,11 @@ Whitehall::Application.configure do
   ENV["GOVUK_ASSET_ROOT"] ||= "https://static.test.gov.uk"
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  #
+  # Uncomment if you want to diagnose Javascript compression/mangling issues
+  # config.assets.js_compressor = :terser
+  # or
+  # config.assets.js_compressor = Terser.new(mangle: false)
 end
 
 require Rails.root.join("test/support/skip_slimmer")


### PR DESCRIPTION
Note that name mangling is disabled for now, for extra safety - need to discuss whether mangling is safe.  (mangling was on for uglifier)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

