### PR TITLE
Remove `statistical_dataset` route

### DIFF
--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -29,4 +29,8 @@ class StatisticalDataSet < Publicationesque
   def base_path
     "/government/statistical-data-sets/#{slug}"
   end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,6 @@ Whitehall::Application.routes.draw do
     # Routes no longer rendered by Whitehall, but retained to maintain the route helpers
     get "/latest", as: "latest", to: rack_404
     get "/organisations", as: "organisations", to: rack_404
-    get "/statistical-data-sets/:id", as: "statistical_data_set", to: rack_404
     get "/statistics(.:locale)", as: "statistics", to: "statistics#index", constraints: { locale: valid_locales_regex }
 
     resources :organisations, only: [] do

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -40,7 +40,7 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
 
   test "returns the statistical_data_set_path for StatisticalDataSet instances" do
     statistical_data_set = create(:statistical_data_set)
-    assert_equal statistical_data_set_path(statistical_data_set.document), public_document_path(statistical_data_set)
+    assert_equal statistical_data_set.public_path, public_document_path(statistical_data_set)
   end
 
   test "returns the correct path for CorporateInformationPage for organisations" do


### PR DESCRIPTION
Done as part of the work to remove routes just used for helper methods out of whitehall.

Trello: https://trello.com/c/0f35j3L6/390-remove-use-of-urlmaker-for-all-remaining-document-types


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
