### PR TITLE
Update people show page to use summary list component

### DIFF
--- a/app/assets/stylesheets/admin/_overrides.scss
+++ b/app/assets/stylesheets/admin/_overrides.scss
@@ -9,3 +9,13 @@
 code {
   color: govuk-colour("red");
 }
+
+.gem-c-summary-list--with-image {
+  .govuk-summary-list__key {
+    vertical-align: top;
+  }
+
+  img {
+    display: block;
+  }
+}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -115,6 +115,10 @@ class Person < ApplicationRecord
     end
   end
 
+  def current_role_appointments_title
+    current_role_appointments.collect(&:role_name).to_sentence
+  end
+
 private
 
   def name_as_words(*elements)

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -6,7 +6,7 @@
 <p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link" %></p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Document navigation tabs",
+  aria_label: "Organisation navigation tabs",
   items: secondary_navigation_tabs_items(@organisation, request.path)
 } %>
 

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Organisation navigation tabs",
       items: secondary_navigation_tabs_items(@edition, request.path)
     } %>
 

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{@person.name} historical accounts" %>
 <% content_for :title, @person.name %>
-<% content_for :context, "Historical accounts" %>
+<% content_for :context, "People" %>
 <% content_for :title_margin_bottom, 4 %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-     aria_label: "Document navigation tabs",
+     aria_label: "People navigation tabs",
      items: secondary_navigation_tabs_items(@person, request.path)
     } %>
 

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -5,6 +5,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @person.current_role_appointments_title.present? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @person.current_role_appointments.collect(&:role_name).to_sentence
+      } %>
+    <% end %>
+
     <p class="govuk-body">
       <%= view_on_website_link_for @person, class: "govuk-link" %>
     </p>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document navigation tabs",
+    aria_label: "Organisation navigation tabs",
     items: secondary_navigation_tabs_items(@organisation, request.path)
   } %>
 </div>

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, person] do |form| %>
+<%= form_for [:admin, person], multipart: true do |form| %>
   <%= hidden_field_tag 'person[privy_counsellor]', "0" %>
 
   <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, @person.name %>
 <% content_for :title, @person.name %>
-<% content_for :context, "Details" %>
+<% content_for :context, "People" %>
 <% content_for :title_margin_bottom, 4 %>
 
 <div class="govuk-grid-row">
@@ -14,7 +14,7 @@
     <p class="govuk-body"><%= view_on_website_link_for @person, class: "govuk-link", target: "blank" %></p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "People navigation tabs",
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
     <% unless @person.destroyable? %>

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -5,13 +5,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @person.current_role_appointments_title.present? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @person.current_role_appointments_title
+      } %>
+    <% end %>
+
     <p class="govuk-body"><%= view_on_website_link_for @person, class: "govuk-link", target: "blank" %></p>
 
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
-
     <% unless @person.destroyable? %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "Note: This person cannot be deleted as they are currently assigned to a role"

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -12,41 +12,53 @@
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
 
-    <% if @person.image_url %>
-      <%= image_tag @person.image.url(:s300) %>
-    <% end %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-       text: @person.current_role_appointments.collect(&:role_name).to_sentence,
-       font_size: "l",
-       margin_bottom: 4,
-     } %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Biography",
-      font_size: "l",
-      margin_bottom: 4,
-    } %>
-
-    <div class="govuk-button-group govuk-!-margin-bottom-4">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Edit",
-        href: [:edit, :admin, @person],
-        secondary_solid: true,
-        margin_bottom: 0,
-      } %>
-
-      <% if @person.destroyable? %>
-        <%= link_to "Delete", confirm_destroy_admin_person_path(@person), class: "govuk-link gem-link--destructive" %>
-      <% end %>
-    </div>
-
     <% unless @person.destroyable? %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "Note: This person cannot be deleted as they are currently assigned to a role"
       } %>
     <% end %>
 
