### PR TITLE
Fix typo in locale file affecting /world

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,7 +518,7 @@ en:
   world_location:
     content:
       complete_list: See the complete %{href}. This includes all embassies, high commissions and consulates.
-      find_out: Find out what is help is available from the UK government if you're abroad.
+      find_out: Find out what help is available from the UK government if you're abroad.
       heading: Help and services around the&nbsp;world
       list_link: list of overseas Foreign, Commonwealth & Development Office posts
     headings:


### PR DESCRIPTION
Fix a typo on https://www.gov.uk/world.

<img width="733" alt="Screenshot 2023-03-30 at 16 01 43" src="https://user-images.githubusercontent.com/16707/228879830-f25153aa-6355-44fe-ab7b-25d1ff19c7a2.png">
