### PR TITLE
Remove ministerial link from roles

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -30,7 +30,7 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-      }.merge(item.ministerial? ? { ministerial: [] } : {})
+      }
     end
 
   private

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -47,7 +47,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ministerial: [],
     }
 
     presented_item = present(role)
@@ -107,7 +106,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      ministerial: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/7550, we emptied the `ministerial` links from roles, in preparation for removing them.

Once the links have been emptied in production, we can remove the key from the presented content.

This is dependent on https://github.com/alphagov/whitehall/pull/7550 being merged, deployed and all roles republished in production.

[Trello card](https://trello.com/c/SFVenvAi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
