### PR TITLE
Move promotional feature Item index page to GDS

### DIFF
--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -25,7 +25,9 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
     end
   end
 
-  def show; end
+  def show
+    render_design_system("show", "legacy_show", next_release: false)
+  end
 
   def edit
     render_design_system("edit", "legacy_edit", next_release: false)
@@ -66,7 +68,7 @@ private
 
   def get_layout
     design_system_actions = %w[reorder update_order confirm_destroy]
-    design_system_actions += %w[edit index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[edit index show] if preview_design_system?(next_release: false)
     if design_system_actions.include?(action_name)
       "design_system"
     else

--- a/app/views/admin/promotional_feature_items/_legacy_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_legacy_promotional_feature_item.html.erb
@@ -1,0 +1,26 @@
+<%= content_tag_for(:section, promotional_feature_item, class: 'well') do %>
+  <% unless promotional_feature_item.image.s300.url.blank? %>
+    <%= image_tag promotional_feature_item.image.s300.url, alt: promotional_feature_item.image_alt_text %>
+  <% end %>
+
+  <% if promotional_feature_item.youtube_video_url.present? %>
+    <p>
+      <%= link_to promotional_feature_item.youtube_video_url, promotional_feature_item.youtube_video_url %>
+    </p>
+  <% end %>
+
+  <% if promotional_feature_item.title.present? %>
+    <p><%= link_to_unless promotional_feature_item.title_url.blank?, promotional_feature_item.title, promotional_feature_item.title_url %></p>
+  <% end %>
+  <p>
+    <%=format_with_html_line_breaks promotional_feature_item.summary %>
+  </p>
+  <p>
+    <% promotional_feature_item.links.each do |link| %>
+      &mdash; <%= link_to link.text, link.url %><br />
+    <% end %>
+  </p>
+
+  <%= link_to "Edit", edit_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature, promotional_feature_item), class: "btn btn-default"%>
+  <%= link_to "Delete", confirm_destroy_admin_organisation_promotional_feature_item_path(@organisation,@promotional_feature, promotional_feature_item), class: 'btn btn-danger btn-sm' %>
+<% end %>

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -1,71 +1,99 @@
+<%
+  def item_row_builder(promotional_feature_item)
+    [
+      *(
+        if promotional_feature_item.title && !promotional_feature_item.title.blank?
+          [{
+             key: "Item title",
+             value: promotional_feature_item.title
+           }]
+        end),
+
+      *(
+        if promotional_feature_item.title_url
+          [{
+             key: "Item title URL",
+             value: "",
+             actions: [
+               {
+                 label: "View",
+                 href: promotional_feature_item.title_url
+               },
+             ]
+           }]
+        end),
+
+      *([{
+           key: "Summary",
+           value: promotional_feature_item.summary
+         }]),
+
+      *(
+        if promotional_feature_item.image.s300.url
+          [{
+             key: "Image",
+             value: "",
+             actions: [
+               {
+                 label: "View",
+                 href: promotional_feature_item.image.s300.url,
+               },
+             ]
+           }]
+        end),
+
+      *(
+        if promotional_feature_item.image_alt_text
+          [{
+             key: "Image description",
+             value: promotional_feature_item.image_alt_text,
+           }]
+        end),
+
+      *(
+        if promotional_feature_item.youtube_video_url
+          [{
+             key: "YouTube video",
+             value: "",
+             actions: [
+               {
+                 label: "View",
+                 href: promotional_feature_item.youtube_video_url,
+               },
+             ]
+           }]
+        end),
+
+      *(
+        if promotional_feature_item.youtube_video_alt_text
+          [{
+             key: "Video description",
+             value: promotional_feature_item.youtube_video_alt_text
+           }]
+        end),
+
+      *(
+        if promotional_feature_item.links
+          promotional_feature_item.links.each_with_index.map do |promo_link, index|
+            {
+               key: "Item link #{index + 1}",
+               value: promo_link.text,
+               actions: [
+                 {
+                   label: "View",
+                   href: promo_link.url
+                 },
+               ]
+             }
+          end
+        end),
+    ]
+  end
+%>
+
 <%= render "components/summary_card_component", {
   title: "Feature item #{promotional_feature_item.id}",
-  rows: [
-    {
-
-      key: "Item title",
-      value: promotional_feature_item.title
-
-    },
-    {
-      key: "Item title URL",
-      value: "",
-      actions: [
-        {
-          label: "View",
-          href: promotional_feature_item.title_url
-        },
-      ]
-    },
-    {
-      key: "Summary",
-      value: promotional_feature_item.summary,
-
-    },
-    if promotional_feature_item.image.s300.url.present?
-      {
-        key: "Image",
-        value: "",
-        actions: [
-          {
-            label: "View",
-            href: promotional_feature_item.image.s300.url,
-          },
-        ]
-      }
-    end,
-    {
-      key: "Image description",
-      value: promotional_feature_item.image_alt_text,
-    },
-    {
-      key: "YouTube video",
-      value: "",
-      actions: [
-        {
-          label: "View",
-          href: promotional_feature_item.youtube_video_url,
-        },
-      ]
-    },
-    {
-      key: "Video description",
-      value: ""
-    },
-    promotional_feature_item.links.each_with_index.map do |promo_link, index|
-      {
-        key: "Item link #{index + 1}",
-        value: promo_link.text,
-        actions: [
-          {
-            label: "View",
-            href: promo_link.url
-          },
-        ]
-      }
-    end
-
-  ].flatten,
+  rows: item_row_builder(promotional_feature_item),
   summary_card_actions: [
     {
       label: "Edit",

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -1,8 +1,9 @@
-<%
-  def item_row_builder(promotional_feature_item)
+<%= render "components/summary_card_component", {
+  title: "Feature item #{promotional_feature_item.promotional_feature.promotional_feature_items.find_index(promotional_feature_item) + 1}",
+  rows:
     [
       *(
-        if promotional_feature_item.title && !promotional_feature_item.title.blank?
+        if promotional_feature_item.title.present?
           [{
              key: "Item title",
              value: promotional_feature_item.title
@@ -10,7 +11,7 @@
         end),
 
       *(
-        if promotional_feature_item.title_url
+        if promotional_feature_item.title_url.present?
           [{
              key: "Item title URL",
              value: "",
@@ -23,10 +24,10 @@
            }]
         end),
 
-      *([{
-           key: "Summary",
-           value: promotional_feature_item.summary
-         }]),
+      {
+        key: "Summary",
+        value: promotional_feature_item.summary
+      },
 
       *(
         if promotional_feature_item.image.s300.url
@@ -43,7 +44,7 @@
         end),
 
       *(
-        if promotional_feature_item.image_alt_text
+        if promotional_feature_item.image_alt_text.present?
           [{
              key: "Image description",
              value: promotional_feature_item.image_alt_text,
@@ -76,24 +77,18 @@
         if promotional_feature_item.links
           promotional_feature_item.links.each_with_index.map do |promo_link, index|
             {
-               key: "Item link #{index + 1}",
-               value: promo_link.text,
-               actions: [
-                 {
-                   label: "View",
-                   href: promo_link.url
-                 },
-               ]
-             }
+              key: "Item link #{index + 1}",
+              value: promo_link.text,
+              actions: [
+                {
+                  label: "View",
+                  href: promo_link.url
+                },
+              ]
+            }
           end
         end),
-    ]
-  end
-%>
-
-<%= render "components/summary_card_component", {
-  title: "Feature item #{promotional_feature_item.id}",
-  rows: item_row_builder(promotional_feature_item),
+    ],
   summary_card_actions: [
     {
       label: "Edit",

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -1,26 +1,82 @@
-<%= content_tag_for(:section, promotional_feature_item, class: 'well') do %>
-  <% unless promotional_feature_item.image.s300.url.blank? %>
-    <%= image_tag promotional_feature_item.image.s300.url, alt: promotional_feature_item.image_alt_text %>
-  <% end %>
+<%= render "components/summary_card_component", {
+  title: "Feature item #{promotional_feature_item.id}",
+  rows: [
+    {
 
-  <% if promotional_feature_item.youtube_video_url.present? %>
-    <p>
-      <%= link_to promotional_feature_item.youtube_video_url, promotional_feature_item.youtube_video_url %>
-    </p>
-  <% end %>
+      key: "Item title",
+      value: promotional_feature_item.title
 
-  <% if promotional_feature_item.title.present? %>
-    <p><%= link_to_unless promotional_feature_item.title_url.blank?, promotional_feature_item.title, promotional_feature_item.title_url %></p>
-  <% end %>
-  <p>
-    <%=format_with_html_line_breaks promotional_feature_item.summary %>
-  </p>
-  <p>
-    <% promotional_feature_item.links.each do |link| %>
-      &mdash; <%= link_to link.text, link.url %><br />
-    <% end %>
-  </p>
+    },
+    {
+      key: "Item title URL",
+      value: "",
+      actions: [
+        {
+          label: "View",
+          href: promotional_feature_item.title_url
+        },
+      ]
+    },
+    {
+      key: "Summary",
+      value: promotional_feature_item.summary,
 
-  <%= link_to "Edit", edit_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature, promotional_feature_item), class: "btn btn-default"%>
-  <%= link_to "Delete", confirm_destroy_admin_organisation_promotional_feature_item_path(@organisation,@promotional_feature, promotional_feature_item), class: 'btn btn-danger btn-sm' %>
-<% end %>
+    },
+    if promotional_feature_item.image.s300.url.present?
+      {
+        key: "Image",
+        value: "",
+        actions: [
+          {
+            label: "View",
+            href: promotional_feature_item.image.s300.url,
+          },
+        ]
+      }
+    end,
+    {
+      key: "Image description",
+      value: promotional_feature_item.image_alt_text,
+    },
+    {
+      key: "YouTube video",
+      value: "",
+      actions: [
+        {
+          label: "View",
+          href: promotional_feature_item.youtube_video_url,
+        },
+      ]
+    },
+    {
+      key: "Video description",
+      value: ""
+    },
+    promotional_feature_item.links.each_with_index.map do |promo_link, index|
+      {
+        key: "Item link #{index + 1}",
+        value: promo_link.text,
+        actions: [
+          {
+            label: "View",
+            href: promo_link.url
+          },
+        ]
+      }
+    end
+
+  ].flatten,
+  summary_card_actions: [
+    {
+      label: "Edit",
+      href: edit_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature, promotional_feature_item),
+    },
+    {
+      label: "Delete",
+      href: confirm_destroy_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature, promotional_feature_item),
+      destructive: true
+    }
+  ]
+}
+%>
+

--- a/app/views/admin/promotional_features/legacy_show.html.erb
+++ b/app/views/admin/promotional_features/legacy_show.html.erb
@@ -1,0 +1,18 @@
+<% page_title "Promotional feature: #{@promotional_feature.title}" %>
+
+<%= content_tag_for(:div, @promotional_feature) do %>
+  <h1>Promotional feature: <%= @promotional_feature.title %></h1>
+  <p><%= link_to "Back to #{@organisation.name}", [:admin, @organisation, PromotionalFeature] %></p>
+
+  <% @promotional_feature.items.each do |promo_item| %>
+    <%= render "admin/promotional_feature_items/legacy_promotional_feature_item", promotional_feature_item: promo_item %>
+  <% end %>
+
+  <% if @promotional_feature.has_reached_item_limit? %>
+    <p><em>(maximum number of feature items reached)</em></p>
+  <% else %>
+    <div class="form-actions">
+      <%= link_to "Add feature item", new_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature), class: "btn btn-lg btn-primary" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/promotional_features/show.html.erb
+++ b/app/views/admin/promotional_features/show.html.erb
@@ -1,16 +1,30 @@
-<% page_title "Promotional feature: #{@promotional_feature.title}" %>
-
-<%= content_tag_for(:div, @promotional_feature) do %>
-  <h1>Promotional feature: <%= @promotional_feature.title %></h1>
-  <p><%= link_to "Back to #{@organisation.name}", [:admin, @organisation, PromotionalFeature] %></p>
-
-  <%= render @promotional_feature.items %>
-
-  <% if @promotional_feature.has_reached_item_limit? %>
-    <p><em>(maximum number of feature items reached)</em></p>
-  <% else %>
-    <div class="form-actions">
-      <%= link_to "Add feature item", new_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature), class: "btn btn-lg btn-primary"%>
-    </div>
-  <% end %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: [:admin, @organisation, PromotionalFeature]
+  } %>
 <% end %>
+<% content_for :page_title, "Promotional feature: #{@promotional_feature.title}" %>
+<% content_for :context, "Promotional feature" %>
+<% content_for :title, @promotional_feature.title %>
+<% content_for :title_margin_bottom, 6 %>
+
+<% if @promotional_feature.has_reached_item_limit? %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "maximum number of feature items reached"
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Add feature item",
+    href: new_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature),
+    margin_bottom: 6,
+    start: true,
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% @promotional_feature.items.each do |promo_item| %>
+    <%= render promo_item %>
+      <%end %>
+  </div>
+</div>

--- a/app/views/admin/promotional_features/show.html.erb
+++ b/app/views/admin/promotional_features/show.html.erb
@@ -10,21 +10,20 @@
 
 <% if @promotional_feature.has_reached_item_limit? %>
   <%= render "govuk_publishing_components/components/inset_text", {
-    text: "maximum number of feature items reached"
+    text: "Maximum number of feature items reached"
   } %>
 <% else %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Add feature item",
     href: new_admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature),
     margin_bottom: 6,
-    start: true,
   } %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% @promotional_feature.items.each do |promo_item| %>
