### PR TITLE
Move edit statistics announcement tags to design system

### DIFF
--- a/app/controllers/admin/statistics_announcement_tags_controller.rb
+++ b/app/controllers/admin/statistics_announcement_tags_controller.rb
@@ -1,10 +1,13 @@
 class Admin::StatisticsAnnouncementTagsController < Admin::BaseController
   before_action :find_statistics_announcement
   before_action :enforce_permissions!
+  layout :get_layout
 
   def edit
     @topic_taxonomy = Taxonomy::TopicTaxonomy.new
     @tag_form = TaxonomyTagForm.load(@statistics_announcement.content_id)
+
+    render_design_system("edit", "legacy_edit", next_release: false)
   end
 
   def update
@@ -38,5 +41,13 @@ private
 
   def invisible_taxons
     params["taxonomy_tag_form"].fetch("invisible_taxons", "").split(",")
+  end
+
+  def get_layout
+    if preview_design_system?(next_release: false)
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -2,20 +2,7 @@
 <% content_for :context, @edition.title %>
 <% content_for :title, "Topic taxonomy tags" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-!-margin-bottom-8">
-      <p class="govuk-body">The topic taxonomy groups content based on what it’s about.</p>
-      <p class="govuk-body">Choose the tag or tags that best describe what this content is about.</p>
-      <p class="govuk-body">You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
-      <p class="govuk-body"><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-    </div>
-    <div class="govuk-!-margin-bottom-8">
-      <p class="govuk-body"><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-      <p class="govuk-body"><%= link_to "Suggest a change to a tag", "#{Whitehall.support_url}/taxonomy_change_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-    </div>
-  </div>
-</div>
+<%= render 'admin/shared/tagging/taxonomy_group_description' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -29,23 +16,10 @@
     } do |form| %>
       <%= form.hidden_field :previous_version %>
 
-      <% if @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons).count() %>
-        <%= render partial: "/components/miller-columns", locals: {
-          id: "taxonomy_tag_form[taxons]",
-          searchable: true,
-          items: @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons),
-        } %>
-      <% else %>
-        <p class="govuk-body">No taxons available</p>
-      <% end %>
-
-      <%= form.hidden_field "invisible_taxons", value: @tag_form.invisible_taxons.join(",") %>
-
-      <%= render "govuk_publishing_components/components/details", {
-        title: "Changes are applied to a live page as soon as you update the tags"
-      } do %>
-        If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
-      <% end %>
+      <%= render "admin/shared/tagging/taxonomy_group_selector", {
+        form: form,
+        tag_form: @tag_form
+      } %>
 
       <div class="govuk-button-group govuk-!-margin-top-7">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-8 govuk-body" >
+      <p>The topic taxonomy groups content based on what it’s about.</p>
+      <p>Choose the tag or tags that best describe what this content is about.</p>
+      <p>You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
+      <p><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+    </div>
+    <div class="govuk-!-margin-bottom-8 govuk-body">
+      <p><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+      <p><%= link_to "Suggest a change to a tag", "#{Whitehall.support_url}/taxonomy_change_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/tagging/_taxonomy_group_selector.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy_group_selector.html.erb
@@ -1,0 +1,17 @@
+<% if @topic_taxonomy.ordered_taxons_transformed(tag_form.selected_taxons).count() %>
+  <%= render "/components/miller-columns", {
+    id: "taxonomy_tag_form[taxons]",
+    searchable: true,
+    items: @topic_taxonomy.ordered_taxons_transformed(tag_form.selected_taxons),
+  } %>
+<% else %>
+  <p class="govuk-body">No taxons available</p>
+<% end %>
+
+<%= form.hidden_field "invisible_taxons", value: tag_form.invisible_taxons.join(",") %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: "Changes are applied to a live page as soon as you update the tags"
+} do %>
+  If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
+<% end %>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -1,48 +1,64 @@
-<% page_title "Edit topics: " + @statistics_announcement.title %>
+<% content_for :page_title, "Edit topics: " + @statistics_announcement.title %>
+<% content_for :context, @statistics_announcement.title %>
+<% content_for :title, "Topic taxonomy tags"%>
 
