### PR TITLE
Move Governments listing page to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -1,8 +1,11 @@
 class Admin::GovernmentsController < Admin::BaseController
   before_action :enforce_permissions!, except: :index
+  layout :get_layout
 
   def index
     @governments = Government.order(start_date: :desc)
+
+    render_design_system("index", "legacy_index", next_release: false)
   end
 
   def new
@@ -66,4 +69,15 @@ private
     RoleAppointment.current.for_ministerial_roles
   end
   helper_method :current_active_ministerial_appointments
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 end

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -1,44 +1,42 @@
-<% page_title "Governments" %>
-<h1>Governments</h1>
+<% content_for :page_title, "Governments" %>
+<% content_for :title, "Governments" %>
 
 <% if can?(:manage, Government) %>
-  <p>
-    <%= link_to "Create a government", new_admin_government_path %>
-  </p>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create new government",
+    href: new_admin_government_path,
+    margin_bottom: 6
+  } %>
 <% end %>
 
-<table class="governments table table-striped table-bordered add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th width="70%">Name</th>
-      <th width="15%">Start date</th>
-      <th width="15%">End date</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @governments.each do |government| %>
-      <%= content_tag_for(:tr, government) do %>
-        <td>
-          <% if can?(:manage, Government) %>
-            <%= link_to government.name, edit_admin_government_path(government) %>
-          <% else %>
-            <%= government.name %>
-          <% end %>
-        </td>
-        <td>
-          <%= government.start_date.to_fs(:govuk_date) %>
-        </td>
-        <td>
-          <%= government.end_date.to_fs(:govuk_date) if government.end_date %>
-        </td>
-      <% end %>
-    <% end %>
-
-    <% if @governments.empty? %>
-      <tr>
-        <td colspan="3">No governments have been created.</td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Name"
+    },
+    {
+      text: "Start date"
+    },
+    {
+      text: "End date"
+    }
+  ],
+  rows:
+    @governments.map do |government|
+    [
+      {
+        text:  if can?(:manage, Government)
+                link_to(government.name, edit_admin_government_path(government), class: "govuk-link")
+               else
+                government.name
+               end
+      },
+      {
+        text: government.start_date.to_fs(:govuk_date)
+      },
+      {
+        text: (government.end_date.to_fs(:govuk_date) if government.end_date)
+      }
+    ]
+  end
+} if @governments.present? %>

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -9,34 +9,38 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/table", {
-  head: [
-    {
-      text: "Name"
-    },
-    {
-      text: "Start date"
-    },
-    {
-      text: "End date"
-    }
-  ],
-  rows:
-    @governments.map do |government|
-    [
+<% if @governments.blank? %>
+  <p class="govuk-body">No governments have been created.</p>
+<% else %>
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
       {
-        text:  if can?(:manage, Government)
-                link_to(government.name, edit_admin_government_path(government), class: "govuk-link")
-               else
-                government.name
-               end
+        text: "Name"
       },
       {
-        text: government.start_date.to_fs(:govuk_date)
+        text: "Start date"
       },
       {
-        text: (government.end_date.to_fs(:govuk_date) if government.end_date)
+        text: "End date"
       }
-    ]
-  end
-} if @governments.present? %>
+    ],
+    rows:
+      @governments.map do |government|
+      [
+        {
+          text:  if can?(:manage, Government)
+                  link_to(government.name, edit_admin_government_path(government), class: "govuk-link")
+                 else
+                  government.name
+                 end
+        },
+        {
+          text: government.start_date.to_fs(:govuk_date)
+        },
+        {
+          text: (government.end_date.to_fs(:govuk_date) if government.end_date)
+        }
+      ]
+    end
+  } %>
+<% end %>

--- a/app/views/admin/governments/legacy_index.html.erb
+++ b/app/views/admin/governments/legacy_index.html.erb
@@ -1,0 +1,44 @@
+<% page_title "Governments" %>
+<h1>Governments</h1>
+
+<% if can?(:manage, Government) %>
+  <p>
+    <%= link_to "Create a government", new_admin_government_path %>
+  </p>
+<% end %>
+
+<table class="governments table table-striped table-bordered add-top-margin">
+  <thead>
+    <tr class="table-header">
+      <th width="70%">Name</th>
+      <th width="15%">Start date</th>
+      <th width="15%">End date</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @governments.each do |government| %>
+      <%= content_tag_for(:tr, government) do %>
+        <td>
+          <% if can?(:manage, Government) %>
+            <%= link_to government.name, edit_admin_government_path(government) %>
+          <% else %>
+            <%= government.name %>
+          <% end %>
+        </td>
+        <td>
+          <%= government.start_date.to_fs(:govuk_date) %>
+        </td>
+        <td>
+          <%= government.end_date.to_fs(:govuk_date) if government.end_date %>
+        </td>
+      <% end %>
+    <% end %>
+
+    <% if @governments.empty? %>
+      <tr>
+        <td colspan="3">No governments have been created.</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/features/governments.feature
+++ b/features/governments.feature
@@ -41,3 +41,10 @@ Feature: governments
     And I create a government called "Robo-alien Overlords"
     And I appoint "Fred Fancy" as the "Minister of Crazy"
     Then I should be able to create a news article associated with "Fred Fancy" as the "Minister of Crazy"
