### PR TITLE
Release 1.6 fixes for DateTime fields

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -84,14 +84,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         deliveredByLabel.textContent = 'Writer (required)'
         hasProfileRadioLabel.textContent = 'Writer has a profile on GOV.UK'
         noProfileRadioLabel.textContent = 'Writer does not have a profile on GOV.UK'
-        deliveredOnLabel.textContent = 'Written on (required)'
+        deliveredOnLabel.textContent = 'Written on'
         locationInput.value = ''
       } else {
         locationDiv.classList.remove('app-view-edit-edition__speech-location--hidden')
         deliveredByLabel.textContent = 'Speaker (required)'
         hasProfileRadioLabel.textContent = 'Speaker has a profile on GOV.UK'
         noProfileRadioLabel.textContent = 'Speaker does not have a profile on GOV.UK'
-        deliveredOnLabel.textContent = 'Delivered on (required)'
+        deliveredOnLabel.textContent = 'Delivered on'
       }
     })
   }

--- a/app/validators/previously_published_validator.rb
+++ b/app/validators/previously_published_validator.rb
@@ -5,7 +5,7 @@ class PreviouslyPublishedValidator < ActiveModel::Validator
     if record.previously_published.nil?
       record.errors.add(:previously_published, "You must specify whether the document has been published before")
       record.has_previously_published_error = true
-    elsif record.previously_published && record.first_published_at.blank?
+    elsif (record.previously_published || record.published_major_version) && record.first_published_at.blank?
       record.errors.add(:first_published_at, "can't be blank")
     end
   end

--- a/app/views/admin/consultations/_date_fields.html.erb
+++ b/app/views/admin/consultations/_date_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Opening date (required)",
+    legend_text: "Opening date",
     heading_size: "l",
     id: "edition_opening_at",
   } do %>
@@ -39,7 +39,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Closing date (required)",
+    legend_text: "Closing date",
     heading_size: "l",
     id: "edition_closing_at",
   } do %>

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -62,6 +62,8 @@
       legend_text: "First published",
       heading_size: "l",
       hint: "For example, 31 3 2000",
+      id: "edition_first_published_at",
+      error_message: errors_for_input(edition.errors, :first_published_at),
     } do %>
       <%= first_published_at_fields %>
     <% end %>

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -59,7 +59,7 @@
 <% else %>
   <div class="govuk-!-margin-bottom-4">
     <%= render "govuk_publishing_components/components/fieldset", {
-      legend_text: "First published (required)",
+      legend_text: "First published",
       heading_size: "l",
       hint: "For example, 31 3 2000",
     } do %>

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -39,7 +39,7 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "edition[previously_published]",
         id: "edition_previously_published",
-        error_items: errors_for(edition.errors, :previously_published),
+        error_items: errors_for(edition.errors, :previously_published) || errors_for(edition.errors, :first_published_at),
         items: [
           {
             value: false,
@@ -49,7 +49,7 @@
           {
             value: true,
             text: "This document has previously been published on another website.",
-            checked: edition.previously_published,
+            checked: edition.previously_published == true,
             conditional: first_published_at_fields
           }
         ]

--- a/app/views/admin/editions/_scheduled_publication_fields.html.erb
+++ b/app/views/admin/editions/_scheduled_publication_fields.html.erb
@@ -17,6 +17,7 @@
               field_name: "scheduled_publication",
               prefix: "edition",
               error_items: errors_for(edition.errors, :scheduled_publication),
+              date_heading: "Date",
               date_hint: "For example, 01 August 2022",
               time_hint: "For example, 09:30 or 19:30",
               year: {

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -91,7 +91,9 @@
   <% end %>
 </div>
 
-<%= render 'first_published_at', form: form, edition: edition %>
+<% unless edition.is_a?(Consultation) %>
+  <%= render 'first_published_at', form: form, edition: edition %>
+<% end %>
 
 <% if current_user.can_preview_images_update? %>
   <% if %w(CaseStudy Speech FatalityNotice).include?(edition.type) %>
@@ -104,8 +106,8 @@
       } %>
       <p class="govuk-body">
         <% if edition.new_record? %>
-          To add images you must save the document first. After saving, use the 
-          tabs at the top of the page to upload, edit and delete images and 
+          To add images you must save the document first. After saving, use the
+          tabs at the top of the page to upload, edit and delete images and
           attachments.
         <% else %>
           Use the tabs at the top of the page to upload, edit and delete images.
@@ -118,7 +120,7 @@
     <% if edition.type == "CaseStudy" %>
       <%= render partial: "image_fields_case_studies", locals: { form: form, edition: form.object } %>
     <% else %>
-      <%= render partial: "image_fields", locals: { form: form, edition: form.object } %> 
+      <%= render partial: "image_fields", locals: { form: form, edition: form.object } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/speeches/_delivered_on_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_on_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: edition.authored_article? ? "Written on (required)" : "Delivered on (required)",
+    legend_text: edition.authored_article? ? "Written on" : "Delivered on",
     heading_size: "l",
     id: "edition_delivered_on",
   } do %>

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -51,7 +51,7 @@
 <%= tag.div class: root_classes, data: data_attributes, id: id do %>
   <% unless date_only && !date_heading %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: date_heading || "Date",
+      text: date_heading || "Date (required)",
       heading_level: heading_level || 3,
       font_size: heading_size || "m",
       padding: true,

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -103,7 +103,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(deliveredByLabel.textContent).toEqual('Writer (required)')
       expect(hasProfileRadioLabel.textContent).toEqual('Writer has a profile on GOV.UK')
       expect(noProfileRadioLabel.textContent).toEqual('Writer does not have a profile on GOV.UK')
