### PR TITLE
Remove UrlMaker for various `html_attachments`

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,12 +12,11 @@ class ApplicationRecord < ActiveRecord::Base
       path = "#{path}.#{options[:format]}"
     end
 
-    if options[:cachebust]
-      query_params = {
-        cachebust: options[:cachebust],
-      }
-      path = "#{path}?#{query_params.to_query}"
-    end
+    query_params = {}
+    query_params[:cachebust] = options[:cachebust] if options[:cachebust]
+    query_params[:preview] = options[:preview] if options[:preview]
+
+    path = "#{path}?#{query_params.to_query}" unless query_params.empty?
 
     path = "#{path}##{options[:anchor]}" if options[:anchor]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,16 +90,11 @@ Whitehall::Application.routes.draw do
     # End of public facing routes still rendered by Whitehall
 
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
-    get "/consultations/:consultation_id/:id", as: "consultation_html_attachment", to: rack_404
-    get "/consultations/:consultation_id/outcome/:id", as: "consultation_outcome_html_attachment", to: rack_404
-    get "/consultations/:consultation_id/public-feedback/:id", as: "consultation_public_feedback_html_attachment", to: rack_404
     get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
-    get "/publications/:publication_id/:id", as: "publication_html_attachment", to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
     get "/statistics/announcements/:id", as: "statistics_announcement", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
-    get "/statistics/:statistics_id/:id", as: "statistic_html_attachment", to: rack_404
 
     resources :organisations, only: [] do
       # These aren't rendered but are coupled to Worldwide organisation corporate information pages

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -34,6 +34,17 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url returns absolute path to the draft stack when previewing with a cachebust" do
+    edition = create(:draft_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+
+    expected = "https://draft-origin.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123&preview=#{attachment.id}"
+    actual = attachment.url(preview: true, full_url: true, cachebust: "123")
+
+    assert_equal expected, actual
+  end
+
   test "#url returns absolute path to the draft stack when previewing for non-english locale" do
     edition = create(:draft_publication, :with_html_attachment)
     attachment = edition.attachments.first


### PR DESCRIPTION
This follows a similar vein in the below PR of making models aware of their own routes so we can stop relying on Rails helper methods to generate URL's. Not quite so simple in this case as this model covered 5 individual routes that were no longer rendered by Whitehall, so rather than completely re-do how URL's for this model are provided elsewhere, I've slightly rejigged the normal application of `public_path` and `public_url`.

This also involved an addition to the `append_url_options` method to allow previews URL's to be generated.

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
