### PR TITLE
Make StatisticsAnnouncements aware of it's own base path

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -143,7 +143,15 @@ class StatisticsAnnouncement < ApplicationRecord
   end
 
   def base_path
-    Whitehall.url_maker.statistics_announcement_path(self)
+    "/government/statistics/announcements/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 
   alias_method :search_link, :base_path

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -11,7 +11,7 @@
         <%= @statistics_announcement.title %>
       </span>
     </h1>
-    <%= link_to "View announcement on GOV.UK", statistics_announcement_url(@statistics_announcement, public_and_cachebusted_url_options) %>
+    <%= view_on_website_link_for @statistics_announcement %>
 
     <% if @statistics_announcement.cancelled? %>
       <div class="alert alert-danger add-top-margin">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -125,6 +125,40 @@
       "note": ""
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "7e1e98f6a994a61f63f282a08bd17ca64302efd1377424988a0fc68b5ee5ab16",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/admin/statistics_announcements/show.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"View announcement on GOV.UK\", StatisticsAnnouncement.friendly.find(params[:id]).public_url(public_and_cachebusted_url_options))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::StatisticsAnnouncementsController",
+          "method": "show",
+          "line": 15,
+          "file": "app/controllers/admin/statistics_announcements_controller.rb",
+          "rendered": {
+            "name": "admin/statistics_announcements/show",
+            "file": "app/views/admin/statistics_announcements/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/statistics_announcements/show"
+      },
+      "user_input": "StatisticsAnnouncement.friendly.find(params[:id]).public_url(public_and_cachebusted_url_options)",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "82dea23cb472eca9cd5c4217767e59cab37e956a57572095a7f225d47aff2db8",
@@ -333,7 +367,7 @@
           "type": "controller",
           "class": "Admin::PeopleController",
           "method": "show",
-          "line": 26,
+          "line": 27,
           "file": "app/controllers/admin/people_controller.rb",
           "rendered": {
             "name": "admin/people/show",
@@ -387,6 +421,6 @@
       "note": "We don't use the user data directly to find the template, it comes from the database."
     }
   ],
-  "updated": "2023-03-14 13:32:00 +0000",
-  "brakeman_version": "5.4.0"
+  "updated": "2023-03-23 12:43:52 +0000",
+  "brakeman_version": "5.3.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,6 @@ Whitehall::Application.routes.draw do
     get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
-    get "/statistics/announcements/:id", as: "statistics_announcement", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
 
     resources :organisations, only: [] do

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -8,7 +8,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
   test "a scheduled statistics announcement presents the correct values" do
     statistics_announcement = create(:statistics_announcement)
 
-    public_path = Whitehall.url_maker.statistics_announcement_path(statistics_announcement)
+    public_path = statistics_announcement.public_path
 
     expected_content = {
       base_path: public_path,
@@ -52,7 +52,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
   test "a cancelled statistics announcement presents the correct values" do
     statistics_announcement = create(:cancelled_statistics_announcement)
 
-    public_path = Whitehall.url_maker.statistics_announcement_path(statistics_announcement)
+    public_path = statistics_announcement.public_path
 
     expected_content = {
       base_path: public_path,
@@ -102,7 +102,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       change_note: "Reasons",
     )
 
-    public_path = Whitehall.url_maker.statistics_announcement_path(statistics_announcement)
+    public_path = statistics_announcement.public_path
 
     expected_content = {
       base_path: public_path,


### PR DESCRIPTION
Done as part of the work to remove the use of UrlMaker from routes no longer rendered by whitehall.

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
