### PR TITLE
Add the Non-GOV.UK government links tab to the features page

### DIFF
--- a/app/assets/stylesheets/admin/views/_features.scss
+++ b/app/assets/stylesheets/admin/views/_features.scss
@@ -39,11 +39,13 @@
   width: 20%;
 }
 
-.app-view-features-search-results__table .govuk-table, {
+.app-view-features-search-results__table .govuk-table,
+.app-view-features-offsite-links__table .govuk-table {
   border-top: 2px solid govuk-colour("black");
 }
 
-.app-view-features-search-results__table .govuk-table__header {
+.app-view-features-search-results__table .govuk-table__header,
+.app-view-features-offsite-links__table .govuk-table__header {
   padding-top: govuk-spacing(4);
 }
 

--- a/app/components/admin/currently_featured_tab_component.html.erb
+++ b/app/components/admin/currently_featured_tab_component.html.erb
@@ -16,6 +16,10 @@
   <div class="app-view-features__table govuk-!-margin-bottom-8">
     <%= table("#{pluralize(live_features.count, "featured document")} live on GOV.UK", live_features) %>
   </div>
+<% else %>
+  <p class="govuk-body">
+    There are currently no featured documents.
+  </p>
 <% end %>
 
 <% if remaining_features.present? %>

--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -32,6 +32,8 @@ class Admin::OffsiteLinksController < Admin::BaseController
     end
   end
 
+  def confirm_destroy; end
+
   def destroy
     @offsite_link.destroy!
     flash[:notice] = "#{@offsite_link.title} has been deleted"
@@ -70,7 +72,7 @@ private
     if @parent.is_a? TopicalEvent
       polymorphic_path([:admin, @parent, :topical_event_featurings])
     else
-      polymorphic_path([:features, :admin, @parent])
+      polymorphic_path([:features, :admin, @parent]) + (preview_design_system?(next_release: false) ? "#non_govuk_government_links_tab" : "")
     end
   end
 

--- a/app/helpers/admin/features_helper.rb
+++ b/app/helpers/admin/features_helper.rb
@@ -1,0 +1,9 @@
+module Admin::FeaturesHelper
+  def featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list)
+    @featurable_offsite_links_for_feature_list ||= featurable_offsite_links.reject do |link|
+      feature_list.features.current.detect do |feature|
+        feature.offsite_link == link
+      end
+    end
+  end
+end

--- a/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
+++ b/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
@@ -37,7 +37,7 @@
           {
             text: link_to(sanitize("Edit #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:edit, :admin, offsite_link.parent, offsite_link]), class: "govuk-link") +
                     link_to(sanitize("Feature #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, feature_list, :feature], offsite_link_id: offsite_link.id), class: 'govuk-link govuk-!-margin-left-2') +
-                      link_to(sanitize("Delete #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), "#", class: 'govuk-link govuk-!-margin-left-2 gem-link--destructive'),
+                      link_to(sanitize("Delete #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:confirm_destroy, :admin, offsite_link.parent, offsite_link]), class: 'govuk-link govuk-!-margin-left-2 gem-link--destructive'),
             format: "numeric"
           }
         ]

--- a/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
+++ b/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
@@ -1,0 +1,49 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Featured non-GOV.UK government links",
+  margin_bottom: 6,
+} %>
+
+<p class="govuk-body">
+  <%= link_to "Create a new link", [:new, :admin, model, :offsite_link], class: "govuk-link" %>
+</p>
+
+<% if featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list).any? %>
+  <p class="govuk-heading-s govuk-!-margin-bottom-3">
+    <%= pluralize(number_with_delimiter(featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list).count), "document") %>
+  </p>
+
+  <div class="app-view-features-offsite-links__table">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title"
+        },
+        {
+          text: "Type",
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden"),
+          format: "numeric"
+        }
+      ],
+      rows: featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list).map do |offsite_link|
+        [
+          {
+            text: tag.p(offsite_link.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
+          },
+          {
+            text: offsite_link.humanized_link_type,
+          },
+          {
+            text: link_to(sanitize("Edit #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:edit, :admin, offsite_link.parent, offsite_link]), class: "govuk-link") +
+                    link_to(sanitize("Feature #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, feature_list, :feature], offsite_link_id: offsite_link.id), class: 'govuk-link govuk-!-margin-left-2') +
+                      link_to(sanitize("Delete #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), "#", class: 'govuk-link govuk-!-margin-left-2 gem-link--destructive'),
+            format: "numeric"
+          }
+        ]
+      end
+    } %>
+  </div>
+<% else %>
+  <p class="govuk-body">There are currently no non-GOV.UK government links.</p>
+<% end %>

--- a/app/views/admin/offsite_links/confirm_destroy.html.erb
+++ b/app/views/admin/offsite_links/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @parent.name %>
+<% content_for :page_title, "Delete offsite link" %>
+<% content_for :title, "Delete #{@offsite_link}" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: [:admin, @parent, @offsite_link], method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete "<%= @offsite_link.title %>" from "<%= @parent.name %>"?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", polymorphic_url([:features, :admin, @parent]) + "#non_govuk_government_links_tab", class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -38,7 +38,11 @@
     {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",
-      content: "",
+      content: render("admin/feature_lists/featureable_offsite_links",
+        model: @world_location_news,
+        feature_list: @feature_list,
+        featurable_offsite_links: @featurable_offsite_links,
+      ),
     }
   ]
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,7 +319,9 @@ Whitehall::Application.routes.draw do
           resources :translations, controller: "world_location_news_translations" do
             get :confirm_destroy, on: :member
           end
-          resources :offsite_links
+          resources :offsite_links do
+            get :confirm_destroy, on: :member
+          end
         end
 
         resources :feature_lists, only: [:show] do

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -66,3 +66,25 @@ Then(/^I see that I have no featured documents$/) do
     expect(page).to have_content "There are currently no featured documents."
   end
 end
+
+Given(/^there is a published document with the tile "([^"]*)"$/) do |title|
+  create(:edition, :published, title:)
+end
+
+And(/^filter documents by all organisations$/) do
+  select "All locations"
+  click_button "Search"
+end
+
+And(/^I feature "([^"]*)"$/) do |title|
+  click_link "Feature #{title}"
+
+  attach_file "Image (required)", jpg_image
+  click_button "Save"
+end
+
+Then(/^I see that "([^"]*)" has been featured$/) do |title|
+  within "#currently_featured_tab" do
+    expect(find("table td:first").text).to eq title
+  end
+end

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -88,3 +88,7 @@ Then(/^I see that "([^"]*)" has been featured$/) do |title|
     expect(find("table td:first").text).to eq title
   end
 end
+
+Given(/^the world location has an offsite link with the title "([^"]*)"$/) do |title|
+  create(:offsite_link, parent_type: "WorldLocationNews", parent: @world_location_news, title:)
+end

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -53,3 +53,16 @@ Then(/^the featured documents should be in the following order:$/) do |featured_
     expect(feature.to_s).to eq(document_titles[index])
   end
 end
+
+And(/^I unfeature the document$/) do
+  within "#currently_featured_tab" do
+    click_link "Unfeature"
+  end
+  click_button "Unfeature"
+end
+
+Then(/^I see that I have no featured documents$/) do
+  within "#currently_featured_tab" do
+    expect(page).to have_content "There are currently no featured documents."
+  end
+end

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -92,3 +92,36 @@ end
 Given(/^the world location has an offsite link with the title "([^"]*)"$/) do |title|
   create(:offsite_link, parent_type: "WorldLocationNews", parent: @world_location_news, title:)
 end
+
+And(/^I create a new a non-GOV.UK link with the title "([^"]*)"$/) do |title|
+  click_link "Create a new link"
+
+  fill_in "Title (required)", with: title
+  fill_in "Summary (required)", with: "Summary"
+  fill_in "URL (required)", with: "https://www.gov.uk/jobsearch"
+
+  click_button "Save"
+end
+
+Then(/^I can see the non-GOV.UK link with the title "([^"]*)"$/) do |title|
+  within "#non_govuk_government_links_tab" do
+    expect(find("table td:first").text).to eq title
+  end
+end
+
+And(/^I update the title of a featured link from "([^"]*)" to "([^"]*)"$/) do |current_title, new_title|
+  click_link "Edit #{current_title}"
+  fill_in "Title (required)", with: new_title
+  click_button "Save"
+end
+
+And(/^I delete "([^"]*)"$/) do |title|
+  click_link "Delete #{title}"
+  click_button "Delete"
+end
+
+Then(/^I can see that "([^"]*)" has been deleted$/) do |title|
+  within "#non_govuk_government_links_tab" do
+    expect(page).not_to have_content title
+  end
+end

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -2,7 +2,12 @@ Given(/^no world locations exist$/) do
   WorldLocation.delete_all
 end
 
