### PR TITLE
Add Documents tab to the WorldLocationNews Features page

### DIFF
--- a/app/assets/stylesheets/admin/views/_features.scss
+++ b/app/assets/stylesheets/admin/views/_features.scss
@@ -22,3 +22,32 @@
 .app-view-edition-index__table .govuk-table__header {
   padding-top: govuk-spacing(4);
 }
+
+.app-view-features-search-results__table .govuk-table__row .govuk-table__header:nth-child(1) {
+  width: 35%;
+}
+
+.app-view-features-search-results__table .govuk-table__row .govuk-table__header:nth-child(2) {
+  width: 20%;
+}
+
+.app-view-features-search-results__table .govuk-table__row .govuk-table__header:nth-child(3) {
+  width: 25%;
+}
+
+.app-view-features-search-results__table .govuk-table__row .govuk-table__header:nth-child(4) {
+  width: 20%;
+}
+
+.app-view-features-search-results__table .govuk-table, {
+  border-top: 2px solid govuk-colour("black");
+}
+
+.app-view-features-search-results__table .govuk-table__header {
+  padding-top: govuk-spacing(4);
+}
+
+.app-view-features-search-results__no_documents {
+  border-top: 2px solid govuk-colour("black");
+  padding-top: govuk-spacing(4);
+}

--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -30,7 +30,11 @@ class Admin::WorldLocationNewsController < Admin::BaseController
     @feature_list = @world_location.world_location_news.load_or_create_feature_list(params[:locale])
     @locale = Locale.new(params[:locale] || :en)
 
-    filter_params = default_filter_params.merge(optional_filter_params).merge(state: "published")
+    filter_params = default_filter_params.merge(
+      optional_filter_params,
+      state: "published",
+      per_page: preview_design_system?(next_release: false) ? Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE : nil,
+    )
 
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @featurable_topical_events = TopicalEvent.active

--- a/app/helpers/admin/pagination_helper.rb
+++ b/app/helpers/admin/pagination_helper.rb
@@ -30,13 +30,29 @@ module Admin::PaginationHelper
     attr_accessor :path, :previous_href, :next_href, :current_page, :total_pages
 
     def normalise_path(path, current_page)
-      if path.include?("page=#{current_page}")
+      if url_has_page_param?(path)
         path
-      elsif path.include?("?")
+      elsif url_has_a_query_string?(path) && !url_has_an_anchor?(path)
         path + "&page=#{current_page}"
+      elsif url_has_a_query_string?(path) && url_has_an_anchor?(path)
+        path.gsub("#", "&page=#{current_page}#")
+      elsif url_has_an_anchor?(path)
+        path.gsub("#", "?page=#{current_page}#")
       else
         path + "?page=#{current_page}"
       end
+    end
+
+    def url_has_page_param?(path)
+      path.include?("page=#{current_page}")
+    end
+
+    def url_has_a_query_string?(path)
+      path.include?("?")
+    end
+
+    def url_has_an_anchor?(path)
+      path.include?("#")
     end
 
     def build_path_for(page)

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -25,6 +25,7 @@ module Admin
         permitted_only(requested_editions),
         total_count: requested_editions.total_count,
       ).page(options[:page])
+      .per(options.fetch(:per_page) { default_page_size })
     end
 
     def each_edition_for_csv(locale = nil)

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -59,7 +59,7 @@
           {
             text: name,
             value: id,
-            selected: @filter.options[:world_location] == id.to_s
+            selected: @filter.options[:world_location].to_s == id.to_s
           }
         end
       } %>

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,10 +1,11 @@
 <%
   filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links]
+  anchor ||= anchor || ""
   raise "filter action required" unless defined?(filter_action)
 %>
 
 <div class="app-view-filter govuk-!-margin-right-5 govuk-!-padding-5">
-  <%= form_with url: filter_action, method: :get do |form| %>
+  <%= form_with url: filter_action + anchor, method: :get do |form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
       margin_bottom: 4,
@@ -141,6 +142,6 @@
       margin_bottom: 4,
     } %>
 
