### PR TITLE
Add currently featured tab to the Topical Event Featurings index page

### DIFF
--- a/app/components/admin/currently_featured_tab_component.html.erb
+++ b/app/components/admin/currently_featured_tab_component.html.erb
@@ -6,15 +6,15 @@
   text: "A maximum of #{maximum_featured_documents} documents will be featured on GOV.UK."
 } %>
 
-<% if features.many? %>
+<% if featured.many? %>
   <p class="govuk-body">
-    <%= link_to "Reorder documents", reorder_admin_feature_list_path(features.first.feature_list), class: "govuk-link" %>
+    <%= link_to "Reorder documents", reorder_path, class: "govuk-link" %>
   </p>
 <% end %>
 
-<% if features.present? %>
+<% if featured.present? %>
   <div class="app-view-features__table govuk-!-margin-bottom-8">
-    <%= table("#{pluralize(live_features.count, "featured document")} live on GOV.UK", live_features) %>
+    <%= table("#{pluralize(live.count, "featured document")} live on GOV.UK", live) %>
   </div>
 <% else %>
   <p class="govuk-body">
@@ -22,8 +22,8 @@
   </p>
 <% end %>
 
-<% if remaining_features.present? %>
+<% if remaining.present? %>
   <div class="app-view-features__table">
-    <%= table(pluralize(remaining_features.count, "remaining featured document"), remaining_features) %>
+    <%= table(pluralize(remaining.count, "remaining featured document"), remaining) %>
   </div>
 <% end %>

--- a/app/components/admin/currently_featured_tab_component.rb
+++ b/app/components/admin/currently_featured_tab_component.rb
@@ -1,138 +1,41 @@
 # frozen_string_literal: true
 
 class Admin::CurrentlyFeaturedTabComponent < ViewComponent::Base
-  include Admin::EditionRoutesHelper
-  include Admin::OrganisationHelper
+  attr_reader :features, :featurings, :maximum_featured_documents
 
-  attr_reader :features, :maximum_featured_documents
-
-  def initialize(features:, maximum_featured_documents:)
-    @features = features || []
+  def initialize(maximum_featured_documents:, features: [], featurings: [])
+    @features = features
+    @featurings = featurings
     @maximum_featured_documents = maximum_featured_documents
   end
 
 private
 
-  def live_features
-    @live_features ||= features.slice(0, maximum_featured_documents)
+  def featured
+    @featured ||= (features.presence || featurings)
   end
 
-  def remaining_features
-    @remaining_features ||= features - live_features
+  def live
+    @live ||= featured.slice(0, maximum_featured_documents)
   end
 
-  def table(caption, features)
-    tag.div(class: "govuk-table--with-actions") do
-      render "govuk_publishing_components/components/table", {
-        caption:,
-        caption_classes: "govuk-heading-s",
-        head: [
-          {
-            text: "Title",
-          },
-          {
-            text: "Type",
-          },
-          {
-            text: "Published",
-          },
-          {
-            text: tag.span("Actions", class: "govuk-visually-hidden"),
-          },
-        ],
-        rows: rows(features),
-      }
-    end
+  def remaining
+    @remaining ||= featured - live
   end
 
-  def rows(features)
-    features.map do |feature|
-      [
-        title_row(feature),
-        type_row(feature),
-        published_row(feature),
-        actions_row(feature),
-      ]
-    end
-  end
-
-  def title_row(feature)
-    {
-      text: tag.p(title(feature), class: "govuk-!-font-weight-bold govuk-!-margin-0"),
-    }
-  end
-
-  def title(feature)
-    if feature.document&.live_edition.present?
-      feature
-    elsif feature.topical_event.present?
-      feature.topical_event
-    elsif feature.offsite_link.present?
-      feature.offsite_link
+  def table(caption, featured)
+    if features.present?
+      render Admin::Features::FeaturedDocumentsTableComponent.new(caption:, features: featured)
     else
-      feature
+      render Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponent.new(caption:, featurings: featured)
     end
   end
 
-  def type_row(feature)
-    {
-      text: type(feature),
-    }
-  end
-
-  def type(feature)
-    if feature.document&.live_edition.present?
-      "#{feature.document.live_edition.type.titleize} (document)"
-    elsif feature.topical_event.present?
-      "Topical Event"
-    elsif feature.offsite_link.present?
-      "#{feature.offsite_link.humanized_link_type} (offsite link)"
+  def reorder_path
+    if features.present?
+      reorder_admin_feature_list_path(features.first.feature_list)
     else
