### PR TITLE
Past pms breadcrumbs

### DIFF
--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -2,6 +2,8 @@ module PublishingApi
   class HistoricalAccountsIndexPresenter
     attr_accessor :update_type
 
+    HISTORY_OF_THE_UK_GOVERNMENT_CONTENT_ID = "db95a864-874f-4f50-a483-352a5bc7ba18".freeze
+
     def initialize(update_type: nil)
       self.update_type = update_type || "major"
     end
@@ -51,6 +53,7 @@ module PublishingApi
     def links
       {
         historical_accounts: HistoricalAccount.all.map(&:content_id),
+        parent: [HISTORY_OF_THE_UK_GOVERNMENT_CONTENT_ID],
       }
     end
   end

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -69,8 +69,9 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::HistoricalAccountPresenter.new(historical_account)
 
     assert_equal expected_hash, presenter.content
-    assert_hash_includes presenter.links, expected_links
     assert_valid_against_publisher_schema(presenter.content, "historic_appointment")
+    assert_hash_includes presenter.links, expected_links
+    assert_valid_against_links_schema({ links: presenter.links }, "historic_appointment")
   end
 
   test "correctly determines the surrounding historical accounts to present, sorted in descending order" do

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -85,9 +85,10 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
 
     presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
 
-    assert_equal presenter.links, expected_links
     assert_equal expected_details, presenter.content[:details]
     assert_valid_against_publisher_schema(presenter.content, "historic_appointments")
+    assert_equal presenter.links, expected_links
+    assert_valid_against_links_schema({ links: presenter.links }, "historic_appointments")
   end
 
   test "when a role appointment is current, does not present these in the details hash" do

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -57,6 +57,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
 
     expected_links = {
       historical_accounts: [@historical_account.content_id],
+      parent: [PublishingApi::HistoricalAccountsIndexPresenter::HISTORY_OF_THE_UK_GOVERNMENT_CONTENT_ID],
     }
 
     expected_details = {


### PR DESCRIPTION
In order to display appropriate breadcrumbs on the past prime ministers page when it is rendered by collections, we need to add a link to the parent page (history of the uk government) in the content item. This is similar to what we do for the hard-coded past foreign secretaries ([here](https://github.com/alphagov/special-route-publisher/blob/main/data/special_routes.yaml#L42-L44)) and past chancellors page ([here](https://github.com/alphagov/special-route-publisher/blob/main/data/special_routes.yaml#L33-L35)) in special route publisher.

As part of this I've also added tests that check that historic appointment(s) links are valid against their schemas - these tests are actually failing given the current state of content schemas. A fix for this is [here](https://github.com/alphagov/publishing-api/pull/2307) so this PR will not pass until that one gets merged.

[Trello](https://trello.com/c/LSd8y4zg/421-render-past-prime-ministers-index-page-in-collections)
 
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
