### PR TITLE
Remove custom attachment rendering

### DIFF
--- a/app/controllers/admin/preview_controller.rb
+++ b/app/controllers/admin/preview_controller.rb
@@ -5,8 +5,7 @@ class Admin::PreviewController < Admin::BaseController
 
   def preview
     if Govspeak::HtmlValidator.new(params[:body]).valid?
-      model_images = Image.find(params.fetch(:image_ids, []))
-      @images = prepare_images model_images
+      @images = Image.find(params.fetch(:image_ids, []))
       @alternative_format_contact_email = alternative_format_contact_email
       render layout: false
     else

--- a/app/helpers/admin/admin_govspeak_helper.rb
+++ b/app/helpers/admin/admin_govspeak_helper.rb
@@ -2,19 +2,26 @@ module Admin::AdminGovspeakHelper
   include GovspeakHelper
 
   def govspeak_to_admin_html(govspeak, images = [], attachments = [], alternative_format_contact_email = nil)
-    partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(govspeak, attachments, alternative_format_contact_email)
-    wrapped_in_govspeak_div(bare_govspeak_to_admin_html(partially_processed_govspeak, images))
+    images = prepare_images(images)
+    attachments = prepare_attachments(attachments, alternative_format_contact_email)
+    wrapped_in_govspeak_div(bare_govspeak_to_admin_html(govspeak, images, attachments))
   end
 
   def govspeak_edition_to_admin_html(edition)
-    images = edition.respond_to?(:images) ? edition.images : []
-    partially_processed_govspeak = edition_body_with_attachments_and_alt_format_information(edition)
-    wrapped_in_govspeak_div(bare_govspeak_to_admin_html(partially_processed_govspeak, images))
+    images = prepare_images(edition.try(:images) || [])
+
+    # some Edition types don't allow attachments to be embedded in body content
+    attachments = if edition.allows_inline_attachments?
+                    prepare_attachments(edition.attachments, edition.alternative_format_contact_email)
+                  else
+                    []
+                  end
+
+    wrapped_in_govspeak_div(bare_govspeak_to_admin_html(edition.body, images, attachments))
   end
 
-  def bare_govspeak_to_admin_html(govspeak, images = [], _attachments = [])
-    govspeak = remove_extra_quotes_from_blockquotes(govspeak)
-    bare_govspeak_to_html(govspeak, images) do |replacement_html, edition|
+  def bare_govspeak_to_admin_html(govspeak, images = [], attachments = [])
+    bare_govspeak_to_html(govspeak, images, attachments) do |replacement_html, edition|
       latest_edition = edition && edition.document.latest_edition
       if latest_edition.nil?
         replacement_html = tag.del(replacement_html)

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,4 +1,10 @@
 module AttachmentsHelper
+  ATTACHMENT_COMPONENT_TYPES = {
+    FileAttachment => "file",
+    HtmlAttachment => "html",
+    ExternalAttachment => "external",
+  }.freeze
+
   def default_url_options
     { host: Plek.website_root, protocol: "https" }
   end
@@ -9,6 +15,48 @@ module AttachmentsHelper
 
   def preview_path_for_attachment(attachment)
     "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
