### PR TITLE
Ensure speech params are cleaned in editions create action

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -256,6 +256,7 @@ private
       :read_consultation_principles,
       :all_nation_applicability,
       :image_display_option,
+      :speaker_radios,
       {
         all_nation_applicability: [],
         secondary_specialist_sector_tags: [],

--- a/app/controllers/admin/speeches_controller.rb
+++ b/app/controllers/admin/speeches_controller.rb
@@ -1,21 +1,22 @@
 class Admin::SpeechesController < Admin::EditionsController
-  before_action :clear_role_appointment_param_on_override, only: %i[update create]
-
 private
 
   def edition_class
     Speech
   end
 
-  def clear_role_appointment_param_on_override
+  def clean_edition_parameters
+    super
     design_system = preview_design_system?(next_release: false)
 
-    if design_system && params[:speaker_radios] == "yes"
+    if design_system && edition_params[:speaker_radios] == "yes"
       edition_params[:person_override] = nil
-    elsif design_system && params[:speaker_radios] == "no"
+    elsif design_system && edition_params[:speaker_radios] == "no"
       edition_params[:role_appointment_id] = nil
     elsif params[:person_override_active] == "1" || edition_params[:person_override].present?
       edition_params[:role_appointment_id] = nil
     end
+
+    edition_params.delete(:speaker_radios)
   end
 end

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/radio", {
-    name: "speaker_radios",
+    name: "edition[speaker_radios]",
     id: "edition_role_appointment",
     heading: edition.authored_article? ? "Writer (required)" : "Speaker (required)",
     heading_size: "l",
@@ -26,5 +26,5 @@
         })
       }
     ]
-  } %>  
+  } %>
 </div>

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -61,7 +61,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
 
   test "create should create a new speech without a real person" do
     speech_type = SpeechType::Transcript
-    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen")
+    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen", speaker_radios: "no")
 
     post :create, params: { edition: attributes }
 
@@ -70,6 +70,24 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     assert_equal "The Queen", speech.person_override
     assert_equal attributes[:delivered_on], speech.delivered_on
     assert_equal attributes[:location], speech.location
+  end
+
+  view_test "create on unsuccessful save it clears the person_override field when the speaker has a profile on GOV.UK radio is selected" do
+    speech_type = SpeechType::Transcript
+    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen", title: nil)
+
+    post :create, params: { edition: attributes }
+
+    assert_select "#edition_person_override", ""
+  end
+
+  view_test "create on unsuccessful save it clears the role_appointment_id field when the speaker does not have a profile on GOV.UK radio is selected" do
+    speech_type = SpeechType::Transcript
+    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen", title: nil, speaker_radios: "no")
+
+    post :create, params: { edition: attributes }
+
+    assert_select "#edition_role_appointment_id option[selected]", count: 0
   end
 
   test "update should save modified speech attributes" do
@@ -94,12 +112,33 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     assert_equal "new-location", speech.location
   end
 
+  view_test "update on unsuccessful save it clears the person_override field when the speaker has a profile on GOV.UK radio is selected" do
+    speech = create(:speech)
+    speech_type = SpeechType::Transcript
+    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen", title: nil)
+
+    post :update, params: { id: speech.id, edition: attributes }
+
+    assert_select "#edition_person_override", ""
+  end
+
+  view_test "update on unsuccessful save it clears the role_appointment_id field when the speaker does not have a profile on GOV.UK radio is selected" do
+    speech = create(:speech)
+    speech_type = SpeechType::Transcript
+    attributes = controller_attributes_for(:speech, speech_type:, person_override: "The Queen", title: nil, speaker_radios: "no")
+
+    post :update, params: { id: speech.id, edition: attributes }
+
+    assert_select "#edition_role_appointment_id option[selected]", count: 0
+  end
+
 private
 
   def controller_attributes_for(edition_type, attributes = {})
     super.except(:role_appointment, :speech_type).reverse_merge(
       role_appointment_id: create(:role_appointment).id,
       speech_type_id: SpeechType::Transcript.id,
+      speaker_radios: "yes",
     )
   end
 end


### PR DESCRIPTION
## Description

At the moment, the clear_role_appointment_param_on_override is called from the SpeechesController. As the SpeechesController inherits from the EditionsController it runs the before_action after the before_action's in the EditionsController.

This means by the time the params for the delivered by are cleaned the edition has already been built.

By moving this to the clean_edition_parameters before_action in the EditionsController the params get cleaned prior to assignment.

## Vid of behaviour before

https://user-images.githubusercontent.com/42515961/234551038-37ccb4ac-6ced-43d1-9f70-50483dc94fb8.mov

## Vid of behaviour after

https://user-images.githubusercontent.com/42515961/234550635-a0e3e057-8925-436c-b93f-8693957c47ef.mov

## Trello card

https://trello.com/c/K8rPB3wP/85-speaker-field-clear-unused-conditional-reveal-fields-on-save

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
