### PR TITLE
[DO NOT MERGE] Make data-ga4-attachment-link appear on all attachment links

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -14,12 +14,9 @@
   # to publishing-api.
   preview = controller.nil? ? nil : params[:preview]
 
-  attachment_data = {}
-  if attachment.html?
-    attachment_data = {
-      ga4_attachment_link: "",
-    }
-  end
+  attachment_data = {
+    ga4_attachment_link: "",
+  }
 %>
 <%= content_tag_for(:section, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded", data: attachment_data) do %>
   <div class="attachment-thumb">


### PR DESCRIPTION
Do not merge as we are deploying/changing the attachment tracking in a stepped process, so that we don't affect the existing `file_download` tracking .

Previously we were tracking HTML attachments as 'attachment' and all other attachment links as file_download using JS. This change makes it so that every attachment link will get the type 'attachment' set on it in our ga4-link-tracker.js in publishing components.

https://trello.com/c/MHFXw6H2/552-change-filedownloads-on-attachment-pages-to-have-attachment-instead-of-generic-download-type

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
