### PR TITLE
Reinstate deleted html attachments

### DIFF
--- a/db/data_migration/20230505140632_reinstate_deleted_html_attachments.rb
+++ b/db/data_migration/20230505140632_reinstate_deleted_html_attachments.rb
@@ -1,0 +1,3 @@
+e = Edition.find(1_432_490)
+HtmlAttachment.unscoped.where(attachable_id: 1_432_490, attachable_type: "Edition").update_all(deleted: false)
+PublishingApiDocumentRepublishingWorker.new.perform(e.document.id)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

The publisher of this document has requested that the html attachments be reinstated.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5311084