### PR TITLE
Remove 'What's New' Banner from Whitehall

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,11 +1,11 @@
 en:
   admin:
     whats_new:
-      show_banner: true
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 2 February 2023
+      last_updated: Last updated 11 May 2023
       introduction:
         heading: Moving to the Design System
         body_govspeak: |


### PR DESCRIPTION
**Description**

This change removes the 'What's new' banner, which is currently displaying for everyone on Whitehall. It also updates the date field that was missed previously, to the last release for 1.6 and major changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
