### PR TITLE
remove Fields of Operation pages from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Whitehall is deployed in two modes:
 
 - CSV Preview pages: [https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview)
 
-### Fields of Operation
-
-- Field of Operation pages: [https://www.gov.uk/government/fields-of-operation/iraq](https://www.gov.uk/government/fields-of-operation/iraq)
-
 ### Government Information
 
 - Current ministers list: [https://www.gov.uk/government/ministers](https://www.gov.uk/government/ministers)


### PR DESCRIPTION
https://github.com/alphagov/government-frontend/pull/2736 and https://github.com/alphagov/whitehall/pull/7544 stopped these pages from being rendered by Whitehall so should be removed from the examples list

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
