### PR TITLE
Transition world_location_news to design system

### DIFF
--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -1,5 +1,6 @@
 class Admin::WorldLocationNewsController < Admin::BaseController
   before_action :load_world_location, only: %i[edit update show features]
+  layout :get_layout
 
   def edit; end
 
@@ -7,6 +8,8 @@ class Admin::WorldLocationNewsController < Admin::BaseController
 
   def index
     @active_world_locations, @inactive_world_locations = WorldLocation.ordered_by_name.partition(&:active?)
+
+    render_design_system("index", "legacy_index", next_release: false)
   end
 
   def update
@@ -57,5 +60,16 @@ private
       featured_links_attributes: %i[url title id _destroy],
       world_location_attributes: %i[active id world_location_type],
     )
+  end
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/views/admin/world_location_news/_legacy_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_legacy_world_location_table.html.erb
@@ -1,0 +1,47 @@
+<h2><%= title %></h2>
+
+<table id="world-locations" class="table table-striped table-bordered">
+  <thead>
+    <tr class="table-header">
+      <th width="10%">Type</th>
+      <th width="60%">Location</th>
+      <th width="10%">Status</th>
+      <th width="30%">Translations</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% world_locations.each do |world_location| %>
+      <%= content_tag_for(:tr, world_location) do %>
+        <td class="type"><%= world_location.display_type %></td>
+
+        <td>
+          <p>
+            <%= link_to world_location.name, [:admin, world_location.world_location_news], class: "name" %>
+          </p>
+          <p>
+            <% if world_location.world_location_news.mission_statement.present? %>
+              <span class="mission_statement"><%= format_with_html_line_breaks(world_location.world_location_news.mission_statement) %></span>
+            <% else %>
+              <em>No mission statement yet</em>, <%= link_to "create one", edit_admin_world_location_news_path(world_location.world_location_news) %>.
+            <% end %>
+          </p>
+        </td>
+
+        <td class="status"><%= world_location.active? ? "active" : "inactive" %></td>
+
+        <td class="translations">
+          <% if world_location.non_english_translated_locales.any? %>
+            <%= world_location.non_english_translated_locales.map do |locale|
+              link_to "#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code)
+            end.to_sentence.html_safe %>
+          <% else %>
+            none
+          <% end %>
+        </td>
+
+      <% end %>
+    <% end %>
+
+  </tbody>
+</table>

--- a/app/views/admin/world_location_news/_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_world_location_table.html.erb
@@ -1,51 +1,55 @@
-<%= render "govuk_publishing_components/components/table", {
-  head: [
-    {
-      text: "Type"
-    },
-    {
-      text: "Location"
-    },
-    {
-      text: "Details"
-    },
-    {
-      text: "Translations"
-    },
-    {
-      text: "Edit"
-    }
-  ],
-  rows:
-    world_locations.map do |world_location|
-      [
-        {
-          text: world_location.display_type
-        },
-        {
-          text: world_location.name
-        },
-        {
-          text:
-            if world_location.world_location_news.mission_statement.present?
-              format_with_html_line_breaks(world_location.world_location_news.mission_statement)
-            else
-              "No mission statement yet."
-            end
-        },
-        {
-          text:
-            if world_location.non_english_translated_locales.any?
-              sanitize(world_location.non_english_translated_locales.map do |locale|
-                link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code), class: "govuk-link")
-              end.to_sentence)
-            else
-              "none"
-            end
-        },
-        {
-          text: link_to(sanitize("Edit#{tag.span(world_location.name, class: "govuk-visually-hidden")}"), [:admin, world_location.world_location_news], class: "govuk-link")
-        }
-      ]
-    end
-} %>
+<% if world_locations.blank? %>
+  <p class="govuk-body"><%= error_message %></p>
+<% else %>
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
+      {
+        text: "Type"
+      },
+      {
+        text: "Location"
+      },
+      {
+        text: "Details"
+      },
+      {
+        text: "Translations"
+      },
+      {
+        text: "Edit"
+      }
+    ],
+    rows:
+      world_locations.map do |world_location|
+        [
+          {
+            text: world_location.display_type
+          },
+          {
+            text: world_location.name
+          },
+          {
+            text:
+              if world_location.world_location_news.mission_statement.present?
+                format_with_html_line_breaks(world_location.world_location_news.mission_statement)
+              else
+                "No mission statement yet."
+              end
+          },
+          {
+            text:
+              if world_location.non_english_translated_locales.any?
+                sanitize(world_location.non_english_translated_locales.map do |locale|
+                  link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code), class: "govuk-link")
+                end.to_sentence)
+              else
+                "none"
+              end
+          },
+          {
+            text: link_to(sanitize("Edit#{tag.span(world_location.name, class: "govuk-visually-hidden")}"), [:admin, world_location.world_location_news], class: "govuk-link")
+          }
+        ]
+      end
+  } %>
+<% end %>

