### PR TITLE
Add Debug gem for IDE Debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "rdbg",
+            "name": "Attach within container",
+            "request": "attach"
+        },
+        {
+            "type": "rdbg",
+            "name": "Attach with rdbg (tcp 1234)",
+            "request": "attach",
+            "debugPort": "172.19.0.12:1234",
+            "localfsMap": "/workspace:${workspaceFolder}"
+        },
+        {
+            "name": "RSpec - active spec file only",
+            "type": "Ruby",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/rspec",
+            "args": [
+                "-I",
+                "${workspaceRoot}",
+                "${file}"
+            ]
+        },
+        {
+            "name": "Cucumber",
+            "type": "Ruby",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/cucumber"
+        },
+    ]
+}

--- a/.vscode/rdbg_autoattach.json
+++ b/.vscode/rdbg_autoattach.json
@@ -1,0 +1,10 @@
+{
+  "type": "rdbg",
+  "name": "Attach with rdbg",
+  "request": "attach",
+  "rdbgPath": "/root/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.7.2/exe/rdbg",
+  "debugPort": "/tmp/ruby-debug-sock-0/ruby-debug-UnknownUser-8491",
+  "localfs": true,
+  "autoAttach": "0.5141252672302551"
+}
+

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "terser"
 gem "transitions", require: ["transitions", "active_record/transitions"]
 gem "validates_email_format_of"
 gem "view_component"
+gem "debug", "~> 1.7"
 gem "whenever", require: false
 
 group :development, :test do
@@ -102,3 +103,4 @@ group :cucumber, :test do
   gem "govuk_test"
   gem "launchy"
 end
+


### PR DESCRIPTION
* # What
* Added Debug gem for using RDBG for debugging
* Added RDBG debug options for VSCode users
* # Why
* IDE Debugging to improve speed and ease
* # Gov-uk Docker PR
* [LINK](https://github.com/alphagov/govuk-docker/pull/654)
* # Trello
* https://trello.com/c/RQHdJQfh/1243-using-whitehall-in-rubymine-intellij

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
