### PR TITLE
Reduce noise in the build output

### DIFF
--- a/test/unit/reports/organisation_attachments_report_test.rb
+++ b/test/unit/reports/organisation_attachments_report_test.rb
@@ -8,7 +8,9 @@ class Reports::OrganisationAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/#{organisation.slug}-attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      capture_io do
+        Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      end
 
       assert_equal Reports::OrganisationAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 1, CSV.read(path, headers: true).count
@@ -29,7 +31,9 @@ class Reports::OrganisationAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/#{organisation.slug}-attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      capture_io do
+        Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      end
 
       assert_equal Reports::OrganisationAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 0, CSV.read(path, headers: true).count

--- a/test/unit/reports/published_attachments_report_test.rb
+++ b/test/unit/reports/published_attachments_report_test.rb
@@ -7,7 +7,9 @@ class Reports::PublishedAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::PublishedAttachmentsReport.new.report
+      capture_io do
+        Reports::PublishedAttachmentsReport.new.report
+      end
 
       assert_equal Reports::PublishedAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 1, CSV.read(path, headers: true).count
@@ -20,7 +22,9 @@ class Reports::PublishedAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::PublishedAttachmentsReport.new.report
+      capture_io do
+        Reports::PublishedAttachmentsReport.new.report
+      end
 
       assert_equal Reports::PublishedAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 0, CSV.read(path, headers: true).count

--- a/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
+++ b/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
@@ -34,7 +34,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
       it "does not send the redirection to the Publishing API" do
         PublishingApiRedirectWorker.any_instance.expects(:perform).never
-        call_html_attachment_redirector
+        capture_io { call_html_attachment_redirector }
       end
 
       it "reports the html attachment that would have changed" do
@@ -53,7 +53,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
         it "raises an exception" do
           assert_raises DataHygiene::EditionNotUnpublished do
-            call_html_attachment_redirector
+            capture_io { call_html_attachment_redirector }
           end
         end
       end
@@ -65,7 +65,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
         it "raises an exception" do
           assert_raises DataHygiene::HtmlAttachmentsNotFound do
-            call_html_attachment_redirector
+            capture_io { call_html_attachment_redirector }
           end
         end
       end
@@ -79,7 +79,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
             .expects(:perform)
             .with(attachment.content_id, redirection, attachment.locale)
 
-          call_html_attachment_redirector
+          capture_io { call_html_attachment_redirector }
         end
 
         it "reports the redirections sent to the Publishing API" do
@@ -95,11 +95,13 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
             .expects(:perform)
             .with(attachment.content_id, redirection, attachment.locale)
 
-          DataHygiene::PublishingApiHtmlAttachmentRedirector.call(
-            attachment.content_id,
-            redirection,
-            dry_run:,
-          )
+          capture_io do
+            DataHygiene::PublishingApiHtmlAttachmentRedirector.call(
+              attachment.content_id,
+              redirection,
+              dry_run:,
+            )
+          end
         end
       end
     end

--- a/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
+++ b/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
@@ -43,6 +43,8 @@ class RepublishDraftHtmlAttachmentsWithAssoicatedResponsesRake < ActiveSupport::
       true,
     ).never
 
-    Rake.application.invoke_task "republish_draft_html_attachments_associated_with_responses"
+    capture_io do
+      Rake.application.invoke_task "republish_draft_html_attachments_associated_with_responses"
+    end
   end
 end

--- a/test/unit/tasks/republish_nation_applicable_html_attachments_test.rb
+++ b/test/unit/tasks/republish_nation_applicable_html_attachments_test.rb
@@ -53,6 +53,8 @@ class RepublishNationApplicableHtmlAttachmentsRake < ActiveSupport::TestCase
       true,
     ).never
 
-    Rake.application.invoke_task "republish_nation_inapplicable_html_attachments"
+    capture_io do
+      Rake.application.invoke_task "republish_nation_inapplicable_html_attachments"
+    end
   end
 end


### PR DESCRIPTION
There's quite a lot of noise (i.e. expected output) in the build output. Reducing this noise will make it easier to see any *unexpected* output which might be important to address. I've tried to categorise the noise that we could reduce:

* [x] Various calls to `Kernel#puts` within code under test.
* [ ] The Sidekiq worker logger seems to be configured to use stdout, e.g. `test/unit/workers/check_organisation_links_worker_test.rb`
* [ ] Asset precompilation looks like it's generating a lot of output, i.e. `RAILS_ENV=test bundle exec rails assets:clobber assets:precompile`
* [ ] The Pact specs seems to be run in a very verbose mode, i.e. `SPEC_OPTS='' /root/.rbenv/versions/3.1.2/bin/ruby -S pact verify --pact-helper /govuk/whitehall/spec/service_consumers/pact_helper.rb`
* [ ] Where does this message come from? "Locale files are in sync, nice job!"
* [ ] There are multiple occurrences of this Ruby parser warning (possibly generated by Rubocop?): `warning: parser/current is loading parser/ruby31, which recognizes 3.1.3-compliant syntax, but you are running 3.1.2. Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.`
* [ ] Do we need to generate coverage reports locally? Maybe disable unless `CI` env var or similar is defined.

/cc @chrisroos @chrislo 