### PR TITLE
Add image upload success banner

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -27,7 +27,7 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image.build_image_data(image_params["image_data"])
 
     if @new_image.save
-      redirect_to edit_admin_edition_image_path(@edition, @new_image.id)
+      redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.image_data.carrierwave_image} successfully uploaded"
     else
       # Removes @new_image from the edition, otherwise the index page will attempt to render it and error
       @edition.images.delete(@new_image)


### PR DESCRIPTION
## What
Adds a success banner for image uploads on the edit page

## Why
There is no image upload success banner at present. 

### Additional information
The original Figma designs intended the success banner to appear on the index page after updating the caption on the edit page. The current workflow means `.new_record?` returns `false` for an uploaded image once the user is redirected to the edit page after upload. This complicates the matter of showing the success banner on the index page. This was discussed with @nnagewad who approved the relocation of the upload success banner to the edit page, simplifying the solution.

## Screenshots 
![whitehall-admin dev gov uk_government_admin_editions_1408685_images_479225_edit(iPad Pro)](https://user-images.githubusercontent.com/94846816/226623524-ebde5ea9-602a-44d5-a95e-a79c3e3fc01a.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
