### PR TITLE
Change validation rules for reslugging documents

### DIFF
--- a/lib/data_hygiene/document_reslugger.rb
+++ b/lib/data_hygiene/document_reslugger.rb
@@ -40,7 +40,7 @@ module DataHygiene
     end
 
     def new_slug_is_a_duplicate
-      documents = Document.where(slug: new_slug)
+      documents = Document.where(document_type: document.document_type, slug: new_slug)
       documents.present? && documents != [document]
     end
 


### PR DESCRIPTION
At the moment, we prevent a document from having it's slug changed if the new slug exists of any document. However Whitehall permits duplicated slugs, provided the document type is different. This is confirmed by the uniqueness in the schema [1] and the rules that are checked when a document is first created.

Therefore updating the reslugging rules to permit a duplicate slug provided the document type is different.  This will allow (for example) a document's base path to be changed to `/guidance/cost-of-living-payment` when `/news/cost-of-living-payment` already exists.

1: https://github.com/alphagov/whitehall/blob/9ea7dae5bfc445eaa56c682b244dc25bc4c5827d/db/schema.rb#L199
2: https://github.com/alphagov/whitehall/blob/9ea7dae5bfc445eaa56c682b244dc25bc4c5827d/app/models/document.rb#L59-L73

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
