### PR TITLE
Add mapped_specialist_topic_content_id to document collection presenter

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -63,6 +63,7 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+        details_hash.merge!({ mapped_specialist_topic_content_id: item.mapped_specialist_topic_content_id }) if item.mapped_specialist_topic_content_id
       end
     end
 

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -437,3 +437,28 @@ class PublishingApi::DocumentCollectionAccessLimitedTest < ActiveSupport::TestCa
     assert_valid_against_links_schema({ links: @presented_document_collection.links }, "document_collection")
   end
 end
+
+class PublishingApi::DocumentCollectionWithMappedSpecialistTopicTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+  end
+
+  test "presents the mapped specialist topic when one exists" do
+    mapped_specialist_topic_content_id = "fc33fada-fe47-4451-b4d3-89fea99bf796"
+    document_collection = create(:document_collection, mapped_specialist_topic_content_id:)
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    assert_equal mapped_specialist_topic_content_id, presented_document_collection.content[:details][:mapped_specialist_topic_content_id]
+
+    assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
+  end
+
+  test "does not present the mapped specialist topic if it is nil" do
+    document_collection = create(:document_collection)
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    assert_not presented_document_collection.content[:details].key?(:mapped_specialist_topic_content_id)
+
+    assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
+  end
+end


### PR DESCRIPTION
This field will be used as part of retiring specialist topics, some of which will be redirected to document collections that have been created to replace them. These document collections will have a mapped_specialist_topic_content_id thatrefers to the specialist topic they are intended to replace.

Having this field present on the document collection means that we will be able to pick out document collections where we can automatically migrate all email subscribers of the specialist topic over to the document collection.

We can remove this field once all specialist topics have been retired.

[Trello](https://trello.com/c/0otI0jLX/1821-add-the-mappedspecialisttopiccontentid-field-to-the-document-collection-content-item-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
