### PR TITLE
Reduce noise in test output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,12 @@ rescue LoadError
   # Pact isn't available in all environments
 end
 
+desc "Run the 'pact verify' command with the RSpec 'progress' formatter"
+task "pact:verify:with_progress_formatter" => :environment do
+  sh "pact verify --format progress --pact-helper spec/service_consumers/pact_helper.rb"
+end
+
 Whitehall::Application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test cucumber jasmine pact:verify]
+task default: %i[lint test cucumber jasmine pact:verify:with_progress_formatter]

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,2 +1,8 @@
 # Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
+
+require "sprockets/rails/task"
+Sprockets::Rails::Task.new(Rails.application) do |t|
+  t.log_level = Logger::WARN
+end
+
 Rake::Task["assets:precompile"].enhance(["yarn:install"])

--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -31,7 +31,7 @@ module Whitehall
 
       def amend(link, changes)
         repeatedly do
-          make_request(:post, documents_url(link:), changes)
+          make_request(:post, documents_url(link:), MultiJson.encode(changes))
         end
       end
 

--- a/test/functional/admin/legacy_take_part_pages_controller_test.rb
+++ b/test/functional/admin/legacy_take_part_pages_controller_test.rb
@@ -41,7 +41,6 @@ class Admin::LegacyTakePartPagesControllerTest < ActionController::TestCase
 
     post :create, params: { take_part_page: take_part_page_attrs }
 
-    puts assigns(:take_part_page).errors.full_messages
     assert assigns(:take_part_page).persisted?
     assert_equal "Wear a monocle!", assigns(:take_part_page).title
     assert_redirected_to admin_take_part_pages_path

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -39,7 +39,6 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
 
     post :create, params: { take_part_page: take_part_page_attrs }
 
-    puts assigns(:take_part_page).errors.full_messages
     assert assigns(:take_part_page).persisted?
     assert_equal "Wear a monocle!", assigns(:take_part_page).title
     assert_redirected_to admin_take_part_pages_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 ENV["RAILS_ENV"] = "test"
 
-require "simplecov"
-SimpleCov.start "rails"
-SimpleCov.command_name "Unit Tests"
-SimpleCov.merge_timeout 3600
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start "rails"
+  SimpleCov.command_name "Unit Tests"
+  SimpleCov.merge_timeout 3600
+end
 
 require File.expand_path("../config/environment", __dir__)
 

--- a/test/unit/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/helpers/admin/tabbed_nav_helper_test.rb
@@ -155,7 +155,6 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
   test "#secondary_navigation_tabs_items for persisted editions which do not allow images" do
     %i[corporate_information_page].each do |type|
       edition = build_stubbed(type)
