### PR TITLE
Update behaviour of select-with-search component

### DIFF
--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -20,7 +20,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.choices = new window.Choices(this.select, {
       allowHTML: true,
       searchPlaceholderValue: 'Search in list',
-      shouldSort: false // show options and groups in the order they were given
+      shouldSort: false, // show options and groups in the order they were given
+      itemSelectText: '',
+      searchResultLimit: 100,
+      // https://fusejs.io/api/options.html
+      fuseOptions: {
+        ignoreLocation: true, // matches any part of the string
+        threshold: 0 // only matches when characters are sequential
+      }
     })
 
     this.module.choices = this.choices

--- a/app/assets/stylesheets/components/_select-with-search.scss
+++ b/app/assets/stylesheets/components/_select-with-search.scss
@@ -212,7 +212,6 @@
     box-shadow: 0 2px 0 #929191;
     line-height: 1;
     color: #0b0c0c;
-    word-break: break-all;
     box-sizing: border-box;
 
     &[data-deletable] {
@@ -246,7 +245,6 @@
     border-top-width: 0;
     top: 100%;
     overflow: hidden;
-    word-break: break-all;
     will-change: visibility;
 
     &.is-active {
@@ -295,7 +293,7 @@
   @media (min-width: 640px) {
     .choices__list--dropdown .choices__item--selectable,
     .choices__list[aria-expanded] .choices__item--selectable {
-      padding-right: 100px;
+      padding-right: 5px;
     }
 
     .choices__list--dropdown .choices__item--selectable:after,


### PR DESCRIPTION
## Description

Based of some feedback we got on our documents search page we're making some changes to the select-with-search components behaviour.

This does the following:

1. Removes the "Press to select" text from options when highlighted
2. Updates fuzzy search to match sequential characters at any part of the string
3. Removes the padding from the right of options where "Press to select" was located. It's now 5px instead of 100px
4. Apply 'word-break: break-word;' so that results are more readable
5. Increase search result limit to 100

All of these changes bring the component more in line with the previous behaviour that Select2 exhibits.

The updates to fuzzy search are using this documentation https://fusejs.io/api/options.html & the update 1 & 6 can be found here https://github.com/Choices-js/Choices#itemselecttext & https://github.com/Choices-js/Choices#searchresultlimit-4

## Screenshots

### removal of "press to select", fuzzy search update, reduced padding & word break

|Bootstrap|Current implementation|New implementation|
|-----------|-----------|------------|
|<img width="428" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/72ca79dd-fc28-43a2-943a-d9bb4745c834">|<img width="514" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/36af3f62-4bad-4809-a7f2-f49873f82b48">|<img width="424" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/329de6aa-5d70-431d-9847-c4cb726b039d">|

### Increase in result limit

The Bootstrap and new implementation are scrollable

|Bootstrap|Current implementation|New implementation|
|-----------|-----------|------------|
|<img width="485" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/76c45b74-94e6-428e-a175-810f334e4aa7">|<img width="404" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/cfddffa1-6b29-49fc-b45d-3e441e245d1d">|<img width="370" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/144258c9-6340-46b2-a1bf-be5d4fec1836">|


## Trello cards

https://trello.com/c/6BE62bVa/164-bug-search-doesnt-display-results-for-shot-versions-of-departments
https://trello.com/c/f8k0oLhf/165-words-cut-off-on-pick-lists

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
