### PR TITLE
Add override for release 1.7 for preview next release pages

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -43,7 +43,7 @@ class Admin::BaseController < ApplicationController
 
   def preview_design_system?(next_release: false)
     # Temporarily force this flag to 'on' for users in production, regardless of their permissions
-    return true if next_release #&& !Rails.env.test?
+    return true if next_release && !Rails.env.test?
 
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release #&& !Rails.env.test?
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/test/functional/admin/legacy_editions_controller_test.rb
+++ b/test/functional/admin/legacy_editions_controller_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
-class Admin::EditionsControllerTest < ActionController::TestCase
+class Admin::LegacyEditionsControllerTest < ActionController::TestCase
+  tests Admin::EditionsController
+
   include Admin::EditionRoutesHelper
 
   setup do
-    login_as_preview_design_system_user :writer
+    login_as :writer
   end
 
   should_be_an_admin_controller
@@ -28,6 +30,19 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     Admin::EditionFilter.expects(:new).with(anything, anything, has_entry(state: "active")).returns(stub_filter)
 
     get :index, params: { type: :publication }
+  end
+
+  view_test "should distinguish between edition types when viewing the list of editions" do
+    guide = create(:draft_detailed_guide)
+    publication = create(:draft_publication)
+    stub_filter = stub_edition_filter(editions: [guide, publication])
+    stub_filter.stubs(:show_stats)
+    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+
+    get :index, params: { state: :draft }
+
+    assert_select_object(guide) { assert_select ".type", text: "Detailed guide: Guidance" }
+    assert_select_object(publication) { assert_select ".type", text: "Publication: Policy paper" }
   end
 
   view_test "#index should respond to xhr requests with only the filter results html" do
@@ -171,7 +186,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   test "index should redirect to department if logged in with no remembered filters" do
     organisation = create(:organisation)
-    login_as_preview_design_system_user(:departmental_editor, organisation)
+    login_as create(:departmental_editor, organisation:)
     get :index
     assert_redirected_to admin_editions_path(organisation: organisation.id, state: :active)
   end
@@ -180,30 +195,33 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     publication = create(:published_publication)
     get :index, params: { state: :published, type: :publication }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
-      assert_select ".govuk-table__cell:nth-child(3)", text: "Published"
-    end
+    assert_select_object(publication)
+    refute_select "tr.force_published"
   end
 
   view_test "should show force published editions as force published" do
     publication = create(:published_publication, force_published: true)
     get :index, params: { state: :published, type: :publication }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
-      assert_select ".govuk-table__cell:nth-child(3)", text: "Force published"
-    end
+    assert_select_object(publication)
+    assert_select "tr.force_published"
   end
 
   view_test "should show force published editions when the filter is active" do
     publication = create(:published_publication, force_published: true)
     get :index, params: { state: :force_published, type: :publication }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
-      assert_select ".govuk-table__cell:nth-child(3)", text: "Force published"
-    end
+    assert_select_object(publication)
+    assert_select "tr.force_published"
+  end
+
+  view_test "should not display the featured column when viewing all active editions" do
+    create(:published_news_article)
+
+    get :index, params: { state: :active, type: "news_article" }
+
+    refute_select "th", text: "Featured"
+    refute_select "td.featured"
   end
 
   view_test "should display state information when viewing all active editions" do
@@ -214,35 +232,24 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
     get :index, params: { state: :active }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: draft_edition.title do |cell|
-        cell.first.parent.xpath("td[3]").text.strip == "Draft"
-      end
-    end
+    assert_select_object(draft_edition) { assert_select ".state", "Draft" }
+    assert_select_object(submitted_edition) { assert_select ".state", "Submitted" }
+    assert_select_object(rejected_edition) { assert_select ".state", "Rejected" }
+    assert_select_object(published_edition) { assert_select ".state", "Published" }
+  end
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: submitted_edition.title do |cell|
-        cell.first.parent.xpath("td[3]").text.strip == "Submitted"
-      end
-    end
+  view_test "should not display state information when viewing editions of a particular state" do
+    draft_edition = create(:draft_publication)
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: rejected_edition.title do |cell|
-        cell.first.parent.xpath("td[3]").text.strip == "Rejected"
-      end
-    end
+    get :index, params: { state: :draft }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: published_edition.title do |cell|
-        cell.first.parent.xpath("td[3]").text.strip == "Published"
-      end
-    end
+    assert_select_object(draft_edition) { refute_select ".state" }
   end
 
   view_test "index should not display limited access editions which I don't have access to" do
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
-    login_as_preview_design_system_user(:writer, my_organisation)
+    login_as(create(:user, organisation: my_organisation))
     accessible = [
       create(:draft_publication),
       create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation]),
