### PR TITLE
Change "Add image details" to "Edit image details"

### DIFF
--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :context, @edition.title %>
-<% content_for :page_title, "Add image details" %>
-<% content_for :title, "Add image details" %>
+<% content_for :page_title, "Edit image details" %>
+<% content_for :title, "Edit image details" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Change the title on the image details page to "Edit"

# Why
The page is used as both part of the image upload process and to edit image details later on so "Edit" is more comprehensive
