### PR TITLE
133 single image upload component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@ $govuk-page-width: 1140px;
 @import "./components/miller-columns";
 @import "./components/secondary-navigation";
 @import "./components/select-with-search";
+@import "./components/single-image-upload";
 
 @import "./admin/overrides";
 @import "./admin/layout";

--- a/app/assets/stylesheets/components/_single-image-upload.scss
+++ b/app/assets/stylesheets/components/_single-image-upload.scss
@@ -1,0 +1,6 @@
+.app-c-single-image-upload {
+  &__uploaded-image {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -35,4 +35,10 @@ class ImageUploader < WhitehallUploader
 
     new_file.content_type !~ /svg/
   end
+
+  def image_cache
+    if send("cache_id").present?
+      file.file.gsub("/govuk/whitehall/carrierwave-tmp/", "")
+    end
+  end
 end

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -44,33 +44,15 @@
         error_items: errors_for(form.object.errors, :body)
       } %>
 
-      <% if form.object.carrierwave_image.present? %>
-        <%= hidden_field_tag "take_part_page[image]", form.object.carrierwave_image %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/file_upload", {
-        label: {
-          text: "Image (required)",
-          heading_size: "l"
-        },
-        name: "take_part_page[image]",
-        id: "take_part_page_image",
-        value: form.object.image,
-        error_items: errors_for(form.object.errors, :image)
-      } %>
-
-      <% if form.object.carrierwave_image.present? %>
-        <p class="govuk-body"><%= "#{File.basename(form.object.carrierwave_image)} already uploaded" %></p>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Image description (alt text)",
-        },
-        heading_size: "l",
-        name: "take_part_page[image_alt_text]",
-        id: "take_part_page_image_alt_text",
-        value: form.object.image_alt_text
+      <%= render "components/single-image-upload", {
+        id: "take_part_page",
+        name: "take_part_page",
+        page_errors: form.object.errors.any?,
+        error_items: errors_for(form.object.errors, :image),
+        filename: form.object.image.filename,
+        image_cache: (form.object.image.image_cache if form.object.image.image_cache.present?),
+        image_src: form.object.image.url,
+        image_alt: form.object.image_alt_text
       } %>
 
       <div class="govuk-button-group">

--- a/app/views/components/_single-image-upload.html.erb
+++ b/app/views/components/_single-image-upload.html.erb
@@ -1,0 +1,72 @@
+<%
+  error_items ||= []
+  page_errors ||= false
+  data_attributes ||= {}
+  image_src ||= nil
+  image_alt ||= nil
+  image_cache ||= nil
+
+  root_classes = %w(app-c-single-image-upload govuk-form-group)
+%>
+
+<%= tag.div class: root_classes, data: data_attributes do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Image (required)",
+    font_size: "l",
+    margin_bottom: 3
+  } %>
+
+  <% if image_src %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Uploaded image",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 3
+    } %>
+
+    <% if page_errors %>
+      <%= hidden_field_tag "#{name}[image_cache]", image_cache %>
+      <p class="govuk-body"><strong>File name: </strong><%= filename %></p>
+      <p class="govuk-body"><strong>Alt text: </strong><%= image_alt == "" ? "None" : image_alt %></p>
+    <% else %>
+      <div class="govuk-grid-row app-c-single-image-upload__uploaded-image">
+        <div class="govuk-grid-column-one-quarter">
+          <img src="<%= image_src %>" alt="" class="app-view-edition-images__image">
+        </div>
+
+        <div class="govuk-grid-column-three-quarters">
+          <p class="govuk-body govuk-!-margin-0"><strong>Alt text: </strong><%= image_alt == "" ? "None" : image_alt %></p>
+        </div>
+      </div>
+    <% end %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <% image_label = "Replace image" %>
+    <% label_size = "m" %>
+  <% else %>
+    <% image_label = "Upload image" %>
+    <% label_size = nil %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/file_upload", {
+    label: {
+      text: image_label,
+      heading_size: label_size
+    },
+    name: "#{name}[image]",
+    hint: "Images must be 960px by 640px",
+    id: "#{id}_image",
+    value: image_src,
+    error_items: error_items
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Image description (alt text)"
+    },
+    name: "#{name}[image_alt_text]",
+    id: "#{id}_image_alt_text",
+    value: image_alt
+  } %>
+<% end %>

