### PR TITLE
Attempt to fix flakey test in document-collections.feature

### DIFF
--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -143,7 +143,8 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   visit admin_document_collection_path(@document_collection)
 
   click_on "Create new edition"
-  fill_in_change_note_if_required
+  choose "Yes - information has been added, updated or removed"
+  fill_in "edition_change_note", with: "changes"
   click_button "Save and continue"
   save_screenshot
   click_button "Update tags"


### PR DESCRIPTION
Trello: https://trello.com/c/bVMUgKC9

The following test has been failing intermittently on CI for a number of weeks:

```
Unable to find button "Update tags" that is not disabled (Capybara::ElementNotFound)
./features/step_definitions/document_collection_steps.rb:148:in `/^I redraft the document collection and remove "(.*?)" from it$/'
features/document-collections.feature:33:in `I redraft the document collection and remove "May 2012 Update" from it'
```

Based on the debug added in PRs [7698][1] and [7713][2] I'm fairly confident that the test fails when the "Yes - information has been added, updated or removed" radio button is selected but the Change note textarea isn't visible. This causes the saving of the edition to fail because the change note can't be blank.

Previously the test attempted to fill the Change note if the textarea was visible on the screen (using `fill_in_change_note_if_required`). Presumably based on the assumption that if the "Yes - information has been added, updated or removed" radio button is selected (because [`Edition#minor_change?` is false][3]) that the change note textarea will be visible. However, the [change note textarea is conditional][4] and therefore [hidden by default][5] until some JavaScript makes it visible. My theory is that there was a race condition in this test that meant it would fail intermittently depending on whether the JavaScript had executed and made the textarea visible before the call to `fill_in_change_note_if_required`.

By explicitly choosing "Yes - information has been added, updated or removed" and then filling the change note textarea (whose appearance Capybara should wait for by default) I hope to avoid the race condition.

[1]: https://github.com/alphagov/whitehall/pull/7698
[2]: https://github.com/alphagov/whitehall/pull/7713
[3]: https://github.com/alphagov/whitehall/blob/96a9ef3f020ed0c3bb18787b1654a9babec52905/app/views/admin/editions/_change_notes.html.erb#L30
[4]: https://github.com/alphagov/whitehall/blob/96a9ef3f020ed0c3bb18787b1654a9babec52905/app/views/admin/editions/_change_notes.html.erb#L31
[5]: https://github.com/alphagov/govuk_publishing_components/blob/47cb6c90d6470230cc3044202405239191cdc610/app/views/govuk_publishing_components/components/_radio.html.erb#L127

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
