### PR TITLE
Add migration to restore coronation TopicalEvent

### DIFF
--- a/db/data_migration/20230411085954_restore_coronation_topical_event.rb
+++ b/db/data_migration/20230411085954_restore_coronation_topical_event.rb
@@ -1,0 +1,1 @@
+TopicalEvent.unscoped.find_by(slug: "coronation").update!(state: "current")


### PR DESCRIPTION
## Description

A user accidentally deleted this TopicalEvent. This migration restores it for them by updating it's state from `deleted` to `current`

## Zendesk ticket

https://govuk.zendesk.com/agent/tickets/5244780

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
