### PR TITLE
Design updates for release 1.8 pages

### DIFF
--- a/app/assets/stylesheets/admin/views/_people-index.scss
+++ b/app/assets/stylesheets/admin/views/_people-index.scss
@@ -1,0 +1,11 @@
+.app-view-people-index__table .govuk-table__row .govuk-table__header:nth-child(1) {
+  width: 40%;
+}
+
+.app-view-people-index__table .govuk-table__row .govuk-table__header:nth-child(2) {
+  width: 55%;
+}
+
+.app-view-people-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
+  width: 5%;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/govspeak-help";
 @import "./admin/views/historical-accounts-index";
 @import "./admin/views/organisations-index";
+@import "./admin/views/people-index";
 @import "./admin/views/take-part";
 @import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -5,10 +5,6 @@ $app-focus-colour: $govuk-focus-colour;
 
 .app-c-autocomplete {
   margin-bottom: govuk-spacing(6);
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(4);
-  }
 }
 
 .app-c-autocomplete--search {

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -22,24 +22,32 @@
       },
       {
         text: "End date"
-      }
+      },
+      *([
+        {
+          text: tag.span("Edit", class: "govuk-visually-hidden"),
+          format: "numeric"
+        }
+      ] if can?(:manage, Government))
     ],
     rows:
       @governments.map do |government|
       [
         {
-          text:  if can?(:manage, Government)
-                  link_to(government.name, edit_admin_government_path(government), class: "govuk-link")
-                 else
-                  government.name
-                 end
+          text: tag.p(government.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
         },
         {
           text: government.start_date.to_fs(:govuk_date)
         },
         {
           text: (government.end_date.to_fs(:govuk_date) if government.end_date)
-        }
+        },
+        *([
+          {
+            text: link_to(sanitize("Edit #{tag.span(government.name, class: "govuk-visually-hidden")}"), edit_admin_government_path(government), class: "govuk-link"),
+            format: "numeric"
+          }
+        ] if can?(:manage, Government))
       ]
     end
   } %>

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -4,30 +4,29 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: "Closing this government will unappoint the following ministerial roles, are you sure?"
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Closing this government will unappoint the following ministerial roles."
     } %>
 
     <%= render "govuk_publishing_components/components/list", {
       aria_label: "A list of active ministerial appointments.",
       visible_counters: true,
-      margin_bottom: 6,
-      items:
-        current_active_ministerial_appointments.map do |appointment|
-            "#{appointment.role.name}: #{appointment.person.name}"
-        end
+      extra_spacing: true,
+      margin_bottom: 8,
+      items: current_active_ministerial_appointments.map do |appointment|
+        "#{appointment.role.name}: #{appointment.person.name}"
+      end
     } %>
 
-    <%= form_tag close_admin_government_path(@government) do %>
+    <%= form_with url: close_admin_government_path(@government) do %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
           text: "Close this government",
           destructive: true
         } %>
+
         <%= link_to("Cancel", edit_admin_government_path(@government), class: "govuk-link") %>
       </div>
     <% end %>
   </div>
 </div>
-

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -21,17 +21,19 @@
         },
       } %>
 
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Summary (required)",
-          heading_size: "l",
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: "Summary (required)",
+            heading_size: "l",
+          },
+          name: "historical_account[summary]",
+          value: historical_account.summary,
+          rows: 4,
+          error_items: errors_for(historical_account.errors, :summary),
         },
         id: "historical_account_summary",
-        name: "historical_account[summary]",
-        value: historical_account.summary,
-        rows: 2,
-        hint: "Summary text should be 160 characters or fewer.",
-        error_items: errors_for(historical_account.errors, :summary),
+        maxlength: 160
       } %>
 
       <%= render "components/autocomplete", {
@@ -96,7 +98,7 @@
         id: "historical_account_major_acts",
         name: "historical_account[major_acts]",
         value: historical_account.major_acts,
-        rows: 2,
+        rows: 4,
         error_items: errors_for(historical_account.errors, :major_acts),
       } %>
 
@@ -108,7 +110,7 @@
         id: "historical_account_interesting_facts",
         name: "historical_account[interesting_facts]",
         value: historical_account.interesting_facts,
-        rows: 2,
+        rows: 4,
         error_items: errors_for(historical_account.errors, :interesting_facts),
       } %>
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -37,9 +37,9 @@
       } %>
 
       <%= render "components/autocomplete", {
-        id: "historical_account_political_party",
+        id: "historical_account_political_parties",
         name: "historical_account[political_party_ids][]",
-        error_items: errors_for(historical_account.errors, :political_party),
+        error_items: errors_for(historical_account.errors, :political_parties),
         label: {
           text: "Political parties (required)",
           heading_size: "l",

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -62,9 +62,13 @@
         margin_bottom: 4,
       } %>
 
-      <p class="govuk-body">No historical accounts</p>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No historical accounts."
+      } %>
     <% else %>
-      <p class="govuk-body">This person does not have any role appointments in roles that support historical accounts.</p>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "This person does not have any role appointments in roles that support historical accounts."
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -13,7 +13,7 @@
   margin_bottom: 8
 } %>
 
