### PR TITLE
Fix crest on Worldwide Organisation pages

### DIFF
--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -9,7 +9,8 @@
       organisation: {
         name: translated_organisation_logo_name(organisation),
         url: link_to_organisation ? organisation.public_path : nil,
-        crest: "single-identity",
+        crest: organisation.sponsoring_organisations.first&.organisation_crest || "single-identity",
+        brand: organisation.sponsoring_organisations.first&.organisation_brand || "single-identity",
       },
       heading_level: 1,
       inline: true,


### PR DESCRIPTION
At the moment, we display the simplified royal coat of arms as the crest on all Worldwide Organisation pages.

This is not correct as some organisation have different logos (e.g. the Department for Business & Trade).

Updating this so we match the logo that is used by the worldwide organisation's first supporting organisation.  In the event of no supporting organisations, we will continue to use the coat of arms.

|                   	| Before 	| After 	|
|-------------------	|--------	|-------	|
| DBT Organisation  	|  ![Screenshot showing organisation logo with single identity crest and black line](https://user-images.githubusercontent.com/6329861/224757301-1b7e724c-4996-4638-9c92-cf8a6599440a.png)      	|       ![Screenshot showing organisation logo with DBT crest and red line](https://user-images.githubusercontent.com/6329861/224757424-b2434710-b4ad-4f30-80f0-4b4d02906db3.png)	|
| FCDO Organisation 	|     ![Screenshot showing organisation logo with single identity crest and black line](https://user-images.githubusercontent.com/6329861/224757517-8020f491-9863-4fdd-a4c1-5d98c08d0c03.png)	|      ![Screenshot showing organisation logo with single identity crest and dark blue line](https://user-images.githubusercontent.com/6329861/224757598-a1179056-8c4c-47f2-9caa-d855f5a931f8.png) 	|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
