### PR TITLE
Remove unused code related to fatality notices

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -111,7 +111,6 @@ $govuk-include-default-font-face: false;
   @import "views/groups";
   @import "views/layouts";
   @import "views/new-document-page";
-  @import "views/operational-field";
   @import "views/site-index";
   @import "views/world-locations";
   @import "views/worldwide-organisations";

--- a/app/assets/stylesheets/frontend/views/_operational-field.scss
+++ b/app/assets/stylesheets/frontend/views/_operational-field.scss
@@ -1,5 +1,0 @@
-.operational-field-show {
-  .fatality-notice {
-    list-style: none;
-  }
-}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,6 @@ Whitehall::Application.routes.draw do
     root to: redirect("/", prefix: ""), via: :get, as: :main_root
 
     # Public facing routes still rendered by Whitehall
-    resources :fatality_notices, path: "fatalities", only: [:show]
     get "/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview" => "csv_preview#show", as: :csv_preview
     # End of public facing routes still rendered by Whitehall
 


### PR DESCRIPTION
Fatality notices are already being rendered by government-frontend.

I couldn't find a commit or pull request to reference when exactly this code might have been moved, but it doesn't appear to be used now, and there are no tests for it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
