### PR TITLE
Make changes to the field of operation pub api presentation

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -30,7 +30,7 @@ module PublishingApi
 
     def links
       {
-        fatality_notices: operational_field.published_fatality_notices.order("first_published_at desc").map(&:content_id),
+        fatality_notices: operational_field.published_fatality_notices.order("first_published_at desc").map { |notice| presentation_info(notice) },
         primary_publishing_organisation: [MINISTRY_OF_DEFENCE_CONTENT_ID],
       }
     end
@@ -38,5 +38,17 @@ module PublishingApi
   private
 
     attr_reader :operational_field
+
+    def presentation_info(notice)
+      {
+        intro: notice.roll_call_introduction,
+        links: notice.fatality_notice_casualties.map do |casualty|
+          {
+            title: casualty.personal_details,
+            href: notice.base_path,
+          }
+        end,
+      }
+    end
   end
 end

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -7,7 +7,12 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       name: "Operational Field name",
       description: "Operational Field description",
     )
-    @fatality_notices_for_operational_field = (0..4).map { |_i| create(:published_fatality_notice, operational_field: @operational_field) }
+    @fatality_notices_for_operational_field = []
+    2.times do |i|
+      notice = create(:published_fatality_notice, roll_call_introduction: "Fatality Notice #{i}", operational_field: @operational_field)
+      2.times { |j| create(:fatality_notice_casualty, fatality_notice: notice, personal_details: "personal details #{i} - #{j}") }
+      @fatality_notices_for_operational_field << notice
+    end
     create(:published_fatality_notice, operational_field: create(:operational_field))
     %i[draft_fatality_notice
        submitted_fatality_notice
@@ -52,8 +57,25 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the expected links" do
+    fatality_notices = [
+      {
+        intro: "Fatality Notice 0",
+        links: [
+          { title: "personal details 0 - 0", href: "/government/fatalities/fatality-title" },
+          { title: "personal details 0 - 1", href: "/government/fatalities/fatality-title" },
+        ],
+      },
+      {
+        intro: "Fatality Notice 1",
+        links: [
+          { title: "personal details 1 - 0", href: "/government/fatalities/fatality-title--2" },
+          { title: "personal details 1 - 1", href: "/government/fatalities/fatality-title--2" },
+        ],
+      },
+    ]
+
     expected_links = {
-      fatality_notices: @fatality_notices_for_operational_field.map(&:content_id),
+      fatality_notices:,
       primary_publishing_organisation: [PublishingApi::OperationalFieldPresenter::MINISTRY_OF_DEFENCE_CONTENT_ID],
     }
 


### PR DESCRIPTION
While working to render these pages in Government FE I noticed that we were lacking some informatio n that Whitehall has access to. This ensures that all the individual casualty data is in the conten t item so they can be individually shown.

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
