### PR TITLE
Update presenter for ministers index page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -194,8 +194,8 @@ class Organisation < ApplicationRecord
   before_destroy { |r| throw :abort unless r.destroyable? }
   after_save :ensure_analytics_identifier
   after_save :update_organisations_index_page
-  after_save :republish_how_government_works_page_to_publishing_api
-  after_destroy :update_organisations_index_page
+  after_save :republish_how_government_works_page_to_publishing_api, :republish_ministers_index_page_to_publishing_api
+  after_destroy :update_organisations_index_page, :republish_ministers_index_page_to_publishing_api
 
   after_save do
     # If the organisation has an about us page and the chart URL changes we need
@@ -227,6 +227,10 @@ class Organisation < ApplicationRecord
 
   def republish_how_government_works_page_to_publishing_api
     PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
+  end
+
+  def republish_ministers_index_page_to_publishing_api
+    PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter) if ministerial_department?
   end
 
   def update_organisations_index_page

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -69,7 +69,7 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
+  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
 
   def republish_organisation_to_publishing_api
@@ -78,8 +78,11 @@ class RoleAppointment < ApplicationRecord
     end
   end
 
-  def republish_how_government_works_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter) if ministerial?
+  def republish_ministerial_pages_to_publishing_api
+    if ministerial?
+      PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
+      PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter)
+    end
   end
 
   def republish_prime_ministers_index_page_to_publishing_api

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -35,6 +35,11 @@ module PublishingApi
         ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
         ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
         ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
+        ordered_house_of_commons_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseOfCommons),
+        ordered_junior_lords_of_the_treasury_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::JuniorLordsoftheTreasury),
+        ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
+        ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
+        ordered_baronessess_and_ladies_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
       }
     end
 
@@ -98,6 +103,17 @@ module PublishingApi
         .includes(ministerial_roles: [:current_people])
         .order("organisations.ministerial_ordering, organisation_roles.ordering")
         .uniq
+        .map(&:content_id)
+    end
+
+    def ordered_whips_content_ids(whip_type)
+      Role
+        .whip
+        .where(whip_organisation_id: whip_type.id)
+        .occupied
+        .order(:whip_ordering)
+        .map(&:current_role_appointment)
+        .map(&:person)
         .map(&:content_id)
     end
   end

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -13,7 +13,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "ministers_index",
+        title: "Ministers",
         update_type:,
       ).base_attributes
 

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -34,6 +34,7 @@ module PublishingApi
       {
         ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
         ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
+        ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
       }
     end
 
@@ -88,6 +89,16 @@ module PublishingApi
       end
 
       sorted_ministers.map(&:content_id)
+    end
+
+    def ordered_ministerial_departments_content_ids
+      Organisation.ministerial_departments
+        .excluding_govuk_status_closed
+        .with_translations_for(:ministerial_roles)
+        .includes(ministerial_roles: [:current_people])
+        .order("organisations.ministerial_ordering, organisation_roles.ordering")
+        .uniq
+        .map(&:content_id)
     end
   end
 end

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -49,9 +49,7 @@ module PublishingApi
     end
 
     def base_path
-      return "/government/ministers" if I18n.locale == :en
-
-      "/government/ministers.#{I18n.locale}"
+      "/government/ministers"
     end
   end
 end

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -37,9 +37,15 @@ module PublishingApi
     def details
       setting = SitewideSetting.find_by(key: :minister_reshuffle_mode)
 
-      return {} unless setting.on
-
-      { reshuffle: { message: setting.govspeak } }
+      if setting.on
+        {
+          reshuffle: { message: setting.govspeak },
+        }
+      else
+        {
+          body: "Read biographies and responsibilities of [Cabinet ministers](#cabinet-ministers) and all [ministers by department](#ministers-by-department), as well as the [whips](#whips) who help co-ordinate parliamentary business.",
+        }
+      end
     end
 
     def base_path

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,7 +88,7 @@ if WorldLocation.where(name: "Test International Delegation").blank?
     Person.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
