### PR TITLE
Spike use prefix route for organisation content items

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
         schema_name:,
       )
       content.merge!(
-        PayloadBuilder::PolymorphicPath.for(item, additional_routes:),
+        PayloadBuilder::PolymorphicPath.for(item, prefix: true, additional_routes:),
       )
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -1,20 +1,21 @@
 module PublishingApi
   module PayloadBuilder
     class PolymorphicPath
-      attr_reader :item, :additional_routes
+      attr_reader :item, :prefix, :additional_routes
 
-      def self.for(item, additional_routes: [])
-        new(item, additional_routes:).call
+      def self.for(item, prefix: false, additional_routes: [])
+        new(item, prefix:, additional_routes:).call
       end
 
-      def initialize(item, additional_routes: [])
+      def initialize(item, prefix: false, additional_routes: [])
         @item = item
+        @prefix = prefix
         @additional_routes = additional_routes
       end
 
       def call
         { base_path: }.merge(
-          PayloadBuilder::Routes.for(base_path, additional_routes:),
+          PayloadBuilder::Routes.for(base_path, prefix:, additional_routes:),
         )
       end
 

--- a/app/presenters/publishing_api/payload_builder/routes.rb
+++ b/app/presenters/publishing_api/payload_builder/routes.rb
@@ -3,22 +3,29 @@ module PublishingApi
     class Routes
       attr_reader :base_path, :additional_routes
 
-      def self.for(base_path, additional_routes: [])
-        new(base_path, additional_routes:).call
+      def self.for(base_path, prefix: false, additional_routes: [])
+        new(base_path, prefix:, additional_routes:).call
       end
 
-      def initialize(base_path, additional_routes: [])
+      def initialize(base_path, prefix: false, additional_routes: [])
         @base_path = base_path
+        @prefix = prefix
         @additional_routes = additional_routes
       end
 
       def call
         routes = []
-        routes << { path: base_path, type: "exact" }
+        routes << { path: base_path, type: }
         additional_routes.each do |additional_route|
           routes << { path: "#{base_path}.#{additional_route}", type: "exact" }
         end
         { routes: }
+      end
+
+    private
+
+      def type
+        @prefix ? "prefix" : "exact"
       end
     end
   end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -50,7 +50,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       publishing_app: "whitehall",
       rendering_app: "collections",
       routes: [
-        { path: public_path, type: "exact" },
+        { path: public_path, type: "prefix" },
         { path: public_atom_path, type: "exact" },
       ],
       redirects: [],
@@ -294,7 +294,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_equal("collections", presented_item.content[:rendering_app])
-    assert_equal([{ path: "/courts-tribunals/court-at-mid-wicket", type: "exact" }], presented_item.content[:routes])
+    assert_equal([{ path: "/courts-tribunals/court-at-mid-wicket", type: "prefix" }], presented_item.content[:routes])
   end
 
   test "present default news image url only when image is SVG" do
@@ -357,7 +357,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       assert_equal organisation.base_path, presented_item.content[:base_path]
 
       assert_equal [
-        { path: organisation.base_path, type: "exact" },
+        { path: organisation.base_path, type: "prefix" },
         { path: "#{organisation.base_path}.atom", type: "exact" },
       ], presented_item.content[:routes]
     end
@@ -368,7 +368,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       assert_equal "#{organisation.base_path}.cy", presented_item.content[:base_path]
 
       assert_equal [
-        { path: "#{organisation.base_path}.cy", type: "exact" },
+        { path: "#{organisation.base_path}.cy", type: "prefix" },
         { path: "#{organisation.base_path}.cy.atom", type: "exact" },
       ], presented_item.content[:routes]
     end

--- a/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
@@ -3,10 +3,22 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class RoutesTest < ActiveSupport::TestCase
-      test "returns a routes payload in the correct form" do
+      test "returns a routes payload without additional routes" do
         base_path = "some/base/path"
 
         assert_equal({ routes: [{ path: base_path, type: "exact" }] }, Routes.for(base_path))
+      end
+
+      test "returns a routes payload with additional routes" do
+        base_path = "some/base/path"
+        additional_routes = %w[atom rss]
+        expected_routes = [
+          { path: base_path, type: "exact" },
+          { path: "#{base_path}.atom", type: "exact" },
+          { path: "#{base_path}.rss", type: "exact" },
+        ]
+
+        assert_equal({ routes: expected_routes }, Routes.for(base_path, additional_routes:))
       end
     end
   end

--- a/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
@@ -9,6 +9,12 @@ module PublishingApi
         assert_equal({ routes: [{ path: base_path, type: "exact" }] }, Routes.for(base_path))
       end
 
+      test "returns a routes payload with a prefix route" do
+        base_path = "some/base/path"
+
+        assert_equal({ routes: [{ path: base_path, type: "prefix" }] }, Routes.for(base_path, prefix: true))
+      end
+
       test "returns a routes payload with additional routes" do
         base_path = "some/base/path"
         additional_routes = %w[atom rss]


### PR DESCRIPTION
Trello: https://trello.com/c/sajxUZnZ

We're hoping that changing the main route for an organisation content item from "exact" to "prefix" will allow us to handle the various redirects for URL paths under the organisation page using Rails routing in the Collections app without breaking other content items that are published with exact routes under the organisation page.

I've sketched out the corresponding changes to the Collections app in https://github.com/alphagov/collections/pull/3244.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
