### PR TITLE
Remove highlight from Warning

### DIFF
--- a/app/views/admin/sitewide_settings/_form.html.erb
+++ b/app/views/admin/sitewide_settings/_form.html.erb
@@ -1,6 +1,5 @@
 <%= render "govuk_publishing_components/components/warning_text", {
-  text: "Changes to sitewide settings appear instantly on the live site.",
-  highlight_text: true
+  text: "Changes to sitewide settings appear instantly on the live site."
 } %>
 <%= form_for [:admin, sitewide_setting], as: :sitewide_setting do |form| %>
   <div class="govuk-grid-row">


### PR DESCRIPTION
* # What
* Removed highlight from warning text
* # Why
* Consistent Design
* Accessibility
* # OG PR https://github.com/alphagov/whitehall/pull/7418/files

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
