### PR TITLE
Ensure legacy form is rendered on edit take part page

### DIFF
--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -20,7 +20,7 @@ class Admin::TakePartPagesController < Admin::BaseController
     if @take_part_page.save
       redirect_to [:admin, TakePartPage], notice: %(Take part page "#{@take_part_page.title}" created!)
     else
-      render :new
+      render_design_system("new", "legacy_new", next_release: false)
     end
   end
 

--- a/app/views/admin/take_part_pages/edit.html.erb
+++ b/app/views/admin/take_part_pages/edit.html.erb
@@ -8,5 +8,4 @@
         data: { confirm: "Are you sure you want to delete this take part page?" } %>
 </h2>
 
-<%= render 'form', take_part_page: @take_part_page %>
-
+<%= render 'legacy_form', take_part_page: @take_part_page %>

--- a/test/functional/admin/legacy_take_part_pages_controller_test.rb
+++ b/test/functional/admin/legacy_take_part_pages_controller_test.rb
@@ -53,7 +53,7 @@ class Admin::LegacyTakePartPagesControllerTest < ActionController::TestCase
 
     assert_not assigns(:take_part_page).persisted?
     assert_response :success
-    assert_template "new"
+    assert_template "legacy_new"
   end
 
   test "GET :edit fetches the supplied instance" do


### PR DESCRIPTION
## Description

When we renamed the legacy_form partial and used it in the legacy new page, we forgot to update the edit page to use the legacy form.

## Screenshot of issue

<img width="964" alt="image" src="https://user-images.githubusercontent.com/42515961/232459390-e137e86d-f5b2-4353-89f2-a4a4ab209e78.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
