### PR TITLE
Reduce batch size in 'each_edition_for_csv' to 100

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -27,7 +27,7 @@ module Admin
     end
 
     def each_edition_for_csv(locale = nil)
-      editions_with_translations(locale).find_each do |edition|
+      editions_with_translations(locale).find_each(batch_size: 100) do |edition|
         yield edition if Whitehall::Authority::Enforcer.new(@current_user, edition).can?(:see)
       end
     end


### PR DESCRIPTION
## Description 

The process is being killed due to a timeout when generating large reports. I suspect reducing the batch size will fix the issue.

I've tested this on Integration and it resolved the issue.

## Zendesk ticket

https://govuk.zendesk.com/agent/tickets/5294552

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
