### PR TITLE
Remove '/latest' route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,6 @@ Whitehall::Application.routes.draw do
     # End of public facing routes still rendered by Whitehall
 
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
-    get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
     get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }


### PR DESCRIPTION
Unused seemingly, removing resulted in zero test failures.

Done as part of the work to remove routes just used for helper methods out of whitehall.

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
