### PR TITLE
Fix legacy create statistics announcement confirmed date bug

### DIFF
--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -93,7 +93,7 @@ private
     if attributes[:precision] == "exact_confirmed"
       attributes[:precision] = StatisticsAnnouncementDate::PRECISION[:exact]
       attributes[:confirmed] = true
-    else
+    elsif attributes[:confirmed].blank?
       attributes[:confirmed] = false
     end
   end

--- a/test/functional/admin/legacy_statistics_announcements_controller_test.rb
+++ b/test/functional/admin/legacy_statistics_announcements_controller_test.rb
@@ -43,7 +43,7 @@ class Admin::LegacyStatisticsAnnouncementsControllerTest < ActionController::Tes
     assert_response :success
   end
 
-  test "POST :create saves the announcement to the database and redirects to the dashboard" do
+  test "POST :create saves the announcement to the database and redirects to the dashboard with provisional date" do
     post :create,
          params: {
            statistics_announcement: {
@@ -65,6 +65,33 @@ class Admin::LegacyStatisticsAnnouncementsControllerTest < ActionController::Tes
     assert_includes announcement.organisations, @organisation
     assert_equal @user, announcement.creator
     assert_equal "November 2012", announcement.display_date
+    assert_equal false, announcement.confirmed?
+    assert_equal @user, announcement.current_release_date.creator
+  end
+
+  test "POST :create saves the announcement to the database and redirects to the dashboard with confirmed date" do
+    post :create,
+         params: {
+           statistics_announcement: {
+             title: "Beard stats 2014",
+             summary: "Summary text",
+             publication_type_id: PublicationType::OfficialStatistics.id,
+             organisation_ids: [@organisation.id],
+             current_release_date_attributes: {
+               release_date: 1.year.from_now,
+               precision: StatisticsAnnouncementDate::PRECISION[:exact],
+               confirmed: "1",
+             },
+           },
+         }
+
+    assert_response :redirect
+    assert announcement = StatisticsAnnouncement.last
+    assert_equal "Beard stats 2014", announcement.title
+    assert_includes announcement.organisations, @organisation
+    assert_equal @user, announcement.creator
+    assert_equal "11 November 2012 11:11am", announcement.display_date
+    assert_equal true, announcement.confirmed?
     assert_equal @user, announcement.current_release_date.creator
   end
 

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -62,6 +62,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     assert_includes announcement.organisations, @organisation
     assert_equal @user, announcement.creator
     assert_equal "November 2012", announcement.display_date
+    assert_equal false, announcement.confirmed?
     assert_equal @user, announcement.current_release_date.creator
   end
 
@@ -86,6 +87,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     assert_includes announcement.organisations, @organisation
     assert_equal @user, announcement.creator
     assert_equal "11 November 2012 11:11am", announcement.display_date
+    assert_equal true, announcement.confirmed?
     assert_equal @user, announcement.current_release_date.creator
   end
 


### PR DESCRIPTION
This fixes a bug with adding a confirmed release date whilst creating a statistics announcement under the legacy view.

Originally implemented in https://github.com/alphagov/whitehall/pull/7565, this missed the logic required for the legacy implementation, and did not have sufficient legacy tests to cover the regression.

This pull request fixes the bugs, and adds the tests to cover the behaviour in both legacy and new views.

## Screenshots

### Before
When a user created a statistics announcement under the legacy view, with a confirmed date:
![whitehall-admin integration publishing service gov uk_government_admin_statistics_announcements_new (3)](https://github.com/alphagov/whitehall/assets/91492293/555fed7e-e635-433a-8d70-60a9f14bcf20)

The summary would show the release date as provisional:
![whitehall-admin integration publishing service gov uk_government_admin_statistics_announcements_title--2](https://github.com/alphagov/whitehall/assets/91492293/c1b1dd51-ac18-4f4e-969a-e6de88888866)

### After
Now the date is confirmed, as required:
![whitehall-admin dev gov uk_government_admin_statistics_announcements_title--17](https://github.com/alphagov/whitehall/assets/91492293/f8302761-df6d-4e6e-8293-f7952f50f49f)

##Trello
https://trello.com/c/tLaCLyKL

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
