### PR TITLE
Amend government feature test to use using_design_system predicate

### DIFF
--- a/features/governments.feature
+++ b/features/governments.feature
@@ -4,7 +4,6 @@ Feature: governments
   I want to be able to associate content with a specific government
   So that we can appropriately identify less relevant content after elections.
 
-  @design-system-only
   Scenario: creating a government
     Given I am a GDS admin
     When I create a government called "2005 to 2010 Labour government" starting on "06/05/2005"
@@ -23,7 +22,6 @@ Feature: governments
     When I edit the government called "2005 to 2010 Labour government" to have dates "06/05/2005" and "11/05/2010"
     Then there should be a government called "2005 to 2010 Labour government" between dates "6 May 2005" and "11 May 2010"
 
-  @design-system-only
   Scenario: changing government after an election
     Given there is a current government
     And I am a GDS admin
@@ -31,7 +29,6 @@ Feature: governments
     And I create a government called "Robo-alien Overlords"
     Then the current government should be "Robo-alien Overlords"
 
-  @design-system-only
   Scenario: appointing a minister to the new government
     Given I am a GDS admin
     And a person called "Fred Fancy"

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -2,7 +2,9 @@ module GovernmentsHelper
   def create_government(name:, start_date: nil, end_date: nil)
     visit admin_governments_path
 
-    click_on "Create new government"
+    button_text = using_design_system? ? "Create new government" : "Create a government"
+
+    click_on button_text
 
     fill_in "Name", with: name
     fill_in "Start date", with: start_date if start_date


### PR DESCRIPTION
## What:

* Remove @Design_system_only annotations
* Add using_design_system predicate to determine correct button text  

## Why:

* Small change in button text following design review resulted in failing feature tests in default profile
* Initially incorrectly handled by annotating out the failing tests
* Now correctly handled with the existing using_design_system predicate
* Which maintains test coverage under the default profile

## Trello:

https://trello.com/c/quWvC2uo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
