### PR TITLE
Handle lead images in the new images tab

### DIFF
--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -39,9 +39,9 @@
   } %>
 </div>
 
-<% if edition.images %>
+<% if @edition.images %>
   <ul class="govuk-list">
-    <% edition.images.each_with_index do |image, index| %>
+    <% @edition.images.each_with_index do |image, index| %>
       <li class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
           <% if image.url.present? %>
@@ -58,7 +58,7 @@
           <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive") %>
         </div>
       </li>
-      <% if image != edition.images.last %>
+      <% if image != @edition.images.last %>
         <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--visible"></li>
       <% end %>
     <% end %>

--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -2,7 +2,8 @@
   text: "Uploaded images",
   font_size: "l",
 } %>
-<div>
+
+<% if can_have_lead_image? %>
   <%= render "govuk_publishing_components/components/heading", {
     text: "Lead image",
     font_size: "m",
@@ -19,48 +20,53 @@
     in the document body.</p>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Use default image",
-    secondary_solid: true,
-    margin_bottom: 4
-  } %>
-</div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <img src="<%= lead_image[:url] %>" alt="<%= lead_image[:preview_alt_text] %>" class="app-view-edition-images__image">
+    </div>
+    <ul class="app-view-edition-images__details govuk-grid-column-two-thirds govuk-list govuk-list--bullet">
+      <li><strong>Caption: </strong><%= lead_image[:caption] %></li>
+      <li><strong>Alt text: </strong><%= lead_image[:alt_text] %></li>
+    </ul>
+    <div class="app-view-edition-images__actions govuk-grid-column-full govuk-button-group">
+      <% if @edition.type == "CaseStudy" %>
+      <% lead_image[:links].each do |link| %><%= link %><% end %>
+    </div>
+  </div>
+<% end %>
 
-<div>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Images available to use in document",
-    font_size: "m",
-    padding: true
-  } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Images available to use in document",
+  font_size: "m",
+  padding: true
+} %>
 
+<% if document_images %>
   <%= render "govuk_publishing_components/components/inset_text", {
     text: "Use the 'Insert image' button in the document tab to add images to body copy.",
     margin_top: 0
   } %>
-</div>
 
-<% if @edition.images %>
   <ul class="govuk-list">
-    <% @edition.images.each_with_index do |image, index| %>
+    <% document_images.each do |image| %>
       <li class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <% if image.url.present? %>
-            <img src="<%= image.url %>" alt="Image <%= index + 1 %>" class="app-view-edition-images__image">
-          <% end %>
+          <img src="<%= image[:url] %>" alt="<%= image[:preview_alt_text] %>" class="app-view-edition-images__image">
         </div>
         <ul class="app-view-edition-images__details govuk-grid-column-two-thirds govuk-list govuk-list--bullet">
-          <li><strong>Caption: </strong><%= image.caption.blank? ? "None" : image.caption %></li>
-          <% if image.alt_text %><li><strong>Alt text: </strong><%= image.alt_text.blank? ? "None" : image.alt_text %></li><% end %>
-          <li><strong>Markdown code: </strong><span>[Image:&nbsp;<%=image.image_data.carrierwave_image %>]</span></li>
+          <li><strong>Caption: </strong><%= image[:caption] %></li>
+          <li><strong>Alt text: </strong><%= image[:alt_text] %></li>
+          <li><strong>Markdown code: </strong><%= image[:markdown] %></li>
         </ul>
         <div class="app-view-edition-images__actions govuk-grid-column-full govuk-button-group">
-          <%= link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link") %>
-          <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive") %>
+          <% image[:links].each do |link| %><%= link %><% end %>
         </div>
       </li>
-      <% if image != @edition.images.last %>
+      <% if image != document_images.last %>
         <li aria-hidden="true"><hr class="app-view-edition-images__section-break govuk-section-break govuk-section-break--visible"></li>
       <% end %>
     <% end %>
   </ul>
+<% else %>
+  <p class="govuk-body">No images uploaded</p>
 <% end %>

--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -19,8 +19,10 @@
     <p class="govuk-body">The lead image appears at the top of the document. It cannot be used
     in the document body.</p>
   <% end %>
+<% end %>
 
