### PR TITLE
72 take part page

### DIFF
--- a/app/assets/stylesheets/admin/views/_take-part.scss
+++ b/app/assets/stylesheets/admin/views/_take-part.scss
@@ -1,0 +1,5 @@
+.app-view-take-part__page-list {
+  .govuk-table__cell:last-child {
+    text-align: right;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/govspeak-help";
 @import "./admin/views/historical-accounts-index";
 @import "./admin/views/organisations-index";
+@import "./admin/views/take-part";
 @import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";
 @import "./admin/views/whats-new";

--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -8,6 +8,7 @@ class Admin::TakePartPagesController < Admin::BaseController
 
   def index
     @take_part_pages = TakePartPage.in_order
+    render_design_system(:index, :legacy_index, next_release: false)
   end
 
   def new
@@ -37,10 +38,18 @@ class Admin::TakePartPagesController < Admin::BaseController
     end
   end
 
+  def confirm_destroy
+    @take_part_page = TakePartPage.friendly.find(params[:id])
+  end
+
   def destroy
     @take_part_page = TakePartPage.friendly.find(params[:id])
     @take_part_page.destroy!
     redirect_to [:admin, TakePartPage], notice: %(Take part page "#{@take_part_page.title}" deleted!)
+  end
+
+  def update_order
+    @take_part_pages = TakePartPage.in_order
   end
 
   def reorder
@@ -53,7 +62,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[new create] if preview_design_system?(next_release: false)
+    design_system_actions += %w[new create index confirm_destroy update_order] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/take_part_pages/confirm_destroy.html.erb
+++ b/app/views/admin/take_part_pages/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @take_part_page.title %>
+<% content_for :page_title, "Delete take part page" %>
+<% content_for :title, "Delete take part page" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this page?</p>
+
+    <%= form_tag [:admin, :take_part_page], id: @take_part_page_to_change, method: :delete do %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", admin_take_part_pages_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/take_part_pages/index.html.erb
+++ b/app/views/admin/take_part_pages/index.html.erb
@@ -1,38 +1,63 @@
-<% page_title 'Get involved' %>
+<% content_for :page_title, "Get involved" %>
+<% content_for :title, "Get involved" %>
+<% content_for :title_margin_bottom, 4 %>
 
-<div class="get-involved-header">
-  <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_url %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      <%= link_to "View on website", get_involved_url, class: "govuk-link", target: "_blank" %>
+    </p>
+  </div>
 </div>
 
-<section class="get-involved">
-  <%= get_involved_tab_navigation %>
-
-  <h2>Take part pages</h2>
-  <p class="warning">
-    Warning: changes to take part page ordering appears instantly on the live site.
-  </p>
-
-  <% if @take_part_pages.any? %>
-    <%= form_tag reorder_admin_take_part_pages_path, method: :post do %>
-      <fieldset class="sortable">
-        <% @take_part_pages.each do |take_part_page| %>
-          <div class="well">
-            <%= label_tag "ordering-#{take_part_page.id}" do %>
-              <%= link_to(take_part_page.title, [:edit, :admin, take_part_page]) %>
-            <% end %>
-
-            <%= text_field_tag "ordering[#{take_part_page.id}]", take_part_page.ordering, id: "ordering-#{take_part_page.id}", class: "ordering" %>
-          </div>
-        <% end %>
-      </fieldset>
-      <%= submit_tag "Update order", class: "btn btn-default" %>
-    <% end %>
-  <% else %>
-    <p class="no-content no-content-bordered">No take part pages</p>
-  <% end %>
-
-  <div class="form-actions">
-    <%= link_to "Add new take part page", new_admin_take_part_page_path, class: "btn btn-lg btn-primary"%>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Get involved tabs",
+      items: [
+        {
+          label: "Get involved",
+          href: admin_get_involved_path
+        },
+        {
+          label: "Take part pages",
+          href: admin_take_part_pages_path,
+          current: true
+        }
+      ]
+    } %>
   </div>
-</section>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/list", {
+      items: [
+        (link_to 'Add new take part page', new_admin_take_part_page_path, class: "govuk-link govuk-link--no-visited-state"),
+        (link_to 'Update order', update_order_admin_take_part_pages_path, class: "govuk-link govuk-link--no-visited-state")
+      ]
+    } %>
+
+    <% if @take_part_pages.any? %>
+      <div class="app-view-take-part__page-list">
+        <%= render "govuk_publishing_components/components/table", {
+          rows: @take_part_pages.map do |take_part_page|
+            [
+              {
+                text: take_part_page.title
+              },
+              {
+                text: (
+                  link_to("Edit", [:edit, :admin, take_part_page], class: "govuk-link") +
+                  link_to("Delete", [:confirm_destroy, :admin, take_part_page], class: "govuk-link gem-link--destructive govuk-!-margin-left-2")
+                )
+              }
+            ]
+          end
+        } %>
+      </div>
+    <% else %>
+      <p class="govuk-body">No take part pages</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/take_part_pages/legacy_index.html.erb
+++ b/app/views/admin/take_part_pages/legacy_index.html.erb
@@ -1,0 +1,38 @@
+<% page_title 'Get involved' %>
+
+<div class="get-involved-header">
+  <h1>Get involved</h1>
+  <%= link_to "View on website", get_involved_url %>
+</div>
+
+<section class="get-involved">
+  <%= get_involved_tab_navigation %>
+
+  <h2>Take part pages</h2>
+  <p class="warning">
+    Warning: changes to take part page ordering appears instantly on the live site.
+  </p>
+
+  <% if @take_part_pages.any? %>
+    <%= form_tag reorder_admin_take_part_pages_path, method: :post do %>
+      <fieldset class="sortable">
+        <% @take_part_pages.each do |take_part_page| %>
+          <div class="well">
+            <%= label_tag "ordering-#{take_part_page.id}" do %>
+              <%= link_to(take_part_page.title, [:edit, :admin, take_part_page]) %>
+            <% end %>
+
+            <%= text_field_tag "ordering[#{take_part_page.id}]", take_part_page.ordering, id: "ordering-#{take_part_page.id}", class: "ordering" %>
+          </div>
+        <% end %>
+      </fieldset>
+      <%= submit_tag "Update order", class: "btn btn-default" %>
+    <% end %>
+  <% else %>
+    <p class="no-content no-content-bordered">No take part pages</p>
+  <% end %>
+
+  <div class="form-actions">
+    <%= link_to "Add new take part page", new_admin_take_part_page_path, class: "btn btn-lg btn-primary"%>
+  </div>
+</section>