-    RoleAppointment.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :republish_ministerial_pages_to_publishing_api)
     HistoricalAccount.skip_callback(:commit, :after, :publish_to_publishing_api)
     HistoricalAccount.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -83,6 +83,11 @@ namespace :publishing_api do
     task republish_operational_fields_index: :environment do
       PresentPageToPublishingApi.new.publish(PublishingApi::OperationalFieldsIndexPresenter)
     end
+
+    desc "Republish the ministers index page to Publishing API"
+    task republish_ministers_index: :environment do
+      PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter)
+    end
   end
 
   namespace :patch_links do

--- a/test/unit/historical_account_test.rb
+++ b/test/unit/historical_account_test.rb
@@ -117,6 +117,7 @@ class HistoricalAccountTest < ActiveSupport::TestCase
 
     test "does not republish the past prime ministers page on create" do
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+      PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
       object.save!
@@ -140,6 +141,7 @@ class HistoricalAccountTest < ActiveSupport::TestCase
       account = create(:historical_account, person: @person, roles: [@pm_role])
 
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+      PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
       account.update!(roles: [@pm_role, create(:historic_role)])

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1126,17 +1126,43 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url
   end
 
-  test "should send the how government works page to publishing api when an organisation is created" do
+  test "should send related pages to publishing api when a non-ministerial department is created" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
 
     create(:organisation)
   end
 
-  test "should send the how government works page to publishing api when an organisation is updated" do
+  test "should send related pages to publishing api when a non-ministerial department is updated" do
     organisation = create(:organisation)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
 
     organisation.update!(name: "New department name")
+  end
+
+  test "should send related pages to publishing api when a ministerial department is created" do
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+
+    create(:ministerial_department)
+  end
+
+  test "should send related pages to publishing api when a ministerial department is updated" do
+    organisation = create(:ministerial_department)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+
+    organisation.update!(name: "New department name")
+  end
+
+  test "should send related pages to publishing api when a ministerial department is deleted" do
+    organisation = create(:ministerial_department)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+
+    organisation.destroy!
   end
 end

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -30,6 +30,17 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       create(:role_appointment, person: create(:person), role: create(:ministerial_role, organisations: [ministerial_department_3]))
       create(:role_appointment, person: create(:person), role: create(:ministerial_role, organisations: [ministerial_department_2]))
 
+      hoc_whip_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::WhipsHouseOfCommons.id, whip_ordering: 2, organisations: [ministerial_department_1]))
+      hoc_whip_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::WhipsHouseOfCommons.id, whip_ordering: 1, organisations: [ministerial_department_1]))
+      junior_treasury_whip_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::JuniorLordsoftheTreasury.id, whip_ordering: 2, organisations: [ministerial_department_1]))
+      junior_treasury_whip_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::JuniorLordsoftheTreasury.id, whip_ordering: 1, organisations: [ministerial_department_1]))
+      assistant_whip_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::AssistantWhips.id, whip_ordering: 2, organisations: [ministerial_department_1]))
+      assistant_whip_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::AssistantWhips.id, whip_ordering: 1, organisations: [ministerial_department_1]))
+      hol_whip_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::WhipsHouseofLords.id, whip_ordering: 2, organisations: [ministerial_department_1]))
+      hol_whip_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::WhipsHouseofLords.id, whip_ordering: 1, organisations: [ministerial_department_1]))
+      baroness_whip_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::BaronessAndLordsInWaiting.id, whip_ordering: 2, organisations: [ministerial_department_1]))
+      baroness_whip_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, whip_organisation_id: Whitehall::WhipOrganisation::BaronessAndLordsInWaiting.id, whip_ordering: 1, organisations: [ministerial_department_1]))
+
       expected_content = {
         title: "Ministers",
         locale: "en",
@@ -65,6 +76,26 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
           ministerial_department_3.content_id,
           ministerial_department_1.content_id,
           ministerial_department_2.content_id,
+        ],
+        ordered_house_of_commons_whips: [
+          hoc_whip_2.person.content_id,
+          hoc_whip_1.person.content_id,
+        ],
+        ordered_junior_lords_of_the_treasury_whips: [
+          junior_treasury_whip_2.person.content_id,
+          junior_treasury_whip_1.person.content_id,
+        ],
+        ordered_assistant_whips: [
+          assistant_whip_2.person.content_id,
+          assistant_whip_1.person.content_id,
+        ],
+        ordered_house_lords_whips: [
+          hol_whip_2.person.content_id,
+          hol_whip_1.person.content_id,
+        ],
+        ordered_baronessess_and_ladies_in_waiting_whips: [
+          baroness_whip_2.person.content_id,
+          baroness_whip_1.person.content_id,
         ],
       }
 

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -5,16 +5,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
     PublishingApi::MinistersIndexPresenter.new
   end
 
