### PR TITLE
Remove old link from content item

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -40,7 +40,6 @@ module PublishingApi
         ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
         ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
         ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
-        ordered_baronessess_and_ladies_in_waiting_whips: [],
       }
     end
 

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -88,7 +88,6 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
           baroness_whip_2.person.content_id,
           baroness_whip_1.person.content_id,
         ],
-        ordered_baronessess_and_ladies_in_waiting_whips: [],
       }
 
       assert_equal expected_content, presented_item.content


### PR DESCRIPTION
Now that we've pushed an empty item to get it removed from the content store[1], we can remove the link entirely from the ministers index presenter.

[1] 97080805c48dbf0bb355d4cd89761c651f825caa

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
