### PR TITLE
Transition Roles index page to GDS Design System 

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -5,6 +5,8 @@ class Admin::RolesController < Admin::BaseController
   def index
     @roles = Role.includes(:role_appointments, :current_people, :translations, organisations: [:translations])
                   .order("organisation_translations.name, roles.type DESC, roles.permanent_secretary DESC, role_translations.name")
+
+    render_design_system("index", "legacy_index", next_release: false)
   end
 
   def new
@@ -75,7 +77,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -34,6 +34,10 @@ class Admin::RolesController < Admin::BaseController
     end
   end
 
+  def confirm_destroy
+    @role = Role.find(params[:id])
+  end
+
   def destroy
     notice = %("#{@role.name}" destroyed.)
     if @role.destroy
@@ -77,7 +81,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index confirm_destroy] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/roles/confirm_destroy.html.erb
+++ b/app/views/admin/roles/confirm_destroy.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Delete role" %>
+<% content_for :title, "Delete #{@role}" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag admin_role_path(@role), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to delete the "<%= @role %>" role?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", admin_roles_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,17 +1,19 @@
 <% content_for :page_title, "Roles" %>
 <% content_for :title, "Roles" %>
-
-<%= render "govuk_publishing_components/components/warning_text", {
-  text: "Do not create ministerial roles without consulting GDS.",
-  highlight_text: true
-} %>
+<% content_for :title_margin_bottom, 6 %>
 
 <%= render "govuk_publishing_components/components/button", {
-  title: "Create a role",
-  text: "Create role",
-  secondary_solid: true,
-  href: new_admin_role_path
+  title: "Create new role",
+  text: "Create new role",
+  href: new_admin_role_path,
+  margin_bottom: 6
 } %>
+
+<div class="govuk-!-margin-bottom-6">
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "Do not create ministerial roles without consulting GDS."
+  } %>
+</div>
 
 <%= render "govuk_publishing_components/components/table", {
   head: [
@@ -31,13 +33,16 @@
       text: "Translations"
     },
     {
-      text: "Actions"
+      text: "Edit"
+    },
+    {
+      text: "Delete"
     }
   ],
   rows: @roles.map do |role|
     [
       {
-        text: link_to(role.name, edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link")
+        text: role.name
       },
       {
         text: role.organisation_names
@@ -55,16 +60,14 @@
           end
       },
       {
+        text: link_to(sanitize("Edit#{tag.span(role.name, class: "govuk-visually-hidden")}"), edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link")
+      },
+      {
         text:
             if role.destroyable?
-                form_tag admin_role_path(role), method: :delete  do
-                  render "govuk_publishing_components/components/button", {
-                    text: "delete",
-                    destructive: true
-                  }
-                end
+                link_to(sanitize("Delete#{tag.span(role.name, class: "govuk-visually-hidden")}"), confirm_destroy_admin_role_path(role), class: "govuk-link govuk-link--no-visited-state gem-link--destructive")
             else
-              tag.span("Cannot delete")
+              ""
             end
       }
     ]

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,42 +1,72 @@
-<% page_title "Roles" %>
-<h1>Roles</h1>
-<p class="warning remove-top-margin">Do not create ministerial roles without consulting GDS.</p>
+<% content_for :page_title, "Roles" %>
+<% content_for :title, "Roles" %>
 
-<%= link_to "Create role", new_admin_role_path, class: "btn btn-default new_resource", title: "Create a Role" %>
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: "Do not create ministerial roles without consulting GDS.",
+  highlight_text: true
+} %>
 
-<table class="roles table table-striped table-bordered add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th width="30%">Name</th>
-      <th width="15%">Organisations</th>
-      <th>Role type</th>
-      <th>Currently appointed</th>
-      <th>Translations</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @roles.each do |role| %>
-      <%= content_tag_for(:tr, role) do %>
-        <td class="name"><%= link_to role.name, edit_admin_role_path(role), title: "Edit role #{role.name}" %></td>
-        <td class="organisations"><%= role.organisation_names %></td>
-        <td class="role_type"><%= role.role_type.humanize %></td>
-        <td class="person"><%= role.current_person_name %></td>
-        <td class="translations">
-            <%= link_to "Manage translations", admin_role_translations_path(role), title: "Manage translations of #{role.name}" %>
-        </td>
-        <td class="delete">
-          <% if role.destroyable? %>
-            <%= button_to 'delete',
-                  admin_role_path(role),
-                  method: :delete,
-                  class: 'btn btn-danger',
-                  data: { confirm: "Are you sure you wish to remove this role?" } %>
-          <% else %>
-            <span>Cannot delete</span>
-          <% end %>
-        </td>
-      <% end %>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/button", {
+  title: "Create a role",
+  text: "Create role",
+  secondary_solid: true,
+  href: new_admin_role_path
+} %>
+
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Name"
+    },
+    {
+      text: "Organistions"
+    },
+    {
+      text: "Role type"
+    },
+    {
+      text: "Currently appointed"
+    },
+    {
+      text: "Translations"
+    },
+    {
+      text: "Actions"
+    }
+  ],
+  rows: @roles.map do |role|
+    [
+      {
+        text: link_to(role.name, edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link")
+      },
+      {
+        text: role.organisation_names
+      },
+      {
+        text: role.role_type.humanize
+      },
+      {
+        text: role.current_person_name
+      },
+      {
+        text:
+          content_tag_for(:div, role) do
+            link_to(sanitize("Manage translations#{tag.span(role.name, class: "govuk-visually-hidden")}"), admin_role_translations_path(role), title: "Manage translations of #{role.name}", class: "govuk-link")
+          end
+      },
+      {
+        text:
+            if role.destroyable?
+                form_tag admin_role_path(role), method: :delete  do
+                  render "govuk_publishing_components/components/button", {
+                    text: "delete",
+                    destructive: true
+                  }
+                end
+            else
+              tag.span("Cannot delete")
+            end
+      }
+    ]
+    end
+} %>