-      puts type
 
       expected_output = [
         {

--- a/test/unit/locales_validation_test.rb
+++ b/test/unit/locales_validation_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class LocalesValidationTest < ActiveSupport::TestCase
   test "should validate all locale files" do
     checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml")
-    assert checker.validate_locales
+    result = false
+    stdout, = capture_io { result = checker.validate_locales }
+    assert result, stdout
   end
 end

--- a/test/unit/reports/organisation_attachments_report_test.rb
+++ b/test/unit/reports/organisation_attachments_report_test.rb
@@ -8,7 +8,9 @@ class Reports::OrganisationAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/#{organisation.slug}-attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      capture_io do
+        Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      end
 
       assert_equal Reports::OrganisationAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 1, CSV.read(path, headers: true).count
@@ -29,7 +31,9 @@ class Reports::OrganisationAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/#{organisation.slug}-attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      capture_io do
+        Reports::OrganisationAttachmentsReport.new(organisation.slug).report
+      end
 
       assert_equal Reports::OrganisationAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 0, CSV.read(path, headers: true).count

--- a/test/unit/reports/published_attachments_report_test.rb
+++ b/test/unit/reports/published_attachments_report_test.rb
@@ -7,7 +7,9 @@ class Reports::PublishedAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::PublishedAttachmentsReport.new.report
+      capture_io do
+        Reports::PublishedAttachmentsReport.new.report
+      end
 
       assert_equal Reports::PublishedAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 1, CSV.read(path, headers: true).count
@@ -20,7 +22,9 @@ class Reports::PublishedAttachmentsReportTest < ActiveSupport::TestCase
     Timecop.freeze do
       path = Rails.root.join("tmp/attachments_#{Time.zone.now.strftime('%d-%m-%Y_%H-%M')}.csv")
 
-      Reports::PublishedAttachmentsReport.new.report
+      capture_io do
+        Reports::PublishedAttachmentsReport.new.report
+      end
 
       assert_equal Reports::PublishedAttachmentsReport::CSV_HEADERS, CSV.read(path)[0]
       assert_equal 0, CSV.read(path, headers: true).count

--- a/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
+++ b/test/unit/tasks/data_hygiene/publishing_api_html_attachment_redirector_test.rb
@@ -34,7 +34,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
       it "does not send the redirection to the Publishing API" do
         PublishingApiRedirectWorker.any_instance.expects(:perform).never
-        call_html_attachment_redirector
+        capture_io { call_html_attachment_redirector }
       end
 
       it "reports the html attachment that would have changed" do
@@ -53,7 +53,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
         it "raises an exception" do
           assert_raises DataHygiene::EditionNotUnpublished do
-            call_html_attachment_redirector
+            capture_io { call_html_attachment_redirector }
           end
         end
       end
@@ -65,7 +65,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
 
         it "raises an exception" do
           assert_raises DataHygiene::HtmlAttachmentsNotFound do
-            call_html_attachment_redirector
+            capture_io { call_html_attachment_redirector }
           end
         end
       end
@@ -79,7 +79,7 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
             .expects(:perform)
             .with(attachment.content_id, redirection, attachment.locale)
 
-          call_html_attachment_redirector
+          capture_io { call_html_attachment_redirector }
         end
 
         it "reports the redirections sent to the Publishing API" do
@@ -95,11 +95,13 @@ class PublishingApiHtmlAttachmentRedirectorTest < ActiveSupport::TestCase
             .expects(:perform)
             .with(attachment.content_id, redirection, attachment.locale)
 
-          DataHygiene::PublishingApiHtmlAttachmentRedirector.call(
-            attachment.content_id,
-            redirection,
-            dry_run:,
-          )
+          capture_io do
+            DataHygiene::PublishingApiHtmlAttachmentRedirector.call(
+              attachment.content_id,
+              redirection,
+              dry_run:,
+            )
+          end
         end
       end
     end

--- a/test/unit/tasks/draft_document_collection_writer_test.rb
+++ b/test/unit/tasks/draft_document_collection_writer_test.rb
@@ -23,7 +23,7 @@ class DraftDocumentCollectionWriteRake < ActiveSupport::TestCase
       create(:document, content_id: whitehall_document_content_id, document_type: "detailed_guide")
       create(:edition, :published, type: "DetailedGuide", document_id: Document.last.id)
 
-      task.invoke(specialist_topic_base_path, "my_email@email.com")
+      capture_io { task.invoke(specialist_topic_base_path, "my_email@email.com") }
 
       assert_equal 1, DocumentCollection.count
     end
@@ -36,7 +36,7 @@ class DraftDocumentCollectionWriteRake < ActiveSupport::TestCase
 
       stub_valid_specialist_topic
 
-      task.invoke(specialist_topic_base_path, "my_email@email.com")
+      capture_io { task.invoke(specialist_topic_base_path, "my_email@email.com") }
       task.reenable
 
       new_document_content_id = "abc436e5-1234-4462-913f-9a497f7e793e"
@@ -57,7 +57,7 @@ class DraftDocumentCollectionWriteRake < ActiveSupport::TestCase
       )
 
       Timecop.travel 1.minute.from_now
-      task.invoke(specialist_topic_base_path, "my_email@email.com")
+      capture_io { task.invoke(specialist_topic_base_path, "my_email@email.com") }
 
       assert_equal 1, DocumentCollection.count
     end
@@ -91,7 +91,7 @@ class DraftDocumentCollectionWriteRake < ActiveSupport::TestCase
         "links" => level_two_topic_links,
       })
 
-      assert_raise { task.invoke(specialist_topic_base_path, "my_email@email.com") }
+      assert_raise { capture_io { task.invoke(specialist_topic_base_path, "my_email@email.com") } }
       assert_equal 0, DocumentCollection.count
     end
   end

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -26,7 +26,7 @@ class PublishingApiRake < ActiveSupport::TestCase
             .any_instance.expects(:publish).with(params.merge(route))
         end
 
-        task.invoke
+        capture_io { task.invoke }
       end
     end
   end
@@ -54,7 +54,7 @@ class PublishingApiRake < ActiveSupport::TestCase
             public_updated_at: Time.zone.now.iso8601,
             update_type: "major",
           }
-          task.invoke
+          capture_io { task.invoke }
           assert_publishing_api_put_content(route[:content_id], params)
           assert_publishing_api_publish(route[:content_id])
         end