-    <%= render promo_item %>
-      <%end %>
+      <%= render promo_item %>
+    <% end %>
   </div>
 </div>

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -30,6 +30,8 @@ When(/^I add a new promotional feature with a single item which has an image$/) 
     fill_in "Item title url (optional)", with: "http://big-cheese.co"
     attach_file :image, Rails.root.join("test/fixtures/big-cheese.960x640.jpg")
     fill_in "Image description (alt text)", with: "The Big Cheese"
+    fill_in "Url", with: "http://test.com"
+    fill_in "Text", with: "someText"
   end
 
   click_button "Save"
@@ -49,6 +51,8 @@ When(/^I add a new promotional feature with a single item which has a YouTube UR
     choose "YouTube video"
     fill_in "YouTube video URL", with: "https://www.youtube.com/watch?v=fFmDQn9Lbl4"
     fill_in "YouTube video description (alt text)", with: "Description of video."
+    fill_in "Url", with: "http://test.com"
+    fill_in "Text", with: "someText"
   end
 
   click_button "Save"
@@ -73,11 +77,12 @@ When(/^I edit the promotional item, set the summary to "([^"]*)"$/) do |new_summ
   click_link "Promotional features"
   if using_design_system?
     click_link "View #{@promotional_feature.title}"
+    click_link "Edit"
   else
     click_link @promotional_feature.title