-      expect(deliveredOnLabel.textContent).toEqual('Written on (required)')
+      expect(deliveredOnLabel.textContent).toEqual('Written on')
       expect(locationDiv.classList[1]).toEqual('app-view-edit-edition__speech-location--hidden')
       expect(locationInput.value).toEqual('')
     })
@@ -127,7 +127,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(deliveredByLabel.textContent).toEqual('Speaker (required)')
       expect(hasProfileRadioLabel.textContent).toEqual('Speaker has a profile on GOV.UK')
       expect(noProfileRadioLabel.textContent).toEqual('Speaker does not have a profile on GOV.UK')
-      expect(deliveredOnLabel.textContent).toEqual('Delivered on (required)')
+      expect(deliveredOnLabel.textContent).toEqual('Delivered on')
       expect(locationDiv.classList.length).toEqual(1)
       expect(locationDiv.classList[0]).toEqual('js-app-view-edit-edition__speech-location-field')
     })
@@ -195,7 +195,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       '</div>' +
 
       '<fieldset class="govuk-fieldset" id="edition_delivered_on">' +
-        '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on (required)</legend>' +
+        '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on</legend>' +
       '</fieldset>' +
 
       '<div class="js-app-view-edit-edition__speech-location-field">' +

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -104,10 +104,12 @@ FactoryBot.define do
 
     trait(:superseded) do
       state { "superseded" }
+      first_published_at { 2.days.ago }
     end
 
     trait(:superseded_with_published) do
       state { "superseded" }
+      first_published_at { 2.days.ago }
 
       after(:create) do |edition|
         create(:published_edition, document: edition.document)

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1096,7 +1096,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "edit subsequent editions should display first_published_at fields, but not show radio buttons" do
-        edition = create(edition_type, published_major_version: 1)
+        edition = create(edition_type, published_major_version: 1, first_published_at: 2.days.ago)
 
         get :edit, params: { id: edition }
 

--- a/test/unit/validators/previously_published_validator_test.rb
+++ b/test/unit/validators/previously_published_validator_test.rb
@@ -18,8 +18,15 @@ class PreviouslyPublishedValidatorTest < ActiveSupport::TestCase
     assert edition.errors.empty?, "No errors were expected"
   end
 
-  test "invalid if first_published_at is nil" do
+  test "invalid if previously published is true and first_published_at is nil" do
     invalid_edition = build(:edition, previously_published: true, first_published_at: nil)
+    @validator.validate(invalid_edition)
+    assert_equal "can't be blank",
+                 invalid_edition.errors[:first_published_at].first
+  end
+
+  test "invalid if the edition has a published_major_version and first_published_at is nil" do
+    invalid_edition = build(:edition, published_major_version: 1, first_published_at: nil)
     @validator.validate(invalid_edition)
     assert_equal "can't be blank",
                  invalid_edition.errors[:first_published_at].first


### PR DESCRIPTION
## Description

Various bug fixes related to DateTime fields for the new/edit edition pages.

### Show (required) on the Date heading to indicate time is optional

<img width="473" alt="image" src="https://user-images.githubusercontent.com/42515961/228873330-98d208ca-5d8b-4dfa-8f51-932d5566d3a3.png">

The more i thought about it. I think we should retain the required on the fieldset for fields that are required.

Otherwise there's no way to distinguish between optional fields which require a date, but not time and optional fields that if the user chooses to provide require a date, but not time. Very open to differing opinions on this though!

<img width="597" alt="image" src="https://user-images.githubusercontent.com/42515961/228873479-f619d787-1abb-43ed-8ac2-28a27121892d.png">

### Remove first published on from consultations

This snuck in when i originally ported the page and is incorrect.

#### Before

<img width="676" alt="image" src="https://user-images.githubusercontent.com/42515961/228874437-be7be921-6f02-46cc-99fe-89f02e926b1f.png">


#### After


<img width="622" alt="image" src="https://user-images.githubusercontent.com/42515961/228874618-5cb6b044-fe4b-453c-a223-f99fdad94b58.png">

### Fix error linking when first_published_at is blank

#### Before

<img width="224" alt="image" src="https://user-images.githubusercontent.com/42515961/228877325-ffe9719b-c330-4529-962e-f7469f51bf4b.png">

<img width="315" alt="image" src="https://user-images.githubusercontent.com/42515961/228877370-074338c8-f636-4a50-a2f1-27c7bc4a5a32.png">


#### After 

<img width="507" alt="image" src="https://user-images.githubusercontent.com/42515961/228875622-3f993edd-a6ad-41ac-a63b-8a62673bacef.png">

### Ensure first published at cannot be set to nil for subsequent editons

#### Before

<img width="362" alt="image" src="https://user-images.githubusercontent.com/42515961/228879042-ed2d2390-66ac-4e3d-9322-6331f572561e.png">

<img width="540" alt="image" src="https://user-images.githubusercontent.com/42515961/228879164-a2dea7f9-fdcd-4974-981d-75e0f81df13c.png">


#### After

<img width="415" alt="image" src="https://user-images.githubusercontent.com/42515961/228878920-082adc54-3001-4e59-a673-1e3b3269ec52.png">

## Guidance for review

Per commit would probs easiest since it's broken down into one issue per commit.

## Trello card 

https://trello.com/c/D65y76ql/86-update-datetime-component-to-specify-date-is-required



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
