### PR TITLE
Add `Currently featured` tab on the world locations news features page

### DIFF
--- a/app/assets/stylesheets/admin/views/_features.scss
+++ b/app/assets/stylesheets/admin/views/_features.scss
@@ -1,0 +1,24 @@
+.app-view-features__table .govuk-table__row .govuk-table__header:nth-child(1) {
+  width: 45%;
+}
+
+.app-view-features__table .govuk-table__row .govuk-table__header:nth-child(2) {
+  width: 20%;
+}
+
+.app-view-features__table .govuk-table__row .govuk-table__header:nth-child(3) {
+  width: 20%;
+}
+
+.app-view-features__table .govuk-table__row .govuk-table__header:nth-child(4) {
+  width: 15%;
+}
+
+.app-view-features__table caption, {
+  border-bottom: 2px solid govuk-colour("black");
+  padding-bottom: govuk-spacing(2);
+}
+
+.app-view-edition-index__table .govuk-table__header {
+  padding-top: govuk-spacing(4);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/edition-summary";
 @import "./admin/views/editions-edition";
 @import "./admin/views/editorial-remarks";
+@import "./admin/views/features";
 @import "./admin/views/filter";
 @import "./admin/views/govspeak-help";
 @import "./admin/views/historical-accounts-index";

--- a/app/components/admin/currently_featured_tab_component.html.erb
+++ b/app/components/admin/currently_featured_tab_component.html.erb
@@ -1,0 +1,25 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Currently featured"
+} %>
+
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: "A maximum of #{maximum_featured_documents} documents will be featured on GOV.UK."
+} %>
+
+<% if features.many? %>
+  <p class="govuk-body">
+    <%= link_to "Reorder documents", "#", class: "govuk-link" %>
+  </p>
+<% end %>
+
+<% if features.present? %>
+  <div class="app-view-features__table govuk-!-margin-bottom-8">
+    <%= table("#{pluralize(live_features.count, "featured document")} live on GOV.UK", live_features) %>
+  </div>
+<% end %>
+
+<% if remaining_features.present? %>
+  <div class="app-view-features__table">
+    <%= table(pluralize(remaining_features.count, "remaining featured document"), remaining_features) %>
+  </div>
+<% end %>

--- a/app/components/admin/currently_featured_tab_component.html.erb
+++ b/app/components/admin/currently_featured_tab_component.html.erb
@@ -8,7 +8,7 @@
 
 <% if features.many? %>
   <p class="govuk-body">
-    <%= link_to "Reorder documents", "#", class: "govuk-link" %>
+    <%= link_to "Reorder documents", reorder_admin_feature_list_path(features.first.feature_list), class: "govuk-link" %>
   </p>
 <% end %>
 

--- a/app/components/admin/currently_featured_tab_component.rb
+++ b/app/components/admin/currently_featured_tab_component.rb
@@ -129,7 +129,7 @@ private
 
   def unfeature_link(feature)
     if feature.document&.live_edition.present? || feature.topical_event.present? || feature.offsite_link.present?
-      link_to(sanitize("Unfeature #{tag.span(title(feature), class: 'govuk-visually-hidden')}"), "#", class: "gem-link--destructive govuk-!-margin-left-2")
+      link_to(sanitize("Unfeature #{tag.span(title(feature), class: 'govuk-visually-hidden')}"), confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature), class: "gem-link--destructive govuk-!-margin-left-2")
     else
       ""
     end

