### PR TITLE
Update error summary width to always be 2/3 of the page

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -47,8 +47,11 @@
         </div>
       <% end %>
 
-      <%= yield(:error_summary) %>
-
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield(:error_summary) %>
+        </div>
+      </div>
 
       <% if yield(:error_summary).blank? %>
         <div class="govuk-grid-row">


### PR DESCRIPTION
## Description

We've been informed by Design that this should only ever render on 2/3 of the page.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
