### PR TITLE
Make worldwide offices publishable

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,7 +20,7 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  after_commit :republish_embassies_index_page_to_publishing_api
+  after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_office_to_publishing_api
 
   include TranslatableModel
   translates :title,
@@ -37,6 +37,10 @@ class Contact < ApplicationRecord
 
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
+  end
+
+  def republish_worldwide_office_to_publishing_api
+    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(WorldwideOffice)
   end
 
   def contactable_name

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -11,6 +11,8 @@ class WorldwideOffice < ApplicationRecord
 
   accepts_nested_attributes_for :contact
 
+  include PublishesToPublishingApi
+
   extend FriendlyId
   friendly_id :title, use: :scoped, scope: :worldwide_organisation
 
@@ -21,7 +23,7 @@ class WorldwideOffice < ApplicationRecord
   contact_methods = Contact.column_names +
     Contact::Translation.column_names +
     %w[contact_numbers country country_code country_name has_postal_address?] -
-    %w[id contactable_id contactable_type contact_id locale created_at updated_at]
+    %w[id contactable_id contactable_type contact_id locale created_at updated_at content_id]
 
   delegate(*contact_methods, to: :contact, allow_nil: true)
   delegate(:non_english_translated_locales, to: :worldwide_organisation)

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -59,7 +59,7 @@ class WorldwideOrganisation < ApplicationRecord
     end
   end
 
-  after_commit :republish_embassies_index_page_to_publishing_api
+  after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_offices
 
   # I'm trying to use a domain centric design rather than a persistence
   # centric design, so I do not want to expose a has_many :home_page_lists
@@ -138,5 +138,11 @@ class WorldwideOrganisation < ApplicationRecord
 
   def republish_embassies_index_page_to_publishing_api
     PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+  end
+
+  def republish_worldwide_offices
+    return if offices.blank?
+
+    offices.each { |office| Whitehall::PublishingApi.republish_async(office) }
   end
 end

--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -1,0 +1,47 @@
+module PublishingApi
+  class WorldwideOfficePresenter
+    attr_accessor :item, :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        title: item.worldwide_organisation.name,
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        details: {
+          access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(item.access_and_opening_times),
+        },
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "worldwide_office",
+      )
+
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+    end
+
+    def links
+      {
+        contact:,
+        parent: [item.worldwide_organisation.content_id],
+      }
+    end
+
+  private
+
+    def contact
+      return [] if item.contact.blank?
+
+      [item.contact.content_id]
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -42,6 +42,8 @@ module PublishingApiPresenters
         PublishingApi::WorldLocationNewsPresenter
       when ::WorldwideOrganisation
         PublishingApi::WorldwideOrganisationPresenter
+      when ::WorldwideOffice
+        PublishingApi::WorldwideOfficePresenter
       when ::Contact
         PublishingApi::ContactPresenter
       when OperationalField

--- a/db/migrate/20230515120104_add_content_id_to_worldwide_offices.rb
+++ b/db/migrate/20230515120104_add_content_id_to_worldwide_offices.rb
@@ -1,0 +1,7 @@
+class AddContentIdToWorldwideOffices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :worldwide_offices, :content_id, :string
+
+    WorldwideOffice.all.each { |office| office.update!(content_id: SecureRandom.uuid) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_05_150919) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_15_120104) do
   create_table "access_and_opening_times", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.string "accessible_type"
@@ -1137,6 +1137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_05_150919) do
     t.integer "worldwide_office_type_id", null: false
     t.string "slug"
     t.text "access_and_opening_times"
+    t.string "content_id"
     t.index ["slug"], name: "index_worldwide_offices_on_slug"
     t.index ["worldwide_organisation_id"], name: "index_worldwide_offices_on_worldwide_organisation_id"
   end

--- a/test/factories/worldwide_offices.rb
+++ b/test/factories/worldwide_offices.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       title { "Contact title" }
     end
     sequence(:slug) { |index| "worldwide-office-#{index}" }
+    content_id { SecureRandom.uuid }
     contact { create :contact_with_country, title: }
     worldwide_organisation
     worldwide_office_type_id { WorldwideOfficeType.all.sample.id }

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
          }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation)
-    assert_equal 1, worldwide_organisation.offices.count
+    assert_equal 1, worldwide_organisation.reload.offices.count
     assert_equal "Main office", worldwide_organisation.offices.first.contact.title
   end
 
@@ -43,7 +43,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
            worldwide_organisation_id: worldwide_organisation.id,
          }
 
-    new_office = worldwide_organisation.offices.last
+    new_office = worldwide_organisation.reload.offices.last
     assert_equal "Main office", new_office.contact.title
     assert worldwide_organisation.office_shown_on_home_page?(new_office)
   end
@@ -64,7 +64,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
            worldwide_organisation_id: worldwide_organisation.id,
          }
 
-    new_office = worldwide_organisation.offices.last
+    new_office = worldwide_organisation.reload.offices.last
     assert_equal "Main office", new_office.contact.title
     assert_not worldwide_organisation.office_shown_on_home_page?(new_office)
   end
@@ -84,7 +84,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
            worldwide_organisation_id: worldwide_organisation.id,
          }
 
-    new_office = worldwide_organisation.offices.last
+    new_office = worldwide_organisation.reload.offices.last
     assert_equal "Main office", new_office.contact.title
     assert_not worldwide_organisation.office_shown_on_home_page?(new_office)
   end
@@ -107,7 +107,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
            worldwide_organisation_id: worldwide_organisation.id,
          }
 
-    assert_equal 1, worldwide_organisation.offices.count
+    assert_equal 1, worldwide_organisation.reload.offices.count
     assert_equal [service1, service2], worldwide_organisation.offices.first.services.sort_by(&:id)
   end
 
