### PR TITLE
Set up take part controller

### DIFF
--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -1,5 +1,7 @@
 class Admin::TakePartPagesController < Admin::BaseController
   before_action :enforce_permissions!
+  layout :get_layout
+
   def enforce_permissions!
     enforce_permission!(:administer, :get_involved_section)
   end
@@ -47,6 +49,17 @@ class Admin::TakePartPagesController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def take_part_page_params
     params.require(:take_part_page).permit(

--- a/test/functional/admin/legacy_take_part_pages_controller_test.rb
+++ b/test/functional/admin/legacy_take_part_pages_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-class Admin::TakePartPagesControllerTest < ActionController::TestCase
+class Admin::LegacyTakePartPagesControllerTest < ActionController::TestCase
+  tests Admin::TakePartPagesController
+
   setup do
-    login_as_preview_design_system_user(:gds_editor)
+    login_as :gds_editor
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
This change sets up the controller to allow developers to work on multiple take part tickets at the same time.

Without this, changes will conflict with each other and will cause a lot of work to merge.

https://trello.com/c/jhNjkaFS/77-take-part-section-setup

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
