### PR TITLE
Develop updated connected documents functionality

### DIFF
--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -8,8 +8,21 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
     end
   end
 
-  private
+  def connect
+    @statistics_announcement.assign_attributes(publication_params)
+
+    @statistics_announcement.save
+
+    redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
+  end
+
+private
+
   def find_statistics_announcement
     @statistics_announcement = StatisticsAnnouncement.friendly.find(params[:statistics_announcement_id])
+  end
+
+  def publication_params
+    { publication_id: params[:publication_id] }
   end
 end

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -26,11 +26,11 @@ private
   end
 
   def get_editions
-    Edition.statistical_publications.with_title_containing(params[:search])
+    Edition.with_title_containing(params[:search])
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
+    params.slice(:page)
           .permit!
           .to_h
   end
@@ -40,15 +40,16 @@ private
   end
 
   def edition_filter_options
-    filter_options = params_filters_with_default_state
+    params_filters_with_default_state
                        .symbolize_keys
                        .merge(
                          include_unpublishing: true,
                          include_link_check_reports: true,
                          include_last_author: true,
+                         type: "publication",
+                         subtypes: @statistics_announcement.publication_type,
+                         per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
                        )
-
-    filter_options.merge(per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE)
   end
 
   def find_statistics_announcement

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -3,20 +3,27 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
   layout "design_system"
 
   def index
-    if params[:search].present?
-      @editions = Edition.statistical_publications.with_title_containing(params[:search])
-    end
+    get_editions
   end
 
   def connect
     @statistics_announcement.assign_attributes(publication_params)
 
-    @statistics_announcement.save
-
-    redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
+    if @statistics_announcement.save
+      redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
+    else
+      get_editions
+      render :index
+    end
   end
 
 private
+
+  def get_editions
+    if params[:search].present?
+      @editions = Edition.statistical_publications.with_title_containing(params[:search])
+    end
+  end
 
   def find_statistics_announcement
     @statistics_announcement = StatisticsAnnouncement.friendly.find(params[:statistics_announcement_id])

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -22,7 +22,11 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
 private
 
   def filter
-    @filter ||= Admin::EditionFilter.new(Edition, current_user, edition_filter_options)
+    @filter ||= Admin::EditionFilter.new(edition_scope, current_user, edition_filter_options)
+  end
+
+  def edition_scope
+    Edition.with_translations(I18n.locale)
   end
 
   def params_filters
