### PR TITLE
Render the Ministers index page via collections

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         base_path:,
         details:,
         document_type: "ministers_index",
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "ministers_index",
       )
 

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -43,7 +43,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
           body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
         },
         document_type: "ministers_index",
-        rendering_app: "whitehall-frontend",
+        rendering_app: "collections",
         schema_name: "ministers_index",
         routes: [
           {


### PR DESCRIPTION
**NOTE** Depends on https://github.com/alphagov/collections/pull/3261 being merged.

Collections can now [render the Ministers index page](https://github.com/alphagov/collections/pull/3261).

Changing the rendering app completes the last step in the journey to move the rendering of the Ministers index page from whitehall to collections.

Dependencies: needs republishing the content item in all environments.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
