### PR TITLE
Remove the word "new" from UI copy

### DIFF
--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -62,7 +62,7 @@
       <p class="govuk-body">
         <% if edition.new_record? %>
           To add images you must save the document first. After saving, use the 
-          new tabs at the top of the page to upload, edit and delete images and 
+          tabs at the top of the page to upload, edit and delete images and 
           attachments.
         <% else %>
           Use the tabs at the top of the page to upload, edit and delete images.

--- a/app/views/admin/editions/_html_version_fields.html.erb
+++ b/app/views/admin/editions/_html_version_fields.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'same tab as the other attachments', admin_edition_attachments_path(@edition), class: "govuk-link" %>.
     <% else %>
       If you’d like to add an HTML attachment to this document, please save
-      it first. You’ll then find a new tab at the top of the page that you
+      it first. You’ll then find a tab at the top of the page that you
       can use to create, edit and delete attachments.
     <% end %>
   </p>

--- a/app/views/admin/editions/_inline_attachments_info.html.erb
+++ b/app/views/admin/editions/_inline_attachments_info.html.erb
@@ -9,11 +9,11 @@
       <p class="govuk-body">
         <% if current_user.can_preview_images_update? && edition.allows_image_attachments? %>
           To add images and attachments you must save the document first. After
-          saving, use the new tabs at the top of the page to upload, edit and
+          saving, use the tabs at the top of the page to upload, edit and
           delete images and attachments.
         <% else %>
           If you’d like to add an attachment to this document, please save
-          it first. You’ll then find a new tab at the top of the page that you
+          it first. You’ll then find a tab at the top of the page that you
           can use to upload, edit and delete attachments.
         <% end %>
       </p>

--- a/app/views/admin/editions/_legacy_html_version_fields.html.erb
+++ b/app/views/admin/editions/_legacy_html_version_fields.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'same tab as the other attachments', admin_edition_attachments_path(@edition) %>.
     <% else %>
       If you’d like to add an HTML attachment to this document, please save
-      it first. You’ll then find a new tab at the top of the page that you
+      it first. You’ll then find a tab at the top of the page that you
       can use to create, edit and delete attachments.
     <% end %>
   </p>

--- a/app/views/admin/editions/_legacy_inline_attachments_info.html.erb
+++ b/app/views/admin/editions/_legacy_inline_attachments_info.html.erb
@@ -3,7 +3,7 @@
   <% if edition.new_record? %>
     <p>
       If you’d like to add an attachment to this document, please save
-      it first. You’ll then find a new tab at the top of the page that you
+      it first. You’ll then find a tab at the top of the page that you
       can use to upload, edit and delete attachments.
     </p>
   <% elsif edition.allows_inline_attachments? %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -105,7 +105,7 @@
       <p class="govuk-body">
         <% if edition.new_record? %>
           To add images you must save the document first. After saving, use the 
-          new tabs at the top of the page to upload, edit and delete images and 
+          tabs at the top of the page to upload, edit and delete images and 
           attachments.
         <% else %>
           Use the tabs at the top of the page to upload, edit and delete images.

--- a/app/views/admin/policy_groups/_form.html.erb
+++ b/app/views/admin/policy_groups/_form.html.erb
@@ -16,7 +16,7 @@
   <% else %>
     <p>
       If you’d like to add an attachment to this group,
-      please save it first. You’ll then find a new tab at the top of the page
+      please save it first. You’ll then find a tab at the top of the page
       that you can use to upload, edit and delete attachments.
     </p>
   <% end %>


### PR DESCRIPTION
Requested by the team as they didn't think it added much meaning.

Relevant thread from Google Doc:
https://docs.google.com/document/d/1c8Cd8TBXm0wSsUdrleWWbGZXy6FddlyKwC5ScQonEo0/edit?disco=AAAAsx8QHfA

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
