### PR TITLE
Render Field of Operation pages in Government Frontend

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
           document_type: "field_of_operation",
           locale: "en",
           publishing_app: "whitehall",
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: "field_of_operation",
           title: operational_field.name,
           update_type:,

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -32,7 +32,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       base_path: "/government/fields-of-operation/operational-field-name",
       details: {},
       document_type: "field_of_operation",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "government-frontend",
       schema_name: "field_of_operation",
       description: Whitehall::GovspeakRenderer.new.govspeak_to_html(@operational_field.description),
       routes: [


### PR DESCRIPTION
This means that after all Field of Operation pages have been republished we can remove lots of code from Whitehall, jolly good.

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
