### PR TITLE
Send the description to publishing api as html

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -7,6 +7,7 @@ module PublishingApi
     def initialize(operational_field, _options = {})
       @operational_field = operational_field
       @update_type = "major"
+      @renderer = Whitehall::GovspeakRenderer.new
     end
 
     delegate :content_id, to: :operational_field
@@ -15,7 +16,7 @@ module PublishingApi
       {}.tap do |content|
         content.merge!(PayloadBuilder::PolymorphicPath.for(operational_field))
         content.merge!(
-          description: operational_field.description,
+          description: @renderer.govspeak_to_html(operational_field.description),
           details: {},
           document_type: "field_of_operation",
           locale: "en",

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -5,7 +5,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
     @operational_field = create(
       :operational_field,
       name: "Operational Field name",
-      description: "Operational Field description",
+      description: "Operational Field description \n\n##Some title",
     )
     @fatality_notices_for_operational_field = (0..4).map { |_i| create(:published_fatality_notice, operational_field: @operational_field) }
     create(:published_fatality_notice, operational_field: create(:operational_field))
@@ -34,7 +34,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       document_type: "field_of_operation",
       rendering_app: "whitehall-frontend",
       schema_name: "field_of_operation",
-      description: "Operational Field description",
+      description: Whitehall::GovspeakRenderer.new.govspeak_to_html(@operational_field.description),
       routes: [
         {
           path: "/government/fields-of-operation/operational-field-name",


### PR DESCRIPTION
This will make it so that our rendering app doesn't have to parse MD

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