@@ -69,7 +69,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "republishes document by slug" do
         document = create(:document)
         PublishingApiDocumentRepublishingWorker.any_instance.expects(:perform).with(document.id)
-        task.invoke(document.slug)
+        capture_io { task.invoke(document.slug) }
       end
     end
 
@@ -79,7 +79,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "Republishes organisation by slug" do
         record = create(:organisation)
         Organisation.any_instance.expects(:publish_to_publishing_api)
-        task.invoke(record.slug)
+        capture_io { task.invoke(record.slug) }
       end
     end
 
@@ -89,7 +89,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "Republishes person by slug" do
         record = create(:person)
         Person.any_instance.expects(:publish_to_publishing_api)
-        task.invoke(record.slug)
+        capture_io { task.invoke(record.slug) }
       end
     end
 
@@ -99,7 +99,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "Republishes role by slug" do
         record = create(:role)
         Role.any_instance.expects(:publish_to_publishing_api)
-        task.invoke(record.slug)
+        capture_io { task.invoke(record.slug) }
       end
     end
   end
@@ -115,7 +115,7 @@ class PublishingApiRake < ActiveSupport::TestCase
         Whitehall::PublishingApi.expects(:patch_links).with(
           organisation, bulk_publishing: true
         ).once
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -125,7 +125,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "patches links for published editions" do
         edition = create(:edition, :published)
         PublishingApiLinksWorker.expects(:perform_async).with(edition.id)
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -135,7 +135,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "sends withdrawn item links to Publishing API" do
         edition = create(:edition, :withdrawn)
         PublishingApiLinksWorker.expects(:perform_async).with(edition.id)
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -145,7 +145,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "sends draft item links to Publishing API" do
         edition = create(:edition)
         PublishingApiLinksWorker.expects(:perform_async).with(edition.id)
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -155,7 +155,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       test "sends item links to Publishing API from document type" do
         edition = create(:published_publication)
         PublishingApiLinksWorker.expects(:perform_async).with(edition.id)
-        task.invoke("Publication")
+        capture_io { task.invoke("Publication") }
       end
     end
   end
@@ -176,7 +176,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         )
 
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -216,7 +216,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true, # Publishing API will queue as low priority
         )
 
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -231,7 +231,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           edition.document_id,
           true,
         )
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -246,7 +246,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           edition.document_id,
           true,
         )
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -261,7 +261,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           edition.document_id,
           true,
         )
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -276,7 +276,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           edition.document_id,
           true,
         )
-        task.invoke
+        capture_io { task.invoke }
       end
     end
 
@@ -304,7 +304,7 @@ class PublishingApiRake < ActiveSupport::TestCase
               document.document_id,
               true,
             )
-            task.invoke(document_type)
+            capture_io { task.invoke(document_type) }
           end
         end
       end
@@ -329,7 +329,7 @@ class PublishingApiRake < ActiveSupport::TestCase
             document = create(document_type.underscore.to_sym) # rubocop:disable Rails/SaveBang
 
             Whitehall::PublishingApi.expects(:bulk_republish_async).with(document)
-            task.invoke(document_type)
+            capture_io { task.invoke(document_type) }
           end
         end
       end
@@ -337,7 +337,9 @@ class PublishingApiRake < ActiveSupport::TestCase
       describe "for non-existent document types" do
         test "it returns an error" do
           document_type = "SomeDocumentTypeThatDoesntExist"
-          assert_raises(SystemExit, /Unknown document type #{document_type}/) { task.invoke(document_type) }
+          assert_raises(SystemExit, /Unknown document type #{document_type}/) do
+            capture_io { task.invoke(document_type) }
+          end
         end
       end
     end
@@ -355,7 +357,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         )
 
-        task.invoke(org.slug)
+        capture_io { task.invoke(org.slug) }
       end
 
       test "Ignores documents owned by other organisations" do
@@ -368,7 +370,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         ).never
 
-        task.invoke(org.slug)
+        capture_io { task.invoke(org.slug) }
       end
     end
 
@@ -384,7 +386,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         )
 
-        task.invoke([edition.content_id])
+        capture_io { task.invoke([edition.content_id]) }
       end
     end
 
@@ -403,7 +405,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         )
 
-        task.invoke(filename)
+        capture_io { task.invoke(filename) }
 
         File.delete("lib/tasks/#{filename}.csv")
       end
@@ -428,7 +430,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           true,
         )
 