+
+  @design-system-only
+  Scenario: There are no governments available to view
+    Given that there no governments available to view
+    And I am a GDS admin
+    When I visit the governments page
+    Then I should see no governments message

--- a/features/governments.feature
+++ b/features/governments.feature
@@ -4,6 +4,7 @@ Feature: governments
   I want to be able to associate content with a specific government
   So that we can appropriately identify less relevant content after elections.
 
+  @design-system-only
   Scenario: creating a government
     Given I am a GDS admin
     When I create a government called "2005 to 2010 Labour government" starting on "06/05/2005"
@@ -22,6 +23,7 @@ Feature: governments
     When I edit the government called "2005 to 2010 Labour government" to have dates "06/05/2005" and "11/05/2010"
     Then there should be a government called "2005 to 2010 Labour government" between dates "6 May 2005" and "11 May 2010"
 
+  @design-system-only
   Scenario: changing government after an election
     Given there is a current government
     And I am a GDS admin
@@ -29,6 +31,7 @@ Feature: governments
     And I create a government called "Robo-alien Overlords"
     Then the current government should be "Robo-alien Overlords"
 
+  @design-system-only
   Scenario: appointing a minister to the new government
     Given I am a GDS admin
     And a person called "Fred Fancy"

--- a/features/step_definitions/government_steps.rb
+++ b/features/step_definitions/government_steps.rb
@@ -47,3 +47,15 @@ end
 Then(/^there should be no active ministerial role appointments$/) do
   expect(0).to eq(count_active_ministerial_role_appointments)
 end
+
+Given(/^that there no governments available to view$/) do
+  Government.delete_all
+end
+
+When(/^I visit the governments page$/) do
+  visit admin_governments_path
+end
+
+Then(/^I should see no governments message$/) do
+  expect(page).to have_selector("p", text: "No governments have been created.")
+end

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -2,7 +2,7 @@ module GovernmentsHelper
   def create_government(name:, start_date: nil, end_date: nil)
     visit admin_governments_path
 
-    click_on "Create a government"
+    click_on "Create new government"
 
     fill_in "Name", with: name
     fill_in "Start date", with: start_date if start_date
@@ -23,16 +23,19 @@ module GovernmentsHelper
     click_on "Save"
   end
 
-  def check_for_government(name:, start_date: nil, end_date: nil, current: false) # rubocop:disable Lint/UnusedMethodArgument
+  def check_for_government(name:, start_date: nil, end_date: nil, current: false)
     visit admin_governments_path
 
-    government = Government.find_by_name(name)
+    rows = all("table tr")
 
-    within("#government_#{government.id}") do
-      expect(page).to have_content(name)
-      expect(page).to have_content(start_date)
-      expect(page).to have_content(end_date) if end_date
+    matching_row = rows.find do |row|
+      row.has_content?(name) &&
+        (start_date.nil? || row.has_content?(start_date)) &&
+        (end_date.nil? || row.has_content?(end_date)) &&
+        (current.nil? || current == row.has_content?("Yes"))
     end
+
+    expect(matching_row).to be_present
   end
 
   def check_for_current_government(name:)

--- a/test/functional/admin/legacy_governments_controller_test.rb
+++ b/test/functional/admin/legacy_governments_controller_test.rb
@@ -1,9 +1,10 @@
 require "test_helper"
 
-class Admin::GovernmentsControllerTest < ActionController::TestCase
+class Admin::LegacyGovernmentsControllerTest < ActionController::TestCase
+  tests Admin::GovernmentsController
+
   setup do
     @government = FactoryBot.create(:government)
-    login_as_preview_design_system_user(:gds_editor)
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
## Description

This ports the governments listing page to the GOV.UK Design System. It appends legacy to the current view. Then adds the new views in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshot

![Screenshot 2023-03-14 at 2 59 46 pm](https://user-images.githubusercontent.com/4599889/225042830-ddae95b6-23e0-45c7-923e-609403abf44b.png)


## Trello

https://trello.com/c/quWvC2uo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
