### PR TITLE
Move 1.8 pages into the next release

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release && !Rails.env.test?
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -5,18 +5,18 @@ class Admin::GovernmentsController < Admin::BaseController
   def index
     @governments = Government.order(start_date: :desc)
 
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index", next_release: true)
   end
 
   def new
     @government = Government.new(start_date: Time.zone.today)
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new", next_release: true)
   end
 
   def edit
     @government = Government.find(params[:id])
 
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit", next_release: true)
   end
 
   def create
@@ -27,7 +27,7 @@ class Admin::GovernmentsController < Admin::BaseController
     if @government.save
       redirect_to admin_governments_path, notice: "Created government information"
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new", next_release: true)
     end
   end
 
@@ -37,14 +37,14 @@ class Admin::GovernmentsController < Admin::BaseController
     if @government.update(government_params)
       redirect_to admin_governments_path, notice: "Updated government information"
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit", next_release: true)
     end
   end
 
   def prepare_to_close
     @government = Government.find(params[:id])
 
-    render_design_system("prepare_to_close", "legacy_prepare_to_close", next_release: false)
+    render_design_system("prepare_to_close", "legacy_prepare_to_close", next_release: true)
   end
 
   def close
@@ -77,7 +77,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index edit new create update prepare_to_close] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index edit new create update prepare_to_close] if preview_design_system?(next_release: true)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/historical_accounts_controller.rb
+++ b/app/controllers/admin/historical_accounts_controller.rb
@@ -5,12 +5,12 @@ class Admin::HistoricalAccountsController < Admin::BaseController
 
   def index
     @historical_accounts = @person.historical_accounts.includes(roles: :translations)
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index, next_release: true)
   end
 
   def new
     @historical_account = @person.historical_accounts.build
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new, next_release: true)
   end
 
   def create
@@ -18,19 +18,19 @@ class Admin::HistoricalAccountsController < Admin::BaseController
     if @historical_account.save
       redirect_to admin_person_historical_accounts_url(@person), notice: "Historical account created"
     else
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new, next_release: true)
     end
   end
 
   def edit
-    render_design_system(:edit, :legacy_edit, next_release: false)
+    render_design_system(:edit, :legacy_edit, next_release: true)
   end
 
   def update
     if @historical_account.update(historical_account_params)
       redirect_to admin_person_historical_accounts_url(@person), notice: "Historical account updated"
     else
-      render_design_system(:edit, :legacy_edit, next_release: false)
+      render_design_system(:edit, :legacy_edit, next_release: true)
     end
   end
 
@@ -46,7 +46,7 @@ class Admin::HistoricalAccountsController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/operational_fields_controller.rb
+++ b/app/controllers/admin/operational_fields_controller.rb
@@ -4,12 +4,12 @@ class Admin::OperationalFieldsController < Admin::BaseController
 
   def index
     @operational_fields = OperationalField.order(:name)
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index, next_release: true)
   end
 
   def new
     @operational_field = OperationalField.new
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new, next_release: true)
   end
 
   def create
@@ -17,13 +17,13 @@ class Admin::OperationalFieldsController < Admin::BaseController
     if @operational_field.save
       redirect_to admin_operational_fields_path, notice: %("#{@operational_field.name}" created.)
     else
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new, next_release: true)
     end
   end
 
   def edit
     @operational_field = OperationalField.friendly.find(params[:id])
-    render_design_system(:edit, :legacy_edit, next_release: false)
+    render_design_system(:edit, :legacy_edit, next_release: true)
   end
 
   def update
@@ -31,14 +31,14 @@ class Admin::OperationalFieldsController < Admin::BaseController
     if @operational_field.update(operational_field_params)
       redirect_to admin_operational_fields_path, notice: %("#{@operational_field.name}" saved.)
     else
-      render_design_system(:edit, :legacy_edit, next_release: false)
+      render_design_system(:edit, :legacy_edit, next_release: true)
     end
   end
 
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -5,12 +5,12 @@ class Admin::PeopleController < Admin::BaseController
 
   def index
     @people = Person.order(:surname, :forename).includes(:translations)
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index, next_release: true)
   end
 
   def new
     @person = Person.new
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new, next_release: true)
   end
 
   def create
@@ -18,23 +18,23 @@ class Admin::PeopleController < Admin::BaseController
     if @person.save
       redirect_to [:admin, @person], notice: %("#{@person.name}" created.)
     else
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new, next_release: true)
     end
   end
 
   def show
-    render_design_system(:show, :legacy_show, next_release: false)
+    render_design_system(:show, :legacy_show, next_release: true)
   end
 
   def edit
-    render_design_system(:edit, :legacy_edit, next_release: false)
+    render_design_system(:edit, :legacy_edit, next_release: true)
   end
 
   def update
     if @person.update(person_params)
       redirect_to [:admin, @person], notice: %("#{@person.name}" saved.)
     else
-      render_design_system(:edit, :legacy_edit, next_release: false)
+      render_design_system(:edit, :legacy_edit, next_release: true)
     end
   end
 
@@ -71,7 +71,7 @@ private
 
   def get_layout
     design_system_actions = %w[reorder_role_appointments update_order_role_appointments]
-    design_system_actions += %w[index show confirm_destroy new create edit update] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index show confirm_destroy new create edit update] if preview_design_system?(next_release: true)
 
     if action_name.in?(design_system_actions)
       "design_system"

--- a/app/controllers/admin/person_translations_controller.rb
+++ b/app/controllers/admin/person_translations_controller.rb
@@ -5,14 +5,14 @@ class Admin::PersonTranslationsController < Admin::BaseController
   before_action :build_translation_locale, only: %i[confirm_destroy]
 
   def index
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index, next_release: true)
   end
 
 private
 
   def get_layout
     design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[edit update index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[edit update index] if preview_design_system?(next_release: true)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/sitewide_settings_controller.rb
+++ b/app/controllers/admin/sitewide_settings_controller.rb
@@ -9,13 +9,13 @@ class Admin::SitewideSettingsController < Admin::BaseController
   def index
     @sitewide_settings = SitewideSetting.all
 
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index", next_release: true)
   end
 
   def edit
     @sitewide_setting = SitewideSetting.find(params[:id])
 
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit", next_release: true)
   end
 
   def update
@@ -23,14 +23,14 @@ class Admin::SitewideSettingsController < Admin::BaseController
     if @sitewide_setting.update(sitewide_settings_params)
       redirect_to admin_sitewide_settings_path, notice: %("#{@sitewide_setting.name}" updated.)
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit", next_release: true)
     end
   end
 
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"


### PR DESCRIPTION
## Description

I did the following to prepare this release

1. Moved pages going out in 1.8 into next release
2. Add return true if next_release override to the preview_design_system? method in the base controller
3. run tests and fix/duplicate non-legacy tests to both implementations have full coverage
4. extend override to include return true if next_release && !Rails.env.test? so override only applies to prod

When i overrode the permission and ran the tests, only legacy tests for the Bootstrap implementation failed so we can be confident we've got full coverage.

## Trello card 

https://trello.com/c/YIwuhpye/223-prepare-release-18

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
