### PR TITLE
Fix bug with promotional feature reordering page using Bootstrap layout

### DIFF
--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -62,8 +62,9 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy reorder update_order]
-    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+    design_system_actions = %w[reorder update_order]
+    design_system_actions += %w[confirm_destroy] if preview_design_system?(next_release: false)
+    if design_system_actions.include?(action_name)
       "design_system"
     else
       "admin"


### PR DESCRIPTION
## Description

This should always be in the GOV.UK Design System. It was accidentally moved behind the "Preview design system" flag when we started to port other pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
