### PR TITLE
Update image data file presence validator error message

### DIFF
--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -10,7 +10,7 @@ class ImageData < ApplicationRecord
 
   mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
 
-  validates :file, presence: true
+  validates :file, presence: { message: "cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF." }
   validates_with ImageValidator, size: [VALID_WIDTH, VALID_HEIGHT]
   validate :filename_is_unique
 

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -82,7 +82,7 @@ Feature: Images tab on edit edition
     When I am on the edit page for publication "Standard Beard Lengths"
     And I navigate to the images tab
     And I click upload without attaching a file
-    Then I should get the error message "Image data file can't be blank"
+    Then I should get the error message "Image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF."
 
   Scenario: Uploading a file with duplicated filename
     And I have the "Preview images update" permission

--- a/test/support/admin_edition_controller_legacy_test_helpers.rb
+++ b/test/support/admin_edition_controller_legacy_test_helpers.rb
@@ -615,7 +615,7 @@ module AdminEditionControllerLegacyTestHelpers
               },
             }
 
-        assert_select ".errors", text: "Images image data file can't be blank"
+        assert_select ".errors", text: "Images image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF."
 
         edition.reload
         assert_equal 0, edition.images.length

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -567,7 +567,7 @@ module AdminEditionControllerTestHelpers
             }
 
         assert_select "div .gem-c-error-summary" do
-          assert_select "a", text: "Images image data file can't be blank"
+          assert_select "a", text: "Images image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF."
         end
 
         edition.reload


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What

[Change the error message Image data file can't be blank to `Image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF.`
](https://trello.com/c/CCXsOaPb/1201-update-image-data-file-cant-be-blank-error-to-something-more-useful)

# Why

This error message is not informative of its cause and could confuse users. 

# Screenshot
## Design System
![whitehall-admin dev gov uk_government_admin_editions_1374126_images(iPad Pro)](https://user-images.githubusercontent.com/9594455/236258541-371e0032-ea78-456c-a0ac-863c4fa7722d.png)

## Bootstrap
![whitehall-admin dev gov uk_government_admin_news_1374132(iPad Pro)](https://user-images.githubusercontent.com/9594455/236263712-0db13eae-e3b6-4b5a-9b5c-1b64f1cd9945.png)