--- a/app/views/admin/roles/legacy_index.html.erb
+++ b/app/views/admin/roles/legacy_index.html.erb
@@ -1,0 +1,42 @@
+<% page_title "Roles" %>
+<h1>Roles</h1>
+<p class="warning remove-top-margin">Do not create ministerial roles without consulting GDS.</p>
+
+<%= link_to "Create role", new_admin_role_path, class: "btn btn-default new_resource", title: "Create a Role" %>
+
+<table class="roles table table-striped table-bordered add-top-margin">
+  <thead>
+    <tr class="table-header">
+      <th width="30%">Name</th>
+      <th width="15%">Organisations</th>
+      <th>Role type</th>
+      <th>Currently appointed</th>
+      <th>Translations</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @roles.each do |role| %>
+      <%= content_tag_for(:tr, role) do %>
+        <td class="name"><%= link_to role.name, edit_admin_role_path(role), title: "Edit role #{role.name}" %></td>
+        <td class="organisations"><%= role.organisation_names %></td>
+        <td class="role_type"><%= role.role_type.humanize %></td>
+        <td class="person"><%= role.current_person_name %></td>
+        <td class="translations">
+            <%= link_to "Manage translations", admin_role_translations_path(role), title: "Manage translations of #{role.name}" %>
+        </td>
+        <td class="delete">
+          <% if role.destroyable? %>
+            <%= button_to 'delete',
+                  admin_role_path(role),
+                  method: :delete,
+                  class: 'btn btn-danger',
+                  data: { confirm: "Are you sure you wish to remove this role?" } %>
+          <% else %>
+            <span>Cannot delete</span>
+          <% end %>
+        </td>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,6 +312,7 @@ Whitehall::Application.routes.draw do
 
         resource :cabinet_ministers, only: %i[show update]
         resources :roles, except: [:show] do
+          get :confirm_destroy, on: :member
           resources :role_appointments, only: %i[new create edit update destroy], shallow: true
           resources :translations, controller: "role_translations"
         end

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -60,8 +60,8 @@ end
 
 When(/^I appoint "(.*?)" as the "(.*?)"$/) do |person_name, role_name|
   visit admin_roles_path
-  role = Role.find_by(name: role_name)
-  click_on role.name
+
+  click_on using_design_system? ? "Edit#{role_name}" : role_name
   click_on "New appointment"
   select person_name, from: "Person"
   click_on "Save"
@@ -79,7 +79,7 @@ end
 
 Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
   role = Role.last
-  click_on role.name
+  click_on using_design_system? ? "Edit#{role.name}" : role.name
   click_on "New appointment"
   select person_name, from: "Person"
   select_date 1.day.ago.to_s, from: "Started at"

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -25,7 +25,7 @@ When(/^I add a new "([^"]*)" role named "([^"]*)" to the "([^"]*)"$/) do |role_t
   @role_name = role_name
 
   visit admin_roles_path
