### PR TITLE
Present the Fields of Operation index page to the publishing API

### DIFF
--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -13,6 +13,12 @@ class OperationalField < ApplicationRecord
   extend FriendlyId
   friendly_id
 
+  after_commit :republish_operational_fields_index_page_to_publishing_api
+
+  def republish_operational_fields_index_page_to_publishing_api
+    PublishOperationalFieldsIndexPage.new.publish
+  end
+
   def search_link
     Whitehall.url_maker.operational_field_path(slug)
   end

--- a/app/presenters/publishing_api/operational_fields_index_presenter.rb
+++ b/app/presenters/publishing_api/operational_fields_index_presenter.rb
@@ -1,0 +1,40 @@
+module PublishingApi
+  class OperationalFieldsIndexPresenter
+    attr_accessor :update_type
+
+    def initialize(update_type: nil)
+      self.update_type = update_type || "major"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: "Fields of operation",
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        base_path:,
+        details: {},
+        document_type: "fields_of_operation",
+        public_updated_at: Time.zone.now,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "fields_of_operation",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def links
+      { fields_of_operation: OperationalField.all.map(&:content_id) }
+    end
+
+    def content_id
+      "53c8e227-3778-4c85-a569-384457c0a281"
+    end
+
+    def base_path
+      "/government/fields-of-operation"
+    end
+  end
+end

--- a/lib/publish_operational_fields_index_page.rb
+++ b/lib/publish_operational_fields_index_page.rb
@@ -1,0 +1,9 @@
+class PublishOperationalFieldsIndexPage
+  def publish
+    payload = PublishingApi::OperationalFieldsIndexPresenter.new
+
+    Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
+    Services.publishing_api.publish(payload.content_id, nil)
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -70,7 +70,7 @@ namespace :publishing_api do
     end
 
     desc "Republish the past prime ministers index page to Publishing API"
-    task republish_past_prime_ministers: :environment do
+    task republish_past_prime_ministers_index: :environment do
       PublishPrimeMinistersIndexPage.new.publish
     end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -78,6 +78,11 @@ namespace :publishing_api do
     task republish_how_government_works: :environment do
       PublishHowGovernmentWorksPage.new.publish
     end
+
+    desc "Republish the fields of operation index page to Publishing API"
+    task republish_operational_fields_index: :environment do
+      PublishOperationalFieldsIndexPage.new.publish
+    end
   end
 
   namespace :patch_links do

--- a/test/unit/operational_field_test.rb
+++ b/test/unit/operational_field_test.rb
@@ -31,4 +31,26 @@ class OperationalFieldTest < ActiveSupport::TestCase
     field.update!(name: "New Field Name")
     assert_equal "field-name", field.slug
   end
+
+  test "should send the fields of operation index page to publishing api when a field of operation is created" do
+    PublishOperationalFieldsIndexPage.any_instance.expects(:publish)
+
+    create(:operational_field)
+  end
+
+  test "should send the fields of operation index page to publishing api when a field of operation is updated" do
+    field = create(:operational_field, name: "Field Name")
+
+    PublishOperationalFieldsIndexPage.any_instance.expects(:publish)
+
+    field.update!(name: "New Field Name")
+  end
+
+  test "should send the fields of operation index page to publishing api when a field of operation is destroyed" do
+    field = create(:operational_field, name: "Field Name")
+
+    PublishOperationalFieldsIndexPage.any_instance.expects(:publish)
+
+    field.destroy!
+  end
 end

--- a/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class PublishingApi::OperationalFieldsIndexPresenterTest < ActiveSupport::TestCase
+  setup do
+    create(:operational_field)
+    create(:operational_field)
+  end
+
+  test "presents a valid content item" do
+    expected_hash = {
+      base_path: "/government/fields-of-operation",
+      details: {},
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      schema_name: "fields_of_operation",
+      document_type: "fields_of_operation",
+      title: "Fields of operation",
+      locale: "en",
+      routes: [
+        {
+          path: "/government/fields-of-operation",
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: Time.zone.now,
+    }
+
+    expected_links = {
+      fields_of_operation: [
+        OperationalField.first.content_id,
+        OperationalField.second.content_id,
+      ],
+    }
+
+    presenter = PublishingApi::OperationalFieldsIndexPresenter.new
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_publisher_schema(presenter.content, "fields_of_operation")
+
+    assert_equal expected_links, presenter.links
+    assert_valid_against_links_schema({ links: presenter.links }, "fields_of_operation")
+  end
+end

--- a/test/unit/publish_operational_fields_index_page.rb
+++ b/test/unit/publish_operational_fields_index_page.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+class PublishOperationalFieldsIndexPageTest < ActiveSupport::TestCase
+  test "sends the page to publishing api" do
+    presenter = PublishingApi::OperationalFieldsIndexPresenter.new
+    expected_content = presenter.content
+
+    Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content)
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, nil)
+
+    PublishOperationalFieldsIndexPage.new.publish
+  end
+end


### PR DESCRIPTION
This presents the fields of operation index page to the publishing API. This will enable us to move the rendering of that page out of Whitehall. 

Relies on - https://github.com/alphagov/publishing-api/pull/2306

Trello - https://trello.com/c/u8eF9mCD/473-create-content-item-for-fields-of-operation-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
