### PR TITLE
Prefix memcache keys and make the prefix configurable.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,8 +68,8 @@ Whitehall::Application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  config.cache_store = :mem_cache_store
+  # Prefix memcache keys to avoid name clashes when sharing a cache.
+  config.cache_store = :mem_cache_store, nil, { namespace: ENV.fetch("MEMCACHE_KEY_PREFIX", "whitehall"), compress: true }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Make Whitehall prefix its memcache keys so that it can share a memcache with other apps without name clashes. Most of the other GOV.UK apps already do this.

Unlike the other apps, Whitehall needs the prefix to be configurable. This is because the same Whitehall binary is run in two different configurations as `whitehall-admin` and `whitehall-frontend`. This way we can be sure that keys from those two deployments aren't going to collide (not that it would necessarily be a practical problem if they did, but it would be unexpected and unnecessarily complex behaviour so allowing the user to keep the keys separate is clearly the least-surprise choice here).

This will allow us to enable the Rails cache for `whitehall-admin`, which we used to have (albeit per EC2 instance) on the old hosting setup.