### PR TITLE
Remove redundant code and data relating to worldwide organisations

### DIFF
--- a/app/controllers/admin/worldwide_organisations_translations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_translations_controller.rb
@@ -38,8 +38,6 @@ private
   end
 
   def translation_params
-    params.require(:worldwide_organisation).permit(
-      :name, :summary, :description, :services
-    )
+    params.require(:worldwide_organisation).permit(:name)
   end
 end

--- a/db/migrate/20230504163453_remove_services_from_worldwide_organisation_translations.rb
+++ b/db/migrate/20230504163453_remove_services_from_worldwide_organisation_translations.rb
@@ -1,0 +1,5 @@
+class RemoveServicesFromWorldwideOrganisationTranslations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :worldwide_organisation_translations, :services, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_07_101416) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_04_163453) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -1153,7 +1153,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_101416) do
     t.integer "worldwide_organisation_id"
     t.string "locale"
     t.string "name"
-    t.text "services"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["locale"], name: "index_worldwide_org_translations_on_locale"


### PR DESCRIPTION
## 1. Remove unused params from permitted WO translation params

The `summary`, `description` & `services` fields were removed from the corresponding form in [this commit][1] as part of [this PR][2] 9 years ago!

Currently `WorldwideOrganisation#summary` is derived from its associated About page via `HasCorporateInformationPages` and not from a translated attribute on `WorldwideOrganisation` itself. It looks as if the summary was moved onto the About page in [that same PR][2].

`WorldwideOrganisation#description` & `#services` were concatenated into the `body` of the About page in [this commit][3] as part of [the same PR][2].

While I doubt this is causing any warnings or errors, it makes the code unnecessarily confusing, particularly as we currently planning to move the `summary` & `body` back from the About page onto the `WorldwideOrganisation` itself! See [this Trello card][4].

## 2. Remove redundant worldwide_organisation_translations.services

`WorldwideOrganisation#services` were concatenated into the `body` of the About page in [this commit][3] as part of [this PR][2] and so this database column is no longer needed. There don't appear to be any references to it left in the code - in particular I've carefully checked the most obvious places...

The following templates:

* `app/views/admin/worldwide_organisations/show.html.erb`
* `app/views/admin/worldwide_organisations_translations/edit.html.erb`
* `app/views/worldwide_organisations/show.html.erb`

And these presenters:

* `WorldwideOrganisationPresenter`
* `Api::WorldwideOrganisationPresenter`
* `PublishingApi::WorldwideOrganisationPresenter`

Note that the `worldwide_organisation_translations.summary` & `worldwide_organisation_translations.description` columns were removed in a migration that ended up in `db/migrate/20140514125051_remove_body_from_worldwide_organisation_translations.rb` - see these three commits: 69591e1595934e54c8ba3c8525c99da4dc1b2245, fc9ef99b8e69972fd2dd7d5bfdb9dc941e410cb6 & 3f57eda2c55d27b9846577bd691f8eea2b3dcf03 for details.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[1]: https://github.com/alphagov/whitehall/commit/1be1339088f6dd7fdd814ac926cb7abfe2334741
[2]: https://github.com/alphagov/whitehall/pull/1476
[3]: https://github.com/alphagov/whitehall/commit/b12e7bf5cbc6161e9cb28810373c204767be2a54
[4]: https://trello.com/c/hwo2GEzk
