### PR TITLE
Added new summary card component and documentation.

### DIFF
--- a/app/views/components/_summary_card_component.html.erb
+++ b/app/views/components/_summary_card_component.html.erb
@@ -1,0 +1,41 @@
+<%
+  id ||= nil
+  data_attributes ||= {}
+  summary_card_actions ||= []
+  rows ||=[]
+%>
+<%= tag.div class: "app-c-summary-card-component", id: id, data: data_attributes do %>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title"><%= title %></h2>
+      <ul class="govuk-summary-card__actions">
+        <% summary_card_actions.each do |action| %>
+          <li class="govuk-summary-card__action">
+            <%= link_to sanitize(action[:label] + tag.span(" #{title}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state #{"gem-link--destructive govuk-!-font-weight-bold" if action[:destructive]}".strip %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <% rows.each do |row| %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= row[:key] %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= row[:value] %>
+            </dd>
+            <% if row[:actions].present? %>
+              <dd class="govuk-summary-list__actions">
+                <% row[:actions].each do |action| %>
+                  <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2 #{"gem-link--destructive" if action[:destructive]}".strip %>
+                <% end %>
+              </dd>
+            <% end %>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+<%end %>

--- a/app/views/components/docs/summary_card_component.yml
+++ b/app/views/components/docs/summary_card_component.yml
@@ -1,0 +1,94 @@
+name: Summary Card Component
+description: An extension of Summary List Component
+accessibility_criteria: |
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+        - key: key two
+          value: value2
+  with_custom-id:
+    data:
+      id: custom_id
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+        - key: key two
+          value: value2
+  with_tracking:
+    data:
+      data_attributes:
+        tracking: GTM-123AB
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+        - key: key two
+          value: value2
+  with_actions:
+    data:
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+        - key: key two
+          value: value2
+      summary_card_actions:
+        - label: View
+          href: "#1"
+        - label: Edit
+          href: "#2"
+  with_destructive_action:
+    data:
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+        - key: key two
+          value: value2
+      summary_card_actions:
+        - label: Delete
+          href: "#1"
+          destructive: true
+
+  with_row_actions:
+    data:
+      title: Title
+      rows:
+        - key: key one
+          value: value1
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+        - key: key two
+          value: value2
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+  with_row_destructive_action:
+    data:
+      title: Title
+      rows:
+        - key: key
+          value: value
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+            - label: Delete
+              href: "#3"
+              destructive: true
+


### PR DESCRIPTION
GOV UK design system recently added the Summary Card Component. We decided to use the same during the transition.
This adds the relevant component with documentation.
This will be used for promotional feature item index page transition.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/bfd97226-abbb-4b85-9b9e-2f416d6b6107)
![image](https://github.com/alphagov/whitehall/assets/131259138/eb836766-c52e-4d44-a4f5-36a3d6ecb0e0)
![image](https://github.com/alphagov/whitehall/assets/131259138/f4fc1928-57cf-4e5d-96e0-a27b720f4b3f)
![image](https://github.com/alphagov/whitehall/assets/131259138/2a83e8e0-f654-493f-9c1f-d497eb161807)
![image](https://github.com/alphagov/whitehall/assets/131259138/2b922705-12fd-4c29-b1e9-c59ed3d11047)
![image](https://github.com/alphagov/whitehall/assets/131259138/8e14cd85-e84f-4cab-a125-fdad69e7a66c)
![image](https://github.com/alphagov/whitehall/assets/131259138/6e0e06f4-6da8-411f-8c8e-575f970da0ea)
![image](https://github.com/alphagov/whitehall/assets/131259138/20890fc0-253a-41a8-a2cc-0f8fb93d37b8)

**Trello:**
https://trello.com/c/G7epREYd/156-add-summary-card-component





