### PR TITLE
Move worldwide organisation about page content onto worldwide organisation

### DIFF
--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -6,7 +6,7 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
 
   def index
     params[:state] = "active" # Ensure that state column is displayed.
-    @paginator = @organisation.corporate_information_pages.where("state != ?", "superseded").order("corporate_information_page_type_id").page(params["page"].to_i || 1).per(100)
+    @paginator = Kaminari.paginate_array(corporate_information_pages).page(params["page"].to_i || 1).per(100)
     @filter = FakeEditionFilter.new @paginator, "Corporate information pages", false, true
 
     render_design_system(:index, :legacy_index, next_release: false)
@@ -26,6 +26,14 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
   end
 
 private
+
+  def corporate_information_pages
+    @organisation
+      .corporate_information_pages
+      .where("state != ?", "superseded")
+      .order("corporate_information_page_type_id")
+      .reject { |cip| cip.about_page? && cip.worldwide_organisation.present? }
+  end
 
   def get_layout
     design_system_actions = %w[confirm_destroy show edit update new create]

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -63,6 +63,8 @@ private
   def worldwide_organisation_params
     params.require(:worldwide_organisation).permit(
       :name,
+      :summary,
+      :body,
       :logo_formatted_name,
       world_location_ids: [],
       sponsoring_organisation_ids: [],

--- a/app/controllers/admin/worldwide_organisations_translations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_translations_controller.rb
@@ -38,6 +38,6 @@ private
   end
 
   def translation_params
-    params.require(:worldwide_organisation).permit(:name)
+    params.require(:worldwide_organisation).permit(:name, :summary, :body)
   end
 end

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -39,7 +39,6 @@ private
 
     if current_user_can_preview?
       expires_now
-      @draft = true
     end
   end
 

--- a/app/helpers/admin/attachable_helper.rb
+++ b/app/helpers/admin/attachable_helper.rb
@@ -63,4 +63,16 @@ module Admin::AttachableHelper
 
     "Attachments need to be referenced in the body markdown to appear in your document."
   end
+
+  def attachments_tab_label(attachable)
+    if attachable.attachments.count.positive?
+      "Attachments <span class='badge'>#{attachable.attachments.count}</span>".html_safe
+    else
+      "Attachments"
+    end
+  end
+
+  def attachments_nav_item_label(attachable)
+    sanitize("Attachments #{tag.span(attachable.attachments.count, class: 'govuk-tag govuk-tag--grey') if attachable.attachments.count.positive?}")
+  end
 end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -1,4 +1,6 @@
 module Admin::EditionsHelper
+  include Admin::AttachableHelper
+
   def edition_type(edition)
     type = if edition.is_a?(Speech) && edition.speech_type.written_article?
              edition.speech_type.singular_name
@@ -206,12 +208,7 @@ module Admin::EditionsHelper
   def default_edition_tabs(edition)
     { "Document" => tab_url_for_edition(edition) }.tap do |tabs|
       if edition.allows_attachments? && edition.persisted?
-        text = if edition.attachments.count.positive?
-                 "Attachments <span class='badge'>#{edition.attachments.count}</span>".html_safe
-               else
-                 "Attachments"
-               end
-        tabs[text] = admin_edition_attachments_path(edition)
+        tabs[attachments_tab_label(edition)] = admin_edition_attachments_path(edition)
       end
 
       if edition.is_a?(DocumentCollection) && !edition.new_record?

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -29,7 +29,7 @@ module Admin::TabbedNavHelper
       },
       *(if edition.persisted? && edition.allows_attachments?
           [{
-            label: sanitize("Attachments #{tag.span(edition.attachments.count, class: 'govuk-tag govuk-tag--grey') if edition.attachments.count.positive?}"),
+            label: attachments_nav_item_label(edition),
             href: admin_edition_attachments_path(edition),
             current: current_path == admin_edition_attachments_path(edition),
           }]
@@ -80,7 +80,7 @@ module Admin::TabbedNavHelper
         current: current_path == edit_admin_policy_group_path(group) || current_path == admin_policy_group_path(group),
       },
       {
-        label: sanitize("Attachments #{tag.span(group.attachments.count, class: 'govuk-tag govuk-tag--grey') if group.attachments.count.positive?}"),
+        label: attachments_nav_item_label(group),
         href: admin_policy_group_attachments_path(group),
         current: current_path == admin_policy_group_attachments_path(group),
       },

--- a/app/helpers/admin/worldwide_organisations_helper.rb
+++ b/app/helpers/admin/worldwide_organisations_helper.rb
@@ -1,7 +1,10 @@
 module Admin::WorldwideOrganisationsHelper
+  include Admin::AttachableHelper
+
   def worldwide_organisation_tabs(worldwide_organisation)
     {
       "Details" => admin_worldwide_organisation_path(worldwide_organisation),
+      attachments_tab_label(worldwide_organisation) => admin_worldwide_organisation_attachments_path(worldwide_organisation),
       "Translations" => admin_worldwide_organisation_translations_path(worldwide_organisation),
       "Offices" => admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation),
       "Access and opening times" => access_info_admin_worldwide_organisation_path(worldwide_organisation),
@@ -16,6 +19,11 @@ module Admin::WorldwideOrganisationsHelper
         label: "Details",
         href: admin_worldwide_organisation_path(worldwide_organisation),
         current: current_path == admin_worldwide_organisation_path(worldwide_organisation),
+      },
+      {
+        label: attachments_nav_item_label(worldwide_organisation),
+        href: admin_worldwide_organisation_attachments_path(worldwide_organisation),
+        current: current_path == admin_worldwide_organisation_attachments_path(worldwide_organisation),
       },
       {
         label: "Translations",

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -19,7 +19,7 @@ module GovspeakHelper
   end
 
   def govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
-    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body, attachments, alternative_format_contact_email))
+    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body.to_s, attachments, alternative_format_contact_email))
   end
 
   def bare_govspeak_edition_to_html(edition)

--- a/app/models/attachable/for_non_editionable_model.rb
+++ b/app/models/attachable/for_non_editionable_model.rb
@@ -1,0 +1,34 @@
+module Attachable
+  module ForNonEditionableModel
+    extend ActiveSupport::Concern
+    include ::Attachable
+
+    def publicly_visible?
+      true
+    end
+
+    def accessible_to?(_user)
+      true
+    end
+
+    def access_limited?
+      false
+    end
+
+    def access_limited_object
+      nil
+    end
+
+    def organisations
+      []
+    end
+
+    def unpublished?
+      false
+    end
+
+    def unpublished_edition
+      nil
+    end
+  end
+end

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -36,6 +36,8 @@ class CorporateInformationPage < Edition
   end
 
   def republish_about_page_to_publishing_api
