### PR TITLE
QA fixes for historical_accounts_index page

### DIFF
--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -16,7 +16,7 @@
 
     <% if @person.can_have_historical_accounts? && @historical_accounts.present? %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Create historical account",
+        text: "Create new historical account",
         href: new_admin_person_historical_account_path,
         margin_bottom: 4,
       } %>
@@ -46,9 +46,9 @@
                 text: historical_account.summary,
               },
               {
-                text: sanitize("<a class='govuk-link' href='#{historical_account.public_path}'>View <span class='govuk-visually-hidden'>#{roles}</span></a>" +
-                  "<a class='govuk-link govuk-!-margin-left-2' href='#{edit_admin_person_historical_account_path(@person, historical_account)}'>Edit <span class='govuk-visually-hidden'>#{roles}</span></a>" +
-                  "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_historical_account_path(@person, historical_account)}'>Delete <span class='govuk-visually-hidden'>#{roles}</span></a>"),
+                text: link_to(sanitize("View #{tag.span(roles, class: 'govuk-visually-hidden')}"), Whitehall.public_host + historical_account.public_path, class: "govuk-link") +
+                  link_to(sanitize("Edit #{tag.span(roles, class: 'govuk-visually-hidden')}"), edit_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2") +
+                  link_to(sanitize("Delete #{tag.span(roles, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive"),
                 format: "numeric"
               }
             ]


### PR DESCRIPTION
## Description 

1. Fix link to view historical account of GOV.UK.
2. Update button text to follow "Create new x" pattern.

## Screenshot 

### Before

<img width="293" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/b5c1249c-5263-43b4-b8ca-1e7ab5b79ace">

### After 

<img width="347" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/6d668f2e-7ca7-4a96-b504-b1e8efdc4285">

## Trello card 

https://trello.com/c/Mc7tkN1R/222-fixes-for-historical-accounts-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
