### PR TITLE
Prepare to close gov page

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -40,6 +40,8 @@ class Admin::GovernmentsController < Admin::BaseController
 
   def prepare_to_close
     @government = Government.find(params[:id])
+
+    render_design_system("prepare_to_close", "legacy_prepare_to_close", next_release: false)
   end
 
   def close
@@ -72,7 +74,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index prepare_to_close] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/governments/legacy_prepare_to_close.html.erb
+++ b/app/views/admin/governments/legacy_prepare_to_close.html.erb
@@ -1,0 +1,23 @@
+<% page_title "Prepare to close this government" %>
+<h1>Prepare to close this government</h1>
+
+<p>
+  Closing this government will unappoint the following ministerial roles, are you sure?
+</p>
+
+<ul>
+  <% current_active_ministerial_appointments.each do |appointment| %>
+    <li><%= appointment.role.name %>: <%= appointment.person.name %></li>
+  <% end %>
+</ul>
+
+<div class="form-actions">
+  <%= form_tag close_admin_government_path(@government) do %>
+    <button type="submit" class="btn btn-danger btn-lg">Yes, close this government</button>
+
+    <span class="or_cancel">
+      or
+      <%= link_to "No! Don’t do that! Noooo!", edit_admin_government_path(@government) %>
+    </span>
+  <% end %>
+</div>

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -1,23 +1,32 @@
-<% page_title "Prepare to close this government" %>
-<h1>Prepare to close this government</h1>
+<% content_for :page_title, "Prepare to close this government" %>
+<% content_for :title, "Prepare to close this government" %>
 
-<p>
-  Closing this government will unappoint the following ministerial roles, are you sure?
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<ul>
-  <% current_active_ministerial_appointments.each do |appointment| %>
-    <li><%= appointment.role.name %>: <%= appointment.person.name %></li>
-  <% end %>
-</ul>
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "Closing this government will unappoint the following ministerial roles, are you sure?"
+    } %>
 
-<div class="form-actions">
-  <%= form_tag close_admin_government_path(@government) do %>
-    <button type="submit" class="btn btn-danger btn-lg">Yes, close this government</button>
+    <%= render "govuk_publishing_components/components/list", {
+      aria_label: "A list of active ministerial appointments.",
+      visible_counters: true,
+      margin_bottom: 6,
+      items:
+        current_active_ministerial_appointments.map do |appointment|
+            "#{appointment.role.name}: #{appointment.person.name}"
+        end
+    } %>
 
-    <span class="or_cancel">
-      or
-      <%= link_to "No! Don’t do that! Noooo!", edit_admin_government_path(@government) %>
-    </span>
-  <% end %>
+    <%= form_tag close_admin_government_path(@government) do %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Yes, close this government",
+          destructive: true
+        } %>
+        <%= link_to("No! Don’t do that! Noooo!", edit_admin_government_path(@government), class: "govuk-link") %>
+      </div>
+    <% end %>
+  </div>
 </div>
+

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -21,10 +21,10 @@
     <%= form_tag close_admin_government_path(@government) do %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Yes, close this government",
+          text: "Close this government",
           destructive: true
         } %>
-        <%= link_to("No! Don’t do that! Noooo!", edit_admin_government_path(@government), class: "govuk-link") %>
+        <%= link_to("Cancel", edit_admin_government_path(@government), class: "govuk-link") %>
       </div>
     <% end %>
   </div>

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -48,7 +48,8 @@ module GovernmentsHelper
     click_on name
 
     click_on "Prepare to close this government"
-    click_on "Yes, close this government"
+
+    click_on using_design_system? ? "Close this government" : "Yes, close this government"
   end
 
   def count_active_ministerial_role_appointments


### PR DESCRIPTION
## Description

This ports the governments prepare to close page to the GOV.UK Design System. It appends legacy to the current view. Then adds the new view in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshot

<img width="1344" alt="Screenshot 2023-03-15 at 16 00 49" src="https://user-images.githubusercontent.com/91492293/225368929-45a39c82-1ad3-4942-9646-56ef06524c6c.png">
<img width="1344" alt="Screenshot 2023-03-15 at 16 01 01" src="https://user-images.githubusercontent.com/91492293/225368992-71f57ea9-a3db-4c71-9705-7ee683bf4e28.png">

## Trello

https://trello.com/c/zgNAxGYe

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