@@ -39,9 +43,6 @@ private
     params_filters_with_default_state
                        .symbolize_keys
                        .merge(
-                         include_unpublishing: true,
-                         include_link_check_reports: true,
-                         include_last_author: true,
                          type: "publication",
                          subtypes: @statistics_announcement.publication_type,
                          per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -3,7 +3,9 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
   layout "design_system"
 
   def index
-    get_editions
+    if params[:search].present?
+      filter
+    end
   end
 
   def connect
@@ -12,17 +14,41 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
     if @statistics_announcement.save
       redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
     else
-      get_editions
+      filter
       render :index
     end
   end
 
 private
 
+  def filter
+    @filter ||= Admin::EditionFilter.new(get_editions, current_user, edition_filter_options)
+  end
+
   def get_editions
-    if params[:search].present?
-      @editions = Edition.statistical_publications.with_title_containing(params[:search])
-    end
+    Edition.statistical_publications.with_title_containing(params[:search])
+  end
+
+  def params_filters
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
+          .permit!
+          .to_h
+  end
+
+  def params_filters_with_default_state
+    params_filters.reverse_merge("state" => "active")
+  end
+
+  def edition_filter_options
+    filter_options = params_filters_with_default_state
+                       .symbolize_keys
+                       .merge(
+                         include_unpublishing: true,
+                         include_link_check_reports: true,
+                         include_last_author: true,
+                       )
+
+    filter_options.merge(per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE)
   end
 
   def find_statistics_announcement

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -1,0 +1,11 @@
+class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseController
+  before_action :find_statistics_announcement
+  layout "design_system"
+
+  def index; end
+
+  private
+  def find_statistics_announcement
+    @statistics_announcement = StatisticsAnnouncement.friendly.find(params[:statistics_announcement_id])
+  end
+end

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -2,7 +2,11 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
   before_action :find_statistics_announcement
   layout "design_system"
 
-  def index; end
+  def index
+    if params[:search].present?
+      @editions = Edition.statistical_publications.with_title_containing(params[:search])
+    end
+  end
 
   private
   def find_statistics_announcement

--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -3,7 +3,7 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
   layout "design_system"
 
   def index
-    if params[:search].present?
+    if params[:title].present?
       filter
     end
   end
@@ -22,15 +22,11 @@ class Admin::StatisticsAnnouncementPublicationsController < Admin::BaseControlle
 private
 
   def filter
-    @filter ||= Admin::EditionFilter.new(get_editions, current_user, edition_filter_options)
-  end
-
-  def get_editions
-    Edition.with_title_containing(params[:search])
+    @filter ||= Admin::EditionFilter.new(Edition, current_user, edition_filter_options)
   end
 
   def params_filters
-    params.slice(:page)
+    params.slice(:title, :page)
           .permit!
           .to_h
   end

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -93,7 +93,7 @@ private
     if attributes[:precision] == "exact_confirmed"
       attributes[:precision] = StatisticsAnnouncementDate::PRECISION[:exact]
       attributes[:confirmed] = true
-    else
+    elsif attributes[:confirmed].blank?
       attributes[:confirmed] = false
     end
   end

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -15,12 +15,13 @@
       } %>
     <% end %>
 
-    <% if @editions %>
-      <p class="govuk-table__caption--m"><%= @editions.length.to_s + " document".pluralize(@editions.length) %></p>
+    <% if @filter %>
+      <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
+      <hr class="govuk-section-break--m">
       <%= render "govuk_publishing_components/components/table", {
         id: 'table',
         rows:
-          @editions.map do |edition|
+          @filter.editions.map do |edition|
             [{
                text: edition.title
              },
@@ -31,7 +32,8 @@
                text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition, search: params[:search]) , class: "govuk-link")
              }]
           end
-    } %>
+      } %>
+      <%= paginate(@filter.editions, theme: "govuk_paginator") %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -3,7 +3,6 @@
 <% content_for :title, "Connect document" %>
 <% content_for :title_margin_bottom, 6 %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |form| %>
@@ -21,7 +20,12 @@
         id: 'table',
         rows:
           @editions.map do |edition|
-            [{text: edition.title}]
+            [{
+               text: edition.title
+             },
+             {
+               text: link_to("View", admin_edition_path(edition), class: "govuk-link")
+             }]
           end
     } %>
     <% end %>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -9,7 +9,7 @@
     <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |form| %>
       <%= render "govuk_publishing_components/components/search", {
         name: "search",
-        value: params[:search],
+        value: params[:title],
         label_text: "Search by title or slug",
         label_size: "l",
       } %>
@@ -29,7 +29,7 @@
                text: link_to("View", admin_edition_path(edition), class: "govuk-link")
              },
              {
-               text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition, search: params[:search]) , class: "govuk-link")
+               text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition, title: params[:title]) , class: "govuk-link")
              }]
           end
       } %>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -2,6 +2,7 @@
 <% content_for :context, @statistics_announcement.title %>
 <% content_for :title, "Connect document" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @statistics_announcement)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -27,7 +28,7 @@
                text: link_to("View", admin_edition_path(edition), class: "govuk-link")
              },
              {
-               text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition) , class: "govuk-link")
+               text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition, search: params[:search]) , class: "govuk-link")
              }]
           end
     } %>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -25,6 +25,9 @@
              },
              {
                text: link_to("View", admin_edition_path(edition), class: "govuk-link")
+             },
+             {
+               text: link_to("Connect", admin_statistics_announcement_publication_connect_path(@statistics_announcement, edition) , class: "govuk-link")
              }]
           end
     } %>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -2,8 +2,28 @@
 <% content_for :context, @statistics_announcement.title %>
 <% content_for :title, "Connect document" %>
 <% content_for :title_margin_bottom, 6 %>
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @statistics_announcement)) %>
 