-    <p class="govuk-body"><%= @person.biography %></p>
+    <div class="gem-c-summary-list--with-image">
+      <%= render "govuk_publishing_components/components/summary_list", {
+        title: "Details",
+        items: [
+          {
+            field: "Rt Hon",
+            value: @person.privy_counsellor ?  "Yes" : nil,
+          },
+          {
+            field: "Title",
+            value: @person.title,
+          },
+          {
+            field: "Forename",
+            value: @person.forename,
+          },
+          {
+            field: "Surname",
+            value: @person.surname,
+          },
+          {
+            field: "Letters",
+            value: @person.letters,
+          },
+          {
+            field: "Image",
+            value: (image_tag(@person.image.url(:s300)) + tag.span("Image present", class: "govuk-visually-hidden") if @person.image.url),
+          },
+          {
+            field: "Biography",
+            value: @person.biography,
+          }
+        ].reject { |row| row[:value].blank? },
+        edit: {
+          href: [:edit, :admin, @person],
+          link_text: "Edit details",
+        },
+        delete: {
+          href: (confirm_destroy_admin_person_path(@person) if @person.destroyable?),
+        }.compact
+      } %>
+    </div>
   </div>
 </div>

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{@person.name}" %>
 <% content_for :title, @person.name %>
-<% content_for :context, "Translations" %>
+<% content_for :context, "People" %>
 <% content_for :title_margin_bottom, 4 %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "People navigation tabs",
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
 

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -5,65 +5,71 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        <%= view_on_website_link_for @person, class: "govuk-link" %>
-      </p>
-
-      <%= render "components/secondary_navigation", {
-        aria_label: "Document navigation tabs",
-        items: secondary_navigation_tabs_items(@person, request.path)
+    <% if @person.current_role_appointments_title.present? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @person.current_role_appointments.collect(&:role_name).to_sentence
       } %>
+    <% end %>
 
-      <% if @person.non_english_translated_locales.present? %>
-        <%= render "govuk_publishing_components/components/table", {
-          head: [
+    <p class="govuk-body">
+      <%= view_on_website_link_for @person, class: "govuk-link" %>
+    </p>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@person, request.path)
+    } %>
+
+    <% if @person.non_english_translated_locales.present? %>
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          {
+            text: "Locale"
+          },
+          {
+            text: tag.span("Actions", class: "govuk-visually-hidden"),
+            format: "numeric",
+          }
+        ],
+        rows: @person.non_english_translated_locales.map do |locale|
+          native_language_name = Locale.coerce(locale).native_language_name
+          [
             {
-              text: "Locale"
+              text: sanitize("#{locale.native_language_name} " + link_to("(view)", @person.public_url(locale: locale.code), class: "govuk-link"))
             },
             {
-              text: tag.span("Actions", class: "govuk-visually-hidden"),
-              format: "numeric",
+              text: sanitize("<a class='govuk-link' href='#{edit_admin_person_translation_path(@person, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{native_language_name}</span></a>" +
+                "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_translation_path(@person, locale.code)}'>Delete <span class='govuk-visually-hidden'>#{native_language_name}</span></a>"),
+              format: "numeric"
             }
-          ],
-          rows: @person.non_english_translated_locales.map do |locale|
-            native_language_name = Locale.coerce(locale).native_language_name
-            [
-              {
-                text: sanitize("#{locale.native_language_name} " + link_to("(view)", @person.public_url(locale: locale.code), class: "govuk-link"))
-              },
-              {
-                text: sanitize("<a class='govuk-link' href='#{edit_admin_person_translation_path(@person, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{native_language_name}</span></a>" +
-                  "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_translation_path(@person, locale.code)}'>Delete <span class='govuk-visually-hidden'>#{native_language_name}</span></a>"),
-                format: "numeric"
-              }
-            ]
+          ]
+        end
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No translations."
+      } %>
+    <% end %>
+
+    <% if @person.missing_translations.any? %>
+      <%= form_tag admin_person_translations_path(@person) do %>
+        <%= render "govuk_publishing_components/components/select", {
+          id: "translation_locale",
+          name: "translation_locale",
+          label: "Locale",
+          heading_size: "l",
+          options: @person.missing_translations.map do |locale|
+            {
+              value: locale.code,
+              text: Locale.coerce(locale).native_and_english_language_name,
+            }
           end
         } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/inset_text", {
-          text: "No translations."
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Create translation"
         } %>
       <% end %>
