### PR TITLE
Switch the rendering of Worldwide Offices to `government-frontend`

### DIFF
--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_office",
       )
 

--- a/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -17,7 +17,7 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
       document_type: "worldwide_office",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "whitehall-frontend",
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
       public_updated_at: worldwide_office.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
https://trello.com/c/FsrP8Lin

The rendering code for Worldwide Offices has been moved to `government-frontend` (https://github.com/alphagov/government-frontend/pull/2793).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
