### PR TITLE
Remove topical event featuring presenter

### DIFF
--- a/app/presenters/topical_event_featuring_presenter.rb
+++ b/app/presenters/topical_event_featuring_presenter.rb
@@ -1,7 +1,0 @@
-class TopicalEventFeaturingPresenter < Whitehall::Decorators::Decorator
-  delegate_instance_methods_of TopicalEventFeaturing
-
-  def image_tag(size)
-    model.image.file.url(size || :s630)
-  end
-end


### PR DESCRIPTION
Have checked and it doesn't appear to be used anywhere

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
