### PR TITLE
expose image srcset information to publishing api

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -54,6 +54,7 @@ module PublishingApi
       {
         url: item.logo_url(:s300),
         alt_text: item.logo_alt_text,
+        srcset: ImageUploader::SRCSET_SIZE_MAP.map { |k, v| { url: item.logo_url(k), size: v } },
       }
     end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,15 @@
 class ImageUploader < WhitehallUploader
   include CarrierWave::MiniMagick
 
+  SRCSET_SIZE_MAP = {
+    s960: "960w",
+    s712: "712w",
+    s630: "630w",
+    s465: "465w",
+    s300: "300w",
+    s216: "216w",
+  }.freeze
+
   configure do |config|
     config.remove_previously_stored_files_after_update = false
   end

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -55,6 +55,14 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
         image: {
           url: topical_event.logo_url(:s300),
           alt_text: topical_event.logo_alt_text,
+          srcset: [
+            { url: topical_event.logo_url(:s960), size: "960w" },
+            { url: topical_event.logo_url(:s712), size: "712w" },
+            { url: topical_event.logo_url(:s630), size: "630w" },
+            { url: topical_event.logo_url(:s465), size: "465w" },
+            { url: topical_event.logo_url(:s300), size: "300w" },
+            { url: topical_event.logo_url(:s216), size: "216w" },
+          ],
         },
         start_date: topical_event.start_date.rfc3339,
         end_date: topical_event.end_date.rfc3339,


### PR DESCRIPTION
Draft for this https://trello.com/c/uW5kvqga/1961-using-srcset-functionality-to-make-images-less-blurry-on-govuk to demonstrate the concept

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
