### PR TITLE
Remove organisations route and reference to organisations_path

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -125,7 +125,7 @@ module OrganisationHelper
       child_relationships_link_text = child_organisations.size.to_s
       child_relationships_link_text += child_organisations.size == 1 ? " public body" : " agencies and public bodies"
 
-      organisation_name += link_to(child_relationships_link_text, organisations_path(anchor: organisation.slug), class: "brand__color")
+      organisation_name += link_to(child_relationships_link_text, organisation.public_path, class: "brand__color")
       organisation_name += "."
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,6 @@ Whitehall::Application.routes.draw do
     # End of public facing routes still rendered by Whitehall
 
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
-    get "/organisations", as: "organisations", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
 
     resources :organisations, only: [] do


### PR DESCRIPTION
Done as part of the work to remove routes just used for helper methods out of whitehall.

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
