### PR TITLE
Update copy around lead images

### DIFF
--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -13,11 +13,7 @@
   <%= render "govuk_publishing_components/components/details", {
         title: "Using a lead image",
       } do %>
-    <p class="govuk-body">Using a lead image is optional. To use a lead image either select the
-    default image for your organisation or upload an image and select it as
-    the lead image.</p>
-    <p class="govuk-body">The lead image appears at the top of the document. It cannot be used
-    in the document body.</p>
+    <% lead_image_guidance %>
   <% end %>
 <% end %>
 

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -39,6 +39,14 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
     "#{new_image_display_option == 'no_image' ? 'Remove lead' : 'Use default'} image"
   end
 
+  def lead_image_guidance
+    if @edition.type == "CaseStudy"
+      tag.p("Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+    else
+      tag.p("The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+    end
+  end
+
 private
 
   def image_to_hash(image, index)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Implement new copy for lead images and add logic for case studies.
Move the message into the component class.

# Why
The original copy was written for functionality that has not been implemented.
Having the message in the component class fixes a bug where the paragraph tags were being rendered twice in the template.

# Screenshots

## Before

![whitehall-admin dev gov uk_government_admin_editions_1374131_images(iPad Pro) (1)](https://github.com/alphagov/whitehall/assets/9594455/828da196-0ccf-40ca-9e70-9960ab4757f1)


## After 
### Case Studies
![whitehall-admin dev gov uk_government_admin_editions_1374131_images(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/3d358bc1-2a58-4430-a1a4-a08f86789af7)

### Other Editions
![whitehall-admin dev gov uk_government_admin_editions_1374126_images(iPad Pro) (1)](https://github.com/alphagov/whitehall/assets/9594455/9a58c06e-e3e5-476a-947e-1c12a5750e35)