-  <div class="govuk-grid-row">
+<div class="govuk-grid-row">
+  <% if lead_image %>
     <div class="govuk-grid-column-one-third">
       <img src="<%= lead_image[:url] %>" alt="<%= lead_image[:preview_alt_text] %>" class="app-view-edition-images__image">
     </div>
@@ -28,12 +30,28 @@
       <li><strong>Caption: </strong><%= lead_image[:caption] %></li>
       <li><strong>Alt text: </strong><%= lead_image[:alt_text] %></li>
     </ul>
-    <div class="app-view-edition-images__actions govuk-grid-column-full govuk-button-group">
-      <% if @edition.type == "CaseStudy" %>
-      <% lead_image[:links].each do |link| %><%= link %><% end %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+
+  <% if lead_image || @edition.type == "CaseStudy" %>
+    <%= form_with(url: update_image_display_option_admin_edition_path(@edition), method: :patch) do |form| %>
+      <div class="app-view-edition-images__actions govuk-grid-column-full govuk-button-group">
+        <% if @edition.type == "CaseStudy" %>
+          <%= hidden_field_tag "edition[image_display_option]", new_image_display_option %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: update_image_display_option_button_text,
+            secondary_solid: true,
+            margin_bottom: 4
+          } %>
+        <% end %>
+
+        <% if lead_image %>
+          <% lead_image[:links].each do |link| %><%= link %><% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+
+</div>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Images available to use in document",

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
+  def initialize(edition:)
+    @edition = edition
+  end
+end

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -3,5 +3,43 @@
 class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
   def initialize(edition:)
     @edition = edition
+    @lead_image = has_lead_image? ? @edition.images.first : nil
+    @document_images = @edition.images.drop(has_lead_image? ? 1 : 0)
+  end
+
+  def has_lead_image?
+    can_have_lead_image? && @edition.images.any?
+  end
+
+  def can_have_lead_image?
+    @edition.is_a? Edition::FirstImagePulledOut
+  end
+
+  def lead_image
+    image_to_hash @lead_image, 0 if has_lead_image?
+  end
+
+  def document_images
+    @document_images.map.with_index(1) { |image, index| image_to_hash image, index }
+  end
+
+private
+
+  def image_to_hash(image, index)
+    {
+      url: image.url,
+      preview_alt_text: index.zero? ? "Lead image" : "Image #{index}",
+      caption: image.caption.presence || "None",
+      alt_text: image.alt_text.presence || "None",
+      markdown: "[#{image.image_data.carrierwave_image}]",
+      links: links_for_image(image),
+    }
+  end
+
+  def links_for_image(image)
+    links = []
+    links << link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link")
+    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive")
+    links
   end
 end

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -23,6 +23,22 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
     @document_images.map.with_index(1) { |image, index| image_to_hash image, index }
   end
 
+  def new_image_display_option
+    if @edition.image_display_option == "no_image"
+      return has_lead_image? ? "custom_image" : "organisation_image"
+    end
+
+    "no_image"
+  end
+
+  def update_image_display_option_button_text
+    if has_lead_image?
+      return "#{new_image_display_option == 'no_image' ? 'Hide' : 'Show'} lead image"
+    end
+
+    "#{new_image_display_option == 'no_image' ? 'Remove lead' : 'Use default'} image"
+  end
+
 private
 
   def image_to_hash(image, index)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -5,7 +5,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
-  before_action :find_edition, only: %i[show edit update revise diff confirm_destroy destroy update_bypass_id history]
+  before_action :find_edition, only: %i[show edit update revise diff confirm_destroy destroy update_bypass_id update_image_display_option history]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_national_exclusion_params, only: %i[create update]
@@ -31,7 +31,7 @@ class Admin::EditionsController < Admin::BaseController
       enforce_permission!(:create, edition_class || Edition)
     when "create"
       enforce_permission!(:create, @edition)
-    when "edit", "update", "revise", "diff", "update_bypass_id"
+    when "edit", "update", "revise", "diff", "update_bypass_id", "update_image_display_option"
       enforce_permission!(:update, @edition)
     when "destroy", "confirm_destroy"
       enforce_permission!(:delete, @edition)
@@ -177,6 +177,17 @@ class Admin::EditionsController < Admin::BaseController
       redirect_to admin_editions_path, notice: "The draft of '#{@edition.title}' has been deleted"
     else
       redirect_to admin_edition_path(@edition), alert: edition_deleter.failure_reason
