### PR TITLE
Move edit role appointments page to GDS Design System 

### DIFF
--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -1,5 +1,6 @@
 class Admin::RoleAppointmentsController < Admin::BaseController
-  before_action :load_role_appointment, only: %i[edit update destroy]
+  before_action :load_role_appointment, only: %i[edit update destroy confirm_destroy]
+  layout :get_layout
 
   def new
     role = Role.find(params[:role_id])
@@ -17,15 +18,19 @@ class Admin::RoleAppointmentsController < Admin::BaseController
     end
   end
 
-  def edit; end
+  def edit
+    render_design_system("edit", "legacy_edit", next_release: false)
+  end
 
   def update
     if @role_appointment.update(role_appointment_params)
       redirect_to edit_admin_role_path(@role_appointment.role), notice: "Appointment has been updated"
     else
-      render :edit
+      render_design_system("edit", "legacy_edit", next_release: false)
     end
   end
+
+  def confirm_destroy; end
 
   def destroy
     if @role_appointment.destroyable?
@@ -33,7 +38,7 @@ class Admin::RoleAppointmentsController < Admin::BaseController
       redirect_to edit_admin_role_path(@role_appointment.role), notice: "Appointment has been deleted"
     else
       flash.now[:alert] = "Appointment can not be deleted"
-      render :edit
+      render_design_system("edit", "legacy_edit", next_release: false)
     end
   end
 
@@ -47,5 +52,16 @@ private
     params.require(:role_appointment).permit(
       :person_id, :started_at, :ended_at, :make_current
     )
+  end
+
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[edit update destroy confirm_destroy] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -5,6 +5,8 @@ class Admin::RoleAppointmentsController < Admin::BaseController
   def new
     role = Role.find(params[:role_id])
     @role_appointment = role.role_appointments.build(started_at: Time.zone.today)
+
+    render_design_system("new", "legacy_new", next_release: false)
   end
 
   def create
@@ -14,7 +16,7 @@ class Admin::RoleAppointmentsController < Admin::BaseController
       redirect_to edit_admin_role_path(role), notice: "Appointment created"
     else
       params[:make_current] = params[:role_appointment][:make_current]
-      render :new
+      render_design_system("new", "legacy_new", next_release: false)
     end
   end
 
@@ -56,7 +58,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[edit update destroy confirm_destroy] if preview_design_system?(next_release: false)
+    design_system_actions += %w[new create edit update destroy confirm_destroy] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -54,7 +54,7 @@ class RoleAppointment < ApplicationRecord
   end
 
   validates :role_id, :person_id, :started_at, presence: true
-  validates_with Validator
+  validates_with Validator, if: -> { started_at.present? }
 
   scope :for_role, ->(role) { where(role_id: role.id) }
   scope :for_person, ->(person) { where(person_id: person.id) }

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -18,7 +18,7 @@
 
 <% if form.object.new_record? %>
   <%= render "govuk_publishing_components/components/inset_text", {
-    text: "Note: Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches."
+    text: "Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches."
   } %>
 <% end %>
 

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -1,31 +1,74 @@
-<%= form.errors %>
-
-<%= form.label :person_id, 'Person' %>
-<%= form.select :person_id,
-                options_for_select(disambiguated_people_names, form.object.person_id),
-                {include_blank: true},
-                class: 'chzn-select form-control',
-                data: { placeholder: "Choose person…" },
-                disabled: !form.object.new_record? %>
+<%= render "/components/select-with-search", {
+  id: :"role_appointment_person_id",
+  label: "Person (required)",
+  heading_size: "m",
+  name: "role_appointment[person_id]",
+  options:
+    disambiguated_people_names.map do |person_name, person_id|
+      {
+        text: person_name,
+        value: person_id,
+        selected: form.object.person_id == person_id
+      }
+    end.select do |option|
+      form.object.new_record? || option[:selected]
+    end,
+  error_message: errors_for_input(form.object.errors, :person_id)
+} %>
 
 <% if form.object.new_record? %>
