### PR TITLE
Add unique filename validation to edition images controller

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -27,7 +27,7 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image.build_image_data(image_params["image_data"])
 
     if @new_image.save
-      redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.image_data.carrierwave_image} successfully uploaded"
+      redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.filename} successfully uploaded"
     elsif new_image_needs_cropping?
       @data_url = image_data_url
       render :crop

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -26,6 +26,8 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image = @edition.images.build
     @new_image.build_image_data(image_params["image_data"])
 
+    @new_image.image_data.validate_on_image = @new_image
+
     if @new_image.save
       redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.filename} successfully uploaded"
     elsif new_image_needs_cropping?

--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -10,7 +10,7 @@
   <%= render "govuk_publishing_components/components/file_upload", {
     name: "image[image_data][file]",
     id: "edition_images_image_data_file",
-    hint: "Images can be JPEG, PNG, SVG or GIF files.",
+    hint: raw('Images can be JPEG, PNG, SVG or GIF files. If you are uploading more than one image, <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos">read the image guidance</a> on using unique file names.'),
     error_items: @new_image.present? ? errors_for(@new_image.errors, :"image_data.file") : nil,
   } %>
 

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -76,3 +76,15 @@ Feature: Images tab on edit edition
     And I navigate to the images tab
     And I click upload without attaching a file
     Then I should get the error message "Image data file can't be blank"
+
+  Scenario: Uploading a file with duplicated filename
+    And I have the "Preview images update" permission
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I am on the edit page for publication "Standard Beard Lengths"
+    And I navigate to the images tab
+    And I upload a 960x640 image
+    And I update the image details and save
+    And I upload a 960x640 image
+    Then I should get the error message "Image data file name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
+
+

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -72,6 +72,18 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".govuk-error-summary li", "Image data file is too small. Select an image that is 960 pixels wide and 640 pixels tall"
   end
 
+  test "#create shows a validation error if image has a duplicated filename" do
+    login_authorised_user
+    edition = create(:news_article)
+    file = upload_fixture("images/960x640_gif.gif")
+    create(:image, edition:, image_data: create(:image_data, file:))
+
+    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+
+    assert_template "admin/edition_images/index"
+    assert_select ".govuk-error-summary li", "Image data file name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
+  end
+
   def login_authorised_user
     user = create(:gds_editor)
     user.permissions << "Preview images update"

--- a/test/unit/image_data_test.rb
+++ b/test/unit/image_data_test.rb
@@ -36,6 +36,25 @@ class ImageDataTest < ActiveSupport::TestCase
     assert image_data.errors.of_kind?(:file, :too_large)
   end
 
+  test "rejects images with duplicate filename on edition" do
+    image_data = build_example("960x640_jpeg.jpg")
+    edition = create(:news_article, images: [build(:image, image_data:)])
+    image = build(:image, image_data:, edition:)
+
+    image_data.validate_on_image = image
+
+    assert_not image_data.valid?
+    assert_equal ["name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."], image_data.errors[:file]
+  end
+
+  test "does not validate unique filename if validate_on_image is not assigned" do
+    image_data = build_example("960x640_jpeg.jpg")
+    edition = create(:news_article, images: [build(:image, image_data:)])
+    build(:image, image_data:, edition:)
+
+    assert image_data.valid?
+  end
+
   test "#bitmap? is false for SVG files" do
     assert_not build_example("test-svg.svg").bitmap?
   end


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/MTqCZng8/1196-add-validation-so-images-have-unique-filenames)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Refactors code to make use of delegations and methods introduced in [PR #7520 ](https://github.com/alphagov/whitehall/pull/7520)
- Adds a custom validation to the `image_data` model which checks whether an image has a unique filename when compared with other images on the same edition. This requires an edition and image, on which the image data will be validated against, to be set via an attribute accessor and for a file to be present.
- Makes use of the `image_data` validation in `edition_images#create` by passing in the uploaded image and edition to ensure images with duplicated filenames cannot be uploaded to an edition.
### Additional information
Passing the edition and uploaded image in as an attribute accessor was required as the `image_data` model does not have access to either in non-persisted state.
## Why
The images update proposed a new way of generating markdown for images using the image filename on upload. This means that we need to avoid having duplicate filenames on an edition, otherwise the markdown for both will be the same. 

## Screenshots
![whitehall-admin dev gov uk_government_admin_editions_1408685_images(iPad Pro) (1)](https://user-images.githubusercontent.com/94846816/228796324-af0ddb35-4a9d-467e-ba1e-2665f56b83b5.png)