### PR TITLE
Use dynamic warning when speeches delivered on is set in the future

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -10,6 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.setupSubtypeFormatAdviceEventListener()
     this.setupWorldNewsStoryVisibilityToggle()
     this.setupSpeechSubtypeEventListeners()
+    this.setupSpeechDeliverdOnWarningEventListener()
   }
 
   EditionForm.prototype.setupSubtypeFormatAdviceEventListener = function () {
@@ -116,6 +117,40 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         noProfileRadioLabel.textContent = 'Speaker does not have a profile on GOV.UK'
         deliveredOnLabel.textContent = 'Delivered on'
       }
+    })
+  }
+
+  EditionForm.prototype.setupSpeechDeliverdOnWarningEventListener = function () {
+    var form = this.module
+    var deliveredOnFieldset = form.querySelector('#edition_delivered_on')
+
+    if (!deliveredOnFieldset) { return }
+
+    var warningDiv = form.querySelector('.js-app-view-edit-edition__delivered-on-warning')
+    var day = form.querySelector('#edition_delivered_on_3i')
+    var month = form.querySelector('#edition_delivered_on_2i')
+    var year = form.querySelector('#edition_delivered_on_1i')
+
+    deliveredOnFieldset.querySelectorAll('select').forEach(function (select) {
+      select.addEventListener('change', function () {
+        var dateIsInvalid = day.value === '' || month.value === '' || year.value === ''
+
+        if (dateIsInvalid) {
+          if (!warningDiv.classList.contains('app-view-edit-edition__delivered-on-warning--hidden')) {
+            warningDiv.classList.add('app-view-edit-edition__delivered-on-warning--hidden')
+          }
+        } else {
+          var date = new Date(year.value, month.value - 1, day.value)
+          var currentDate = new Date()
+          if (currentDate < date) {
+            var dateFields = deliveredOnFieldset.querySelector('.app-c-datetime-fields__date-time-wrapper')
+            dateFields.after(warningDiv)
+            warningDiv.classList.remove('app-view-edit-edition__delivered-on-warning--hidden')
+          } else if (!warningDiv.classList.contains('app-view-edit-edition__delivered-on-warning--hidden')) {
+            warningDiv.classList.add('app-view-edit-edition__delivered-on-warning--hidden')
+          }
+        }
+      })
     })
   }
 

--- a/app/assets/stylesheets/admin/views/_edit-edition.scss
+++ b/app/assets/stylesheets/admin/views/_edit-edition.scss
@@ -25,6 +25,11 @@
 .app-view-edit-edition__appointment-fields--hidden,
 .app-view-edit-edition__organisation-fields--hidden,
 .app-view-edit-edition__world-location-fields--hidden,
-.app-view-edit-edition__speech-location--hidden {
+.app-view-edit-edition__speech-location--hidden,
+.app-view-edit-edition__delivered-on-warning--hidden {
   display: none;
+}
+
+.app-view-edit-edition__delivered-on-warning .gem-c-warning-text {
+  margin-bottom: 0;
 }

--- a/app/views/admin/speeches/_delivered_on_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_on_fields.html.erb
@@ -33,4 +33,10 @@
       }
     %>
   <% end %>