@@ -253,28 +260,27 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :active }
 
     accessible.each do |edition|
-      assert_select ".govuk-table__cell:nth-child(1)", text: edition.title
+      assert_select_object(edition)
     end
-    refute_select ".govuk-table__cell:nth-child(1)", text: inaccessible.title
+    refute_select_object(inaccessible)
   end
 
   view_test "index should indicate the protected status of limited access editions which I do have access to" do
     my_organisation = create(:organisation)
-    login_as_preview_design_system_user(:writer, my_organisation)
+    login_as(create(:user, organisation: my_organisation))
     publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation])
 
     get :index, params: { state: :active }
 
-    assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
-      assert_select ".govuk-table__cell:nth-child(3)", text: "Draft Limited access"
+    assert_select_object(publication) do
+      assert_select "span", "limited access"
     end
   end
 
   test "prevents revising of access-limited editions" do
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
-    login_as_preview_design_system_user(:writer, my_organisation)
+    login_as(create(:user, organisation: my_organisation))
     inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
 
     post :revise, params: { id: inaccessible }
@@ -282,7 +288,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   end
 
   view_test "prevents oversized exports" do
-    login_as_preview_design_system_user(:gds_editor)
+    login_as(create(:gds_editor))
     Admin::EditionFilter.any_instance.stubs(exportable?: false)
     post :export,
          params: {

--- a/test/integration/legacy_admin_analytics_test.rb
+++ b/test/integration/legacy_admin_analytics_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "capybara/rails"
+
+class LegacyAdminAnalyticsTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  def log_out
+    GDS::SSO.test_user = nil
+  end
+
+  setup do
+    ENV["GDS_SSO_MOCK_INVALID"] = "1"
+  end
+
+  teardown do
+    ENV.delete("GDS_SSO_MOCK_INVALID")
+  end
+
+  # GA is noisy in tests because all GA calls become console.log so we
+  # don't want it enabled for all tests, use this to selectively turn it on
+  def with_ga_enabled
+    GovukAdminTemplate.configure { |c| c.enable_google_analytics_in_tests = true }
+    yield
+  ensure
+    GovukAdminTemplate.configure { |c| c.enable_google_analytics_in_tests = false }
+  end
+
+  def refute_dimension_is_set(dimension)
+    assert_no_match(/#{Regexp.escape("GOVUKAdmin.setDimension(#{dimension}")}/, page.body)
+  end
+
+  def assert_dimension_is_set(dimension, with_value: nil)
+    dimension_set_js_code = "GOVUKAdmin.setDimension(#{dimension}"
+    dimension_set_js_code += ", \"#{with_value}\")" if with_value.present?
+    assert_match(/#{Regexp.escape(dimension_set_js_code)}/, page.body)
+  end
+
+  test "send a GA event including the users org slug when successfully signed-in" do
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: "ministry-of-lindy-hop"))
+      visit admin_root_path
+      assert_dimension_is_set(8, with_value: "ministry-of-lindy-hop")
+    end
+  end
+
+  test "send a GA event including '(not set)' for the org slug when the user has no org" do
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: nil))
+      visit admin_root_path
+      assert_dimension_is_set(8, with_value: "(not set)")
+    end
+  end
+
+  test "does not send GA event for logged in users on non admin pages" do
+    organisation = create(:worldwide_organisation)
+
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: "ministry-of-lindy-hop"))
+      visit admin_root_path
+      assert_dimension_is_set(8)
+
+      visit worldwide_organisation_path(organisation)
+      refute_dimension_is_set(8)
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR prepares the 1.7 release. I've done the following to get it ready

1. forced the override in the `preview_design_system?` method in the base controller
2. Duplicated and fixed failing tests so that both flows are covered
3. updated the override to only work in non-test envs

That way we can be sure we have full test coverage, then remove the old tests at the same time we remove all the legacy code,

## Trello card 

https://trello.com/c/3ZJVdN3c/180-prepare-release-17

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