@@ -130,6 +130,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
          }
 
     actual_numbers = worldwide_organisation
+                       .reload
                        .offices
                        .first
                        .contact
@@ -196,7 +197,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
         }
 
     assert_equal "Head office", office.reload.contact.title
-    assert_not worldwide_organisation.office_shown_on_home_page?(office)
+    assert_not worldwide_organisation.reload.office_shown_on_home_page?(office)
   end
 
   test "put update updates an office without changing the home page state if no suggestion made" do
@@ -300,7 +301,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)
     assert_equal %("#{office.title}" removed from home page successfully), flash[:notice]
-    assert_not worldwide_organisation.office_shown_on_home_page?(office)
+    assert_not worldwide_organisation.reload.office_shown_on_home_page?(office)
   end
 
   test "POST on :add_to_home_page adds office to the home page of the worldwide organisation" do

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -180,4 +180,28 @@ class ContactTest < ActiveSupport::TestCase
 
     contact.destroy!
   end
+
+  test "republishes worldwide office on creation of related contact" do
+    worldwide_office = create(:worldwide_office)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
+
+    create(:contact, contactable: worldwide_office)
+  end
+
+  test "republishes worldwide office on update of related contact" do
+    worldwide_office = create(:worldwide_office)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
+
+    worldwide_office.contact.update!(locality: "new-locality")
+  end
+
+  test "republishes worldwide office on deletion of related contact" do
+    worldwide_office = create(:worldwide_office)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
+
+    worldwide_office.contact.destroy!
+  end
 end

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -158,7 +158,7 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
   test "it includes contact details for international delegation" do
     world_location_news = build(:world_location_news)
     world_location = create(:international_delegation, :with_worldwide_organisations, world_location_news:)
-    create(:worldwide_office, worldwide_organisation: world_location.worldwide_organisations.first)
+    create(:worldwide_office, worldwide_organisation: world_location.worldwide_organisations.first.reload)
 
     presented_links = present(world_location_news).links
 

--- a/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
+  def present(...)
+    PublishingApi::WorldwideOfficePresenter.new(...)
+  end
+
+  test "presents a Worldwide Office ready for adding to the publishing API" do
+    access_and_opening_times = "## About us\r\n\r\nVisit our [profile page](https://www.gov.uk/government/world/organisations/british-consulate-general-atlanta)"
+    worldwide_office = create(:worldwide_office, access_and_opening_times:)
+    public_path = worldwide_office.public_path
+
+    expected_hash = {
+      base_path: public_path,
+      title: worldwide_office.worldwide_organisation.name,
+      schema_name: "worldwide_office",
+      document_type: "worldwide_office",
+      locale: "en",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: "whitehall-frontend",
+      public_updated_at: worldwide_office.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      details: {
+        access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_office.access_and_opening_times),
+      },
+      update_type: "major",
+    }
+
+    expected_links = {
+      contact: [
+        worldwide_office.contact.content_id,
+      ],
+      parent: [
+        worldwide_office.worldwide_organisation.content_id,
+      ],
+    }
+
+    presented_item = present(worldwide_office)
+
+    assert_equal expected_hash, presented_item.content
+    assert_hash_includes presented_item.links, expected_links
+    assert_equal "major", presented_item.update_type
+    assert_equal worldwide_office.content_id, presented_item.content_id
+
+    assert_valid_against_publisher_schema(presented_item.content, "worldwide_office")
+    assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_office")
+  end
+end

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -76,7 +76,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         worldwide_org.corporate_information_pages[4].content_id,
       ],
       ordered_contacts: [
-        worldwide_org.offices.first.contact.content_id,
+        worldwide_org.reload.offices.first.contact.content_id,
       ],
       sponsoring_organisations: [
         worldwide_org.sponsoring_organisations.first.content_id,

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -357,4 +357,21 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     organisation.destroy!
   end
+
+  test "republishes related offices on change" do
+    organisation = create(:worldwide_organisation, :with_office)
+    organisation.reload
+
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation.offices.first).once
+
+    organisation.update!(default_access_and_opening_times: "new access and opening times")
+  end
+
+  test "does not try to republish offices when there are none" do
+    organisation = create(:worldwide_organisation)
+
+    Whitehall::PublishingApi.expects(:republish_async).never
+
+    organisation.update!(default_access_and_opening_times: "new access and opening times")
+  end
 end


### PR DESCRIPTION
> After this is merged we could do with running a task to republish all Offices `rake publishing_api:bulk_republish:document_type["WorldwideOffice"]
`

https://trello.com/c/CUp57yUx

### Add WorldwideOffice presenter
We have added a new content item for Worldwide Offices.

This adds a presenter for Worldwide Offices so that they can be published to
the Publishing API.

### Add `content_id` to Worldwide Offices
Worldwide Offices are currently rendered by Whitehall.

This adds a `content_id` column to the `worldwide_offices` table, and generates
a random UUID for existing Offices.

### Make Worldwide Office publishable
Worldwide Offices have been updated to have a `content_id` and Publishing API
presenter.

This includes the PublishesToPublishingApi module, so that Worldwide Offices
are published when changed.

The WorldwideOffice model currently delegates a bunch of methods to it's
related Contact. We need to add `content_id` to the list of excluded methods so
that the presenter is calling the method on the correct model.

### Republish Worldwide Offices when related Contacts change
The content item for Worldwide Offices contains a link to a related Contact. We
need to republish the content item if a related Contact is created or deleted
to ensure that the links from the office are current.

### Republish related Offices when Worldwide Organisations are changed
We want to make sure Worldwide Offices are republished when their parent
Worldwide Organisation changes. This will ensure any changes to default access
and opening times will be reflected in the offices that use them.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
