### PR TITLE
Ensure first_published_at param is cleaned on update

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -465,6 +465,14 @@ private
     edition_params.delete(:create_foreign_language_only)
     edition_params[:external_url] = nil if edition_params[:external] == "0"
     edition_params[:change_note] = nil if edition_params[:minor_change] == "true"
+
+    if edition_params[:previously_published] == "false"
+      edition_params["first_published_at(1i)"] = ""
+      edition_params["first_published_at(2i)"] = ""
+      edition_params["first_published_at(3i)"] = ""
+      edition_params["first_published_at(4i)"] = ""
+      edition_params["first_published_at(5i)"] = ""
+    end
   end
 
   def clear_scheduled_publication_if_not_activated

--- a/test/functional/admin/legacy_publications_controller_test.rb
+++ b/test/functional/admin/legacy_publications_controller_test.rb
@@ -71,6 +71,7 @@ class Admin::LegacyPublicationsControllerTest < ActionController::TestCase
            edition: controller_attributes_for(
              :publication,
              first_published_at: Time.zone.parse("2001-10-21 00:00:00"),
+             previously_published: "true",
              publication_type_id: PublicationType::ResearchAndAnalysis.id,
            ),
          }

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -71,6 +71,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
            edition: controller_attributes_for(
              :publication,
              first_published_at: Time.zone.parse("2001-10-21 00:00:00"),
+             previously_published: "true",
              publication_type_id: PublicationType::ResearchAndAnalysis.id,
            ),
          }

--- a/test/support/admin_edition_controller_legacy_test_helpers.rb
+++ b/test/support/admin_edition_controller_legacy_test_helpers.rb
@@ -1122,7 +1122,7 @@ module AdminEditionControllerLegacyTestHelpers
         first_published_at = 3.months.ago
         post :create,
              params: {
-               edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago),
+               edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago, previously_published: "true"),
              }
 
         edition = edition_class.last

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -701,7 +701,7 @@ module AdminEditionControllerTestHelpers
         first_published_at = 3.months.ago
         post :create,
              params: {
-               edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago),
+               edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago, previously_published: "true"),
              }
 
         edition = edition_class.last
@@ -722,6 +722,21 @@ module AdminEditionControllerTestHelpers
 
         edition.reload
         assert_equal first_published_at, edition.first_published_at
+      end
+
+      test "updates first_published_at to nil when previously_published is false" do
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        first_published_at = 3.months.ago
+
+        patch :update, params: {
+          id: edition,
+          edition: {
+            previously_published: "false",
+            first_published_at:,
+          },
+        }
+
+        assert_nil edition.reload.first_published_at
       end
     end
 


### PR DESCRIPTION
## Description

At the moment, there's an issue with the first_published_at value not being set to nil when a user chooses 'This document has never been published before.' for the document status radios.

When you update the radio from previously published to not previously published the first_published_at params are still submitted on save. As these params are not cleaned before save they continue to be persisted on the edition.

## Trello card

https://trello.com/c/7O1ypSvX/145-document-status-conditional-field-cannot-be-changed

## Video of before & after

https://github.com/alphagov/whitehall/assets/42515961/50f56d0b-4680-47d3-85f2-c1ca332913aa


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