-  <p>Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches.</p>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "Note: Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches."
+  } %>
 <% end %>
 
-<div class="form-group">
-  <%= form.label :started_at %>
-  <div class="form-inline">
-    <%= form.date_select :started_at, { include_blank: true, start_year: Date.today.year, end_year: 1700 }, { :class => "date form-control" } %>
-  </div>
-</div>
+<%= render "components/datetime_fields", {
+  date_heading: "Started at (required)",
+  field_name: "started_at",
+  prefix: "role_appointment",
+  id: "role_appointment_started_at",
+  date_only: true,
+  year: {
+    value: form.object.started_at&.year,
+    start_year: Date.today.year,
+    end_year: 1700,
+    id: "role_appointment_started_at_1i",
+  },
+  month: {
+    value: form.object.started_at&.month,
+    id: "role_appointment_started_at_2i",
+  },
+  day: {
+    value: form.object.started_at&.day,
+    id: "role_appointment_started_at_3i",
+  },
+  error_items: errors_for(form.object.errors, :started_at),
+}
+%>
 
 <% if params[:make_current].blank? %>
-  <div class="form-group">
-    <%= form.label :ended_at %>
-    <div class="form-inline">
-      <%= form.date_select :ended_at, { include_blank: true, start_year: Date.today.year, end_year: 1700 }, { :class => "date form-control" } %>
-    </div>
-  </div>
+  <%= render "components/datetime_fields", {
+    date_heading: "Ended at",
+    field_name: "ended_at",
+    prefix: "role_appointment",
+    id: "role_appointment_ended_at",
+    date_only: true,
+    year: {
+      value: form.object.ended_at&.year,
+      start_year: Date.today.year,
+      end_year: 1700,
+      id: "role_appointment_ended_at_1i",
+    },
+    month: {
+      value: form.object.ended_at&.month,
+      id: "role_appointment_ended_at_2i",
+    },
+    day: {
+      value: form.object.ended_at&.day,
+      id: "role_appointment_ended_at_3i",
+    }
+  }
+  %>
 <% end %>
 
 <% if params[:make_current] %>

--- a/app/views/admin/role_appointments/_legacy_form.html.erb
+++ b/app/views/admin/role_appointments/_legacy_form.html.erb
@@ -1,0 +1,33 @@
+<%= form.errors %>
+
+<%= form.label :person_id, 'Person' %>
+<%= form.select :person_id,
+                options_for_select(disambiguated_people_names, form.object.person_id),
+                {include_blank: true},
+                class: 'chzn-select form-control',
+                data: { placeholder: "Choose person…" },
+                disabled: !form.object.new_record? %>
+
+<% if form.object.new_record? %>
+  <p>Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches.</p>
+<% end %>
+
+<div class="form-group">
+  <%= form.label :started_at %>
+  <div class="form-inline">
+    <%= form.date_select :started_at, { include_blank: true, start_year: Date.today.year, end_year: 1700 }, { :class => "date form-control" } %>
+  </div>
+</div>
+
+<% if params[:make_current].blank? %>
+  <div class="form-group">
+    <%= form.label :ended_at %>
+    <div class="form-inline">
+      <%= form.date_select :ended_at, { include_blank: true, start_year: Date.today.year, end_year: 1700 }, { :class => "date form-control" } %>
+    </div>
+  </div>
+<% end %>
+
+<% if params[:make_current] %>
+  <%= form.hidden_field :make_current, value: true %>
+<% end %>

--- a/app/views/admin/role_appointments/confirm_destroy.html.erb
+++ b/app/views/admin/role_appointments/confirm_destroy.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Delete appointment" %>
+<% content_for :title, "Delete the appointment of #{@role_appointment.person.name} to #{@role_appointment.role}" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag admin_role_appointment_path(@role_appointment), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to delete the appointment of "<%= @role_appointment.person.name %>" to "<%= @role_appointment.role %>"?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", admin_role_appointment_path(@role_appointment), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/role_appointments/edit.html.erb
+++ b/app/views/admin/role_appointments/edit.html.erb
@@ -1,42 +1,64 @@
-<% page_title "Edit appointment to #{@role_appointment.role.name}"  %>
+<% content_for :page_title, "Edit appointment to #{@role_appointment.role.name}"  %>
+<% content_for :title, "Edit appointment to #{@role_appointment.role.name}" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @role_appointment)) %>
 