-  test "presenter is valid against ministers index schema" do
-    I18n.with_locale(:en) do
-      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
-
-      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
-      assert_valid_against_links_schema({ links: presented_item.links }, "ministers_index")
-    end
-  end
-
-  test "presents ministers index page ready for the publishing-api in english" do
+  test "presents a valid content item containing the correct information when reshuffle mode is off" do
     I18n.with_locale(:en) do
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
 
@@ -100,11 +91,14 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       }
 
       assert_equal expected_content, presented_item.content
+      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
+
       assert_equal expected_links, presented_item.links
+      assert_valid_against_links_schema({ links: presented_item.links }, "ministers_index")
     end
   end
 
-  test "presents ministers index page ready for the publishing-api with correct reshuffle message" do
+  test "presents a valid content item without information when reshuffle mode is on" do
     I18n.with_locale(:en) do
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
 
@@ -117,7 +111,10 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       expected_links = {}
 
       assert_equal expected_details, presented_item.content[:details]
+      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
+
       assert_equal expected_links, presented_item.links
+      assert_valid_against_links_schema({ links: presented_item.links }, "ministers_index")
     end
   end
 end

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -56,31 +56,4 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       assert_equal expected_details, presented_item.content[:details]
     end
   end
-
-  test "presents ministers index page ready for the publishing-api in welsh" do
-    I18n.with_locale(:cy) do
-      create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
-
-      expected_hash = {
-        title: "ministers_index",
-        locale: "cy",
-        publishing_app: "whitehall",
-        redirects: [],
-        update_type: "major",
-        base_path: "/government/ministers.cy",
-        details: {},
-        document_type: "ministers_index",
-        rendering_app: "whitehall-frontend",
-        schema_name: "ministers_index",
-        routes: [
-          {
-            path: "/government/ministers.cy",
-            type: "exact",
-          },
-        ],
-      }
-
-      assert_equal expected_hash, presented_item.content
-    end
-  end
 end

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -25,7 +25,9 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         redirects: [],
         update_type: "major",
         base_path: "/government/ministers",
-        details: {},
+        details: {
+          body: "Read biographies and responsibilities of [Cabinet ministers](#cabinet-ministers) and all [ministers by department](#ministers-by-department), as well as the [whips](#whips) who help co-ordinate parliamentary business.",
+        },
         document_type: "ministers_index",
         rendering_app: "whitehall-frontend",
         schema_name: "ministers_index",

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
 
       expected_hash = {
-        title: "ministers_index",
+        title: "Ministers",
         locale: "en",
         publishing_app: "whitehall",
         redirects: [],

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -18,11 +18,17 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
     I18n.with_locale(:en) do
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
 
-      prime_minister = create(:role_appointment, person: create(:person), role: create(:prime_minister_role, cabinet_member: true, seniority: 0))
-      cabinet_member_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 2))
-      cabinet_member_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 1))
-      also_attends_cabinet_minister_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 4))
-      also_attends_cabinet_minister_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 3))
+      ministerial_department_1 = create(:ministerial_department, ministerial_ordering: 2)
+      ministerial_department_2 = create(:ministerial_department, ministerial_ordering: 3)
+      ministerial_department_3 = create(:ministerial_department, ministerial_ordering: 1)
+
+      prime_minister = create(:role_appointment, person: create(:person), role: create(:prime_minister_role, cabinet_member: true, seniority: 0, organisations: [ministerial_department_3]))
+      cabinet_member_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 2, organisations: [ministerial_department_3]))
+      cabinet_member_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 1, organisations: [ministerial_department_1]))
+      also_attends_cabinet_minister_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 4, organisations: [ministerial_department_1]))
+      also_attends_cabinet_minister_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 3, organisations: [ministerial_department_3]))
+      create(:role_appointment, person: create(:person), role: create(:ministerial_role, organisations: [ministerial_department_3]))
+      create(:role_appointment, person: create(:person), role: create(:ministerial_role, organisations: [ministerial_department_2]))
 
       expected_content = {
         title: "Ministers",
@@ -54,6 +60,11 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         ordered_also_attends_cabinet: [
           also_attends_cabinet_minister_2.person.content_id,
           also_attends_cabinet_minister_1.person.content_id,
+        ],
+        ordered_ministerial_departments: [
+          ministerial_department_3.content_id,
+          ministerial_department_1.content_id,
+          ministerial_department_2.content_id,
         ],
       }
 

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -18,7 +18,13 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
     I18n.with_locale(:en) do
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
 