-    <p class="govuk-body"><%= link_to "Reset all fields", filter_action + "?state=active" %></p>
+    <p class="govuk-body"><%= link_to "Reset all fields", filter_action + "?state=active" + anchor, class: "govuk-link" %></p>
   <% end %>
 </div>

--- a/app/views/admin/feature_lists/_featureable_editions.html.erb
+++ b/app/views/admin/feature_lists/_featureable_editions.html.erb
@@ -1,0 +1,15 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: filter.page_title,
+  margin_bottom: 8,
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render 'admin/editions/filter_options', filter_by: filter_by, filter_action: filter_action, locale: feature_list.locale %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-view-features-search-results__table">
+      <%= render 'admin/feature_lists/search_results', filter: filter, paginator: filter.editions(feature_list.locale), feature_list: feature_list %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/feature_lists/_featureable_editions.html.erb
+++ b/app/views/admin/feature_lists/_featureable_editions.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= render 'admin/editions/filter_options', filter_by: filter_by, filter_action: filter_action, locale: feature_list.locale %>
+    <%= render 'admin/editions/filter_options', filter_by: filter_by, filter_action: filter_action, locale: feature_list.locale, anchor: anchor %>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-features-search-results__table">

--- a/app/views/admin/feature_lists/_featureable_editions.html.erb
+++ b/app/views/admin/feature_lists/_featureable_editions.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-features-search-results__table">
-      <%= render 'admin/feature_lists/search_results', filter: filter, paginator: filter.editions(feature_list.locale), feature_list: feature_list %>
+      <%= render 'admin/feature_lists/search_results', filter: filter, paginator: filter.editions(feature_list.locale), feature_list: feature_list, anchor: anchor %>
     </div>
   </div>
 </div>

--- a/app/views/admin/feature_lists/_search_results.html.erb
+++ b/app/views/admin/feature_lists/_search_results.html.erb
@@ -44,5 +44,5 @@
       .compact
   } %>
 
-  <%= paginate(paginator, theme: "govuk_paginator") %>
+  <%= paginate(paginator, anchor: anchor, theme: "govuk_paginator") %>
 <% end %>

