### PR TITLE
Adds missing tracking to Govspeak help section

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -44,7 +44,11 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-    title: "Links"
+    title: "Links",
+    data_attributes: {
+      track_category: "formatting-help",
+      track_action: "Links",
+    },
   } do %>
     <p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
     <pre class='govspeak-help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>


### PR DESCRIPTION
There is some event tracking missing on the GovSpeak Formatting panel on pages where that is rendered, specifically the "Links" section (other sections are working as expected). This change adds the required tracking data to that section. 

![Screenshot 2023-03-14 at 11 10 53](https://user-images.githubusercontent.com/6080548/224983587-96323a16-dd13-4830-8430-35b43e2f8343.png)