-      ""
-    end
-  end
-
-  def published_row(feature)
-    {
-      text: published_at(feature),
-    }
-  end
-
-  def published_at(feature)
-    if feature.document&.live_edition.present?
-      localize(feature.document.live_edition.major_change_published_at.to_date)
-    elsif feature.topical_event.present?
-      topical_event_dates_string(feature.topical_event)
-    elsif feature.offsite_link.present?
-      (localize(feature.offsite_link.date.to_date) if feature.offsite_link.date) || ""
-    else
-      ""
-    end
-  end
-
-  def actions_row(feature)
-    {
-      text: sanitize(edit_link(feature) + unfeature_link(feature)),
-    }
-  end
-
-  def edit_link(feature)
-    if feature.document&.live_edition.present?
-      link_to(sanitize("Edit #{tag.span(feature, class: 'govuk-visually-hidden')}"), admin_edition_path(feature.document.live_edition), class: "govuk-link")
-    elsif feature.topical_event.present?
-      link_to(sanitize("Edit #{tag.span(feature.topical_event, class: 'govuk-visually-hidden')}"), edit_admin_topical_event_path(feature.topical_event), class: "govuk-link")
-    elsif feature.offsite_link.present?
-      link_to(sanitize("Edit #{tag.span(feature.offsite_link, class: 'govuk-visually-hidden')}"), polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link]), class: "govuk-link")
-    else
-      ""
-    end
-  end
-
-  def unfeature_link(feature)
-    if feature.document&.live_edition.present? || feature.topical_event.present? || feature.offsite_link.present?
-      link_to(sanitize("Unfeature #{tag.span(title(feature), class: 'govuk-visually-hidden')}"), confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature), class: "gem-link--destructive govuk-!-margin-left-2")
-    else
-      ""
+      reorder_admin_topical_event_topical_event_featurings_path(featurings.first.topical_event)
     end
   end
 end

--- a/app/components/admin/features/featured_documents_table_component.html.erb
+++ b/app/components/admin/features/featured_documents_table_component.html.erb
@@ -1,0 +1,20 @@
+<%= render "govuk_publishing_components/components/table", {
+  caption:,
+  caption_classes: "govuk-heading-s",
+  head: [
+    {
+      text: "Title",
+    },
+    {
+      text: "Type",
+    },
+    {
+      text: "Published",
+    },
+    {
+      text: tag.span("Actions", class: "govuk-visually-hidden"),
+      format: "numeric",
+    },
+  ],
+  rows: rows(features),
+} %>