-<%= render "govuk_publishing_components/components/search", {
-  name: "statistics_announcement[publication]"
-} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |form| %>
+      <%= render "govuk_publishing_components/components/search", {
+        name: "search",
+        value: params[:search],
+        label_text: "Search by title or slug",
+        label_size: "l",
+      } %>
+    <% end %>
+
+    <% if @editions %>
+      <p class="govuk-table__caption--m"><%= @editions.length.to_s + " document".pluralize(@editions.length) %></p>
+      <%= render "govuk_publishing_components/components/table", {
+        id: 'table',
+        rows:
+          @editions.map do |edition|
+            [{text: edition.title}]
+          end
+    } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, "Connect document" %>
+<% content_for :context, @statistics_announcement.title %>
+<% content_for :title, "Connect document" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @statistics_announcement)) %>
+
+<%= render "govuk_publishing_components/components/search", {
+  name: "statistics_announcement[publication]"
+} %>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |form| %>
+    <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |_form| %>
       <%= render "govuk_publishing_components/components/search", {
-        name: "search",
+        name: "title",
         value: params[:title],
         label_text: "Search by title or slug",
         label_size: "l",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,9 @@ Whitehall::Application.routes.draw do
           resource :tags, only: %i[edit update], controller: :statistics_announcement_tags
           resources :statistics_announcement_date_changes, as: "changes", path: "changes"
           resource :statistics_announcement_unpublishings, as: "unpublish", path: "unpublish", only: %i[new create]
-          resources :statistics_announcement_publications, as: "publication", path: "publication", only: %i[index]
+          resources :statistics_announcement_publications, as: "publication", path: "publication", only: %i[index] do
+            get "connect"
+          end
         end
 
         resources :suggestions, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Whitehall::Application.routes.draw do
           resource :tags, only: %i[edit update], controller: :statistics_announcement_tags
           resources :statistics_announcement_date_changes, as: "changes", path: "changes"
           resource :statistics_announcement_unpublishings, as: "unpublish", path: "unpublish", only: %i[new create]
+          resources :statistics_announcement_publications, as: "publication", path: "publication", only: %i[index]
         end
 
         resources :suggestions, only: [:index]

--- a/test/functional/admin/legacy_statistics_announcements_controller_test.rb
+++ b/test/functional/admin/legacy_statistics_announcements_controller_test.rb
@@ -80,7 +80,7 @@ class Admin::LegacyStatisticsAnnouncementsControllerTest < ActionController::Tes
              current_release_date_attributes: {
                release_date: 1.year.from_now,
                precision: StatisticsAnnouncementDate::PRECISION[:exact],
-               confirmed: "1"
+               confirmed: "1",
              },
            },
          }

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -3,16 +3,15 @@ require "test_helper"
 class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController::TestCase
   setup do
     @user = login_as_preview_design_system_user(:gds_editor)
-    @announcement = create(:statistics_announcement)
-    @statistics_publication = create(:published_statistics)
-    @generic_publication = create(:publication)
+    @official_statistics_announcement = create(:statistics_announcement)
+    @official_statistics_publication = create(:published_statistics)
     @search = "publication-title"
   end
 
   should_be_an_admin_controller
 
   view_test "GET :index with no search value renders search bar only" do
-    get :index, params: { statistics_announcement_id: @announcement }
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement }
 
     assert_response :success
     assert_select ".govuk-label"
