### PR TITLE
Change branding labels for departments

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -147,10 +147,10 @@ class OrganisationBrandColour
     title: "Civil Service",
     class_name: "civil-service",
   )
-  DepartmentForInternationalTrade = create!(
+  DepartmentForBusinessAndTrade = create!(
     id: 29,
-    title: "Department for International Trade",
-    class_name: "department-for-international-trade",
+    title: "Department for Business & Trade",
+    class_name: "department-for-business-and-trade",
   )
   ForeignCommonwealthDevelopmentOffice = create!(
     id: 30,

--- a/app/models/organisation_logo_type.rb
+++ b/app/models/organisation_logo_type.rb
@@ -49,7 +49,7 @@ class OrganisationLogoType
   CustomLogo = create!(
     id: 14, title: "Use custom logo for organisations exempt from the single identity", class_name: "custom",
   )
-  DepartmentInternationalTrade = create!(
-    id: 15, title: "Department for International Trade", class_name: "dit",
+  DepartmentForBusinessAndTrade = create!(
+    id: 15, title: "Department for Business & Trade", class_name: "dbt",
   )
 end


### PR DESCRIPTION
We are updating Department of International Trade to Department for Business & Trade

[Trello card](https://trello.com/c/rtK4IWUx/1206-update-department-of-business-trade-branding-labels-in-publishing-components)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
<img width="1015" alt="Screenshot 2023-05-05 at 07 48 25" src="https://user-images.githubusercontent.com/4563521/236393247-56149d35-973d-4f0b-b0a8-59777581d460.png">