-<div class="row">
-  <div class="col-md-8">
-    <h1>Edit appointment to position of <%= @role_appointment.role.name %> </h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for [:admin, @role_appointment] do |form| %>
+      <%= render 'admin/role_appointments/form', form: form %>
 
-    <%= form_for [:admin, @role_appointment], html: {class: 'well'} do |form| %>
-      <%= render partial: 'admin/role_appointments/form', locals: { form: form } %>
-
-      <%= form.save_or_cancel cancel: edit_admin_role_path(@role_appointment.role) %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+            "track-label": "Save"
+          }
+        } %>
+        <% if @role_appointment.destroyable? %>
+          <%= link_to("Delete", confirm_destroy_admin_role_appointment_path(@role_appointment), class: "govuk-link govuk-link--no-visited-state gem-link--destructive") %>
+        <% end %>
+        <%= link_to("Cancel", edit_admin_role_path(@role_appointment.role), class: "govuk-link") %>
+      </div>
     <% end %>
 
-    <% if @role_appointment.destroyable? %>
-      <%= button_to "Delete", admin_role_appointment_path(@role_appointment), method: :delete, class: "btn btn-danger" %>
-    <% else %>
-      <p>Cannot delete</p>
+    <% unless @role_appointment.destroyable? %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "Note: This appointment cannot be deleted"
+      } %>
     <% end %>
   </div>
 
-  <div class="col-md-4">
+  <div class="govuk-grid-column-one-third">
     <section class="speeches">
-      <h2>Speeches during this appointment</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Speeches during this appointment",
+        margin_bottom: 4
+      } %>
 
       <% if @role_appointment.speeches.any? %>
-        <ul class="speeches">
-        <% @role_appointment.speeches.each do |speech| %>
-          <li><%= link_to speech.title, [:admin, speech] %></li>
-        <% end %>
-        </ul>
+        <%= render "govuk_publishing_components/components/list", {
+          visible_counters: true,
+          items: @role_appointment.speeches.map do |speech|
+              link_to(speech.title, [:admin, speech], class: "govuk-link")
+            end
+        } %>
       <% else %>
-        <p>None</p>
+        <p class="govuk-body">None</p>
       <% end %>
     </section>
 
-    <h2>Other appointments to this role</h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Other appointments to this role",
+      margin_bottom: 4
+    } %>
     <% if @role_appointment.other_appointments_for_same_role.any? %>
-      <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.other_appointments_for_same_role }%>
+      <%= render "admin/role_appointments/list", role_appointments: @role_appointment.other_appointments_for_same_role %>
     <% else %>
-      <p>None</p>
+      <p class="govuk-body">None</p>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/role_appointments/edit.html.erb
+++ b/app/views/admin/role_appointments/edit.html.erb
@@ -8,6 +8,12 @@
     <%= form_for [:admin, @role_appointment] do |form| %>
       <%= render 'admin/role_appointments/form', form: form %>
 
+      <% unless @role_appointment.destroyable? %>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          text: "This appointment cannot be deleted"
+        } %>
+      <% end %>
+
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",
@@ -23,12 +29,6 @@
         <% end %>
         <%= link_to("Cancel", edit_admin_role_path(@role_appointment.role), class: "govuk-link") %>
       </div>
-    <% end %>
-
-    <% unless @role_appointment.destroyable? %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: "Note: This appointment cannot be deleted"
-      } %>
     <% end %>
   </div>
 

