### PR TITLE
Roles edit page transition to design system

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -24,13 +24,15 @@ class Admin::RolesController < Admin::BaseController
 
   def edit
     @role = Role.find(params[:id])
+
+    render_design_system("edit", "legacy_edit", next_release: false)
   end
 
   def update
     if @role.update(role_params)
       redirect_to index_or_edit_path, notice: %("#{@role.name}" updated.)
     else
-      render action: "edit"
+      render_design_system("edit", "legacy_edit", next_release: false)
     end
   end
 
@@ -81,7 +83,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index confirm_destroy] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index confirm_destroy edit update] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/role_appointments/_legacy_list.html.erb
+++ b/app/views/admin/role_appointments/_legacy_list.html.erb
@@ -1,0 +1,8 @@
+<ul>
+<% role_appointments.select(&:persisted?).each do |role_appointment| %>
+  <li>
+    <%= role_appointment.person.name %> (<%= l(role_appointment.started_at.to_date) %> &ndash; <%= role_appointment.ended_at ? l(role_appointment.ended_at.to_date) : 'present' %>)
+    <%= link_to "edit", [:edit, :admin, role_appointment] %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/admin/role_appointments/_list.html.erb
+++ b/app/views/admin/role_appointments/_list.html.erb
@@ -1,8 +1,7 @@
-<ul>
-<% role_appointments.select(&:persisted?).each do |role_appointment| %>
-  <li>
-    <%= role_appointment.person.name %> (<%= l(role_appointment.started_at.to_date) %> &ndash; <%= role_appointment.ended_at ? l(role_appointment.ended_at.to_date) : 'present' %>)
-    <%= link_to "edit", [:edit, :admin, role_appointment] %>
-  </li>
-<% end %>
-</ul>
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items:
+    role_appointments.select(&:persisted?).map do |role_appointment|
+      "#{role_appointment.person.name} (#{l(role_appointment.started_at.to_date)} - #{role_appointment.ended_at ? l(role_appointment.ended_at.to_date) : 'present'}) #{link_to("edit", [:edit, :admin, role_appointment], class: "govuk-link")}"
+    end
+} %>

--- a/app/views/admin/role_appointments/edit.html.erb
+++ b/app/views/admin/role_appointments/edit.html.erb
@@ -34,7 +34,7 @@
 
     <h2>Other appointments to this role</h2>
     <% if @role_appointment.other_appointments_for_same_role.any? %>
-      <%= render partial: "admin/role_appointments/list", locals: {role_appointments: @role_appointment.other_appointments_for_same_role }%>
+      <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.other_appointments_for_same_role }%>
     <% else %>
       <p>None</p>
     <% end %>

--- a/app/views/admin/role_appointments/new.html.erb
+++ b/app/views/admin/role_appointments/new.html.erb
@@ -12,6 +12,6 @@
   </div>
   <div class="col-md-4">
     <h2>Existing appointments</h2>
-    <%= render partial: "admin/role_appointments/list", locals: {role_appointments: @role_appointment.role.role_appointments} %>
+    <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.role.role_appointments} %>
   </div>
 </div>

--- a/app/views/admin/roles/_appointments_tab.html.erb
+++ b/app/views/admin/roles/_appointments_tab.html.erb
@@ -1,0 +1,11 @@
+<%= render "govuk_publishing_components/components/button", {
+  text: "New appointment",
+  href: new_admin_role_role_appointment_path(role, make_current: true)
+} %>
+
+<%= render "admin/role_appointments/list", role_appointments: role.role_appointments %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Add previous appointment",
+  href: new_admin_role_role_appointment_path(role)
+} %>

--- a/app/views/admin/roles/_appointments_tab.html.erb
+++ b/app/views/admin/roles/_appointments_tab.html.erb
@@ -1,6 +1,7 @@
 <%= render "govuk_publishing_components/components/button", {
   text: "New appointment",
-  href: new_admin_role_role_appointment_path(role, make_current: true)
+  href: new_admin_role_role_appointment_path(role, make_current: true),
+  margin_bottom: 4
 } %>
 
 <%= render "admin/role_appointments/list", role_appointments: role.role_appointments %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -4,49 +4,138 @@
 %>
 
 <%= form_for role, as: :role, url: role_url_for(role) do |form| %>