--- a/app/components/admin/currently_featured_tab_component.rb
+++ b/app/components/admin/currently_featured_tab_component.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+class Admin::CurrentlyFeaturedTabComponent < ViewComponent::Base
+  include Admin::EditionRoutesHelper
+  include Admin::OrganisationHelper
+
+  attr_reader :features, :maximum_featured_documents
+
+  def initialize(features:, maximum_featured_documents:)
+    @features = features || []
+    @maximum_featured_documents = maximum_featured_documents
+  end
+
+private
+
+  def live_features
+    @live_features ||= features.slice(0, maximum_featured_documents)
+  end
+
+  def remaining_features
+    @remaining_features ||= features - live_features
+  end
+
+  def table(caption, features)
+    render "govuk_publishing_components/components/table", {
+      caption:,
+      caption_classes: "govuk-heading-s",
+      head: [
+        {
+          text: "Title",
+        },
+        {
+          text: "Type",
+        },
+        {
+          text: "Published",
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden"),
+          format: "numeric",
+        },
+      ],
+      rows: rows(features),
+    }
+  end
+
+  def rows(features)
+    features.map do |feature|
+      [
+        title_row(feature),
+        type_row(feature),
+        published_row(feature),
+        actions_row(feature),
+      ]
+    end
+  end
+
+  def title_row(feature)
+    {
+      text: tag.p(title(feature), class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+    }
+  end
+
+  def title(feature)
+    if feature.document&.live_edition.present?
+      feature
+    elsif feature.topical_event.present?
+      feature.topical_event
+    elsif feature.offsite_link.present?
+      feature.offsite_link
+    else
+      feature
+    end
+  end
+
+  def type_row(feature)
+    {
+      text: type(feature),
+    }
+  end
+
+  def type(feature)
+    if feature.document&.live_edition.present?
+      "#{feature.document.live_edition.type.titleize} (document)"
+    elsif feature.topical_event.present?
+      "Topical Event"
+    elsif feature.offsite_link.present?
+      "#{feature.offsite_link.humanized_link_type} (offsite link)"
+    else
+      ""
+    end
+  end
+
+  def published_row(feature)
+    {
+      text: published_at(feature),
+    }
+  end
+
+  def published_at(feature)
+    if feature.document&.live_edition.present?
+      localize(feature.document.live_edition.major_change_published_at.to_date)
+    elsif feature.topical_event.present?
+      topical_event_dates_string(feature.topical_event)
+    elsif feature.offsite_link.present?
+      (localize(feature.offsite_link.date.to_date) if feature.offsite_link.date) || ""
+    else
+      ""
+    end
+  end
+
+  def actions_row(feature)
+    {
+      text: sanitize(edit_link(feature) + unfeature_link(feature)),
+    }
+  end
+
+  def edit_link(feature)
+    if feature.document&.live_edition.present?
+      link_to(sanitize("Edit #{tag.span(feature, class: 'govuk-visually-hidden')}"), admin_edition_path(feature.document.live_edition), class: "govuk-link")
+    elsif feature.topical_event.present?
+      link_to(sanitize("Edit #{tag.span(feature.topical_event, class: 'govuk-visually-hidden')}"), edit_admin_topical_event_path(feature.topical_event), class: "govuk-link")
+    elsif feature.offsite_link.present?
+      link_to(sanitize("Edit #{tag.span(feature.offsite_link, class: 'govuk-visually-hidden')}"), polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link]), class: "govuk-link")
+    else
+      ""
+    end
+  end
+
+  def unfeature_link(feature)
+    if feature.document&.live_edition.present? || feature.topical_event.present? || feature.offsite_link.present?
+      link_to(sanitize("Unfeature #{tag.span(title(feature), class: 'govuk-visually-hidden')}"), "#", class: "gem-link--destructive govuk-!-margin-left-2")
+    else
+      ""
+    end
+  end
+end

--- a/app/controllers/admin/feature_lists_controller.rb
+++ b/app/controllers/admin/feature_lists_controller.rb
@@ -1,11 +1,14 @@
 class Admin::FeatureListsController < Admin::BaseController
   before_action :find_feature_list
+  layout "design_system"
 
   def show
     redirect_to feature_list_path(@feature_list)
   end
 
-  def reorder
+  def reorder; end
+
+  def update_order
     new_order = ordering_params.to_h.sort_by { |_k, v| v.to_i }.map(&:first)
     message = if @feature_list.reorder!(new_order)
                 { notice: "Feature order updated" }

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -1,6 +1,6 @@
 class Admin::FeaturesController < Admin::BaseController
   before_action :find_feature_list
-  before_action :build_feature
+  before_action :build_feature, only: %i[new create]
   before_action :find_edition, :find_topical_event, :find_offsite_link, only: [:new]
   layout :get_layout
 
@@ -17,6 +17,10 @@ class Admin::FeaturesController < Admin::BaseController
       flash.now[:alert] = "Unable to create feature"
       render_design_system(:new, :legacy_new, next_release: false)
     end
+  end
+
+  def confirm_unfeature
+    @feature = @feature_list.features.find(params[:id])
   end
 
   def unfeature

--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -28,6 +28,7 @@ class Admin::WorldLocationNewsController < Admin::BaseController
 
   def features
     @feature_list = @world_location.world_location_news.load_or_create_feature_list(params[:locale])
