### PR TITLE
Remove redundant AttachmentsController#update_many

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -43,25 +43,6 @@ class Admin::AttachmentsController < Admin::BaseController
     end
   end
 
-  def update_many
-    errors = {}
-    params[:attachments].each do |id, attributes|
-      attachment = attachable.attachments.find(id)
-      attachment.assign_attributes(attributes.permit(:title))
-      if attachment.save(context: :user_input)
-        attachment_updater(attachment.attachment_data)
-      else
-        errors[id] = attachment.errors.full_messages
-      end
-    end
-
-    if errors.empty?
-      render json: { result: :success }
-    else
-      render json: { result: :failure, errors: }, status: :unprocessable_entity
-    end
-  end
-
   def confirm_destroy; end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,7 +243,6 @@ Whitehall::Application.routes.draw do
           resources :attachments, except: [:show] do
             put :order, on: :collection
             get :reorder, on: :collection
-            put :update_many, on: :collection, constraints: { format: "json" }
             get :confirm_destroy, on: :member
           end
           resources :bulk_uploads, except: %i[show edit update] do

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -413,32 +413,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_equal "whitepaper.pdf", attachment.filename
   end
 
-  test "PUT :update_many changes attributes of multiple attachments" do
-    files = Dir.glob(Rails.root.join("test/fixtures/*.csv")).take(4)
-    files.each_with_index do |f, i|
-      create(:file_attachment, title: "attachment_#{i}", attachable: @edition, file: File.open(f))
-    end
-    attachments = @edition.reload.attachments
-
-    # append '_' to every attachment title in the collection
-    new_data = attachments.map { |a| [a.id.to_s, { title: "#{a.title}_" }] }
-    put :update_many, params: { edition_id: @edition, attachments: Hash[new_data] }
-
-    @edition.reload.attachments.each do |attachment|
-      assert_match(/.+_$/, attachment.title)
-    end
-  end
-
-  test "update_many returns validation errors in JSON" do
-    attachment = create(:file_attachment, attachable: @edition)
-
-    new_data = { attachment.id.to_s => { title: "" } }
-    put :update_many, params: { edition_id: @edition, attachments: new_data }
-
-    response_json = JSON.parse(@response.body)
-    assert_equal ["Title can't be blank"], response_json["errors"][attachment.id.to_s]
-  end
-
   test "attachment access is forbidden for users without access to the edition" do
     login_as :world_editor
     get :new, params: { edition_id: @edition }


### PR DESCRIPTION
The last reference to this appears to have been removed in 0b9423c960365db02af2cdb12715a8a26a36ea67 as part of #7027 when `app/assets/javascripts/admin_legacy/rename_attachments.js` was removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