--- a/app/views/admin/role_appointments/legacy_edit.html.erb
+++ b/app/views/admin/role_appointments/legacy_edit.html.erb
@@ -1,0 +1,42 @@
+<% page_title "Edit appointment to #{@role_appointment.role.name}"  %>
+
+<div class="row">
+  <div class="col-md-8">
+    <h1>Edit appointment to position of <%= @role_appointment.role.name %> </h1>
+
+    <%= form_for [:admin, @role_appointment], html: {class: 'well'} do |form| %>
+      <%= render partial: 'admin/role_appointments/legacy_form', locals: { form: form } %>
+
+      <%= form.save_or_cancel cancel: edit_admin_role_path(@role_appointment.role) %>
+    <% end %>
+
+    <% if @role_appointment.destroyable? %>
+      <%= button_to "Delete", admin_role_appointment_path(@role_appointment), method: :delete, class: "btn btn-danger" %>
+    <% else %>
+      <p>Cannot delete</p>
+    <% end %>
+  </div>
+
+  <div class="col-md-4">
+    <section class="speeches">
+      <h2>Speeches during this appointment</h2>
+
+      <% if @role_appointment.speeches.any? %>
+        <ul class="speeches">
+        <% @role_appointment.speeches.each do |speech| %>
+          <li><%= link_to speech.title, [:admin, speech] %></li>
+        <% end %>
+        </ul>
+      <% else %>
+        <p>None</p>
+      <% end %>
+    </section>
+
+    <h2>Other appointments to this role</h2>
+    <% if @role_appointment.other_appointments_for_same_role.any? %>
+      <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.other_appointments_for_same_role }%>
+    <% else %>
+      <p>None</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/role_appointments/legacy_new.html.erb
+++ b/app/views/admin/role_appointments/legacy_new.html.erb
@@ -1,0 +1,17 @@
+<% page_title "Create new appointment to #{@role_appointment.role.name}"  %>
+
+<div class="row">
+  <div class="col-md-8">
+    <h1>Create new appointment to position of <%= @role_appointment.role.name %> </h1>
+
+    <%= form_for [:admin, @role_appointment.role.becomes(Role), @role_appointment], html: {class: 'well'} do |form| %>
+      <%= render partial: 'admin/role_appointments/legacy_form', locals: { form: form } %>
+
+      <%= form.save_or_cancel cancel: edit_admin_role_path(@role_appointment.role) %>
+    <% end %>
+  </div>
+  <div class="col-md-4">
+    <h2>Existing appointments</h2>
+    <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.role.role_appointments} %>
+  </div>
+</div>

--- a/app/views/admin/role_appointments/new.html.erb
+++ b/app/views/admin/role_appointments/new.html.erb
@@ -5,7 +5,7 @@
     <h1>Create new appointment to position of <%= @role_appointment.role.name %> </h1>
 
     <%= form_for [:admin, @role_appointment.role.becomes(Role), @role_appointment], html: {class: 'well'} do |form| %>
-      <%= render partial: 'admin/role_appointments/form', locals: { form: form } %>
+      <%= render partial: 'admin/role_appointments/legacy_form', locals: { form: form } %>
 
       <%= form.save_or_cancel cancel: edit_admin_role_path(@role_appointment.role) %>
     <% end %>

--- a/app/views/admin/role_appointments/new.html.erb
+++ b/app/views/admin/role_appointments/new.html.erb
@@ -1,17 +1,33 @@
-<% page_title "Create new appointment to #{@role_appointment.role.name}"  %>
+<% content_for :page_title, "Create new appointment to #{@role_appointment.role.name}"  %>
+<% content_for :title, "Create new appointment to #{@role_appointment.role.name}" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @role_appointment)) %>
 
-<div class="row">
-  <div class="col-md-8">
-    <h1>Create new appointment to position of <%= @role_appointment.role.name %> </h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for [:admin, @role_appointment.role.becomes(Role), @role_appointment] do |form| %>
+      <%= render 'admin/role_appointments/form', form: form %>
 
