### PR TITLE
Add data migration to change withdrawal date on specific edition

### DIFF
--- a/db/data_migration/20230504091401_change_edition_withdrawal_date.rb
+++ b/db/data_migration/20230504091401_change_edition_withdrawal_date.rb
@@ -1,0 +1,4 @@
+# This changes the withdrawal date of a specific edition, as requested by the publisher
+edition = Edition.find(1_433_080)
+edition.unpublishing.update!(unpublished_at: "2023-04-03")
+PublishingApiDocumentRepublishingWorker.new.perform(edition.document.id)


### PR DESCRIPTION
The publisher of this document have requested that the withdrawal date bee changed to match the date the policy was actually withdrawn.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5313714

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
