### PR TITLE
#119-Added tracking to promotional feature delete button

### DIFF
--- a/app/views/admin/promotional_features/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_features/confirm_destroy.html.erb
@@ -14,8 +14,14 @@
         <%= render "govuk_publishing_components/components/button", {
           text: "Delete",
           destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "role-button",
+            "track-label": "Delete"
+          }
         } %>
-        <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature] ,class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", [:admin, @promotional_feature.organisation, PromotionalFeature], class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>


### PR DESCRIPTION
This PR adds tracking to delete button for promotional feature page.

**Trello:**
https://trello.com/c/0h93Ko8L/119-promotional-feature-confirm-delete-page