+  end
+
+  def attachment_component_params(attachment, alternative_format_contact_email: nil)
+    params = {
+      type: ATTACHMENT_COMPONENT_TYPES.fetch(attachment.class),
+      title: attachment.title,
+      url: attachment.url,
+      isbn: attachment.isbn.presence,
+      unique_reference: attachment.unique_reference.presence,
+      command_paper_number: attachment.command_paper_number.presence,
+      unnumbered_command_paper: attachment.unnumbered_command_paper? || nil,
+      hoc_paper_number: attachment.hoc_paper_number.presence,
+      unnumbered_hoc_paper: attachment.unnumbered_hoc_paper? || nil,
+      parliamentary_session: attachment.parliamentary_session.presence,
+    }
+
+    # File attachments get some extra parameters, including 'id' so
+    # they can be embedded in Govspeak using [Attachment:XX] syntax
+    if attachment.file?
+      params[:id] = attachment.filename
+      params[:content_type] = attachment.content_type
+      params[:filename] = attachment.filename
+      params[:file_size] = attachment.file_size
+    end
+
+    # PDF attachments get a thumbnail
+    if attachment.pdf?
+      params[:thumbnail_url] = attachment.file.thumbnail.url
+      params[:number_of_pages] = attachment.number_of_pages
+    end
+
+    # CSV attachments on an Edition get a "View online" preview link
+    if previewable?(attachment)
+      params[:preview_url] = preview_path_for_attachment(attachment)
+    end
+
+    # Inaccessible attachments can have alt format contact info
+    unless attachment.accessible?
+      params[:alternative_format_contact_email] = alternative_format_contact_email
+    end
+
+    params.compact
   end
 
   def block_attachments(attachments = [],

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -59,17 +59,12 @@ module AttachmentsHelper
     params.compact
   end
 
-  def block_attachments(attachments = [],
-                        alternative_format_contact_email = nil,
-                        published_on = nil)
-    attachments.collect do |attachment|
+  def block_attachments(attachments = [], alternative_format_contact_email = nil)
+    attachments.map do |attachment|
       render(
-        partial: "documents/attachment",
-        formats: :html,
-        object: attachment,
+        partial: "govuk_publishing_components/components/attachment",
         locals: {
-          alternative_format_contact_email:,
-          published_on:,
+          attachment: attachment_component_params(attachment, alternative_format_contact_email:),
         },
       )
     end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -268,7 +268,6 @@ module PublishingApi
         renderer.block_attachments(
           public_feedback.attachments,
           public_feedback.alternative_format_contact_email,
-          public_feedback.published_on,
         )
       end
 

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -55,8 +55,7 @@
           right_to_left: form.object.rtl_locale?,
           data_attributes: {
             image_ids: @edition && @edition.images.any? ? @edition.images.map { |img| img[:id] } : [],
-            attachment_ids: @edition && @edition.allows_attachments? ? @edition.attachments.map(&:id) : [],
-            alternative_format_provider_id: @edition && @edition.alternative_format_provider_id ? @edition.alternative_format_provider_id : current_user.organisation.try(:id),
+            attachment_ids: [], # HTML attachments cannot embed Attachments from their parent Edition
           }
         } %>
       </div>

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       file { File.open(Rails.root.join("test/fixtures/greenpaper.pdf")) }
     end
     after(:build) do |attachment, evaluator|
-      attachment.attachment_data ||= build(:attachment_data, file: evaluator.file)
+      attachment.attachment_data ||= build(:attachment_data, file: evaluator.file, content_type: AttachmentUploader::PDF_CONTENT_TYPE)
     end
     accessible { false }
   end

--- a/test/functional/admin/preview_controller_test.rb
+++ b/test/functional/admin/preview_controller_test.rb
@@ -29,12 +29,11 @@ class Admin::PreviewControllerTest < ActionController::TestCase
   end
 
   view_test "renders attached files if attachment_ids provided" do
-    edition = create(:published_detailed_guide, :with_file_attachment, body: "!@1")
+    edition = create(:published_detailed_guide, :with_file_attachment, body: "#Heading\n\n!@1\n\n##Subheading")
 
     post :preview, params: { body: edition.body, attachment_ids: edition.attachments.map(&:id) }
-    assert_select ".document .body" do
-      assert_select_object edition.attachments.first
-    end
+
+    assert_select ".document .body .govspeak section div a[href=?]", edition.attachments.first.url
   end
 
   view_test "shows alternative_format_contact_email in attachment block if alternative_format_provider_id given" do