-  end
-  within record_css_selector(@promotional_item) do
-    click_link "Edit"
+    within record_css_selector(@promotional_item) do
+      click_link "Edit"
+    end
   end
   fill_in "Summary", with: new_summary
   click_button "Save"
@@ -88,28 +93,48 @@ When(/^I delete the promotional item$/) do
   click_link "Promotional features"
   if using_design_system?
     click_link "View #{@promotional_feature.title}"
+    click_link "Delete"
   else
     click_link @promotional_feature.title
+    within record_css_selector(@promotional_feature) do
+      click_link "Delete"
+    end
   end
-  within record_css_selector(@promotional_feature) do
-    click_link "Delete"
-  end
+
   click_button "Delete"
 end
 
 Then(/^I should see the promotional feature on the organisation's page$/) do
   promotional_feature = @executive_office.reload.promotional_features.first
+  item = promotional_feature.items.first
   expect(current_url).to eq(admin_organisation_promotional_feature_url(@executive_office, promotional_feature))
 
-  within record_css_selector(promotional_feature) do
+  if using_design_system?
     expect(page).to have_selector("h1", text: promotional_feature.title)
-
-    item = promotional_feature.items.first
-    within record_css_selector(item) do
-      expect(page).to have_content(item.summary)
-      expect(page).to have_link(item.title, href: item.title_url)
-      expect(page).to have_selector("img[src='#{item.image.s300.url}'][alt='#{item.image_alt_text}']") if item.image.present?
-      expect(page).to have_selector("a[href='#{item.youtube_video_url}']") if item.youtube_video_url.present?
+    within ".govuk-summary-card__content" do
+      expect(all(".govuk-summary-list__row")[0]).to have_selector("dd", text: item.title)
+      expect(all(".govuk-summary-list__row")[1].find(".govuk-summary-list__actions")).to have_link("View", href: item.title_url)
+      expect(all(".govuk-summary-list__row")[2]).to have_selector("dd", text: item.summary)
+      if item.image.present?
+        expect(all(".govuk-summary-list__row")[3].find(".govuk-summary-list__actions")).to have_link("View", href: item.image.s300.url)
+        expect(all(".govuk-summary-list__row")[4]).to have_selector("dd", text: item.image_alt_text)
+      end
+      if item.youtube_video_url.present?
+        expect(all(".govuk-summary-list__row")[3].find(".govuk-summary-list__actions")).to have_link("View", href: item.youtube_video_url)
+        expect(all(".govuk-summary-list__row")[4]).to have_selector("dd", text: item.youtube_video_alt_text)
+      end
+      expect(all(".govuk-summary-list__row")[5].find(".govuk-summary-list__actions")).to have_link("View", href: item.links.first.url)
+      expect(all(".govuk-summary-list__row")[5]).to have_selector("dd", text: item.links.first.text)
+    end
+  else
+    within record_css_selector(promotional_feature) do
+      expect(page).to have_selector("h1", text: promotional_feature.title)
+      within record_css_selector(item) do
+        expect(page).to have_content(item.summary)
+        expect(page).to have_link(item.title, href: item.title_url)
+        expect(page).to have_selector("img[src='#{item.image.s300.url}'][alt='#{item.image_alt_text}']") if item.image.present?
+        expect(page).to have_selector("a[href='#{item.youtube_video_url}']") if item.youtube_video_url.present?
+      end
     end
   end
 end
@@ -121,15 +146,22 @@ end
 
 Then(/^I should see the promotional feature item's summary has been updated to "([^"]*)"$/) do |summary_text|
   expect(current_url).to eq(admin_organisation_promotional_feature_url(@executive_office, @promotional_feature))
-
-  within record_css_selector(@promotional_item) do
-    expect(page).to have_selector("p", text: summary_text)
+  if using_design_system?
+    expect(page).to have_selector("dd", text: summary_text)
+  else
+    within record_css_selector(@promotional_item) do
+      expect(page).to have_selector("p", text: summary_text)
+    end
   end
 end
 
 Then(/^I should no longer see the promotional item$/) do
-  within record_css_selector(@promotional_feature) do
-    expect(page).to_not have_selector(record_css_selector(@promotional_item))
+  if using_design_system?
+    expect(page).to_not have_selector("h2", text: @promotional_feature.title)
+  else
+    within record_css_selector(@promotional_feature) do
+      expect(page).to_not have_selector(record_css_selector(@promotional_item))
+    end
   end
 end
 

--- a/test/functional/admin/legacy_promotional_features_controller_test.rb
+++ b/test/functional/admin/legacy_promotional_features_controller_test.rb
@@ -51,7 +51,7 @@ class Admin::LegacyPromotionalFeaturesControllerTest < ActionController::TestCas
     get :show, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_response :success
-    assert_template :show
+    assert_template :legacy_show
     assert_equal promotional_feature, assigns(:promotional_feature)
   end
 


### PR DESCRIPTION
This PR implements promotional feature item index page with GDS components
It has following changes
Duplicated show html file and corresponding  partial with legacy .
Creates new show html land partial with GDS Summary Card components.
Fixed the corresponding feature tests.

Screen shots 
**Before:**
![image](https://github.com/alphagov/whitehall/assets/131259138/5e00675c-c9b7-4728-bd71-19517f932b4b)


**After:**

![image](https://github.com/alphagov/whitehall/assets/131259138/a00a8a18-d849-4f1c-a8ba-c8417bb1c420)


**Trello:**
https://trello.com/c/8zDKsJgI/123-promotional-feature-item-index-page