-<div class="row">
-  <h1><%= @statistics_announcement.title %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-8">
+      <p class="govuk-body">The topic taxonomy groups content based on what it’s about.</p>
+      <p class="govuk-body">Choose the tag or tags that best describe what this content is about.</p>
+      <p class="govuk-body">You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
+      <p class="govuk-body"><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+    </div>
+    <div class="govuk-!-margin-bottom-8">
+      <p class="govuk-body"><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+      <p class="govuk-body"><%= link_to "Suggest a change to a tag", "#{Whitehall.support_url}/taxonomy_change_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+    </div>
+  </div>
 </div>
-<div class="row">
-  <div class="col-md-12">
-    <h2>Topics (new taxonomy)</h2>
-    <hr>
 
-    <%= form_for @tag_form, url: admin_statistics_announcement_tags_path(@statistics_announcement), method: :put do |form| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Selected Topics",
+      margin_bottom: 2,
+    } %>
+
+    <%= form_for @tag_form, url: admin_statistics_announcement_tags_path(@statistics_announcement), method: :put, data: {
+      module: "track-selected-taxons"
+    } do |form| %>
       <%= form.hidden_field :previous_version %>
 
-      <div class="form-group"
-        data-module="taxonomy-tree-checkboxes"
-        data-content-id="<%= @statistics_announcement.content_id %>"
-        data-content-format="statistics_announcement"
-        data-content-public-path="<%= @statistics_announcement.base_path %>">
+      <% if @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons).count() %>
+        <%= render partial: "/components/miller-columns", locals: {
+          id: "taxonomy_tag_form[taxons]",
+          searchable: true,
+          items: @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons),
+        } %>
+      <% else %>
+        <p class="govuk-body">No taxons available</p>
+      <% end %>
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.ordered_taxons } %>
+      <%= form.hidden_field "invisible_taxons", value: @tag_form.invisible_taxons.join(",") %>
 
-      </div>
+      <%= render "govuk_publishing_components/components/details", {
+        title: "Changes are applied to a live page as soon as you update the tags"
+      } do %>
+        If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
+      <% end %>
 
-      <p>
-        <%= link_to "Suggest a new topic",
-          "#{Whitehall.support_url}/taxonomy_new_topic_request/new",
-          class: "feedback-link"
-        %>
-        or
-        <%= link_to "Suggest a change to a topic",
-          "#{Whitehall.support_url}/taxonomy_change_topic_request/new",
-          class: "feedback-link"
-        %>
-      </p>
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update tags",
+          data_attributes: {
+            module: 'gem-track-click',
+            track_category: 'form-button',
+            track_label: "Save tagging changes",
+            track_action: "taxonomy-tag-form-button",
+          }
+        } %>
 
-      <h2>Selected topics</h2>
-      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
-      </div>
-
-      <p class="warning">
-        Warning: topic changes to published content appear instantly on the live site.
-      </p>
-
-      <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_statistics_announcement_path(@statistics_announcement)) %>
+        <%= link_to("Cancel", admin_statistics_announcement_path(@statistics_announcement), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -2,20 +2,7 @@
 <% content_for :context, @statistics_announcement.title %>
 <% content_for :title, "Topic taxonomy tags"%>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-!-margin-bottom-8">
-      <p class="govuk-body">The topic taxonomy groups content based on what it’s about.</p>
-      <p class="govuk-body">Choose the tag or tags that best describe what this content is about.</p>
-      <p class="govuk-body">You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
-      <p class="govuk-body"><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-    </div>
-    <div class="govuk-!-margin-bottom-8">
-      <p class="govuk-body"><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-      <p class="govuk-body"><%= link_to "Suggest a change to a tag", "#{Whitehall.support_url}/taxonomy_change_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
-    </div>
-  </div>
-</div>
+<%= render 'admin/shared/tagging/taxonomy_group_description' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -29,23 +16,10 @@
     } do |form| %>
       <%= form.hidden_field :previous_version %>
 
