### PR TITLE
Add support for bulk retagging organisations to Statistics Announcements

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -39,23 +39,16 @@ module DataHygiene
 
       return if slug.blank?
 
-      if document_type.blank?
-        documents = Document.where(slug: slug.strip).to_a
+      documents = Document.where(slug:)
+      documents = Document.where(slug:, document_type:) if documents.many? && document_type.present?
 
-        if documents.length > 1
-          puts "error: ambiguous slug: #{slug} (document_types: #{documents.map(&:document_type)})"
-        else
-          document = documents.first
-        end
+      if documents.many?
+        puts "error: ambiguous slug: #{slug} (document_types: #{documents.map(&:document_type)})"
+      elsif documents.any?
+        documents.first
       else
-        document = Document.find_by(slug:, document_type:)
-      end
-
-      if document.nil?
         puts "error: #{slug}: could not find document"
       end
-
-      document
     end
 
     def find_organisations(row, column)


### PR DESCRIPTION
Statistics Announcements are not Documents in Whitehall. But they still have organisations, and still need to be retagged when Machinery of Government changes happen. So I've extended the existing 'Bulk Organisation Updater' to add support for Statistics Announcement documents.

This is what powers the Rake task `data_hygiene:bulk_update_organisation[csv_file]` that's [documented in the GOV.UK developer docs](https://docs.publishing.service.gov.uk/manual/government-changes.html#bulk-retagging-documents).

## Reviewing this PR

While working on this piece of code, I took the opportunity to refactor/clarify some of the existing functionality and tests.

So it's probably best to review this PR commit-by-commit to see how each change follows on from the last:

1. [Stub stdout to avoid noisy tests](https://github.com/alphagov/whitehall/pull/7423/commits/cd451c747971446bacf908becf8be38ca3552ed6)
2. [Ignore 'document type' unless slug is ambiguous](https://github.com/alphagov/whitehall/pull/7423/commits/b807896663e82dfc800406352c52d2d2f2e59bce)
3. [Add support for retagging Statistics Announcements](https://github.com/alphagov/whitehall/pull/7423/commits/13c0c5cd366a8ef8d0e45427b511d84682b23d54)

## Potential code smell

The use of `rubocop:disable Rails/SaveBang` is a bit of a smell. It indicates that we don't actually check that the database save was successful.

However, this is in keeping with the existing behaviour of this class - i.e. it's already used by the `update_edition` method. So I've decided to use the same approach so as to be consistent with the existing behaviour.

If we find this behaviour to be problematic, then we should change it in both places.

---

Trello: https://trello.com/c/41AHX9sb/1194-extend-datahygienebulkupdateorganisation-rake-task-to-support-statistics-announcements

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
