### PR TITLE
1.11 Release Brief QA

### DIFF
--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -3,10 +3,10 @@
 <% content_for :title, @organisation.name %>
 <% content_for :title_margin_bottom, 4 %>
 
-<p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link" %></p>
+<p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link", target: "blank" %></p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Document navigation tabs",
+  aria_label: "Corporate information tabs",
   items: secondary_navigation_tabs_items(@organisation, request.path)
 } %>
 
@@ -15,6 +15,10 @@
     text: "Create new corporate information page",
     href: new_polymorphic_path([:admin, @organisation, CorporateInformationPage.new]),
     margin_bottom: 6,
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "No Corporate information pages have been created."
   } %>
 <% end %>
 

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Corporate information tabs",
       items: secondary_navigation_tabs_items(@edition, request.path)
     } %>
 

--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -1,9 +1,15 @@
+<%# content_for :page_title, "Feature document" %>
+<%# content_for :title, "Feature ‘#{@feature}’ within ‘#{@feature_list}’" %>
+<%# content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @feature)) %>
+
+<%# Suggested edit, possibly check with Nikin. If not remove below and uncomment above %>
 <% content_for :page_title, "Feature document" %>
-<% content_for :title, "Feature ‘#{@feature}’ within ‘#{@feature_list}’" %>
+<% content_for :title, "Feature ‘#{@feature}’" %>
+<% content_for :context, @feature_list%>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @feature)) %>
 
 <%= render "govuk_publishing_components/components/warning_text", {
-  text: "Warning: changes to features appear instantly on the live site."
+  text: "Changes to features appear instantly on the live site."
 } %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-     aria_label: "Document navigation tabs",
+     aria_label: "Historic account tabs",
      items: secondary_navigation_tabs_items(@person, request.path)
     } %>
 
@@ -62,9 +62,13 @@
         margin_bottom: 4,
       } %>
 
-      <p class="govuk-body">No historical accounts</p>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No historical accounts."
+      } %>
     <% else %>
-      <p class="govuk-body">This person does not have any role appointments in roles that support historical accounts.</p>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "This person does not have any role appointments in roles that support historical accounts."
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -35,5 +35,7 @@
     } %>
   </div>
 <% else %>
-  <p class="govuk-body">No organisation have been created.</p>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "No organisation have been created."
+  } %>
 <% end %>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
+    aria_label: "Organisation navigation tabs",
     items: secondary_navigation_tabs_items(@organisation, request.path)
   } %>
 </div>

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -8,7 +8,7 @@
     <p class="govuk-body"><%= view_on_website_link_for @person, class: "govuk-link", target: "blank" %></p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "People navigation tabs",
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
 

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -10,7 +10,7 @@
       </p>
 
       <%= render "components/secondary_navigation", {
-        aria_label: "Document navigation tabs",
+        aria_label: "People translation navigation tabs",
         items: secondary_navigation_tabs_items(@person, request.path)
       } %>
 
@@ -40,7 +40,9 @@
           end
         } %>
       <% else %>
-        <p class="govuk-body">No translations</p>
+        <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No translations."
+        } %>
       <% end %>
 
       <% if @person.missing_translations.any? %>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document tabs",
+    aria_label: "World Location News navigation tabs",
     items: secondary_navigation_tabs_items(@world_location_news, request.path)
   } %>
 </div>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link", target: "_blank" %>
     </p>
     <%= render "components/secondary_navigation", {
-      aria_label: "Document tabs",
+      aria_label: "World Location News navigation tabs",
       items: secondary_navigation_tabs_items(@world_location_news, request.path)
     } %>
     <div class="govuk-!-margin-bottom-4">


### PR DESCRIPTION
* # What & Why
* `features/new`
* Removed warning from string
* Added suggestion for context to shorten title
* `organisations/index`
* Changed to inset warning to follow style
* `corporate_information_pages/index`
* Changed Aria_label
* Added none created
* Added tab target
* aria_labels
* Changed aria labels to match pages
* Unchanged aria labels of attached image as Edition seems like doc
* # Note
* All the changed insets could have view_tests added

![Screenshot 2023-05-11 at 11 42 09](https://github.com/alphagov/whitehall/assets/125891738/34b75502-8a8f-42cc-8880-7c577018d88a)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