+    @locale = Locale.new(params[:locale] || :en)
 
     filter_params = default_filter_params.merge(optional_filter_params).merge(state: "published")
 
@@ -38,7 +39,7 @@ class Admin::WorldLocationNewsController < Admin::BaseController
     if request.xhr?
       render partial: "admin/feature_lists/legacy_search_results", locals: { feature_list: @feature_list }
     else
-      render :legacy_features
+      render_design_system("features", "legacy_features", next_release: false)
     end
   end
 
@@ -73,7 +74,7 @@ private
   end
 
   def get_layout
-    design_system_actions = %w[show index edit update]
+    design_system_actions = %w[show index edit update features]
     if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
       "design_system"
     else

--- a/app/helpers/admin/world_location_helper.rb
+++ b/app/helpers/admin/world_location_helper.rb
@@ -14,7 +14,7 @@ module Admin::WorldLocationHelper
       {
         label: "Features (#{Locale.new(:en).native_language_name})",
         href: features_admin_world_location_news_path(world_location_instance, locale: I18n.locale),
-        current: path == features_admin_world_location_news_path(world_location_instance),
+        current: path == features_admin_world_location_news_path(world_location_instance, locale: :en),
       },
       world_location_instance.non_english_translated_locales.map do |locale|
         {

--- a/app/views/admin/feature_lists/_legacy_current_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_legacy_current_feature_list.html.erb
@@ -11,7 +11,7 @@
       To change the order of your featured documents, drag them up or down and then click "Save ordering".
     </p>
   <% end %>
-  <%= form_for feature_list, url: reorder_admin_feature_list_path(feature_list), method: :post do |form| %>
+  <%= form_for feature_list, url: update_order_admin_feature_list_path(feature_list), method: :post do |form| %>
     <fieldset class="sortable">
       <% feature_list.features.current.each do |feature| %>
         <div class="well feature-list">

--- a/app/views/admin/feature_lists/reorder.html.erb
+++ b/app/views/admin/feature_lists/reorder.html.erb
@@ -1,0 +1,32 @@
+<% content_for :context, "Currently featured documents" %>
+<% content_for :page_title, "Reorder list" %>
+<% content_for :title, "Reorder list" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with url: update_order_admin_feature_list_path(@feature_list) do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @feature_list.features.current.map do |feature|
+          {
+            id: feature.id,
+            title: feature,
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order",
+        } %>
+
+        <%= link_to("Cancel", polymorphic_url([:features, :admin, @feature_list.featurable], locale: @feature_list.locale), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/features/confirm_unfeature.html.erb
+++ b/app/views/admin/features/confirm_unfeature.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, "Features (#{Locale.new(@feature_list.locale).native_language_name})" %>
+<% content_for :page_title, "Unfeature ‘#{@feature}’" %>
+<% content_for :title, "Unfeature ‘#{@feature}’" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: unfeature_admin_feature_list_feature_path(@feature_list, @feature), method: :post do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to unfeature ‘<%= @feature %>’ from ‘<%= @feature_list.featurable.name %>’?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Unfeature",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", polymorphic_url([:features, :admin, @feature_list.featurable], locale: @feature_list.locale), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, @world_location_news.name %>
+<% content_for :title, @world_location_news.name %>
+<% content_for :context, "Features (#{@locale.native_language_name})" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<p class="govuk-body">
+  <%= link_to "View on website", @world_location_news.public_url({locale: params[:locale]}.merge(cachebust_url_options)), class: "govuk-link", target: "_blank" %>
+</p>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document tabs",
+    items: secondary_navigation_tabs_items(current_user, @world_location_news, request.path)
+  } %>
+</div>
+
+<%= render "govuk_publishing_components/components/tabs", {
+  tabs: [
+    {
+      id: "currently_featured_tab",
+      label: "Currently featured",
+      content: "",
+    },
+    {
+      id: "documents_tab",
+      label: "Documents",
+      content: "",
+      tab_data_attributes: {
+      }
+    },
+    {
+      id: "topical_events_tab",
+      label: "Topical events",
+      content: "",
+    },
+    {
+      id: "non_govuk_government_links_tab",
+      label: "Non-GOV.UK government links",
+      content: "",
+    }
+  ]
+} %>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -19,7 +19,10 @@
     {
       id: "currently_featured_tab",
       label: "Currently featured",
-      content: "",
+      content: render(Admin::CurrentlyFeaturedTabComponent.new(
+        features: @feature_list.features.current,
+        maximum_featured_documents: @world_location_news.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT
+      ))
     },
     {
       id: "documents_tab",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,6 +326,7 @@ Whitehall::Application.routes.draw do
           post :update_order, on: :member
 
           resources :features, only: %i[new create] do
+            get :confirm_unfeature, on: :member
             post :unfeature, on: :member
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,7 +322,8 @@ Whitehall::Application.routes.draw do
         end
 
         resources :feature_lists, only: [:show] do
-          post :reorder, on: :member
+          get :reorder, on: :member
+          post :update_order, on: :member
 
           resources :features, only: %i[new create] do
             post :unfeature, on: :member

--- a/test/components/admin/currently_featured_tab_component_test.rb
+++ b/test/components/admin/currently_featured_tab_component_test.rb
@@ -9,6 +9,7 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
 
   setup do
     @maximum_featured_documents = 5
+    @feature_list = build_stubbed(:feature_list)
   end
 
   test "renders h2 so that screen readers have context for which tab they're in" do
@@ -30,15 +31,13 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "renders link to the reorder page if more than 1 feature_list item" do
-    feature_list = build_stubbed(:feature_list)
-
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, 2, feature_list:),
+                    features: build_list(:feature, 2, feature_list: @feature_list),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
     assert_selector ".govuk-link", text: "Reorder documents" do |link|
-      assert link[:href] == reorder_admin_feature_list_path(feature_list)
+      assert link[:href] == reorder_admin_feature_list_path(@feature_list)
     end
   end
 
@@ -52,10 +51,8 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "Only renders the live featured documents table when feature_list count is <= to maximum_featured_documents" do
-    feature_list = build_stubbed(:feature_list)
-
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, @maximum_featured_documents, feature_list:),
+                    features: build_list(:feature, @maximum_featured_documents, feature_list: @feature_list),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
@@ -64,10 +61,8 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "renders the live featured documents table and the remaining documents table when feature_list count is great than maximum_featured_documents" do
-    feature_list = build_stubbed(:feature_list)
-
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, @maximum_featured_documents + 1, feature_list:),
+                    features: build_list(:feature, @maximum_featured_documents + 1, feature_list: @feature_list),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
@@ -80,10 +75,11 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
     document = build(:document)
     edition = build_stubbed(:news_article, :published)
     document.stubs(:live_edition).returns(edition)