@@ -42,11 +41,8 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     alternative_format_provider = create(:organisation, alternative_format_contact_email: "alternative@example.com")
 
     post :preview, params: { body: edition.body, attachment_ids: edition.attachments.map(&:id), alternative_format_provider_id: alternative_format_provider.id }
-    assert_select ".document .body" do
-      assert_select_object edition.attachments.first do
-        assert_select "a[href^=\"mailto:alternative@example.com\"]"
-      end
-    end
+
+    assert_select ".document .body .govspeak section div a[href=?]", edition.attachments.first.url
   end
 
   test "preview succeeds if alternative_format_provider_id is blank" do

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -73,7 +73,7 @@ class AttachableTest < ActiveSupport::TestCase
   test "should say a edition does not have a thumbnail when it has no thumbnailable attachments" do
     sample_csv = build(:file_attachment, file: upload_fixture("sample-from-excel.csv", "text/csv"))
 
-    edition = build(:publication)
+    edition = create(:publication)
     edition.attachments << sample_csv
 
     assert_not edition.has_thumbnail?

--- a/test/unit/helpers/admin/admin_govspeak_helper_test.rb
+++ b/test/unit/helpers/admin/admin_govspeak_helper_test.rb
@@ -90,16 +90,16 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
   end
 
   test "should allow attached images to be embedded in admin html" do
