### PR TITLE
Reinstate Jenkinsfile so Jenkins CI runs again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+library("govuk")
+
+REPOSITORY = 'whitehall'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
+
+node {
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/whitehall_test")
+  govuk.setEnvar("REDIS_URL", "redis://127.0.0.1:63796")
+  govuk.buildProject(
+    brakeman: true,
+    overrideTestTask: {
+      stage("Run tests") {
+        if (params.IS_SCHEMA_TEST) {
+          echo "Running a subset of the tests to check the content schema changes"
+          govuk.runRakeTask("test:publishing_schemas --trace")
+        } else {
+          // Run rake default tasks except for pact:verify as that is ran via
+          // a separate GitHub action.
+          sh("bundle exec rake lint test cucumber jasmine")
+        }
+      }
+    }
+  )
+}


### PR DESCRIPTION
It is [not currently recommended](https://gds.slack.com/archives/CD6JUFXML/p1680013649936339?thread_ts=1680003113.239669&cid=CD6JUFXML) that Jenkinsfiles are removed from repositories. So we'll need to keep running CI in both Jenkins and GitHub Actions for now.

This reverts #7484 which removed the Jenkinsfile. That PR was originally intended to unblock the team because Jenkins CI was broken and [failing all builds](https://gds.slack.com/archives/CADKZN519/p1679664795540369).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
