### PR TITLE
Update the image usage guidance

### DIFF
--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -61,7 +61,7 @@
 
 <% if document_images %>
   <%= render "govuk_publishing_components/components/inset_text", {
-    text: "Use the 'Insert image' button in the document tab to add images to body copy.",
+    text: "Copy the image markdown code to add images to the document body.",
     margin_top: 0
   } %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
[Remove the reference to the "Insert image" button in the image usage guidance.](https://trello.com/c/vOZPG9Pt/1216-remove-references-to-insert-image-modal-because-its-not-part-of-release-16)

# Why
The ‘Insert image’ button does not exist in Release 1.6.