+    end
+  end
+
+  def update_image_display_option
+    @edition.assign_attributes(edition_params)
+
+    if updater.can_perform? && @edition.save_as(current_user)
+      updater.perform!
+      redirect_to admin_edition_images_path(@edition), notice: "The lead image has been updated"
+    else
+      redirect_to admin_edition_images_path(@edition), alert: updater.failure_reason
     end
   end
 

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -11,7 +11,7 @@
     } %>
 
     <%= render "image_upload", edition: @edition %>
-    <%= render "uploaded_images", edition: @edition %>
+    <%= render Admin::EditionImages::UploadedImagesComponent.new(edition: @edition) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,7 @@ Whitehall::Application.routes.draw do
             get :audit_trail, to: "edition_audit_trail#index"
             get :document_history, to: "edition_document_history#index"
             patch :update_bypass_id
+            patch :update_image_display_option
             get :history, to: "editions#history"
             get :confirm_destroy
           end

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -40,6 +40,13 @@ Feature: Images tab on edit edition
     Then I should see a updated banner
     Then I should see the updated image details
 
+  Scenario: Lead image setting can be updated from the images tab
+    And I have the "Preview images update" permission
+    And a draft case study with images exists
+    When I visit the images tab of the document with images
+    And I click to hide the lead image
+    Then I should see a button to show the lead image
+
   Scenario: Image uploaded with no cropping required
     And I have the "Preview images update" permission
     And I start drafting a new publication "Standard Beard Lengths"

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -3,6 +3,11 @@ Given("a draft document with images exists") do
   @edition = create(:draft_publication, body: "!!2", images:)
 end
 
+Given("a draft case study with images exists") do
+  images = [build(:image), build(:image)]
+  @edition = create(:draft_case_study, body: "!!2", images:)
+end
+
 When("I visit the images tab of the document with images") do
   visit admin_edition_images_path(@edition)
 end
@@ -38,6 +43,10 @@ When("I click to edit the details of an image") do
   first("a", text: "Edit details").click
 end
 
+When("I click to hide the lead image") do
+  find("button", text: "Hide lead image").click
+end
+
 When("I confirm the deletion") do
   find("button", text: "Delete image").click
 end
@@ -57,6 +66,10 @@ end
 
 Then "I should see the updated image details" do
   expect(page).to have_content("Test caption")
+end
+
+Then "I should see a button to show the lead image" do
+  expect(page).to have_content("Show lead image")
 end
 
 And(/^I navigate to the images tab$/) do

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Admin::EditionImages::UploadedImagesComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -3,10 +3,23 @@
 require "test_helper"
 
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
-  def test_component_renders_something_useful
-    # assert_equal(
-    #   %(<span>Hello, components!</span>),
-    #   render_inline(Admin::EditionImages::UploadedImagesComponent.new(message: "Hello, components!")).css("span").to_html
-    # )
+  test "lead image rendered for case study" do
+    images = [build(:image), build(:image)]
+    edition = create(:draft_case_study, images:)
+    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
+
+    assert_selector "img", count: 2
+    assert_selector "img[alt='Lead image']"
+    assert_selector "img[alt='Image 1']"
+  end
+
+  test "lead image not rendered for publication" do
+    images = [build(:image), build(:image)]
+    edition = create(:draft_publication, images:)
+    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
+
+    assert_selector "img", count: 2
+    assert_selector "img[alt='Image 1']"
+    assert_selector "img[alt='Image 2']"
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Move uploaded images to View Component.
[Pull out lead image from uploaded images.
Add button to hide or show the lead image for Case Studies.](https://trello.com/c/4Eogck71/1136-add-like-for-like-lead-image-functionality-to-images-tab)

# Why
This brings the new images tab functionality up to the existing page.
We have decided not to alter the lead image behaviour in the initial image workflow redesign.

# Screenshots
![whitehall-admin dev gov uk_government_admin_editions_1374131_images(iPad Pro)](https://user-images.githubusercontent.com/9594455/231706524-77eac071-6363-4f00-8e26-5849792ed9ff.png)
![whitehall-admin dev gov uk_government_admin_editions_1374131_images(iPhone 12 Pro)](https://user-images.githubusercontent.com/9594455/231706536-611a7a57-ce5f-499a-9c53-0a687a79877d.png)
