### PR TITLE
Move release 1.7 pages behind Preview next release permission & revert override 

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,9 +42,6 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
-    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
-    return true if next_release && !Rails.env.test?
-
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -12,13 +12,13 @@ class Admin::DashboardController < Admin::BaseController
       end
     end
 
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index, next_release: true)
   end
 
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -48,7 +48,7 @@ class Admin::EditionsController < Admin::BaseController
       if request.xhr?
         render partial: "legacy_search_results"
       else
-        render_design_system(:index, :legacy_index, next_release: false)
+        render_design_system(:index, :legacy_index, next_release: true)
       end
     elsif session_filters.any?
       redirect_to session_filters
@@ -195,7 +195,7 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy diff show edit update new create]
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index] if preview_design_system?(next_release: true)
 
     if design_system_actions.include?(action_name)
       "design_system"
@@ -412,7 +412,7 @@ private
         include_last_author: true,
       )
 
-    filter_options = filter_options.merge(per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE) if preview_design_system?(next_release: false)
+    filter_options = filter_options.merge(per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE) if preview_design_system?(next_release: true)
     filter_options
   end
 

--- a/app/controllers/admin/responses_controller.rb
+++ b/app/controllers/admin/responses_controller.rb
@@ -8,7 +8,7 @@ class Admin::ResponsesController < Admin::BaseController
 
   def show
     @response = response_class.find_by(edition_id: @edition) || response_class.new(published_on: Time.zone.today)
-    render_design_system("show", "show_legacy", next_release: false)
+    render_design_system("show", "show_legacy", next_release: true)
   end
 
   def create
@@ -17,19 +17,19 @@ class Admin::ResponsesController < Admin::BaseController
     if @response.save
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} saved"
     else
-      render_design_system("show", "show_legacy", next_release: false)
+      render_design_system("show", "show_legacy", next_release: true)
     end
   end
 
   def edit
-    render_design_system("edit", "edit_legacy", next_release: false)
+    render_design_system("edit", "edit_legacy", next_release: true)
   end
 
   def update
     if @response.update(response_params)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} updated"
     else
-      render_design_system("edit", "edit_legacy", next_release: false)
+      render_design_system("edit", "edit_legacy", next_release: true)
     end
   end
 
@@ -37,7 +37,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[show create edit update] if preview_design_system?(next_release: false)
+    design_system_actions += %w[show create edit update] if preview_design_system?(next_release: true)
 
     if design_system_actions.include?(action_name)
       "design_system"


### PR DESCRIPTION
## Description

This moves the following pages going out in 1.7 behind the Preview next release permission

1. Dashboard index page (landing page)
2. Documents index page (documents search page)
3. Consultation response edit page
4. Consultation response page

These are the final pages outside of the Document Collections tab in the Documents section to be ported.

It also removes the override for the "Preview next release" method.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
