### PR TITLE
Move Government edit to GDS Design System

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -10,10 +10,13 @@ class Admin::GovernmentsController < Admin::BaseController
 
   def new
     @government = Government.new(start_date: Time.zone.today)
+    render_design_system("new", "legacy_new", next_release: false)
   end
 
   def edit
     @government = Government.find(params[:id])
+
+    render_design_system("edit", "legacy_edit", next_release: false)
   end
 
   def create
@@ -24,7 +27,7 @@ class Admin::GovernmentsController < Admin::BaseController
     if @government.save
       redirect_to admin_governments_path, notice: "Created government information"
     else
-      render action: "new"
+      render_design_system("new", "legacy_new", next_release: false)
     end
   end
 
@@ -34,7 +37,7 @@ class Admin::GovernmentsController < Admin::BaseController
     if @government.update(government_params)
       redirect_to admin_governments_path, notice: "Updated government information"
     else
-      render action: "edit"
+      render_design_system("edit", "legacy_edit", next_release: false)
     end
   end
 
@@ -74,7 +77,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index prepare_to_close] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index edit new create update prepare_to_close] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -1,18 +1,87 @@
-<%= form_for [:admin, government], as: :government, html: {class: 'government-form'} do |government_form| %>
-  <%= government_form.errors %>
-  <p><%= government_form.text_field :name, {placeholder: "eg 2005 to 2010 Labour government"} %></p>
-  <p><%= government_form.text_field :start_date, {placeholder: "eg 2005-05-06"} %></p>
-  <p><%= government_form.text_field :end_date, {placeholder: "eg 2010-05-11"} %></p>
+<%= form_for [:admin, government], as: :government do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: "Changes to government appear instantly on the live site.",
+      } %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Name"
+        },
+        name: "government[name]",
+        id: "government_name",
+        heading_size: "l",
+        value: government.name,
+        error_message: errors_for_input(government.errors, :name)
+      } %>
 
-  <% if government.persisted? %>
-    <p>
-      <%= link_to "Prepare to close this government", prepare_to_close_admin_government_path(government) %>
-    </p>
-  <% end %>
+      <%= render "components/datetime_fields", {
+        date_only: true,
+        prefix: "government",
+        field_name: "start_date",
+        id: "government_start_date",
+        heading_size: "l",
+        date_hint: "For example, 01 August 2015",
+        date_heading: "Start date",
 
-  <p class="warning">
-    Warning: changes to government information will appear instantly on the live site.
-  </p>
+        year: {
+          value: government.start_date.to_date,
+          start_year: 1800
+        },
+        month: {
+          value: government.start_date.to_date
+        },
+        day: {
+          value: government.start_date.to_date
+        },
 
-  <%= government_form.save_or_cancel(cancel: admin_governments_path) %>
+        error_items: errors_for_input(government.errors, :start_date)
+      } %>
+
+      <% if government.ended? %>
+        <%= render "components/datetime_fields", {
+          date_only: true,
+          prefix: "government",
+          field_name: "end_date",
+          id: "government_end_date",
+          heading_level: 3,
+          heading_size: "m",
+          date_hint: "For example, 01 August 2022",
+          date_heading: "End date",
+          year: {
+            value: government.end_date.to_date,
+            start_year: 1800
+          },
+          month: {
+            value: government.end_date.to_date
+          },
+          day: {
+            value: government.end_date.to_date
+          },
+        } %>
+      <% else %>
+        <%= render "components/datetime_fields", {
+          date_only: true,
+          prefix: "government",
+          field_name: "end_date",
+          id: "government_end_date",
+          heading_level: 3,
+          heading_size: "m",
+          date_hint: "For example, 01 August 2022",
+          date_heading: "End date",
+        } %>
+      <% end %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save"
+        } %>
+        <%= link_to("cancel", admin_governments_path(), class: "govuk-link") %>
+      </div>
+      <% if government.persisted? %>
+        <%= link_to("Prepare to close this government", prepare_to_close_admin_government_path(government), class:
+          "govuk-link gem-link--destructive") %>
+      <% end %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/admin/governments/_legacy_form.html.erb
+++ b/app/views/admin/governments/_legacy_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_for [:admin, government], as: :government, html: {class: 'government-form'} do |government_form| %>
+  <%= government_form.errors %>
+  <p><%= government_form.text_field :name, {placeholder: "eg 2005 to 2010 Labour government"} %></p>
+  <p><%= government_form.text_field :start_date, {placeholder: "eg 2005-05-06"} %></p>
+  <p><%= government_form.text_field :end_date, {placeholder: "eg 2010-05-11"} %></p>
+
+  <% if government.persisted? %>
+    <p>
+      <%= link_to "Prepare to close this government", prepare_to_close_admin_government_path(government) %>
+    </p>
+  <% end %>
+
+  <p class="warning">
+    Warning: changes to government information will appear instantly on the live site.
+  </p>
+
+  <%= government_form.save_or_cancel(cancel: admin_governments_path) %>
+<% end %>

--- a/app/views/admin/governments/edit.html.erb
+++ b/app/views/admin/governments/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title "Edit a government" %>
-<h1>Edit a government</h1>
-
-<%= render "form", government: @government %>
+<% content_for :title, "Edit a government" %>
+<% content_for :page_title, "Edit a government" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @government)) %>
+<%= render partial: "form", locals: { government: @government } %>

--- a/app/views/admin/governments/legacy_edit.html.erb
+++ b/app/views/admin/governments/legacy_edit.html.erb
@@ -1,0 +1,4 @@
+<% page_title "Edit a government" %>
+<h1>Edit a government</h1>
+
+<%= render "legacy_form", government: @government %>

