### PR TITLE
Fix bug with destroy group cancel link

### DIFF
--- a/app/views/admin/policy_groups/confirm_destroy.html.erb
+++ b/app/views/admin/policy_groups/confirm_destroy.html.erb
@@ -14,7 +14,7 @@
           destructive: true,
         } %>
 
-        <%= link_to("Cancel", admin_policy_group_path(@policy_group), class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", admin_policy_groups_path, class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>


### PR DESCRIPTION
## Description

Previously, this linked to the show endpoint which doesn't exist.

## Trello card 

https://trello.com/c/enCSheLp/92-group-listing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
