### PR TITLE
Remove further uses of `UrlMaker`

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Admin::Editions::Show::SidebarActionsComponent < ViewComponent::Base
+  include Admin::EditionRoutesHelper
+
   def initialize(edition:, current_user:)
-    @url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
     @enforcer = Whitehall::Authority::Enforcer.new(current_user, edition)
     @scheduler = Whitehall.edition_services.scheduler(edition)
     @force_scheduler = Whitehall.edition_services.force_scheduler(edition)
@@ -77,7 +78,7 @@ private
     if @edition.editable?
       actions << render("govuk_publishing_components/components/button", {
         text: "Edit draft",
-        href: @url_maker.edit_admin_edition_path(@edition),
+        href: edit_admin_edition_path(@edition),
         secondary_quiet: true,
         data_attributes: {
           module: "gem-track-click",
@@ -248,14 +249,14 @@ private
   def add_view_action
     if @edition.publicly_visible?
       actions << link_to("View on website (opens in new tab)",
-                         @url_maker.public_document_url(@edition),
+                         @edition.public_url,
                          class: "govuk-link",
                          target: "_blank",
                          rel: "noopener",
                          data: {
                            module: "gem-track-click",
                            track_category: "external-link-clicked",
-                           track_action: @url_maker.public_document_url(@edition),
+                           track_action: @edition.public_url,
                            track_label: "View on website",
                          })
     end

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -7,12 +7,11 @@ class Admin::DocumentsController < Admin::BaseController
       HtmlAttachment.find_by(content_id: params[:content_id])&.attachable&.document
     )
 
-    url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
     if document
-      redirect_to url_maker.admin_edition_path(document.latest_edition)
+      redirect_to admin_edition_path(document.latest_edition)
     else
       flash[:error] = "The requested content was not found"
-      redirect_to url_maker.admin_editions_path
+      redirect_to admin_editions_path
     end
   end
 end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -55,7 +55,7 @@ module ServiceListeners
       previous_edition = edition.previous_edition
 
       if previous_edition
-        edition_url = Whitehall::UrlMaker.new.public_document_url(edition)
+        edition_url = edition.public_url
         removed_locales = previous_edition.translations.map(&:locale) - edition.translations.map(&:locale)
         removed_locales.each do |locale|
           PublishingApiGoneWorker.new.perform(

--- a/test/functional/admin/documents_controller_test.rb
+++ b/test/functional/admin/documents_controller_test.rb
@@ -7,12 +7,11 @@ class Admin::DocumentsControllerTest < ActionController::TestCase
   def setup
     login_as :user
     @document = create(:edition, :with_document).document
-    @url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
   end
 
   view_test "GET by-content-id redirects to content by content_id" do
     get :by_content_id, params: { content_id: @document.content_id }
-    assert_redirected_to @url_maker.admin_edition_path(@document.latest_edition)
+    assert_redirected_to @controller.admin_edition_path(@document.latest_edition)
   end
 
   view_test "GET by-content-id supports HTML Attachments" do
@@ -20,11 +19,11 @@ class Admin::DocumentsControllerTest < ActionController::TestCase
     document = attachment.attachable.document
 
     get :by_content_id, params: { content_id: attachment.content_id }
-    assert_redirected_to @url_maker.admin_edition_path(document.latest_edition)
+    assert_redirected_to @controller.admin_edition_path(document.latest_edition)
   end
 
   view_test "GET by-content-id redirects to a search if content_id is not found" do
     get :by_content_id, params: { content_id: "#{@document.content_id}wrong-id" }
-    assert_redirected_to @url_maker.admin_editions_path
+    assert_redirected_to admin_editions_path
   end
 end

--- a/test/functional/admin/needs_controller_test.rb
+++ b/test/functional/admin/needs_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::NeedsControllerTest < ActionController::TestCase
   def setup
     login_as :user
     @document = create(:edition, :with_document).document
-    @url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
 
     @need1 = {
       "content_id" => SecureRandom.uuid,

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -157,7 +157,7 @@ module ServiceListeners
         .expects(:new)
         .returns(pusher)
 
-      expected_original_url = Whitehall::UrlMaker.new.public_document_url(new_edition)
+      expected_original_url = new_edition.public_url
 
       pusher.expects(:perform).with(
         new_edition.document.content_id,


### PR DESCRIPTION
There were some uses of `UrlMaker` that we had not previously identified.

This removes all the direct uses of `UrlMaker`.  There are also indirect uses via `Whitehall.url_maker`, which will be written up as another card.

[Trello card](https://trello.com/c/swZNpdoQ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
