### PR TITLE
Release 1.6 - comms and release to all users

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release && !Rails.env.test?
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/app/views/shared/_whats_new_banner.html.erb
+++ b/app/views/shared/_whats_new_banner.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "What's new",
-    message: sanitize("Edition summary page moves to the GOV.UK Design System and changes to history and notes -
+    message: sanitize("Improvements to uploading and managing images -
       #{
         link_to(
           "read more about the changes",

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     whats_new:
-      show_banner: false
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
@@ -22,6 +22,21 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: New page for uploading and managing images
+            area: Creating and updating documents
+            type: change
+            date: 11 May 2023
+            body_govspeak: |
+              There is now an images tab where you can upload and manage images for your document. This appears after you save a document.
+
+              You can now upload images bigger than 960 pixels wide by 640 pixels high for edition or document pages and resize them with a new cropping tool.
+
+              The image file name is now used as the Markdown to add the image to the body text.
+          - heading: Edit edition page moved to the Design System
+            type: improvement
+            date: 11 May 2023
+            body_govspeak: |
+              The edit edition page has moved to use the GOV.UK Design System. This includes translations.
           - heading: Document history and notes can now be filtered
             area: Creating and updating documents
             type: change


### PR DESCRIPTION
### Changes in this PR

- makes Release 1.6 available to all users
- updates the "What's new" page
- enables the "What's new" banner

### What's new page

| Content added to "What's new" page |
| --- |
| ![Changes to _What's new_ page](https://github.com/alphagov/whitehall/assets/7735945/f4864979-bed6-4c36-b601-4b69f283838b) |


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