--- a/app/components/admin/features/featured_documents_table_component.rb
+++ b/app/components/admin/features/featured_documents_table_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+class Admin::Features::FeaturedDocumentsTableComponent < ViewComponent::Base
+  include Admin::EditionRoutesHelper
+  include Admin::OrganisationHelper
+
+  attr_reader :caption, :features
+
+  def initialize(caption:, features:)
+    @caption = caption
+    @features = features
+  end
+
+private
+
+  def rows(features)
+    features.map do |feature|
+      [
+        title_row(feature),
+        type_row(feature),
+        published_row(feature),
+        actions_row(feature),
+      ]
+    end
+  end
+
+  def title_row(feature)
+    {
+      text: tag.p(title(feature), class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+    }
+  end
+
+  def title(feature)
+    if feature.document&.live_edition.present?
+      feature
+    elsif feature.topical_event.present?
+      feature.topical_event
+    elsif feature.offsite_link.present?
+      feature.offsite_link
+    else
+      feature
+    end
+  end
+
+  def type_row(feature)
+    {
+      text: type(feature),
+    }
+  end
+
+  def type(feature)
+    if feature.document&.live_edition.present?
+      "#{feature.document.live_edition.type.titleize} (document)"
+    elsif feature.topical_event.present?
+      "Topical Event"
+    elsif feature.offsite_link.present?
+      "#{feature.offsite_link.humanized_link_type} (offsite link)"
+    else
+      ""
+    end
+  end
+
+  def published_row(feature)
+    {
+      text: published_at(feature),
+    }
+  end
+
+  def published_at(feature)
+    if feature.document&.live_edition.present?
+      localize(feature.document.live_edition.major_change_published_at.to_date)
+    elsif feature.topical_event.present?
+      topical_event_dates_string(feature.topical_event)
+    elsif feature.offsite_link.present?
+      (localize(feature.offsite_link.date.to_date) if feature.offsite_link.date) || ""
+    else
+      ""
+    end
+  end
+
+  def actions_row(feature)
+    {
+      text: sanitize(edit_link(feature) + unfeature_link(feature)),
+    }
+  end
+
+  def edit_link(feature)
+    if feature.document&.live_edition.present?
+      link_to(sanitize("Edit #{tag.span(feature, class: 'govuk-visually-hidden')}"), admin_edition_path(feature.document.live_edition), class: "govuk-link")
+    elsif feature.topical_event.present?
+      link_to(sanitize("Edit #{tag.span(feature.topical_event, class: 'govuk-visually-hidden')}"), edit_admin_topical_event_path(feature.topical_event), class: "govuk-link")
+    elsif feature.offsite_link.present?
+      link_to(sanitize("Edit #{tag.span(feature.offsite_link, class: 'govuk-visually-hidden')}"), polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link]), class: "govuk-link")
+    else
+      ""
+    end
+  end
+
+  def unfeature_link(feature)
+    if feature.document&.live_edition.present? || feature.topical_event.present? || feature.offsite_link.present?
+      link_to(sanitize("Unfeature #{tag.span(title(feature), class: 'govuk-visually-hidden')}"), confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature), class: "gem-link--destructive govuk-!-margin-left-2")
+    else
+      ""
+    end
+  end
+end

--- a/app/components/admin/topical_events/featurings/featured_documents_table_component.html.erb
+++ b/app/components/admin/topical_events/featurings/featured_documents_table_component.html.erb
@@ -1,0 +1,20 @@
+<%= render "govuk_publishing_components/components/table", {
+  caption:,
+  caption_classes: "govuk-heading-s",
+  head: [
+    {
+      text: "Title",
+    },
+    {
+      text: "Type",
+    },
+    {
+      text: "Published",
+    },
+    {
+      text: tag.span("Actions", class: "govuk-visually-hidden"),
+      format: "numeric",
+    },
+  ],
+  rows: rows(featurings),
+} %>

