### PR TITLE
Add missed tracking for operational fields

### DIFF
--- a/app/views/admin/operational_fields/_form.html.erb
+++ b/app/views/admin/operational_fields/_form.html.erb
@@ -26,6 +26,12 @@
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", {
       text: "Save",
+      data_attributes: {
+         module: "gem-track-click",
+         "track-category": "form-button",
+         "track-action": "operational-field-button",
+         "track-label": "Save"
+       }
     } %>
 
     <%= link_to "Cancel", admin_operational_fields_path, class: "govuk-link" %>


### PR DESCRIPTION
## Description 

Adding tracking to the save button was missed for the operational field new/edit pages.

This adds it in

<img width="471" alt="image" src="https://user-images.githubusercontent.com/42515961/229512059-ad3c8fc4-9687-4c96-92d4-54f2ed3cca54.png">


## Trello card

https://trello.com/c/3AAFoZLH/34-field-of-operation-edit-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
