### PR TITLE
119 promotional feature confirm delete to gds

### DIFF
--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PromotionalFeaturesController < Admin::BaseController
   before_action :load_organisation
-  before_action :load_promotional_feature, only: %i[show edit update destroy]
+  before_action :load_promotional_feature, only: %i[show edit update destroy confirm_destroy]
   before_action :clean_image_or_youtube_video_url_param, only: %i[create]
   layout :get_layout
 
@@ -33,7 +33,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
       Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature updated"
     else
-      render action: :edit
+      render :edit
     end
   end
 
@@ -63,11 +63,11 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy reorder update_order]
-      if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
-          "design_system"
-      else
-        "admin"
-      end
+    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
   end
 
   def load_organisation

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -33,7 +33,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
       Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature updated"
     else
-      render :edit
+      render action: :edit
     end
   end
 
@@ -42,6 +42,8 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
     Whitehall::PublishingApi.republish_async(@organisation)
     redirect_to [:admin, @organisation, PromotionalFeature], notice: "Promotional feature deleted."
   end
+
+  def confirm_destroy; end
 
   def reorder
     redirect_to admin_organisation_promotional_features_path(@organisation) and return unless @organisation.promotional_features.many?
@@ -60,12 +62,12 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 private
 
   def get_layout
-    case action_name
-    when "reorder", "update_order"
-      "design_system"
-    else
-      "admin"
-    end
+    design_system_actions = %w[confirm_destroy reorder update_order]
+      if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+          "design_system"
+      else
+        "admin"
+      end
   end
 
   def load_organisation

--- a/app/views/admin/promotional_features/_promotional_feature.html.erb
+++ b/app/views/admin/promotional_features/_promotional_feature.html.erb
@@ -5,6 +5,6 @@
   </td>
   <td>
     <%= link_to "Rename", edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: 'btn btn-default btn-sm' %>
-    <%= link_to "Delete", admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: 'btn btn-danger btn-sm' %>
+    <%= link_to "Delete", confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: 'btn btn-danger btn-sm' %>
   </td>
 <% end %>

--- a/app/views/admin/promotional_features/_promotional_feature.html.erb
+++ b/app/views/admin/promotional_features/_promotional_feature.html.erb
@@ -5,10 +5,6 @@
   </td>
   <td>
     <%= link_to "Rename", edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: 'btn btn-default btn-sm' %>
-    <%= button_to "Delete",
-          admin_organisation_promotional_feature_path(@organisation, promotional_feature),
-          method: "delete",
-          class: "btn btn-sm btn-danger",
-          data: { confirm: "Are you sure you want to delete the '#{promotional_feature.title}' feature?" } %>
+    <%= link_to "Delete", admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: 'btn btn-danger btn-sm' %>
   </td>
 <% end %>

--- a/app/views/admin/promotional_features/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_features/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :context, @organisation.name %>
+<% content_for :page_title, "Delete #{promotional_feature.title}" %>
+<% content_for :title, "Delete #{promotional_feature.title}" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    promotional_feature.title
+    <%= form_tag admin_organisation_promotional_feature_path(@organisation, promotional_feature), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete the "<%= promotional_feature.title %>" from "<% @organisation.name %>"?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature], class: "govuk-link govuk-link--no-visited-state") %>
+
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/promotional_features/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_features/confirm_destroy.html.erb
@@ -5,18 +5,18 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-      <%= form_with url: admin_organisation_promotional_feature_path(@organisation, @promotional_feature), method:
-        :delete do %>
+    <%= form_with url: admin_organisation_promotional_feature_path(@organisation, @promotional_feature), method:
+      :delete do %>
       <p class="govuk-body govuk-!-margin-bottom-4">Are you sure you want to delete <%= @promotional_feature.title %>
         item?</p>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Delete",
-              destructive: true,
-            } %>
-            <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature] ,class: "govuk-link govuk-link--no-visited-state") %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature] ,class: "govuk-link govuk-link--no-visited-state") %>
       </div>
-<% end %>
+    <% end %>
   </section>
 </div>

--- a/app/views/admin/promotional_features/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_features/confirm_destroy.html.erb
@@ -1,23 +1,22 @@
 <% content_for :context, @organisation.name %>
-<% content_for :page_title, "Delete #{promotional_feature.title}" %>
-<% content_for :title, "Delete #{promotional_feature.title}" %>
+<% content_for :page_title, "Delete #{@promotional_feature.title}" %>
+<% content_for :title, "Delete #{@promotional_feature.title}" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    promotional_feature.title
-    <%= form_tag admin_organisation_promotional_feature_path(@organisation, promotional_feature), method: :delete do %>
-      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete the "<%= promotional_feature.title %>" from "<% @organisation.name %>"?</p>
+      <%= form_with url: admin_organisation_promotional_feature_path(@organisation, @promotional_feature), method:
+        :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-4">Are you sure you want to delete <%= @promotional_feature.title %>
+        item?</p>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Delete",
-          destructive: true,
-        } %>
-
-        <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature], class: "govuk-link govuk-link--no-visited-state") %>
-
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Delete",
+              destructive: true,
+            } %>
+            <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature] ,class: "govuk-link govuk-link--no-visited-state") %>
       </div>
