### PR TITLE
Ensure promotional_features#confirm_delete uses correct layout

### DIFF
--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -65,8 +65,8 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[reorder update_order]
-    design_system_actions += %w[edit confirm_destroy index] if preview_design_system?(next_release: false)
+    design_system_actions = %w[reorder update_order confirm_destroy]
+    design_system_actions += %w[edit index] if preview_design_system?(next_release: false)
     if design_system_actions.include?(action_name)
       "design_system"
     else


### PR DESCRIPTION
## Description 

This page was recently added in the GOV.UK Design System. As it was built using the design system and doesn't have a legacy view built in Bootstrap, it should always use the 'design system' layout.

## Screenshots

without preview design system permission

### Before 

<img width="705" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/510a731d-dfd1-407d-835c-fdb69376e2d6">

### After

<img width="555" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/924c623f-a0e2-489c-8036-bc9005b1fdd0">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
