### PR TITLE
Publish embassies index

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,6 +20,8 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
+  after_commit :republish_embassies_index_page_to_publishing_api
+
   include TranslatableModel
   translates :title,
              :comments,
@@ -74,5 +76,9 @@ class Contact < ApplicationRecord
 
   def missing_translations
     super & contactable.non_english_translated_locales
+  end
+
+  def republish_embassies_index_page_to_publishing_api
+    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
   end
 end

--- a/app/models/embassy.rb
+++ b/app/models/embassy.rb
@@ -21,7 +21,7 @@ class Embassy
     elsif can_assist_in_other_location?
       remote_office = offices_in_remote_location.first
       RemoteOffice.new(name: remote_office.worldwide_organisation.name,
-                       location: remote_office.country,
+                       location: remote_office.country.name,
                        path: remote_office.worldwide_organisation.public_path)
     end
   end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -18,6 +18,8 @@ class WorldLocation < ApplicationRecord
   accepts_nested_attributes_for :world_location_news
   delegate :title, to: :world_location_news
 
+  after_commit :republish_embassies_index_page_to_publishing_api
+
   enum world_location_type: { world_location: 1, international_delegation: 3 }
 
   accepts_nested_attributes_for :edition_world_locations
@@ -89,4 +91,8 @@ class WorldLocation < ApplicationRecord
 
   extend FriendlyId
   friendly_id
+
+  def republish_embassies_index_page_to_publishing_api
+    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+  end
 end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -7,6 +7,8 @@ class WorldwideOffice < ApplicationRecord
   has_one :default_access_and_opening_times, through: :worldwide_organisation, source: :access_and_opening_times
   validates :worldwide_organisation, :contact, :worldwide_office_type_id, presence: true
 
+  after_commit :republish_embassies_index_page_to_publishing_api
+
   accepts_nested_attributes_for :contact
 
   extend FriendlyId
@@ -39,5 +41,9 @@ class WorldwideOffice < ApplicationRecord
 
   def available_in_multiple_languages?
     false
+  end
+
+  def republish_embassies_index_page_to_publishing_api
+    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
   end
 end

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -58,6 +58,8 @@ class WorldwideOrganisation < ApplicationRecord
     end
   end
 
+  after_commit :republish_embassies_index_page_to_publishing_api
+
   # I'm trying to use a domain centric design rather than a persistence
   # centric design, so I do not want to expose a has_many :home_page_lists
   # and all that this implies. I really only want to expose a list of
@@ -131,5 +133,9 @@ class WorldwideOrganisation < ApplicationRecord
 
   def public_url(options = {})
     Plek.website_root + public_path(options)
+  end
+
+  def republish_embassies_index_page_to_publishing_api
+    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
   end
 end

--- a/app/presenters/publishing_api/base_item_presenter.rb
+++ b/app/presenters/publishing_api/base_item_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
       {
         title:,
         locale:,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         redirects: [],
         update_type:,
       }

--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -27,7 +27,7 @@ module PublishingApi
         document_type:,
         locale:,
         public_updated_at:,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         details:,
         phase:,
         update_type:,