-
-      <% if @person.missing_translations.any? %>
-        <%= form_tag admin_person_translations_path(@person) do %>
-          <%= render "govuk_publishing_components/components/select", {
-            id: "translation_locale",
-            name: "translation_locale",
-            label: "Locale",
-            heading_size: "l",
-            options: @person.missing_translations.map do |locale|
-              {
-                value: locale.code,
-                text: Locale.coerce(locale).native_and_english_language_name,
-              }
-            end
-          } %>
-
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Create translation"
-          } %>
-        <% end %>
-      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Promotional features navigation tabs",
+      aria_label: "Organisation navigation tabs",
       items: secondary_navigation_tabs_items(@organisation, request.path)
     } %>
 

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document tabs",
+    aria_label: "World location news navigation tabs",
     items: secondary_navigation_tabs_items(@world_location_news, request.path)
   } %>
 </div>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link", target: "_blank" %>
     </p>
     <%= render "components/secondary_navigation", {
-      aria_label: "Document tabs",
+      aria_label: "World location news navigation tabs",
       items: secondary_navigation_tabs_items(@world_location_news, request.path)
     } %>
     <div class="govuk-!-margin-bottom-4">

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -11,7 +11,7 @@
       </p>
 
       <%= render "components/secondary_navigation", {
-        aria_label: "World location translation items",
+        aria_label: "World location news navigation tabs",
         items: secondary_navigation_tabs_items(@world_location_news, request.path)
       } %>
 

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -63,6 +63,44 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_template :show
   end
 
+  view_test "GET on :show displays the users infomration in a summary list component and renders delete and edit link" do
+    person = create(
+      :person,
+      forename: "Rishi",
+      surname: "Sunak",
+      privy_counsellor: true,
+      title: "Mr",
+      letters: "OBE",
+      biography: "He is the PM.",
+    )
+
+    get :show, params: { id: person }
+
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Rt Hon"
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "Yes"
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Title"
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "Mr"
+    assert_select ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Forename"
+    assert_select ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: "Rishi"
+    assert_select ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Surname"
+    assert_select ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "Sunak"
+    assert_select ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Letters"
+    assert_select ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "OBE"
+    assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Biography"
+    assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "He is the PM."
+    assert_select ".govuk-summary-list__actions-list a[href='#{edit_admin_person_path(person)}']", text: /Edit details/
+    assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details"
+  end
+
+  view_test "GET on :show renders an inset text component when user cannot be deleted" do
+    person = create(:pm)
+
+    get :show, params: { id: person }
+
+    assert_select ".gem-c-inset-text", text: "Note: This person cannot be deleted as they are currently assigned to a role"
+    assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details", count: 0
+  end
+
   view_test "editing shows form for editing a person" do
     person = create(:person, image: upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
     get :edit, params: { id: person }

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -222,4 +222,15 @@ class PersonTest < ActiveSupport::TestCase
 
     assert_equal false, person.current_or_previous_prime_minister?
   end
+
+  test "#current_role_appointments_title returns their role appointment names in a sentence" do
+    person = build(:person)
+    role1 = build(:role, :occupied, name: "Prime Minister")
+    role2 = build(:role, :occupied, name: "Big Cheese")
+    role_appointment1 = build(:role_appointment, person:, role: role1)
+    role_appointment2 = build(:role_appointment, person:, role: role2)
+    person.stubs(:current_role_appointments).returns([role_appointment1, role_appointment2])
+
+    assert_equal "Prime Minister and Big Cheese", person.current_role_appointments_title
+  end
 end


### PR DESCRIPTION
## Description

This uses the summary list component rather than edit and delete buttons and the biography.

It adds rows for the rt hon prefix, title, forename, surname, image and biography and only renders the row if a value is present.

It also adds in the persons title as a lead paragraph between the title and link to view them on GOV.UK

## Screenshots

### Before

<img width="721" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8f77bc7c-b325-40aa-84c1-0ebbe8852f7f">


When deleteable

<img width="560" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2f8c5ca2-a231-4d2e-9eb3-94956776f12c">


### After

<img width="737" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7d77e310-b55c-4539-8fa5-3dd100981d45">

<img width="668" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3ae4705b-9481-4301-bc30-ed00e3790785">

I've updated the caption to "People"

<img width="621" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/67db0a66-4899-443a-856d-d1996b450f75">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
