### PR TITLE
Prefix the page title with "Error: " when a form has errors

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -9,7 +9,7 @@
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Whitehall Publisher",
   environment: environment,
-  browser_title: yield(:page_title).presence || yield(:title) do %>
+  browser_title: ("Error: " unless yield(:error_summary).blank?).to_s + (yield(:page_title).presence || yield(:title)) do %>
 
   <!-- This element exists to initialise the JS module that configures custom Analytics behaviour -->
   <div data-module="app-analytics"></div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
[Add the word “Error” into the page title whenever the `error_summary` is populated.
](https://trello.com/c/Hjs3GPZm/1229-prefix-the-page-title-with-error-when-a-form-has-errors)
#  Why
https://accessibility.blog.gov.uk/2018/02/28/how-weve-made-gov-uk-elements-even-more-accessible/
For many screen readers the page title is the very first thing they read out.