+    return if worldwide_organisation.present?
+
     about_us = owning_organisation&.about_us
     return unless about_us
 

--- a/app/models/has_about_us_corporate_information_page.rb
+++ b/app/models/has_about_us_corporate_information_page.rb
@@ -1,0 +1,19 @@
+module HasAboutUsCorporateInformationPage
+  extend ActiveSupport::Concern
+
+  def summary
+    about_us.summary if about_us.present?
+  end
+
+  def body
+    about_us.body if about_us.present?
+  end
+
+  def about_us
+    @about_us ||= corporate_information_pages.published.for_slug("about")
+  end
+
+  def draft_about_us
+    @draft_about_us ||= corporate_information_pages.draft.for_slug("about")
+  end
+end

--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -8,14 +8,6 @@ module HasCorporateInformationPages
     end
   end
 
-  def summary
-    about_us.summary if about_us.present?
-  end
-
-  def body
-    about_us.body if about_us.present?
-  end
-
   def unused_corporate_information_page_types
     CorporateInformationPageType.all - corporate_information_pages.map(&:corporate_information_page_type)
   end
@@ -28,13 +20,5 @@ module HasCorporateInformationPages
 
   def published_corporate_information_pages
     corporate_information_pages.published
-  end
-
-  def about_us
-    @about_us ||= corporate_information_pages.published.for_slug("about")
-  end
-
-  def draft_about_us
-    @draft_about_us ||= corporate_information_pages.draft.for_slug("about")
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -24,6 +24,7 @@ class Organisation < ApplicationRecord
   has_many :edition_organisations, dependent: :destroy, inverse_of: :organisation
   # This include is dependant on the above has_many
   include HasCorporateInformationPages
+  include HasAboutUsCorporateInformationPage
 
   has_many :editions, through: :edition_organisations
 

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -1,6 +1,6 @@
 class PolicyGroup < ApplicationRecord
   include Searchable
-  include ::Attachable
+  include ::Attachable::ForNonEditionableModel
   include PublishesToPublishingApi
 
   validates :email, email_format: true, allow_blank: true
@@ -30,30 +30,6 @@ class PolicyGroup < ApplicationRecord
 
   def remove_all_dependencies
     policy_group_dependencies.delete_all
-  end
-
-  def access_limited_object
-    nil
-  end
-
-  def access_limited?
-    false
-  end
-
-  def publicly_visible?
-    true
-  end
-
-  def accessible_to?(*)
-    true
-  end
-
-  def unpublished?
-    false
-  end
-
-  def unpublished_edition
-    nil
   end
 
   def has_summary?

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -16,7 +16,6 @@ class WorldwideOrganisation < ApplicationRecord
   has_many :edition_worldwide_organisations, dependent: :destroy, inverse_of: :worldwide_organisation
   # This include is dependant on the above has_many
   include HasCorporateInformationPages
-  include HasAboutUsCorporateInformationPage
 
   has_many :editions, through: :edition_worldwide_organisations
 
@@ -32,12 +31,16 @@ class WorldwideOrganisation < ApplicationRecord
   self.analytics_prefix = "WO"
 
   include TranslatableModel
-  translates :name
+  translates :name, :summary, :body
 
   alias_method :original_main_office, :main_office
 
   validates_with SafeHtmlValidator
+  validates_with NoFootnotesInGovspeakValidator, attribute: :body
+
   validates :name, presence: true
+  validates :body, length: { maximum: 16_777_215 }
+  validates :summary, length: { maximum: 65_535 }
 
   include PublishesToPublishingApi
 

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -3,6 +3,8 @@ class WorldwideOrganisation < ApplicationRecord
   SECONDARY_ROLES = [DeputyHeadOfMissionRole].freeze
   OFFICE_ROLES = [WorldwideOfficeStaffRole].freeze
 
+  include ::Attachable::ForNonEditionableModel
+
   has_many :worldwide_organisation_world_locations, dependent: :destroy
   has_many :world_locations, through: :worldwide_organisation_world_locations
   has_many :social_media_accounts, as: :socialable, dependent: :destroy

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -16,6 +16,7 @@ class WorldwideOrganisation < ApplicationRecord
   has_many :edition_worldwide_organisations, dependent: :destroy, inverse_of: :worldwide_organisation
   # This include is dependant on the above has_many
   include HasCorporateInformationPages
+  include HasAboutUsCorporateInformationPage
 
   has_many :editions, through: :edition_worldwide_organisations
 

--- a/app/presenters/publishing_api/working_group_presenter.rb
+++ b/app/presenters/publishing_api/working_group_presenter.rb
@@ -50,11 +50,7 @@ module PublishingApi
 
     def body
       # It looks 'wrong' using the description as the body, but it isn't
-      if item.description.present?
-        Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.description, item.attachments, item.email)
-      else
-        ""
-      end
+      Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.description, item.attachments, item.email)
     end
   end
 end

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -10,6 +10,12 @@
   items: secondary_navigation_tabs_items(@organisation, request.path)
 } %>
 
+<% if @organisation.is_a?(WorldwideOrganisation) %>
+  <p id="worldwide-organisation-about-page-explanation">
+    Content for the Worldwide Organisation page can now be edited under the <%= link_to "Details tab", admin_worldwide_organisation_path(@organisation) %> instead of in the "About us" page.
+  </p>
+<% end %>
+
 <% if @organisation.unused_corporate_information_page_types.any? %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Create new corporate information page",

--- a/app/views/admin/editions/_legacy_search_results.html.erb
+++ b/app/views/admin/editions/_legacy_search_results.html.erb
@@ -2,6 +2,13 @@
 <h1>
   <%= "#{@filter.page_title}" %>
 </h1>
+
+<% if @organisation.is_a?(WorldwideOrganisation) %>
+  <p id="worldwide-organisation-about-page-explanation">
+    Content for the Worldwide Organisation page can now be edited under the <%= link_to "Details tab", admin_worldwide_organisation_path(@organisation) %> instead of in the "About us" page.
+  </p>
+<% end %>
+
 <% if @filter.editions.blank? %>
   <div class="add-top-margin no-content no-content-bordered">
     No documents found

--- a/app/views/admin/worldwide_organisations/_form.html.erb
+++ b/app/views/admin/worldwide_organisations/_form.html.erb
@@ -3,6 +3,13 @@
   <fieldset>
     <%= form.text_field :name %>
 
