### PR TITLE
Update rendering application for fields of operation index and how government works pages

### DIFF
--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
         description: "About the UK system of government. Understand who runs government, and how government is run.",
         document_type: "how_government_works",
         public_updated_at: Time.zone.now,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "how_government_works",
         details:,
       )

--- a/app/presenters/publishing_api/operational_fields_index_presenter.rb
+++ b/app/presenters/publishing_api/operational_fields_index_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
         details: {},
         document_type: "fields_of_operation",
         public_updated_at: Time.zone.now,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "fields_of_operation",
       )
 

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       expected_hash = {
         base_path: "/government/how-government-works",
         publishing_app: "whitehall",
-        rendering_app: "whitehall-frontend",
+        rendering_app: "government-frontend",
         schema_name: "how_government_works",
         document_type: "how_government_works",
         title: "How government works",
@@ -80,7 +80,7 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       expected_hash = {
         base_path: "/government/how-government-works",
         publishing_app: "whitehall",
-        rendering_app: "whitehall-frontend",
+        rendering_app: "government-frontend",
         schema_name: "how_government_works",
         document_type: "how_government_works",
         title: "How government works",

--- a/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
@@ -11,7 +11,7 @@ class PublishingApi::OperationalFieldsIndexPresenterTest < ActiveSupport::TestCa
       base_path: "/government/fields-of-operation",
       details: {},
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "government-frontend",
       schema_name: "fields_of_operation",
       document_type: "fields_of_operation",
       title: "Fields of operation",


### PR DESCRIPTION
This updates the rendering application for two content types which have recently had their rendering code added to government frontend:

* How government works (dependent on deploying [this PR](https://github.com/alphagov/government-frontend/pull/2710))
* Fields of operation index page (dependent on deploying [this PR](https://github.com/alphagov/government-frontend/pull/2711))


[Trello](https://trello.com/c/qLDPkv8T/474-add-rendering-of-fields-of-operation-index-page-to-government-frontend)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
