### PR TITLE
Fix 'flash of unstyled content' on subnav menus

### DIFF
--- a/app/assets/javascripts/admin/modules/navbar-toggle.js
+++ b/app/assets/javascripts/admin/modules/navbar-toggle.js
@@ -10,6 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   NavbarToggle.prototype.init = function () {
     this.menu.classList.add('govuk-visually-hidden')
+    this.menu.classList.remove('hide-before-js-module-init')
     this.toggler.setAttribute('tabindex', 0)
     this.initToggleListeners()
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,6 +45,15 @@ $govuk-page-width: 1140px;
   .app-js-only {
     display: block;
   }
+
+  // The .js-enabled class gets applied immediately while the page is still loading,
+  // whereas GOV.UK JS Modules only initialise once the entire HTML document has loaded (on DOMContentLoaded).
+  // To avoid a 'flash of unstyled content', elements can use .hide-before-js-module-init to
+  // temporarily hide the element. The element's JS module can then remove it once
+  // initialised and apply the correct styling.
+  .hide-before-js-module-init {
+    display: none;
+  }
 }
 
 .legacy-whitehall {

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -105,7 +105,7 @@ module Admin::EditionActionsHelper
   # If adding new models also update filter_options_for_edition
   def document_creation_dropdown
     tag.ul(
-      class: "masthead-menu list-unstyled js-hidden js-navbar-toggle__menu",
+      class: "masthead-menu list-unstyled js-hidden js-navbar-toggle__menu hide-before-js-module-init",
       id: "new-document-menu",
       role: "menu",
       "aria-labelledby" => "new-document-label",

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -63,7 +63,7 @@
       <%= admin_user_organisation_header_link %>
       <li class="js-more-nav masthead-tab-item" data-module="navbar-toggle">
         <a href="#more-links-menu" id="more-links-label" class="toggler js-navbar-toggle__toggler">More</a>
-        <ul id="more-links-menu" class="masthead-menu masthead-menu-right js-hidden unstyled js-navbar-toggle__menu" role="menu" aria-labelledby="more-links-label">
+        <ul id="more-links-menu" class="masthead-menu masthead-menu-right js-hidden unstyled js-navbar-toggle__menu hide-before-js-module-init" role="menu" aria-labelledby="more-links-label">
           <%= admin_organisations_header_menu_link %>
           <%= admin_policy_groups_header_menu_link %>
           <%= admin_roles_header_menu_link %>


### PR DESCRIPTION
This change fixes a brief [flash of unstyled content][1] that caused an unsightly flickering of the subnav menus on page load.

The no-JS experience is for all subnav menus to be expanded and visible. For JS-enabled users, the subnavs will hide immediately once the JavaScript module 'navbar-toggle' has initialised.

However there's an 'in between' period where the HTML document is still loading, so the JS modules haven't initialised yet, and the subnav menus are visible on screen.

To handle this case, I've introduced the `.hide-before-js-module-init` class which will be hidden so long as JavaScript is enabled. JS modules can then remove the class once they're styled elements as required.

## Demo

This behaviour is most evident on large HTML pages which may not load immediately. The image cropping page is a good example of this, because it uses a [Data URL][2] to embed a user uploaded image that needs to be cropped. It's therefore possible for this HTML response to be several megabytes in size, and take several seconds to complete loading.

### Before

The subnav menus appear until the page has finished loading.

https://user-images.githubusercontent.com/7735945/235162454-6dc088a7-48fb-4de9-ac16-68813d834f5a.mov

### After

The subnav menus are hidden throughout page load.

https://user-images.githubusercontent.com/7735945/235162493-7c507518-f85c-4593-8cdc-273c71aadeb7.mov

[1]: https://en.wikipedia.org/wiki/Flash_of_unstyled_content
[2]: https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls

Trello: https://trello.com/c/A7QSA5m1/1252-fix-flash-of-unstyled-content-on-subnav-menus

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