-    <% end %>
+<% end %>
   </section>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Whitehall::Application.routes.draw do
           resources :translations, controller: "organisation_translations"
           resources :promotional_features do
             get :reorder, on: :collection
+            get :confirm_destroy, on: :member
             patch :update_order, on: :collection
             resources :promotional_feature_items, as: :items, path: "items", except: [:index]
           end

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -59,8 +59,9 @@ When(/^I delete the promotional feature$/) do
   click_link "Promotional features"
 
   within record_css_selector(@promotional_feature) do
-    click_button "Delete"
+    click_link "Delete"
   end
+  click_button "Delete"
 end
 
 When(/^I edit the promotional item, set the summary to "([^"]*)"$/) do |new_summary|

--- a/test/functional/admin/legacy_promotional_features_controller_test.rb
+++ b/test/functional/admin/legacy_promotional_features_controller_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
-class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
+class Admin::LegacyPromotionalFeaturesControllerTest < ActionController::TestCase
+  tests Admin::PromotionalFeaturesController
   setup do
     login_as :writer
     @organisation = create(:executive_office)

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -80,6 +80,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
     delete :destroy, params: { organisation_id: @organisation, id: promotional_feature }
 
+    assert_redirected_to admin_organisation_promotional_features_url(@organisation)
     assert_not PromotionalFeature.exists?(promotional_feature.id)
     assert_equal "Promotional feature deleted.", flash[:notice]
   end

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   setup do
-    login_as :writer
+    login_as_preview_design_system_user :writer
     @organisation = create(:executive_office)
   end
 
@@ -121,5 +121,14 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
     assert_redirected_to admin_organisation_promotional_features_path(@organisation)
     assert_equal "Promotional features reordered successfully", flash[:notice]
+  end
+
+  test "GET :confirm_destroy calls correctly" do
+    promotional_feature = create(:promotional_feature, organisation: @organisation)
+
+    get :confirm_destroy, params: { organisation_id: @organisation, id: promotional_feature }
+
+    assert_response :success
+    assert_equal promotional_feature, assigns(:promotional_feature)
   end
 end

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -15,6 +15,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
       get :index, params: { organisation_id: organisation }
     end
   end
+
   test "GET :index loads the promotional organisation and renders the index template" do
     create(:promotional_feature, organisation: @organisation)
     get :index, params: { organisation_id: @organisation }
@@ -50,23 +51,6 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     assert_response :success
     assert_template :show
     assert_equal promotional_feature, assigns(:promotional_feature)
-  end
-
-  view_test "confirm_destroy should display form for deleting an existing promotional feature" do
-    @promotional_feature = create(:promotional_feature, organisation: @organisation)
-
-    get :confirm_destroy, params: { organisation: @organisation, promotional_feature: @promotional_feature }
-
-    assert_select "form[action='#{admin_organisation_promotional_feature_path(@organisation, @promotional_feature)}']" do
-      assert_select "button[type='submit']", "Delete"
-      # assert_select "a[href=?]", [:admin, @promotional_feature.organisation, PromotionalFeature].to_s, "Cancel"
-    end
-  end
-
-  test "delete removes an appointment" do
-    appointment = create(:role_appointment)
-    delete :destroy, params: { id: appointment.id }
-    assert_nil RoleAppointment.find_by(id: appointment.id)
   end
 
   test "GET :edit loads the promotional feature and renders the template" do

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -15,7 +15,6 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
       get :index, params: { organisation_id: organisation }
     end
   end
-
   test "GET :index loads the promotional organisation and renders the index template" do
     create(:promotional_feature, organisation: @organisation)
     get :index, params: { organisation_id: @organisation }
@@ -51,6 +50,23 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     assert_response :success
     assert_template :show
     assert_equal promotional_feature, assigns(:promotional_feature)
+  end
+
+  view_test "confirm_destroy should display form for deleting an existing promotional feature" do
+    @promotional_feature = create(:promotional_feature, organisation: @organisation)
+
+    get :confirm_destroy, params: { organisation: @organisation, promotional_feature: @promotional_feature }
+
+    assert_select "form[action='#{admin_organisation_promotional_feature_path(@organisation, @promotional_feature)}']" do
+      assert_select "button[type='submit']", "Delete"
+      # assert_select "a[href=?]", [:admin, @promotional_feature.organisation, PromotionalFeature].to_s, "Cancel"
+    end
+  end
+
+  test "delete removes an appointment" do
+    appointment = create(:role_appointment)
+    delete :destroy, params: { id: appointment.id }
+    assert_nil RoleAppointment.find_by(id: appointment.id)
   end
 
   test "GET :edit loads the promotional feature and renders the template" do


### PR DESCRIPTION
* # What
* Added Confirm delete page
* Added confirm del to the controller
* # Why
* Confirm Del page to GDS
* # Trello
https://trello.com/c/0h93Ko8L/119-promotional-feature-confirm-delete-page
* # Pics
* Completed page
![Screenshot 2023-05-03 at 15-39-53 Delete Transparency - GOV UK Whitehall Publisher](https://user-images.githubusercontent.com/125891738/235970856-644151e9-9688-40ca-bddb-95089fcec46e.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