-      <% if @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons).count() %>
-        <%= render partial: "/components/miller-columns", locals: {
-          id: "taxonomy_tag_form[taxons]",
-          searchable: true,
-          items: @topic_taxonomy.ordered_taxons_transformed(@tag_form.selected_taxons),
-        } %>
-      <% else %>
-        <p class="govuk-body">No taxons available</p>
-      <% end %>
-
-      <%= form.hidden_field "invisible_taxons", value: @tag_form.invisible_taxons.join(",") %>
-
-      <%= render "govuk_publishing_components/components/details", {
-        title: "Changes are applied to a live page as soon as you update the tags"
-      } do %>
-        If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
-      <% end %>
+      <%= render "admin/shared/tagging/taxonomy_group_selector", {
+        form: form,
+        tag_form: @tag_form
+      } %>
 
       <div class="govuk-button-group govuk-!-margin-top-7">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/statistics_announcement_tags/legacy_edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/legacy_edit.html.erb
@@ -1,0 +1,49 @@
+<% page_title "Edit topics: " + @statistics_announcement.title %>
+
+<div class="row">
+  <h1><%= @statistics_announcement.title %></h1>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <h2>Topics (new taxonomy)</h2>
+    <hr>
+
+    <%= form_for @tag_form, url: admin_statistics_announcement_tags_path(@statistics_announcement), method: :put do |form| %>
+      <%= form.hidden_field :previous_version %>
+
+      <div class="form-group"
+        data-module="taxonomy-tree-checkboxes"
+        data-content-id="<%= @statistics_announcement.content_id %>"
+        data-content-format="statistics_announcement"
+        data-content-public-path="<%= @statistics_announcement.base_path %>">
+
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.ordered_taxons } %>
+
+      </div>
+
+      <p>
+        <%= link_to "Suggest a new topic",
+          "#{Whitehall.support_url}/taxonomy_new_topic_request/new",
+          class: "feedback-link"
+        %>
+        or
+        <%= link_to "Suggest a change to a topic",
+          "#{Whitehall.support_url}/taxonomy_change_topic_request/new",
+          class: "feedback-link"
+        %>
+      </p>
+
+      <h2>Selected topics</h2>
+      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
+      </div>
+
+      <p class="warning">
+        Warning: topic changes to published content appear instantly on the live site.
+      </p>
+
+      <div class="publishing-controls well">
+        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_statistics_announcement_path(@statistics_announcement)) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/test/functional/admin/legacy_statistics_announcement_tags_controller_test.rb
+++ b/test/functional/admin/legacy_statistics_announcement_tags_controller_test.rb
@@ -1,11 +1,13 @@
 require "test_helper"
 
-class Admin::StatisticsAnnouncementTagsControllerTest < ActionController::TestCase
+class Admin::LegacyStatisticsAnnouncementTagsControllerTest < ActionController::TestCase
+  tests Admin::StatisticsAnnouncementTagsController
+
   include TaxonomyHelper
   should_be_an_admin_controller
 
   setup do
-    @user = login_as_preview_design_system_user(:departmental_editor)
+    @user = login_as(:departmental_editor)
     @publishing_api_endpoint = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT
     organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
     @announcement = create(:statistics_announcement, organisations: [organisation])


### PR DESCRIPTION
## Description

This PR transitions the edit Statistics Announcements Tags page to the GOV.UK Design System.

It does the following:

1. Duplicates the statistics announcements tags controller tests and assigns the non-legacy specs user the "Preview design system permission.
2. Prepends legacy to the edit view for the bootstrap implementation and adds the logic to the controller to render the correct implementation based on the users permissions
3. Adds the view in the GOV.UK Design System

## Screenshots

### Before
![Screenshot 2023-04-13 at 16 54 30](https://user-images.githubusercontent.com/91492293/231816409-31e7465a-19cf-4364-8ce8-20d6f864fd12.png)
![Screenshot 2023-04-13 at 16 54 46](https://user-images.githubusercontent.com/91492293/231816426-9f937c7e-85f1-44fc-8203-6c4cbb034c65.png)
![Screenshot 2023-04-13 at 16 54 55](https://user-images.githubusercontent.com/91492293/231816438-68418f0b-b8f9-4dc4-9962-66a24e24ed8b.png)

### After
![Screenshot 2023-04-13 at 16 42 32](https://user-images.githubusercontent.com/91492293/231816570-190c7f5b-5799-49d0-8adf-478058897c1d.png)
![Screenshot 2023-04-13 at 16 42 52](https://user-images.githubusercontent.com/91492293/231816648-d04713fb-4d04-439f-898f-40a613d5d4c8.png)

## Trello

https://trello.com/c/SPg3sgnk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