-    <%= form_for [:admin, @role_appointment.role.becomes(Role), @role_appointment], html: {class: 'well'} do |form| %>
-      <%= render partial: 'admin/role_appointments/legacy_form', locals: { form: form } %>
-
-      <%= form.save_or_cancel cancel: edit_admin_role_path(@role_appointment.role) %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+            "track-label": "Save"
+          }
+        } %>
+        <%= link_to("Cancel", edit_admin_role_path(@role_appointment.role), class: "govuk-link") %>
+      </div>
     <% end %>
   </div>
-  <div class="col-md-4">
-    <h2>Existing appointments</h2>
-    <%= render partial: "admin/role_appointments/legacy_list", locals: { role_appointments: @role_appointment.role.role_appointments} %>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Existing appointments",
+      margin_bottom: 4
+    } %>
+
+    <%= render "admin/role_appointments/list", role_appointments: @role_appointment.role.role_appointments %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,9 @@ Whitehall::Application.routes.draw do
         resource :cabinet_ministers, only: %i[show update]
         resources :roles, except: [:show] do
           get :confirm_destroy, on: :member
-          resources :role_appointments, only: %i[new create edit update destroy], shallow: true
+          resources :role_appointments, only: %i[new create edit update destroy], shallow: true do
+            get :confirm_destroy, on: :member
+          end
           resources :translations, controller: "role_translations"
         end
 

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -82,7 +82,13 @@ Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
   click_on using_design_system? ? "Edit#{role.name}" : role.name
   click_on "New appointment"
   select person_name, from: "Person"
-  select_date 1.day.ago.to_s, from: "Started at"
+  if using_design_system?
+    within "#role_appointment_started_at" do
+      fill_in_date_fields(1.day.ago.to_s)
+    end
+  else
+    select_date 1.day.ago.to_s, from: "Started at"
+  end
   click_on "Save"
 end
 

--- a/test/functional/admin/legacy_role_appointments_controller_test.rb
+++ b/test/functional/admin/legacy_role_appointments_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
+class Admin::LegacyRoleAppointmentsControllerTest < ActionController::TestCase
+  tests Admin::RoleAppointmentsController
+
   setup do
-    login_as_preview_design_system_user(:writer)
+    login_as :writer
   end
 
   should_be_an_admin_controller
@@ -79,17 +81,16 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     assert_select "form[action=?]", admin_role_appointment_path(appointment)
   end
 
-  view_test "edit should show a link to delete an appointment" do
-    destroyable_appointment = create(:role_appointment)
-    get :edit, params: { id: destroyable_appointment.id }
-    assert_select "a[href=?]", confirm_destroy_admin_role_appointment_path(destroyable_appointment), text: "Delete"
+  view_test "edit should show a button to delete an appointment" do
+    appointment = create(:role_appointment)
+    get :edit, params: { id: appointment.id }
+    assert_select "form[action=?]", admin_role_appointment_path(appointment)
   end
 
-  view_test "edit should not show a link to delete an undeleteable appointment" do
+  view_test "edit should not show a button to delete an undeleteable appointment" do
     appointment = create(:role_appointment)
-    create(:speech, title: "Some Speech", role_appointment: appointment)
     get :edit, params: { id: appointment.id }
-    refute_select "a[href=?]", confirm_destroy_admin_role_appointment_path(appointment), text: "Delete"
+    assert_select "form[action=?]", admin_role_appointment_path(appointment)
   end
 
   view_test "edit should show speeches associated with this appointment" do
@@ -102,9 +103,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   view_test "edit should not allow the person to be changed" do
     appointment = create(:role_appointment)
     get :edit, params: { id: appointment.id }
-    assert_select "select#role_appointment_person_id" do
-      assert_select "option", count: 1
-    end
+    assert_select "select#role_appointment_person_id[disabled=disabled]"
   end
 
   test "update should update an existing role appointment" do
@@ -123,18 +122,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   view_test "update shows errors if validation failed" do
     appointment = create(:role_appointment, started_at: 3.days.ago, ended_at: 2.days.ago)
     put :update, params: { id: appointment.id, role_appointment: { started_at: 1.day.from_now } }
