### PR TITLE
Hide and show correct fields on edition edit

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -42,17 +42,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   EditionForm.prototype.setupWorldNewsStoryVisibilityToggle = function () {
     var form = this.module
 
-    var select = form.querySelector('#edition_news_article_type_id')
+    var subtypeSelect = form.querySelector('#edition_news_article_type_id')
 
-    if (!select) { return }
+    if (!subtypeSelect) { return }
 
-    var container = form.querySelector('.app-view-edit-edition__locale-field')
-    var localeCheckbox = container.querySelector('#edition_create_foreign_language_only-0')
-    var localeSelect = container.querySelector('#edition_primary_locale')
+    var localeDiv = form.querySelector('.app-view-edit-edition__locale-field')
+    var localeCheckbox = localeDiv.querySelector('#edition_create_foreign_language_only-0')
+    var localeSelect = localeDiv.querySelector('#edition_primary_locale')
     var worldNewsArticleTypeId = '4'
-    var ministers = form.querySelector('.app-view-edit-edition__appointment-fields')
-    var organisations = form.querySelector('.app-view-edit-edition__organisation-fields')
-    var world_location = form.querySelector('.app-view-edit-edition__world-location-fields')
+    var ministersDiv = form.querySelector('.app-view-edit-edition__appointment-fields')
+    var organisationsDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
+    var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
 
     if (subtypeSelect.value === worldNewsArticleTypeId) {
       ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
@@ -61,14 +61,27 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       worldLocationDiv.classList.add('app-view-edit-edition__world-location-fields--hidden')
     }
 
-    select.addEventListener('change', function () {
-      if (select.value !== worldNewsArticleTypeId) {
-        container.classList.add('app-view-edit-edition__locale-field--hidden')
+    subtypeSelect.addEventListener('change', function () {
+      if (subtypeSelect.value !== worldNewsArticleTypeId) {
+        localeDiv.classList.add('app-view-edit-edition__locale-field--hidden')
         localeCheckbox.value = '0'
         localeCheckbox.checked = false
         localeSelect.value = ''
+        ministersDiv.classList.remove('app-view-edit-edition__appointment-fields--hidden')
+        organisationsDiv.classList.remove('app-view-edit-edition__organisation-fields--hidden')
+        worldLocationDiv.classList.add('app-view-edit-edition__world-location-fields--hidden')
+        worldLocationDiv.querySelector('select').value = ''
       } else {
-        container.classList.remove('app-view-edit-edition__locale-field--hidden')
+        localeDiv.classList.remove('app-view-edit-edition__locale-field--hidden')
+        worldLocationDiv.classList.remove('app-view-edit-edition__world-location-fields--hidden')
+
+        ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
+        ministersDiv.querySelector('select').value = ''
+
+        organisationsDiv.classList.add('app-view-edit-edition__organisation-fields--hidden')
+        organisationsDiv.querySelectorAll('select').forEach(function (select) {
+          select.value = ''
+        })
       }
     })
   }

--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -49,10 +49,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var container = form.querySelector('.app-view-edit-edition__locale-field')
     var localeCheckbox = container.querySelector('#edition_create_foreign_language_only-0')
     var localeSelect = container.querySelector('#edition_primary_locale')
-    var newArticleTypeId = '4'
+    var worldNewsArticleTypeId = '4'
+    var ministers = form.querySelector('.app-view-edit-edition__appointment-fields')
+    var organisations = form.querySelector('.app-view-edit-edition__organisation-fields')
+    var world_location = form.querySelector('.app-view-edit-edition__world-location-fields')
+
+    if (subtypeSelect.value === worldNewsArticleTypeId) {
+      ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
+      organisationsDiv.classList.add('app-view-edit-edition__organisation-fields--hidden')
+    } else {
+      worldLocationDiv.classList.add('app-view-edit-edition__world-location-fields--hidden')
+    }
 
     select.addEventListener('change', function () {
-      if (select.value !== newArticleTypeId) {
+      if (select.value !== worldNewsArticleTypeId) {
         container.classList.add('app-view-edit-edition__locale-field--hidden')
         localeCheckbox.value = '0'
         localeCheckbox.checked = false

--- a/app/assets/stylesheets/admin/views/_edit-edition.scss
+++ b/app/assets/stylesheets/admin/views/_edit-edition.scss
@@ -22,6 +22,9 @@
 }
 
 .app-view-edit-edition__locale-field--hidden,
+.app-view-edit-edition__appointment-fields--hidden,
+.app-view-edit-edition__organisation-fields--hidden,
+.app-view-edit-edition__world-location-fields--hidden,
 .app-view-edit-edition__speech-location--hidden {
   display: none;
 }

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -13,11 +13,20 @@
     id: "associations"
   } do %>
     <div class="govuk-!-margin-bottom-4">
-      <%= render 'appointment_fields', form: form, edition: edition %>
+      <div class="app-view-edit-edition__appointment-fields">
+        <%= render 'appointment_fields', form: form, edition: edition %>
+      </div>
+
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
-      <%= render 'world_location_fields', form: form, edition: edition %>
-      <%= render 'organisation_fields', form: form, edition: edition %>
+
+      <div class="app-view-edit-edition__world-location-fields">
+        <%= render 'world_location_fields', form: form, edition: edition %>
+      </div>
+
+      <div class="app-view-edit-edition__organisation-fields">
+        <%= render 'organisation_fields', form: form, edition: edition %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -51,23 +51,38 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(organisationFields.classList).toContain('app-view-edit-edition__organisation-fields--hidden')
     })
 
-    it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {
-      var select = form.querySelector('#edition_news_article_type_id')
+    it('should reset & hide the locale & world location fields, and show the organisation and ministers fields when WorldNewsStory is deselected', function () {
+      var subtypeSelect = form.querySelector('#edition_news_article_type_id')
+      var localeDiv = form.querySelector('.app-view-edit-edition__locale-field')
       var localeCheckbox = form.querySelector('#edition_create_foreign_language_only-0')
       var localeSelect = form.querySelector('#edition_primary_locale')
 
-      select.value = '4'
-      select.dispatchEvent(new Event('change'))
+      var ministersDiv = form.querySelector('.app-view-edit-edition__appointment-fields')
+      var organisationDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
+      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
+      var worldLocationSelect = worldLocationDiv.querySelector('select')
+
+      subtypeSelect.value = '4'
+      subtypeSelect.dispatchEvent(new Event('change'))
 
       localeCheckbox.checked = true
       localeCheckbox.value = '1'
       localeSelect.value = 'ar'
-      select.value = '1'
-      select.dispatchEvent(new Event('change'))
+      subtypeSelect.value = '1'
+      worldLocationSelect.value = '1'
 
+      subtypeSelect.dispatchEvent(new Event('change'))
+
+      expect(localeDiv.classList).toContain('app-view-edit-edition__locale-field--hidden')
       expect(localeCheckbox.value).toEqual('0')
       expect(localeCheckbox.checked).toEqual(false)
       expect(localeSelect.value).toEqual('')
+
+      expect(worldLocationDiv.classList).toContain('app-view-edit-edition__world-location-fields--hidden')
+      expect(worldLocationSelect.value).toEqual('')
+
+      expect(ministersDiv.classList).not.toContain('app-view-edit-edition__ministers-fields--hidden')
+      expect(organisationDiv.classList).not.toContain('app-view-edit-edition__organisation-fields--hidden')
     })
   })
 
@@ -86,21 +101,33 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(worldLocationFields.classList).toContain('app-view-edit-edition__world-location-fields--hidden')
     })
 