+    <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
+    <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
+
+    <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, data: {
+      module: "paste-html-to-govspeak"
+    } %>
+
     <%= form.label :world_location_ids, 'World location' %>
     <%= form.select :world_location_ids, WorldLocation.ordered_by_name.collect {|org| [org.name, org.id]}, {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose world locations…"} %>
 

--- a/app/views/admin/worldwide_organisations/show.html.erb
+++ b/app/views/admin/worldwide_organisations/show.html.erb
@@ -25,7 +25,7 @@
 
               <div class="body description">
                 <div class="content govspeak">
-                  <%= govspeak_to_html @worldwide_organisation.body %>
+                  <%= govspeak_with_attachments_to_html @worldwide_organisation.body, @worldwide_organisation.attachments, @worldwide_organisation.alternative_format_contact_email %>
                 </div>
               </div>
             </article>

--- a/app/views/admin/worldwide_organisations_translations/edit.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/edit.html.erb
@@ -7,6 +7,10 @@
       <%= form.errors %>
 
       <%= form.translated_text_field :name %>
+      <%= form.translated_text_area :summary %>
+      <%= form.translated_text_area :body, rows: 20, cols: 9000, data: {
+        module: "paste-html-to-govspeak"
+      } %>
 
       <%= form.save_or_cancel cancel: admin_worldwide_organisation_translations_path(@english_worldwide_organisation) %>
     <% end %>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -10,11 +10,7 @@
   <div class="about-us govuk-grid-column-two-thirds worldwide-org-content">
     <p class="govuk-body-l worldwide-org-summary"><%= @worldwide_organisation.summary %></p>
     <div class="worldwide-org-description">
-      <% if @draft %>
-        <%= govspeak_edition_to_html @worldwide_organisation.draft_about_us %>
-      <% else %>
-        <%= govspeak_edition_to_html @worldwide_organisation.about_us %>
-      <% end %>
+      <%= govspeak_to_html @worldwide_organisation.body %>
     </div>
   </div>
   <% if @worldwide_organisation.social_media_accounts.any? %>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -10,7 +10,7 @@
   <div class="about-us govuk-grid-column-two-thirds worldwide-org-content">
     <p class="govuk-body-l worldwide-org-summary"><%= @worldwide_organisation.summary %></p>
     <div class="worldwide-org-description">
-      <%= govspeak_to_html @worldwide_organisation.body %>
+      <%= govspeak_with_attachments_to_html @worldwide_organisation.body, @worldwide_organisation.attachments, @worldwide_organisation.alternative_format_contact_email %>
     </div>
   </div>
   <% if @worldwide_organisation.social_media_accounts.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,9 @@ Whitehall::Application.routes.draw do
         end
 
         resources :worldwide_organisations do
+          resources :attachments, except: [:show] do
+            get :confirm_destroy, on: :member
+          end
           member do
             put :set_main_office
             get :access_info

--- a/db/migrate/20230515141021_add_summary_and_body_to_worldwide_organisation_translations.rb
+++ b/db/migrate/20230515141021_add_summary_and_body_to_worldwide_organisation_translations.rb
@@ -5,6 +5,7 @@ class AddSummaryAndBodyToWorldwideOrganisationTranslations < ActiveRecord::Migra
   class CorporateInformationPage < Edition
     ABOUT_US_TYPE_ID = 20
     scope :published, -> { where(state: "published") }
+    scope :draft, -> { where(state: "draft") }
     translates :summary, :body
   end
 
@@ -18,6 +19,12 @@ class AddSummaryAndBodyToWorldwideOrganisationTranslations < ActiveRecord::Migra
         corporate_information_page_type_id: CorporateInformationPage::ABOUT_US_TYPE_ID,
       )
     end
+
+    def draft_about_us
+      @draft_about_us ||= corporate_information_pages.draft.find_by(
+        corporate_information_page_type_id: CorporateInformationPage::ABOUT_US_TYPE_ID,
+      )
+    end
   end
 
   def up
@@ -26,17 +33,43 @@ class AddSummaryAndBodyToWorldwideOrganisationTranslations < ActiveRecord::Migra
       t.column :body, :text, size: :medium
     end
 
+    number_of_worldwide_organisations = 0
+    number_of_worldwide_organisations_without_about_page = 0
+    number_of_worldwide_organisations_with_draft_content = 0
+    number_of_worldwide_organisation_translations_created = 0
+
     WorldwideOrganisation.all.each do |worldwide_organisation|
-      next if worldwide_organisation.about_us.nil?
+      write "Copying content from WorldOrganisation: #{worldwide_organisation.slug}"
+      number_of_worldwide_organisations += 1
+
+      if worldwide_organisation.about_us.nil?
+        write "  WorldOrganisation #{worldwide_organisation.slug} has no about page"
+        number_of_worldwide_organisations_without_about_page += 1
+        next
+      end
+
+      if worldwide_organisation.draft_about_us.present?
+        write "  Draft content for WorldOrganisation #{worldwide_organisation.slug} exists but will not be copied"
+        number_of_worldwide_organisations_with_draft_content += 1
+      end
 
       worldwide_organisation.about_us.translations.each do |source_translation|
+        write "  Processing #{source_translation.locale} translation from about page"
         target_translation = worldwide_organisation.translations.find_by(locale: source_translation.locale)
         if target_translation.nil?
+          write "    Creating #{source_translation.locale} translation for WorldwideOrganisation; name attribute will not be set so rendered page will fallback to english name"
+          number_of_worldwide_organisation_translations_created += 1
           target_translation = worldwide_organisation.translations.create!(locale: source_translation.locale)
         end
+        write "    Copying content from about page to WorldwideOrganisation"
         target_translation.update!(summary: source_translation.summary, body: source_translation.body)
       end
     end
+
+    write "Number of WorldwideOrganisations: #{number_of_worldwide_organisations}"
+    write "Number of WorldwideOrganisations without an about page: #{number_of_worldwide_organisations_without_about_page}"
+    write "Number of WorldwideOrganisations with draft content: #{number_of_worldwide_organisations_with_draft_content}"
+    write "Number of WorldwideOrganisation translations created: #{number_of_worldwide_organisation_translations_created}"
   end
 
   def down

