### PR TITLE
Add message for users without JS on crop page

### DIFF
--- a/app/views/admin/edition_images/crop.html.erb
+++ b/app/views/admin/edition_images/crop.html.erb
@@ -7,7 +7,9 @@
 
   <section class="govuk-grid-column-two-thirds">
     <%= form_tag admin_edition_images_path(@edition), multipart: true do %>
-      <p class="govuk-body govuk-!-margin-bottom-7">Select part of the image to use. The part you select will be resized for GOV.UK. The shape is fixed.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7 app-no-js">The image you selected needs to be cropped to fit on GOV.UK. Enable JavaScript in your browser or use an alternative browser to crop and resize the image.</p>
+
+      <p class="govuk-body govuk-!-margin-bottom-7 app-js-only">Select part of the image to use. The part you select will be resized for GOV.UK. The shape is fixed.</p>
 
       <%= render "components/image-cropper", {
         name: "image[image_data][file]",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Add a message telling users to enable javascript or change browser to upload oversized images.
Clicking "Save and continue" will redirect users back to the upload page.

# Why
This is the simplest solution to the JS free experience which should not be encountered often - the alternative - appending browser features to the upload form is unnecessarily complex.

# Screenshot
![whitehall-admin dev gov uk_government_admin_editions_1370963_images(iPad Pro)](https://user-images.githubusercontent.com/9594455/235680846-49256000-2793-4193-8fb7-a29a5d836af1.png)