-    it('should render the locale fields when WorldNewsStory is selected', function () {
+    it('should show the locale & world location fields, and hide and reset the ministers & org fields when WorldNewsStory is selected', function () {
       var select = form.querySelector('#edition_news_article_type_id')
 
       select.value = '4'
       select.dispatchEvent(new Event('change'))
 
       var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+      var ministersDiv = form.querySelector('.app-view-edit-edition__appointment-fields')
+      var ministersSelect = ministersDiv.querySelector('select')
+      var organisationDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
+      var organisationSelect1 = organisationDiv.querySelectorAll('select')[0]
+      var organisationSelect2 = organisationDiv.querySelectorAll('select')[1]
+      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
 
-      expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
+      expect(localeFields.classList).not.toContain('app-view-edit-edition__locale-field--hidden')
+      expect(worldLocationDiv.classList).not.toContain('app-view-edit-edition__world-location-fields--hidden')
+      expect(ministersDiv.classList).toContain('app-view-edit-edition__appointment-fields--hidden')
+      expect(ministersSelect.value).toEqual('')
+      expect(organisationDiv.classList).toContain('app-view-edit-edition__organisation-fields--hidden')
+      expect(organisationSelect1.value).toEqual('')
+      expect(organisationSelect2.value).toEqual('')
     })
   })
 
   describe('#setupSpeechSubtypeEventListeners', function () {
     beforeEach(function () {
-      form.innerHTML = speechFields() + associationsFields()
+      form.innerHTML = speechFields()
       var editionForm = new GOVUK.Modules.EditionForm(form)
       editionForm.init()
     })
@@ -201,10 +228,30 @@ describe('GOVUK.Modules.EditionForm', function () {
   function associationsFields () {
     return (
       '<div class="app-view-edit-edition__appointment-fields">' +
+        '<select name="edition[role_appointment_ids][]" id="edition_role_appointment_ids-select">' +
+          '<option value=""></option>' +
+          '<option value="1" selected="selected">Random Lord 1</option>' +
+          '<option value="2">Random Lord 2</option>' +
+        '</select>' +
       '</div>' +
       '<div class="app-view-edit-edition__organisation-fields">' +
+        '<select name="edition[lead_organisation_ids][]" id="edition_lead_organisation_ids_1">' +
+          '<option value=""></option>' +
+          '<option value="1" selected="selected">Org 1</option>' +
+          '<option value="2">Org 2</option>' +
+        '</select>' +
+        '<select name="edition[lead_organisation_ids][]" id="edition_lead_organisation_ids_2">' +
+          '<option value=""></option>' +
+          '<option value="1">Org 1</option>' +
+          '<option value="2" selected="selected">Org 2</option>' +
+        '</select>' +
       '</div>' +
       '<div class="app-view-edit-edition__world-location-fields">' +
+        '<select name="edition[world_location_ids][]" id="edition_world_location_ids-select">' +
+          '<option value=""></option>' +
+          '<option value="1" selected="selected">Country 1</option>' +
+          '<option value="2">Country 2</option>' +
+        '</select>' +
       '</div>'
     )
   }

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -8,7 +8,7 @@ describe('GOVUK.Modules.EditionForm', function () {
 
   describe('#setupSubtypeFormatAdviceEventListener', function () {
     beforeEach(function () {
-      form.innerHTML = subtypeFields() + localeFields()
+      form.innerHTML = subtypeFields() + localeFields() + associationsFields()
       var editionForm = new GOVUK.Modules.EditionForm(form)
       editionForm.init()
     })
@@ -36,28 +36,19 @@ describe('GOVUK.Modules.EditionForm', function () {
     })
   })
 
-  describe('#setupSubtypeFormatAdviceEventListener', function () {
+  describe('#setupWorldNewsStoryVisibilityToggle when a NewsArticle is a WorldNewsStory', function () {
     beforeEach(function () {
-      form.innerHTML = subtypeFields() + localeFields()
+      form.innerHTML = subtypeFieldsWithWorldNewsStorySelected() + localeFields() + associationsFields()
       var editionForm = new GOVUK.Modules.EditionForm(form)
       editionForm.init()
     })
 
-    it('should hide the locale fields when a NewsArticle is not a WorldNewsStory', function () {
-      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+    it('should hide the ministers and organisation fields on page load', function () {
+      var ministersFields = form.querySelector('.app-view-edit-edition__appointment-fields')
+      var organisationFields = form.querySelector('.app-view-edit-edition__organisation-fields')
 
-      expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
-    })
-
-    it('should render the locale fields when the WorldNewsStory is selected', function () {
-      var select = form.querySelector('#edition_news_article_type_id')
-
-      select.value = '4'
-      select.dispatchEvent(new Event('change'))
-
-      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
-
-      expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
+      expect(ministersFields.classList).toContain('app-view-edit-edition__appointment-fields--hidden')
+      expect(organisationFields.classList).toContain('app-view-edit-edition__organisation-fields--hidden')
     })
 
     it('should reset the locale checkbox and select values when WorldNewsStory is deselected', function () {
@@ -80,9 +71,36 @@ describe('GOVUK.Modules.EditionForm', function () {
     })
   })
 
-  describe('#setupSubtypeFormatAdviceEventListener', function () {
+  describe('#setupWorldNewsStoryVisibilityToggle when a NewsArticle is not a WorldNewsStory', function () {
     beforeEach(function () {
-      form.innerHTML = speechFields()
+      form.innerHTML = subtypeFields() + localeFields() + associationsFields()
+      var editionForm = new GOVUK.Modules.EditionForm(form)
+      editionForm.init()
+    })
+
+    it('should hide the locale fields and world-location-fields on page load', function () {
+      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+      var worldLocationFields = form.querySelector('.app-view-edit-edition__world-location-fields')
+
+      expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
+      expect(worldLocationFields.classList).toContain('app-view-edit-edition__world-location-fields--hidden')
+    })
+
+    it('should render the locale fields when WorldNewsStory is selected', function () {
+      var select = form.querySelector('#edition_news_article_type_id')
+
+      select.value = '4'
+      select.dispatchEvent(new Event('change'))
+
+      var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
+
+      expect(localeFields.style.display).not.toContain('app-view-edit-edition__locale-field--hidden')
+    })
+  })
+
+  describe('#setupSpeechSubtypeEventListeners', function () {
+    beforeEach(function () {
+      form.innerHTML = speechFields() + associationsFields()
       var editionForm = new GOVUK.Modules.EditionForm(form)
       editionForm.init()
     })
@@ -149,6 +167,22 @@ describe('GOVUK.Modules.EditionForm', function () {
     )
   }
 
+  function subtypeFieldsWithWorldNewsStorySelected () {
+    return (
+      '<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the “Speech” format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Don’t duplicate news published by another department.\u003c/p\u003e&quot;}">' +
+        '<div class="govuk-form-group gem-c-select">' +
+          '<label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>' +
+          '<select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">' +
+            '<option value=""></option>' +
+            '<option value="1">News story</option>' +
+            '<option value="2">Press release</option>' +
+            '<option value="3">Government response</option>' +
+            '<option value="4" selected="selected">World news story</option></select>' +
+        '</div>' +
+      '</div>'
+    )
+  }
+
   function localeFields () {
     return (
       '<div class="app-view-edit-edition__locale-field app-view-edit-edition__locale-field--hidden">' +
@@ -160,6 +194,17 @@ describe('GOVUK.Modules.EditionForm', function () {
           '<option value="az">Azeri (Azeri)</option>' +
           '<option value="be">Беларуская (Belarusian)</option>' +
         '</select>' +
+      '</div>'
+    )
+  }
+
+  function associationsFields () {
+    return (
+      '<div class="app-view-edit-edition__appointment-fields">' +
+      '</div>' +
+      '<div class="app-view-edit-edition__organisation-fields">' +
+      '</div>' +
+      '<div class="app-view-edit-edition__world-location-fields">' +
       '</div>'
     )
   }


### PR DESCRIPTION
## Description

There's lot of details on the card and commit history for this, but essentially the WorldNewsStory subtype of News Article requires different fields to the other types of News Articles

On page load: 

When the NewsArticles type is WorldNewsStory on page load:

1. the world news location select should show
2. the document language fields should show
3. the ministers select should be hidden
4. the org fields should be hidden

When the NewsArticles is any other type:

1. the the world news location select should be hidden
2. the document language fields should be hidden (this
has already been implemented)
3. the minsters select should show
4. the org fields should show

On change of subtype

When the WorldNewsStory type is selected the following behaviour
should happen:

1. the world news location select should show
2. the document language fields should show
3. the ministers select should be hidden and the value should be reset
4. the org fields should be hidden and all selects' values should be
reset

When another type is selected (or nil) the inverse should happen

1. the the world news location select should be hidden and reset
2. the document language fields should be hidden and reset (this
has already been implemented)
3. the minsters select should show
4. the org fields should show


## Screenshots

### World news story

#### Before

<img width="251" alt="image" src="https://user-images.githubusercontent.com/42515961/230359355-11cb9b49-b1a4-4107-b9f9-0278185eb28f.png">

<img width="350" alt="image" src="https://user-images.githubusercontent.com/42515961/230359386-4d171f44-e27d-4eb2-8b2a-fb5dbbfb82f3.png">

#### After

<img width="251" alt="image" src="https://user-images.githubusercontent.com/42515961/230359355-11cb9b49-b1a4-4107-b9f9-0278185eb28f.png">

<img width="271" alt="image" src="https://user-images.githubusercontent.com/42515961/230359494-67437efd-d483-4a07-b1b2-511feb72ce96.png">

### Other subtypes

#### Before

<img width="222" alt="image" src="https://user-images.githubusercontent.com/42515961/230359183-3261975b-a51b-4b8c-b552-95422ba68865.png">

<img width="360" alt="image" src="https://user-images.githubusercontent.com/42515961/230359240-92012366-8402-4c57-8e66-2b774a60734e.png">


#### After

<img width="222" alt="image" src="https://user-images.githubusercontent.com/42515961/230359183-3261975b-a51b-4b8c-b552-95422ba68865.png">

<img width="316" alt="image" src="https://user-images.githubusercontent.com/42515961/230359594-5a04f469-d593-4bc9-ae55-376751d719b5.png">



## Trello 

https://trello.com/c/i32CgsOI/79-edit-edition-page-vary-associations-by-news-article-type

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