+    feature = build_stubbed(:feature, document:, feature_list: @feature_list)
     title = edition.title
 
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: [build(:feature, document:)],
+                    features: [feature],
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
@@ -93,12 +89,11 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
 
     actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
     actions_column.assert_selector "a[href='#{admin_edition_path(edition)}']", text: "Edit #{title}"
-    # this will be updated when i add the unfeatued endpoint
-    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(@feature_list, feature)}']", text: "Unfeature #{title}"
   end
 
   test "renders the correct row when the feature list item belongs to a topical event" do
-    feature = build_stubbed(:feature, :with_topical_event_association)
+    feature = build_stubbed(:feature, :with_topical_event_association, feature_list: @feature_list)
     title = feature.topical_event.name
 
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
@@ -112,12 +107,11 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
 
     actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
     actions_column.assert_selector "a[href='#{edit_admin_topical_event_path(feature.topical_event)}']", text: "Edit #{title}"
-    # this will be updated when i add the unfeatued endpoint
-    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature)}']", text: "Unfeature #{title}"
   end
 
   test "renders the correct row when the feature list item belongs to a offsite link" do
-    feature = build_stubbed(:feature, :with_offsite_link_association)
+    feature = build_stubbed(:feature, :with_offsite_link_association, feature_list: @feature_list)
     title = feature.offsite_link.title
 
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
@@ -131,8 +125,7 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
 
     actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
     actions_column.assert_selector "a[href='#{polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link])}']", text: "Edit #{title}"
-    # this will be updated when i add the unfeatued endpoint
-    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature)}']", text: "Unfeature #{title}"
   end
 
   test "renders the correct row when the feature list item does not have an association" do

