### PR TITLE
Add rake task for cloning a HTML Attachment from a Published to Draft edition

### DIFF
--- a/lib/tasks/clone_published_html_attachment_to_draft_edition.rake
+++ b/lib/tasks/clone_published_html_attachment_to_draft_edition.rake
@@ -1,0 +1,12 @@
+desc "Clone a documents published HTML attachment to the draft edition"
+task :clone_published_html_attachment_to_draft_edition, %i[html_attachment_id] => :environment do |_task, args|
+  html_attachment = HtmlAttachment.find(args[:html_attachment_id])
+
+  edition = html_attachment.attachable
+  raise "The HTML attachment must belong to a published or superseded edition" if %w[published superseded].exclude?(edition.state)
+
+  latest_edition  = edition.document.latest_edition
+  raise "The HTML attachments associated document must have an edition in a pre-published state." if Edition::PRE_PUBLICATION_STATES.exclude?(latest_edition.state)
+
+  latest_edition.attachments << html_attachment.deep_clone
+end

--- a/test/unit/tasks/clone_published_html_attachment_to_draft_edition_test.rb
+++ b/test/unit/tasks/clone_published_html_attachment_to_draft_edition_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "rake"
+
+class ClonePublishedHtmlAttachmentToDraftEditionRake < ActiveSupport::TestCase
+  STATES = Edition.state_machine.states.map(&:name).map(&:to_s).freeze
+
+  teardown do
+    Rake::Task["clone_published_html_attachment_to_draft_edition"].reenable
+  end
+
+  test "it deep clones an html attachment from a published edition to a pre-published edition" do
+    published_edition = create(:edition, :published)
+    html_attachment = create(:html_attachment, attachable: published_edition, body: "test")
+    draft_edition = create(:edition, :draft, document: published_edition.document)
+
+    Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
+
+    attachment = draft_edition.attachments.first
+
+    assert_equal 1, draft_edition.reload.attachments.count
+    assert_equal "test", attachment.body
+    assert_equal "test", attachment.govspeak_content.body
+  end
+
+  test "it deep clones an html attachment from a superseded edition to a pre-published edition" do
+    superseded_edition = create(:edition, :superseded)
+    html_attachment = create(:html_attachment, attachable: superseded_edition, body: "test")
+    draft_edition = create(:edition, :draft, document: superseded_edition.document)
+
+    Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
+
+    attachment = draft_edition.attachments.first
+
+    assert_equal 1, draft_edition.reload.attachments.count
+    assert_equal "test", attachment.body
+    assert_equal "test", attachment.govspeak_content.body
+  end
+
+  (STATES - %w[published superseded]).each do |state|
+    test "it raises an error if the html attachments edition is in the #{state} state" do
+      edition = create(:edition, state)
+      html_attachment = create(:html_attachment, attachable: edition, body: "test")
+
+      assert_raises(StandardError, "The HTML attachment must belong to a published or superseded edition") do
+        Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
+      end
+    end
+  end
+
+  (STATES - Edition::PRE_PUBLICATION_STATES).each do |state|
+    test "it raises an error if latest edition is in the #{state} state" do
+      edition = create(:edition, %i[published superseded].sample)
+      html_attachment = create(:html_attachment, attachable: edition, body: "test")
+      create(
+        :edition,
+        state:,
+        document: edition.document,
+        major_change_published_at: state == "published" ? Time.zone.now : nil,
+      )
+
+      assert_raises(StandardError, "The HTML attachments associated document must have an edition in a pre-published state.") do
+        Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

We've run into an issue a couple of times now where a user has created a new draft edition and the HTML Attachment has not been carried across due to the Govspeak being invalid.

This can occur when updates happen to the Govspeak gem between the HTML Attachment being created and a new edition draft edition being created as the validator only validates the govspeak content when a change is made.

While we can fix the govspeak then ask the user to delete and re-create the draft edition, if they've started to make changes it could cause them a bit of hassle. This rake task hopefully alleviates that issue by building out the functionality to clone the attachment across from a published edition to a draft edition.

I've personally had this happen to me twice so hopefully this will make it easier to fix going forward.

## Zendesk ticket 

https://govuk.zendesk.com/agent/tickets/5278334

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
