### PR TITLE
Remove all remaining uses of `UrlMaker`

### DIFF
--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -1,4 +1,6 @@
 class FileAttachment < Attachment
+  include Rails.application.routes.url_helpers
+
   extend FriendlyId
   include HasContentId
   friendly_id { |config| config.routes = false }
@@ -58,10 +60,12 @@ private
 
   def preview_url
     if csv? && attachable.is_a?(Edition)
-      Whitehall.url_maker.csv_preview_url(
+      csv_preview_url(
         id: attachment_data.id,
         file: filename_without_extension,
         extension: file_extension,
+        host: Whitehall.public_host,
+        protocol: Whitehall.public_protocol,
       )
     end
   end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -50,4 +50,16 @@ class WorldwideOffice < ApplicationRecord
   def republish_embassies_index_page_to_publishing_api
     PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
   end
+
+  def base_path
+    "/world/organisations/#{worldwide_organisation.slug}/office/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
+  end
 end

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -5,7 +5,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       title: model.name,
       format: "Worldwide Organisation",
       updated_at: model.updated_at,
-      web_url: Whitehall.url_maker.worldwide_organisation_url(model),
+      web_url: model.public_url,
       details: {
         slug: model.slug,
       },
@@ -47,7 +47,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       title: office_worldwide_organisation.contact.title,
       format: "World Office",
       updated_at: office_worldwide_organisation.updated_at,
-      web_url: Whitehall.url_maker.worldwide_organisation_worldwide_office_url(model, office_worldwide_organisation),
+      web_url: office_worldwide_organisation.public_url,
       details: {
         email: office_worldwide_organisation.contact.email || "",
         description: office_worldwide_organisation.contact.comments || "",

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -1,4 +1,7 @@
 class DocumentListExportPresenter
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
   attr_accessor :edition
 
   def initialize(edition)
@@ -62,7 +65,7 @@ class DocumentListExportPresenter
   delegate :public_url, to: :edition
 
   def admin_url
-    Whitehall.url_maker.admin_edition_url(edition)
+    admin_edition_url(edition)
   end
 
   def first_published_on_govuk

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -288,9 +288,8 @@ module PublishingApi
         new(consultation).call
       end
 
-      def initialize(consultation, url_helpers: Whitehall.url_maker)
+      def initialize(consultation)
         self.consultation = consultation
-        self.url_helpers = url_helpers
       end
 
       def call
@@ -310,7 +309,7 @@ module PublishingApi
 
     private
 
-      attr_accessor :consultation, :url_helpers
+      attr_accessor :consultation
 
       delegate :consultation_participation, to: :consultation
       delegate :consultation_response_form, to: :participation

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -111,11 +111,9 @@ module PublishingApi
       end
 
       def initialize(corporate_information_page,
-                     context = ActionController::Base,
-                     url_maker = Whitehall.url_maker)
+                     context = ActionController::Base)
         self.context = context
         self.corporate_information_page = corporate_information_page
-        self.url_maker = url_maker
       end
 
       def call
@@ -129,7 +127,7 @@ module PublishingApi
 
     private
 
-      attr_accessor :context, :corporate_information_page, :url_maker
+      attr_accessor :context, :corporate_information_page
 
       delegate :helpers, to: :context
       delegate :owning_organisation, to: :corporate_information_page

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -22,11 +22,7 @@ module PublishingApi
     private
 
       def base_path
-        @base_path ||= if item.respond_to?(:public_path)
-                         item.public_path(locale: I18n.locale)
-                       else
-                         Whitehall.url_maker.polymorphic_path(item)
-                       end
+        @base_path ||= item.public_path(locale: I18n.locale)
       end
     end
   end

--- a/app/services/author_notifier_service.rb
+++ b/app/services/author_notifier_service.rb
@@ -1,4 +1,7 @@
 class AuthorNotifierService
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
   attr_accessor :edition, :excluded_authors
 
   def self.call(edition, *excluded_authors)
@@ -31,7 +34,7 @@ class AuthorNotifierService
   end
 
   def edition_admin_url
-    Whitehall.url_maker.admin_edition_url(edition)
+    admin_edition_url(edition)
   end
 
   def public_document_url

--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -1,4 +1,7 @@
 class LinkReporterCsvService
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
   def initialize(reports_dir:, organisation: nil)
     @organisation = organisation
     @reports_dir = reports_dir
@@ -58,7 +61,7 @@ private
   end
 
   def admin_url(edition)
-    Whitehall.url_maker.admin_edition_url(edition, host: admin_host, protocol: "https")
+    admin_edition_url(edition, host: admin_host, protocol: "https")
   end
 
   def timestamp(edition)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -30,7 +30,7 @@ namespace :export do
             edition.id,
             edition.title,
             edition.state,
-            Whitehall.url_maker.admin_edition_url(edition),
+            admin_edition_url(edition),
             *edition.authors.uniq.map(&:name),
           ]
         end
