### PR TITLE
Present appointed people in the content item

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -40,6 +40,9 @@ module PublishingApi
       {
         corporate_information_pages:,
         ordered_contacts:,
+        primary_role_person:,
+        secondary_role_person:,
+        office_staff:,
         sponsoring_organisations:,
         world_locations:,
       }
@@ -57,6 +60,22 @@ module PublishingApi
       return [] unless item.offices.any?
 
       item.offices.map(&:contact).map(&:content_id)
+    end
+
+    def primary_role_person
+      return [] unless item.primary_role
+
+      [item.primary_role.current_person.content_id]
+    end
+
+    def secondary_role_person
+      return [] unless item.secondary_role
+
+      [item.secondary_role.current_person.content_id]
+    end
+
+    def office_staff
+      item.office_staff_roles.map(&:current_person).map(&:content_id)
     end
 
     def corporate_information_pages

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -15,6 +15,16 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            name: "Locationia Embassy",
                            analytics_identifier: "WO123")
 
+    primary_role = create(:ambassador_role)
+    ambassador = create(:person)
+    create(:ambassador_role_appointment, role: primary_role, person: ambassador)
+    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: primary_role)
+
+    secondary_role = create(:deputy_head_of_mission_role)
+    deputy_head_of_mission = create(:person)
+    create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
+    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
+
     public_path = worldwide_org.public_path
 
     expected_hash = {
@@ -81,6 +91,13 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       ordered_contacts: [
         worldwide_org.reload.offices.first.contact.content_id,
       ],
+      primary_role_person: [
+        ambassador.content_id,
+      ],
+      secondary_role_person: [
+        deputy_head_of_mission.content_id,
+      ],
+      office_staff: worldwide_org.reload.office_staff_roles.map(&:current_person).map(&:content_id),
       sponsoring_organisations: [
         worldwide_org.sponsoring_organisations.first.content_id,
       ],


### PR DESCRIPTION
Whitehall currently shows any people who are appointed to certain roles in a worldwide org in the following way:
- image and details for the person in a primary role, if they exist
- details only for people in secondary and office roles.

In order to render them in government-frontend, we need the appointed people and their roles in the content item.

Whitehall distinguishes "secondary" and "office" roles in the backend, but not when displaying them.

I chose to keep this distinction in the content item, to allow for future developments if the distinction ever becomes meaningful for displaying.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
