### PR TITLE
World_news show replace bootstrap with GDS

### DIFF
--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -4,7 +4,9 @@ class Admin::WorldLocationNewsController < Admin::BaseController
 
   def edit; end
 
-  def show; end
+  def show
+    render_design_system("show", "legacy_show", next_release: false)
+  end
 
   def index
     @active_world_locations, @inactive_world_locations = WorldLocation.ordered_by_name.partition(&:active?)
@@ -63,10 +65,8 @@ private
   end
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    design_system_actions = %w[show]
+    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"

--- a/app/helpers/admin/world_location_helper.rb
+++ b/app/helpers/admin/world_location_helper.rb
@@ -1,4 +1,31 @@
 module Admin::WorldLocationHelper
+  def world_location_news_nav_items(world_location_instance, path)
+    [
+      {
+        label: "Details",
+        href: admin_world_location_news_path(world_location_instance),
+        current: path == admin_world_location_news_path(world_location_instance),
+      },
+      {
+        label: "Translations",
+        href: admin_world_location_news_translations_path(world_location_instance),
+        current: path == admin_world_location_news_translations_path(world_location_instance),
+      },
+      {
+        label: "Features (#{Locale.new(:en).native_language_name})",
+        href: features_admin_world_location_news_path(world_location_instance, locale: I18n.locale),
+        current: path == features_admin_world_location_news_path(world_location_instance),
+      },
+      world_location_instance.non_english_translated_locales.map do |locale|
+        {
+          label: "Features (#{locale.native_language_name})",
+          href: features_admin_world_location_news_path(world_location_instance, locale: locale.code),
+          current: path == features_admin_world_location_news_path(world_location_instance, locale: locale.code),
+        }
+      end,
+    ].flatten.compact
+  end
+
   def world_location_news_tabs(world_location)
     tabs = {
       "Details" => admin_world_location_news_path(world_location),

--- a/app/views/admin/world_location_news/edit.html.erb
+++ b/app/views/admin/world_location_news/edit.html.erb
@@ -3,12 +3,12 @@
 <div class="row">
   <section class="col-md-8">
     <h1>Edit world location</h1>
-  <p class="warning">Warning: changes to worldwide locations appear instantly on the live site.</p>
+    <p class="warning">Warning: changes to worldwide locations appear instantly on the live site.</p>
     <%= form_for([:admin, @world_location_news]) do |form| %>
       <%= form.fields_for :world_location, @world_location do |location_form| %>
         <div class="form-group">
           <%= location_form.label :world_location_type, 'Type' %>
-          <%= location_form.select :world_location_type, WorldLocation.world_location_types.keys.map {|key| [I18n.t("world_location.type.#{key}", count: 1), key]}, {}, {class: 'form-control input-md-3'} %>
+          <%= location_form.select :world_location_type, WorldLocation.world_location_types.keys.map { |key| [I18n.t("world_location.type.#{key}", count: 1), key] }, {}, { class: 'form-control input-md-3' } %>
         </div>
 
         <%= form.text_field :title %>
@@ -18,7 +18,7 @@
         } %>
 
         <%= location_form.check_box :active,
-                  label_text: "Active (can visitors click through from the world location list?)" %>
+                                    label_text: "Active (can visitors click through from the world location list?)" %>
 
         <%= render 'admin/shared/featured_link_fields', form: form %>
       <% end %>

--- a/app/views/admin/world_location_news/legacy_show.html.erb
+++ b/app/views/admin/world_location_news/legacy_show.html.erb
@@ -1,0 +1,24 @@
+<% page_title @world_location_news.name %>
+<% page_class "world-location-show" %>
+
+<%= content_tag_for(:div, @world_location_news) do %>
+  <div class="world-location-header">
+    <h1>
+      <span class="name"><%= @world_location_news.name %></span>
+    </h1>
+    <p>
+      <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %>
+  </div>
+
+  <section class="world-location-details">
+    <%= tab_navigation_for(@world_location_news) %>
+
+    <div class="mission-statement lead">
+      <%= govspeak_to_html @world_location_news.mission_statement %>
+    </div>
+
+    <div class="form-actions">
+      <%= link_to "Edit", [:edit, :admin, @world_location_news], class: "btn btn-lg btn-primary" %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
-        <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link" %>
+        <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link", target: "_blank" %>
       </p>
       <%= render "components/secondary_navigation", {
         aria_label: "Document tabs",

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -1,24 +1,25 @@
-<% page_title @world_location_news.name %>
-<% page_class "world-location-show" %>
-
-<%= content_tag_for(:div, @world_location_news) do %>
-  <div class="world-location-header">
-    <h1>
-      <span class="name"><%= @world_location_news.name %></span>
-    </h1>
-    <p>
-    <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options) %>
-  </div>
-
-  <section class="world-location-details">
-    <%= tab_navigation_for(@world_location_news) %>
-
-    <div class="mission-statement lead">
+<% content_for :page_title, @world_location_news.name %>
+<% content_for :context, "World location" %>
+<% content_for :title, @world_location_news.name %>
+<% content_for :title_margin_bottom, 4 %>
+<div class="govuk-!-margin-bottom-8">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link" %>
+      </p>
+      <%= render "components/secondary_navigation", {
+        aria_label: "Document tabs",
+        items: world_location_news_nav_items(@world_location_news, current_page?)
+      } %>
+      <div class="govuk-!-margin-bottom-4">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Edit",
+          secondary_solid: true,
+          href: [:edit, :admin, @world_location_news]
+        } %>
+      </div>
       <%= govspeak_to_html @world_location_news.mission_statement %>
     </div>
-
-    <div class="form-actions">
-      <%= link_to "Edit", [:edit, :admin, @world_location_news], class: "btn btn-lg btn-primary"%>
-    </div>
-  </section>
-<% end %>
+  </div>
+</div>

--- a/test/functional/admin/legacy_world_location_news_controller_test.rb
+++ b/test/functional/admin/legacy_world_location_news_controller_test.rb
@@ -1,8 +1,7 @@
 require "test_helper"
 
 class Admin::LegacyWorldLocationNewsControllerTest < ActionController::TestCase
-  tests Admin::WorldLocationNewsController
-
+  tests(Admin::WorldLocationNewsController)
   setup do
     login_as :writer
   end

--- a/test/functional/admin/world_location_news_controller_test.rb
+++ b/test/functional/admin/world_location_news_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::WorldLocationNewsControllerTest < ActionController::TestCase
   setup do
-    login_as_preview_design_system_user(:gds_editor)
+    login_as_preview_design_system_user :writer
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
# What
* Dupe and Rename `show`
* Dupe and Rename `controller_test`
* Added `next_release` to `controller`
* Added `layout` to `controller`
* GDS to `show` 
# Why
* Show to GDS 
# Trello
https://trello.com/c/kNntszsl/51-world-location-news-show-page
# Pics
![Screenshot 2023-03-17 at 14 03 49](https://user-images.githubusercontent.com/125891738/225927418-3cd3ef76-2b7a-481b-ad38-41d2b7f00bd1.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