--- a/app/views/components/docs/single-image-upload.yml
+++ b/app/views/components/docs/single-image-upload.yml
@@ -1,0 +1,40 @@
+name: Single Image Upload
+description: A component for use where a single image is uploaded within the page
+body: This component is used to provide an image upload section on pages where a single image needs to be uploaded and there is no dedicated image tab.
+part_of_admin_layout: true
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form input elements
+  - have correctly associated labels
+examples:
+  default:
+    data:
+      id: single-image-upload
+      name: single-image-upload
+  with_error:
+    data:
+      id: single-image-upload-with-error
+      name: single-image-upload-with-error
+      error_items:
+        - text: Image can't be blank
+  with_image_uploaded:
+    data:
+      id: single-image-upload-with-image
+      name: single-image-upload-with-image
+      image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg
+      image_alt: Some optional text that describes the image
+  with_errors_on_page:
+    data:
+      id: single-image-upload-with-errors-on-page
+      name: single-image-upload-with-errors-on-page
+      image_alt: Some optional text that describes the image
+      page_errors: true
+      image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg
+      filename: No10DoorAjar-2.jpg,
+      image_cache: 1686052895-990540429428995-0004-6416/No10DoorAjar-2.jpg

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -14,7 +14,7 @@ When(/^I create a new take part page called "([^"]*)"$/) do |title|
   fill_in "Title", with: title
   fill_in "Summary", with: "A short description of #{title.downcase}"
   fill_in "Body", with: "A longer description of #{title.downcase}, with some markdown"
-  attach_file "Image", jpg_image
+  attach_file using_design_system? ? "Upload image" : "Image", jpg_image
   fill_in "Image description (alt text)", with: "A description of the image"
 
   click_on "Save"


### PR DESCRIPTION
[Trello Card](https://trello.com/c/Bm92hDFN/133-in-page-single-image-upload-reusable-pattern-dev)

This PR 
- creates a new component for reuse in areas where a single image needs to be uploaded within the page, i.e. there is no dedicated image tab. The component deals with 4 scenarios: 
  - the default: the user is creating a new page
  - the user saves the newly created page without uploading an image triggering an error
  - the user edits an existing page which already has an uploaded image associated with it. In this case the uploaded image is displayed and the user has the option to replace that with a different one. 
  - the user edits an existing page which already has an uploaded image associated with it and tries to save the page which has errors. In this case a text reference to the uploaded image is displayed rather than the image itself. 
- applies this component to the "Take Part" pages 

|Scenario|Component|
|-|-|
|Default| ![Screenshot 2023-05-11 at 11 27 43](https://github.com/alphagov/whitehall/assets/6080548/bab04853-551e-499f-b1fc-ce380e7dcd73) |
|With errors| ![Screenshot 2023-05-11 at 11 28 02](https://github.com/alphagov/whitehall/assets/6080548/36c693a3-e5c4-4f5f-8d30-5edbf759cb7b) |
|Edit page when an image is already uploaded| ![Screenshot 2023-05-11 at 11 28 16](https://github.com/alphagov/whitehall/assets/6080548/6f20562e-5260-4270-9c43-fa2f45c7c741) |
|Edit page when there are errors on the page| ![Screenshot 2023-06-06 at 14 30 33](https://github.com/alphagov/whitehall/assets/6080548/c52c9852-7f12-49a2-894f-d8d0d75f5545) |

|Scenario|Component implemented on "Take Part"|
|-|-|
|Default| ![Screenshot_1](https://github.com/alphagov/whitehall/assets/6080548/537345e4-d8d4-485e-9233-d62ed17d5800) |
|With errors| ![Screenshot_2](https://github.com/alphagov/whitehall/assets/6080548/553e5f4f-d6aa-4e48-89bf-4f05a6be5ae4) |
|Edit page when an image is already uploaded| ![Screenshot_3](https://github.com/alphagov/whitehall/assets/6080548/5a7c8883-d18c-4a8d-9b92-d3b3b120d92a) |
Edit page when there are errors on the page| ![Screenshot 2023-06-06 at 14 39 22](https://github.com/alphagov/whitehall/assets/6080548/1e7b176b-5211-4b87-9f44-1fababb0f917) |