--- a/app/presenters/publishing_api/embassies_index_presenter.rb
+++ b/app/presenters/publishing_api/embassies_index_presenter.rb
@@ -1,0 +1,86 @@
+module PublishingApi
+  class EmbassiesIndexPresenter
+    WORLD_INDEX_CONTENT_ID = "369729ba-7776-4123-96be-2e3e98e153e1".freeze
+
+    def content_id
+      "430df081-f28e-4a1f-b812-8977fdac6e9a"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: I18n.t("organisation.embassies.find_an_embassy_title"),
+        update_type: "minor",
+      ).base_attributes
+
+      content.merge!(
+        base_path:,
+        details:,
+        document_type: "embassies_index",
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "embassies_index",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def links
+      { parent: [WORLD_INDEX_CONTENT_ID] }
+    end
+
+  private
+
+    def base_path
+      "/world/embassies"
+    end
+
+    def details
+      {
+        world_locations: world_locations.map do |embassy|
+          hash = {
+            name: embassy.name,
+            assistance_available: assistance_available(embassy),
+          }
+          if assistance_available(embassy) == "local"
+            hash["organisations_with_embassy_offices"] = embassy.organisations_with_embassy_offices.map do |organisation|
+              {
+                locality: organisation.embassy_offices.first.contact.locality,
+                name: organisation.name,
+                path: organisation.public_path,
+              }
+            end
+          end
+          if assistance_available(embassy) == "remote"
+            hash["remote_office"] = {
+              name: embassy.remote_office.name,
+              country: embassy.remote_office.location,
+              path: embassy.remote_office.path,
+            }
+          end
+          hash
+        end,
+      }
+    end
+
+    def world_locations
+      WorldLocation.geographical.order(:slug).map { |location|
+        # We don't want to show the UK on the embassies page.
+        next if location.name.in?(["United Kingdom"])
+
+        Embassy.new(location)
+      }.reject(&:blank?)
+    end
+
+    def assistance_available(embassy)
+      if embassy.can_assist_british_nationals?
+        if embassy.can_assist_in_location?
+          "local"
+        else
+          "remote"
+        end
+      else
+        "none"
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
           details: {},
           document_type: "field_of_operation",
           locale: "en",
-          publishing_app: "whitehall",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: "field_of_operation",
           title: operational_field.name,

--- a/app/presenters/publishing_api/publish_intent_presenter.rb
+++ b/app/presenters/publishing_api/publish_intent_presenter.rb
@@ -8,7 +8,7 @@ module PublishingApi
     def as_json
       {
         publish_time: @publish_timestamp,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         routes: [{ path: @base_path, type: "exact" }],
       }

--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -14,7 +14,7 @@ module PublishingApi
         title:,
         locale:,
         details:,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         update_type:,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,

--- a/lib/publish_organisations_index_page.rb
+++ b/lib/publish_organisations_index_page.rb
@@ -21,7 +21,7 @@ private
         schema_name: "organisations_homepage",
         locale: "en",
         base_path: BASE_PATH,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         routes: [
           {

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -41,14 +41,6 @@ class PublishStaticPages
         base_path: "/government/ministers",
         locales: Locale.non_english.map(&:code),
       },
-      {
-        content_id: "430df081-f28e-4a1f-b812-8977fdac6e9a",
-        title: "Find a British embassy, high commission or consulate",
-        base_path: "/world/embassies",
-        document_type: "finder",
-        schema_name: "embassies_index",
-        description: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
-      },
     ]
   end
 

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -87,7 +87,7 @@ class PublishStaticPages
         schema_name: (page[:schema_name] || "placeholder"),
         locale: "en",
         base_path: page[:base_path],
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: page.fetch(:rendering_app, Whitehall::RenderingApp::WHITEHALL_FRONTEND),
         routes:,
         public_updated_at: Time.zone.now.iso8601,

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -88,6 +88,11 @@ namespace :publishing_api do
     task republish_ministers_index: :environment do
       PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter)
     end
+
+    desc "Republish the embassies index page to Publishing API"
+    task republish_embassies_index: :environment do
+      PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+    end
   end
 
   namespace :patch_links do

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,7 +12,7 @@ namespace :publishing_api do
       publisher.publish(
         {
           format: "special_route",
-          publishing_app: "whitehall",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           update_type: "major",
           type: "prefix",
@@ -39,7 +39,7 @@ namespace :publishing_api do
             destination: route[:destination],
           },
         ],
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         public_updated_at: Time.zone.now.iso8601,
         update_type: "major",
       )

--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -15,7 +15,7 @@ module Whitehall
           base_path:,
           document_type: "redirect",
           schema_name: "redirect",
-          publishing_app: "whitehall",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
           update_type: "major",
           redirects:,
         }

--- a/lib/whitehall/publishing_app.rb
+++ b/lib/whitehall/publishing_app.rb
@@ -1,0 +1,5 @@
+module Whitehall
+  module PublishingApp
+    WHITEHALL = "whitehall".freeze
+  end
+end

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -43,7 +43,7 @@ class ContactTest < ActiveSupport::TestCase
         schema_name: "contact",
         document_type: "contact",
         locale: "en",
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
       ),
     )
 

--- a/test/integration/world_location_integration_test.rb
+++ b/test/integration/world_location_integration_test.rb
@@ -49,6 +49,13 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
     has_entries(locale:, title:, details: has_entries(mission_statement:))
   end
 
+  def expect_embassies_index_to_be_published
+    presenter = PublishingApi::EmbassiesIndexPresenter.new
+    Services.publishing_api.expects(:put_content).with(presenter.content_id, presenter.content)
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, anything)
+  end
+
   test "when updating, makes the correct calls to publishing api" do
     Sidekiq::Testing.inline! do
       world_location_news_without_translations = build(:world_location_news)
