### PR TITLE
Remove "Current ministers list" from list of rendered pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Whitehall is deployed in two modes:
 
 - CSV Preview pages: [https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview)
 
-### Government Information
-
-- Current ministers list: [https://www.gov.uk/government/ministers](https://www.gov.uk/government/ministers)
-
 ### World Information
 
 - Help and services around the world: [https://www.gov.uk/world](https://www.gov.uk/world)


### PR DESCRIPTION
The ministers list is no longer rendered by Whitehall, therefore it can be removed from the list of examples.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