+
+  <div class="app-view-edit-edition__delivered-on-warning js-app-view-edit-edition__delivered-on-warning app-view-edit-edition__delivered-on-warning--hidden govuk-!-margin-top-6" aria-live="polite">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "You have set the date in the future, please ensure that this will not be published before this date."
+    } %>
+  </div>
 </div>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -1,9 +1,10 @@
 describe('GOVUK.Modules.EditionForm', function () {
-  var form
+  var form, currentYear
 
   beforeEach(function () {
     form = document.createElement('form')
     form.setAttribute('data-module', 'EditionForm')
+    currentYear = new Date().getFullYear()
   })
 
   describe('#setupSubtypeFormatAdviceEventListener', function () {
@@ -127,7 +128,7 @@ describe('GOVUK.Modules.EditionForm', function () {
 
   describe('#setupSpeechSubtypeEventListeners', function () {
     beforeEach(function () {
-      form.innerHTML = speechFields()
+      form.innerHTML = speechFields(currentYear)
       var editionForm = new GOVUK.Modules.EditionForm(form)
       editionForm.init()
     })
@@ -175,6 +176,40 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(deliveredOnLabel.textContent).toEqual('Delivered on')
       expect(locationDiv.classList.length).toEqual(1)
       expect(locationDiv.classList[0]).toEqual('js-app-view-edit-edition__speech-location-field')
+    })
+
+    describe('#setupSpeechDeliverdOnWarningEventListener', function () {
+      beforeEach(function () {
+        form.innerHTML = speechFields(currentYear)
+        var editionForm = new GOVUK.Modules.EditionForm(form)
+        editionForm.init()
+      })
+
+      it('shows the speech delivered_on in future warning to the user when they select a date in the future', function () {
+        var deliveredOnFieldset = form.querySelector('#edition_delivered_on')
+        deliveredOnFieldset.querySelector('select').value = '1'
+        deliveredOnFieldset.querySelectorAll('select')[1].value = '1'
+        deliveredOnFieldset.querySelectorAll('select')[2].value = currentYear + 1
+
+        deliveredOnFieldset.querySelector('select').dispatchEvent(new Event('change'))
+
+        var warning = form.querySelector('.js-app-view-edit-edition__delivered-on-warning')
+
+        expect(warning.classList).not.toContain('app-view-edit-edition__delivered-on-warning--hidden')
+      })
+
+      it('does not show the speech delivered_on in future warning to the user when they select a date in the past', function () {
+        var deliveredOnFieldset = form.querySelector('#edition_delivered_on')
+        deliveredOnFieldset.querySelector('select').value = '1'
+        deliveredOnFieldset.querySelectorAll('select')[1].value = '1'
+        deliveredOnFieldset.querySelectorAll('select')[2].value = currentYear
+
+        deliveredOnFieldset.dispatchEvent(new Event('change'))
+
+        var warning = form.querySelector('.js-app-view-edit-edition__delivered-on-warning')
+
+        expect(warning.classList).toContain('app-view-edit-edition__delivered-on-warning--hidden')
+      })
     })
   })
 
@@ -258,41 +293,57 @@ describe('GOVUK.Modules.EditionForm', function () {
 
   function speechFields () {
     return (
-      '<div>' +
-        '<div class="govuk-form-group gem-c-select">' +
-          '<label class="govuk-label govuk-label--s" for="edition_speech_type_id">Speech type</label>' +
-          '<select name="edition[speech_type_id]" id="edition_speech_type_id" class="govuk-select gem-c-select__select--full-width">' +
-            '<option value=""></option>' +
-            '<option value="1">Transcript</option>' +
-            '<option value="2">Draft text</option>' +
-            '<option value="3">Speaking notes</option>' +
-            '<option value="4">Written statement to Parliament</option>' +
-            '<option value="5">Oral statement to Parliament</option>' +
-            '<option value="6">Authored article</option>' +
-          '</select>' +
+      `
+        '<div>' +
+          '<div class="govuk-form-group gem-c-select">' +
+            '<label class="govuk-label govuk-label--s" for="edition_speech_type_id">Speech type</label>' +
+            '<select name="edition[speech_type_id]" id="edition_speech_type_id" class="govuk-select gem-c-select__select--full-width">' +
+              '<option value=""></option>' +
+              '<option value="1">Transcript</option>' +
+              '<option value="2">Draft text</option>' +
+              '<option value="3">Speaking notes</option>' +
+              '<option value="4">Written statement to Parliament</option>' +
+              '<option value="5">Oral statement to Parliament</option>' +
+              '<option value="6">Authored article</option>' +
+            '</select>' +
+          '</div>' +
         '</div>' +
-      '</div>' +
 
-      '<div id="edition_role_appointment">' +
-        '<fieldset class="govuk-fieldset">' +
-           '<legend class="govuk-fieldset__legend">' +
-              '<h2 class="govuk-fieldset__heading">Speaker (required)</h2>' +
-           '</legend>' +
-             '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_on_govuk">' +
-             '<label for="edition_role_appointment_speaker_on_govuk">Speaker has a profile on GOV.UK</label>' +
-             '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_not_on_govuk">' +
-             '<label for="edition_role_appointment_speaker_not_on_govuk">Speaker does not have a profile on GOV.UK</label>' +
-           '</div>' +
+        '<div id="edition_role_appointment">' +
+          '<fieldset class="govuk-fieldset">' +
+             '<legend class="govuk-fieldset__legend">' +
+                '<h2 class="govuk-fieldset__heading">Speaker (required)</h2>' +
+             '</legend>' +
+               '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_on_govuk">' +
+               '<label for="edition_role_appointment_speaker_on_govuk">Speaker has a profile on GOV.UK</label>' +
+               '<input type="radio" name="speaker_radios" id="edition_role_appointment_speaker_not_on_govuk">' +
+               '<label for="edition_role_appointment_speaker_not_on_govuk">Speaker does not have a profile on GOV.UK</label>' +
+             '</div>' +
+          '</fieldset>' +
+        '</div>' +
+        '<fieldset class="govuk-fieldset" id="edition_delivered_on">' +
+          '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on</legend>' +
+          '<div class="app-c-datetime-fields__date-time-wrapper">' +
+            '<select id="edition_delivered_on_3i" name="edition[delivered_on(3i)]">' +
+              '<option value="" label=" "></option>' +
+              '<option value="1">1</option>' +
+            '</select>'
+            '<select id="edition_delivered_on_2i" name="edition[delivered_on(2i)]">' +
+              '<option value="" label=" "></option>' +
+              '<option value="1">January</option>' +
+            '</select>' +
+            '<select id="edition_delivered_on_1i" name="edition[delivered_on(1i)]">' +
+              '<option value="${currentYear}">${currentYear}</option>' +
+              '<option value="${currentYear + 1}">${currentYear + 1}</option>' +
+            '</select>' +
+          '</div>' +
         '</fieldset>' +
-      '</div>' +
-
-      '<fieldset class="govuk-fieldset" id="edition_delivered_on">' +
-        '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on</legend>' +
-      '</fieldset>' +
-
-      '<div class="js-app-view-edit-edition__speech-location-field">' +
-        '<input name="edition[location]" type="text">' +
-      '</div>'
+        '<div class="js-app-view-edit-edition__delivered-on-warning app-view-edit-edition__delivered-on-warning--hidden">' +
+        '</div>' +
+        '<div class="js-app-view-edit-edition__speech-location-field">' +
+          '<input name="edition[location]" type="text">' +
+        '</div>'
+      `
     )
   }
 })


### PR DESCRIPTION
## Description

This pops up warning text below the date inputs when the user selects a date in the future for the delivered on field.

When JS is not present the warning will not show as it's hidden via CSS.

## Screenshot

### Without warning

<img width="662" alt="image" src="https://user-images.githubusercontent.com/42515961/232466728-d6e5d56c-da06-417d-909e-9d5c05719f1f.png">

### With warning

<img width="669" alt="image" src="https://user-images.githubusercontent.com/42515961/232471876-1abf5185-3509-4ac8-b445-8abff43d5f31.png">

## Trello card

https://trello.com/c/gX8vPdmg/82-show-a-warning-message-if-speech-delivered-on-date-is-in-the-future

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
