### PR TITLE
Add summary and body to worldwide organisation translations

### DIFF
--- a/db/data_migration/20230427150648_copy_summary_and_body_from_worldwide_organisation_about_page_to_worldwide_organisation.rb
+++ b/db/data_migration/20230427150648_copy_summary_and_body_from_worldwide_organisation_about_page_to_worldwide_organisation.rb
@@ -1,0 +1,38 @@
+WorldwideOrganisation.all.each do |worldwide_organisation|
+  puts "Processing #{worldwide_organisation.slug}"
+
+  if worldwide_organisation.about_us.nil?
+    puts "No published about page".indent(2)
+    next
+  end
+
+  if worldwide_organisation.about_us.translations.none?
+    puts "No translations for published about page".indent(2)
+    next
+  end
+
+  worldwide_organisation.about_us.translations.each do |source_translation|
+    puts "Processing source translation for #{source_translation.locale}".indent(2)
+
+    target_translation = worldwide_organisation.translations.find_by(locale: source_translation.locale)
+
+    if target_translation.nil?
+      puts "Creating target translation - name & services fields will be blank".indent(4)
+
+      target_translation = worldwide_organisation.translations.create!(locale: source_translation.locale)
+    else
+      puts "Found existing translation".indent(4)
+    end
+
+    puts "Updating target translation for #{target_translation.locale}".indent(4)
+    target_translation.update!(
+      summary: source_translation.summary,
+      body: source_translation.body,
+    )
+  end
+
+  if worldwide_organisation.draft_about_us.present?
+    puts "#{worldwide_organisation.name} has a draft about page - this data may be lost".indent(2)
+    next
+  end
+end

--- a/db/migrate/20230427150022_add_summary_and_body_to_worldwide_organisation_translations.rb
+++ b/db/migrate/20230427150022_add_summary_and_body_to_worldwide_organisation_translations.rb
@@ -1,0 +1,8 @@
+class AddSummaryAndBodyToWorldwideOrganisationTranslations < ActiveRecord::Migration[7.0]
+  def change
+    change_table :worldwide_organisation_translations, bulk: true do |t|
+      t.column :summary, :text
+      t.column :body, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_07_101416) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_150022) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -1156,6 +1156,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_101416) do
     t.text "services"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.text "summary"
+    t.text "body"
     t.index ["locale"], name: "index_worldwide_org_translations_on_locale"
     t.index ["worldwide_organisation_id"], name: "index_worldwide_org_translations_on_worldwide_organisation_id"
   end


### PR DESCRIPTION
Trello: https://trello.com/c/hwo2GEzk

This is an initial draft PR to illustrate what we might do if we want to move the content currently stored on the "about" `CorporateInformationPage` for a `WorldwideOrganisation` onto the `WorldwideOrganisation` itself.

This PR doesn't yet include code changes which make use of these new fields since the Trello card doesn't seem to want me to do that. However, I feel extremely nervous about making these database changes without first seeing how we'll make use of them and, in particular, how we'll change the editor UI.

This PR currently just includes a regular database migration (to add the new columns) and a data migration (to copy data to those new columns); eventually we'd probably want to delete all the "about" `CorporateInformationPages`. There are a few potential gotchas in the data migration:

1. Although the Trello card talks about moving the fields from the "about" `CorporateInformationPages` to the `WorldwideOrganisation`, in fact I think we need to move them from the translations associated with the former to the translations for the same locale for the latter.
2. Some `WorldwideOrganisations` have a draft "about" `CorporateInformationPage`. Only data in the latest published edition of the "about" `CorporateInformationPage` will be copied. If we want to retain any other data, we'll need to make separate provision for that.
3. Some `WorldwideOrganisations` do not currently have a translation for all the locales translated on the "about" `CorporateInformationPage`. The data migration will create them, but this means the translations for the `name` & `services` fields will be blank for that locale.

I haven't yet dealt with attachments, but the plan would be to include the `Attachable` concern into `WorldwideOrganisations` and update the `attachable_id` & `attachable_type` on the `Attachments` associated with the latest published edition of the "about" `CorporateInformationPage`. However, again I'm pretty nervous about making this change in the absence of making the changes to the editor UI.

We _might_ also want to capture some of the edition-related document history from the "about" `CorporateInformationPage` in the new non-editionable document history being created in [this Trello card](https://trello.com/c/7snah8vf).

If this still feels like the right direction, then I think I'd prefer to convert the Trello card into something more complete (even if it's only just a spike), i.e. to actually change the editor UI to use the new fields.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
