### PR TITLE
Dashboard page fixes and small redesign

### DIFF
--- a/app/assets/stylesheets/admin/views/dashboard-index.scss
+++ b/app/assets/stylesheets/admin/views/dashboard-index.scss
@@ -1,17 +1,13 @@
 .app-view-dashboard-index__table .govuk-table__row .govuk-table__header:nth-child(1) {
-  width: 15%;
+  width: 50%;
 }
 
 .app-view-dashboard-index__table .govuk-table__row .govuk-table__header:nth-child(2) {
-  width: 35%;
+  width: 20%;
 }
 
 .app-view-dashboard-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
   width: 25%;
-}
-
-.app-view-dashboard-index__table .govuk-table__row .govuk-table__header:nth-child(4) {
-  width: 20%;
 }
 
 .app-view-dashboard-index__table .govuk-table__row .govuk-table__header:nth-child(5) {

--- a/app/views/admin/dashboard/_document_table.html.erb
+++ b/app/views/admin/dashboard/_document_table.html.erb
@@ -7,22 +7,19 @@
    text: "No #{title}"
   } %>
 <% else %>
-  <% action = title == "draft documents" ? "Edit" : "Review" %>
+  <% action = title == "draft documents" ? "View" : "Review" %>
 
   <div class="app-view-dashboard-index__table govuk-!-margin-bottom-9">
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {
-          text: "Type"
-        },
-        {
           text: "Title",
         },
         {
-          text: "Updated",
+          text: "Type"
         },
         {
-          text: "Status",
+          text: "Updated",
         },
         {
           text: tag.span("Actions", class: "govuk-visually-hidden"),
@@ -32,17 +29,14 @@
       rows: documents.map do |edition|
         [
           {
-            text: edition.type.titleize,
+            text: tag.p(edition.title, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
           },
           {
-            text: edition.title,
+            text: edition.type.titleize,
           },
           {
             text: sanitize(tag.p("Updated #{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0")) +
               sanitize("by #{linked_author(edition.last_author, class: 'govuk-link')}")
-          },
-          {
-            text: render(Admin::Editions::TagsComponent.new(edition)),
           },
           {
             text: link_to(sanitize("#{action} #{tag.span(edition.title, class: 'govuk-visually-hidden')}"), admin_edition_path(edition), class: "govuk-link"),

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -80,7 +80,7 @@
     heading_level: 2,
     margin_bottom: 4,
   } %>
+  <p class="govuk-body"><%= link_to "View complete list of forced-published documents", admin_editions_path(state: :force_published, organisation: current_user.organisation), class: "govuk-link" %></p>
 
   <%= render 'document_table', documents: @force_published_documents, title: 'force published documents' %>
-  <p class="govuk-body"><%= link_to "See all", admin_editions_path(state: :force_published, organisation: current_user.organisation), class: "govuk-link" %></p>
 <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -48,7 +48,16 @@
       visible_counters: true,
       items: [
         link_to("Inside GOV.UK blog", "https://insidegovuk.blog.gov.uk/", class: "govuk-link"),
-        link_to("GOV.UK style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link"),
+        link_to(
+          "What's new",
+          admin_whats_new_path,
+          class: "govuk-link",
+          data: {
+            module: "gem-track-click",
+            track_category: 'dashboardLink',
+            track_action: "What's new",
+            track_label: 'whats-new-click'
+        }),
       ]
     } %>
   </div>

--- a/features/step_definitions/admin_dashboard_steps.rb
+++ b/features/step_definitions/admin_dashboard_steps.rb
@@ -4,7 +4,7 @@ end
 
 Then(/^I should see the draft document "([^"]*)"$/) do |title|
   if using_design_system?
-    expect(all(".govuk-table")[0].all(".govuk-table__cell")[1].text).to eq title
+    expect(all(".govuk-table")[0].all(".govuk-table__cell")[0].text).to eq title
   else
     edition = Edition.find_by!(title:).document.latest_edition
     expect(page).to have_selector(".draft-documents #{record_css_selector(edition)}")
@@ -13,7 +13,7 @@ end
 
 Then(/^I should see the force published document "([^"]*)"$/) do |title|
   if using_design_system?
-    expect(all(".govuk-table")[1].all(".govuk-table__cell")[1].text).to eq title
+    expect(all(".govuk-table")[1].all(".govuk-table__cell")[0].text).to eq title
   else
     edition = Edition.find_by!(title:).document.latest_edition
     expect(page).to have_selector(".force-published-documents #{record_css_selector(edition)}")
@@ -22,7 +22,7 @@ end
 
 Then(/^I should see a link to the content data app$/) do
   ## We track all external link clicks in the design_system layout
-  ## so we don't need to check it for when suing the design system.
+  ## so we don't need to check it for when using the design system.
 
   if using_design_system?
     expect(find_link("Content Data", href: "https://content-data.test.gov.uk/content")).not_to be_nil


### PR DESCRIPTION
## Description 

We've done an aduit of the pages being released in Release 1.7. This PR makes this changes. It does the following:

1. Adds a missing link to the product development list
2.  Updates the design of the tables on the Dashboard page (landing page) by reordering the columns, bolding the title and removing the state column
3. Moves the `See all` force published link above the table.


## Screenshots

|Before|After|
|-----------|-----------|
|<img width="491" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/113f696d-c830-4096-add5-2c8b794d7aef">|<img width="480" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/b3f5bef8-84c9-486a-b58a-fda7e5c65031">|

|Before|After|
|-----------|-----------|
|<img width="510" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/bd22035f-4521-431b-90e7-83d4a0f9b7f1">|<img width="507" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2d54c2ea-3768-45c0-ad68-ab5d90b1509f">|

## Trello card 

https://trello.com/c/zT6hbt2Q/179-post-qa-update-to-homepage


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
