### PR TITLE
Skip callback when creating a world location in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,6 +45,7 @@ if Government.where(name: "Test Government").blank?
 end
 
 WorldLocationNews.skip_callback(:commit, :after, :publish_to_publishing_api)
+WorldLocation.skip_callback(:commit, :after, :republish_embassies_index_page_to_publishing_api)
 
 if WorldLocation.where(name: "Test World Location").blank?
   world_location = WorldLocation.create!(


### PR DESCRIPTION
We've recently added callbacks to ensure that the embassies index page is republised when other content changes. However, when we create data in the seeds this can lead to an attempt to call publishing, leading database seeding to fail.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
