### PR TITLE
Use Search With Select Component on the New/Edit Edition pages

### DIFF
--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -23,6 +23,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       shouldSort: false // show options and groups in the order they were given
     })
 
+    this.module.choices = this.choices
+
     if (this.enableTracking) {
       this.module.addEventListener('change', this.trackChange.bind(this))
     }

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -3,13 +3,14 @@
   <%= form.hidden_field :lock_version %>
 
   <% unless form.object.persisted? %>
-    <%= render "govuk_publishing_components/components/select", {
+    <%= render "components/select-with-search", {
       id: "edition_corporate_information_page_type_id",
       name: "edition[corporate_information_page_type_id]",
       label: "Type",
       heading_size: "s",
       error_message: errors_for_input(edition.errors, :corporate_information_page_type_id),
-      options: ([nil] + corporate_information_page_types(@organisation)).map do |type, value|
+      include_blank: true,
+      options: corporate_information_page_types(@organisation).map do |type, value|
         {
           text: type,
           value: value,
@@ -61,8 +62,8 @@
       } %>
       <p class="govuk-body">
         <% if edition.new_record? %>
-          To add images you must save the document first. After saving, use the 
-          tabs at the top of the page to upload, edit and delete images and 
+          To add images you must save the document first. After saving, use the
+          tabs at the top of the page to upload, edit and delete images and
           attachments.
         <% else %>
           Use the tabs at the top of the page to upload, edit and delete images.

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -6,20 +6,20 @@
     heading_size: "l",
     no_hint_text: true,
     error_items: errors_for_input(edition.errors, :create_foreign_language_only),
+    include_blank: true,
     items: [
       {
         label: "Create a foreign language only #{edition.model_name.human.downcase}",
         value: "1",
         checked: form.object.primary_locale != "en",
-        conditional: (render "govuk_publishing_components/components/select", {
+        conditional: (render "components/select-with-search", {
           id: "edition_primary_locale",
           name: "edition[primary_locale]",
           label: "Document language",
           heading_size: "m",
-          full_width: true,
-          allow_blank: true,
+          include_blank: true,
           errors: errors_for(edition.errors, :primary_locale),
-          options: ([nil] + options_for_locales(Locale.non_english)).map do |language, value|
+          options: options_for_locales(Locale.non_english).map do |language, value|
             {
               text: language,
               value: value,

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -1,14 +1,15 @@
-<%= render "govuk_publishing_components/components/select", {
+<%= render "components/select-with-search", {
   id: "edition_operational_field_id",
   label: "Field of operation (required)",
   name: "edition[operational_field_id]",
   heading_size: "l",
   error_message: errors_for_input(edition.errors, :operational_field_id),
-  options: ([nil] + OperationalField.all).map do |operation|
+  include_blank: true,
+  options: OperationalField.all.map do |operation|
     {
-      text: operation&.name,
-      value: operation&.id,
-      selected: operation&.id == edition.operational_field_id
+      text: operation.name,
+      value: operation.id,
+      selected: operation.id == edition.operational_field_id
     }
   end
 } %>

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -10,12 +10,13 @@
       <% 0.upto(3) do |index| %>
         <% lead_organisation_id = lead_organisation_id_at_index(edition, index) %>
         <% cache_if lead_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
-          <%= render "govuk_publishing_components/components/select", {
+          <%= render "components/select-with-search", {
               id: "edition_lead_organisation_ids_#{index + 1}",
               name: "edition[lead_organisation_ids][]",
               label: "Lead organisation #{index + 1}",
               heading_size: "s",
-              options: ([""] + taggable_organisations_container).map do |name, id|
+              include_blank: true,
+              options: taggable_organisations_container.map do |name, id|
               {
                 text: name,
                 value: id,
@@ -36,12 +37,13 @@
     <% 0.upto(5) do |index| %>
       <% supporting_organisation_id = supporting_organisation_id_at_index(edition, index) %>
       <% cache_if supporting_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
-        <%= render "govuk_publishing_components/components/select", {
+        <%= render "components/select-with-search", {
           id: "edition_supporting_organisation_ids_#{index + 1}",
           name: "edition[supporting_organisation_ids][]",
           label: "Supporting organisation #{index + 1}",
           heading_size: "s",
-          options: ([""] + taggable_organisations_container).map do |name, id|
+          include_blank: true,
+          options: taggable_organisations_container.map do |name, id|
           {
             text: name,
             value: id,

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -1,17 +1,17 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= NewsArticleType::FORMAT_ADVICE %>">
-  <%= render "govuk_publishing_components/components/select", {
+  <%= render "components/select-with-search", {
     name: "edition[news_article_type_id]",
     id: "edition_news_article_type_id",
-    label: "News article type",
+    label: "News article type (required)",
     heading_size: "l",
-    full_width: true,
     value: edition.news_article_type_id,
     error_message: errors_for_input(edition.errors, :news_article_type_id),
-    options: ([nil]+ NewsArticleType.all).map do |type|
+    include_blank: true,
+    options: NewsArticleType.all.map do |type|
       {
-        text: type&.singular_name,
-        value: type&.id,
-        selected: edition.news_article_type_id == type&.id
+        text: type.singular_name,
+        value: type.id,
+        selected: edition.news_article_type_id == type.id
       }
     end
   } %>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,33 +1,39 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
-  <div class="govuk-!-margin-bottom-8 govuk-form-group <%= "govuk-form-group--error" if errors_for_input(edition.errors, :publication_type_id).present? %>">
-    <label class="gem-c-label govuk-label govuk-label--l govuk-!-font-weight-bold" for="edition_publication_type_id">
-      Publication type
-    </label>
-    <% if errors_for_input(edition.errors, :publication_type_id).present? %>
-      <%= render "govuk_publishing_components/components/error_message", {
-        text: errors_for_input(edition.errors, :publication_type_id),
-      } %>
-    <% end %>
-
-    <select class="govuk-select govuk-select gem-c-select__select--full-width" id="edition_publication_type_id" name="edition[publication_type_id]">
-      <option></option>
-      <optgroup label="Common types">
-        <% PublicationType.primary.each do |publication_type| %>
-          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-        <% end %>
-      <optgroup/>
-      <optgroup label="Less common types">
-        <% PublicationType.less_common.each do |publication_type| %>
-          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-        <% end %>
-      <optgroup/>
-      <optgroup label="Use discouraged">
-        <% PublicationType.use_discouraged.each do |publication_type| %>
-          <option value=<%= publication_type.id %> <%= "selected" if edition.publication_type_id == publication_type.id %>><%=publication_type.singular_name %></option>
-        <% end %>
-      <optgroup/>
-    </select>
-  </div>
+  <%= render "components/select-with-search", {
+    id: "edition_publication_type_id",
+    name: "edition[publication_type_id]",
+    label: "Publication type (required)",
+    heading_size: "l",
+    value: edition.publication_type_id,
+    error_message: errors_for_input(edition.errors, :publication_type_id),
+    include_blank: true,
+    grouped_options: [
+      [
+        "Common types",
+        PublicationType.primary,
+      ],
+      [
+        "Less common types",
+        PublicationType.less_common,
+      ],
+      [
+        "Use discouraged",
+        PublicationType.use_discouraged,
+      ]
+    ]
+    .map do |group|
+      [
+        group.first,
+        group.second.map do |publication_type|
+          {
+            text: publication_type.singular_name,
+            value: publication_type.id,
+            selected: edition.publication_type_id == publication_type.id,
+          }
+        end
+      ]
+    end
+  } %>
 
   <% if edition.publication_type_id.present? %>
     <%= render "subtype_format_advice", guidance: JSON.parse(PublicationType::FORMAT_ADVICE)[edition.publication_type_id.to_s].html_safe %>

--- a/app/views/admin/speeches/_speaker_select_field.html.erb
+++ b/app/views/admin/speeches/_speaker_select_field.html.erb
@@ -1,11 +1,11 @@
 <% cache_if edition.role_appointment_id.nil?, "#{taggable_role_appointments_cache_digest}-design-system" do %>
-  <%= render "govuk_publishing_components/components/select", {
+  <%= render "components/select-with-search", {
     id: "edition_role_appointment_id",
     name: "edition[role_appointment_id]",
     label: "",
     error_message: errors_for_input(edition.errors, :role_appointment_id),
-    full_width: true,
-    options: ([nil] + taggable_role_appointments_container).map do |speaker, value|
+    include_blank: true,
+    options: taggable_role_appointments_container.map do |speaker, value|
       {
         text: speaker,
         value: value,

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -1,17 +1,17 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= SpeechType::FORMAT_ADVICE %>">
-  <%= render "govuk_publishing_components/components/select", {
+  <%= render "components/select-with-search", {
     name: "edition[speech_type_id]",
     id: "edition_speech_type_id",
     label: "Speech type",
     heading_size: "l",
-    full_width: true,
     value: edition.speech_type_id,
     error_message: errors_for_input(edition.errors, :speech_type_id),
-    options: ([nil] + SpeechType.primary).map do |type|
+    include_blank: true,
+    options: SpeechType.primary.map do |type|
       {
-        text: type&.singular_name,
-        value: type&.id,
-        selected: edition.speech_type_id == type&.id
+        text: type.singular_name,
+        value: type.id,
+        selected: edition.speech_type_id == type.id
       }
     end
   } %>

--- a/app/views/components/docs/select-with-search.yml
+++ b/app/views/components/docs/select-with-search.yml
@@ -27,11 +27,57 @@ examples:
         value: option2
       - text: Option three
         value: option3
+  with_blank_option:
+    description: Include a blank option
+    data:
+      id: dropdown-with-blank
+      label: With blank option
+      include_blank: true
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
   with_grouped_options:
     description: Options can be grouped
     data:
       id: dropdown-with-grouped-options
       label: Select a city
+      grouped_options:
+      - - England
+        - - text: Bath
+            value: bath
+          - text: Bristol
+            value: bristol
+          - text: London
+            value: london
+          - text: Manchester
+            value: manchester
+      - - Northern Ireland
+        - - text: Bangor
+            value: bangor
+          - text: Belfast
+            value: belfast
+      - - Scotland
+        - - text: Dundee
+            value: dundee
+          - text: Edinburgh
+            value: edinburgh
+          - text: Glasgow
+            value: glasgow
+      - - Wales
+        - - text: Cardiff
+            value: cardiff
+          - text: Swansea
+            value: swansea
+  with_grouped_options_and_blank_option:
+    description: Options can be grouped and include a blank option
+    data:
+      id: dropdown-with-grouped-options-and-blank
+      label: Select a city
+      include_blank: true
       grouped_options:
       - - England
         - - text: Bath
@@ -126,9 +172,8 @@ examples:
       label: How will you be travelling to the conference?
       error_message: Please choose an option
       error_id: error_id
+      include_blank: true
       options:
-      - text: ""
-        value: ""
       - text: Public transport
         value: option1
       - text: Will make own arrangements

--- a/features/support/javascript.rb
+++ b/features/support/javascript.rb
@@ -37,9 +37,16 @@ World(JavascriptHelper)
 # selector matches more than one element, but it also doesn't like interacting with invisible elements.
 # And because we use the chosen jQuery extension to enhance admin form select fields, we need some
 # jiggery pokery to make sure we can select stuff in our javascript-enabled tests.
+
+# We've also had to add functionality to ensure that Choices.js works as we use
+# it in our SelectWithSearch component. Unfortunately, its behaviour is more
+# obtuse than Chosen.js because it doesn't preserve the original <select> element.
+
 module Capybara::DSL
   def select(value, options = {})
-    if options.key?(:from)
+    if use_choices_select?(value, options)
+      select_from_choices(value, options)
+    elsif options.key?(:from)
       element = find(:select, options[:from], visible: :all).find(:option, value, visible: :all)
       if element.visible?
         from = options.delete(:from)
@@ -63,5 +70,56 @@ module Capybara::DSL
 
     execute_script("$('##{field[:id]}').val(#{option_value.to_json})")
     execute_script("$('##{field[:id]}').trigger('liszt:updated').trigger('change')")
+  end
+
+  def use_choices_select?(value, options)
+    return unless running_javascript?
+
+    return_choices_div(value, options).present?
+  end
+
+  def return_choices_div(value, options)
+    if options.key?(:from).present?
+      # selects based on on id or label pased in and returns the parent div
+      find(:select, options[:from], visible: :all).ancestor(".app-c-select-with-search", wait: false)
+    else
+      # selects based on on value input by the user.
+      # will throw and error for ambiguous matches.
+      find(
+        "div[role='option'][class='choices__item choices__item--choice choices__item--selectable']",
+        text: value,
+        visible: false,
+        wait: false,
+      )
+       .ancestor(".app-c-select-with-search", wait: false)
+    end
+  rescue Capybara::ElementNotFound
+    nil
+  end
+
+  def select_from_choices(value, options)
+    div = return_choices_div(value, options)
+    select = div.find("select", visible: false)
+
+    # if the option is already selected we don't need to do anything
+    # the selector below will complain as the divs masquerading as options
+    # are dynamically created/removed when options are selected/deselected
+    select_has_value_as_text = all(".choices__list.choices__list--single", visible: false, text: value, wait: false).present?
+    return if select_has_value_as_text || select.value == value
+
+    choices_option = div.find(
+      "div[role='option'][class='choices__item choices__item--choice choices__item--selectable']",
+      text: value,
+      visible: false,
+    )
+
+    data_value = choices_option["data-value"]
+
+    execute_script("arguments[0].choices.setChoiceByValue(arguments[1])", div, data_value)
+
+    # As we are directly interfacing with the Choices.js API, we need to manually
+    # trigger a change event on the hidden <select> element so event listeners
+    # know it has changed.
+    execute_script("arguments[0].dispatchEvent(new Event('change'))", select)
   end
 end

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -22,6 +22,7 @@ module GovukPublishingComponents
         @select_helper = SelectHelper.new(local_assigns.except(:options, :grouped_options))
         @options = local_assigns[:options]
         @grouped_options = local_assigns[:grouped_options]
+        @include_blank = local_assigns[:include_blank]
         @local_assigns = local_assigns
       end
 
@@ -33,15 +34,17 @@ module GovukPublishingComponents
 
       def options_html
         if @grouped_options.present?
-          grouped_options_for_select(
-            transform_grouped_options(@grouped_options),
-            selected_option,
-          )
+          blank_option_if_include_blank +
+            grouped_options_for_select(
+              transform_grouped_options(@grouped_options),
+              selected_option,
+            )
         elsif @options.present?
-          options_for_select(
-            transform_options(@options),
-            selected_option,
-          )
+          blank_option_if_include_blank +
+            options_for_select(
+              transform_options(@options),
+              selected_option,
+            )
         end
       end
 
@@ -69,6 +72,12 @@ module GovukPublishingComponents
         grouped_options.map do |(group, options)|
           [group, transform_options(options)]
         end
+      end
+
+      def blank_option_if_include_blank
+        return "".html_safe if @include_blank.blank?
+
+        options_for_select([["", ""]])
       end
     end
   end

--- a/spec/javascripts/components/select-with-search.spec.js
+++ b/spec/javascripts/components/select-with-search.spec.js
@@ -68,23 +68,23 @@ describe('GOVUK.Modules.SelectWithSearch', function () {
         <label for="example">Choose a city</label>
         <select id="example">
           <optgroup label="England">
-            <option value="bath">Bath</label>
-            <option value="bristol">Bristol</label>
-            <option value="london">London</label>
-            <option value="manchester">Manchester</label>
+            <option value="bath">Bath</option>
+            <option value="bristol">Bristol</option>
+            <option value="london">London</option>
+            <option value="manchester">Manchester</option>
           </optgroup>
           <optgroup label="Ireland">
-            <option value="bangor">Bangor</label>
-            <option value="belfast">Belfast</label>
+            <option value="bangor">Bangor</option>
+            <option value="belfast">Belfast</option>
           </optgroup>
           <optgroup label="Scotland">
-            <option value="dundee">Dundee</label>
-            <option value="edinburgh">Edinburgh</label>
-            <option value="glasgow">Glasgow</label>
+            <option value="dundee">Dundee</option>
+            <option value="edinburgh">Edinburgh</option>
+            <option value="glasgow">Glasgow</option>
           </optgroup>
           <optgroup label="Wales">
-            <option value="cardiff">Cardiff</label>
-            <option value="swansea">Swansea</label>
+            <option value="cardiff">Cardiff</option>
+            <option value="swansea">Swansea</option>
           </optgroup>
         </select>
       `


### PR DESCRIPTION
## Description

Now the `search-with-select` component has been merged we can use it in the new/edit edition pages.

I've left all the native selects as native selects with one exception. 

<img width="683" alt="image" src="https://user-images.githubusercontent.com/42515961/229133489-1675b1dd-3a7a-4779-95de-57f8e25bbe88.png">

<img width="693" alt="image" src="https://user-images.githubusercontent.com/42515961/229133513-8bf2fc61-ea97-4d95-92b5-8d4f4bfbb9ae.png">

There's ~100 languages in the dropdown so it seems like a free win. I can remove it if people disagree.


I've tweaked the component so that opt groups so there's an option to pass in a blank option


<img width="921" alt="image" src="https://user-images.githubusercontent.com/42515961/233433617-fc84f457-d8b7-4e50-bb9c-603713a40d40.png">

In order to get the feature specs passing i've had to write some additional functionality into the select helper. It was a bit of a mare. More info in that commit message.

## Trello card

https://trello.com/c/fxqZiF3E/88-use-new-select-with-search-component-on-edit-edition-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