-    assert_select ".govuk-error-message", text: "Error: Started at should not be in the future"
-  end
-
-  view_test "confirm_destroy should display form for deleting an existing appointment" do
-    appointment = create(:role_appointment)
-
-    get :confirm_destroy, params: { id: appointment }
-
-    assert_select "form[action='#{admin_role_appointment_path(appointment)}']" do
-      assert_select "button[type='submit']", "Delete"
-      assert_select "a[href=?]", admin_role_appointment_path(appointment).to_s, "Cancel"
-    end
+    assert_select ".field_with_errors", text: "Started at*"
   end
 
   test "delete removes an appointment" do

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -62,7 +62,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     _person = create(:person)
     post :create, params: { role_id: role.id, role_appointment: { started_at: 3.days.ago } }
     assert role.role_appointments.empty?
-    assert_select ".field_with_errors", text: "Person*"
+    assert_select ".govuk-error-message", text: "Error: Person can't be blank"
   end
 
   test "create should curtail previous appointments if make_current is present" do

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -35,6 +35,11 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     assert_not role_appointment.valid?
   end
 
+  test "should be invalid with no started_at but with ended_at"  do
+    role_appointment = build(:role_appointment, started_at: nil, ended_at: Time.zone.parse("1999-01-01"))
+    assert_not role_appointment.valid?
+  end
+
   test "should not be current if not started" do
     role_appointment = build(:role_appointment, started_at: nil, ended_at: nil)
     assert_not role_appointment.current?


### PR DESCRIPTION
## Description

This ports the role appointments edit page to the GOV.UK Design System. Then adds the new view in the GOV.UK Design System and conditionally renders the Bootstrap or GOV.UK Design System based on whether the user has the "Preview design system" permission.

## Screenshots

### Before

#### On landing (can delete, no speeches)
![Screenshot 2023-03-31 at 15 39 33](https://user-images.githubusercontent.com/91492293/229151841-f713a735-cd69-4b5b-8e77-1a7e9e5773d0.png)

#### On landing (can't delete, with speeches)
![Screenshot 2023-03-31 at 15 37 47](https://user-images.githubusercontent.com/91492293/229152032-ad0d03de-a5f3-46e9-9217-1b2c62ba14d0.png)

#### Error (no started at date, no ended at date)
![Screenshot 2023-03-31 at 15 38 19](https://user-images.githubusercontent.com/91492293/229152161-e2651e9c-d5ab-4a7b-91c5-eb0d8d6a8f53.png)

#### Error (no started at date, but with end date)
![Screenshot 2023-03-31 at 15 38 37](https://user-images.githubusercontent.com/91492293/229152326-2c7863ee-199b-4ee4-a87c-77c453c9237c.png)

### After

#### On landing (can delete, no speeches)
<img width="1792" alt="Screenshot 2023-04-05 at 17 00 39" src="https://user-images.githubusercontent.com/91492293/230138438-86a3fb23-179c-4339-a999-5cd80f2e4d1f.png">

#### On landing (can't delete, with speeches)
![Screenshot 2023-04-06 at 11 28 46](https://user-images.githubusercontent.com/91492293/230351756-81df6ac8-e49e-4b9f-9b91-1d83ac7b78f8.png)

#### On landing (single option on drop down for edit)
![Screenshot 2023-04-06 at 11 31 02](https://user-images.githubusercontent.com/91492293/230351843-82c859cd-8500-4eeb-b83f-c13af8a2aabb.png)

#### Error (no started at date, no ended at date)
<img width="1792" alt="Screenshot 2023-04-05 at 17 02 03" src="https://user-images.githubusercontent.com/91492293/230138643-5e0d9ecc-a478-4b7b-831c-fc24e8439ce3.png">

#### Error (no started at date, but with end date)
<img width="1792" alt="Screenshot 2023-04-05 at 17 02 24" src="https://user-images.githubusercontent.com/91492293/230138673-df6b8c85-7cfa-49c5-8bb3-372c41646a8a.png">

## Trello

https://trello.com/c/R5A32Kau

Add content_for page_title, title, and error_summary

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
