### PR TITLE
Remove Embassies index from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Whitehall is deployed in two modes:
 ### World Information
 
 - Help and services around the world: [https://www.gov.uk/world](https://www.gov.uk/world)
-- World Embassies list: [https://www.gov.uk/world/embassies](https://www.gov.uk/world/embassies)
 - Worldwide Organisation pages: [https://www.gov.uk/world/organisations/british-embassy-paris](https://www.gov.uk/world/organisations/british-embassy-paris)
 
 ## Running the Application


### PR DESCRIPTION
This is now rendered by Collections, so can be removed from the list of content still rendered by Whitehall.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
