### PR TITLE
Debug flakey test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,9 @@ jobs:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
         run: bundle exec rails cucumber
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: capybara-screenshots
+          path: tmp/capybara/capybara-*.png

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -145,6 +145,7 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   click_on "Create new edition"
   fill_in_change_note_if_required
   click_button "Save and continue"
+  save_screenshot
   click_button "Update tags"
 
   click_on "Edit draft"


### PR DESCRIPTION
https://trello.com/c/bVMUgKC9

We've seen the following test fail a number of times on CI:

```
Unable to find button "Update tags" that is not disabled (Capybara::ElementNotFound)
./features/step_definitions/document_collection_steps.rb:148:in `/^I redraft the document collection and remove "(.*?)" from it$/'
features/document-collections.feature:33:in `I redraft the document collection and remove "May 2012 Update" from it'
```

I haven't managed to replicate the failure locally but have a suspicion that it's triggered when the ["Save and continue" button is clicked][1] but the save fails because the change note is missing.

The [`fill_in_change_note_if_required` method][2] will only fill in a change note if the field is present. There's some JavaScript behaviour to hide/show this field so my guess is that the field isn't present at the time this method is called even though it's required for us to be able to save the document collection.

I'm hoping that the call to `save_screenshot` will give us a better idea of what's happening at the time of this test failing.

We use the [upload-artifact][3] action to upload the screenshot to GitHub.

[1]: https://github.com/alphagov/whitehall/blob/866ebd7cac7c02f482a9225ed772b125530fec98/features/step_definitions/document_collection_steps.rb#LL147C35-L147C35
[2]: https://github.com/alphagov/whitehall/blob/866ebd7cac7c02f482a9225ed772b125530fec98/features/support/document_helper.rb#L140
[3]: https://github.com/actions/upload-artifact