### PR TITLE
Ensure Government#edit page handles blank start date gracefully & design updates

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -6,7 +6,7 @@ class Government < ApplicationRecord
   validates :content_id, presence: true, uniqueness: { case_sensitive: false }
   validates :start_date, presence: true
 
-  validate :not_overlapping?
+  validate :not_overlapping?, if: -> { start_date.present? }
 
   before_validation on: :create do |government|
     government.slug = government.name.to_s.parameterize

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -6,7 +6,7 @@
       } %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: "Name"
+          text: "Name (required)"
         },
         name: "government[name]",
         id: "government_name",
@@ -15,60 +15,49 @@
         error_message: errors_for_input(government.errors, :name)
       } %>
 
-      <%= render "components/datetime_fields", {
-        date_only: true,
-        prefix: "government",
-        field_name: "start_date",
-        id: "government_start_date",
-        heading_size: "l",
-        date_hint: "For example, 01 August 2015",
-        date_heading: "Start date",
+      <%= render "govuk_publishing_components/components/fieldset", {
+        legend_text: "Dates",
+        heading_size: "l"
+      } do %>
+        <%= render "components/datetime_fields", {
+          date_only: true,
+          prefix: "government",
+          field_name: "start_date",
+          id: "government_start_date",
+          heading_size: "m",
+          date_hint: "For example, 01 August 2015",
+          date_heading: "Start date (required)",
+          year: {
+            value: government.start_date&.year,
+            start_year: 1800,
+          },
+          month: {
+            value: government.start_date&.month
+          },
+          day: {
+            value: government.start_date&.day,
+          },
+          error_items: errors_for(government.errors, :start_date)
+        } %>
 
-        year: {
-          value: government.start_date.to_date,
-          start_year: 1800
-        },
-        month: {
-          value: government.start_date.to_date
-        },
-        day: {
-          value: government.start_date.to_date
-        },
-
-        error_items: errors_for_input(government.errors, :start_date)
-      } %>
-
-      <% if government.ended? %>
         <%= render "components/datetime_fields", {
           date_only: true,
           prefix: "government",
           field_name: "end_date",
           id: "government_end_date",
-          heading_level: 3,
           heading_size: "m",
           date_hint: "For example, 01 August 2022",
           date_heading: "End date",
           year: {
-            value: government.end_date.to_date,
+            value: government.end_date&.year,
             start_year: 1800
           },
           month: {
-            value: government.end_date.to_date
+            value: government.end_date&.month
           },
           day: {
-            value: government.end_date.to_date
+            value: government.end_date&.day
           },
-        } %>
-      <% else %>
-        <%= render "components/datetime_fields", {
-          date_only: true,
-          prefix: "government",
-          field_name: "end_date",
-          id: "government_end_date",
-          heading_level: 3,
-          heading_size: "m",
-          date_hint: "For example, 01 August 2022",
-          date_heading: "End date",
         } %>
       <% end %>
 
@@ -82,7 +71,7 @@
             "track-label": "Save"
        }
         } %>
-        <%= link_to("cancel", admin_governments_path(), class: "govuk-link") %>
+        <%= link_to("Cancel", admin_governments_path(), class: "govuk-link") %>
       </div>
       <% if government.persisted? %>
         <%= link_to("Prepare to close this government", prepare_to_close_admin_government_path(government), class:

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -73,7 +73,8 @@
         } %>
         <%= link_to("Cancel", admin_governments_path(), class: "govuk-link") %>
       </div>
-      <% if government.persisted? %>
+
+      <% if government.current? %>
         <%= link_to("Prepare to close this government", prepare_to_close_admin_government_path(government), class:
           "govuk-link gem-link--destructive") %>
       <% end %>

--- a/app/views/admin/governments/edit.html.erb
+++ b/app/views/admin/governments/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Edit a government" %>
 <% content_for :page_title, "Edit a government" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @government)) %>
-<%= render partial: "form", locals: { government: @government } %>
+
+<%= render "form", government: @government %>

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -19,7 +19,7 @@
  year ||= {}
  year_value = year[:value]
  start_year = year[:start_year]