@@ -20,28 +19,22 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     refute_select ".govuk-table"
   end
 
-  test "GET :index will only return statistical publications" do
-    Admin::EditionFilter.expects(:new).with([@statistics_publication], anything, anything)
-
-    get :index, params: { statistics_announcement_id: @announcement, search: @search }
-  end
-
   test "GET :index will filter by title containing search param" do
     create(:published_statistics, title: "something else")
 
-    Admin::EditionFilter.expects(:new).with([@statistics_publication], anything, anything)
+    Admin::EditionFilter.expects(:new).with([@official_statistics_publication], anything, anything)
 
-    get :index, params: { statistics_announcement_id: @announcement, search: @search }
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement, search: @search }
   end
 
   view_test "GET :index with search value renders paginated results" do
     editions = []
-    16.times { editions << @statistics_publication }
+    16.times { editions << @official_statistics_publication }
 
     stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
-    get :index, params: { statistics_announcement_id: @announcement, search: @search }
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement, search: @search }
 
     assert_response :success
     assert_template :index
@@ -54,17 +47,19 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   end
 
   test "GET :connect will add a document to a statistics announcement" do
-    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @statistics_publication }
+    get :connect, params: { statistics_announcement_id: @official_statistics_announcement, publication_id: @official_statistics_publication }
 
-    assert_equal @statistics_publication, @announcement.reload.publication
-    assert_redirected_to admin_statistics_announcement_path(@announcement)
+    assert_equal @official_statistics_publication, @official_statistics_announcement.reload.publication
+    assert_redirected_to admin_statistics_announcement_path(@official_statistics_announcement)
   end
 
   view_test "GET :connect will handle an error in adding not a statistics publication to statistics announcement" do
-    stub_filter = stub_edition_filter({ editions: [@statistics_publication], options: { per_page: 15 } })
+    @generic_publication = create(:publication)
+
+    stub_filter = stub_edition_filter({ editions: [@official_statistics_publication], options: { per_page: 15 } })
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
-    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @generic_publication, search: @search }
+    get :connect, params: { statistics_announcement_id: @official_statistics_announcement, publication_id: @generic_publication, search: @search }
 
     assert_response :success
     has_search_results_table
@@ -79,9 +74,9 @@ private
     assert_select ".govuk-heading-s", "1 document"
     assert_select ".govuk-table" do
       assert_select "tr", count: 1
-      assert_select "td", @statistics_publication.title
-      assert_select "a[href=?]", admin_publication_path(@statistics_publication), text: "View"
-      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication, search: @search), text: "Connect"
+      assert_select "td", @official_statistics_publication.title
+      assert_select "a[href=?]", admin_publication_path(@official_statistics_publication), text: "View"
+      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@official_statistics_announcement, @official_statistics_publication, search: @search), text: "Connect"
     end
   end
 

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -4,14 +4,29 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   setup do
     @user = login_as_preview_design_system_user(:gds_editor)
     @announcement = create(:statistics_announcement)
+    @statistics_publication = create(:published_statistics)
+    @generic_publication = create(:publication)
+    @search_string = "publication-title"
   end
 
   should_be_an_admin_controller
 
-  view_test "GET :new renders search bar" do
+  view_test "GET :index with no search value renders search bar only" do
     get :index, params: { statistics_announcement_id: @announcement }
 
     assert_response :success
-    assert_select "input[name='statistics_announcement[publication]']"
+    assert_select ".govuk-label"
+    assert_select "input[name='search']"
+    refute_select ".govuk-table"
+  end
+
+  view_test "GET :index with search value renders search bar and list of statistical publications only" do
+    get :index, params: { statistics_announcement_id: @announcement, search: "publication-title" }
+
+    assert_response :success
+    assert_select "input[name='search']"
+    assert_select "p", "1 document"
+    assert_select ".govuk-table"
+    assert_select "td", @statistics_publication.title
   end
 end

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     @announcement = create(:statistics_announcement)
     @statistics_publication = create(:published_statistics)
     @generic_publication = create(:publication)