--- a/app/views/admin/world_location_news/_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_world_location_table.html.erb
@@ -1,47 +1,51 @@
-<h2><%= title %></h1>
+<%= render "govuk_publishing_components/components/heading", {
+  text: title
+} %>
 
-<table id="world-locations" class="table table-striped table-bordered">
-  <thead>
-    <tr class="table-header">
-      <th width="10%">Type</th>
-      <th width="60%">Location</th>
-      <th width="10%">Status</th>
-      <th width="30%">Translations</th>
-    </tr>
-  </thead>
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Type"
+    },
+    {
+      text: "Location"
+    },
+    {
+      text: "Status"
+    },
+    {
+      text: "Translations"
+    }
+  ],
+  rows:
+    world_locations.map do |world_location|
+      [
+        {
+          text: world_location.display_type
+        },
+        {
+          text:
+            tag.p(link_to(world_location.name, [:admin, world_location.world_location_news], class: "govuk-link"), class: "govuk-body govuk-!-margin-bottom-4") +
+              if world_location.world_location_news.mission_statement.present?
+                format_with_html_line_breaks(world_location.world_location_news.mission_statement)
+              else
+                sanitize(tag.span(tag.em("No mission statement yet, ") + link_to("create one", edit_admin_world_location_news_path(world_location.world_location_news), class: "govuk-link")+ "."))
+              end
+        },
+        {
+          text: world_location.active? ? "active" : "inactive"
+        },
+        {
+          text:
+            sanitize(if world_location.non_english_translated_locales.any?
+              world_location.non_english_translated_locales.map do |locale|
+                link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code), class: "govuk-link")
+              end.to_sentence.html_safe
+            else
+              "none"
+            end)
+        }
+      ]
+    end
+} %>
 
-  <tbody>
-    <% world_locations.each do |world_location| %>
-      <%= content_tag_for(:tr, world_location) do %>
-        <td class="type"><%= world_location.display_type %></td>
-
-        <td>
-          <p>
-            <%= link_to world_location.name, [:admin, world_location.world_location_news], class: "name" %>
-          </p>
-          <p>
-            <% if world_location.world_location_news.mission_statement.present? %>
-              <span class="mission_statement"><%= format_with_html_line_breaks(world_location.world_location_news.mission_statement) %></span>
-            <% else %>
-              <em>No mission statement yet</em>, <%= link_to "create one", edit_admin_world_location_news_path(world_location.world_location_news) %>.
-            <% end %>
-          </p>
-        </td>
-
-        <td class="status"><%= world_location.active? ? "active" : "inactive" %></td>
-
-        <td class="translations">
-          <% if world_location.non_english_translated_locales.any? %>
-            <%= world_location.non_english_translated_locales.map do |locale|
-              link_to "#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code)
-            end.to_sentence.html_safe %>
-          <% else %>
-            none
-          <% end %>
-        </td>
-
-      <% end %>
-    <% end %>
-
-  </tbody>
-</table>

--- a/app/views/admin/world_location_news/_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_world_location_table.html.erb
@@ -1,7 +1,3 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: title
-} %>
-
 <%= render "govuk_publishing_components/components/table", {
   head: [
     {
@@ -11,10 +7,13 @@
       text: "Location"
     },
     {
-      text: "Status"
+      text: "Details"
     },
     {
       text: "Translations"
+    },
+    {
+      text: "Edit"
     }
   ],
   rows:
@@ -24,28 +23,29 @@
           text: world_location.display_type
         },
         {
-          text:
-            tag.p(link_to(world_location.name, [:admin, world_location.world_location_news], class: "govuk-link"), class: "govuk-body govuk-!-margin-bottom-4") +
-              if world_location.world_location_news.mission_statement.present?
-                format_with_html_line_breaks(world_location.world_location_news.mission_statement)
-              else
-                sanitize(tag.span(tag.em("No mission statement yet, ") + link_to("create one", edit_admin_world_location_news_path(world_location.world_location_news), class: "govuk-link")+ "."))
-              end
-        },
-        {
-          text: world_location.active? ? "active" : "inactive"
+          text: world_location.name
         },
         {
           text:
-            sanitize(if world_location.non_english_translated_locales.any?
-              world_location.non_english_translated_locales.map do |locale|
+            if world_location.world_location_news.mission_statement.present?
+              format_with_html_line_breaks(world_location.world_location_news.mission_statement)
+            else
+              "No mission statement yet."
+            end
+        },
+        {
+          text:
+            if world_location.non_english_translated_locales.any?
+              sanitize(world_location.non_english_translated_locales.map do |locale|
                 link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code), class: "govuk-link")
-              end.to_sentence.html_safe
+              end.to_sentence)
             else
               "none"
-            end)
+            end
+        },
+        {
+          text: link_to(sanitize("Edit#{tag.span(world_location.name, class: "govuk-visually-hidden")}"), [:admin, world_location.world_location_news], class: "govuk-link")
         }
       ]
     end
 } %>