- end_year = year[:end_year]
+ end_year = year[:end_year] || Date.current.year + 5
  year_select_id = year[:id] || "select-year-#{SecureRandom.hex(4)}"
  year_label_id = "year-#{SecureRandom.hex(4)}"
 

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -10,7 +10,6 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
 
   %i[new edit prepare_to_close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
-      login_as :gds_editor
       get action_method, params: { id: @government.id }
       assert_response 403
     end
@@ -18,27 +17,32 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
 
   %i[create update close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
-      login_as :gds_editor
       post action_method, params: { id: @government.id }
       assert_response 403
     end
   end
 
-  view_test "new should have the default start date of today" do
-    login_as :gds_admin
+  view_test "new should have the correct form fields and default start date of today" do
+    login_as_preview_design_system_user :gds_admin
     get :new
-    assert_select "input[name='government[start_date]'][value='#{Time.zone.today}']"
+    assert_select "input[name='government[name]']"
+    assert_select "select[name='government[start_date(1i)]'] option[value='#{Time.zone.today.year}'][selected='selected']"
+    assert_select "select[name='government[start_date(2i)]'] option[value='#{Time.zone.today.month}'][selected='selected']"
+    assert_select "select[name='government[start_date(3i)]'] option[value='#{Time.zone.today.day}'][selected='selected']"
+    assert_select "select[name='government[end_date(1i)]']"
+    assert_select "select[name='government[end_date(2i)]']"
+    assert_select "select[name='government[end_date(3i)]']"
   end
 
   test "#close sets the end date to today" do
-    login_as :gds_admin
+    login_as_preview_design_system_user :gds_admin
     post :close, params: { id: @government.id }
     @government.reload
     assert_equal Time.zone.today, @government.end_date
   end
 
   test "#close doesn't overwrite an end date if there is one" do
-    login_as :gds_admin
+    login_as_preview_design_system_user :gds_admin
     @government.update!(end_date: 10.days.ago.to_date)
     post :close, params: { id: @government.id }
     @government.reload
@@ -46,7 +50,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
   end
 
   test "#close ends all the current ministerial role appointments on the same day as the government closes" do
-    login_as :gds_admin
+    login_as_preview_design_system_user :gds_admin
     @government.update!(end_date: 1.day.ago.to_date)
     ministerial = create(:ministerial_role_appointment)
     ambassadorial = create(:ambassador_role_appointment)
@@ -58,9 +62,17 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     assert ambassadorial.current?
   end
 
-  view_test "edit renders the prepare to close link when editing the current government" do
+  view_test "edit renders the correct fields and prepare to close link when editing the current government" do
     login_as_preview_design_system_user :gds_admin
     get :edit, params: { id: @government.id }
+
+    assert_select "input[name='government[name]'][value='#{@government.name}']"
+    assert_select "select[name='government[start_date(1i)]'] option[value='#{@government.start_date.year}'][selected='selected']"
+    assert_select "select[name='government[start_date(2i)]'] option[value='#{@government.start_date.month}'][selected='selected']"
+    assert_select "select[name='government[start_date(3i)]'] option[value='#{@government.start_date.day}'][selected='selected']"
+    assert_select "select[name='government[end_date(1i)]']"
+    assert_select "select[name='government[end_date(2i)]']"
+    assert_select "select[name='government[end_date(3i)]']"
     assert_select "a[href='#{prepare_to_close_admin_government_path(@government)}']", text: "Prepare to close this government"
   end
 

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -57,4 +57,18 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     assert_nil ambassadorial.ended_at
     assert ambassadorial.current?
   end
+
+  view_test "edit renders the prepare to close link when editing the current government" do
+    login_as_preview_design_system_user :gds_admin
+    get :edit, params: { id: @government.id }
+    assert_select "a[href='#{prepare_to_close_admin_government_path(@government)}']", text: "Prepare to close this government"
+  end
+
+  view_test "edit does not render the prepare to close link when editing a previous government" do
+    @government.update!(end_date: 1.minute.ago)
+    create(:government, start_date: Time.zone.now)
+    login_as_preview_design_system_user :gds_admin
+    get :edit, params: { id: @government.id }
+    assert_select "a[href='#{prepare_to_close_admin_government_path(@government)}']", text: "Prepare to close this government", count: 0
+  end
 end

--- a/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
+++ b/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
@@ -115,13 +115,13 @@ module AdminEditionControllerScheduledPublishingTestHelpers
       end
 
       view_test "edit displays scheduled_publication date and time fields" do
-        edition = create(edition_type, scheduled_publication: Time.zone.parse("2060-06-03 10:30"))
+        edition = create(edition_type, scheduled_publication: Time.zone.parse("#{Time.zone.today.year + 1}-06-03 10:30"))
 
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "input[type=checkbox][name='scheduled_publication_active'][checked='checked']"
-          assert_select "select[name='edition[scheduled_publication(1i)]'] option[value='2060'][selected='selected']"
+          assert_select "select[name='edition[scheduled_publication(1i)]'] option[value='#{Time.zone.today.year + 1}'][selected='selected']"
           assert_select "select[name='edition[scheduled_publication(2i)]'] option[value='6'][selected='selected']"
           assert_select "select[name='edition[scheduled_publication(3i)]'] option[value='3'][selected='selected']"
           assert_select "select[name='edition[scheduled_publication(4i)]'] option[value='10'][selected='selected']"

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -32,6 +32,14 @@ class GovernmentTest < ActiveSupport::TestCase
     assert_not nil_government.valid?
   end
 
+  test "doesn't check construct an error for governments overlapping if start date is blank" do
+    nil_government = build(:government, start_date: nil)
+    nil_government.valid?
+
+    assert_equal 1, nil_government.errors.count
+    assert_equal "Start date can't be blank", nil_government.errors.first.full_message
+  end
+
   test "enforces unique names" do
     create(:government, name: "2005 to 2010 Labour government")
     duplicate_government = build(:government, name: "2005 to 2010 Labour government")


### PR DESCRIPTION
## Description

At the moment, this is blowing up as a model on the validation expects start date to be present. This updates the validation for overlapping governments to only run when start_date is present.

It also fixes a bunch of issues with the code itself. Duplicate fields, values not being set in inputs correctly, label size etc. and implements the changes outlined by Nikin post his 1.8 audit. 

## Screenshots

### Before 

<img width="467" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0f5d78de-4cc7-4203-becc-2d2f86ea8ba8">

<img width="689" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d542ef44-4702-428c-b3a1-2b2b22a14531">


### After

<img width="690" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/bce340e3-7a9e-4b6b-af45-9d2075db724d">

previous govt cannot be closed 

<img width="707" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/dba345cc-6688-41f9-9145-938120237d97">


## Trello card 

https://trello.com/c/nSDC5uV7/191-revisit-edit-government-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
