### PR TITLE
73 take part page to design system

### DIFF
--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -12,6 +12,7 @@ class Admin::TakePartPagesController < Admin::BaseController
 
   def new
     @take_part_page = TakePartPage.new
+    render_design_system("new", "legacy_new", next_release: false)
   end
 
   def create
@@ -52,7 +53,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[] if preview_design_system?(next_release: false)
+    design_system_actions += %w[new create] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -1,24 +1,92 @@
-<div class="row">
-  <div class="col-md-8">
-    <p class="warning">
-      Warning: changes to take part pages appears instantly on the live site.
-    </p>
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to take part pages appears instantly on the live site."
+    } %>
 
-    <%= form_for take_part_page, url: [:admin, take_part_page] do |form| %>
-      <%= form.errors %>
-      <%= form.text_field :title %>
-      <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
-      <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
-      <%= form.text_area :body, rows: 20, class: "previewable", required: true, data: {
-        module: "paste-html-to-govspeak"
+    <%= form_for take_part_page, url: [:admin, take_part_page], multipart: true do |form| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title (required)"
+        },
+        name: "take_part_page[title]",
+        id: "take_part_page_title",
+        hint: "Title text should be 255 characters or fewer.",
+        heading_level: 2,
+        heading_size: "l",
+        value: form.object.title,
+        error_items: errors_for(form.object.errors, :title)
       } %>
-      <%= form.upload :image %>
-      <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
-      <%= form.save_or_cancel cancel: admin_take_part_pages_path %>
-    <% end %>
-  </div>
 
-  <div class="col-md-4">
-    <%= legacy_simple_formatting_sidebar %>
-  </div>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Summary (required)",
+          heading_level: 2,
+          heading_size: "l",
+        },
+        name: "take_part_page[summary]",
+        id: "take_part_page_summary",
+        rows: 2,
+        hint: "Summary text should be 255 characters or fewer.",
+        value: form.object.summary,
+        error_items: errors_for(form.object.errors, :summary)
+      } %>
+
+      <%= render "components/govspeak-editor", {
+        label: {
+          heading_size: "l",
+          text: "Body (required)"
+        },
+        name: "take_part_page[body]",
+        id: "take_part_page_body",
+        rows: 20,
+        value: form.object.body,
+        error_items: errors_for(form.object.errors, :body)
+      } %>
+
+      <%= render "govuk_publishing_components/components/file_upload", {
+        label: {
+          text: "Image (required)",
+          heading_size: "l"
+        },
+        name: "take_part_page[image]",
+        id: "take_part_page_image",
+        value: form.object.image,
+        error_items: errors_for(form.object.errors, :image)
+      } %>
+
+      <% if form.object.carrierwave_image.present? %>
+        <%= hidden_field_tag "take_part_page[image]", form.object.carrierwave_image %>
+        <p class="govuk-body"><%= "#{File.basename(form.object.carrierwave_image)} already uploaded" %></p>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Image description (alt text)",
+        },
+        heading_size: "l",
+        name: "take_part_page[image_alt_text]",
+        id: "take_part_page_image_alt_text",
+        value: form.object.image_alt_text
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "take-part-page-button",
+            "track-label": "Save"
+          }
+        } %>
+
+        <%= link_to "Cancel", admin_take_part_pages_path, class:"govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </section>
+
+  <section class="govuk-grid-column-one-third">
+    <%= simple_formatting_sidebar %>
+  </section>
 </div>

--- a/app/views/admin/take_part_pages/_legacy_form.html.erb
+++ b/app/views/admin/take_part_pages/_legacy_form.html.erb
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="col-md-8">
+    <p class="warning">
+      Warning: changes to take part pages appears instantly on the live site.
+    </p>
+
+    <%= form_for take_part_page, url: [:admin, take_part_page] do |form| %>
+      <%= form.errors %>
+      <%= form.text_field :title %>
+      <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
+      <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
+      <%= form.text_area :body, rows: 20, class: "previewable", required: true, data: {
+        module: "paste-html-to-govspeak"
+      } %>
+      <%= form.upload :image %>
+      <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>
+      <%= form.save_or_cancel cancel: admin_take_part_pages_path %>
+    <% end %>
+  </div>
+
+  <div class="col-md-4">
+    <%= legacy_simple_formatting_sidebar %>
+  </div>
+</div>

--- a/app/views/admin/take_part_pages/legacy_new.html.erb
+++ b/app/views/admin/take_part_pages/legacy_new.html.erb
@@ -1,0 +1,5 @@
+<% page_title "New take part page" %>
+
+<h2>New take part page</h2>
+
+<%= render 'legacy_form', take_part_page: @take_part_page %>

--- a/app/views/admin/take_part_pages/new.html.erb
+++ b/app/views/admin/take_part_pages/new.html.erb
@@ -1,5 +1,5 @@
-<% page_title "New take part page" %>
-
-<h2>New take part page</h2>
+<% content_for :page_title, "New take part page" %>
+<% content_for :title, "New take part page" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @take_part_page, parent_class: "take_part_page")) %>
 
 <%= render 'form', take_part_page: @take_part_page %>

--- a/test/functional/admin/legacy_take_part_pages_controller_test.rb
+++ b/test/functional/admin/legacy_take_part_pages_controller_test.rb
@@ -27,7 +27,7 @@ class Admin::LegacyTakePartPagesControllerTest < ActionController::TestCase
     assert assigns(:take_part_page).is_a? TakePartPage
     assert_not assigns(:take_part_page).persisted?
     assert_response :success
-    assert_template "new"
+    assert_template "legacy_new"
   end
 
   test "POST :create saves a new instance with the supplied valid params" do


### PR DESCRIPTION
[Trello](https://trello.com/c/elfoyfNE/73-add-new-take-part-page)

The changes in this PR port the "Take part" landing page to the design system. Screenshots below.

Some points to note: 
- Although the field for the image description (alt text) is currently marked as required this does not return an error when the user saves the page without that so it appears to not be required. 
- The current implementation includes a warning to the user when they exceed 160 characters in the summary field that is not included in the Design System port. This is consistent with other pages that include a character count though the actual limit is inconsistent across Whitehall. The error that is generated when the text is too long is actually when that text exceeds 255 characters so the hint text here reflects that. 
- Additionally the title field is subject tot he same limit so a hint has been added to that. 

| Bootstrap | Design System |
| - | - |
| ![Screenshot 2023-04-12 at 11 51 28](https://user-images.githubusercontent.com/6080548/231436309-ebcec2f9-7dd4-44b1-8155-e582c07c22fd.png) | ![Screenshot 2023-04-12 at 11 52 46](https://user-images.githubusercontent.com/6080548/231436549-9623bc50-422b-4633-96d9-05a896dd227e.png) |