### PR TITLE
Fix bug with alternative_format_provider field

### DIFF
--- a/app/views/admin/editions/_inline_attachments_info.html.erb
+++ b/app/views/admin/editions/_inline_attachments_info.html.erb
@@ -44,7 +44,7 @@
             <option
               value="<%= id %>"
               <%="disabled='disabled'" if name.end_with?('(-)') %>
-              <%="selected" if (id == edition.alternative_format_provider_id || id == current_user.organisation.try(:id)) %>>
+              <%="selected" if (id == edition.alternative_format_provider_id || (edition.alternative_format_provider_id.blank? && id == current_user.organisation.try(:id))) %>>
               <%= name %>
             </option>
           <% end %>


### PR DESCRIPTION
## Description

This logic is faulty. With the previous logic an option is selected in two circumstances.

1. If the alternative_format_provider_id on the edition matches the value of the option
2. If the users organisation's id matches the options id

Both of these can be correct, but not concurrently.

At the moment, as two options are being marked as selected, the organisation that falls later in the alphabet is being marked as selected.

The correct behaviour is:

When an alternative_format_provider_id is present on an edition, we should use that to select the correct option.

When alternative_format_provider is nil, we should select the users organisation.

## Trello card

https://trello.com/c/5hUidaWF/84-bug-the-email-address-for-ordering-attachment-files-in-an-alternative-format-doesnt-always-save-properly

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
