### PR TITLE
Modify ci.yml to upload screenshot artifacts on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: capybara-screenshots
           path: tmp/capybara/capybara-*.png


### PR DESCRIPTION
We've seen the flakey test fail again since merging [PR 7698][1] to main. Unfortunately the previous implementation doesn't upload the artifacts in the previous step fails! Which is the opposite of what we want.

Using `if: failure()` seems to do what we want. I tested this in a branch by manually inserting a failure into a cucumber feature and observing that the screenshots were uploaded.

[1]: https://github.com/alphagov/whitehall/pull/7698
