### PR TITLE
Adds specific styles to people summary list for rendering line breaks

### DIFF
--- a/app/assets/stylesheets/admin/views/_people.scss
+++ b/app/assets/stylesheets/admin/views/_people.scss
@@ -9,3 +9,9 @@
 .app-view-people-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
   width: 5%;
 }
+
+.app-view-people-details__summary_list {
+  .govuk-summary-list__value {
+    white-space: pre-line;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/govspeak-help";
 @import "./admin/views/historical-accounts-index";
 @import "./admin/views/organisations-index";
-@import "./admin/views/people-index";
+@import "./admin/views/people";
 @import "./admin/views/take-part";
 @import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -23,7 +23,7 @@
       } %>
     <% end %>
 
-    <div class="gem-c-summary-list--with-image">
+    <div class="gem-c-summary-list--with-image app-view-people-details__summary_list">
       <%= render "govuk_publishing_components/components/summary_list", {
         title: "Details",
         items: [


### PR DESCRIPTION
[Trello](https://trello.com/c/P2E2ZWIy/228-loss-of-line-breaks-on-people-details-page)

This PR restores the display of line-breaks in the display of a person's biography for reasons of readability. This was rendered in the bootstrap version of the page, which was displayed in a `<pre>` element. This replicates that by assigning the element a CSS value of `white-space: pre-line;`. 

I have repurposed the existing `people-index` stylesheet and renamed it to the slightly more generic `people` for the style update. 

||||
|-|-|-|
|Bootstrap|Design System|These changes|
| ![Screenshot 2023-05-31 at 13 22 11](https://github.com/alphagov/whitehall/assets/6080548/1462d055-d716-4711-8eee-63b8e3544e07) | ![Screenshot 2023-05-31 at 13 23 06](https://github.com/alphagov/whitehall/assets/6080548/e1ec5da6-5558-44bc-9418-18e21fe09d30) | ![Screenshot 2023-05-31 at 13 23 41](https://github.com/alphagov/whitehall/assets/6080548/0474cefe-9d35-4212-be91-6e1486096caf) |