-    @search_string = "publication-title"
+    @search = "publication-title"
   end
 
   should_be_an_admin_controller
@@ -20,11 +20,37 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     refute_select ".govuk-table"
   end
 
-  view_test "GET :index with search value renders search bar and list of statistical publications only" do
-    get :index, params: { statistics_announcement_id: @announcement, search: @search_string }
+  test "GET :index will only return statistical publications" do
+    Admin::EditionFilter.expects(:new).with([@statistics_publication], anything, anything)
+
+    get :index, params: { statistics_announcement_id: @announcement, search: @search }
+  end
+
+  test "GET :index will filter by title containing search param" do
+    create(:published_statistics, title: "something else")
+
+    Admin::EditionFilter.expects(:new).with([@statistics_publication], anything, anything)
+
+    get :index, params: { statistics_announcement_id: @announcement, search: @search }
+  end
+
+  view_test "GET :index with search value renders paginated results" do
+    editions = []
+    16.times { editions << @statistics_publication }
+
+    stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
+    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+
+    get :index, params: { statistics_announcement_id: @announcement, search: @search }
 
     assert_response :success
-    has_search_results_table
+    assert_template :index
+    assert_select "input[name='search']"
+    assert_select ".govuk-heading-s", "16 documents"
+    assert_select ".govuk-table" do
+      assert_select "tr", count: 15
+    end
+    assert_select "nav.govuk-pagination"
   end
 
   test "GET :connect will add a document to a statistics announcement" do
@@ -35,24 +61,39 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   end
 
   view_test "GET :connect will handle an error in adding not a statistics publication to statistics announcement" do
-    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @generic_publication, search: @search_string }
+    stub_filter = stub_edition_filter({ editions: [@statistics_publication], options: { per_page: 15 } })
+    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+
+    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @generic_publication, search: @search }
 
     assert_response :success
     has_search_results_table
     assert_select "ul.govuk-error-summary__list a[data-track-action='statistics announcement-error'][data-track-label=\"Publication type does not match: must be statistics\"]", text: "Publication type does not match: must be statistics"
   end
 
-  private
+private
 
   def has_search_results_table
     assert_template :index
     assert_select "input[name='search']"
-    assert_select ".govuk-table__caption--m", "1 document"
+    assert_select ".govuk-heading-s", "1 document"
     assert_select ".govuk-table" do
       assert_select "tr", count: 1
       assert_select "td", @statistics_publication.title
       assert_select "a[href=?]", admin_publication_path(@statistics_publication), text: "View"
-      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication, search: @search_string), text: "Connect"
+      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication, search: @search), text: "Connect"
     end
+  end
+
+  def stub_edition_filter(attributes = {})
+    default_attributes = {
+      editions: Kaminari.paginate_array(attributes[:editions] || [], limit: attributes[:options][:per_page]).page(1),
+      page_title: "",
+      edition_state: "",
+      valid?: true,
+      options: {},
+      hide_type: false,
+    }
+    stub("edition filter", default_attributes.merge(attributes.except(:editions)))
   end
 end

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -5,7 +5,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     @user = login_as_preview_design_system_user(:gds_editor)
     @official_statistics_announcement = create(:statistics_announcement)
     @official_statistics_publication = create(:published_statistics)
-    @search = "publication-title"
+    @title = "publication-title"
   end
 
   should_be_an_admin_controller
@@ -15,16 +15,8 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
 
     assert_response :success
     assert_select ".govuk-label"
-    assert_select "input[name='search']"
+    assert_select "input[name='title']"
     refute_select ".govuk-table"
-  end
-
-  test "GET :index will filter by title containing search param" do
-    create(:published_statistics, title: "something else")
-
-    Admin::EditionFilter.expects(:new).with([@official_statistics_publication], anything, anything)
-
-    get :index, params: { statistics_announcement_id: @official_statistics_announcement, search: @search }
   end
 
   view_test "GET :index with search value renders paginated results" do
