### PR TITLE
Setup get involved controller

### DIFF
--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -1,9 +1,21 @@
 class Admin::GetInvolvedController < Admin::BaseController
   before_action :enforce_permissions!
+  layout :get_layout
 
   def enforce_permissions!
     enforce_permission!(:administer, :get_involved_section)
   end
 
   def index; end
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 end

--- a/test/functional/admin/legacy_get_involved_controller_test.rb
+++ b/test/functional/admin/legacy_get_involved_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-class Admin::GetInvolvedControllerTest < ActionController::TestCase
+class Admin::LegacyGetInvolvedControllerTest < ActionController::TestCase
+  tests Admin::GetInvolvedController
+
   setup do
-    login_as_preview_design_system_user(:gds_editor)
+    login_as :gds_editor
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
This change sets up the controller to allow developers to work on multiple get involved tickets at the same time.

Without this, changes will conflict with each other and will cause a lot of work to merge.

https://trello.com/c/OfkNmDQz/75-get-involved-section-setup

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