-

--- a/app/views/admin/world_location_news/index.html.erb
+++ b/app/views/admin/world_location_news/index.html.erb
@@ -6,12 +6,12 @@
     {
       id: "active_tab",
       label: "Active",
-      content: render(partial: "world_location_table", locals: {world_locations: @active_world_locations})
+      content: render(partial: "world_location_table", locals: {world_locations: @active_world_locations, error_message: "No active world location news."})
     },
     {
       id: "inactive_tab",
       label: "Inactive",
-      content: render(partial: "world_location_table", locals: {world_locations: @inactive_world_locations})
+      content: render(partial: "world_location_table", locals: {world_locations: @inactive_world_locations, error_message: "No inactive world location news."})
     }
   ]
 } %>

--- a/app/views/admin/world_location_news/index.html.erb
+++ b/app/views/admin/world_location_news/index.html.erb
@@ -1,6 +1,17 @@
 <% content_for :page_title, "World location news" %>
 <% content_for :title, "World location news" %>
 
-<%= render partial: "world_location_table", locals: {title: "Active", world_locations: @active_world_locations } %>
-
-<%= render partial: "world_location_table", locals: {title: "Inactive", world_locations: @inactive_world_locations } %>
+<%= render "govuk_publishing_components/components/tabs", {
+  tabs: [
+    {
+      id: "active_tab",
+      label: "Active",
+      content: render(partial: "world_location_table", locals: {world_locations: @active_world_locations})
+    },
+    {
+      id: "inactive_tab",
+      label: "Inactive",
+      content: render(partial: "world_location_table", locals: {world_locations: @inactive_world_locations})
+    }
+  ]
+} %>

--- a/app/views/admin/world_location_news/index.html.erb
+++ b/app/views/admin/world_location_news/index.html.erb
@@ -1,5 +1,5 @@
-<% page_title "World location news" %>
-<h1>World location news</h1>
+<% content_for :page_title, "World location news" %>
+<% content_for :title, "World location news" %>
 
 <%= render partial: "world_location_table", locals: {title: "Active", world_locations: @active_world_locations } %>
 

--- a/app/views/admin/world_location_news/legacy_index.html.erb
+++ b/app/views/admin/world_location_news/legacy_index.html.erb
@@ -1,0 +1,6 @@
+<% page_title "World location news" %>
+<h1>World location news</h1>
+
+<%= render partial: "legacy_world_location_table", locals: {title: "Active", world_locations: @active_world_locations } %>
+
+<%= render partial: "legacy_world_location_table", locals: {title: "Inactive", world_locations: @inactive_world_locations } %>

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -1,0 +1,15 @@
+Given(/^no world locations exist$/) do
+  WorldLocation.delete_all
+end
+
+When(/^I visit the world location news page$/) do
+  visit admin_world_location_news_index_path
+end
+
+When(/^I click the Inactive tab$/) do
+  click_link "Inactive", class: "govuk-tabs__tab"
+end
+
+Then(/^I should see the "([^"]*)" message$/) do |message|
+  expect(page).to have_selector("p", text: "#{message}.")
+end

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -1,0 +1,9 @@
+Feature: Administering world location news information
+  @design-system-only
+  Scenario: Viewing the list presents no world location news message, when no news exists
+    Given no world locations exist
+    And I am a GDS admin
+    When I visit the world location news page
+    Then I should see the "No active world location news" message
+    When I click the Inactive tab
+    Then I should see the "No inactive world location news" message

--- a/test/functional/admin/legacy_world_location_news_controller_test.rb
+++ b/test/functional/admin/legacy_world_location_news_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-class Admin::WorldLocationNewsControllerTest < ActionController::TestCase
+class Admin::LegacyWorldLocationNewsControllerTest < ActionController::TestCase
+  tests Admin::WorldLocationNewsController
+
   setup do
-    login_as_preview_design_system_user(:gds_editor)
+    login_as :writer
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
## Description

This ports the world_location_news index page to the GOV.UK Design System. It appends legacy to the current view. Then adds the new view in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshots
<img width="1344" alt="Screenshot 2023-03-17 at 14 55 27" src="https://user-images.githubusercontent.com/91492293/225940753-68c6cc77-ee1b-42f9-b97b-41520beb4cca.png">
<img width="1344" alt="Screenshot 2023-03-17 at 14 55 35" src="https://user-images.githubusercontent.com/91492293/225940775-3d7d0e3d-525e-4c53-9512-a6639335459e.png">

![Screenshot 2023-03-21 at 10 37 19](https://user-images.githubusercontent.com/91492293/226582240-f0bcc976-9b94-4c40-aeb5-b7a1f9e8b04b.png)

![Screenshot 2023-03-21 at 10 37 23](https://user-images.githubusercontent.com/91492293/226582273-0a84bebb-fd61-4db1-812b-77a263c29995.png)

## Trello

https://trello.com/c/DdEO3vou

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
