### PR TITLE
116-promotional-features-index-page-to-gds

### DIFF
--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -66,7 +66,7 @@ private
 
   def get_layout
     design_system_actions = %w[reorder update_order]
-    design_system_actions += %w[edit confirm_destroy] if preview_design_system?(next_release: false)
+    design_system_actions += %w[edit confirm_destroy index] if preview_design_system?(next_release: false)
     if design_system_actions.include?(action_name)
       "design_system"
     else

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -6,6 +6,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def index
     @promotional_features = @organisation.promotional_features
+    render_design_system("index", "legacy_index", next_release: false)
   end
 
   def new

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      <%= view_on_website_link_for @organisation, class: "govuk-link" %>
+      <%= view_on_website_link_for @organisation, class: "govuk-link", target: "blank" %>
     </p>
 
     <%= render "components/secondary_navigation", {
@@ -47,9 +47,9 @@
         end
       } %>
     <% else %>
-        <div class="govuk-body app-view-features-search-results__no_documents">
-          No promotional features
-        </div>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No promotional features."
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -9,7 +9,7 @@
 
 <%= render "components/secondary_navigation", {
   aria_label: "Promotional features navigation tabs",
-  items: secondary_navigation_tabs_items(current_user, @organisation, request.path)
+  items: secondary_navigation_tabs_items( @organisation, request.path)
 } %>
 
 <%= render "govuk_publishing_components/components/warning_text", {

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -1,39 +1,54 @@
-<% page_title @organisation.name %>
+<% content_for :context, "Organisation" %>
+<% content_for :title, @organisation.name %>
+<% content_for :title_margin_bottom, 4 %>
 
-<div class="organisation-header">
-  <h1><%= @organisation.name %></h1>
-  <%= view_on_website_link_for @organisation %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+<p class="govuk-body">
+  <%= view_on_website_link_for @organisation, class: "govuk-link" %></p>
+
+<%= render "components/secondary_navigation", {
+  aria_label: "Promotional features navigation tabs",
+  items: secondary_navigation_tabs_items(current_user, @organisation, request.path)
+} %>
+
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: "Changes to promotional features appear instantly on the live site."
+} %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "New promotional feature",
+  href: new_admin_organisation_promotional_feature_path,
+  margin_bottom: 6,
+} %>
+
+<% if @promotional_features.many? %>
+  <p class="govuk-body">
+    <%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation), class: "govuk-link", target: "_blank" %>
+  </p>
+<% end %>
+
+<% if @promotional_features.present? %>
+  <%= render "govuk_publishing_components/components/table" , {
+    width:60,
+    rows: @promotional_features.map do |promotional_feature|
+      [
+        {
+          text: promotional_feature.title
+        },
+        {
+          text: link_to(sanitize("View #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link govuk-!-margin-right-2") +
+            (link_to(sanitize("Rename #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link") )+
+            (link_to(sanitize("Delete #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+          format: "numeric",
+        }
+      ]
+    end
+  } %>
+<% else %>
+  <div class="govuk-body app-view-features-search-results__no_documents">
+    No promotional features
+  </div>
+<% end %>
+  </div>
 </div>
-
-<section class="organisation-details">
-  <%= tab_navigation_for(@organisation) do %>
-
-    <p class="warning">Warning: changes to promotional features appear instantly on the live site.</p>
-
-    <% if @promotional_features.many? %>
-      <p><%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation) %></p>
-    <% end %>
-
-    <% if @promotional_features.present? %>
-      <table class="table table-bordered">
-        <thead>
-          <tr class="table-header">
-            <th>Promotional Feature</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <%= render @promotional_features, organisation: @organisation %>
-        </tbody>
-      </table>
-    <% else %>
-      <p class="no-content no-content-bordered">No promotional features</p>
-    <% end %>
-
-    <div class="form-actions">
-      <%= link_to "New promotional feature", new_admin_organisation_promotional_feature_path, class: "btn btn-lg btn-primary"%>
-    </div>
-
-  <% end %>
-</section>

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @organisation.name %>
 <% content_for :context, "Organisation" %>
 <% content_for :title, @organisation.name %>
 <% content_for :title_margin_bottom, 4 %>

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -30,7 +30,6 @@
 
 <% if @promotional_features.present? %>
   <%= render "govuk_publishing_components/components/table" , {
-    width:60,
     rows: @promotional_features.map do |promotional_feature|
       [
         {

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -5,50 +5,51 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-<p class="govuk-body">
-  <%= view_on_website_link_for @organisation, class: "govuk-link" %></p>
+    <p class="govuk-body">
+      <%= view_on_website_link_for @organisation, class: "govuk-link" %>
+    </p>
 
-<%= render "components/secondary_navigation", {
-  aria_label: "Promotional features navigation tabs",
-  items: secondary_navigation_tabs_items( @organisation, request.path)
-} %>
+    <%= render "components/secondary_navigation", {
+      aria_label: "Promotional features navigation tabs",
+      items: secondary_navigation_tabs_items(@organisation, request.path)
+    } %>
 
-<%= render "govuk_publishing_components/components/warning_text", {
-  text: "Changes to promotional features appear instantly on the live site."
-} %>
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to promotional features appear instantly on the live site."
+    } %>
 
-<%= render "govuk_publishing_components/components/button", {
-  text: "New promotional feature",
-  href: new_admin_organisation_promotional_feature_path,
-  margin_bottom: 6,
-} %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "New promotional feature",
+      href: new_admin_organisation_promotional_feature_path,
+      margin_bottom: 6,
+    } %>
 
-<% if @promotional_features.many? %>
-  <p class="govuk-body">
-    <%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation), class: "govuk-link", target: "_blank" %>
-  </p>
-<% end %>
+    <% if @promotional_features.many? %>
+      <p class="govuk-body">
+        <%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation), class: "govuk-link" %>
+      </p>
+    <% end %>
 
-<% if @promotional_features.present? %>
-  <%= render "govuk_publishing_components/components/table" , {
-    rows: @promotional_features.map do |promotional_feature|
-      [
-        {
-          text: promotional_feature.title
-        },
-        {
-          text: link_to(sanitize("View #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link govuk-!-margin-right-2") +
-            (link_to(sanitize("Rename #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link") )+
-            (link_to(sanitize("Delete #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
-          format: "numeric",
-        }
-      ]
-    end
-  } %>
-<% else %>
-  <div class="govuk-body app-view-features-search-results__no_documents">
-    No promotional features
-  </div>
-<% end %>
+    <% if @promotional_features.present? %>
+      <%= render "govuk_publishing_components/components/table", {
+        rows: @promotional_features.map do |promotional_feature|
+          [
+            {
+              text: promotional_feature.title
+            },
+            {
+              text: link_to(sanitize("View #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link govuk-!-margin-right-2") +
+                (link_to(sanitize("Rename #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link")) +
+                (link_to(sanitize("Delete #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+              format: "numeric",
+            }
+          ]
+        end
+      } %>
+    <% else %>
+        <div class="govuk-body app-view-features-search-results__no_documents">
+          No promotional features
+        </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/promotional_features/legacy_index.html.erb
+++ b/app/views/admin/promotional_features/legacy_index.html.erb
@@ -1,0 +1,39 @@
+<% page_title @organisation.name %>
+
+<div class="organisation-header">
+  <h1><%= @organisation.name %></h1>
+  <%= view_on_website_link_for @organisation %>
+</div>
+
+<section class="organisation-details">
+  <%= tab_navigation_for(@organisation) do %>
+
+    <p class="warning">Warning: changes to promotional features appear instantly on the live site.</p>
+
+    <% if @promotional_features.many? %>
+      <p><%= link_to "Reorder promotional features", reorder_admin_organisation_promotional_features_path(@organisation) %></p>
+    <% end %>
+
+    <% if @promotional_features.present? %>
+      <table class="table table-bordered">
+        <thead>
+          <tr class="table-header">
+            <th>Promotional Feature</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <%= render @promotional_features, organisation: @organisation %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="no-content no-content-bordered">No promotional features</p>
+    <% end %>
+
+    <div class="form-actions">
+      <%= link_to "New promotional feature", new_admin_organisation_promotional_feature_path, class: "btn btn-lg btn-primary"%>
+    </div>
+
+  <% end %>
+</section>

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -25,9 +25,9 @@ When(/^I add a new promotional feature with a single item which has an image$/) 
   fill_in "Feature title", with: "Big Cheese"
 
   within "form.promotional_feature_item" do
-    fill_in "Summary",                      with: "The Big Cheese is coming."
-    fill_in "Item title (optional)",        with: "The Big Cheese"
-    fill_in "Item title url (optional)",    with: "http://big-cheese.co"
+    fill_in "Summary", with: "The Big Cheese is coming."
+    fill_in "Item title (optional)", with: "The Big Cheese"
+    fill_in "Item title url (optional)", with: "http://big-cheese.co"
     attach_file :image, Rails.root.join("test/fixtures/big-cheese.960x640.jpg")
     fill_in "Image description (alt text)", with: "The Big Cheese"
   end
@@ -43,9 +43,9 @@ When(/^I add a new promotional feature with a single item which has a YouTube UR
   fill_in "Feature title", with: "Big Cheese"
 
   within "form.promotional_feature_item" do
-    fill_in "Summary",                      with: "The Big Cheese is coming."
-    fill_in "Item title (optional)",        with: "The Big Cheese"
-    fill_in "Item title url (optional)",    with: "http://big-cheese.co"
+    fill_in "Summary", with: "The Big Cheese is coming."
+    fill_in "Item title (optional)", with: "The Big Cheese"
+    fill_in "Item title url (optional)", with: "http://big-cheese.co"
     choose "YouTube video"
     fill_in "YouTube video URL", with: "https://www.youtube.com/watch?v=fFmDQn9Lbl4"
     fill_in "YouTube video description (alt text)", with: "Description of video."
@@ -58,8 +58,12 @@ When(/^I delete the promotional feature$/) do
   visit admin_organisation_path(@executive_office)
   click_link "Promotional features"
 
-  within record_css_selector(@promotional_feature) do
-    click_link "Delete"
+  if using_design_system?
+    click_link "Delete #{@promotional_feature.title}"
+  else
+    within record_css_selector(@promotional_feature) do
+      click_link "Delete"
+    end
   end
   click_button "Delete"
 end
@@ -67,7 +71,11 @@ end
 When(/^I edit the promotional item, set the summary to "([^"]*)"$/) do |new_summary|
   visit admin_organisation_path(@executive_office)
   click_link "Promotional features"
-  click_link @promotional_feature.title
+  if using_design_system?
+    click_link "View #{@promotional_feature.title}"
+  else
+    click_link @promotional_feature.title
+  end
   within record_css_selector(@promotional_item) do
     click_link "Edit"
   end
@@ -78,8 +86,11 @@ end
 When(/^I delete the promotional item$/) do
   visit admin_organisation_path(@executive_office)
   click_link "Promotional features"
-  click_link @promotional_feature.title
-
+  if using_design_system?
+    click_link "View #{@promotional_feature.title}"
+  else
+    click_link @promotional_feature.title
+  end
   within record_css_selector(@promotional_item) do
     click_button "Delete"
   end
@@ -158,10 +169,19 @@ When(/^I set the order of the promotional features to:$/) do |promotional_featur
 end
 
 Then(/^the promotional features should be in the following order:$/) do |promotional_feature_list|
-  promotion_feature_ids = all(".promotional_feature").map { |element| element[:id] }
+  if using_design_system?
+    promotion_feature_ids = all(".govuk-table__cell").select.with_index { |_element, index| index.even? }.map(&:text)
 
-  promotional_feature_list.hashes.each_with_index do |feature_info, index|
-    promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
-    expect("promotional_feature_#{promotional_feature.id}").to eq(promotion_feature_ids[index])
+    promotional_feature_list.hashes.each_with_index do |feature_info, index|
+      promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
+      expect(promotional_feature.title.to_s).to eq(promotion_feature_ids[index])
+    end
+  else
+    promotion_feature_ids = all(".promotional_feature").map { |element| element[:id] }
+
+    promotional_feature_list.hashes.each_with_index do |feature_info, index|
+      promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
+      expect("promotional_feature_#{promotional_feature.id}").to eq(promotion_feature_ids[index])
+    end
   end
 end

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -169,19 +169,10 @@ When(/^I set the order of the promotional features to:$/) do |promotional_featur
 end
 
 Then(/^the promotional features should be in the following order:$/) do |promotional_feature_list|
-  if using_design_system?
-    promotion_feature_ids = all(".govuk-table__cell").select.with_index { |_element, index| index.even? }.map(&:text)
+  promotion_feature_ids = all("table td:first").map(&:text)
 
-    promotional_feature_list.hashes.each_with_index do |feature_info, index|
-      promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
-      expect(promotional_feature.title.to_s).to eq(promotion_feature_ids[index])
-    end
-  else
-    promotion_feature_ids = all(".promotional_feature").map { |element| element[:id] }
-
-    promotional_feature_list.hashes.each_with_index do |feature_info, index|
-      promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
-      expect("promotional_feature_#{promotional_feature.id}").to eq(promotion_feature_ids[index])
-    end
+  promotional_feature_list.hashes.each_with_index do |feature_info, index|
+    promotional_feature = PromotionalFeature.find_by(title: feature_info[:title])
+    expect(promotional_feature.title.to_s).to eq(promotion_feature_ids[index])
   end
 end

--- a/test/functional/admin/legacy_promotional_features_controller_test.rb
+++ b/test/functional/admin/legacy_promotional_features_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::LegacyPromotionalFeaturesControllerTest < ActionController::TestCas
     assert_response :success
     assert_equal @organisation, assigns(:organisation)
     assert_equal @organisation.reload.promotional_features, assigns(:promotional_features)
-    assert_template :index
+    assert_template :legacy_index
   end
 
   test "GET :new prepares a promotional feature" do


### PR DESCRIPTION
**Description**
This PR transitions the Promotional Features Index page to the GOV.UK Design System.

It does the following:

Duplicates the promotional features controller tests and assigns the non-legacy specs user the "Preview design system permission".
Prepends legacy to the existing index html for the bootstrap implementation and adds the logic to the controller to render the correct implementation based on the users permissions
Adds the new index html  implemented with  GOV.UK Design System
Modified a feature test for coverage of promotional feature index page.

**Screen shots**
**Before:**
<img width="991" alt="Old_index_page" src="https://github.com/alphagov/whitehall/assets/131259138/fcb5a978-3ca2-4ce9-bd63-6cbeb917d2f2">

**After :**
<img width="1629" alt="Index_gds_pf" src="https://github.com/alphagov/whitehall/assets/131259138/835f35a0-47a6-4703-9a41-56870db92bd9">

**Screen shot with no promotional features:**
<img width="1600" alt="Index_with_no_pf" src="https://github.com/alphagov/whitehall/assets/131259138/9153ab28-9c2b-41ea-9040-920ff593f1bc">

**Trello:**
https://trello.com/c/P2TvBUC6/116-promotional-features-index-page