-When(/^I visit the world location news page$/) do
+And(/^a world location news exists$/) do
+  @world_location = build(:world_location, slug: "foo")
+  @world_location_news = create(:world_location_news, world_location: @world_location)
+end
+
+When(/^I visit the world location news index page$/) do
   visit admin_world_location_news_index_path
 end
 
@@ -12,4 +17,39 @@ end
 
 Then(/^I should see the "([^"]*)" message$/) do |message|
   expect(page).to have_selector("p", text: "#{message}.")
+end
+
+Given(/^the world location has a feature list with (\d+) featured (?:document|documents)$/) do |count|
+  @feature_list = create(:feature_list, featurable: @world_location_news)
+
+  count.times do |i|
+    edition = create(:edition, :published, title: "Document #{i + 1}")
+
+    create(:feature, feature_list: @feature_list, document: edition.document)
+  end
+end
+
+When(/^I visit the world location news page$/) do
+  visit features_admin_world_location_news_path(@world_location, locale: I18n.default_locale)
+end
+
+And(/^I set the order of the featured documents to:$/) do |featured_documents_order|
+  visit features_admin_world_location_news_path(@world_location, locale: I18n.default_locale)
+  click_link "Reorder documents"
+
+  featured_documents_order.hashes.each do |hash|
+    feature = @feature_list.features.select { |f| f.to_s == hash[:title] }.first
+    fill_in "ordering[#{feature.id}]", with: hash[:order]
+  end
+
+  click_button "Update order"
+end
+
+Then(/^the featured documents should be in the following order:$/) do |featured_documents_titles|
+  document_titles = all("table td:first").map(&:text)
+
+  featured_documents_titles.hashes.each_with_index do |hash, index|
+    feature = @feature_list.features.select { |f| f.to_s == hash[:title] }.first
+    expect(feature.to_s).to eq(document_titles[index])
+  end
 end

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -22,3 +22,9 @@ Feature: Administering world location news information
       | title      |
       | Document 2 |
       | Document 1 |