--- a/test/components/admin/currently_featured_tab_component_test.rb
+++ b/test/components/admin/currently_featured_tab_component_test.rb
@@ -30,14 +30,15 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "renders link to the reorder page if more than 1 feature_list item" do
+    feature_list = build_stubbed(:feature_list)
+
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, 2),
+                    features: build_list(:feature, 2, feature_list:),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
     assert_selector ".govuk-link", text: "Reorder documents" do |link|
-      # this will be updated when i add the reorder endpoint
-      assert link[:href] == "#"
+      assert link[:href] == reorder_admin_feature_list_path(feature_list)
     end
   end
 
@@ -51,8 +52,10 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "Only renders the live featured documents table when feature_list count is <= to maximum_featured_documents" do
+    feature_list = build_stubbed(:feature_list)
+
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, @maximum_featured_documents),
+                    features: build_list(:feature, @maximum_featured_documents, feature_list:),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 
@@ -61,8 +64,10 @@ class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
   end
 
   test "renders the live featured documents table and the remaining documents table when feature_list count is great than maximum_featured_documents" do
+    feature_list = build_stubbed(:feature_list)
+
     render_inline(Admin::CurrentlyFeaturedTabComponent.new(
-                    features: build_list(:feature, @maximum_featured_documents + 1),
+                    features: build_list(:feature, @maximum_featured_documents + 1, feature_list:),
                     maximum_featured_documents: @maximum_featured_documents,
                   ))
 