-  click_on "Create role"
+  click_on using_design_system? ? "Create new role" : "Create role"
   fill_in "Role title", with: role_name
   select role_type, from: "Role type"
   select organisation_name, from: "Organisations"
@@ -34,7 +34,7 @@ end
 
 When(/^I add a new "([^"]*)" role named "([^"]*)" to the "([^"]*)" worldwide organisation$/) do |role_type, role_name, worldwide_organisation_name|
   visit admin_roles_path
-  click_on "Create role"
+  click_on using_design_system? ? "Create new role" : "Create role"
   fill_in "Role title", with: role_name
   select role_type, from: "Role type"
   select worldwide_organisation_name, from: "Worldwide organisations"

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -148,7 +148,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "provides delete buttons for destroyable roles" do
+  view_test "provides delete link for destroyable roles" do
     destroyable_role = create(:role_without_organisations)
     edition = create(:edition)
     indestructable_role = create(:ministerial_role)
@@ -158,13 +158,10 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table__body" do
       assert_select "tr:nth-child(1)" do
-        assert_select "form[action='#{admin_role_path(destroyable_role)}']" do
-          assert_select "input[name='_method'][value='delete']"
-          assert_select "button[type='submit']", "delete"
-        end
+        assert_select "a[href=?]", confirm_destroy_admin_role_path(destroyable_role), text: "Delete#{destroyable_role.name}"
       end
       assert_select "tr:nth-child(2)" do
-        refute_select "form[action='#{admin_role_path(indestructable_role)}']"
+        refute_select "a[href=?]", confirm_destroy_admin_role_path(indestructable_role), text: "Delete#{destroyable_role.name}"
       end
     end
   end
@@ -326,6 +323,17 @@ class Admin::RolesControllerTest < ActionController::TestCase
     put :update, params: { id: role, role: attributes_for(:role, name: nil) }
 
     assert_select ".form-errors"
+  end
+
+  view_test "confirm_destroy should display form for deleting an existing role" do
+    role = create(:role_without_organisations, name: "Prime Minister")
+
+    get :confirm_destroy, params: { id: role }
+
+    assert_select "form[action='#{admin_role_path(role)}']" do
+      assert_select "button[type='submit']", "Delete"
+      assert_select "a[href=?]", "/government/admin/roles", "Cancel"
+    end
   end
 
   test "should be able to destroy a destroyable role" do

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -13,35 +13,35 @@ class Admin::RolesControllerTest < ActionController::TestCase
     person = create(:person, forename: "person-name")
     ministerial_role = create(:ministerial_role, name: "ministerial-role", cabinet_member: true, organisations: [org_one, org_two])
     create(:role_appointment, role: ministerial_role, person:)
-    management_role = create(:board_member_role, name: "management-role", permanent_secretary: true, organisations: [org_one])
-    military_role = create(:military_role, name: "military-role", organisations: [org_two])
-    chief_professional_officer_role = create(:chief_professional_officer_role, name: "chief-professional-officer-role", organisations: [org_one])
+    create(:board_member_role, name: "management-role", permanent_secretary: true, organisations: [org_one])
+    create(:military_role, name: "military-role", organisations: [org_two])
+    create(:chief_professional_officer_role, name: "chief-professional-officer-role", organisations: [org_one])
     get :index
 
-    assert_select ".roles" do
-      assert_select_object ministerial_role do
-        assert_select ".name", "ministerial-role"
-        assert_select ".role_type", "Cabinet minister"
-        assert_select ".organisations", "org-one and org-two"
-        assert_select ".person", "person-name"
+    assert_select ".govuk-table__body" do
+      assert_select "tr:nth-child(1)" do
+        assert_select "td:nth-child(1).govuk-table__cell", "ministerial-role"
+        assert_select "td:nth-child(2).govuk-table__cell", "org-one and org-two"
+        assert_select "td:nth-child(3).govuk-table__cell", "Cabinet minister"
+        assert_select "td:nth-child(4).govuk-table__cell", "person-name"
       end
-      assert_select_object management_role do
-        assert_select ".name", "management-role"
-        assert_select ".role_type", "Permanent secretary"
-        assert_select ".organisations", "org-one"
-        assert_select ".person", "No one is assigned to this role"
+      assert_select "tr:nth-child(2)" do
+        assert_select "td:nth-child(1).govuk-table__cell", "chief-professional-officer-role"
+        assert_select "td:nth-child(2).govuk-table__cell", "org-one"
+        assert_select "td:nth-child(3).govuk-table__cell", "Chief professional officer"
+        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
       end