-        task.invoke
+        capture_io { task.invoke }
       end
     end
   end
@@ -451,7 +453,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           },
         )
 
-        task.invoke(content_id, path, locale)
+        capture_io { task.invoke(content_id, path, locale) }
 
         assert_requested request
       end
@@ -472,7 +474,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           dry_run: false,
         )
 
-        task.invoke(content_id, path)
+        capture_io { task.invoke(content_id, path) }
       end
     end
   end

--- a/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
+++ b/test/unit/tasks/republish_draft_html_attachments_associated_with_responses_test.rb
@@ -43,6 +43,8 @@ class RepublishDraftHtmlAttachmentsWithAssoicatedResponsesRake < ActiveSupport::
       true,
     ).never
 
-    Rake.application.invoke_task "republish_draft_html_attachments_associated_with_responses"
+    capture_io do
+      Rake.application.invoke_task "republish_draft_html_attachments_associated_with_responses"
+    end
   end
 end

--- a/test/unit/tasks/republish_historically_political_html_attachments_test.rb
+++ b/test/unit/tasks/republish_historically_political_html_attachments_test.rb
@@ -65,6 +65,8 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
       true,
     ).never
 
-    Rake.application.invoke_task "republish_historically_political_html_attachments"
+    capture_io do
+      Rake.application.invoke_task "republish_historically_political_html_attachments"
+    end
   end
 end

--- a/test/unit/tasks/republish_nation_applicable_html_attachments_test.rb
+++ b/test/unit/tasks/republish_nation_applicable_html_attachments_test.rb
@@ -53,6 +53,8 @@ class RepublishNationApplicableHtmlAttachmentsRake < ActiveSupport::TestCase
       true,
     ).never
 
-    Rake.application.invoke_task "republish_nation_inapplicable_html_attachments"
+    capture_io do
+      Rake.application.invoke_task "republish_nation_inapplicable_html_attachments"
+    end
   end
 end

--- a/test/unit/workers/check_all_organisations_links_worker_test.rb
+++ b/test/unit/workers/check_all_organisations_links_worker_test.rb
@@ -30,7 +30,7 @@ class CheckAllOrganisationsLinksWorkerTest < ActiveSupport::TestCase
     stub_news_article
 
     Sidekiq::Testing.inline! do
-      CheckAllOrganisationsLinksWorker.new.perform
+      capture_subprocess_io { CheckAllOrganisationsLinksWorker.new.perform }
     end
 
     assert_equal 2, LinkCheckerApiReport.count

--- a/test/unit/workers/check_organisation_links_worker_test.rb
+++ b/test/unit/workers/check_organisation_links_worker_test.rb
@@ -21,7 +21,7 @@ class CheckOrganisationLinksWorkerTest < ActiveSupport::TestCase
   test "when given an organisation it only calls LinkCheckerApiService with editions for that organisation" do
     new_edition = stub_published_publication
 
-    CheckOrganisationLinksWorker.new.perform(@hmrc.id)
+    capture_subprocess_io { CheckOrganisationLinksWorker.new.perform(@hmrc.id) }
 
     assert_equal 1, LinkCheckerApiReport.count
     assert_requested new_edition
@@ -69,7 +69,7 @@ class CheckOrganisationLinksWorkerTest < ActiveSupport::TestCase
       body: "no links here",
     )
 
-    CheckOrganisationLinksWorker.new.perform(org.id)
+    capture_subprocess_io { CheckOrganisationLinksWorker.new.perform(org.id) }
     assert_equal(1, publication.link_check_reports.count)
     assert_equal(false, publication.link_check_reports.last.has_problems?)
   end
@@ -79,7 +79,7 @@ private
   def assert_report_count_increased
     stub_organisation_edition_limit(2) do
       assert_difference "LinkCheckerApiReport.count", 2 do
-        CheckOrganisationLinksWorker.new.perform(@hmrc.id)
+        capture_subprocess_io { CheckOrganisationLinksWorker.new.perform(@hmrc.id) }
       end
     end
   end


### PR DESCRIPTION
There's quite a lot of noise (i.e. expected or unintended output) in the build output. Reducing this noise will make it easier to see any *unexpected* output which might be important to address.

This PR doesn't deal with *all* the noise, but hopefully it's a significant improvement. We can always do more and (ideally) fail fast if any more gets added.

I don't think there's anything particularly controversial in this PR, but I'd be particularly interested in any thoughts about the Rummager-related fix I've done in the "Avoid RestClient warning from RummageableTest" commit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
