### PR TITLE
Align error summary to GOV.UK Design System

### DIFF
--- a/app/components/admin/error_summary_component.rb
+++ b/app/components/admin/error_summary_component.rb
@@ -5,11 +5,9 @@ class Admin::ErrorSummaryComponent < ViewComponent::Base
 
   attr_reader :object
 
-  def initialize(object:, parent_class: nil, verb: nil, noun: nil)
+  def initialize(object:, parent_class: nil)
     @object = object
     @parent_class = parent_class
-    @verb = verb
-    @noun = noun
   end
 
   def render?
@@ -19,15 +17,7 @@ class Admin::ErrorSummaryComponent < ViewComponent::Base
 private
 
   def title
-    "To #{verb} the #{noun} please fix the following issues:"
-  end
-
-  def verb
-    @verb ||= "save"
-  end
-
-  def noun
-    @noun ||= humanized_class_name
+    "There is a problem"
   end
 
   def humanized_class_name

--- a/app/views/admin/edition_unpublishing/edit.html.erb
+++ b/app/views/admin/edition_unpublishing/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
 <% content_for :title, "Edit #{withdrawal_or_unpublishing(@unpublishing.edition)} explanation" %>
 <% content_for :title_margin_bottom, 6 %>
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing, noun: "#{withdrawal_or_unpublishing(@unpublishing.edition)} explanation")) %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing)) %>
 <% render "admin/tracking/subtype_tracking", document_type: @unpublishing.edition.type, document: @unpublishing.edition %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "#{@edition.title}: Withdraw or unpublish" %>
 <% content_for :title, "Withdraw or unpublish" %>
 <% content_for :context, @edition.title %>
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing, verb: "withdraw or unpublish", noun: @edition.format_name)) %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @unpublishing)) %>
 <% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 
 <%

--- a/app/views/admin/responses/edit.html.erb
+++ b/app/views/admin/responses/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Editing #{@response.friendly_name} for: #{@edition.title}" %>
 <% content_for :title, "Editing #{@response.friendly_name} for consultation" %>
 <% content_for :context, "#{@edition.title}" %>
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response, noun: "consultation #{@response.friendly_name}")) %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -12,35 +12,6 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_empty page.text
   end
 
-  test "uses the noun to construct the title if one is passed in" do
-    render_inline(Admin::ErrorSummaryComponent.new(object: @object_with_errors, noun: "withdrawal explanation"))
-    assert_selector "h2", text: "To save the withdrawal explanation please fix the following issues:"
-  end
-
-  test "editions use the self.format_name method to construct the noun in the title if one is not passed in" do
-    detailed_guide = build(:detailed_guide, title: nil)
-    detailed_guide.validate
-    render_inline(Admin::ErrorSummaryComponent.new(object: detailed_guide))
-
-    assert_selector "h2", text: "To save the detailed guidance please fix the following issues:"
-  end
-
-  test "other objects use the class of the object to construct the title if no noun is passed in" do
-    render_inline(Admin::ErrorSummaryComponent.new(object: @object_with_errors))
-
-    assert_selector "h2", text: "To save the error summary test object please fix the following issues:"
-  end
-
-  test "uses the `verb` to constuct the title if passed in" do
-    render_inline(Admin::ErrorSummaryComponent.new(object: @object_with_errors, verb: "karate chop"))
-    assert_selector "h2", text: "To karate chop the error summary test object please fix the following issues:"
-  end
-
-  test "defaults the verb of the to `save` if a verb is not passed in" do
-    render_inline(Admin::ErrorSummaryComponent.new(object: @object_with_errors))
-    assert_selector "h2", text: "To save the error summary test object please fix the following issues:"
-  end
-
   test "constructs a list of links which link to an id based on the objects class and attribute of the error" do
     render_inline(Admin::ErrorSummaryComponent.new(object: @object_with_errors))
 


### PR DESCRIPTION
## Description

This PR aligns the error summary component with the GOV.UK Design System

It does the following:

1. Updates the title to "There is a problem"
2. Removes the noun and verb params
3. Updates the tests to reflect the simplified behaviour.

## Screenshots

### Before
![Screenshot 2023-04-26 at 12 06 34](https://user-images.githubusercontent.com/91492293/234557323-7b32e9d0-bb89-4c49-aaef-d11aaef1773c.png)


### After
![Screenshot 2023-04-26 at 12 06 58](https://user-images.githubusercontent.com/91492293/234557314-ddfc98e1-8489-4313-a7bb-22c65a9e975f.png)

## Trello
https://trello.com/c/e0nBZ0oW

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