+
+    Scenario: Unfeaturing a document
+      Given the world location has a feature list with 1 featured document
+      When I visit the world location news page
+      And I unfeature the document
+      Then I see that I have no featured documents

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -35,3 +35,9 @@ Feature: Administering world location news information
       And filter documents by all organisations
       And I feature "Featured document"
       Then I see that "Featured document" has been featured
+
+    Scenario: Featuring a non-GOV.UK link
+      Given the world location has an offsite link with the title "Featured link"
+      When I visit the world location news page
+      And I feature "Featured link"
+      Then I see that "Featured link" has been featured

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -1,9 +1,24 @@
+@design-system-only
 Feature: Administering world location news information
-  @design-system-only
+  Background:
+    Given I am a GDS admin
+    And a world location news exists
+
   Scenario: Viewing the list presents no world location news message, when no news exists
     Given no world locations exist
-    And I am a GDS admin
-    When I visit the world location news page
+    When I visit the world location news index page
     Then I should see the "No active world location news" message
     When I click the Inactive tab
     Then I should see the "No inactive world location news" message
+
+  Scenario: Reordering currently featured documents
+    Given the world location has a feature list with 2 featured documents
+    When I visit the world location news page
+    And I set the order of the featured documents to:
+      | title      | order |
+      | Document 2 | 0     |
+      | Document 1 | 1     |
+    Then the featured documents should be in the following order:
+      | title      |
+      | Document 2 |
+      | Document 1 |

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -28,3 +28,10 @@ Feature: Administering world location news information
       When I visit the world location news page
       And I unfeature the document
       Then I see that I have no featured documents
+
+    Scenario: Featuring a document
+      Given there is a published document with the tile "Featured document"
+      When I visit the world location news page
+      And filter documents by all organisations
+      And I feature "Featured document"
+      Then I see that "Featured document" has been featured

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -41,3 +41,20 @@ Feature: Administering world location news information
       When I visit the world location news page
       And I feature "Featured link"
       Then I see that "Featured link" has been featured
+
+    Scenario: Creating a non-GOV.UK link
+      When I visit the world location news page
+      And I create a new a non-GOV.UK link with the title "Featured link"
+      Then I can see the non-GOV.UK link with the title "Featured link"
+
+    Scenario: Editing a non-GOV.UK link
+      Given the world location has an offsite link with the title "Featured link"
+      When I visit the world location news page
+      And I update the title of a featured link from "Featured link" to "New title"
+      Then I can see the non-GOV.UK link with the title "New title"
+
+    Scenario: Deleting a non-GOV.UK link
+      Given the world location has an offsite link with the title "Featured link"
+      When I visit the world location news page
+      And I delete "Featured link"
+      Then I can see that "Featured link" has been deleted

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -43,6 +43,13 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  test "GET :confirm_destroy calls correctly" do
+    get :confirm_destroy, params: { world_location_news_id: @world_location_news.slug, id: @offsite_link.id }
+
+    assert_response :success
+    assert_equal @offsite_link, assigns(:offsite_link)
+  end
+
   test "DELETE :destroy removes offsite link" do
     assert_difference("OffsiteLink.count", -1) do
       delete :destroy, params: {


### PR DESCRIPTION
## Description

This follows on from #7606 which added the documents tab to the WorldLocationNews#features endpoint.

It adds the non_govuk_government_links tab and the confirm delete offsite link endpoints.

## Screenshot

<img width="855" alt="image" src="https://user-images.githubusercontent.com/42515961/237038982-64f3c84b-3f75-4074-be84-e47aeb9c31d5.png">

<img width="735" alt="image" src="https://user-images.githubusercontent.com/42515961/237037653-0719e05e-f886-4d92-a775-dd77dd37c316.png">

## Trello card

https://trello.com/c/YBTlvGI8/54-world-location-features-page-epic-card

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
