### PR TITLE
Fix rendering of multiple recent openings

### DIFF
--- a/app/views/admin/editions/_recent_openings.html.erb
+++ b/app/views/admin/editions/_recent_openings.html.erb
@@ -5,7 +5,7 @@
     description_govspeak = render("govuk_publishing_components/components/list", {
       visible_counters: true,
       items: recent_openings.map do |opening|
-              render_govspeak("
+              sanitize("
                 #{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work.
                 Contact #{mail_to(opening.editor.email)} if you think they are still working on it.
               ")

--- a/app/views/admin/editions/_recent_openings.html.erb
+++ b/app/views/admin/editions/_recent_openings.html.erb
@@ -5,10 +5,7 @@
     description_govspeak = render("govuk_publishing_components/components/list", {
       visible_counters: true,
       items: recent_openings.map do |opening|
-              sanitize("
-                #{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work.
-                Contact #{mail_to(opening.editor.email)} if you think they are still working on it.
-              ")
+              sanitize("#{opening.editor.name} started editing this #{edition.format_name} #{time_ago_in_words opening.created_at} ago and hasn’t yet saved their work. Contact #{mail_to(opening.editor.email)} if you think they are still working on it.")
              end
     })
   else

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -765,10 +765,8 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select ".govuk-notification-banner__heading", "Multiple people have started editing this #{edition.format_name}:"
-        assert_select ".govuk-notification-banner__content li", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.
-            Contact <a href=\"mailto:joe@example.com\">joe@example.com</a> if you think they are still working on it."
-        assert_equal assert_select(".govuk-notification-banner__content li")[1].text.strip,  "Josie Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work.
-            Contact <a href=\"mailto:josie@example.com\">josie@example.com</a> if you think they are still working on it."
+        assert_select ".govuk-notification-banner__content li", "Joe Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work. Contact joe@example.com if you think they are still working on it."
+        assert_equal assert_select(".govuk-notification-banner__content li")[1].text.strip, "Josie Bloggs started editing this #{edition.format_name} about 1 hour ago and hasn’t yet saved their work. Contact josie@example.com if you think they are still working on it."
       end
 
       test "saving a #{edition_type} should remove any RecentEditionOpening records for the current user" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What 
Use `sanitize` instead of `render_govspeak`.

# Why
The latter was rendering a code block.

# Screenshots
## After
![whitehall-admin dev gov uk_government_admin_news_1374126_edit(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/82af176e-9c40-4ffe-8e95-f215263d014e)


## Before
![whitehall-admin dev gov uk_government_admin_news_1374126_edit(iPad Pro) (1)](https://github.com/alphagov/whitehall/assets/9594455/5049a725-4d0f-49c8-a747-8248320ffc92)