@@ -57,8 +64,10 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       new_mission_statement = "a different mission"
       fill_in "world_location_news_mission_statement", with: new_mission_statement
 
+      expect_embassies_index_to_be_published
       Services.publishing_api.expects(:put_content).once.with(world_location_news_without_translations.content_id, put_content_hash_containing("en", world_location_news_without_translations.title, new_mission_statement))
-      Services.publishing_api.expects(:publish).at_least_once
+      Services.publishing_api.expects(:patch_links).with(world_location_news_without_translations.content_id, anything)
+      Services.publishing_api.expects(:publish).with(world_location_news_without_translations.content_id, anything, anything)
 
       click_on "Save"
     end
@@ -114,6 +123,7 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       new_title = "a new title"
       fill_in "Title", match: :first, with: new_title
 
+      PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
       Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("en", new_title, new_mission_statement))
       Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("fr", @original_french_title, @original_french_mission_statement))
       Services.publishing_api.expects(:publish).at_least_once
@@ -134,6 +144,7 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       new_title = "un titre différent"
       fill_in "Title", with: new_title
 
+      PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
       Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("en", @original_english_title, @original_english_mission_statement))
       Services.publishing_api.expects(:put_content).at_least_once.with(@world_location_news.content_id, put_content_hash_containing("fr", new_title, new_mission_statement))
       Services.publishing_api.expects(:publish).at_least_once

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -20,7 +20,7 @@ module PublishingApiTestHelpers
     editions.each do |edition|
       Services.publishing_api.expects(:put_content)
         .with(edition.content_id,
-              has_entries({ publishing_app: "whitehall" }.merge(content_entries)))
+              has_entries({ publishing_app: Whitehall::PublishingApp::WHITEHALL }.merge(content_entries)))
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)
@@ -32,7 +32,7 @@ module PublishingApiTestHelpers
     editions.each do |edition|
       Services.publishing_api.expects(:put_content)
         .with(edition.content_id,
-              has_entries({ publishing_app: "whitehall" }.merge(content_entries)))
+              has_entries({ publishing_app: Whitehall::PublishingApp::WHITEHALL }.merge(content_entries)))
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)

--- a/test/support/specialist_topic_helpers.rb
+++ b/test/support/specialist_topic_helpers.rb
@@ -101,7 +101,7 @@ module SpecialistTopicHelper
       "base_path": document_collection_base_path,
       "content_id": document_collection_content_id,
       "document_type": "document_collection",
-      "publishing_app": "whitehall" }
+      "publishing_app": Whitehall::PublishingApp::WHITEHALL }
   end
 
   def specialist_topic_content_item

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -126,6 +126,7 @@ class ContactTest < ActiveSupport::TestCase
       ServiceListeners::EditionDependenciesPopulator.new(news_article).populate!
       ServiceListeners::EditionDependenciesPopulator.new(corp_info_page).populate!
 
+      PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
       expect_publishing(contact)
       expect_republishing(news_article, corp_info_page)
 
@@ -156,5 +157,27 @@ class ContactTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.expects(:republish_async).with(policy_group).once
 
     contact.update!(title: "A new name")
+  end
+
+  test "republishes embassies index page on creation of contact" do
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    create(:contact)
+  end
+
+  test "republishes embassies index page on update of contact" do
+    contact = create(:contact_with_country)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    contact.update!(locality: "new-locality")
+  end
+
+  test "republishes embassies index page on deletion of contact" do
+    contact = create(:contact)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    contact.destroy!
   end
 end

--- a/test/unit/models/embassy_test.rb
+++ b/test/unit/models/embassy_test.rb
@@ -138,7 +138,7 @@ class EmbassyTest < ActiveSupport::TestCase
     it "returns #remote_office" do
       expected = Embassy::RemoteOffice.new(
         name: "org-name",
-        location: other_location,
+        location: other_location.name,
         path: "/world/organisations/org-slug",
       )
       assert_equal expected, embassy.remote_office
@@ -168,7 +168,7 @@ class EmbassyTest < ActiveSupport::TestCase
     it "returns the remote office from #remote_office" do
       expected = Embassy::RemoteOffice.new(
         name: "org-name",
-        location: other_location,
+        location: other_location.name,
         path: "/world/organisations/org-slug",
       )
       assert_equal expected, embassy.remote_office
