### PR TITLE
Adjust presentation of operational fields to include casualties

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -16,7 +16,9 @@ module PublishingApi
         content.merge!(PayloadBuilder::PolymorphicPath.for(operational_field))
         content.merge!(
           description: operational_field.description,
-          details: {},
+          details: {
+            casualties:,
+          },
           document_type: "field_of_operation",
           locale: "en",
           publishing_app: "whitehall",
@@ -26,6 +28,11 @@ module PublishingApi
           update_type:,
         )
       end
+    end
+
+    def casualties
+      notices = operational_field.published_fatality_notices.order("first_published_at desc")
+      Hash[notices.map { |notice| [notice.id, notice.fatality_notice_casualties.map(&:personal_details)] }]
     end
 
     def links

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -7,7 +7,17 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       name: "Operational Field name",
       description: "Operational Field description",
     )
-    @fatality_notices_for_operational_field = (0..4).map { |_i| create(:published_fatality_notice, operational_field: @operational_field) }
+    @fatality_notices_for_operational_field = []
+    @casualty_hash = {}
+    2.times do |i|
+      notice = create(:published_fatality_notice, roll_call_introduction: "Fatality Notice #{i}", operational_field: @operational_field)
+      @casualty_hash[notice.id] = []
+      2.times do |j|
+        casualty = create(:fatality_notice_casualty, fatality_notice: notice, personal_details: "personal details #{i} - #{j}")
+        @casualty_hash[notice.id] << casualty.personal_details
+      end
+      @fatality_notices_for_operational_field << notice
+    end
     create(:published_fatality_notice, operational_field: create(:operational_field))
     %i[draft_fatality_notice
        submitted_fatality_notice
@@ -30,7 +40,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       publishing_app: "whitehall",
       update_type: "major",
       base_path: "/government/fields-of-operation/operational-field-name",
-      details: {},
+      details: { casualties: @casualty_hash },
       document_type: "field_of_operation",
       rendering_app: "whitehall-frontend",
       schema_name: "field_of_operation",


### PR DESCRIPTION
This will allow us to show this information on the field pages

Relies on - https://github.com/alphagov/whitehall/compare/adjust-presentation?expand=1
Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
