### PR TITLE
Update how contents list is called

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (34.14.0)
+    govuk_publishing_components (35.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -511,7 +511,7 @@ GEM
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
       actioncable (= 7.0.4.3)

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -22,7 +22,9 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-margin-bottom-9">
         <%= render "govuk_publishing_components/components/contents_list", {
-          aria_label: "Pages in this guide",
+          aria: {
+            label: "Pages in this guide",
+          },
           contents: [
             {
               href: "#who-runs-government",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Updates how the contents list component is called. Specifically the `aria_label` option for the contents list component has been replaced with the `aria` option (passing a hash of aria options).

## Why
Updates to the component in the gem mean that this option would no longer work, needed updating. Note that this PR should not be merged until the change below is merged into a new version of the gem and updated in this application as part of this PR.

Related PR: https://github.com/alphagov/govuk_publishing_components/pull/3254

## Visual changes
None.