### PR TITLE
Get Involved page to GOVUK Design system

### DIFF
--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -9,10 +9,7 @@ class Admin::GetInvolvedController < Admin::BaseController
   def index; end
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: false)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -6,7 +6,9 @@ class Admin::GetInvolvedController < Admin::BaseController
     enforce_permission!(:administer, :get_involved_section)
   end
 
-  def index; end
+  def index
+    render_design_system("index", "legacy_index", next_release: false)
+  end
 
   def get_layout
     if preview_design_system?(next_release: false)

--- a/app/views/admin/get_involved/index.html.erb
+++ b/app/views/admin/get_involved/index.html.erb
@@ -1,9 +1,26 @@
-<% page_title 'Get involved' %>
+<% content_for :page_title, "Get involved" %>
+<% content_for :title, "Get involved" %>
+<% content_for :title_margin_bottom, 4 %>
 
-<div class="get-involved-header">
-  <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_url %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= link_to "View on website", get_involved_url, class: "govuk-link", target: "_blank" %>
+    </p>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Get involved tabs",
+      items: [
+        {
+          label: "Get involved",
+          href: admin_get_involved_path,
+          current: true,
+        },
+        {
+          label: "Take part pages",
+          href: admin_take_part_pages_path,
+        }
+      ]
+    } %>
+  </div>
 </div>
-<section class="get-involved">
-  <%= get_involved_tab_navigation %>
-</section>

--- a/app/views/admin/get_involved/legacy_index.html.erb
+++ b/app/views/admin/get_involved/legacy_index.html.erb
@@ -1,0 +1,9 @@
+<% page_title 'Get involved' %>
+
+<div class="get-involved-header">
+  <h1>Get involved</h1>
+  <%= link_to "View on website", get_involved_url %>
+</div>
+<section class="get-involved">
+  <%= get_involved_tab_navigation %>
+</section>

--- a/test/functional/admin/legacy_get_involved_controller_test.rb
+++ b/test/functional/admin/legacy_get_involved_controller_test.rb
@@ -13,6 +13,6 @@ class Admin::LegacyGetInvolvedControllerTest < ActionController::TestCase
     get :index
 
     assert_response :success
-    assert_template "index"
+    assert_template "legacy_index"
   end
 end


### PR DESCRIPTION
## What

This moves the get involved page to GOVUK Design system

## Why

This work is part of the transition to GOVUK Design project for Whitehall.

https://trello.com/c/z2EmXoY5/71-get-involved-page

## Screenshot

### Before

![whitehall-admin dev gov uk_government_admin_get-involved(iPad Pro) (1)](https://user-images.githubusercontent.com/4599889/227505876-927de913-0c72-4803-9d4f-1debfb304fde.png)

### After

![whitehall-admin dev gov uk_government_admin_get-involved(iPad Pro)](https://user-images.githubusercontent.com/4599889/227505912-40da278a-f32f-47d2-a5af-de3f23b28e72.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
