### PR TITLE
Update search results partial link text to "View"

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -46,18 +46,18 @@
       end
   } %>
 
-    <% if paginate(paginator, theme: "govuk_paginator").present? && show_export && can?(:export, Edition) %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
-          <%= paginate(paginator, theme: "govuk_paginator") %>
-        </div>
-        <div class="govuk-grid-column-one-quarter">
-          <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
-        </div>
+  <% if paginate(paginator, theme: "govuk_paginator").present? && show_export && can?(:export, Edition) %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <%= paginate(paginator, theme: "govuk_paginator") %>
       </div>
-    <% elsif paginate(paginator, theme: "govuk_paginator").present? && !(show_export && can?(:export, Edition)) %>
-      <%= paginate(paginator, theme: "govuk_paginator") %>
-    <% elsif show_export && can?(:export, Edition) %>
-      <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
-    <% end %>
+      <div class="govuk-grid-column-one-quarter">
+        <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
+      </div>
+    </div>
+  <% elsif paginate(paginator, theme: "govuk_paginator").present? && !(show_export && can?(:export, Edition)) %>
+    <%= paginate(paginator, theme: "govuk_paginator") %>
+  <% elsif show_export && can?(:export, Edition) %>
+    <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
+  <% end %>
 <% end %>

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -21,7 +21,7 @@
         text: "State"
       },
       {
-        text: tag.span("Edit", class: "govuk-visually-hidden")
+        text: tag.span("View", class: "govuk-visually-hidden")
       }
     ],
     rows:
@@ -39,7 +39,7 @@
              text: render(Admin::Editions::TagsComponent.new(edition)),
            },
            {
-             text: link_to(sanitize("Edit <span class='govuk-visually-hidden'> #{edition.title}</span>"), admin_edition_path(edition), class: "govuk-link"),
+             text: link_to(sanitize("View #{tag.span(edition.title, class: 'govuk-visually-hidden')}"), admin_edition_path(edition), class: "govuk-link"),
              format: "numeric",
            },
         ]


### PR DESCRIPTION
## Description

This goes to a show page so should say "View" not "Edit".

## Screenshots

### Before

<img width="555" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/16ccfebc-7509-4d41-8f06-c23349c7717a">

### After 

<img width="527" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4e35fd84-ef34-4102-98c1-4c3f3b2e8351">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
