### PR TITLE
Link to Worldwide Organisation from Worldwide Office

### DIFF
--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -33,6 +33,7 @@ module PublishingApi
       {
         contact:,
         parent: [item.worldwide_organisation.content_id],
+        worldwide_organisation: [item.worldwide_organisation.content_id],
       }
     end
 

--- a/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -34,6 +34,9 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
       parent: [
         worldwide_office.worldwide_organisation.content_id,
       ],
+      worldwide_organisation: [
+        worldwide_office.worldwide_organisation.content_id,
+      ],
     }
 
     presented_item = present(worldwide_office)


### PR DESCRIPTION
We are currently retrieving the Worldwide Organisation that a Worldwide Office
belongs to through the `parent` link.

However, we now also need to be able to retrieve the Sponsored Organisations
and World Locations that are linked to the parent Worldwide Organisation.

To achieve this, we have defined multi level links in the `publishing-api` (https://github.com/alphagov/publishing-api/pull/2378)

This adds in the link to Worldwide Organisation from Worldwide Offices.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