--- a/app/components/admin/topical_events/featurings/featured_documents_table_component.rb
+++ b/app/components/admin/topical_events/featurings/featured_documents_table_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponent < ViewComponent::Base
+  include Admin::EditionRoutesHelper
+
+  attr_reader :caption, :featurings
+
+  def initialize(caption:, featurings:)
+    @caption = caption
+    @featurings = featurings
+  end
+
+private
+
+  def rows(featurings)
+    featurings.map do |featuring|
+      [
+        title_row(featuring),
+        type_row(featuring),
+        published_row(featuring),
+        actions_row(featuring),
+      ]
+    end
+  end
+
+  def title_row(featuring)
+    {
+      text: tag.p(featuring.title, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+    }
+  end
+
+  def type_row(featuring)
+    {
+      text: type(featuring),
+    }
+  end
+
+  def type(featuring)
+    if featuring.offsite?
+      "#{featuring.offsite_link.humanized_link_type} (offsite link)"
+    else
+      "#{featuring.edition.type.titleize} (document)"
+    end
+  end
+
+  def published_row(featuring)
+    {
+      text: published_at(featuring),
+    }
+  end
+
+  def published_at(featuring)
+    if featuring.offsite?
+      (localize(featuring.offsite_link.date.to_date) if featuring.offsite_link.date) || ""
+    else
+      localize(featuring.edition.major_change_published_at.to_date)
+    end
+  end
+
+  def actions_row(featuring)
+    {
+      text: sanitize(edit_link(featuring) + unfeature_link(featuring)),
+    }
+  end
+
+  def edit_link(featuring)
+    if featuring.offsite?
+      link_to(sanitize("Edit #{tag.span(featuring.offsite_link, class: 'govuk-visually-hidden')}"), edit_admin_topical_event_offsite_link_path(featuring.topical_event, featuring.offsite_link), class: "govuk-link")
+    else
+      link_to(sanitize("Edit #{tag.span(featuring.title, class: 'govuk-visually-hidden')}"), admin_edition_path(featuring.edition), class: "govuk-link")
+    end
+  end
+
+  def unfeature_link(featuring)
+    link_to(sanitize("Unfeature #{tag.span(featuring.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_topical_event_topical_event_featuring_path(featuring.topical_event, featuring), class: "gem-link--destructive govuk-!-margin-left-2")
+  end
+end

--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -44,6 +44,8 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
     end
   end
 
+  def reorder; end
+
   def order
     params[:ordering].each do |topical_event_featuring_id, ordering|
       @topical_event.topical_event_featurings.find(topical_event_featuring_id).update_column(:ordering, ordering)
@@ -78,7 +80,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[new create index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[new create index reorder] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -1,5 +1,6 @@
 class Admin::TopicalEventFeaturingsController < Admin::BaseController
   before_action :load_topical_event
+  before_action :load_topical_event_featuring, only: %i[confirm_destroy destroy]
   layout :get_layout
 
   def index
@@ -56,9 +57,9 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
     redirect_to polymorphic_path([:admin, @topical_event, :topical_event_featurings]), notice: "Featured items re-ordered"
   end
 
-  def destroy
-    @topical_event_featuring = @topical_event.topical_event_featurings.find(params[:id])
+  def confirm_destroy; end
 
+  def destroy
     if featuring_a_document?
       edition = @topical_event_featuring.edition
       @topical_event_featuring.destroy!
@@ -80,7 +81,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[new create index reorder] if preview_design_system?(next_release: false)
+    design_system_actions += %w[new create index reorder confirm_destroy] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"
@@ -91,6 +92,10 @@ private
 
   def load_topical_event
     @topical_event = TopicalEvent.find(params[:topical_event_id] || params[:topic_id])
+  end
+
+  def load_topical_event_featuring
+    @topical_event_featuring = @topical_event.topical_event_featurings.find(params[:id])
   end
 
   def editions_to_show

--- a/app/views/admin/topical_event_featurings/confirm_destroy.html.erb
+++ b/app/views/admin/topical_event_featurings/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @topical_event.name %>
+<% content_for :page_title, "Unfeature ‘#{@topical_event_featuring.title}’" %>
+<% content_for :title, "Unfeature ‘#{@topical_event_featuring.title}’" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_topical_event_topical_event_featuring_path(@topical_event, @topical_event_featuring), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to unfeature ‘<%= @topical_event_featuring.title %>’ for ‘<%= @topical_event.name %>’?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Unfeature",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", admin_topical_event_topical_event_featurings_path(@topical_event), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/topical_event_featurings/index.html.erb
+++ b/app/views/admin/topical_event_featurings/index.html.erb
@@ -16,16 +16,19 @@
 
 <%= render "govuk_publishing_components/components/tabs", {
   tabs: [
-  {
-    id: "currently_featured_tab",
-    label: "Currently featured",
-    content: ""
-  },
-  {
-    id: "documents_tab",
-    label: "Documents",
-    content: ""
-  },
+    {
+      id: "currently_featured_tab",
+      label: "Currently featured",
+      content: render(Admin::CurrentlyFeaturedTabComponent.new(
+        featurings: @topical_event_featurings,
+        maximum_featured_documents: 5
+      ))
+    },
+    {
+      id: "documents_tab",
+      label: "Documents",
+      content: ""
+    },
     {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",

--- a/app/views/admin/topical_event_featurings/reorder.html.erb
+++ b/app/views/admin/topical_event_featurings/reorder.html.erb
@@ -25,7 +25,7 @@
           text: "Update order",
         } %>
 
-        <%= link_to("Cancel", admin_topical_event_topical_event_featurings_path, class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", admin_topical_event_topical_event_featurings_path(@topical_event), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/topical_event_featurings/reorder.html.erb
+++ b/app/views/admin/topical_event_featurings/reorder.html.erb
@@ -1,0 +1,32 @@
+<% content_for :context, "Currently featured documents" %>
+<% content_for :page_title, "Reorder list" %>
+<% content_for :title, "Reorder list" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: order_admin_topical_event_topical_event_featurings_path(@topical_event), method: :put do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @topical_event.topical_event_featurings.map do |featuring|
+          {
+            id: featuring.id,
+            title: featuring.title,
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order",
+        } %>
+
+        <%= link_to("Cancel", admin_topical_event_topical_event_featurings_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Whitehall::Application.routes.draw do
         resources :topical_events, path: "topical-events" do
           resource :topical_event_about_pages, path: "about"
           resources :topical_event_featurings, path: "featurings" do
+            get :reorder, on: :collection
             put :order, on: :collection
           end
           resources :offsite_links do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Whitehall::Application.routes.draw do
           resources :topical_event_featurings, path: "featurings" do
             get :reorder, on: :collection
             put :order, on: :collection
+            get :confirm_destroy, on: :member
           end
           resources :offsite_links do
             get :confirm_destroy, on: :member

--- a/features/step_definitions/topical_event_featurings_steps.rb
+++ b/features/step_definitions/topical_event_featurings_steps.rb
@@ -9,3 +9,31 @@ end
 When(/^I visit the topical event featuring index page$/) do
   visit admin_topical_event_topical_event_featurings_path(@topical_event)
 end
+
+And(/^two featurings exist for "([^"]*)"$/) do |name|
+  topical_event = TopicalEvent.find_by(name:)
+  offsite_link1 = create(:offsite_link, parent_type: "TopicalEvent", parent: topical_event, title: "Featured link 1")
+  offsite_link2 = create(:offsite_link, parent_type: "TopicalEvent", parent: topical_event, title: "Featured link 2")
+  create(:offsite_topical_event_featuring, topical_event:, offsite_link: offsite_link1)
+  create(:offsite_topical_event_featuring, topical_event:, offsite_link: offsite_link2)
+end
+
+And(/^I set the order of the topical event featurings to:$/) do |featurings_order|
+  click_link "Reorder documents"
+
+  featurings_order.hashes.each do |hash|
+    featuring = @topical_event.topical_event_featurings.select { |f| f.title == hash[:title] }.first
+    fill_in "ordering[#{featuring.id}]", with: hash[:order]
+  end
+
+  click_button "Update order"
+end
+
+Then(/^the topical event featurings should be in the following order:$/) do |featurings_titles|
+  featuring_titles = all("table td:first").map(&:text)
+
+  featurings_titles.hashes.each_with_index do |hash, index|
+    featuring = @topical_event.topical_event_featurings.select { |f| f.title == hash[:title] }.first
+    expect(featuring.title).to eq(featuring_titles[index])
+  end
+end

--- a/features/topical_event_featurings.feature
+++ b/features/topical_event_featurings.feature
@@ -24,3 +24,9 @@ Feature:
     When I visit the topical event featuring index page
     And I delete "Featured link"
     Then I can see that "Featured link" has been deleted
+
+  Scenario: Featuring a non-GOV.UK link
+    Given the topical event has an offsite link with the title "Featured link"
+    When I visit the topical event featuring index page
+    And I feature "Featured link"
+    Then I see that "Featured link" has been featured

--- a/features/topical_event_featurings.feature
+++ b/features/topical_event_featurings.feature
@@ -30,3 +30,15 @@ Feature:
     When I visit the topical event featuring index page
     And I feature "Featured link"
     Then I see that "Featured link" has been featured
+
+  Scenario: Reordering currently featured documents
+    Given two featurings exist for "Really topical"
+    When I visit the topical event featuring index page
+    And I set the order of the topical event featurings to:
+      | title           | order |
+      | Featured link 2 | 0     |
+      | Featured link 1 | 1     |
+    Then the topical event featurings should be in the following order:
+      | title           |
+      | Featured link 2 |
+      | Featured link 1 |

--- a/test/components/admin/features/featured_table_component_test.rb
+++ b/test/components/admin/features/featured_table_component_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Features::FeaturedDocumentsTableComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+  include Admin::OrganisationHelper
+
+  setup do
+    @feature_list = build_stubbed(:feature_list)
+  end
+
+  test "renders the correct row when the feature list item belongs to a document with a live edition" do
+    document = build(:document)
+    edition = build_stubbed(:news_article, :published)
+    document.stubs(:live_edition).returns(edition)
+    feature = build_stubbed(:feature, document:, feature_list: @feature_list)
+    title = edition.title
+
+    render_inline(Admin::Features::FeaturedDocumentsTableComponent.new(caption: "caption", features: [feature]))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "News Article (document)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, I18n.localize(edition.major_change_published_at.to_date)
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{admin_edition_path(edition)}']", text: "Edit #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(@feature_list, feature)}']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item belongs to a topical event" do
+    feature = build_stubbed(:feature, :with_topical_event_association, feature_list: @feature_list)
+    title = feature.topical_event.name
+
+    render_inline(Admin::Features::FeaturedDocumentsTableComponent.new(caption: "caption", features: [feature]))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "Topical Event"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, topical_event_dates_string(feature.topical_event)
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{edit_admin_topical_event_path(feature.topical_event)}']", text: "Edit #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature)}']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item belongs to a offsite link" do
+    feature = build_stubbed(:feature, :with_offsite_link_association, feature_list: @feature_list)
+    title = feature.offsite_link.title
+
+    render_inline(Admin::Features::FeaturedDocumentsTableComponent.new(caption: "caption", features: [feature]))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "Alert (offsite link)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, ""
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{polymorphic_path([:edit, :admin, feature.offsite_link.parent, feature.offsite_link])}']", text: "Edit #{title}"
+    actions_column.assert_selector "a[href='#{confirm_unfeature_admin_feature_list_feature_path(feature.feature_list, feature)}']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the feature list item does not have an association" do
+    feature = build_stubbed(:feature, document: nil)
+
+    render_inline(Admin::Features::FeaturedDocumentsTableComponent.new(caption: "caption", features: [feature]))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, "Feature #{feature.id}"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, ""
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, ""
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3].text, ""
+  end
+end

--- a/test/components/admin/topical_events/featurings/featured_table_component_test.rb
+++ b/test/components/admin/topical_events/featurings/featured_table_component_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
+  test "renders the correct row when the featurable is associated with an edition" do
+    edition = build_stubbed(:news_article, :published)
+    topical_event = build_stubbed(:topical_event)
+    featuring = build_stubbed(:topical_event_featuring, edition:, topical_event:)
+    title = featuring.title
+
+    render_inline(Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponent.new(
+                    caption: "caption",
+                    featurings: [featuring],
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "News Article (document)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, I18n.localize(edition.major_change_published_at.to_date)
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{admin_edition_path(edition)}']", text: "Edit #{title}"
+    actions_column.assert_selector "a[href='#{confirm_destroy_admin_topical_event_topical_event_featuring_path(topical_event, featuring)}']", text: "Unfeature #{title}"
+  end
+
+  test "renders the correct row when the featurable is associated with an offsite link" do
+    topical_event = build_stubbed(:topical_event)
+    featuring = build_stubbed(:offsite_topical_event_featuring, topical_event:)
+    title = featuring.offsite_link.title
+
+    render_inline(Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponent.new(
+                    caption: "caption",
+                    featurings: [featuring],
+                  ))
+
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[0].text, title
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[1].text, "Alert (offsite link)"
+    assert_equal page.all(".govuk-table .govuk-table__row .govuk-table__cell")[2].text, ""
+
+    actions_column = page.all(".govuk-table .govuk-table__row .govuk-table__cell")[3]
+    actions_column.assert_selector "a[href='#{polymorphic_path([:edit, :admin, topical_event, featuring.offsite_link])}']", text: "Edit #{title}"
+    actions_column.assert_selector "a[href='#{confirm_destroy_admin_topical_event_topical_event_featuring_path(topical_event, featuring)}']", text: "Unfeature #{title}"
+  end
+end


### PR DESCRIPTION
## Description 

This follows on from https://github.com/alphagov/whitehall/pull/7691 which added the Non-GOV.UK government links tab.

This adds the currently featured tab and the reorder & confirm delete featurings pages.

I've had to do a fairly chunky refactor here to get the CurrentlyFeaturedTabComponent to work for  features and topical event featurings. 

I've tried to keep the commits sensible so it's probs worth reviewing per commit 

## Screenshots

### index page currently featured tab

<img width="801" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ac61fd1b-1dbe-4a39-ad53-8309cbf7df26">

### Confirm delete 

<img width="489" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/bc003d34-2902-4002-a21d-d153bcd40127">

### Reorder 

<img width="647" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7f50bbbe-87ea-4a0b-9821-f2d7fae02265">

## Trello card

https://trello.com/c/EgRz8GpE/151-topical-event-featuring-index-page
 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