--- a/app/views/admin/governments/legacy_new.html.erb
+++ b/app/views/admin/governments/legacy_new.html.erb
@@ -1,0 +1,4 @@
+<% page_title "Create a government" %>
+<h1>Create a government</h1>
+
+<%= render "legacy_form", government: @government %>

--- a/app/views/admin/governments/new.html.erb
+++ b/app/views/admin/governments/new.html.erb
@@ -1,4 +1,4 @@
-<% page_title "Create a government" %>
-<h1>Create a government</h1>
-
-<%= render "form", government: @government %>
+<% content_for :title, "Create a government" %>
+<% content_for :page_title, "Create a government" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @government)) %>
+<%= render partial: "form", locals: { government: @government } %>

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -1,6 +1,7 @@
 <%
  prefix = prefix
  field_name = field_name
+ id = id
  date_only ||= false
  date_heading ||= nil
 
@@ -47,7 +48,7 @@
  data_attributes ||= {}
 %>
 
-<%= tag.div class: root_classes, data: data_attributes do %>
+<%= tag.div class: root_classes, data: data_attributes, id: id do %>
   <% unless date_only && !date_heading %>
     <%= render "govuk_publishing_components/components/heading", {
       text: date_heading || "Date",

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -15,11 +15,11 @@ When(/^I draft a new "(.*?)" language consultation "(.*?)"$/) do |locale, title|
 
   if using_design_system?
     within "#edition_opening_at" do
-      fill_in_datetime_field(1.day.ago.to_s)
+      fill_in_date_and_time_field(1.day.ago.to_s)
     end
 
     within "#edition_closing_at" do
-      fill_in_datetime_field(6.days.from_now.to_s)
+      fill_in_date_and_time_field(6.days.from_now.to_s)
     end
 
     check "Does not apply to Wales"

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -76,7 +76,7 @@ end
 Then(/^I should be able to choose the date it was written on$/) do
   if using_design_system?
     within "#edition_delivered_on" do
-      fill_in_datetime_field(1.day.ago.to_s)
+      fill_in_date_and_time_field(1.day.ago.to_s)
     end
   else
     select_date 1.day.ago.to_s, from: "Written on"

--- a/features/support/datetime_field_helper.rb
+++ b/features/support/datetime_field_helper.rb
@@ -1,0 +1,20 @@
+module DatetimeFieldHelper
+  def fill_in_date_and_time_field(date)
+    date = Time.zone.parse(date)
+
+    select date.year, from: "Year"
+    select date.strftime("%B"), from: "Month"
+    select date.day, from: "Day"
+    select date.strftime("%H"), from: "Hour"
+    select date.strftime("%M"), from: "Minute"
+  end
+
+  def fill_in_date_fields(date)
+    date = Time.zone.parse(date)
+
+    select date.year, from: "Year"
+    select date.strftime("%B"), from: "Month"
+    select date.day, from: "Day"
+  end
+end
+World(DatetimeFieldHelper)

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -193,16 +193,6 @@ module DocumentHelper
     query = { preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i }
     document_path(edition, options.merge(query))
   end
-
-  def fill_in_datetime_field(date)
-    date = Time.zone.parse(date)
-
-    select date.year, from: "Year"
-    select date.strftime("%B"), from: "Month"
-    select date.day, from: "Day"
-    select date.strftime("%H"), from: "Hour"
-    select date.strftime("%M"), from: "Minute"
-  end
 end
 
 World(DocumentHelper)

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -2,13 +2,22 @@ module GovernmentsHelper
   def create_government(name:, start_date: nil, end_date: nil)
     visit admin_governments_path
 
-    button_text = using_design_system? ? "Create new government" : "Create a government"
-
-    click_on button_text
+    click_on using_design_system? ? "Create new government" : "Create a government"
 
     fill_in "Name", with: name
-    fill_in "Start date", with: start_date if start_date
-    fill_in "End date", with: end_date if end_date
+
+    if using_design_system?
+      within "#government_start_date" do
+        fill_in_date_fields(start_date) if start_date
+      end
+
+      within "#government_end_date" do
+        fill_in_date_fields(end_date) if end_date
+      end
+    else
+      fill_in "Start date", with: start_date if start_date
+      fill_in "End date", with: end_date if end_date
+    end
 
     click_on "Save"
   end
@@ -18,8 +27,18 @@ module GovernmentsHelper
 
     click_on name
 
-    attributes.each do |attribute, value|
-      fill_in attribute.to_s.humanize, with: value
+    if using_design_system?
+      within "#government_start_date" do
+        fill_in_date_fields(attributes[:start_date]) if attributes[:start_date]
+      end
+
+      within "#government_end_date" do
+        fill_in_date_fields(attributes[:end_date]) if attributes[:end_date]
+      end
+    else
+      attributes.each do |attribute, value|
+        fill_in attribute.to_s.humanize, with: value
+      end
     end
 
     click_on "Save"
@@ -46,7 +65,6 @@ module GovernmentsHelper
 
   def close_government(name:)
     visit admin_governments_path
-
     click_on name
 
     click_on "Prepare to close this government"


### PR DESCRIPTION
# What
* Added `render_design_system` feature flag to `government_controller`
* Added `design_system_actions` to `government_controller`
* Duplicated `_form` and renamed to `_legacy_form`
* Duplicated `edit` and renamed to `legacy_edit`
* Duplicated `new` and renamed to `legacy_new`
* Added `id` to `_datetime_fields`
* Refactored `datetime_field_helper`
* Added function too `datetime_field_helper`
* Updated `edit` to use GDS components
* Updated `form` to use GDS components
* Updated `new` to use GDS components
# Why
Align edit, form & new with the GDS Design System
Improve `datetime_fields` and add date only use
# Trello
https://trello.com/c/MAIwCKsw/31-edit-government-page


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