-<div class="app-c-govuk-table--filterable">
+<div class="app-c-govuk-table--filterable app-view-people-index__table">
 <%= render "govuk_publishing_components/components/table", {
   filterable: true,
   label: "Filter people",
@@ -24,14 +24,22 @@
     {
       text: "Biography",
     },
+    {
+      text: tag.span("View", class: "govuk-visually-hidden"),
+      format: "numeric"
+    },
   ],
   rows: @people.map do |person|
     [
       {
-        text: link_to(person.name, [:admin, person], title: "View #{person.name}", class: "govuk-link"),
+        text: tag.p(person.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
       },
       {
         text: truncate(person.biography, length: 60),
+      },
+      {
+        text: link_to(sanitize("View #{tag.span(person.name, class: "govuk-visually-hidden")}"), [:admin, person], class: "govuk-link"),
+        format: "numeric"
       }
     ]
   end

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -7,9 +7,8 @@
 } %>
 
 <%= render "govuk_publishing_components/components/button", {
-  text: "Create person",
+  text: "Create new person",
   href: new_admin_person_path,
-  secondary_solid: true,
   margin_bottom: 8
 } %>
 

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -40,7 +40,9 @@
           end
         } %>
       <% else %>
-        <p class="govuk-body">No translations</p>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          text: "No translations."
+        } %>
       <% end %>
 
       <% if @person.missing_translations.any? %>

--- a/app/views/admin/sitewide_settings/index.html.erb
+++ b/app/views/admin/sitewide_settings/index.html.erb
@@ -1,15 +1,11 @@
 <% content_for :page_title, "Sitewide settings" %>
 <% content_for :title, "Sitewide settings" %>
 <% content_for :title_margin_bottom, 4 %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% unless @sitewide_settings.present? %>
-      <p class="govuk-body"></p>
-      <%= render "components/inset_prompt",{
-        description: "No sitewide settings available to configure."
-      }%>
-    <% end %>
-    <%= render "govuk_publishing_components/components/table", {
+    <% if @sitewide_settings.present? %>
+      <%= render "govuk_publishing_components/components/table", {
         head: [
           {
             text: "Name"
@@ -18,22 +14,28 @@
             text: "On/Off"
           },
           {
-            text: "Edit"
+            text: tag.span("Edit", class: "govuk-visually-hidden"),
+            format: "numeric"
           }
         ],
         rows: @sitewide_settings.map do |sitewide_setting|
           [
             {
-              text: link_to(sitewide_setting.name, edit_admin_sitewide_setting_path(sitewide_setting), title: "View #{sitewide_setting.name}", class: "govuk-link")
+              text: tag.p(sitewide_setting.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
             },
             {
               text: sitewide_setting.human_status
             },
             {
-              text: link_to("Edit", edit_admin_sitewide_setting_path(sitewide_setting), title: "Edit #{sitewide_setting.name}", class: "govuk-link")
+              text: link_to(sanitize("Edit #{tag.span(sitewide_setting.name, class: "govuk-visually-hidden")}"), edit_admin_sitewide_setting_path(sitewide_setting), class: "govuk-link")
             },
           ]
-    end
-} if @sitewide_settings.present? %>
+        end
+      } %>
+    <% else %>
+      <%= render "components/inset_prompt",{
+        description: "No sitewide settings available to configure."
+      } %>
+    <% end %>
   </div>
 </div>

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -13,7 +13,7 @@ end
 
 When(/^I add a new person called "([^"]*)"$/) do |name|
   visit_people_admin
-  click_link "Create person"
+  click_link using_design_system? ? "Create new person" : "Create person"
   fill_in_person_name name
   fill_in "Biography", with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   attach_file using_design_system? ? "Upload a file" : "Image", jpg_image


### PR DESCRIPTION
## Description 

Nik has done an audit of some of the 1.8 pages and out together a list of quick fixes we can make to standardise the pages.

This goes through the cards he made and updates the pages with the fixes

## Screenshots

### Historical account edit page

#### Before

<img width="428" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7a2016c9-989e-4ffe-b4e8-899992feafe1">

#### After

<img width="403" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2900ce2f-6cbb-4ee4-b560-0c0c4b9104ce">

### Prepare to close government page

#### Before

<img width="457" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/1873dcd8-a3c2-44b6-8185-847081ff7b69">

<img width="451" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d4a20b97-0326-4268-85d4-bb405a74ff8b">


#### After

<img width="488" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/bed84c99-370f-4208-b365-9bad63b04986">

<img width="497" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e9431b81-0f4d-44d7-9fe1-bea2401312ca">

### Government index page

#### Before

<img width="673" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/49751b92-d40a-4a8e-8d97-1cdb2eca2628">


#### After

<img width="659" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/6b8a6c7c-7870-4891-94b3-bc5a42950fbb">


### People index page

#### Before

<img width="655" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0045be3f-d5d6-4382-acb2-f6a71bab3a63">


#### After

<img width="625" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e7a137e7-87e8-467e-9312-e4c2a0c4225b">


### Sitewide settings index page

#### Before

<img width="454" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/c5d29ab4-3daa-4df9-919f-8f1c880f01a6">


#### After

<img width="535" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7201d1bd-5f6f-4169-a9e8-da2d3390ccb1">

### Use inset text

#### Before

<img width="707" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/831b365b-68ec-40f2-91f3-9f2745ed9abd">

<img width="689" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/dbb35631-4c92-4c80-8b03-f783201250bd">

<img width="706" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/799d3c5b-1bfd-4bee-ab6d-e4af8df35d65">

#### After

<img width="657" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/76f52a9f-3ea0-4c59-973b-6d0a9aa8a7fe">

<img width="644" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3bcf94a5-37cb-44ce-9eb1-bf827073eb4f">

<img width="707" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/204bd149-fc39-43db-b347-75e2da5367b4">


## Trello card

https://trello.com/c/s1TfQUwB/184-increase-row-count-for-text-area-edit-historical-account-page
https://trello.com/c/MNN7alN5/185-update-prepare-to-close-government-page
https://trello.com/c/SYQO6owi/186-missing-view-link-on-listing-page-table
https://trello.com/c/czAALDmI/187-missing-view-link-on-people-list-page-table
https://trello.com/c/VtXVX4eW/188-fix-table-on-sitewide-settings-listing-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