--- a/db/migrate/20230515141021_add_summary_and_body_to_worldwide_organisation_translations.rb
+++ b/db/migrate/20230515141021_add_summary_and_body_to_worldwide_organisation_translations.rb
@@ -1,0 +1,48 @@
+class AddSummaryAndBodyToWorldwideOrganisationTranslations < ActiveRecord::Migration[7.0]
+  class Edition < ApplicationRecord
+  end
+
+  class CorporateInformationPage < Edition
+    ABOUT_US_TYPE_ID = 20
+    scope :published, -> { where(state: "published") }
+    translates :summary, :body
+  end
+
+  class WorldwideOrganisation < ApplicationRecord
+    has_many :edition_worldwide_organisations
+    has_many :corporate_information_pages, through: :edition_worldwide_organisations, source: :edition, class_name: "::CorporateInformationPage"
+    translates :summary, :body
+
+    def about_us
+      @about_us ||= corporate_information_pages.published.find_by(
+        corporate_information_page_type_id: CorporateInformationPage::ABOUT_US_TYPE_ID,
+      )
+    end
+  end
+
+  def up
+    change_table :worldwide_organisation_translations, bulk: true do |t|
+      t.column :summary, :text
+      t.column :body, :text, size: :medium
+    end
+
+    WorldwideOrganisation.all.each do |worldwide_organisation|
+      next if worldwide_organisation.about_us.nil?
+
+      worldwide_organisation.about_us.translations.each do |source_translation|
+        target_translation = worldwide_organisation.translations.find_by(locale: source_translation.locale)
+        if target_translation.nil?
+          target_translation = worldwide_organisation.translations.create!(locale: source_translation.locale)
+        end
+        target_translation.update!(summary: source_translation.summary, body: source_translation.body)
+      end
+    end
+  end
+
+  def down
+    change_table :worldwide_organisation_translations, bulk: true do |t|
+      t.remove :summary
+      t.remove :body
+    end
+  end
+end

--- a/db/migrate/20230516102343_move_attachments_from_worldwide_organisation_about_pages_to_worldwide_organisations.rb
+++ b/db/migrate/20230516102343_move_attachments_from_worldwide_organisation_about_pages_to_worldwide_organisations.rb
@@ -1,0 +1,40 @@
+class MoveAttachmentsFromWorldwideOrganisationAboutPagesToWorldwideOrganisations < ActiveRecord::Migration[7.0]
+  class Attachment < ApplicationRecord
+    belongs_to :attachable, polymorphic: true
+  end
+
+  class Edition < ApplicationRecord
+  end
+
+  class CorporateInformationPage < Edition
+    ABOUT_US_TYPE_ID = 20
+    has_many :attachments, as: :attachable, inverse_of: :attachable
+    scope :published, -> { where(state: "published") }
+  end
+
+  class WorldwideOrganisation < ApplicationRecord
+    has_many :edition_worldwide_organisations
+    has_many :corporate_information_pages, through: :edition_worldwide_organisations, source: :edition, class_name: "::CorporateInformationPage"
+    has_many :attachments, as: :attachable, inverse_of: :attachable
+
+    def about_us
+      @about_us ||= corporate_information_pages.published.find_by(
+        corporate_information_page_type_id: CorporateInformationPage::ABOUT_US_TYPE_ID,
+      )
+    end
+  end
+
+  def up
+    WorldwideOrganisation.all.each do |worldwide_organisation|
+      next if worldwide_organisation.about_us.nil?
+
+      worldwide_organisation.about_us.attachments.each do |attachment|
+        attachment.update!(attachable: worldwide_organisation)
+      end
+    end
+  end
+
+  def down
+    # intentionally left blank
+  end
+end

--- a/db/migrate/20230516102343_move_attachments_from_worldwide_organisation_about_pages_to_worldwide_organisations.rb
+++ b/db/migrate/20230516102343_move_attachments_from_worldwide_organisation_about_pages_to_worldwide_organisations.rb
@@ -25,13 +25,27 @@ class MoveAttachmentsFromWorldwideOrganisationAboutPagesToWorldwideOrganisations
   end
 
   def up
+    number_of_worldwide_organisations = 0
+    number_of_attachments = 0
+
     WorldwideOrganisation.all.each do |worldwide_organisation|
-      next if worldwide_organisation.about_us.nil?
+      write "Moving attachments for WorldOrganisation: #{worldwide_organisation.slug}"
+      number_of_worldwide_organisations += 1
+
+      if worldwide_organisation.about_us.nil?
+        write "  WorldOrganisation #{worldwide_organisation.slug} has no about page"
+        next
+      end
 
       worldwide_organisation.about_us.attachments.each do |attachment|
+        write "  Processing attachment: #{attachment.id}"
+        number_of_attachments += 1
         attachment.update!(attachable: worldwide_organisation)
       end
     end
+
+    write "Number of WorldwideOrganisations: #{number_of_worldwide_organisations}"
+    write "Number of Attachments moved: #{number_of_attachments}"
   end
 
   def down

--- a/db/pending_migration_cleanups/20230516160033_delete_worldwide_organisation_about_pages.rb
+++ b/db/pending_migration_cleanups/20230516160033_delete_worldwide_organisation_about_pages.rb
@@ -2,8 +2,30 @@ class DeleteWorldwideOrganisationAboutPages < ActiveRecord::Migration[7.0]
   class Edition < ApplicationRecord
   end
 
+  class Attachment < ApplicationRecord
+    scope :not_deleted, -> { where(deleted: false) }
+
+    def delete
+      update_column(:deleted, true)
+    end
+
+    def destroy
+      callbacks_result = transaction do
+        run_callbacks(:destroy) do
+          delete
+        end
+      end
+      callbacks_result ? self : false
+    end
+  end
+
   class CorporateInformationPage < Edition
     ABOUT_US_TYPE_ID = 20
+
+    has_many :attachments,
+             -> { not_deleted.order("attachments.ordering, attachments.id") },
+             as: :attachable,
+             inverse_of: :attachable
   end
 
   class WorldwideOrganisation < ApplicationRecord
@@ -16,9 +38,38 @@ class DeleteWorldwideOrganisationAboutPages < ActiveRecord::Migration[7.0]
   end
 
   def up
+    worldwide_organisations = WorldwideOrganisation.all
+    about_us_pages = worldwide_organisations.flat_map(&:about_us_page_editions)
+    about_us_pages_attachments = about_us_pages.flat_map(&:attachments)
+    worldwide_organisations_count_before = worldwide_organisations.count
+    about_us_pages_count_before = about_us_pages.count
+    about_us_pages_attachments_count_before = about_us_pages_attachments.count
+
     WorldwideOrganisation.all.each do |worldwide_organisation|
-      worldwide_organisation.about_us_page_editions.destroy_all
+      write "Processing #{worldwide_organisation.class} #{worldwide_organisation.id} - #{worldwide_organisation.slug}"
+      worldwide_organisation.about_us_page_editions.each do |page|
+        write "  Deleting #{page.class} #{page.id} - #{page.title}"
+        page.attachments.each do |attachment|
+          write "    Deleting #{attachment.class} #{attachment.id} - #{attachment.title}"
+          attachment.destroy # rubocop:disable Rails/SaveBang
+        end
+        page.destroy!
+      end
     end
