### PR TITLE
Add audit history for non-editionable models

### DIFF
--- a/app/components/admin/model_history_component.html.erb
+++ b/app/components/admin/model_history_component.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <h4><%= action %></h4>
+
+  <p>
+    <%= time %> by <%= actor %>
+  </p>
+</div>

--- a/app/components/admin/model_history_component.rb
+++ b/app/components/admin/model_history_component.rb
@@ -1,0 +1,29 @@
+class Admin::ModelHistoryComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :version
+
+  def initialize(version:)
+    @version = version
+  end
+
+private
+
+  def action
+    case version.event
+    when "update" then "Document updated"
+    when "create" then "Document created"
+    else "Unknown action"
+    end
+  end
+
+  def actor
+    user = version.user
+
+    user ? linked_author(user, class: "govuk-link") : "User (removed)"
+  end
+
+  def time
+    absolute_time(version.created_at)
+  end
+end

--- a/app/components/admin/model_history_list_component.html.erb
+++ b/app/components/admin/model_history_list_component.html.erb
@@ -1,0 +1,12 @@
+<div class="">
+  <%= link_to_previous_page(versions, 'Newer') %>
+  <%= link_to_next_page(versions, 'Older') %>
+</div>
+
+<ul class="list-unstyled">
+  <% versions.each do |version| %>
+    <li>
+      <%= render Admin::ModelHistoryComponent.new(version: version) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/components/admin/model_history_list_component.rb
+++ b/app/components/admin/model_history_list_component.rb
@@ -1,0 +1,7 @@
+class Admin::ModelHistoryListComponent < ViewComponent::Base
+  attr_reader :versions
+
+  def initialize(versions:)
+    @versions = versions
+  end
+end

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -1,4 +1,6 @@
 class Admin::WorldwideOrganisationsController < Admin::BaseController
+  VERSIONS_PER_PAGE = 2
+
   respond_to :html
 
   before_action :find_worldwide_organisation, except: %i[index new create]
@@ -28,7 +30,12 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
     respond_with :admin, @worldwide_organisation
   end
 
-  def show; end
+  def show
+    @versions = Kaminari
+                  .paginate_array(@worldwide_organisation.versions_desc)
+                  .page(params[:page])
+                  .per(VERSIONS_PER_PAGE)
+  end
 
   def access_info
     @access_and_opening_times = @worldwide_organisation.access_and_opening_times ||

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -39,6 +39,10 @@ class WorldwideOrganisation < ApplicationRecord
 
   include PublishesToPublishingApi
 
+  attr_accessor :state
+
+  include Edition::AuditTrail
+
   extend FriendlyId
   friendly_id
 

--- a/app/views/admin/worldwide_organisations/show.html.erb
+++ b/app/views/admin/worldwide_organisations/show.html.erb
@@ -8,34 +8,43 @@
 
   <section class="organisation-details">
     <%= tab_navigation_for(@worldwide_organisation) do %>
-      <h2>Details</h2>
-      <article class="document">
-        <p class="sponsoring-organisations">
-          Part of <%= @worldwide_organisation.sponsoring_organisations.map {|o| link_to(o.name, [:admin, o]) }.to_sentence.html_safe %>
-        </p>
+      <div class="container">
+        <div class="col-md-8">
+          <h2>Details</h2>
+          <article class="document">
+            <p class="sponsoring-organisations">
+              Part
+              of <%= @worldwide_organisation.sponsoring_organisations.map { |o| link_to(o.name, [:admin, o]) }.to_sentence.html_safe %>
+            </p>
 
-        <div class="summary">
-          <div class="content">
-            <%= @worldwide_organisation.summary %>
+            <div class="summary">
+              <div class="content">
+                <%= @worldwide_organisation.summary %>
+              </div>
+            </div>
+
+            <div class="body description">
+              <div class="content govspeak">
+                <%= govspeak_to_html @worldwide_organisation.body %>
+              </div>
+            </div>
+          </article>
+
+          <% if @worldwide_organisation.default_news_image %>
+            <div class="document">
+              <p>Default News Image</p>
+              <%= image_tag @worldwide_organisation.default_news_image.file.url(:s300) %>
+            </div>
+          <% end %>
+
+          <div class="form-actions">
+            <%= link_to "Edit", edit_admin_worldwide_organisation_path(@worldwide_organisation), class: "btn btn-lg btn-primary" %>
           </div>
         </div>
 
-        <div class="body description">
-          <div class="content govspeak">
-            <%= govspeak_to_html @worldwide_organisation.body %>
-          </div>
+        <div>
+          <%= render(Admin::ModelHistoryListComponent.new(versions: @versions)) %>
         </div>
-      </article>
-
-      <% if @worldwide_organisation.default_news_image %>
-      <div class="document">
-        <p>Default News Image</p>
-        <%= image_tag @worldwide_organisation.default_news_image.file.url(:s300) %>
-      </div>
-      <% end %>
-
-      <div class="form-actions">
-        <%= link_to "Edit", edit_admin_worldwide_organisation_path(@worldwide_organisation), class: "btn btn-lg btn-primary"%>
       </div>
     <% end %>
   </section>

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -290,3 +290,8 @@ Then(/^I should be able to associate "([^"]*)" with the topical event "([^"]*)"$
   select topical_event_title, from: "edition_topical_event_ids"
   click_on "Save"
 end
+
+Then(/^I should see my edit in the audit trail for this organisation/) do
+  visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
+  expect(page).to have_content(@user.name)
+end

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -27,6 +27,7 @@ Feature: Administering worldwide organisation
     And I should see that it is part of the "Department of Beards"
     When I update the worldwide organisation to set the name to "Department of Beards and Moustaches in France"
     Then I should see the updated worldwide organisation information on the public website
+    Then I should see my edit in the audit trail for this organisation
     When I delete the worldwide organisation
     Then the worldwide organisation should not be visible from the public website
 


### PR DESCRIPTION
https://trello.com/c/7snah8vf

This is a proof of concept to add an audit history to non-editionable models. 

We need to remove the rendering of Worldwide organisation pages away from Whitehall. Currently there’s a load of complexity in those pages because they get the majority of their content from an attached Corporate information page. These CI pages are editionable and hold history, FCDO don’t want to lose this entirely so we’ve agreed to add some basic history functions to them.

This uses the existing `Edition::AuditTrail` model in order to persist the audit history, despite it's namespace it is quite generic and is not Edition specific. Advantages of this are (a) that we can re-use the existing Version model; (b) we can make use of the existing before filter (setting the user) and callbacks (storing the event & author); and (c) we’re not introducing another audit trail implementation. A couple of downsides are (a) the name is confusing (because it’s in the Edition namespace), but we could change that; and (b) we’d need to implement WorldwideOrganisation#state, but we could hard-code that to something like “non-editionable”

However, the view components are new, as the existing view components rely on Edition specific functionality. This PR does include pagination, but for the moment, it's not JavaScript pagination (which editionable audit history is); if we wanted to do this, we may have to create a separate (simpler) implementation. As this is a proof of concept, we haven't spent much time on styling.

We would also possibly want to backfill the audit history of the existing Worldwide Organisations.

Ultimately, we want to know whether this approach of reusing the `Edition::AuditTrail`, while creating new view components makes sense, or if there may be a more sensible path to take?

<img width="987" alt="image" src="https://user-images.githubusercontent.com/47089130/233373194-a00ea137-ac85-4e33-8f6b-b54dbb4108ab.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

