### PR TITLE
Fix linking to child org pages

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -125,7 +125,8 @@ module OrganisationHelper
       child_relationships_link_text = child_organisations.size.to_s
       child_relationships_link_text += child_organisations.size == 1 ? " public body" : " agencies and public bodies"
 
-      organisation_name += link_to(child_relationships_link_text, organisation.public_path, class: "brand__color")
+      organisation_name += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
+
       organisation_name += "."
     end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -548,6 +548,10 @@ class Organisation < ApplicationRecord
     append_url_options(base_path, options)
   end
 
+  def link_to_section_on_organisation_list_page
+    append_url_options("/government/organisations", anchor: slug)
+  end
+
   def public_url(options = {})
     website_root = if options[:draft]
                      Plek.external_url_for("draft-origin")

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -1126,6 +1126,12 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal "https://www.test.gov.uk/courts-tribunals/#{tribunal.slug}", tribunal.public_url
   end
 
+  test "can create anchored link on organisation list page" do
+    org = create(:organisation)
+
+    assert_equal "/government/organisations##{org.slug}", org.link_to_section_on_organisation_list_page
+  end
+
   test "should send related pages to publishing api when a non-ministerial department is created" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -181,6 +181,19 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal(govspeak_to_html(""), presented_item.content[:details][:body])
   end
 
+  test "presents an organisation with children" do
+    child_organisation = create(:organisation, name: "Department for Stuff")
+    organisation = create(
+      :organisation,
+      name: "Organisation of Things",
+      child_organisations: [child_organisation],
+    )
+
+    presented_item = present(organisation)
+
+    assert_includes presented_item.content.dig(:details, :body), "/government/organisations#organisation-of-things"
+  end
+
   test "presents an eligible organisation with promotional features" do
     promotional_feature1 = create(:promotional_feature)
     promotional_feature_item1 = create(:promotional_feature_item, promotional_feature: promotional_feature1)


### PR DESCRIPTION
This fixes an issue where the link to the child organisations of a page linked to the wrong place. It now links to the org list with an anchor.

See link for example: https://www.gov.uk/government/organisations/department-for-energy-security-and-net-zero#what-we-do

[Zendesk](https://govuk.zendesk.com/agent/tickets/5304898)