-      assert_select_object chief_professional_officer_role do
-        assert_select ".name", "chief-professional-officer-role"
-        assert_select ".role_type", "Chief professional officer"
-        assert_select ".organisations", "org-one"
-        assert_select ".person", "No one is assigned to this role"
+      assert_select "tr:nth-child(3)" do
+        assert_select "td:nth-child(1).govuk-table__cell", "management-role"
+        assert_select "td:nth-child(2).govuk-table__cell", "org-one"
+        assert_select "td:nth-child(3).govuk-table__cell", "Permanent secretary"
+        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
       end
-      assert_select_object military_role do
-        assert_select ".name", "military-role"
-        assert_select ".role_type", "Chief of staff"
-        assert_select ".organisations", "org-two"
-        assert_select ".person", "No one is assigned to this role"
+      assert_select "tr:nth-child(4)" do
+        assert_select "td:nth-child(1).govuk-table__cell", "military-role"
+        assert_select "td:nth-child(2).govuk-table__cell", "org-two"
+        assert_select "td:nth-child(3).govuk-table__cell", "Chief of staff"
+        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
       end
     end
   end
@@ -127,11 +127,13 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select_object role_one do
-      assert_select "a[href='#{edit_admin_role_path(role_one)}']"
-    end
-    assert_select_object role_two do
-      assert_select "a[href='#{edit_admin_role_path(role_two)}']"
+    assert_select ".govuk-table__body" do
+      assert_select "tr:nth-child(1)" do
+        assert_select "a[href='#{edit_admin_role_path(role_one)}']"
+      end
+      assert_select "tr:nth-child(2)" do
+        assert_select "a[href='#{edit_admin_role_path(role_two)}']"
+      end
     end
   end
 
@@ -139,8 +141,10 @@ class Admin::RolesControllerTest < ActionController::TestCase
     role = create(:ministerial_role)
     get :index
 
-    assert_select_object role do
-      assert_select "a[href=?]", admin_role_translations_path(role), text: "Manage translations"
+    assert_select ".govuk-table__body" do
+      assert_select "tr:nth-child(1)" do
+        assert_select "a[href=?]", admin_role_translations_path(role), text: "Manage translations#{role.name}"
+      end
     end
   end
 
@@ -152,14 +156,16 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select_object destroyable_role do
-      assert_select ".delete form[action='#{admin_role_path(destroyable_role)}']" do
-        assert_select "input[name='_method'][value='delete']"
-        assert_select "input[type='submit']"
+    assert_select ".govuk-table__body" do
+      assert_select "tr:nth-child(1)" do
+        assert_select "form[action='#{admin_role_path(destroyable_role)}']" do
+          assert_select "input[name='_method'][value='delete']"
+          assert_select "button[type='submit']", "delete"
+        end
       end
-    end
-    assert_select_object indestructable_role do
-      refute_select ".delete form[action='#{admin_role_path(indestructable_role)}']"
+      assert_select "tr:nth-child(2)" do
+        refute_select "form[action='#{admin_role_path(indestructable_role)}']"
+      end
     end
   end
 


### PR DESCRIPTION
## Description

This ports the roles index page to the GOV.UK Design System. Then adds the new view in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshots

### On landing:
![Screenshot 2023-03-24 at 11 18 23](https://user-images.githubusercontent.com/91492293/227508153-0786e61d-258c-4b56-8439-9c37cf901b68.png)
![Screenshot 2023-03-24 at 11 18 39](https://user-images.githubusercontent.com/91492293/227508165-13226b72-dc46-4e4f-ac4d-e9a55982858a.png)
![Screenshot 2023-03-24 at 11 18 52](https://user-images.githubusercontent.com/91492293/227508180-33c69773-c1e6-46ff-a868-ff20df4b8b1a.png)


### Confirmation of Delete view
![Screenshot 2023-03-24 at 11 19 28](https://user-images.githubusercontent.com/91492293/227508258-9d8d17aa-99e6-49ec-a78f-6a95fe198d16.png)

### Following deletion of role
![Screenshot 2023-03-24 at 11 19 54](https://user-images.githubusercontent.com/91492293/227508271-2a67dde6-37c7-41c8-8f3d-41898c3876a7.png)

## Trello

https://trello.com/c/MApp6pCM

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
