### PR TITLE
Remove ministers index page from links in roles

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -30,7 +30,7 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-      }.merge(item.ministerial? ? { ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f] } : {})
+      }.merge(item.ministerial? ? { ministerial: [] } : {})
     end
 
   private

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -47,7 +47,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f],
+      ministerial: [],
     }
 
     presented_item = present(role)
@@ -107,7 +107,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ministerial: %w[324e4708-2285-40a0-b3aa-cb13af14ec5f],
+      ministerial: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
At the moment, we are including a link to the ministers index page in the links for every ministerial role (including past roles).

This results in a reverse link in the ministers index page content item that has become too large to work with.  The content item is not currently being used by any frontend applications.

In later work, this will be replaced with a link to the current and relevant ministers only in the index page's content item.

We are having to make this change in two steps (step one: empty the array, step two: remove the `ministerial` link completely), as patching the links won't remove the link if the key is not included. A later PR will remove the key completely from the presenter.

After deployment, all roles will need to be republished using the following rake task:

```
publishing_api:bulk_republish:document_type[Role]
```

[Trello card](https://trello.com/c/SFVenvAi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