--- a/app/views/admin/feature_lists/_search_results.html.erb
+++ b/app/views/admin/feature_lists/_search_results.html.erb
@@ -1,0 +1,48 @@
+<p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></p>
+
+<% if paginator.blank? %>
+  <div class="govuk-body app-view-features-search-results__no_documents">
+    No documents found
+  </div>
+<% else %>
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
+      {
+        text: "Title"
+      },
+      {
+        text: "Type"
+      },
+      {
+        text: "Published"
+      },
+      {
+        text: tag.span("Actions", class: "govuk-visually-hidden")
+      }
+    ],
+    rows:
+      paginator.map do |edition|
+        localised_edition = LocalisedModel.new(edition, feature_list.locale)
+        next if feature_list.features.current.detect { |f| f.document == localised_edition.document }
+        [
+           {
+             text: tag.p(localised_edition.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
+           },
+           {
+             text: localised_edition.type.titleize,
+           },
+           {
+             text: localize(localised_edition.major_change_published_at.to_date),
+           },
+           {
+             text: link_to(sanitize("View #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), admin_edition_path(localised_edition), class: "govuk-link") +
+               link_to(sanitize("Feature #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, @feature_list, :feature], edition_id: localised_edition), class: "govuk-link govuk-!-margin-left-2"),
+             format: "numeric",
+           },
+        ]
+      end
+      .compact
+  } %>
+
+  <%= paginate(paginator, theme: "govuk_paginator") %>
+<% end %>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -31,6 +31,7 @@
         filter: @filter,
         feature_list: @feature_list,
         filter_by: [:title, :type, :world_location],
+        anchor: "#documents_tab",
         filter_action: polymorphic_url([:features, :admin, @feature_list.featurable]),
       ),
     },

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -27,14 +27,12 @@
     {
       id: "documents_tab",
       label: "Documents",
-      content: "",
-      tab_data_attributes: {
-      }
-    },
-    {
-      id: "topical_events_tab",
-      label: "Topical events",
-      content: "",
+      content: render("admin/feature_lists/featureable_editions",
+        filter: @filter,
+        feature_list: @feature_list,
+        filter_by: [:title, :type, :world_location],
+        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable]),
+      ),
     },
     {
       id: "non_govuk_government_links_tab",

--- a/app/views/kaminari/govuk_paginator/_paginator.erb
+++ b/app/views/kaminari/govuk_paginator/_paginator.erb
@@ -1,5 +1,7 @@
+<% anchor = anchor.presence || "" %>
+
 <% if total_pages > 1 %>
-  <% Admin::PaginationHelper.pagination_hash(current_page: current_page.to_i, total_pages:, path: request.url).tap do |hash| %>
+  <% Admin::PaginationHelper.pagination_hash(current_page: current_page.to_i, total_pages:, path: request.url + anchor).tap do |hash| %>
     <%= render "components/pagination", {
       previous_href: hash[:previous_href],
       next_href: hash[:next_href],

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -321,6 +321,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     3.times { create(:news_article) }
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
     assert_equal 2, filter.editions.count
+    assert_equal 2, filter.editions.total_pages
   end
 
   test "editions_for_csv should not be paginated" do

--- a/test/unit/helpers/admin/paginator_helper_test.rb
+++ b/test/unit/helpers/admin/paginator_helper_test.rb
@@ -208,6 +208,49 @@ class Admin::PaginationHelperTest < ActionView::TestCase
     assert_equal expected_hash, Admin::PaginationHelper.pagination_hash(current_page: 1, total_pages: 2, path:)
   end
 
+  test "#pagination_hash when the request has an anchor and but query strings it constructs the url correctly" do
+    path = "#{admin_organisation_corporate_information_pages_path(@organisation)}#document_tab"
+
+    expected_hash = {
+      previous_href: nil,
+      next_href: "#{path_for_page(2)}#document_tab",
+      items: [
+        {
+          href: "#{path_for_page(1)}#document_tab",
+          current: true,
+        },
+        {
+          href: "#{path_for_page(2)}#document_tab",
+          current: false,
+        },
+      ],
+    }
+
+    assert_equal expected_hash, Admin::PaginationHelper.pagination_hash(current_page: 1, total_pages: 2, path:)
+  end
+
+  test "#pagination_hash when the request has an anchor but and query strings it constructs the url correctly" do
+    path = "#{admin_organisation_corporate_information_pages_path(@organisation, random_query_string: 'random')}#document_tab"
+    base_path = admin_organisation_corporate_information_pages_path(@organisation, random_query_string: "random")
+
+    expected_hash = {
+      previous_href: nil,
+      next_href: "#{base_path}&page=2#document_tab",
+      items: [
+        {
+          href: "#{base_path}&page=1#document_tab",
+          current: true,
+        },
+        {
+          href: "#{base_path}&page=2#document_tab",
+          current: false,
+        },
+      ],
+    }
+
+    assert_equal expected_hash, Admin::PaginationHelper.pagination_hash(current_page: 1, total_pages: 2, path:)
+  end
+
   def path_for_page(page)
     admin_organisation_corporate_information_pages_path(@organisation, page:)
   end


### PR DESCRIPTION
## Description

This follows on from https://github.com/alphagov/whitehall/pull/7598 which added the `Currently featured` tab. This PR adds the `Documents` tab.

I ran into a couple of complications while adding this around the page loading with the `Documents` tab open when the user filters or clicks one of the pagination links.

The page by default renders with the first tab open (`Currently featured`). I've managed to work around this by passing the documents tab id to the filter form, and updating the pagination module to respect an anchor when one is present.

It also fixes a bug with the EditionFilter where the per page paramater wasn't functioning correctly. More in the commits on all the above.

## Screenshot

### english features tab

<img width="664" alt="image" src="https://user-images.githubusercontent.com/42515961/235977886-9b27dcdb-150c-450f-a4fc-0dc8b2e633f1.png">


### translated feature tab

<img width="635" alt="image" src="https://user-images.githubusercontent.com/42515961/235977732-714309d3-5114-4fa4-8c79-b3eb2513d024.png">


## Trello card 

https://trello.com/c/YBTlvGI8/54-world-location-features-page-epic-card
https://trello.com/c/QZe4KYu1/131-documents-tab-has-been-ported


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
