### PR TITLE
Make migration to add content ID to Worldwide Offices more robust

### DIFF
--- a/db/data_migration/20230518113916_generate_content_ids_for_worldwide_offices.rb
+++ b/db/data_migration/20230518113916_generate_content_ids_for_worldwide_offices.rb
@@ -1,0 +1,15 @@
+def log_message
+  %(
+    Number of WorldwideOffices: #{WorldwideOffice.count},
+    Number of WorldwideOffices with content_id: #{WorldwideOffice.where.not(content_id: nil).count}
+    Number of WorldwideOffices without content_id: #{WorldwideOffice.where(content_id: nil).count}
+  )
+end
+
+puts "BEFORE: #{log_message}"
+
+WorldwideOffice.where(content_id: nil).each do |office|
+  office.update!(content_id: SecureRandom.uuid)
+end
+
+puts "AFTER: #{log_message}"

--- a/db/migrate/20230515120104_add_content_id_to_worldwide_offices.rb
+++ b/db/migrate/20230515120104_add_content_id_to_worldwide_offices.rb
@@ -1,7 +1,11 @@
 class AddContentIdToWorldwideOffices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :worldwide_offices, :content_id, :string
+  def up
+    unless column_exists? :worldwide_offices, :content_id
+      add_column :worldwide_offices, :content_id, :string
+    end
+  end
 
-    WorldwideOffice.all.each { |office| office.update!(content_id: SecureRandom.uuid) }
+  def down
+    remove_column :worldwide_offices, :content_id, :string
   end
 end


### PR DESCRIPTION
This migration seems to have failed part way through when running on the live
environments.

This means that it has not been added to the schema migrations table as a
successful migration, and is trying to run again. Because the first part of the
migration (adding the column) was successful, we now see an error
`Mysql2::Error: Duplicate column name 'content_id'` on subsequent attempts.

This makes the migration conditional on the presence of the column, and moves
the part that generates the UUIDs into a separate data migration so that we can
run it in a more controlled manner.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
