### PR TITLE
Ensure corporate_information_pages#index view renders in Boostrap layout

### DIFF
--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -28,10 +28,13 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
 private
 
   def get_layout
-    if action_name == "index" && preview_design_system?(next_release: false)
+    design_system_actions = %w[confirm_destroy show edit update new create]
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
       "design_system"
     else
-      super
+      "admin"
     end
   end
 


### PR DESCRIPTION
## Description

At the moment, the index view is rendering in design system layout for the index page when it should be rendering in Bootstrap.

When super is called it returns `design_system` for the editions_controller#index action. This page hasn't been released for corp information pages so it needs to return `admin`.

## Screenshots

### Before

<img width="840" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ed72ca60-2c20-4b5f-b061-af0eb2ba2997">


### After

<img width="1075" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/c28d2ed4-6362-4566-bb54-42bb5745fb4d">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
