### PR TITLE
Handle legacy organisation-related redirects

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
         schema_name:,
       )
       content.merge!(
-        PayloadBuilder::PolymorphicPath.for(item, additional_routes:),
+        PayloadBuilder::PolymorphicPath.for(item, prefix: use_prefix_route?, additional_routes:),
       )
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
@@ -60,6 +60,10 @@ module PublishingApi
 
     def schema_name
       "organisation"
+    end
+
+    def use_prefix_route?
+      !court_or_tribunal?
     end
 
     def additional_routes

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -1,20 +1,21 @@
 module PublishingApi
   module PayloadBuilder
     class PolymorphicPath
-      attr_reader :item, :additional_routes
+      attr_reader :item, :prefix, :additional_routes
 
-      def self.for(item, additional_routes: [])
-        new(item, additional_routes:).call
+      def self.for(item, prefix: false, additional_routes: [])
+        new(item, prefix:, additional_routes:).call
       end
 
-      def initialize(item, additional_routes: [])
+      def initialize(item, prefix: false, additional_routes: [])
         @item = item
+        @prefix = prefix
         @additional_routes = additional_routes
       end
 
       def call
         { base_path: }.merge(
-          PayloadBuilder::Routes.for(base_path, additional_routes:),
+          PayloadBuilder::Routes.for(base_path, prefix:, additional_routes:),
         )
       end
 

--- a/app/presenters/publishing_api/payload_builder/routes.rb
+++ b/app/presenters/publishing_api/payload_builder/routes.rb
@@ -3,22 +3,29 @@ module PublishingApi
     class Routes
       attr_reader :base_path, :additional_routes
 
-      def self.for(base_path, additional_routes: [])
-        new(base_path, additional_routes:).call
+      def self.for(base_path, prefix: false, additional_routes: [])
+        new(base_path, prefix:, additional_routes:).call
       end
 
-      def initialize(base_path, additional_routes: [])
+      def initialize(base_path, prefix: false, additional_routes: [])
         @base_path = base_path
+        @prefix = prefix
         @additional_routes = additional_routes
       end
 
       def call
         routes = []
-        routes << { path: base_path, type: "exact" }
+        routes << { path: base_path, type: }
         additional_routes.each do |additional_route|
           routes << { path: "#{base_path}.#{additional_route}", type: "exact" }
         end
         { routes: }
+      end
+
+    private
+
+      def type
+        @prefix ? "prefix" : "exact"
       end
     end
   end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -50,7 +50,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       publishing_app: "whitehall",
       rendering_app: "collections",
       routes: [
-        { path: public_path, type: "exact" },
+        { path: public_path, type: "prefix" },
         { path: public_atom_path, type: "exact" },
       ],
       redirects: [],
@@ -286,7 +286,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal("<div class=\"govspeak\"><p>Habeus loudius noisus</p>\n</div>", presented_item.content[:details][:body])
   end
 
-  test "renders courts and tribunals using Collections" do
+  test "renders courts and tribunals with 'exact' route using Collections" do
     organisation = create(
       :court,
       name: "Court at mid-wicket",
@@ -357,7 +357,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       assert_equal organisation.base_path, presented_item.content[:base_path]
 
       assert_equal [
-        { path: organisation.base_path, type: "exact" },
+        { path: organisation.base_path, type: "prefix" },
         { path: "#{organisation.base_path}.atom", type: "exact" },
       ], presented_item.content[:routes]
     end
@@ -368,7 +368,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       assert_equal "#{organisation.base_path}.cy", presented_item.content[:base_path]
 
       assert_equal [
-        { path: "#{organisation.base_path}.cy", type: "exact" },
+        { path: "#{organisation.base_path}.cy", type: "prefix" },
         { path: "#{organisation.base_path}.cy.atom", type: "exact" },
       ], presented_item.content[:routes]
     end

--- a/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
@@ -3,10 +3,22 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class RoutesTest < ActiveSupport::TestCase
-      test "returns a routes payload in the correct form" do
+      test "returns a routes payload without additional routes" do
         base_path = "some/base/path"
 
         assert_equal({ routes: [{ path: base_path, type: "exact" }] }, Routes.for(base_path))
+      end
+
+      test "returns a routes payload with additional routes" do
+        base_path = "some/base/path"
+        additional_routes = %w[atom rss]
+        expected_routes = [
+          { path: base_path, type: "exact" },
+          { path: "#{base_path}.atom", type: "exact" },
+          { path: "#{base_path}.rss", type: "exact" },
+        ]
+
+        assert_equal({ routes: expected_routes }, Routes.for(base_path, additional_routes:))
       end
     end
   end

--- a/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/routes_test.rb
@@ -9,6 +9,12 @@ module PublishingApi
         assert_equal({ routes: [{ path: base_path, type: "exact" }] }, Routes.for(base_path))
       end
 
+      test "returns a routes payload with a prefix route" do
+        base_path = "some/base/path"
+
+        assert_equal({ routes: [{ path: base_path, type: "prefix" }] }, Routes.for(base_path, prefix: true))
+      end
+
       test "returns a routes payload with additional routes" do
         base_path = "some/base/path"
         additional_routes = %w[atom rss]


### PR DESCRIPTION
Trello: https://trello.com/c/sajxUZnZ

Currently a number of legacy organisation-related redirects are implemented in whitehall as Rails routes:

https://github.com/alphagov/whitehall/blob/f871f66c9e4f21c23132fa9cf9505e7a449dcacc/config/routes.rb#L66-L73

Changing the main route for an organisation content item from "exact" to "prefix" will allow us to handle the paths for those legacy organisation-related redirects using Rails routing in the collections app without breaking other content items that are published with exact routes under the organisation page, e.g. corporate information pages. The latter will not be affected, because they have more specific routes which take precedence in the router.

This will allow us to remove the legacy redirects from whitehall's routes moving us another step closer to being able to switch off whitehall-frontend.

Although courts & tribunals are organisations and a republished using the `PublishingApi::OrganisationPresenter`, they're published under a different path, e.g. `/courts-tribunals/court-of-protection`. This means that the legacy redirects don't make sense for them and so I've added logic in `PublishingApi::OrganisationPresenter#use_prefix_route?` to retain the "exact" route type in this case.

Note that we did consider adding a set of more-specific routes to the organisation content item (instead of a single prefix route), but unfortunately some awkwardness with locales meant that it would've made the whitehall code a lot more complicated and it didn't seem worth it just to implement these old redirects.

Important: this PR should not be deployed until [the corresponding PR in the collections app](https://github.com/alphagov/collections/pull/3247) is deployed. And once this PR is deployed we will need to republish all of the organisations before finally we'll be able to actually remove the redirects from the whitehall Rails routes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