@@ -34,11 +26,11 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
-    get :index, params: { statistics_announcement_id: @official_statistics_announcement, search: @search }
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement, title: @title }
 
     assert_response :success
     assert_template :index
-    assert_select "input[name='search']"
+    assert_select "input[name='title']"
     assert_select ".govuk-heading-s", "16 documents"
     assert_select ".govuk-table" do
       assert_select "tr", count: 15
@@ -59,7 +51,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     stub_filter = stub_edition_filter({ editions: [@official_statistics_publication], options: { per_page: 15 } })
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
-    get :connect, params: { statistics_announcement_id: @official_statistics_announcement, publication_id: @generic_publication, search: @search }
+    get :connect, params: { statistics_announcement_id: @official_statistics_announcement, publication_id: @generic_publication, title: @title }
 
     assert_response :success
     has_search_results_table
@@ -70,13 +62,13 @@ private
 
   def has_search_results_table
     assert_template :index
-    assert_select "input[name='search']"
+    assert_select "input[name='title']"
     assert_select ".govuk-heading-s", "1 document"
     assert_select ".govuk-table" do
       assert_select "tr", count: 1
       assert_select "td", @official_statistics_publication.title
       assert_select "a[href=?]", admin_publication_path(@official_statistics_publication), text: "View"
-      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@official_statistics_announcement, @official_statistics_publication, search: @search), text: "Connect"
+      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@official_statistics_announcement, @official_statistics_publication, title: @title), text: "Connect"
     end
   end
 

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController::TestCase
+  setup do
+    @user = login_as_preview_design_system_user(:gds_editor)
+    @announcement = create(:statistics_announcement)
+  end
+
+  should_be_an_admin_controller
+
+  view_test "GET :new renders search bar" do
+    get :index, params: { statistics_announcement_id: @announcement }
+
+    assert_response :success
+    assert_select "input[name='statistics_announcement[publication]']"
+  end
+end

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -21,24 +21,38 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   end
 
   view_test "GET :index with search value renders search bar and list of statistical publications only" do
-    get :index, params: { statistics_announcement_id: @announcement, search: "publication-title" }
+    get :index, params: { statistics_announcement_id: @announcement, search: @search_string }
 
     assert_response :success
-    assert_select "input[name='search']"
-    assert_select "p", "1 document"
-    assert_select ".govuk-table" do
-      assert_select "tr", count: 1
-      assert_select "td", @statistics_publication.title
-      assert_select "a[href=?]", admin_publication_path(@statistics_publication), text: "View"
-      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication), text: "Connect"
-    end
+    has_search_results_table
   end
 
   test "GET :connect will add a document to a statistics announcement" do
     get :connect, params: { statistics_announcement_id: @announcement, publication_id: @statistics_publication }
 
     assert_equal @statistics_publication, @announcement.reload.publication
-
     assert_redirected_to admin_statistics_announcement_path(@announcement)
+  end
+
+  view_test "GET :connect will handle an error in adding not a statistics publication to statistics announcement" do
+    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @generic_publication, search: @search_string }
+
+    assert_response :success
+    has_search_results_table
+    assert_select "ul.govuk-error-summary__list a[data-track-action='statistics announcement-error'][data-track-label=\"Publication type does not match: must be statistics\"]", text: "Publication type does not match: must be statistics"
+  end
+
+  private
+
+  def has_search_results_table
+    assert_template :index
+    assert_select "input[name='search']"
+    assert_select ".govuk-table__caption--m", "1 document"
+    assert_select ".govuk-table" do
+      assert_select "tr", count: 1
+      assert_select "td", @statistics_publication.title
+      assert_select "a[href=?]", admin_publication_path(@statistics_publication), text: "View"
+      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication, search: @search_string), text: "Connect"
+    end
   end
 end

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -6,6 +6,12 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     @official_statistics_announcement = create(:statistics_announcement)
     @official_statistics_publication = create(:published_statistics)
     @title = "publication-title"