-      expected_hash = {
+      prime_minister = create(:role_appointment, person: create(:person), role: create(:prime_minister_role, cabinet_member: true, seniority: 0))
+      cabinet_member_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 2))
+      cabinet_member_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true, seniority: 1))
+      also_attends_cabinet_minister_1 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 4))
+      also_attends_cabinet_minister_2 = create(:role_appointment, person: create(:person), role: create(:ministerial_role, attends_cabinet_type_id: RoleAttendsCabinetType::AttendsCabinet.id, seniority: 3))
+
+      expected_content = {
         title: "Ministers",
         locale: "en",
         publishing_app: "whitehall",
@@ -39,7 +45,20 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         ],
       }
 
-      assert_equal expected_hash, presented_item.content
+      expected_links = {
+        ordered_cabinet_ministers: [
+          prime_minister.person.content_id,
+          cabinet_member_2.person.content_id,
+          cabinet_member_1.person.content_id,
+        ],
+        ordered_also_attends_cabinet: [
+          also_attends_cabinet_minister_2.person.content_id,
+          also_attends_cabinet_minister_1.person.content_id,
+        ],
+      }
+
+      assert_equal expected_content, presented_item.content
+      assert_equal expected_links, presented_item.links
     end
   end
 
@@ -53,7 +72,10 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         },
       }
 
+      expected_links = {}
+
       assert_equal expected_details, presented_item.content[:details]
+      assert_equal expected_links, presented_item.links
     end
   end
 end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -444,6 +444,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment = create(:role_appointment, person: create(:person), role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
     role_appointment.update!(ended_at: Time.zone.now)
@@ -453,6 +454,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role = create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     create(:role_appointment, person: create(:person), role:)
@@ -470,6 +472,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
                                  roles: [role])
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
@@ -480,31 +483,35 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
   end
 
-  test "should send the how government works page to publishing api when the role created is a current prime minister" do
+  test "should send the related pages to publishing api when the role created is a current prime minister" do
     role = create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
 
     create(:role_appointment, person: create(:person), role:)
   end
 
-  test "should send the how government works page to publishing api when someone is appointed to a ministerial role" do
+  test "should send the related pages to publishing api when someone is appointed to a ministerial role" do
     role = create(:ministerial_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
 
     create(:role_appointment, person: create(:person), role:)
   end
 
-  test "should not send the how government works page to publishing api when someone is appointed to a non-ministerial role" do
+  test "should not send the related pages to publishing api when someone is appointed to a non-ministerial role" do
     role = create(:non_ministerial_role_without_organisations)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
 
     create(:role_appointment, person: create(:person), role:)
   end


### PR DESCRIPTION
The content item for the ministers index page currently contains a lot of information (e.g. all historic ministers) but lacks other information needed to render the page outside of Whitehall (e.g. the types of whip).  The amount of information is so vast that browser-based JSON formatters fail to format the page.

Therefore removing the inverse link from the role content item (to stop all this content appearing in the index page) and updating the presenter to include only the required information.

This is dependent on https://github.com/alphagov/publishing-api/pull/2341 and https://github.com/alphagov/publishing-api/pull/2344.

Once merged, the following rake task will need to be run to publish the updated version of this page:
```
rake publishing_api:republish:republish_ministers_index
```

[Trello card](https://trello.com/c/SFVenvAi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