-  <%= form.errors %>
+    <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Role title (required)",
+          heading_size: "l"
+        },
+        value: role.name,
+        name: "role[name]",
+        id: "role_name",
+        type: "text",
+        error_items: errors_for(role.errors, :name)
+    }
+    %>
 
-  <fieldset>
-    <%= form.text_field :name, label_text: 'Role title' %>
-
-    <div class="form-group">
-      <%= form.label :role_type %>
-      <%= form.select :role_type, grouped_options_for_select(role_type_options, role.role_type), { include_blank: true }, {class: 'form-control input-md-3'} %>
-    </div>
-    <div class="form-group">
-      <%= form.label :organisation_ids, 'Organisations' %>
-      <%= form.select :organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en), 'id', 'select_name', role.organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose organisations…" } %>
-    </div>
-    <div class="form-group">
-      <%= form.label :whip_organisation_id, 'Whip Organisation' %>
-      <%= form.select :whip_organisation_id, options_from_collection_for_select(Whitehall::WhipOrganisation.all, 'id', 'name', role.whip_organisation_id),  { include_blank: true }, {class: 'form-control input-md-3'} %>
-    </div>
-    <div class="form-group">
-      <%= form.label :role_payment_type_id, 'Payment options' %>
-      <%= form.select :role_payment_type_id, options_from_collection_for_select(RolePaymentType.all, :id, :name, form.object.role_payment_type_id), { include_blank: true }, {class: 'form-control input-md-3'}%>
-    </div>
-    <div class="form-group">
-      <%= form.label :attends_cabinet_type_id, 'Attends cabinet options' %>
-      <%= form.select :attends_cabinet_type_id, options_from_collection_for_select(RoleAttendsCabinetType.all, :id, :name, form.object.attends_cabinet_type_id), { include_blank: true }, {class: 'form-control input-md-3'} %>
-    </div>
-    <div class="form-group">
-      <%= form.label :worldwide_organisation_ids, 'Worldwide organisations' %>
-      <%= form.select :worldwide_organisation_ids, options_from_collection_for_select(WorldwideOrganisation.all, 'id', 'name', role.worldwide_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose worldwide organisations…" } %>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <%= form.text_area :responsibilities, rows: 20, class: "previewable", data: {
-      module: "paste-html-to-govspeak"
+    <%= render "govuk_publishing_components/components/select", {
+      id: "role_type",
+      label: "Role type (required)",
+      heading_size: "l",
+      name: "role[role_type]",
+      options:
+        [{ value: nil, text: nil }] + role_type_options.map do |group, name_vs_type|
+          name_vs_type.map do |name, type|
+            {
+              text: name,
+              value: type,
+              selected: role.role_type == type
+            }
+          end
+        end.flatten,
+      error_message: errors_for_input(role.errors, :type)
     } %>
-  </fieldset>
-  <p class="warning">
-    <% if show_instantly_live_warning %>
-      Warning: changes to roles appear instantly on the live site.
-    <% end %>
-    <% if show_consult_gds_warning %>
-      Do not create ministerial roles without consulting GDS.
-    <% end %>
-  </p>
-  <%= form.save_or_continue_or_cancel cancel: admin_roles_path %>
+
+    <%= render "components/autocomplete", {
+      id: "role_organisation_ids",
+      label: {
+        text: "Organisations",
+        heading_size: "l"
+      },
+      name: "role[organisation_ids][]",
+      select: {
+        options:  options_from_collection_for_select(Organisation.with_translations(:en), 'id', 'select_name', role.organisation_ids),
+        multiple: true
+      }
+    } %>
+
+    <%= render "govuk_publishing_components/components/select", {
+      id: "role_whip_organisation_id",
+      label: "Whip Organisation",
+      heading_size: "l",
+      name: "role[whip_organisation_id]",
+      options: ([nil] + Whitehall::WhipOrganisation.all).map do |whip_organisation|
+          {
+            text: whip_organisation&.label,
+            value: whip_organisation&.id,
+            selected: whip_organisation&.id == role.whip_organisation_id
+          }
+        end
+    } %>
+
+    <%= render "govuk_publishing_components/components/select", {
+      id: "role_role_payment_type_id",
+      label: "Payment options",
+      heading_size: "l",
+      name: "role[role_payment_type_id]",
+      options: ([nil] + RolePaymentType.all).map do |role_payment_type|
+        {
+          text: role_payment_type&.name,
+          value: role_payment_type&.id,
+          selected: role.role_payment_type_id == role_payment_type&.id
+        }
+      end
+    } %>
+
+    <%= render "govuk_publishing_components/components/select", {
+      id: "role_attends_cabinet_type_id",
+      label: "Attends cabinet options",
+      heading_size: "l",
+      name: "role[attends_cabinet_type_id]",
+      options: ([nil] + RoleAttendsCabinetType.all).map do |role_attends_cabinet_type|
+        {
+          text: role_attends_cabinet_type&.name,
+          value: role_attends_cabinet_type&.id,
+          selected: role.attends_cabinet_type_id == role_attends_cabinet_type&.id
+        }
+      end
+    } %>
+
+    <%= render "components/autocomplete", {
+      id: "role_worldwide_organisation_ids",
+      label: {
+        text: "Worldwide organisations",
+        heading_size: "l"
+      },
+      name: "role[worldwide_organisation_ids][]",
+      select: {
+        options:  options_from_collection_for_select(WorldwideOrganisation.all, 'id', 'name', role.worldwide_organisation_ids),
+        multiple: true
+      }
+    } %>
+
+    <%= render "components/govspeak-editor", {
+      label: {
+        text: "Responsibilities",
+        heading_size: "l"
+      },
+      id: "role_responsibilities",
+      name: "role[responsibilities]",
+      value: role.responsibilities_without_markup,
+      rows: 20
+    } %>
+
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to roles appear instantly on the live site."
+    } if show_instantly_live_warning %>
+
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Do not create ministerial roles without consulting GDS."
+    } if show_consult_gds_warning %>
+
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        name: "save",
+        value: "Save",
+        type: "submit"
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save and continue",
+        name: "save_and_continue",
+        value: "Save and continue",
+        type: "submit",
+        secondary: true
+      } %>
+      <%= link_to("Cancel", admin_roles_path, class: "govuk-link") %>
+    </div>
 <% end %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -7,7 +7,7 @@
     <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Role title (required)",