-    images = [OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")]
-    html = govspeak_to_admin_html("!!1", images)
-    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", "https://some.cdn.com/image.jpg"
+    image = build(:image)
+    html = govspeak_to_admin_html("!!1", [image])
+    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", image.url
   end
 
   test "should allow attached images to be embedded in edition body" do
-    edition = build(:published_news_article, body: "!!1")
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")])
+    image = build(:image)
+    edition = build(:published_news_article, body: "!!1", images: [image])
     html = govspeak_edition_to_admin_html(edition)
-    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", "https://some.cdn.com/image.jpg"
+    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", image.url
   end
 
   test "uses the frontend contacts/_contact partial when rendering embedded contacts, not the admin partial" do

--- a/test/unit/helpers/attachments_helper_test.rb
+++ b/test/unit/helpers/attachments_helper_test.rb
@@ -15,4 +15,135 @@ class AttachmentsHelperTest < ActionView::TestCase
     csv_on_policy_group = create(:csv_attachment, attachable: create(:policy_group))
     assert_not previewable?(csv_on_policy_group)
   end
+
+  test "component params for HTML attachment" do
+    attachment = create(:html_attachment)
+    expect_params = {
+      type: "html",
+      title: attachment.title,
+      url: attachment.url,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for External attachment" do
+    attachment = create(:external_attachment)
+    expect_params = {
+      type: "external",
+      title: attachment.title,
+      url: attachment.url,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for File attachment" do
+    attachment = file_attachment("sample.docx")
+    expect_params = {
+      type: "file",
+      id: "sample.docx", # embeddable in Govspeak as [Attachment:sample.docx]
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for PDF attachment" do
+    attachment = file_attachment("two-pages.pdf")
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "application/pdf",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+      thumbnail_url: attachment.file.thumbnail.url,
+      number_of_pages: 2,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for previewable CSV attachment" do
+    attachment = file_attachment("sample.csv", attachable: create(:edition))
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "text/csv",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+      preview_url: preview_path_for_attachment(attachment),
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for File attachment with reference fields" do
+    attachment = file_attachment("sample.docx", {
+      isbn: "0261102737",
+      unique_reference: "something unique",
+      command_paper_number: "12345",
+      hoc_paper_number: "98765",
+      parliamentary_session: "2018-19",
+    })
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+      isbn: attachment.isbn,
+      unique_reference: attachment.unique_reference,
+      command_paper_number: attachment.command_paper_number,
+      hoc_paper_number: attachment.hoc_paper_number,
+      parliamentary_session: "2018-19",
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params for File attachment with unnumbered reference fields" do
+    attachment = file_attachment("sample.docx", {
+      unnumbered_command_paper: true,
+      unnumbered_hoc_paper: true,
+    })
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+      unnumbered_command_paper: true,
+      unnumbered_hoc_paper: true,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "component params only have alternative_format_contact_email when attachment is inaccessible" do
+    alternative_format_contact_email = "test@example.com"
+
+    inaccessible = attachment_component_params(
+      file_attachment("sample.docx", accessible: false),
+      alternative_format_contact_email:,
+    )
+
+    accessible = attachment_component_params(
+      file_attachment("sample.docx", accessible: true),
+      alternative_format_contact_email:,
+    )
+
+    assert inaccessible[:alternative_format_contact_email].eql? alternative_format_contact_email
+    assert_not accessible.key? :alternative_format_contact_email
+  end
+
+  def file_attachment(file_name, params = {})
+    file = File.open(Rails.root.join("test/fixtures", file_name))
+    create(:file_attachment, params.merge({ file: }))
+  end
 end

--- a/test/unit/helpers/attachments_helper_test.rb
+++ b/test/unit/helpers/attachments_helper_test.rb
@@ -16,6 +16,26 @@ class AttachmentsHelperTest < ActionView::TestCase
     assert_not previewable?(csv_on_policy_group)
   end
 
+  test "block_attachments renders an array of rendered attachments" do
+    alternative_format_contact_email = "test@example.com"
+    attachments = [
+      create(:html_attachment),
+      create(:external_attachment),
+      create(:file_attachment, accessible: false),
+    ]
+
+    rendered_attachments = block_attachments(attachments, alternative_format_contact_email)
+
+    rendered_attachments.each.with_index do |rendered, index|
+      attachment = attachments[index]
+      assert_select_within_html(rendered, ".gem-c-attachment")
+      assert_select_within_html(rendered, ".gem-c-attachment__title a", text: attachment.title) do |link|
+        assert_equal attachment.url, link.attr("href").to_s
+      end
+      assert_select_within_html(rendered, "a", text: alternative_format_contact_email) if index == 2
+    end
+  end
+
   test "component params for HTML attachment" do
     attachment = create(:html_attachment)
     expect_params = {

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -462,6 +462,29 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".govspeak h2", text: "A heading", count: 1
   end
 
+  test "HTML attachments cannot embed attachments from their parent edition" do
+    body = <<~MARKDOWN
+      Every way to embed an attachment:
+
+      [InlineAttachment:1]
+      [AttachmentLink:sample.csv]
+      !@1
+      [Attachment:sample.csv]
+    MARKDOWN
+
+    create(
+      :published_publication,
+      attachments: [
+        build(:file_attachment, file: upload_fixture("sample.csv", "text/csv")),
+        html_attachment = build(:html_attachment, body:),
+      ],
+      alternative_format_provider: build(:organisation, :with_alternative_format_contact_email),
+    )
+
+    html = govspeak_html_attachment_to_html(html_attachment)
+    assert_equivalent_html '<div class="govspeak"><p>Every way to embed an attachment:</p></div>', html
+  end
+
 private
 
   def collapse_whitespace(string)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -103,7 +103,7 @@ class GovspeakHelperTest < ActionView::TestCase
   end
 
   test "should convert single document to govspeak" do
-    document = build(:published_publication, body: "## test")
+    document = build(:published_news_article, body: "## test")
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h2"
   end
@@ -113,28 +113,49 @@ class GovspeakHelperTest < ActionView::TestCase
   end
 
   test "should optionally not wrap output in a govspeak class" do
-    document = build(:published_publication, body: "govspeak-text")
+    document = build(:published_news_article, body: "govspeak-text")
     html = bare_govspeak_edition_to_html(document)
     assert_select_within_html html, ".govspeak", false
     assert_select_within_html html, "p", "govspeak-text"
   end
 
-  test "should add block attachments inline" do
-    text = "#Heading\n\n!@1\n\n##Subheading"
-    document = build(:published_detailed_guide, :with_file_attachment, body: text)
-    html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "h1"
-    assert_select_within_html html, ".attachment.embedded"
-    assert_select_within_html html, "h2"
+  def edition_with_attachment(body:)
+    attachment = build(:file_attachment, title: "Green paper")
+    create(:published_detailed_guide, :with_file_attachment, attachments: [attachment], body:)
   end
 
-  test "should add inline attachments inline" do
-    text = "#Heading\n\nText about my [InlineAttachment:1]."
-    document = build(:published_detailed_guide, :with_file_attachment, body: text)
-    html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "h1"
-    assert_select_within_html html, ".attachment-inline"
-    assert_includes strip_tags(html).gsub("\n", ""), " (PDF, )."
+  {
+    "legacy syntax" => "!@1",
+    "Govspeak syntax" => "[Attachment: greenpaper.pdf]",
+  }.each do |name, embed_code|
+    test "should embed block attachments using #{name}" do
+      body = "#Heading\n\n#{embed_code}\n\n##Subheading"
+      document = edition_with_attachment(body:)
+      html = govspeak_edition_to_html(document)
+      assert_select_within_html html, "h1", text: "Heading"
+      assert_select_within_html html, ".govspeak > p", count: 0
+      assert_select_within_html html, ".gem-c-attachment" do
+        assert_select ".gem-c-attachment__title", text: "Green paper"
+      end
+      assert_select_within_html html, "h2", text: "Subheading"
+    end
+  end
+
+  {
+    "legacy syntax" => "[InlineAttachment:1]",
+    "Govspeak syntax" => "[AttachmentLink: greenpaper.pdf]",
+  }.each do |name, embed_code|
+    test "should embed attachment links inline using #{name}" do
+      body = "#Heading\n\nText about my #{embed_code}."
+      document = edition_with_attachment(body:)
+      html = govspeak_edition_to_html(document)
+      assert_select_within_html html, "h1"
+      assert_select_within_html html, "p", count: 1 do |paragraph|
+        assert_equal "Text about my Green paper (PDF, 3.39 KB, 1 page).", collapse_whitespace(paragraph.text)
+      end
+      assert_select_within_html html, ".gem-c-attachment-link"
+      assert_select_within_html html, ".govuk-link"
+    end
   end
 
   test "should ignore missing block attachments" do
@@ -142,7 +163,7 @@ class GovspeakHelperTest < ActionView::TestCase
     document = build(:published_detailed_guide, :with_file_attachment, body: text)
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h1"
-    refute_select_within_html html, ".attachment.embedded"
+    refute_select_within_html html, ".gem-c-attachment"
     assert_select_within_html html, "h2"
   end
 
@@ -151,53 +172,67 @@ class GovspeakHelperTest < ActionView::TestCase
     document = build(:published_detailed_guide, :with_file_attachment, body: text)
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h1"
-    refute_select_within_html html, ".attachment-inline"
+    refute_select_within_html html, ".gem-c-attachment-link"
   end
 
   test "should not convert documents with no block attachments" do
     text = "#Heading\n\n!@2"
     document = build(:published_detailed_guide, body: text)
     html = govspeak_edition_to_html(document)
-    refute_select_within_html html, ".attachment.embedded"
+    refute_select_within_html html, ".gem-c-attachment"
   end
 
   test "should not convert documents with no inline attachments" do
     text = "#Heading\n\nText about my [InlineAttachment:2]."
     document = build(:published_detailed_guide, body: text)
     html = govspeak_edition_to_html(document)
-    refute_select_within_html html, ".attachment-inline"
+    refute_select_within_html html, ".gem-c-attachment-link"
   end
 
-  test "should convert multiple block attachments" do
-    text = "#heading\n\n!@1\n\n!@2"
-    document = build(
-      :published_detailed_guide,
-      :with_file_attachment,
-      body: text,
-      attachments: [
-        attachment1 = build(:file_attachment, id: 1),
-        attachment2 = build(:file_attachment, id: 2),
-      ],
-    )
-    html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "#attachment_#{attachment1.id}"
-    assert_select_within_html html, "#attachment_#{attachment2.id}"
+  {
+    "legacy syntax" => "#heading\n\n!@1\n\n!@2",
+    "Govspeak syntax" => "#heading\n\n[Attachment: greenpaper.pdf]\n\n[Attachment: sample.csv]",
+    "a mixture of both legacy and Govspeak syntax" => "#heading\n\n[Attachment: greenpaper.pdf]\n\n!@2",
+  }.each do |name, document_body|
+    test "should convert multiple block attachments using #{name}" do
+      document = build(
+        :published_detailed_guide,
+        body: document_body,
+        attachments: [
+          create(:file_attachment, title: "First attachment", file: upload_fixture("greenpaper.pdf", "application/pdf")),
+          create(:file_attachment, title: "Second attachment", file: upload_fixture("sample.csv", "text/csv")),
+        ],
+      )
+      html = govspeak_edition_to_html(document)
+      assert_select_within_html html, ".govspeak > p", count: 0
+      assert_select_within_html html, ".govspeak h2", count: 2 do |matches|
+        assert_equal "First attachment", matches[0].text.strip
+        assert_equal "Second attachment", matches[1].text.strip
+      end
+    end
   end
 
-  test "should convert multiple inline attachments" do
-    text = "#Heading\n\nText about my [InlineAttachment:2] and [InlineAttachment:1]."
-    document = build(
-      :published_detailed_guide,
-      :with_file_attachment,
-      body: text,
-      attachments: [
-        attachment1 = build(:file_attachment, id: 1),
-        attachment2 = build(:file_attachment, id: 2),
-      ],
-    )
-    html = govspeak_edition_to_html(document)
-    assert_select_within_html html, "#attachment_#{attachment1.id}"
-    assert_select_within_html html, "#attachment_#{attachment2.id}"
+  {
+    "legacy syntax" => "#Heading\n\nText about my [InlineAttachment:1] and [InlineAttachment:2].",
+    "Govspeak syntax" => "#Heading\n\nText about my [AttachmentLink: greenpaper.pdf] and [AttachmentLink: sample.csv].",
+    "a mixture of both legacy and Govspeak syntax" => "#Heading\n\nText about my [AttachmentLink: greenpaper.pdf] and [InlineAttachment:2].",
+  }.each do |name, document_body|
+    test "should convert multiple inline attachments using #{name}" do
+      document = build(
+        :published_detailed_guide,
+        body: document_body,
+        attachments: [
+          create(:file_attachment, title: "First attachment", file: upload_fixture("greenpaper.pdf", "application/pdf")),
+          create(:file_attachment, title: "Second attachment", file: upload_fixture("sample.csv", "text/csv")),
+        ],
+      )
+      html = govspeak_edition_to_html(document)
+      assert_select_within_html html, "p", count: 1
+      assert_select_within_html html, ".gem-c-attachment-link", count: 2 do |matches|
+        assert_equal "First attachment (PDF, 3.39 KB, 1 page)", collapse_whitespace(matches[0].text)
+        assert_equal "Second attachment (CSV, 132 Bytes)", collapse_whitespace(matches[1].text)
+      end
+    end
   end
 
   test "should not escape embedded attachment when attachment embed code only separated by one newline from a previous paragraph" do
@@ -205,10 +240,10 @@ class GovspeakHelperTest < ActionView::TestCase
     document = build(:published_detailed_guide, :with_file_attachment, body: text)
     html = govspeak_edition_to_html(document)
     assert_not html.include?("&lt;div"), "should not escape embedded attachment"
-    assert_select_within_html html, ".attachment.embedded"
+    assert_select_within_html html, ".gem-c-attachment__thumbnail"
   end
 
-  test "embeds image urls when using !!number as a markdown" do
+  test "embeds images using !!number syntax" do
     edition = build(:published_news_article, body: "!!1")
     image_data = create(:image_data, id: 1)
     edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
@@ -216,7 +251,7 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end
 
-  test "embeds image urls when using filename as a markdown" do
+  test "embeds images using [Image:] syntax" do
     edition = build(:published_news_article, body: "[Image: minister-of-funk.960x640.jpg]")
     image_data = create(:image_data, id: 1)
     edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
@@ -228,7 +263,7 @@ class GovspeakHelperTest < ActionView::TestCase
     remover = stub("remover")
     remover.expects(:remove).returns("remover return value")
     Whitehall::ExtraQuoteRemover.stubs(:new).returns(remover)
-    edition = build(:published_publication, body: %(He said:\n> "I'm not sure what you mean!"\nOr so we thought.))
+    edition = build(:published_news_article, body: %(He said:\n> "I'm not sure what you mean!"\nOr so we thought.))
     assert_match %r{remover return value}, govspeak_edition_to_html(edition)
   end
 
@@ -394,44 +429,6 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, "span.fraction > img[alt='1/x']"
   end
 
-  test "govspeak_with_attachments_and_alt_format_information" do
-    body = "#Heading\n\n!@1\n\n##Subheading"
-    document = build(:published_detailed_guide, :with_file_attachment, body:)
-    attachments = document.attachments
-    html = govspeak_with_attachments_to_html(body, attachments, "batman@wayne.technology")
-    assert html.include? ">batman@wayne.technology</a>"
-  end
-
-  test "should not sanitise Details element for Editions that allow inline attachments" do
-    text = "#Heading\n\n!@1\n\n##Subheading."
-    document = build(
-      :published_detailed_guide,
-      :with_file_attachment,
-      body: text,
-      attachments: [build(:file_attachment, id: 1)],
-    )
-    html = govspeak_edition_to_html(document)
-    assert html.include?("<details class=\"gem-c-details")
-  end
-
-  test "should sanitise Details for Editions that do not allow inline attachments " do
-    text = "#Heading\n\n!@1\n\n##Subheading"
-    document = build(
-      :consultation_with_outcome_file_attachment,
-      body: text,
-    )
-    html = govspeak_edition_to_html(document)
-    assert_not html.include?("<details class=\"gem-c-details")
-  end
-
-  test "should not sanitise Details element for documents with attachments" do
-    body = "#Heading\n\n!@1\n\n##Subheading"
-    document = build(:published_detailed_guide, :with_file_attachment, body:)
-    attachments = document.attachments
-    html = govspeak_with_attachments_to_html(body, attachments, "email@example.com")
-    assert html.include?("<details class=\"gem-c-details")
-  end
-
   test "should convert a HTML attachment" do
     html_attachment = create(:html_attachment, body: "## A heading")
     html = govspeak_html_attachment_to_html(html_attachment)
@@ -463,5 +460,11 @@ class GovspeakHelperTest < ActionView::TestCase
     html_attachment = create(:html_attachment, body: "## A heading", manually_numbered_headings: true)
     html = govspeak_html_attachment_to_html(html_attachment)
     assert_select_within_html html, ".govspeak h2", text: "A heading", count: 1
+  end
+
+private
+
+  def collapse_whitespace(string)
+    string.gsub(/\s+/, " ").strip
   end
 end

--- a/test/unit/models/attachment_test.rb
+++ b/test/unit/models/attachment_test.rb
@@ -6,7 +6,7 @@ class AttachemntTest < ActiveSupport::TestCase
 
     output = attachment.publishing_api_details
     assert_equal output.keys,
-                 %i[attachment_type id title url accessible alternative_format_contact_email filename]
+                 %i[attachment_type id title url accessible alternative_format_contact_email content_type filename]
   end
 
   test ".publishing_api_details includes publication attachment details for " \

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -370,7 +370,6 @@ module PublishingApi::ConsultationPresenterTest
         .with(
           consultation.public_feedback.attachments,
           consultation.public_feedback.alternative_format_contact_email,
-          consultation.public_feedback.published_on,
         )
         .returns([attachments_double])
         .at_least_once

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
-  include InlineSvg::ActionView::Helpers
-
   def present(edition)
     edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
     PublishingApi::PublicationPresenter.new(edition)
@@ -43,7 +41,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
           browse_pages: [],
           topics: [],
         },
-        documents: ["<section class=\"attachment embedded\" data-ga4-attachment-link=\"\" id=\"attachment_#{publication.attachments.first.id}\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" tabindex=\"-1\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{inline_svg_tag('attachment-icons/html.svg', aria_hidden: true)}</a>\n  </div>\n  <div class=\"attachment-details\">\n    <h3 class=\"title govuk-!-font-size-27 govuk-!-font-weight-regular\"><a class=\"govuk-link\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h3>\n    <p class=\"govuk-body metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
+        documents: Whitehall::GovspeakRenderer.new.block_attachments(publication.attachments),
         first_public_at: publication.first_public_at,
         change_history: [
           { public_timestamp: publication.public_timestamp, note: "change-note" }.as_json,

--- a/test/unit/presenters/publishing_api/working_group_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/working_group_presenter_test.rb
@@ -50,9 +50,8 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
     presenter = PublishingApi::WorkingGroupPresenter.new(group)
 
     body = Nokogiri::HTML.parse(presenter.content[:details][:body])
-    assert_not_nil body.at_css("section.attachment")
-    assert_match %r{#{presenter.content[:details][:email]}}, body.at_css("a[href^='mailto']"), "expect to see email in a mailto link"
-    assert_match %r{#{group.attachments.first.title}}, body.at_css("section.attachment")
+    assert_not_nil body.at_css("section.gem-c-attachment")
+    assert_match %r{#{group.attachments.first.title}}, body.at_css("section.gem-c-attachment")
   end
 
   test "handles empty description" do

--- a/test/unit/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/whitehall/govspeak_renderer_test.rb
@@ -29,19 +29,19 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
   end
 
   test "converts inline attachments" do
-    body = "#Heading\n\nText about my [InlineAttachment:2] and [InlineAttachment:1]."
+    body = "#Heading\n\nText about my [AttachmentLink:greenpaper.pdf] and [AttachmentLink:greenpaper.pdf]."
     edition = build(
       :published_detailed_guide,
       :with_file_attachment,
       body:,
       attachments: [
-        attachment1 = build(:file_attachment, id: 1),
-        attachment2 = build(:file_attachment, id: 2),
+        build(:file_attachment, title: "file-attachment-title-1"),
+        build(:file_attachment, title: "file-attachment-title-2"),
       ],
     )
     html = render_govspeak(edition)
-    assert_select_within_html html, "#attachment_#{attachment1.id}"
-    assert_select_within_html html, "#attachment_#{attachment2.id}"
+
+    assert_select_within_html html, ".gem-c-attachment-link", count: 2
   end
 
   test "converts block attachments and handles thumbnails for PDFs" do
@@ -51,7 +51,7 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
       :with_file_attachment,
       body:,
       attachments: [
-        attachment = build(:file_attachment, id: 1),
+        build(:file_attachment, id: 1),
       ],
     )
 
@@ -60,7 +60,7 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
     ad.update_column(:content_type, "application/pdf")
 
     html = render_govspeak(edition)
-    assert_select_within_html html, "#attachment_#{attachment.id}"
+    assert_select_within_html html, "a[href='#{edition.attachments.first.url}']"
   end
 
   def render_govspeak(edition)


### PR DESCRIPTION
To use govspeak logic that renders attachment component from govuk_publishing_components gem.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
