### PR TITLE
Add data migration to restore deleted edition

### DIFF
--- a/db/data_migration/20230503074940_restore_deleted_edition.rb
+++ b/db/data_migration/20230503074940_restore_deleted_edition.rb
@@ -1,0 +1,4 @@
+# This restores an edition that was deleted by a user in error
+edition = Edition.unscoped.find(1_432_490)
+edition.update!(state: "draft")
+PublishingApiDocumentRepublishingWorker.new.perform(edition.document.id)


### PR DESCRIPTION
A user accidentally deleted an edition and needs it restored, so they can publish it.

This marks the edition as draft and sends it downstream (so it appears in draft content store).

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5311084

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