-          heading_size: "l"
+          heading_size: "m"
         },
         value: role.name,
         name: "role[name]",
@@ -20,7 +20,7 @@
     <%= render "govuk_publishing_components/components/select", {
       id: "role_type",
       label: "Role type (required)",
-      heading_size: "l",
+      heading_size: "m",
       name: "role[role_type]",
       options:
         [{ value: nil, text: nil }] + role_type_options.map do |group, name_vs_type|
@@ -39,7 +39,7 @@
       id: "role_organisation_ids",
       label: {
         text: "Organisations",
-        heading_size: "l"
+        heading_size: "m"
       },
       name: "role[organisation_ids][]",
       select: {
@@ -51,7 +51,7 @@
     <%= render "govuk_publishing_components/components/select", {
       id: "role_whip_organisation_id",
       label: "Whip Organisation",
-      heading_size: "l",
+      heading_size: "m",
       name: "role[whip_organisation_id]",
       options: ([nil] + Whitehall::WhipOrganisation.all).map do |whip_organisation|
           {
@@ -65,7 +65,7 @@
     <%= render "govuk_publishing_components/components/select", {
       id: "role_role_payment_type_id",
       label: "Payment options",
-      heading_size: "l",
+      heading_size: "m",
       name: "role[role_payment_type_id]",
       options: ([nil] + RolePaymentType.all).map do |role_payment_type|
         {
@@ -79,7 +79,7 @@
     <%= render "govuk_publishing_components/components/select", {
       id: "role_attends_cabinet_type_id",
       label: "Attends cabinet options",
-      heading_size: "l",
+      heading_size: "m",
       name: "role[attends_cabinet_type_id]",
       options: ([nil] + RoleAttendsCabinetType.all).map do |role_attends_cabinet_type|
         {
@@ -94,7 +94,7 @@
       id: "role_worldwide_organisation_ids",
       label: {
         text: "Worldwide organisations",
-        heading_size: "l"
+        heading_size: "m"
       },
       name: "role[worldwide_organisation_ids][]",
       select: {
@@ -106,7 +106,7 @@
     <%= render "components/govspeak-editor", {
       label: {
         text: "Responsibilities",
-        heading_size: "l"
+        heading_size: "m"
       },
       id: "role_responsibilities",
       name: "role[responsibilities]",

--- a/app/views/admin/roles/_legacy_form.html.erb
+++ b/app/views/admin/roles/_legacy_form.html.erb
@@ -1,0 +1,52 @@
+<%
+  show_instantly_live_warning ||= false
+  show_consult_gds_warning ||= false
+%>
+
+<%= form_for role, as: :role, url: role_url_for(role) do |form| %>
+  <%= form.errors %>
+
+  <fieldset>
+    <%= form.text_field :name, label_text: 'Role title' %>
+
+    <div class="form-group">
+      <%= form.label :role_type %>
+      <%= form.select :role_type, grouped_options_for_select(role_type_options, role.role_type), { include_blank: true }, {class: 'form-control input-md-3'} %>
+    </div>
+    <div class="form-group">
+      <%= form.label :organisation_ids, 'Organisations' %>
+      <%= form.select :organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en), 'id', 'select_name', role.organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose organisations…" } %>
+    </div>
+    <div class="form-group">
+      <%= form.label :whip_organisation_id, 'Whip Organisation' %>
+      <%= form.select :whip_organisation_id, options_from_collection_for_select(Whitehall::WhipOrganisation.all, 'id', 'name', role.whip_organisation_id),  { include_blank: true }, {class: 'form-control input-md-3'} %>
+    </div>
+    <div class="form-group">
+      <%= form.label :role_payment_type_id, 'Payment options' %>
+      <%= form.select :role_payment_type_id, options_from_collection_for_select(RolePaymentType.all, :id, :name, form.object.role_payment_type_id), { include_blank: true }, {class: 'form-control input-md-3'}%>
+    </div>
+    <div class="form-group">
+      <%= form.label :attends_cabinet_type_id, 'Attends cabinet options' %>
+      <%= form.select :attends_cabinet_type_id, options_from_collection_for_select(RoleAttendsCabinetType.all, :id, :name, form.object.attends_cabinet_type_id), { include_blank: true }, {class: 'form-control input-md-3'} %>
+    </div>
+    <div class="form-group">
+      <%= form.label :worldwide_organisation_ids, 'Worldwide organisations' %>
+      <%= form.select :worldwide_organisation_ids, options_from_collection_for_select(WorldwideOrganisation.all, 'id', 'name', role.worldwide_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose worldwide organisations…" } %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <%= form.text_area :responsibilities, rows: 20, class: "previewable", data: {
+      module: "paste-html-to-govspeak"
+    } %>
+  </fieldset>
+  <p class="warning">
+    <% if show_instantly_live_warning %>
+      Warning: changes to roles appear instantly on the live site.
+    <% end %>
+    <% if show_consult_gds_warning %>
+      Do not create ministerial roles without consulting GDS.
+    <% end %>
+  </p>
+  <%= form.save_or_continue_or_cancel cancel: admin_roles_path %>
+<% end %>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -1,21 +1,33 @@
-<% page_title "Edit #{@role.name}"  %>
-<div class="row">
-  <section class="col-md-8">
-    <h1>Edit role</h1>
-    <p class="warning">Warning: changes to roles appear instantly on the live site.</p>
-    <%= render partial: "form", locals: {role: @role, show_instantly_live_warning: true} %>
-  </section>
-  <div class="col-md-4">
-    <%= sidebar_tabs appointments: "Appointments", govspeak_help: "Help" do |tabs| %>
-      <%= tabs.pane id: "appointments" do %>
-        <h1>Appointments</h1>
-        <p><%= link_to "New appointment", new_admin_role_role_appointment_path(@role, make_current: true), class: "btn btn-default" %></p>
-        <%= render partial: "admin/role_appointments/list", locals: {role_appointments: @role.role_appointments} %>
-        <p><%= link_to "Add previous appointment", new_admin_role_role_appointment_path(@role), class: "btn btn-default" %></p>
-      <% end %>
-      <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
-        <%= render partial: "admin/editions/legacy_govspeak_help" %>
-      <% end %>
-    <% end %>
+<% content_for :page_title, "Edit #{@role.name}" %>
+<% content_for :title, "Edit role" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @role, parent_class: "role")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to roles appear instantly on the live site."
+    } %>
+    <%= render "form", {
+       role: @role,
+       show_instantly_live_warning: true
+    } %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/tabs", {
+      tabs: [
+        {
+          id: "appointments",
+          label: "Appointments",
+          content:
+            render("admin/roles/appointments_tab", role: @role )
+        },
+        {
+          id: "help",
+          label: "Help",
+          content: simple_formatting_sidebar
+        }
+      ]
+    } %>
   </div>
 </div>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -9,8 +9,7 @@
       text: "Changes to roles appear instantly on the live site."
     } %>
     <%= render "form", {
-       role: @role,
-       show_instantly_live_warning: true
+       role: @role
     } %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/admin/roles/legacy_edit.html.erb
+++ b/app/views/admin/roles/legacy_edit.html.erb
@@ -1,0 +1,21 @@
+<% page_title "Edit #{@role.name}"  %>
+<div class="row">
+  <section class="col-md-8">
+    <h1>Edit role</h1>
+    <p class="warning">Warning: changes to roles appear instantly on the live site.</p>
+    <%= render partial: "legacy_form", locals: {role: @role, show_instantly_live_warning: true} %>
+  </section>
+  <div class="col-md-4">
+    <%= sidebar_tabs appointments: "Appointments", govspeak_help: "Help" do |tabs| %>
+      <%= tabs.pane id: "appointments" do %>
+        <h1>Appointments</h1>
+        <p><%= link_to "New appointment", new_admin_role_role_appointment_path(@role, make_current: true), class: "btn btn-default" %></p>
+        <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role.role_appointments} %>
+        <p><%= link_to "Add previous appointment", new_admin_role_role_appointment_path(@role), class: "btn btn-default" %></p>
+      <% end %>
+      <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
+        <%= render partial: "admin/editions/legacy_govspeak_help" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/roles/new.html.erb
+++ b/app/views/admin/roles/new.html.erb
@@ -3,7 +3,7 @@
   <section class="col-md-8">
     <h1>New role</h1>
     <p class="warning">Do not create ministerial roles without consulting GDS.</p>
-    <%= render partial: "form", locals: {role: @role, show_consult_gds_warning: true} %>
+    <%= render partial: "legacy_form", locals: {role: @role, show_consult_gds_warning: true} %>
   </section>
   <div class="col-md-4">
     <%= legacy_simple_formatting_sidebar %>

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -277,7 +277,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
       assert_select "select[name*='role[organisation_ids]']" do
         assert_select "option[selected='selected']", text: "org-name"
       end
-      assert_select "input[type='submit']"
+      assert_select "button[type='submit']"
     end
   end
 
@@ -322,7 +322,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     put :update, params: { id: role, role: attributes_for(:role, name: nil) }
 
-    assert_select ".form-errors"
+    assert_select ".govuk-error-summary"
   end
 
   view_test "confirm_destroy should display form for deleting an existing role" do


### PR DESCRIPTION
## Description

This ports the roles edit page to the GOV.UK Design System. Then adds the new view in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshots

### Before
<img width="1786" alt="Screenshot 2023-03-28 at 10 53 47" src="https://user-images.githubusercontent.com/91492293/228199794-95c5c734-f64f-4d07-9654-962d12ccd90e.png">
<img width="1786" alt="Screenshot 2023-03-28 at 10 53 58" src="https://user-images.githubusercontent.com/91492293/228199807-ece54dc3-9b76-42f4-8a8f-daad7d2f10c1.png">

### After with Appointments Tab:
![Screenshot 2023-03-28 at 17 09 22](https://user-images.githubusercontent.com/91492293/228302404-0303f84f-dff9-4bc1-b482-0998847dcca1.png)
![Screenshot 2023-03-28 at 17 09 32](https://user-images.githubusercontent.com/91492293/228302420-dba6fcc3-be18-4794-8254-6fa3ea124209.png)

### After with Help Tab:
![Screenshot 2023-03-28 at 17 09 59](https://user-images.githubusercontent.com/91492293/228302468-b1315da2-cc06-488e-a2b4-035e6d08ecd8.png)
![Screenshot 2023-03-28 at 17 09 48](https://user-images.githubusercontent.com/91492293/228302484-541629e3-7f6b-4c1e-a917-05dbc63f000c.png)

## Trello

https://trello.com/c/H7za8win

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