+
+    write "## Summary"
+    write "### Before"
+    write "WorldwideOrganisations: #{worldwide_organisations_count_before}"
+    write "About Us Corporate Information Pages: #{about_us_pages_count_before}"
+    write "Attachments: #{about_us_pages_attachments_count_before}"
+
+    write "### After"
+    worldwide_organisations = WorldwideOrganisation.all
+    about_us_pages = worldwide_organisations.flat_map(&:about_us_page_editions)
+    about_us_pages_attachments = about_us_pages.flat_map(&:attachments)
+    write "WorldwideOrganisations: #{worldwide_organisations.count}"
+    write "About Us Corporate Information Pages: #{about_us_pages.count}"
+    write "Attachments: #{about_us_pages_attachments.count}"
   end
 
   def down

--- a/db/pending_migration_cleanups/20230516160033_delete_worldwide_organisation_about_pages.rb
+++ b/db/pending_migration_cleanups/20230516160033_delete_worldwide_organisation_about_pages.rb
@@ -1,0 +1,27 @@
+class DeleteWorldwideOrganisationAboutPages < ActiveRecord::Migration[7.0]
+  class Edition < ApplicationRecord
+  end
+
+  class CorporateInformationPage < Edition
+    ABOUT_US_TYPE_ID = 20
+  end
+
+  class WorldwideOrganisation < ApplicationRecord
+    has_many :edition_worldwide_organisations
+    has_many :corporate_information_pages, through: :edition_worldwide_organisations, source: :edition, class_name: "::CorporateInformationPage"
+
+    def about_us_page_editions
+      corporate_information_pages.where(corporate_information_page_type_id: CorporateInformationPage::ABOUT_US_TYPE_ID)
+    end
+  end
+
+  def up
+    WorldwideOrganisation.all.each do |worldwide_organisation|
+      worldwide_organisation.about_us_page_editions.destroy_all
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_120104) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_15_141021) do
   create_table "attachment_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_file"
     t.string "content_type"
@@ -1148,6 +1148,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_120104) do
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.text "summary"
+    t.text "body", size: :medium
     t.index ["locale"], name: "index_worldwide_org_translations_on_locale"
     t.index ["worldwide_organisation_id"], name: "index_worldwide_org_translations_on_worldwide_organisation_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_141021) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_16_102343) do
   create_table "attachment_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_file"
     t.string "content_type"

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -1,17 +1,11 @@
 Given(/^a worldwide organisation that is translated exists$/) do
   world_location = create(:world_location, active: true)
