### PR TITLE
Add the edition edit page to the next release

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -100,7 +100,7 @@ class Admin::EditionsController < Admin::BaseController
   def edit
     @edition.open_for_editing_as(current_user)
     fetch_version_and_remark_trails
-    render_design_system(:edit, :edit_legacy, next_release: false)
+    render_design_system(:edit, :edit_legacy, next_release: true)
   end
 
   def update


### PR DESCRIPTION
# What
Add the edition edit page to the next release

# Why
This page was incorrectly labelled as not being part of the next release.

# Release activities Trello card
https://trello.com/c/QczUn9Tn/128-release-activities-for-16

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
