### PR TITLE
Allow html to be passed into select-with-search component

### DIFF
--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -18,7 +18,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     this.choices = new window.Choices(this.select, {
-      allowHTML: false,
+      allowHTML: true,
       searchPlaceholderValue: 'Search in list',
       shouldSort: false // show options and groups in the order they were given
     })


### PR DESCRIPTION
## Description 


Without this option text is presented as textContent so we see sanitised output.

This has caused some bugs on various pages where organisations are passed in some of which include '&' which is presented as &amp;.

![image](https://github.com/alphagov/whitehall/assets/42515961/a838ece1-79d9-407f-b06d-c38d223fab64)

This module only consumes options generated by Rails which have been sanitised by default which rules out xss vulnerabilities.

## Trello card

https://trello.com/c/PgchG5iR/143-fix-the-in-fcdo-pick-list-shown-on-the-documents-page-and-when-editing-an-edition

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