-  worldwide_organisation = create(
+  create(
     :worldwide_organisation,
     world_locations: [world_location],
     name: "en-organisation",
-    translated_into: { fr: { name: "fr-organisation" } },
-  )
-  create(
-    :about_corporate_information_page,
-    organisation: nil,
-    worldwide_organisation:,
     summary: "en-summary",
-    translated_into: { fr: { summary: "fr-summary" } },
+    translated_into: { fr: { name: "fr-organisation", summary: "fr-summary", body: "fr-body" } },
   )
 end
 
@@ -21,6 +15,7 @@ end
 
 Then(/^I should see the translation of that world organisation$/) do
   expect(page).to have_selector(".worldwide-org-summary", text: "fr-summary")
+  expect(page).to have_selector(".worldwide-org-description", text: "fr-body")
 end
 
 Given(/^I have drafted a translatable document "([^"]*)"$/) do |title|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -221,8 +221,6 @@ Then(/^when viewing the worldwide organisation "([^"]*)" with the locale "([^"]*
   visit worldwide_organisation.public_path(locale:)
 
   expect(page).to have_selector(".worldwide-org-summary", text: translation["summary"])
-  expect(page).to have_selector(".worldwide-org-description", text: translation["description"])
-  expect(page).to have_selector(".worldwide-org-content", text: translation["services"])
 end
 
 Given(/^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/) do |name, native_locale_name|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -269,3 +269,8 @@ Then(/^I should see an update record in the audit trail for the worldwide organi
     expect(page).to have_content(@user.name)
   end
 end
+
+Given(/^I edit the attachments for the worldwide organisation$/) do
+  visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
+  click_on "Attachments"
+end

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -1,7 +1,10 @@
-When(/^I create a worldwide organisation "([^"]*)" sponsored by the "([^"]*)"$/) do |name, sponsoring_organisation|
+When(/^I create a worldwide organisation "([^"]*)" sponsored by the "([^"]*)" with:$/) do |name, sponsoring_organisation, table|
+  attributes = table.rows_hash
   visit new_admin_worldwide_organisation_path
   fill_in "Name", with: name
   fill_in "Logo formatted name", with: name
+  fill_in "Summary", with: attributes["summary"]
+  fill_in "Body", with: attributes["body"]
   select sponsoring_organisation, from: "Sponsoring organisations"
   click_on "Save"
 end
@@ -18,6 +21,8 @@ Then(/^I should see the(?: updated)? worldwide organisation information on the p
   worldwide_organisation = WorldwideOrganisation.last
   visit worldwide_organisation.public_path
   expect(page).to have_title(worldwide_organisation.name)
+  expect(page).to have_content(worldwide_organisation.summary)
+  expect(page).to have_content(worldwide_organisation.body)
 end
 
 Then(/^the "([^"]*)" logo should show correctly with the HMG crest$/) do |name|
@@ -40,6 +45,15 @@ end
 When(/^I update the worldwide organisation to set the name to "([^"]*)"$/) do |new_title|
   visit edit_admin_worldwide_organisation_path(WorldwideOrganisation.last)
   fill_in "Name", with: new_title
+  click_on "Save"
+end
+
+When(/^I update the worldwide organisation to set:$/) do |table|
+  attributes = table.rows_hash
+  visit edit_admin_worldwide_organisation_path(WorldwideOrganisation.last)
+  fill_in "Name", with: attributes["name"]
+  fill_in "Summary", with: attributes["summary"]
+  fill_in "Body", with: attributes["body"]
   click_on "Save"
 end
 
@@ -221,6 +235,7 @@ Then(/^when viewing the worldwide organisation "([^"]*)" with the locale "([^"]*
   visit worldwide_organisation.public_path(locale:)
 
   expect(page).to have_selector(".worldwide-org-summary", text: translation["summary"])
+  expect(page).to have_selector(".worldwide-org-description", text: translation["body"])
 end
 
 Given(/^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/) do |name, native_locale_name|

--- a/features/support/worldwide_organisations_helper.rb
+++ b/features/support/worldwide_organisations_helper.rb
@@ -10,6 +10,8 @@ module WorldwideOrganisationsHelper
     select translation["locale"], from: "Locale"
     click_on "Create translation"
     fill_in "Name", with: translation["name"]
+    fill_in "Summary", with: translation["summary"]
+    fill_in "Body", with: translation["body"]
     click_on "Save"
   end
 
@@ -22,6 +24,8 @@ module WorldwideOrganisationsHelper
     end
 
     fill_in "Name", with: translation["name"]
+    fill_in "Summary", with: translation["summary"]
+    fill_in "Body", with: translation["body"]
     click_on "Save"
   end
 end

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -21,12 +21,17 @@ Feature: Administering worldwide organisation
 
   Scenario: Creating worldwide organisation
     Given the organisation "Department of Beards" exists
-    When I create a worldwide organisation "Department of Beards in France" sponsored by the "Department of Beards"
+    When I create a worldwide organisation "Department of Beards in France" sponsored by the "Department of Beards" with:
+      | summary | Beards Summary |
+      | body    | Beards Body    |
     Then I should see the worldwide organisation information on the public website
     And the "Department of Beards in France" logo should show correctly with the HMG crest
     And I should see that it is part of the "Department of Beards"
     Then I should see a create record in the audit trail for the worldwide organisation
-    When I update the worldwide organisation to set the name to "Department of Beards and Moustaches in France"
+    When I update the worldwide organisation to set:
+      | name    | Department of Beards & Moustaches in France |
+      | summary | Beards & Moustaches Summary                 |
+      | body    | Beards & Moustaches Body                    |
     Then I should see the updated worldwide organisation information on the public website
     Then I should see an update record in the audit trail for the worldwide organisation
     When I delete the worldwide organisation

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -96,17 +96,25 @@ Feature: Administering worldwide organisation
   Scenario: Adding a new translation
     Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "Français"
     When I add a new translation to the worldwide organisation "Department of Beards in France" with:
-      | locale | Français                         |
-      | name   | Département des barbes en France |
+      | locale  | Français                         |
+      | name    | Département des barbes en France |
+      | summary | Résumé des barbes                |
+      | body    | Corp des barbes                  |
     Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
-      | name | Département des barbes en France |
+      | name    | Département des barbes en France |
+      | summary | Résumé des barbes                |
+      | body    | Corp des barbes                  |
 
   Scenario: Editing an existing translation
     Given a worldwide organisation "Department of Beards in France" exists with a translation for the locale "Français"
     When I edit the "Français" translation for the worldwide organisation "Department of Beards in France" setting:
       | name | Le super département des barbes en France |
+      | summary | Résumé des barbes spectaculaires       |
+      | body    | Corp des barbes spectaculaires         |
     Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
       | name | Le super département des barbes en France |
+      | summary | Résumé des barbes spectaculaires       |
+      | body    | Corp des barbes spectaculaires         |
 
   Scenario: Translating a corporate information page for a worldwide organisation
     Given a worldwide organisation "Department of Beards in France"

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -122,3 +122,9 @@ Feature: Administering worldwide organisation
     When I translate the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     Then I should be able to read the translated "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France" on the site
+
+  Scenario: Managing attachments for a worldwide organisation
+    Given a worldwide organisation "Department of Beards in France"
+    And I edit the attachments for the worldwide organisation
+    And I upload a file attachment with the title "French Beard Length Graphs 2012" and the file "greenpaper.pdf"
+    Then I can see the attachment title "French Beard Length Graphs 2012"

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :worldwide_organisation, traits: [:translated] do
     sequence(:name) { |index| "worldwide-organisation-#{index}" }
     logo_formatted_name { name.to_s.split.join("\n") }
+    body { "This is the body text of a worldwide organisation" }
+    summary { "This is the summary text of a worldwide organisation" }
 
     trait(:with_corporate_information_pages) do
       after :create do |organisation, _evaluator|

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -21,6 +21,33 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     assert assigns(:filter).hide_type
   end
 
+  view_test "GET :index should exclude about us pages for worldwide organisations" do
+    worldwide_organisation = create(:worldwide_organisation)
+    about_us = create(:about_corporate_information_page, worldwide_organisation:, organisation: nil)
+    draft_about_us = create(:draft_about_corporate_information_page, document: about_us.document, worldwide_organisation:, organisation: nil)
+    other_corporate_information_page = create(:recruitment_corporate_information_page, worldwide_organisation:, organisation: nil)
+
+    get :index, params: { worldwide_organisation_id: worldwide_organisation }
+
+    assert_select "#worldwide-organisation-about-page-explanation a[href='#{admin_worldwide_organisation_path(worldwide_organisation)}']"
+    assert_select "tr td", text: other_corporate_information_page.title
+    refute_select "tr td", text: about_us.title
+    refute_select "tr td", text: draft_about_us.title
+  end
+
+  view_test "GET :index should include about us pages for organisations" do
+    about_us = create(:about_corporate_information_page, organisation: @organisation)
+    draft_about_us = create(:draft_about_corporate_information_page, document: about_us.document, organisation: @organisation)
+    other_corporate_information_page = create(:recruitment_corporate_information_page, organisation: @organisation)
+
+    get :index, params: { organisation_id: @organisation }
+
+    refute_select "#worldwide-organisation-about-page-explanation"
+    assert_select "tr td", text: other_corporate_information_page.title
+    assert_select "tr td", text: about_us.title
+    assert_select "tr td", text: draft_about_us.title
+  end
+
   view_test "GET :new should display form" do
     get :new, params: { organisation_id: @organisation }
 

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -20,16 +20,16 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   test "creates a worldwide organisation" do
-    post :create,
-         params: {
-           worldwide_organisation: {
-             name: "Organisation",
-           },
-         }
+    name = "Organisation"
+    summary = "A Worldwide Organisation"
+    body = "Some more information"
+    post :create, params: { worldwide_organisation: { name:, summary:, body: } }
 
     worldwide_organisation = WorldwideOrganisation.last
     assert_kind_of WorldwideOrganisation, worldwide_organisation
-    assert_equal "Organisation", worldwide_organisation.name
+    assert_equal name, worldwide_organisation.name
+    assert_equal summary, worldwide_organisation.summary
+    assert_equal body, worldwide_organisation.body
 
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
@@ -52,19 +52,27 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "updates an existing objects with new values" do
     organisation = create(:worldwide_organisation)
+    new_name = "New name"
+    new_body = "New body"
+    new_summary = "New summary"
+    file_name = "minister-of-funk.960x640.jpg"
     put :update,
         params: {
           id: organisation.id,
           worldwide_organisation: {
-            name: "New name",
+            name: new_name,
+            body: new_body,
+            summary: new_summary,
             default_news_image_attributes: {
-              file: upload_fixture("minister-of-funk.960x640.jpg"),
+              file: upload_fixture(file_name),
             },
           },
         }
     worldwide_organisation = WorldwideOrganisation.last
-    assert_equal "New name", worldwide_organisation.name
-    assert_equal "minister-of-funk.960x640.jpg", worldwide_organisation.default_news_image.file.file.filename
+    assert_equal new_name, worldwide_organisation.name
+    assert_equal file_name, worldwide_organisation.default_news_image.file.file.filename
+    assert_equal new_body, worldwide_organisation.body
+    assert_equal new_summary, worldwide_organisation.summary
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
 
@@ -98,11 +106,9 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   view_test "shows the name summary and description of the worldwide organisation" do
-    organisation = create(:worldwide_organisation, name: "Ministry of Silly Walks in Madrid")
-    about_us = create(
-      :about_corporate_information_page,
-      organisation: nil,
-      worldwide_organisation: organisation,
+    organisation = create(
+      :worldwide_organisation,
+      name: "Ministry of Silly Walks in Madrid",
       summary: "We have a nice organisation in madrid",
       body: "# Organisation\nOur organisation is on the main road\n",
     )
@@ -111,7 +117,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     assert_select_object organisation do
       assert_select "h1", organisation.name
-      assert_select ".summary", about_us.summary
+      assert_select ".summary", organisation.summary
       assert_select ".description" do
         assert_select "h1", "Organisation"
         assert_select "p", "Our organisation is on the main road"

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -10,8 +10,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   test "sets meta description" do
-    organisation = create(:worldwide_organisation)
-    create(:about_corporate_information_page, organisation: nil, worldwide_organisation: organisation, summary: "my summary")
+    organisation = create(:worldwide_organisation, summary: "my summary")
 
     get :show, params: { id: organisation.id }
 
@@ -62,33 +61,5 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     worldwide_organisation.reload
     assert_not worldwide_organisation.has_home_page_offices_list?
-  end
-
-  view_test "showing a preview of draft content when requested and a user is logged in" do
-    login_as :gds_editor
-
-    worldwide_organisation = create(:worldwide_organisation)
-    create(:about_corporate_information_page, organisation: nil, worldwide_organisation:, body: "pre-edit body")
-    get :show, params: { id: worldwide_organisation }
-    assert_select ".worldwide-org-description", text: "pre-edit body"
-
-    draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation:, body: "post-edit body")
-
-    get :show, params: { id: worldwide_organisation }
-    assert_select ".worldwide-org-description", text: "pre-edit body"
-
-    get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
-    assert_select ".worldwide-org-description", text: "post-edit body"
-  end
-
-  view_test "not showing a preview of draft content when requested and a user is not logged in" do
-    worldwide_organisation = create(:worldwide_organisation)
-    create(:about_corporate_information_page, organisation: nil, worldwide_organisation:, body: "pre-edit body")
-    get :show, params: { id: worldwide_organisation }
-    assert_select ".worldwide-org-description", text: "pre-edit body"
-
-    draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation:, body: "post-edit body")
-    get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
-    assert_select ".worldwide-org-description", text: "pre-edit body"
   end
 end

--- a/test/unit/helpers/admin/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/admin/worldwide_organisations_helper_test.rb
@@ -6,6 +6,7 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
 
     expected_output = [
       "Details",
+      "Attachments",
       "Translations",
       "Offices",
       "Access and opening times",
@@ -16,12 +17,20 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
     assert_equal expected_output, worldwide_organisation_tabs(worldwide_organisation).keys
   end
 
+  test "#worldwide_organisation_tabs includes Attachments tab with badge when worldwide organisation has attachments" do
+    worldwide_organisation = build_stubbed(:worldwide_organisation)
+    worldwide_organisation.stubs(:attachments).returns(stub("attachments", count: 1))
+
+    assert_includes worldwide_organisation_tabs(worldwide_organisation).keys, "Attachments <span class='badge'>1</span>"
+  end
+
   test "#worldwide_organisation_nav_items returns an array of hashes with the correct items" do
     worldwide_organisation = build_stubbed(:worldwide_organisation)
     current_path = admin_worldwide_organisation_path(worldwide_organisation)
 
     expected_output = [
       { label: "Details", href: admin_worldwide_organisation_path(worldwide_organisation), current: true },
+      { label: "Attachments ", href: admin_worldwide_organisation_attachments_path(worldwide_organisation), current: false },
       { label: "Translations", href: admin_worldwide_organisation_translations_path(worldwide_organisation), current: false },
       { label: "Offices", href: admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation), current: false },
       { label: "Access and opening times", href: access_info_admin_worldwide_organisation_path(worldwide_organisation), current: false },
@@ -30,5 +39,15 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
     ]
 
     assert_equal expected_output, worldwide_organisation_nav_items(worldwide_organisation, current_path)
+  end
+
+  test "#worldwide_organisation_nav_items includes Attachments nav item with badge when worldwide organisation has attachments" do
+    worldwide_organisation = build_stubbed(:worldwide_organisation)
+    worldwide_organisation.stubs(:attachments).returns(stub("attachments", count: 1))
+    current_path = admin_worldwide_organisation_path(worldwide_organisation)
+
+    labels = worldwide_organisation_nav_items(worldwide_organisation, current_path).map { |ni| ni[:label] }
+
+    assert_includes labels, %(Attachments <span class="govuk-tag govuk-tag--grey">1</span>)
   end
 end

--- a/test/unit/helpers/admin/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/admin/worldwide_organisations_helper_test.rb
@@ -1,6 +1,21 @@
 require "test_helper"
 
 class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
+  test "#worldwide_organisation_tabs returns relevant tabs" do
+    worldwide_organisation = build_stubbed(:worldwide_organisation)
+
+    expected_output = [
+      "Details",
+      "Translations",
+      "Offices",
+      "Access and opening times",
+      "Social media accounts",
+      "Corporate information pages",
+    ]
+
+    assert_equal expected_output, worldwide_organisation_tabs(worldwide_organisation).keys
+  end
+
   test "#worldwide_organisation_nav_items returns an array of hashes with the correct items" do
     worldwide_organisation = build_stubbed(:worldwide_organisation)
     current_path = admin_worldwide_organisation_path(worldwide_organisation)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -394,6 +394,11 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, "span.fraction > img[alt='1/x']"
   end
 
+  test "govspeak_with_attachments_to_html with nil body" do
+    html = govspeak_with_attachments_to_html(nil)
+    assert_select_within_html html, ".govspeak", text: ""
+  end
+
   test "govspeak_with_attachments_and_alt_format_information" do
     body = "#Heading\n\n!@1\n\n##Subheading"
     document = build(:published_detailed_guide, :with_file_attachment, body:)

--- a/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_presenter_test.rb
@@ -195,7 +195,6 @@ class PublishingApi::WorldLocationNewsPresenterTest < ActiveSupport::TestCase
   test "it includes a link to worldwide organisations for international delegation" do
     world_location_news = build(:world_location_news)
     world_location = create(:international_delegation, :with_worldwide_organisations, world_location_news:)
-    create(:about_corporate_information_page, organisation: nil, worldwide_organisation: world_location.worldwide_organisations.first)
 
     presented_links = present(world_location_news).links
 

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -30,7 +30,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     expected_hash = {
       base_path: public_path,
       title: "Locationia Embassy",
-      description: "edition-summary",
+      description: "This is the summary text of a worldwide organisation",
       schema_name: "worldwide_organisation",
       document_type: "worldwide_organisation",
       locale: "en",
@@ -40,7 +40,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
-        body: "<div class=\"govspeak\"><p>Some stuff</p>\n</div>",
+        body: "<div class=\"govspeak\"><p>This is the body text of a worldwide organisation</p>\n</div>",
         logo: {
           crest: "single-identity",
           formatted_title: "Locationia\nEmbassy",

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -218,8 +218,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   test "search index data for a worldwide organisation includes name, summary, the correct link and format" do
-    worldwide_organisation = create(:worldwide_organisation, content_id: "7d58b5d8-6d91-4dbb-b3e1-c2a27f131046", name: "British Embassy to Hat land", slug: "british-embassy-to-hat-land")
-    create(:published_corporate_information_page, corporate_information_page_type: CorporateInformationPageType.find("about"), worldwide_organisation:, organisation: nil, summary: "Providing assistance to uk residents in hat land")
+    worldwide_organisation = create(:worldwide_organisation, content_id: "7d58b5d8-6d91-4dbb-b3e1-c2a27f131046", name: "British Embassy to Hat land", summary: "Providing assistance to uk residents in hat land", slug: "british-embassy-to-hat-land")
 
     assert_equal(
       { "title" => worldwide_organisation.name,


### PR DESCRIPTION
This PR moves the details for a worldwide organisation page (e.g. https://www.gov.uk/world/organisations/british-embassy-paris) from the CorporateInformationPage model into the worldwide organisation. 

This fixes an oddity in Whitehall, where the contents of the Worldwide Organisation page are not directly editable from the Worldwide Organisation itself (even though the contents are viewable under the details tab on the admin page), but instead these have to be edited on a separate 'About Us' corporate information page which is itself not published anywhere on GOV.UK. This is a confusing experience, and has led to tech debt where we still publish a draft of the Worldwide Org's about page to the draft content store, and this can conflict with the base path for the Worldwide Organisation itself.

It's worth noting that _Organisations_ (as opposed to Worldwide Organisations) can have About Us pages that do appear on GOV.UK (with a separate URL path) and shouldn't be affected by any of these changes.

One implication of this change is that, since Corporate Information pages are editioned, but Worldwide Organisations are not, the editionable functionality of the body and summary text for the Worldwide Organisation is lost. This has been discussed and agreed with FCDO, and we have [introduced a simple audit history](https://github.com/alphagov/whitehall/pull/7583) for Worldwide Organisations to make up for some of this lost functionality.

This PR contains:
* Some initial tidying commits that make the switch easier
* A migration to copy data from Worldwide Organisation About Us pages (and translations) to the Worldwide Organisation, and updates to the UI to make this content editable under the Worldwide Organisation. This migration took ~11 secs to run on a developer machine against a recent database dump.
* A migration to update Worldwide Organisation About Us pages' attachments to instead be attached to the Worldwide Organisation, and adds the component to edit attachments to the Worldwide Organisation. This migration took ~3 secs to run on a developer machine against a recent database dump.
* Logic to suppress the About Us pages from being viewable from the Worldwide Organisation's corporate information pages, and some explanatory text to explain that this content should now be edited under the main details tab
* A pending migration to delete the Worldwide Organisation about us pages

UI Screenshots:

| Feature | Previous to this PR | After this PR |
| ------ | ----- | ------- |
| Editing the Worldwide Organisation | <img width="1458" alt="Screenshot 2023-05-18 at 15 55 12" src="https://github.com/alphagov/whitehall/assets/25515510/1546c004-8dca-4509-85e5-226982ddb87e"> |![whitehall-admin dev gov uk_government_admin_worldwide_organisations_british-consulate-general-milan_edit (1)](https://github.com/alphagov/whitehall/assets/25515510/ed29aa1e-a66d-4367-b80a-69bb1df10b58)|
| Editing the Worldwide Organisation Translation |<img width="1456" alt="Screenshot 2023-05-18 at 15 55 43" src="https://github.com/alphagov/whitehall/assets/25515510/39917e93-9933-40d5-9823-efb1f3491feb"> |![whitehall-admin dev gov uk_government_admin_worldwide_organisations_british-consulate-general-milan_translations_it_edit](https://github.com/alphagov/whitehall/assets/25515510/09c128d1-ffbb-4cf8-897e-e52be3eb070e)|
| Viewing all corporate information pages for a Worldwide Org |<img width="1457" alt="redacted_screenshot" src="https://github.com/alphagov/whitehall/assets/25515510/517e99b4-d1f3-423d-879d-0605584940db"> | ![whitehall-admin dev gov uk_government_admin_worldwide_organisations_british-consulate-general-milan_corporate_information_pages](https://github.com/alphagov/whitehall/assets/25515510/5373dcae-98fe-433c-9801-c293247de78e)|

Screenshots of adding attachments for the body: 
![whitehall-admin dev gov uk_government_admin_worldwide_organisations_british-consulate-general-milan](https://github.com/alphagov/whitehall/assets/25515510/e85e76e5-5d0f-46e3-b6ed-daa7c16f483b)
![whitehall-admin dev gov uk_government_admin_worldwide_organisations_british-consulate-general-milan_attachments](https://github.com/alphagov/whitehall/assets/25515510/cbcdbc90-8207-403a-9cce-43ff2e88b7ea)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
