### PR TITLE
Skip additional callbacks in database seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ end
 
 if Organisation.where(name: "HM Revenue & Customs").blank?
   Organisation.skip_callback(:commit, :after, :publish_to_publishing_api)
+  Organisation.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
   Organisation.create!(
     name: "HM Revenue & Customs",
     slug: "hm-revenue-customs",
@@ -86,6 +87,10 @@ if WorldLocation.where(name: "Test International Delegation").blank?
     Role.skip_callback(:commit, :after, :publish_to_publishing_api)
     Person.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:commit, :after, :publish_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
+    HistoricalAccount.skip_callback(:commit, :after, :publish_to_publishing_api)
+    HistoricalAccount.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
 
     prime_minister_role = Role.create!(
       name: "Prime Minister",


### PR DESCRIPTION
When running the seeds on a fresh project install (such as through `make whitehall` in `govuk-docker`), there are several calls made to `publishing-api` which fail, causing the seeds to break and stop running any further.

Looking through the seeds, these calls to `publishing-api` are unintentional and the relevant callbacks should be skipped as they already are for some of the seeds.