@@ -199,7 +199,7 @@ class EmbassyTest < ActiveSupport::TestCase
     it "returns the embassy office from #remote_office" do
       expected = Embassy::RemoteOffice.new(
         name: "org-name",
-        location: third_location,
+        location: third_location.name,
         path: "/world/organisations/org-slug",
       )
       assert_equal expected, embassy.remote_office

--- a/test/unit/presenters/publishing_api/base_item_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/base_item_presenter_test.rb
@@ -9,7 +9,7 @@ module PublishingApi
       expected_hash = {
         title: stubbed_item.title,
         locale: "fr",
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         redirects: [],
         update_type: "major",
       }

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -22,7 +22,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       document_type: "case_study",
       locale: "en",
       public_updated_at: case_study.public_timestamp,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -42,7 +42,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
       locale: "en",
       phase: "live",
       public_updated_at: @updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       update_type: "major",
       details: {
         description: "Quiet at weekends",

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -46,7 +46,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       schema_name: "detailed_guide",
       document_type: "detailed_guide",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -46,7 +46,7 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the publishing_app as whitehall" do
-    assert_equal "whitehall", @presented_content[:publishing_app]
+    assert_equal Whitehall::PublishingApp::WHITEHALL, @presented_content[:publishing_app]
   end
 
   test "it presents the rendering_app as government-frontend" do

--- a/test/unit/presenters/publishing_api/embassies_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/embassies_index_presenter_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class PublishingApi::EmbassiesIndexPresenterTest < ActiveSupport::TestCase
+  test "generates a valid document for world locations with no embassies" do
+    create(:world_location)
+
+    assert_valid_embassies_index_document
+  end
+
+  test "generates a valid document for world locations with local embassies" do
+    world_location = build(:world_location)
+    organisation = create(:worldwide_organisation, world_locations: [world_location])
+    contact = create(:contact_with_country, country: world_location, locality: "locality")
+    create(:worldwide_office,
+           contact:,
+           worldwide_organisation: organisation,
+           worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
+
+    assert_valid_embassies_index_document
+  end
+
+  test "generates a valid document for world locations with remote embassies" do
+    world_location = build(:world_location)
+    other_location = create(:world_location)
+    organisation = create(:worldwide_organisation, world_locations: [world_location])
+    contact = create(:contact_with_country, country: other_location)
+    create(:worldwide_office,
+           contact:,
+           worldwide_organisation: organisation,
+           worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
+
+    assert_valid_embassies_index_document
+  end
+
+  def assert_valid_embassies_index_document
+    presenter = PublishingApi::EmbassiesIndexPresenter.new
+    presented_page = presenter.content
+
+    validator = GovukSchemas::Validator.new(
+      presented_page[:schema_name],
+      "publisher",
+      presented_page,
+    )
+    assert validator.valid?, validator.error_message
+  end
+end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -44,7 +44,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the publishing_app as whitehall" do
-    assert_equal "whitehall", @presented_content[:publishing_app]
+    assert_equal Whitehall::PublishingApp::WHITEHALL, @presented_content[:publishing_app]
   end
 
   test "it presents the rendering_app as government-frontend" do

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -28,7 +28,7 @@ module PublishingApi
         document_type: "press_release",
         locale: "en",
         public_updated_at: edition.updated_at,
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: "government-frontend",
         routes: [
           { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_account_presenter_test.rb
@@ -23,7 +23,7 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       base_path: public_path,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       schema_name: "historic_appointment",
       document_type: "historic_appointment",

--- a/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -17,7 +17,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
   test "presents a valid content item" do
     expected_hash = {
       base_path: "/government/history/past-prime-ministers",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       schema_name: "historic_appointments",
       document_type: "historic_appointments",

--- a/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -23,7 +23,7 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     test "presents a valid content item" do
       expected_hash = {
         base_path: "/government/how-government-works",
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: "government-frontend",
         schema_name: "how_government_works",
         document_type: "how_government_works",
@@ -79,7 +79,7 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
     test "presents a valid content item without any details or links" do
       expected_hash = {
         base_path: "/government/how-government-works",
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         rendering_app: "government-frontend",
         schema_name: "how_government_works",
         document_type: "how_government_works",

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -26,7 +26,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       document_type: "html_publication",
       locale: "en",
       public_updated_at: html_attachment.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: html_attachment.url, type: "exact" },

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -35,7 +35,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       expected_content = {
         title: "Ministers",
         locale: "en",
-        publishing_app: "whitehall",
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
         redirects: [],
         update_type: "major",
         base_path: "/government/ministers",

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -27,7 +27,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
     expected_hash = {
       title: "Operational Field name",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       update_type: "major",
       base_path: "/government/fields-of-operation/operational-field-name",
       details: {},

--- a/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_fields_index_presenter_test.rb
@@ -10,7 +10,7 @@ class PublishingApi::OperationalFieldsIndexPresenterTest < ActiveSupport::TestCa
     expected_hash = {
       base_path: "/government/fields-of-operation",
       details: {},
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       schema_name: "fields_of_operation",
       document_type: "fields_of_operation",

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -47,7 +47,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       schema_name: "organisation",
       document_type: "organisation",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       routes: [
         { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -28,7 +28,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       schema_name: "person",
       document_type: "person",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       public_updated_at: person.updated_at,
       routes: [{ path: public_path, type: "exact" }],

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -28,7 +28,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       document_type: "policy_paper",
       locale: "en",
       public_updated_at: publication.public_timestamp,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -27,7 +27,7 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
       schema_name: "role_appointment",
       document_type: "role_appointment",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       public_updated_at: role.updated_at,
       update_type: "major",
       details: {

--- a/test/unit/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_presenter_test.rb
@@ -20,7 +20,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       schema_name: "role",
       document_type: "ministerial_role",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       public_updated_at: role.updated_at,
       routes: [
@@ -76,7 +76,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       schema_name: "role",
       document_type: "ministerial_role",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       public_updated_at: role.updated_at,
       routes: [
@@ -129,7 +129,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
       schema_name: "role",
       document_type: "board_member_role",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       public_updated_at: role.updated_at,
       routes: [],

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -16,7 +16,7 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
       schema_name: "generic",
       document_type: "services_and_information",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       public_updated_at: organisation.updated_at,
       routes: [{ path: public_path, type: "exact" }],

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -64,11 +64,11 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       end
 
       it "contains the expected values" do
-        assert_equal("Speech title",          presented.content[:title])
-        assert_equal("The description",       presented.content[:description])
-        assert_equal("whitehall",             presented.content[:publishing_app])
-        assert_equal("government-frontend",   presented.content[:rendering_app])
-        assert_equal([speech.auth_bypass_id], presented.content[:auth_bypass_ids])
+        assert_equal("Speech title",                      presented.content[:title])
+        assert_equal("The description",                   presented.content[:description])
+        assert_equal(Whitehall::PublishingApp::WHITEHALL, presented.content[:publishing_app])
+        assert_equal("government-frontend",               presented.content[:rendering_app])
+        assert_equal([speech.auth_bypass_id],             presented.content[:auth_bypass_ids])
 
         details = presented.content[:details]
         assert_not(details[:political])

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -41,7 +41,7 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the publishing_app as whitehall" do
-    assert_equal "whitehall", @presented_content[:publishing_app]
+    assert_equal Whitehall::PublishingApp::WHITEHALL, @presented_content[:publishing_app]
   end
 
   test "it presents the rendering_app as government-frontend" do

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       document_type: "official_statistics_announcement",
       locale: "en",
       public_updated_at: statistics_announcement.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },
@@ -62,7 +62,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       document_type: "official_statistics_announcement",
       locale: "en",
       public_updated_at: statistics_announcement.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },
@@ -112,7 +112,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       document_type: "official_statistics_announcement",
       locale: "en",
       public_updated_at: statistics_announcement.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" },

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
       document_type: "take_part",
       locale: "en",
       public_updated_at: take_part_page.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: "/government/get-involved/take-part/#{take_part_page.slug}", type: "exact" },

--- a/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
@@ -16,7 +16,7 @@ class PublishingApi::TopicalEventAboutPagePresenterTest < ActiveSupport::TestCas
       document_type: "topical_event_about_page",
       locale: "en",
       public_updated_at: topical_event_about_page.updated_at,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [
         { path: topical_event_about_page.search_link, type: "exact" },

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -28,7 +28,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       base_path: public_path,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       schema_name: "topical_event",
       document_type: "topical_event",
@@ -101,7 +101,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       base_path: public_path,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "collections",
       schema_name: "topical_event",
       document_type: "topical_event",

--- a/test/unit/presenters/publishing_api/working_group_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/working_group_presenter_test.rb
@@ -14,7 +14,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
 
     expected_hash = {
       base_path: public_path,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       schema_name: "working_group",
       document_type: "working_group",

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -30,7 +30,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
     expected = {
       title: "Aardistan and the Uk",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       redirects: [],
       description: "Updates, news and events from the UK government in Aardistan",
       details: {

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -14,7 +14,7 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
       schema_name: "world_location",
       document_type: "world_location",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "whitehall-frontend",
       public_updated_at: world_location.updated_at,
       redirects: [],

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -23,7 +23,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       schema_name: "worldwide_organisation",
       document_type: "worldwide_organisation",
       locale: "en",
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "whitehall-frontend",
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -14,7 +14,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       Timecop.freeze do
         params = {
           format: "special_route",
-          publishing_app: "whitehall",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           update_type: "major",
           type: "prefix",
@@ -50,7 +50,7 @@ class PublishingApiRake < ActiveSupport::TestCase
                 destination: route[:destination],
               },
             ],
-            publishing_app: "whitehall",
+            publishing_app: Whitehall::PublishingApp::WHITEHALL,
             public_updated_at: Time.zone.now.iso8601,
             update_type: "major",
           }

--- a/test/unit/whitehall/publishing_api/redirect_test.rb
+++ b/test/unit/whitehall/publishing_api/redirect_test.rb
@@ -19,7 +19,7 @@ class Whitehall::PublishingApi::RedirectTest < ActiveSupport::TestCase
   end
 
   test "sets the publishing_app to 'whitehall'" do
-    assert_equal "whitehall", @output_hash[:publishing_app]
+    assert_equal Whitehall::PublishingApp::WHITEHALL, @output_hash[:publishing_app]
   end
 
   test "sets the redirects as provided" do

--- a/test/unit/workers/publishing_api_schedule_worker_test.rb
+++ b/test/unit/workers/publishing_api_schedule_worker_test.rb
@@ -9,7 +9,7 @@ class PublishingApiScheduleWorkerTest < ActiveSupport::TestCase
 
     expected_payload = {
       publish_time:,
-      publishing_app: "whitehall",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [{ path: base_path, type: "exact" }],
     }

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -118,4 +118,26 @@ class WorldLocationTest < ActiveSupport::TestCase
     object = create(:world_location, slug: "foo")
     assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", object.public_url(cachebust: "123")
   end
+
+  test "republishes embassies index page on creation of world location" do
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    create(:world_location)
+  end
+
+  test "republishes embassies index page on update of world location" do
+    location = create(:world_location)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    location.update!(name: "new-name")
+  end
+
+  test "republishes embassies index page on deletion of world location" do
+    location = create(:world_location)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    location.destroy!
+  end
 end

--- a/test/unit/worldwide_office_test.rb
+++ b/test/unit/worldwide_office_test.rb
@@ -96,4 +96,29 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
 
     assert_not list.shown_on_home_page?(office)
   end
+
+  test "republishes embassies index page on creation of worldwide office" do
+    worldwide_organisation = create(:worldwide_organisation)
+    contact = create(:contact)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
+
+    create(:worldwide_office, worldwide_organisation:, contact:)
+  end
+
+  test "republishes embassies index page on update of worldwide office" do
+    office = create(:worldwide_office)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    office.update!(slug: "new-slug")
+  end
+
+  test "republishes embassies index page on deletion of worldwide office" do
+    office = create(:worldwide_office)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
+
+    office.destroy!
+  end
 end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -342,4 +342,26 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
       default_news_image: create(:default_news_organisation_image_data),
     )
   end
+
+  test "republishes embassies index page on creation of worldwide organisation" do
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    create(:worldwide_organisation)
+  end
+
+  test "republishes embassies index page on update of worldwide organisation" do
+    organisation = create(:worldwide_organisation)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    organisation.update!(name: "new-name")
+  end
+
+  test "republishes embassies index page on deletion of worldwide organisation" do
+    organisation = create(:worldwide_organisation)
+
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+
+    organisation.destroy!
+  end
 end


### PR DESCRIPTION
Trello link: https://trello.com/c/MMUcRbIT

This PR enables Whitehall to publish an `embassy_index` document to the Publishing API and keep that document up-to-date with changes made to its underlying data. We need this document to be published so that we can switch over the rendering of the `/world/embassies` page from Whitehall to Collections. 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
