### PR TITLE
Republish topical event page on publish of about page

### DIFF
--- a/app/models/topical_event_about_page.rb
+++ b/app/models/topical_event_about_page.rb
@@ -12,6 +12,8 @@ class TopicalEventAboutPage < ApplicationRecord
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
 
+  after_commit :republish_topical_event_to_publishing_api
+
   searchable title: :name,
              link: :search_link,
              content: :indexable_content,
@@ -35,5 +37,9 @@ class TopicalEventAboutPage < ApplicationRecord
 
   def public_url(options = {})
     Plek.website_root + public_path(options)
+  end
+
+  def republish_topical_event_to_publishing_api
+    Whitehall::PublishingApi.republish_async(topical_event)
   end
 end

--- a/test/unit/topical_event_about_page_test.rb
+++ b/test/unit/topical_event_about_page_test.rb
@@ -24,4 +24,30 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
   end
 
   should_not_accept_footnotes_in :body
+
+  test "republishes topical event when its about page is created" do
+    topical_event = create(:topical_event)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(topical_event)
+
+    create(:topical_event_about_page, topical_event:)
+  end
+
+  test "republishes topical event when its about page is updated" do
+    topical_event = create(:topical_event)
+    about_page = create(:topical_event_about_page, topical_event:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(topical_event)
+
+    about_page.save!
+  end
+
+  test "republishes topical event when its about page is destroyed" do
+    topical_event = create(:topical_event)
+    about_page = create(:topical_event_about_page, topical_event:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(topical_event)
+
+    about_page.destroy!
+  end
 end


### PR DESCRIPTION
Previously content editors were updating about pages and were confused as to why the corresponding topical event page wasn't also being updated.

Normally this would be done by dependency resolution, but since the topical event can be created without an about page, we'd need to define this logic on create of an about page too. Alternatively we could add a reverse link in the about page, but this is the simpler option for now.

[Trello](https://trello.com/c/r99oD6Hz/557-republish-topical-events-when-their-about-pages-change)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
