### PR TITLE
Fix bug with preview link for Foreign Only Consultations not rendering

### DIFF
--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -49,7 +49,7 @@
           "track-category": "button-clicked",
           "track-action": "#{@edition.model_name.singular.dasherize}-button",
           "track-label": "Preview on website",
-        }) if @edition.available_in_english? %>
+        }) if @edition.available_in_english? || @edition.non_english_edition? %>
       </p>
       <% if @edition.translatable? && @edition.available_in_multiple_languages? %>
         <%= render "govuk_publishing_components/components/details", {

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -139,6 +139,16 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     assert_select ".page-header .govuk-body-lead", text: "a-simple-summary"
   end
 
+  view_test "show renders the preview link for foreign only consultations" do
+    french_consultation = create(:draft_consultation, primary_locale: "fr")
+    french_consultation.translations.first.update!(locale: "fr")
+
+    stub_publishing_api_expanded_links_with_taxons(french_consultation.content_id, [])
+
+    get :show, params: { id: french_consultation }
+    assert_select ".app-view-edition-summary__section a", text: "Preview on website  (opens in new tab)", href: preview_document_url(french_consultation)
+  end
+
   view_test "edit displays consultation fields" do
     response_form = create(:consultation_response_form)
     participation = create(:consultation_participation, consultation_response_form: response_form)


### PR DESCRIPTION
At the moment, the preview link only renders if the document is available in English. This means that the link does not render for Foreign Only Consultations.

This renders the preview link if the edition is a non-english edition (it's primary locale is not :en)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