--- a/app/views/admin/take_part_pages/update_order.html.erb
+++ b/app/views/admin/take_part_pages/update_order.html.erb
@@ -1,0 +1,32 @@
+<% content_for :context, "Take part pages" %>
+<% content_for :page_title, "Reorder list" %>
+<% content_for :title, "Reorder list" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-full">
+    <%= form_tag(reorder_admin_take_part_pages_path(@take_part_pages)) do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @take_part_pages.map do |take_part_page|
+          {
+            id: take_part_page.id,
+            title: take_part_page.title
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order",
+        } %>
+
+        <%= link_to("Cancel", admin_take_part_pages_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,6 +346,8 @@ Whitehall::Application.routes.draw do
           root to: "get_involved#index", as: :get_involved, via: :get
           resources :take_part_pages, except: [:show] do
             post :reorder, on: :collection
+            get :confirm_destroy, on: :member
+            get :update_order, on: :collection
           end
         end
 

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -22,11 +22,16 @@ When(/^I create a new take part page called "([^"]*)"$/) do |title|
 end
 
 When(/^I reorder the take part pages to highlight my new page$/) do
-  visit admin_take_part_pages_path
+  if using_design_system?
+    visit update_order_admin_take_part_pages_path
+  else
+    visit admin_take_part_pages_path
+  end
 
   @the_take_part_pages_in_order.each.with_index do |take_part_page, idx|
     fill_in take_part_page.title, with: idx + 2
   end
+
   fill_in @the_new_take_part_page.title, with: 1
 
   @the_take_part_pages_in_order = [@the_new_take_part_page, *@the_take_part_pages_in_order]
@@ -39,7 +44,8 @@ Then(/^I see the take part pages in my specified order including the new page on
   click_on "Take part pages"
 
   # Note that the selector is for the non-JS version of the page
-  take_part_pages = page.all(".well label a").map(&:text)
+  take_part_pages = using_design_system? ? page.all(".gem-c-table .govuk-table__row td:first").map(&:text) : page.all(".well label a").map(&:text)
+
   @the_take_part_pages_in_order.each.with_index do |take_part_page, idx|
     expect(take_part_page.title).to eq(take_part_pages[idx])
   end
@@ -49,11 +55,21 @@ When(/^I remove one of the take part pages because it's not something we want to
   visit admin_get_involved_path
   click_on "Take part pages"
 
-  click_on @page1.title
-  click_on "Delete"
+  if using_design_system?
+    find(".gem-c-table .govuk-table__row:nth-child(2)").find("a", text: "Delete").click
+    find("button", text: "Delete").click
+  else
+    click_on @page1.title
+    click_on "Delete"
+  end
 
-  click_on @page2.title
-  click_on "Delete"
+  if using_design_system?
+    find(".gem-c-table .govuk-table__row:nth-child(2)").find("a", text: "Delete").click
+    find("button", text: "Delete").click
+  else
+    click_on @page2.title
+    click_on "Delete"
+  end
 
   @the_removed_pages = [@the_take_part_pages_in_order[0], @the_take_part_pages_in_order[2]]
   @the_take_part_pages_in_order = [@the_take_part_pages_in_order[1]]

--- a/test/functional/admin/legacy_take_part_pages_controller_test.rb
+++ b/test/functional/admin/legacy_take_part_pages_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::LegacyTakePartPagesControllerTest < ActionController::TestCase
 
     assert_equal [page1, page2, page3], assigns(:take_part_pages)
     assert_response :success
-    assert_template "index"
+    assert_template "legacy_index"
   end
 
   test "GET :new prepares an unsaved instance" do


### PR DESCRIPTION
[Trello](https://trello.com/c/isQwsOg9/72-take-part-page)

Ports the "Take part" landing page, update order page and delete page to the design system. Screenshots below. 

| Page | Design System |
|-|-|
| Landing page | ![Screenshot 2023-04-20 at 14 38 28](https://user-images.githubusercontent.com/6080548/233384821-81035b6d-dc98-4af8-bd01-5e2b488449ca.png) |
| Update order page | ![Screenshot 2023-04-19 at 12 38 43](https://user-images.githubusercontent.com/6080548/233063576-97c3e765-b16b-4e49-a65a-6916ef9819b2.png) |
| Delete page | ![Screenshot 2023-04-19 at 12 31 31](https://user-images.githubusercontent.com/6080548/233062052-37e1ca9b-f45e-4a5e-8bf9-66a10baab7d2.png) |
