### PR TITLE
Update title and summary to use char component

### DIFF
--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -7,7 +7,7 @@
       id: "edition_corporate_information_page_type_id",
       name: "edition[corporate_information_page_type_id]",
       label: "Type",
-      heading_size: "s",
+      heading_size: "l",
       error_message: errors_for_input(edition.errors, :corporate_information_page_type_id),
       include_blank: true,
       options: corporate_information_page_types(@organisation).map do |type, value|
@@ -19,23 +19,25 @@
     } %>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: "Summary",
-       bold: true
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        text: "Summary",
+        heading_size: "l",
+      },
+      name: "edition[summary]",
+      value: edition.summary,
+      rows: 4,
+      error_items: errors_for(form.object.errors, :summary),
     },
-    name: "edition[summary]",
     id: "edition_summary",
-    value: edition.summary,
-    rows: 4,
-    hint: "Summary text should be 160 characters or fewer.",
-    error_items: errors_for(form.object.errors, :summary),
+    maxlength: 160
   } %>
 
   <%= render "components/govspeak-editor", {
     label: {
       text: "Body (required)",
-        bold: true
+      heading_size: "l",
     },
     name: "edition[body]",
     id: "edition_body",
@@ -61,8 +63,8 @@
     } %>
   <p class="govuk-body">
     <% if edition.new_record? %>
-      To add images you must save the document first. After saving, use the 
-      tabs at the top of the page to upload, edit and delete images and 
+      To add images you must save the document first. After saving, use the
+      tabs at the top of the page to upload, edit and delete images and
       attachments.
     <% else %>
       Use the tabs at the top of the page to upload, edit and delete images.

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -11,36 +11,41 @@
   <% end %>
 
   <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: "Title (required)",
+    <%= render "govuk_publishing_components/components/character_count", {
+      textarea: {
+        label: {
+          text: "Title (required)",
+          heading_size: "l",
+        },
+        name: "edition[title]",
+        value: edition.title,
+        error_items: errors_for(edition.errors, :title),
+        right_to_left: form.object.translation_rtl?,
+        right_to_left_help: false,
+        rows: 1
       },
-      name: "edition[title]",
       id: "edition_title",
-      heading_size: "l",
-      value: edition.title,
-      hint: "Title text should be 65 characters or fewer",
-      error_items: errors_for(edition.errors, :title),
-      right_to_left: form.object.translation_rtl?,
-      right_to_left_help: false
+      maxlength: 65
     } %>
   </div>
 
   <div class="js-locale-switcher-field">
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: "Summary" + "#{' (required)' if form.object.summary_required?}",
-        heading_size: "l",
+    <%= render "govuk_publishing_components/components/character_count", {
+      textarea: {
+        label: {
+          text: "Summary" + "#{' (required)' if form.object.summary_required?}",
+          heading_size: "l",
+        },
+        name: "edition[summary]",
+        value: edition.summary,
+        rows: 4,
+        error_items: errors_for(edition.errors, :summary),
+        right_to_left: form.object.translation_rtl?,
+        right_to_left_help: false,
+        margin_bottom: 8,
       },
-      name: "edition[summary]",
       id: "edition_summary",
-      value: edition.summary,
-      rows: 4,
-      hint: "Summary text should be 160 characters or fewer.",
-      error_items: errors_for(edition.errors, :summary),
-      right_to_left: form.object.translation_rtl?,
-      right_to_left_help: false,
-      margin_bottom: 8,
+      maxlength: 160
     } %>
   </div>
 

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -203,7 +203,11 @@ Then(/^I should see that the statistics announcement has been cancelled$/) do
 end
 
 Then(/^the document fields are pre-filled based on the announcement$/) do
-  expect(page).to have_selector("input[id=edition_title][value='#{@statistics_announcement.title}']")
+  if using_design_system?
+    expect(page).to have_selector("textarea[id=edition_title]", text: @statistics_announcement.title)
+  else
+    expect(page).to have_selector("input[id=edition_title][value='#{@statistics_announcement.title}']")
+  end
   expect(page).to have_selector("textarea[id=edition_summary]", text: @statistics_announcement.summary)
 end
 

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -31,7 +31,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     get :new
 
     assert_select "form[action=?]", admin_document_collections_path do
-      assert_select "input[type=text][name=?]", "edition[title]"
+      assert_select "textarea[name=?]", "edition[title]"
       assert_select "textarea[name=?]", "edition[summary]"
       assert_select "textarea[name=?]", "edition[body]"
     end
@@ -73,7 +73,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
 
     assert_select "form[action=?]", admin_document_collection_path(document_collection) do
       assert_select "input[name='edition[slug]'][value=?]", document_collection.slug
-      assert_select "input[name='edition[title]'][value=?]", document_collection.title
+      assert_select "textarea[name='edition[title]']", document_collection.title
       assert_select "textarea[name='edition[summary]']", text: document_collection.summary
       assert_select "textarea[name='edition[body]']", text: document_collection.body
     end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -47,7 +47,7 @@ module AdminEditionControllerTestHelpers
 
         admin_editions_path = send("admin_#{edition_type.to_s.tableize}_path")
         assert_select "form#new_edition[action='#{admin_editions_path}']" do
-          assert_select "input[name='edition[title]'][type='text']"
+          assert_select "textarea[name='edition[title]']"
           assert_select "textarea[name='edition[summary]']"
           assert_select "textarea[name='edition[body]']"
           assert_select "button[type='submit']"
@@ -165,7 +165,7 @@ module AdminEditionControllerTestHelpers
 
         admin_edition_path = send("admin_#{edition_type}_path", edition)
         assert_select "form#edit_edition[action='#{admin_edition_path}']" do
-          assert_select "input[name='edition[title]'][type='text']"
+          assert_select "textarea[name='edition[title]']"
           assert_select "textarea[name='edition[body]']"
           assert_select "button[type='submit']"
         end


### PR DESCRIPTION
## Description

We've had a ticket come in saying that the character count message was useful for title and summary. This adds in the character count component to the fields.

I've checked that it still works with RTL languages.

I've also updated the heading size for labels to large on the edit corp inf page so it's consistent with the edit edition page

## Screenshots

### Edit edition page 

##### Before

<img width="564" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/330457d5-1f34-4ecb-aba7-6032336cf79a">


#### After ltr 

<img width="671" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/1b436afc-98a9-4f37-81dd-c04247ea4ec7">

#### After rtl 

<img width="594" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/f173eef9-4b13-4761-936f-471c44b253d8">

### Edit corporate information page

#### Before

<img width="633" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a69cfdcb-fdf5-4226-9982-b6e296e4f780">

#### After

<img width="706" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/93c6c9cc-cbda-4f4d-aaf6-86cf3dbe652b">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