@@ -69,7 +69,7 @@ namespace :export do
           csv << [
             org.display_name,
             edition.public_url,
-            Whitehall.url_maker.admin_edition_url(edition),
+            admin_edition_url(edition),
             edition.title,
             edition.display_type,
             edition.public_timestamp,

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -3,7 +3,6 @@ module Whitehall
   autoload :RandomKey, "whitehall/random_key"
   autoload :FormBuilder, "whitehall/form_builder"
   autoload :Uploader, "whitehall/uploader"
-  autoload :UrlMaker, "whitehall/url_maker"
   autoload :ExtraQuoteRemover, "whitehall/extra_quote_remover"
   autoload :GovspeakRenderer, "whitehall/govspeak_renderer"
 
@@ -183,10 +182,6 @@ module Whitehall
 
   def self.rummager_work_queue_name
     "rummager-delayed-indexing"
-  end
-
-  def self.url_maker
-    @url_maker ||= Whitehall::UrlMaker.new(host: Whitehall.public_host, protocol: Whitehall.public_protocol)
   end
 
   def self.atom_feed_maker

--- a/script/content-operating-model-report
+++ b/script/content-operating-model-report
@@ -51,7 +51,6 @@ def document_format(edition)
   end
 end
 
-url_maker = Whitehall.url_maker
 CSV.open(output_filename, "w") do |csv|
   csv << ["URL", "Organisation", "First published on GOV.UK", "Format", "Status", "Timestamp of last state change"]
   Organisation.ordered_by_name_ignoring_prefix.each do |org|
@@ -59,7 +58,7 @@ CSV.open(output_filename, "w") do |csv|
       sorted_editions = editions.sort_by(&:lock_version)
       latest_edition = sorted_editions.last
       csv << [
-        url_maker.public_document_url(latest_edition),
+        latest_edition.public_url,
         org.name,
         first_published(sorted_editions),
         document_format(latest_edition),

--- a/test/factories/worldwide_offices.rb
+++ b/test/factories/worldwide_offices.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       title { "Contact title" }
     end
+    sequence(:slug) { |index| "worldwide-office-#{index}" }
     contact { create :contact_with_country, title: }
     worldwide_organisation
     worldwide_office_type_id { WorldwideOfficeType.all.sample.id }

--- a/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController::TestCase
   include TaxonomyHelper
   tests Admin::GenericEditionsController
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
 
   setup do
     login_as :writer
@@ -42,7 +44,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
 
     get :show, params: { id: new_draft }
 
-    assert_select ".app-c-inset-prompt a", text: "Go to published edition", href: Whitehall.url_maker.admin_edition_path(original_edition)
+    assert_select ".app-c-inset-prompt a", text: "Go to published edition", href: admin_edition_path(original_edition)
   end
 
   view_test "show for a published edition links to a new draft" do
@@ -52,6 +54,6 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
 
     get :show, params: { id: original_edition }
 
-    assert_select ".app-c-inset-prompt a", text: "Go to draft", href: Whitehall.url_maker.admin_edition_path(new_draft)
+    assert_select ".app-c-inset-prompt a", text: "Go to draft", href: admin_edition_path(new_draft)
   end
 end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class CorporateInformationPagesControllerTest < ActionController::TestCase
+  include Rails.application.routes.url_helpers
+
   should_be_a_public_facing_controller
 
   view_test "show renders the summary as plain text" do
@@ -99,7 +101,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
   test "finds unpublishing for a corporate information page" do
     organisation = create(:organisation)
     cip = create(:corporate_information_page, :unpublished, organisation:)
-    alternative_url = Whitehall.url_maker.root_url
+    alternative_url = Plek.website_root
     cip.unpublishing.update!(redirect: true, slug: cip.slug, alternative_url:)
 
     get :show, params: { organisation_id: cip.organisation, id: cip.slug }
@@ -111,8 +113,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     organisation2 = create(:organisation, slug: "another_organisation")
     cip = create(:corporate_information_page, :unpublished, organisation:)
-    alternative_url = Whitehall.url_maker.root_url
-    cip.unpublishing.update!(redirect: true, slug: cip.slug, alternative_url:)
+    cip.unpublishing.update!(redirect: true, slug: cip.slug, alternative_url: Plek.website_root)
     draft_cip = create(:corporate_information_page, organisation: organisation2)
 
     # Even though the Unpublishing has the same slug as the draft CIP, we should

--- a/test/unit/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/govspeak/admin_link_replacer_test.rb
@@ -2,6 +2,9 @@ require "test_helper"
 
 module Govspeak
   class AdminLinkReplacerTest < ActiveSupport::TestCase
+    include Rails.application.routes.url_helpers
+    include Admin::EditionRoutesHelper
+
     test "rewrites admin links for published editions" do
       speech     = create(:published_speech)
       public_url = speech.public_url
@@ -14,7 +17,7 @@ module Govspeak
 
     test "unpublished edition links are replaced with plain text" do
       draft_speech = create(:draft_speech)
-      _admin_path  = Whitehall.url_maker.admin_speech_path(draft_speech)
+      _admin_path  = admin_speech_path(draft_speech)
       fragment     = govspeak_to_nokogiri_fragment("this is an [unpublished thing](/government/admin/speeches/#{draft_speech.id})")
 
       AdminLinkReplacer.new(fragment).replace!
@@ -25,7 +28,7 @@ module Govspeak
 
     test "rewrites admin links to published corporate information pages" do
       cip        = create(:published_corporate_information_page)
-      admin_path = Whitehall.url_maker.polymorphic_path([:admin, cip.organisation, cip])
+      admin_path = polymorphic_path([:admin, cip.organisation, cip])
       public_url = cip.public_url
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to an [info page](#{admin_path})")
 
@@ -37,7 +40,7 @@ module Govspeak
     test "handles cips on world orgs" do
       world_org  = create(:worldwide_organisation)
       cip        = create(:published_corporate_information_page, organisation: nil, worldwide_organisation: world_org)
-      admin_path = Whitehall.url_maker.polymorphic_path([:admin, world_org, cip])
+      admin_path = polymorphic_path([:admin, world_org, cip])
       public_url = cip.public_url
       fragment   = govspeak_to_nokogiri_fragment("Here is a link to a [world info page](#{admin_path})")
 

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -72,7 +72,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public world organisations url as web_url" do
-    assert_equal Whitehall.url_maker.worldwide_organisation_url(@world_org), @presenter.as_json[:web_url]
+    assert_equal @world_org.public_url, @presenter.as_json[:web_url]
   end
 
   test "json includes office sponsoring org name in sponsors array as title" do
@@ -95,7 +95,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public office url in offices as web_url" do
-    assert_equal Whitehall.url_maker.worldwide_organisation_worldwide_office_url(@world_org, @office), @presenter.as_json[:offices][:main][:web_url]
+    assert_equal @office.public_url, @presenter.as_json[:offices][:main][:web_url]
   end
 
   test "json includes office contact comments in offices as description" do

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -134,14 +134,12 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
       :worldwide_office,
       contact: stub_translatable_record(:contact, title: "best-office", contact_numbers: []),
       services: [],
-      worldwide_organisation: nil,
       access_and_opening_times: "never",
     )
     office2 = stub_record(
       :worldwide_office,
       contact: stub_translatable_record(:contact, title: "worst-office", contact_numbers: []),
       services: [],
-      worldwide_organisation: nil,
       access_and_opening_times: "never",
     )
 

--- a/test/unit/presenters/publishing_api/payload_builder/polymorphic_path_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/polymorphic_path_test.rb
@@ -3,15 +3,12 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class PolymorphicPathTest < ActiveSupport::TestCase
-      test "returns political details for the item" do
-        dummy_item = Object.new
-        Whitehall.url_maker.expects(:polymorphic_path)
-          .with(dummy_item)
-          .returns("/polymorphic/doc/path")
+      test "returns routes for the item" do
+        dummy_item = create(:news_article)
 
         expected_hash = {
-          base_path: "/polymorphic/doc/path",
-          routes: [{ path: "/polymorphic/doc/path", type: "exact" }],
+          base_path: "/government/news/news-title",
+          routes: [{ path: "/government/news/news-title", type: "exact" }],
         }
 
         assert_equal PolymorphicPath.for(dummy_item), expected_hash

--- a/test/unit/services/link_reporter_csv_service_test.rb
+++ b/test/unit/services/link_reporter_csv_service_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
 
 class LinkReporterCsvServiceTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
   # Tests are run in parallel. Any shared resources (like files) which the
   # tests use need to be managed carefully. For example the setup method
   # creates a directory, and the teardown method removes it - it's important
@@ -79,14 +82,14 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     hmrc_csv = CSV.read(reports_dir_pathname.join("hm-revenue-customs_links_report.csv"))
     assert_equal 3, hmrc_csv.size
     assert_equal [detailed_guide.public_url,
-                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{admin_detailed_guide_path(detailed_guide)}",
                   detailed_guide.public_timestamp.to_s,
                   "DetailedGuide",
                   "2",
                   "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
     assert_equal [publication.public_url,
-                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{admin_publication_path(publication)}",
                   publication.public_timestamp.to_s,
                   "Publication",
                   "1",
@@ -152,15 +155,15 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     LinkReporterCsvService.new(reports_dir:, organisation: hmrc).generate
     hmrc_csv = CSV.read(reports_dir_pathname.join("hm-revenue-customs_links_report.csv"))
     assert_equal 2, hmrc_csv.size
-    assert_equal ["https://www.test.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
-                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+    assert_equal ["https://www.test.gov.uk#{detailed_guide.public_path}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{admin_detailed_guide_path(detailed_guide)}",
                   detailed_guide.public_timestamp.to_s,
                   "DetailedGuide",
                   "2",
                   "https://www.test.gov.uk/bad-link\r\nhttps://www.test.gov.uk/missing-link"],
                  hmrc_csv[1]
     assert_not_equal [publication.public_url,
-                      "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                      "https://whitehall-admin.publishing.service.gov.uk#{admin_publication_path(publication)}",
                       publication.public_timestamp.to_s,
                       "Publication",
                       "0",
@@ -190,7 +193,7 @@ class LinkReporterCsvServiceTest < ActiveSupport::TestCase
     assert_equal 2, csv.size
     assert_equal ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"], csv[0]
     assert_equal [speech.public_url,
-                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{admin_speech_path(speech)}",
                   speech.public_timestamp.to_s,
                   "Speech",
                   "1",

--- a/test/unit/whitehall/admin_link_lookup_test.rb
+++ b/test/unit/whitehall/admin_link_lookup_test.rb
@@ -2,6 +2,9 @@ require "test_helper"
 
 module Whitehall
   class AdminLinkLookupTest < ActiveSupport::TestCase
+    include Rails.application.routes.url_helpers
+    include Admin::EditionRoutesHelper
+
     test "finds published edition" do
       speech = create(:published_speech)
 
@@ -12,7 +15,7 @@ module Whitehall
 
     test "finds corporate information page" do
       cip = create(:published_corporate_information_page)
-      admin_path = Whitehall.url_maker.polymorphic_path([:admin, cip.organisation, cip])
+      admin_path = polymorphic_path([:admin, cip.organisation, cip])
 
       edition = AdminLinkLookup.find_edition(admin_path)
 
@@ -22,7 +25,7 @@ module Whitehall
     test "finds worldwide corporate information page" do
       world_org = create(:worldwide_organisation)
       cip = create(:published_corporate_information_page, organisation: nil, worldwide_organisation: world_org)
-      admin_path = Whitehall.url_maker.polymorphic_path([:admin, world_org, cip])
+      admin_path = polymorphic_path([:admin, world_org, cip])
 
       edition = AdminLinkLookup.find_edition(admin_path)
 


### PR DESCRIPTION
We have updated all models to know their own routes (through the `public_path` and `public_url` methods), with an aim to removing the "magic" that was previously used to determine the public path of a document.

This removes all remaining use of `UrlMaker` from the application.

`UrlMaker` (and it's associated code) will be removed in a later PR.

[Trello card](https://trello.com/c/Fs7mTsmi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