--- a/test/components/admin/currently_featured_tab_component_test.rb
+++ b/test/components/admin/currently_featured_tab_component_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::CurrentlyFeaturedTabComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+  include Admin::OrganisationHelper
+
+  setup do
+    @maximum_featured_documents = 5
+  end
+
+  test "renders h2 so that screen readers have context for which tab they're in" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector "h2", text: "Currently featured"
+  end
+
+  test "informs the user how many documents they can feature" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector ".gem-c-inset-text", text: "A maximum of 5 documents will be featured on GOV.UK."
+  end
+
+  test "renders link to the reorder page if more than 1 feature_list item" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: build_list(:feature, 2),
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector ".govuk-link", text: "Reorder documents" do |link|
+      # this will be updated when i add the reorder endpoint
+      assert link[:href] == "#"
+    end
+  end
+
+  test "does not render link to the reorder page if less than 2 feature_list items" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [build(:feature)],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector ".govuk-link", text: "reorder", count: 0
+  end
+
+  test "Only renders the live featured documents table when feature_list count is <= to maximum_featured_documents" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: build_list(:feature, @maximum_featured_documents),
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector ".govuk-table", count: 1
+    assert_selector ".govuk-table__caption", text: "#{@maximum_featured_documents} featured documents live on GOV.UK"
+  end
+
+  test "renders the live featured documents table and the remaining documents table when feature_list count is great than maximum_featured_documents" do
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: build_list(:feature, @maximum_featured_documents + 1),
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_selector ".govuk-table", count: 2
+    assert_selector ".govuk-table__caption", text: "#{@maximum_featured_documents} featured documents live on GOV.UK"
+    assert_selector ".govuk-table__caption", text: "1 remaining featured document"
+  end
+
+  test "renders the correct row when the feature list item belongs to a document with a live edition" do
+    document = build(:document)
+    edition = build_stubbed(:news_article, :published)
+    document.stubs(:live_edition).returns(edition)
+    title = edition.title
+
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [build(:feature, document:)],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "News Article (document)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, I18n.localize(edition.major_change_published_at.to_date)
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{admin_edition_path(edition)}']", text: "Edit #{title}"
+    # this will be updated when i add the unfeatued endpoint
+    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item belongs to a topical event" do
+    feature = build_stubbed(:feature, :with_topical_event_association)
+    title = feature.topical_event.name
+
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [feature],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "Topical Event"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, topical_event_dates_string(feature.topical_event)
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{edit_admin_topical_event_path(feature.topical_event)}']", text: "Edit #{title}"
+    # this will be updated when i add the unfeatued endpoint
+    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item belongs to a offsite link" do
+    feature = build_stubbed(:feature, :with_offsite_link_association)
+    title = feature.offsite_link.title
+
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [feature],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "Alert (offsite link)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, ""
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link])}']", text: "Edit #{title}"
+    # this will be updated when i add the unfeatued endpoint
+    actions_column.assert_selector "a[href='#']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item does not have an association" do
+    feature = build_stubbed(:feature, document: nil)
+
+    render_inline(Admin::CurrentlyFeaturedTabComponent.new(
+                    features: [feature],
+                    maximum_featured_documents: @maximum_featured_documents,
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, "Feature #{feature.id}"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, ""
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, ""
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3].text, ""
+  end
+end

--- a/test/factories/features.rb
+++ b/test/factories/features.rb
@@ -2,5 +2,15 @@ FactoryBot.define do
   factory :feature do
     document
     image { image_fixture_file }
+
+    trait :with_topical_event_association do
+      topical_event
+      document { nil }
+    end
+
+    trait :with_offsite_link_association do
+      offsite_link
+      document { nil }
+    end
   end
 end

--- a/test/functional/admin/feature_lists_controller_test.rb
+++ b/test/functional/admin/feature_lists_controller_test.rb
@@ -15,14 +15,24 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
     assert_redirected_to features_admin_world_location_news_path(feature_list.featurable, locale: feature_list.locale)
   end
 
-  test "post reorder reorders the feature list" do
+  test "get reorder assigns the feature list" do
+    world_location_news = build(:world_location_news)
+    create(:world_location, world_location_news:)
+    feature_list = create(:feature_list, featurable: world_location_news, locale: :fr)
+
+    get :reorder, params: { id: feature_list }
+
+    assert_equal feature_list, assigns[:feature_list]
+  end
+
+  test "post update_order updates the order of the feature list" do
     world_location_news = build(:world_location_news)
     create(:world_location, world_location_news:)
     feature_list = create(:feature_list, featurable: world_location_news, locale: :fr)
     feature1 = create(:feature, feature_list:, ordering: 1)
     feature2 = create(:feature, feature_list:, ordering: 2)
 
-    post :reorder,
+    post :update_order,
          params: { id: feature_list,
                    ordering: {
                      feature2.id.to_s => "1",
@@ -32,12 +42,12 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
     assert_equal [feature2, feature1], feature_list.reload.features
   end
 
-  test "post reorder with no ordering does nothing" do
+  test "post update_order with no ordering does nothing" do
     world_location_news = build(:world_location_news)
     create(:world_location, world_location_news:)
     feature_list = create(:feature_list, featurable: world_location_news, locale: :fr)
 
-    post :reorder, params: { id: feature_list }
+    post :update_order, params: { id: feature_list }
 
     assert_redirected_to features_admin_world_location_news_path(feature_list.featurable, locale: feature_list.locale)
   end

--- a/test/functional/admin/world_location_news_controller_test.rb
+++ b/test/functional/admin/world_location_news_controller_test.rb
@@ -123,6 +123,6 @@ class Admin::WorldLocationNewsControllerTest < ActionController::TestCase
     create(:feature_list, locale: :en, featurable: world_location, features: [first_feature])
     get :features, params: { id: world_location }
 
-    assert_match(/Please note that you can only feature a maximum of [\d+] documents.*/, response.body)
+    assert_match(/A maximum of [\d+] documents will be featured on GOV.UK.*/, response.body)
   end
 end


### PR DESCRIPTION
## Description 

This PR follows on from #7587 which prepended legacy to all the views and partials used on the features page for the `world locations news` and `organisation`'s.

This PR starts to add the new design laid out in this design card https://trello.com/c/mgckMCcS/809-currently-featured-design-placeholder in the GOV.UK Design System.

It is the first of 4 PRs, each of which will add one of the four tabs. This PR adds the `Currently featured` tab.

I've added a view component for the tab as there's a lot going on so i think it should be unit tested.

This tab links off to a reorder and an unfeature page. I've added those pages in the last two commits.

I'd recommend you review this per commit as it's quite a large PR. I've tried to break it down into smaller commits.

## Screenshot

### Features page 

<img width="818" alt="image" src="https://user-images.githubusercontent.com/42515961/235711886-33d2e093-5227-4754-b98c-97543d1f3722.png">


### Reorder page 

<img width="715" alt="image" src="https://user-images.githubusercontent.com/42515961/235721243-9150d946-6eb9-44ab-b24a-4628ed94b684.png">

### Unfeature page

<img width="589" alt="image" src="https://user-images.githubusercontent.com/42515961/235747502-fd0a97d8-41cc-42ee-b322-1ef1d07527b2.png">

## Trello card

https://trello.com/c/YBTlvGI8/54-world-location-features-page-epic-card
https://trello.com/c/IgIw4PQ7/122-currently-featured-development

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
