### PR TITLE
Fix bug with world locations not showing for new stories

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -53,13 +53,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var worldNewsArticleTypeId = '4'
     var ministersDiv = form.querySelector('.app-view-edit-edition__appointment-fields')
     var organisationsDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
-    var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
+    var worldOrganisationDiv = form.querySelector('.app-view-edit-edition__world-organisation-fields')
 
     if (subtypeSelect.value === worldNewsArticleTypeId) {
       ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
       organisationsDiv.classList.add('app-view-edit-edition__organisation-fields--hidden')
     } else {
-      worldLocationDiv.classList.add('app-view-edit-edition__world-location-fields--hidden')
+      worldOrganisationDiv.classList.add('app-view-edit-edition__world-organisation-fields--hidden')
     }
 
     subtypeSelect.addEventListener('change', function () {
@@ -70,11 +70,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         localeSelect.value = ''
         ministersDiv.classList.remove('app-view-edit-edition__appointment-fields--hidden')
         organisationsDiv.classList.remove('app-view-edit-edition__organisation-fields--hidden')
-        worldLocationDiv.classList.add('app-view-edit-edition__world-location-fields--hidden')
-        worldLocationDiv.querySelector('select').value = ''
+        worldOrganisationDiv.classList.add('app-view-edit-edition__world-organisation-fields--hidden')
+        worldOrganisationDiv.querySelector('select').value = ''
       } else {
         localeDiv.classList.remove('app-view-edit-edition__locale-field--hidden')
-        worldLocationDiv.classList.remove('app-view-edit-edition__world-location-fields--hidden')
+        worldOrganisationDiv.classList.remove('app-view-edit-edition__world-organisation-fields--hidden')
 
         ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
         ministersDiv.querySelector('select').value = ''

--- a/app/assets/stylesheets/admin/views/_edit-edition.scss
+++ b/app/assets/stylesheets/admin/views/_edit-edition.scss
@@ -24,7 +24,7 @@
 .app-view-edit-edition__locale-field--hidden,
 .app-view-edit-edition__appointment-fields--hidden,
 .app-view-edit-edition__organisation-fields--hidden,
-.app-view-edit-edition__world-location-fields--hidden,
+.app-view-edit-edition__world-organisation-fields--hidden,
 .app-view-edit-edition__speech-location--hidden,
 .app-view-edit-edition__delivered-on-warning--hidden {
   display: none;

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -18,11 +18,12 @@
       </div>
 
       <%= render 'topical_event_fields', form: form, edition: edition %>
-      <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
 
-      <div class="app-view-edit-edition__world-location-fields">
-        <%= render 'world_location_fields', form: form, edition: edition %>
+      <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
+        <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
       </div>
+
+      <%= render 'world_location_fields', form: form, edition: edition %>
 
       <div class="app-view-edit-edition__organisation-fields">
         <%= render 'organisation_fields', form: form, edition: edition %>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -60,7 +60,7 @@ describe('GOVUK.Modules.EditionForm', function () {
 
       var ministersDiv = form.querySelector('.app-view-edit-edition__appointment-fields')
       var organisationDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
-      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
+      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-organisation-fields')
       var worldLocationSelect = worldLocationDiv.querySelector('select')
 
       subtypeSelect.value = '4'
@@ -79,7 +79,7 @@ describe('GOVUK.Modules.EditionForm', function () {
       expect(localeCheckbox.checked).toEqual(false)
       expect(localeSelect.value).toEqual('')
 
-      expect(worldLocationDiv.classList).toContain('app-view-edit-edition__world-location-fields--hidden')
+      expect(worldLocationDiv.classList).toContain('app-view-edit-edition__world-organisation-fields--hidden')
       expect(worldLocationSelect.value).toEqual('')
 
       expect(ministersDiv.classList).not.toContain('app-view-edit-edition__ministers-fields--hidden')
@@ -96,10 +96,10 @@ describe('GOVUK.Modules.EditionForm', function () {
 
     it('should hide the locale fields and world-location-fields on page load', function () {
       var localeFields = form.querySelector('.app-view-edit-edition__locale-field')
-      var worldLocationFields = form.querySelector('.app-view-edit-edition__world-location-fields')
+      var worldLocationFields = form.querySelector('.app-view-edit-edition__world-organisation-fields')
 
       expect(localeFields.classList).toContain('app-view-edit-edition__locale-field--hidden')
-      expect(worldLocationFields.classList).toContain('app-view-edit-edition__world-location-fields--hidden')
+      expect(worldLocationFields.classList).toContain('app-view-edit-edition__world-organisation-fields--hidden')
     })
 
     it('should show the locale & world location fields, and hide and reset the ministers & org fields when WorldNewsStory is selected', function () {
@@ -114,10 +114,10 @@ describe('GOVUK.Modules.EditionForm', function () {
       var organisationDiv = form.querySelector('.app-view-edit-edition__organisation-fields')
       var organisationSelect1 = organisationDiv.querySelectorAll('select')[0]
       var organisationSelect2 = organisationDiv.querySelectorAll('select')[1]
-      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-location-fields')
+      var worldLocationDiv = form.querySelector('.app-view-edit-edition__world-organisation-fields')
 
       expect(localeFields.classList).not.toContain('app-view-edit-edition__locale-field--hidden')
-      expect(worldLocationDiv.classList).not.toContain('app-view-edit-edition__world-location-fields--hidden')
+      expect(worldLocationDiv.classList).not.toContain('app-view-edit-edition__world-organisation-fields--hidden')
       expect(ministersDiv.classList).toContain('app-view-edit-edition__appointment-fields--hidden')
       expect(ministersSelect.value).toEqual('')
       expect(organisationDiv.classList).toContain('app-view-edit-edition__organisation-fields--hidden')
@@ -281,7 +281,7 @@ describe('GOVUK.Modules.EditionForm', function () {
           '<option value="2" selected="selected">Org 2</option>' +
         '</select>' +
       '</div>' +
-      '<div class="app-view-edit-edition__world-location-fields">' +
+      '<div class="app-view-edit-edition__world-organisation-fields">' +
         '<select name="edition[world_location_ids][]" id="edition_world_location_ids-select">' +
           '<option value=""></option>' +
           '<option value="1" selected="selected">Country 1</option>' +


### PR DESCRIPTION
## Description

We've accidentally made it so that world organisations, rather than world locations always show for news stories and world locations only appear for the world news stories subtype.

The correct behaviour is the inverse.

## Screenshots

<img width="258" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/88f4a69e-9f1d-4fa6-a4cf-051c695dbc23">

<img width="306" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/1cea626c-eca2-4d74-bb70-f8ea2ef58ea0">

<img width="311" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ef3f5a90-5740-4130-bb92-06e64ea484d8">

<img width="276" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/983a4c38-bf95-4fca-9574-d21c8a07cfdc">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
