### PR TITLE
Add dsit brand colour

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -162,4 +162,9 @@ class OrganisationBrandColour
     title: "Department for Levelling Up, Housing & Communities",
     class_name: "department-for-levelling-up-housing-and-communities",
   )
+  DepartmentForScienceInnovationAndTechnology = create!(
+    id: 32,
+    title: "Department for Science, Innovation & Technology",
+    class_name: "department-for-science-innovation-and-technology",
+  )
 end


### PR DESCRIPTION
adds the brand colour as an option for the organisation in Whitehall.

Not to be merged until https://github.com/alphagov/govuk_publishing_components/pull/3349 has been merged and the gem bumped in collections, government-frontend and whitehall.