### PR TITLE
Convert reshuffle govspeak to HTML before storing

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class MinistersIndexPresenter
+    include GovspeakHelper
+
     attr_accessor :update_type
 
     def initialize(update_type: nil)
@@ -48,7 +50,7 @@ module PublishingApi
     def details
       if reshuffle_in_progress?
         {
-          reshuffle: { message: SitewideSetting.find_by(key: :minister_reshuffle_mode).govspeak },
+          reshuffle: { message: bare_govspeak_to_html(SitewideSetting.find_by(key: :minister_reshuffle_mode).govspeak) },
         }
       else
         {

--- a/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -100,11 +100,16 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
 
   test "presents a valid content item without information when reshuffle mode is on" do
     I18n.with_locale(:en) do
-      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+      create(
+        :sitewide_setting,
+        key: :minister_reshuffle_mode,
+        on: true,
+        govspeak: "Check [latest appointments](/government/news/ministerial-appointments-february-2023).",
+      )
 
       expected_details = {
         reshuffle: {
-          message: "example text",
+          message: "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n",
         },
       }
 


### PR DESCRIPTION
We don't want to introduce more govspeak rendering knowledge into frontend apps than necessary.

The reshuffle message used for the latest reshuffle included govspeak. Convert it to HTML before storing it in the content item.

`bare_govspeak_to_html` was the method I found that introduced the least amount of HTML, to avoid interfering with the components used in the rendering app (in this case collections).

It still introduces a `p` tag and a newline (as seen in the test). The `p` tag makes it show a bit wonky (too much blank space on top) when rendering it inside a title-less notice component in collections:
![Screenshot 2023-05-24 at 14 22 43](https://github.com/alphagov/whitehall/assets/579522/562842b7-8553-4d72-aada-ba2229f2a9ac)

If someone has a better idea how to store and/or render this, please let me know!

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
