### PR TITLE
Create initial audits for worldwide organisations

### DIFF
--- a/db/data_migration/20230424100641_add_initial_worldwide_organisation_audits.rb
+++ b/db/data_migration/20230424100641_add_initial_worldwide_organisation_audits.rb
@@ -1,0 +1,19 @@
+EVENT_TYPE = "initial".freeze
+
+def log_message
+  %(
+    Number of WorldwideOrganisations: #{WorldwideOrganisation.count},
+    Number of WorldwideOrganisation initial Versions: #{Version.where(item_type: WorldwideOrganisation.name, event: EVENT_TYPE).count}
+  )
+end
+
+worldwide_organisation_ids = WorldwideOrganisation.pluck(:id)
+initial_versions = []
+
+worldwide_organisation_ids.each do |id|
+  initial_versions << { event: EVENT_TYPE, item_type: WorldwideOrganisation.name, item_id: id }
+end
+
+puts "BEFORE: #{log_message}"
+Version.insert_all!(initial_versions)
+puts "AFTER: #{log_message}"


### PR DESCRIPTION
> Part 1 of a 2 part deployment. [Part 2 here](https://github.com/alphagov/whitehall/pull/7583)

### [Create initial audits for worldwide organisations](https://github.com/alphagov/whitehall/pull/7590/commits/f5ee5f3b1452c8abd27a6f07b112b0d02df1abd2)

We will soon be auditing worldwide organisations; this will create a `Version`
record when a worldwide organisation is created or updated. However, until
auditing is added, we have no way of knowing what changes were made or by
whom.

This migration creates a `Version` with an "initial" event type for all worldwide
organisations. We can then handle this in the UI in an appropriate way by
displaying "No history before this time".

We want to deploy the worldwide organisation auditing work in two steps -
first, by running this migration, then, by merging separate work that adds audits.
There may be audits that are not recorded in the period between the two steps.
We have decided that this is only a minor issue, and we will attempt to deploy
the follow up work shortly after this migration is run in order to reduce the
likelihood of this happening.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/47089130/234907794-4c3fd8c2-7ba6-48ba-a967-d0f7bca1d42b.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
