### PR TITLE
Update schema for /world/embassies

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -10,7 +10,7 @@ on:
       publishingApiRef:
         description: 'The branch, tag or SHA to checkout Publishing API'
         required: false
-        default: 'deployed-to-production'
+        default: 'main'
         type: string
 
 jobs:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 library("govuk")
 
 REPOSITORY = 'whitehall'
-DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
+DEFAULT_SCHEMA_BRANCH = 'main'
 
 node {
   govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/whitehall_test")

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -46,6 +46,7 @@ class PublishStaticPages
         title: "Find a British embassy, high commission or consulate",
         base_path: "/world/embassies",
         document_type: "finder",
+        schema_name: "embassies_index",
         description: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
       },
     ]


### PR DESCRIPTION
Previously, this was using a schema_name of 'placeholder'. Placeholder content items are not sent to router, meaning that router did not know about this content item, and when the prefix route for /world was removed, this page 404'd. Updating this to use the barebones schema for embassies to avoid this problem when we republish the /world content item. Later work to migrate this page out of being rendered by whitehall will add additional details to this content item and schema.

This also updates the branch of publishing api that is checked out for schemas to be 'main' instead of 'deployed_to_production', since the concept of a 'deployed to production' branch is no longer used in the new world.

Depends on [schemas PR](https://github.com/alphagov/publishing-api/pull/2334)

[Trello](https://trello.com/c/7kBEEWUL/517-create-content-item-for-help-and-services-around-the-world)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
