### PR TITLE
Fix historic account view link on admin page

### DIFF
--- a/app/views/admin/historical_accounts/_historical_account.html.erb
+++ b/app/views/admin/historical_accounts/_historical_account.html.erb
@@ -6,7 +6,7 @@
     <%= historical_account.summary %>
   </td>
   <td class="actions">
-    <%= link_to 'View', historic_appointment_path(person), class: "btn btn-default" %>
+    <%= link_to 'View', historical_account.public_path, class: "btn btn-default" %>
     <%= link_to 'Edit', edit_admin_person_historical_account_path(person, historical_account), class: "btn btn-default" %>
     <%= button_to 'Delete',
           admin_person_historical_account_path(person, historical_account),


### PR DESCRIPTION
The routes have now been removed so this helper method is unavailable

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
