### PR TITLE
Add test for images both "too large" & "too small"

### DIFF
--- a/test/unit/image_data_test.rb
+++ b/test/unit/image_data_test.rb
@@ -36,6 +36,12 @@ class ImageDataTest < ActiveSupport::TestCase
     assert image_data.errors.of_kind?(:file, :too_large)
   end
 
+  test "rejects image as 'too small' when it's too large in one dimension but too small in another" do
+    image_data = build_example("300x1000_png.png")
+    assert_not image_data.valid?
+    assert image_data.errors.of_kind?(:file, :too_small)
+  end
+
   test "rejects images with duplicate filename on edition" do
     image_data = build_example("960x640_jpeg.jpg")
     edition = create(:news_article, images: [build(:image, image_data:)])


### PR DESCRIPTION
Images should be considered "too small" (and therefore not croppable) even if one dimension is too large, but the other is too small.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