+    @default_filter_params = {
+      state: "active",
+      type: "publication",
+      subtypes: @official_statistics_announcement.publication_type,
+      per_page: 15,
+    }
   end
 
   should_be_an_admin_controller
@@ -17,6 +23,14 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     assert_select ".govuk-label"
     assert_select "input[name='title']"
     refute_select ".govuk-table"
+  end
+
+  test "GET :index with search value passes title and default params to filter" do
+    default_filter_params_with_title = @default_filter_params.merge(title: @title)
+
+    Admin::EditionFilter.expects(:new).with([@official_statistics_publication], @user, default_filter_params_with_title)
+
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement, title: @title }
   end
 
   view_test "GET :index with search value renders paginated results" do

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -26,7 +26,19 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     assert_response :success
     assert_select "input[name='search']"
     assert_select "p", "1 document"
-    assert_select ".govuk-table"
-    assert_select "td", @statistics_publication.title
+    assert_select ".govuk-table" do
+      assert_select "tr", count: 1
+      assert_select "td", @statistics_publication.title
+      assert_select "a[href=?]", admin_publication_path(@statistics_publication), text: "View"
+      assert_select "a[href=?]", admin_statistics_announcement_publication_connect_path(@announcement, @statistics_publication), text: "Connect"
+    end
+  end
+
+  test "GET :connect will add a document to a statistics announcement" do
+    get :connect, params: { statistics_announcement_id: @announcement, publication_id: @statistics_publication }
+
+    assert_equal @statistics_publication, @announcement.reload.publication
+
+    assert_redirected_to admin_statistics_announcement_path(@announcement)
   end
 end

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -62,6 +62,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     assert_includes announcement.organisations, @organisation
     assert_equal @user, announcement.creator
     assert_equal "November 2012", announcement.display_date
+    assert_equal false, announcement.confirmed?
     assert_equal @user, announcement.current_release_date.creator
   end
 
@@ -86,6 +87,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     assert_includes announcement.organisations, @organisation
     assert_equal @user, announcement.creator
     assert_equal "11 November 2012 11:11am", announcement.display_date
+    assert_equal true, announcement.confirmed?
     assert_equal @user, announcement.current_release_date.creator
   end
 


### PR DESCRIPTION
## Description

This PR implements a new flow for the connection of documents to statistics announcements, incorporating the GOV.UK design system.

It has established two new routes:

* /government/admin/statistics_announcements/{statistics_announcement_slug}/publication
* /government/admin/statistics_announcements/{statistics_announcement_slug}/publication/{publication_id}/connect

Note, this flow is not yet fully implemented end to end, and will be completed as part of 'move the statistics announcement summary to design system' story.

In addition, it appears manual testing of the filtered results suggests some slightly odd behaviour, with un permitted documents being filtered out of the page results. As such some paginated sets have less than 15 results.

The PR does the following:

1. Add statistics announcements publication index page
2. Add basic document table, conditional rendering on search param being provided
3. Add view links to results table
4. Add connect links and functionality to results table
5. Add error handling to connect links functionality
6. Add pagination to search results

## Screenshots

#### Before search string entered
![whitehall-admin dev gov uk_government_admin_statistics_announcements_title--13_publication (1)](https://github.com/alphagov/whitehall/assets/91492293/13071407-770e-4efd-b64d-14190cbc90f5)

#### With search results
![whitehall-admin dev gov uk_government_admin_statistics_announcements_title--13_publication_search=transport](https://github.com/alphagov/whitehall/assets/91492293/13ccf28b-1f72-43ba-9e94-9ab279e6d581)

## Trello
https://trello.com/c/HNwwVfU0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
