### PR TITLE
Remove the `too_large` error in the new images flow

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -34,6 +34,7 @@ class Admin::EditionImagesController < Admin::BaseController
       @data_url = image_data_url
       render :crop
     else
+      @new_image.errors.delete(:"image_data.file", :too_large)
       # Remove @new_image from @edition.images array, otherwise the view will render it in the 'Uploaded images' list
       @edition.images.delete(@new_image)
       render :index

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -70,3 +70,14 @@ Feature: Images tab on edit edition
     And I update the image details and save
     And I upload a 960x640 image
     Then I should get the error message "Image data file name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
+
+  @javascript
+  Scenario: Uploading an oversized file with duplicated filename
+    When a draft document with images exists
+    And I visit the images tab of the document with images
+    And I upload a 960x960 image
+    And I am redirected to a page for image cropping
+    And I click the "Save and continue" button on the crop page
+    And I update the image details and save
+    And I upload a 960x960 image
+    Then I should get 1 error message

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -50,26 +50,11 @@ Feature: Images tab on edit edition
     And I update the image details and save
     Then I should see a list with 3 image
 
-  Scenario: Small image uploaded
-    And I start drafting a new publication "Standard Beard Lengths"
-    When I visit the images tab of the document "Standard Beard Lengths"
-    And I upload a 64x96 image
-    Then I should get the error message "Image data file is too small. Select an image that is 960 pixels wide and 640 pixels tall"
-
   Scenario: No file uploaded
     And I start drafting a new publication "Standard Beard Lengths"
     When I visit the images tab of the document "Standard Beard Lengths"
     And I click upload without attaching a file
     Then I should get the error message "Image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF."
-
-  Scenario: Uploading a file with duplicated filename
-    And I have the "Preview images update" permission
-    And I start drafting a new publication "Standard Beard Lengths"
-    When I visit the images tab of the document "Standard Beard Lengths"
-    And I upload a 960x640 image
-    And I update the image details and save
-    And I upload a 960x640 image
-    Then I should get the error message "Image data file name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
 
   @javascript
   Scenario: Uploading an oversized file with duplicated filename

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -95,3 +95,7 @@ end
 Then(/^I should get the error message "(.*?)"$/) do |error_message|
   expect(page).to have_content(error_message)
 end
+
+Then(/^I should get (\d+) error message$/) do |count|
+  expect(page).to have_selector(".gem-c-error-summary__list-item", count:)
+end


### PR DESCRIPTION
The new flow allows cropping so this error should not be displayed to users.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
