### PR TITLE
Use custom class instead of format numeric for tables with actions

### DIFF
--- a/app/assets/stylesheets/admin/_overrides.scss
+++ b/app/assets/stylesheets/admin/_overrides.scss
@@ -2,6 +2,12 @@
   table-layout: fixed;
 }
 
+.govuk-table--with-actions {
+  .govuk-table__cell:last-child {
+    text-align: right;
+  }
+}
+
 .govuk-tag--s {
   @include govuk-font(14, $weight: bold, $line-height: 1);
 }

--- a/app/components/admin/currently_featured_tab_component.rb
+++ b/app/components/admin/currently_featured_tab_component.rb
@@ -22,26 +22,27 @@ private
   end
 
   def table(caption, features)
-    render "govuk_publishing_components/components/table", {
-      caption:,
-      caption_classes: "govuk-heading-s",
-      head: [
-        {
-          text: "Title",
-        },
-        {
-          text: "Type",
-        },
-        {
-          text: "Published",
-        },
-        {
-          text: tag.span("Actions", class: "govuk-visually-hidden"),
-          format: "numeric",
-        },
-      ],
-      rows: rows(features),
-    }
+    tag.div(class: "govuk-table--with-actions") do
+      render "govuk_publishing_components/components/table", {
+        caption:,
+        caption_classes: "govuk-heading-s",
+        head: [
+          {
+            text: "Title",
+          },
+          {
+            text: "Type",
+          },
+          {
+            text: "Published",
+          },
+          {
+            text: tag.span("Actions", class: "govuk-visually-hidden"),
+          },
+        ],
+        rows: rows(features),
+      }
+    end
   end
 
   def rows(features)

--- a/app/views/admin/dashboard/_document_table.html.erb
+++ b/app/views/admin/dashboard/_document_table.html.erb
@@ -9,7 +9,7 @@
 <% else %>
   <% action = title == "draft documents" ? "View" : "Review" %>
 
-  <div class="app-view-dashboard-index__table govuk-!-margin-bottom-9">
+  <div class="app-view-dashboard-index__table govuk-!-margin-bottom-9 govuk-table--with-actions">
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {
@@ -23,7 +23,6 @@
         },
         {
           text: tag.span("Actions", class: "govuk-visually-hidden"),
-          format: "numeric"
         }
       ],
       rows: documents.map do |edition|
@@ -40,7 +39,6 @@
           },
           {
             text: link_to(sanitize("#{action} #{tag.span(edition.title, class: 'govuk-visually-hidden')}"), admin_edition_path(edition), class: "govuk-link"),
-            format: "numeric"
           }
         ]
       end

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -9,42 +9,43 @@
 <% if filter.editions.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No documents found</p>
 <% else %>
-  <%= render "govuk_publishing_components/components/table", {
-    head: [
-      {
-        text: "Title"
-      },
-      {
-        text: "Updated by"
-      },
-      {
-        text: "State"
-      },
-      {
-        text: tag.span("View", class: "govuk-visually-hidden")
-      }
-    ],
-    rows:
-      filter.editions.map do |edition|
-        [
-           {
-             text: index_table_title_row(edition)
-           },
-           {
-             text: tag.p("#{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-0") +
-                    "by " +
-                    linked_author(edition.last_author, class: 'govuk-link')
-           },
-           {
-             text: render(Admin::Editions::TagsComponent.new(edition)),
-           },
-           {
-             text: link_to(sanitize("View #{tag.span(edition.title, class: 'govuk-visually-hidden')}"), admin_edition_path(edition), class: "govuk-link"),
-             format: "numeric",
-           },
-        ]
-      end
-  } %>
+  <div class="govuk-table--with-actions">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title"
+        },
+        {
+          text: "Updated by"
+        },
+        {
+          text: "State"
+        },
+        {
+          text: tag.span("View", class: "govuk-visually-hidden")
+        }
+      ],
+      rows:
+        filter.editions.map do |edition|
+          [
+             {
+               text: index_table_title_row(edition)
+             },
+             {
+               text: tag.p("#{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-0") +
+                      "by " +
+                      linked_author(edition.last_author, class: 'govuk-link')
+             },
+             {
+               text: render(Admin::Editions::TagsComponent.new(edition)),
+             },
+             {
+               text: link_to(sanitize("View #{tag.span(edition.title, class: 'govuk-visually-hidden')}"), admin_edition_path(edition), class: "govuk-link"),
+             },
+          ]
+        end
+    } %>
+  </div>
 
   <% if paginate(paginator, theme: "govuk_paginator").present? && show_export && can?(:export, Edition) %>
     <div class="govuk-grid-row">

--- a/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
+++ b/app/views/admin/feature_lists/_featureable_offsite_links.html.erb
@@ -12,7 +12,7 @@
     <%= pluralize(number_with_delimiter(featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list).count), "document") %>
   </p>
 
-  <div class="app-view-features-offsite-links__table">
+  <div class="app-view-features-offsite-links__table govuk-table--with-actions">
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {
@@ -23,7 +23,6 @@
         },
         {
           text: tag.span("Actions", class: "govuk-visually-hidden"),
-          format: "numeric"
         }
       ],
       rows: featurable_offsite_links_for_feature_list(featurable_offsite_links, feature_list).map do |offsite_link|
@@ -38,7 +37,6 @@
             text: link_to(sanitize("Edit #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:edit, :admin, offsite_link.parent, offsite_link]), class: "govuk-link") +
                     link_to(sanitize("Feature #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, feature_list, :feature], offsite_link_id: offsite_link.id), class: 'govuk-link govuk-!-margin-left-2') +
                       link_to(sanitize("Delete #{tag.span(offsite_link.title, class: "govuk-visually-hidden")}"), polymorphic_url([:confirm_destroy, :admin, offsite_link.parent, offsite_link]), class: 'govuk-link govuk-!-margin-left-2 gem-link--destructive'),
-            format: "numeric"
           }
         ]
       end

--- a/app/views/admin/feature_lists/_search_results.html.erb
+++ b/app/views/admin/feature_lists/_search_results.html.erb
@@ -5,44 +5,45 @@
     No documents found
   </div>
 <% else %>
-  <%= render "govuk_publishing_components/components/table", {
-    head: [
-      {
-        text: "Title"
-      },
-      {
-        text: "Type"
-      },
-      {
-        text: "Published"
-      },
-      {
-        text: tag.span("Actions", class: "govuk-visually-hidden")
-      }
-    ],
-    rows:
-      paginator.map do |edition|
-        localised_edition = LocalisedModel.new(edition, feature_list.locale)
-        next if feature_list.features.current.detect { |f| f.document == localised_edition.document }
-        [
-           {
-             text: tag.p(localised_edition.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
-           },
-           {
-             text: localised_edition.type.titleize,
-           },
-           {
-             text: localize(localised_edition.major_change_published_at.to_date),
-           },
-           {
-             text: link_to(sanitize("View #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), admin_edition_path(localised_edition), class: "govuk-link") +
-               link_to(sanitize("Feature #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, @feature_list, :feature], edition_id: localised_edition), class: "govuk-link govuk-!-margin-left-2"),
-             format: "numeric",
-           },
-        ]
-      end
-      .compact
-  } %>
+  <div class="govuk-table--with-actions">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title"
+        },
+        {
+          text: "Type"
+        },
+        {
+          text: "Published"
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden")
+        }
+      ],
+      rows:
+        paginator.map do |edition|
+          localised_edition = LocalisedModel.new(edition, feature_list.locale)
+          next if feature_list.features.current.detect { |f| f.document == localised_edition.document }
+          [
+             {
+               text: tag.p(localised_edition.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
+             },
+             {
+               text: localised_edition.type.titleize,
+             },
+             {
+               text: localize(localised_edition.major_change_published_at.to_date),
+             },
+             {
+               text: link_to(sanitize("View #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), admin_edition_path(localised_edition), class: "govuk-link") +
+                 link_to(sanitize("Feature #{tag.span(localised_edition.title, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, @feature_list, :feature], edition_id: localised_edition), class: "govuk-link govuk-!-margin-left-2"),
+             },
+          ]
+        end
+        .compact
+    } %>
+  </div>
 
   <%= paginate(paginator, anchor: anchor, theme: "govuk_paginator") %>
 <% end %>

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -12,43 +12,43 @@
 <% if @governments.blank? %>
   <p class="govuk-body">No governments have been created.</p>
 <% else %>
-  <%= render "govuk_publishing_components/components/table", {
-    head: [
-      {
-        text: "Name"
-      },
-      {
-        text: "Start date"
-      },
-      {
-        text: "End date"
-      },
-      *([
+  <div class="<%='govuk-table--with-actions' if can?(:manage, Government) %>">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
         {
-          text: tag.span("Edit", class: "govuk-visually-hidden"),
-          format: "numeric"
-        }
-      ] if can?(:manage, Government))
-    ],
-    rows:
-      @governments.map do |government|
-      [
-        {
-          text: tag.p(government.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+          text: "Name"
         },
         {
-          text: government.start_date.to_fs(:govuk_date)
+          text: "Start date"
         },
         {
-          text: (government.end_date.to_fs(:govuk_date) if government.end_date)
+          text: "End date"
         },
         *([
           {
-            text: link_to(sanitize("Edit #{tag.span(government.name, class: "govuk-visually-hidden")}"), edit_admin_government_path(government), class: "govuk-link"),
-            format: "numeric"
+            text: tag.span("Edit", class: "govuk-visually-hidden"),
           }
         ] if can?(:manage, Government))
-      ]
-    end
-  } %>
+      ],
+      rows:
+        @governments.map do |government|
+        [
+          {
+            text: tag.p(government.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+          },
+          {
+            text: government.start_date.to_fs(:govuk_date)
+          },
+          {
+            text: (government.end_date.to_fs(:govuk_date) if government.end_date)
+          },
+          *([
+            {
+              text: link_to(sanitize("Edit #{tag.span(government.name, class: "govuk-visually-hidden")}"), edit_admin_government_path(government), class: "govuk-link"),
+            }
+          ] if can?(:manage, Government))
+        ]
+      end
+    } %>
+  </div>
 <% end %>

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -27,7 +27,7 @@
         margin_bottom: 4,
       } %>
 
-      <div class="app-view-historical-accounts-index__table">
+      <div class="app-view-historical-accounts-index__table govuk-table--with-actions">
         <%= render "govuk_publishing_components/components/table", {
           head: [
             {
@@ -38,7 +38,6 @@
             },
             {
               text: tag.span("Actions", class: "govuk-visually-hidden"),
-              format: "numeric",
             }
           ],
           rows: @historical_accounts.map do |historical_account|
@@ -55,7 +54,6 @@
                 text: link_to(sanitize("View #{tag.span(roles, class: 'govuk-visually-hidden')}"), Whitehall.public_host + historical_account.public_path, class: "govuk-link") +
                   link_to(sanitize("Edit #{tag.span(roles, class: 'govuk-visually-hidden')}"), edit_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2") +
                   link_to(sanitize("Delete #{tag.span(roles, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive"),
-                format: "numeric"
               }
             ]
           end

--- a/app/views/admin/operational_fields/index.html.erb
+++ b/app/views/admin/operational_fields/index.html.erb
@@ -9,27 +9,28 @@
       margin_bottom: 6,
     } %>
 
-    <%= render "govuk_publishing_components/components/table", {
-      head: [
-        {
-          text: "Name"
-        },
-        {
-          text: tag.span("Actions", class: "govuk-visually-hidden"),
-        }
-      ],
-      rows:
-        @operational_fields.map do |operational_field|
-          [
-            {
-              text: operational_field.name,
-            },
-            {
-              text: sanitize("<a href='#{edit_admin_operational_field_path(operational_field)}' class='govuk-link'>Edit<span class='govuk-visually-hidden'> #{operational_field.name}</span></a>"),
-              format: "numeric",
-            },
-          ]
-        end
-    } %>
+    <div class="govuk-table--with-actions">
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: tag.span("Actions", class: "govuk-visually-hidden"),
+          }
+        ],
+        rows:
+          @operational_fields.map do |operational_field|
+            [
+              {
+                text: operational_field.name,
+              },
+              {
+                text: sanitize("<a href='#{edit_admin_operational_field_path(operational_field)}' class='govuk-link'>Edit<span class='govuk-visually-hidden'> #{operational_field.name}</span></a>"),
+              },
+            ]
+          end
+      } %>
+    </div>
   </div>
 </div>

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -12,34 +12,33 @@
   margin_bottom: 8
 } %>
 
-<div class="app-c-govuk-table--filterable app-view-people-index__table">
-<%= render "govuk_publishing_components/components/table", {
-  filterable: true,
-  label: "Filter people",
-  head: [
-    {
-      text: "Name"
-    },
-    {
-      text: "Biography",
-    },
-    {
-      text: tag.span("View", class: "govuk-visually-hidden"),
-      format: "numeric"
-    },
-  ],
-  rows: @people.map do |person|
-    [
+<div class="app-c-govuk-table--filterable app-view-people-index__table govuk-table--with-actions">
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: "Filter people",
+    head: [
       {
-        text: tag.p(person.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+        text: "Name"
       },
       {
-        text: truncate(person.biography, length: 60),
+        text: "Biography",
       },
       {
-        text: link_to(sanitize("View #{tag.span(person.name, class: "govuk-visually-hidden")}"), [:admin, person], class: "govuk-link"),
-        format: "numeric"
-      }
-    ]
-  end
-} %>
+        text: tag.span("View", class: "govuk-visually-hidden"),
+      },
+    ],
+    rows: @people.map do |person|
+      [
+        {
+          text: tag.p(person.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+        },
+        {
+          text: truncate(person.biography, length: 60),
+        },
+        {
+          text: link_to(sanitize("View #{tag.span(person.name, class: "govuk-visually-hidden")}"), [:admin, person], class: "govuk-link"),
+        }
+      ]
+    end
+  } %>
+</div>

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -21,30 +21,30 @@
     } %>
 
     <% if @person.non_english_translated_locales.present? %>
-      <%= render "govuk_publishing_components/components/table", {
-        head: [
-          {
-            text: "Locale"
-          },
-          {
-            text: tag.span("Actions", class: "govuk-visually-hidden"),
-            format: "numeric",
-          }
-        ],
-        rows: @person.non_english_translated_locales.map do |locale|
-          native_language_name = Locale.coerce(locale).native_language_name
-          [
+      <div class="govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
             {
-              text: sanitize("#{locale.native_language_name} " + link_to("(view)", @person.public_url(locale: locale.code), class: "govuk-link"))
+              text: "Locale"
             },
             {
-              text: sanitize("<a class='govuk-link' href='#{edit_admin_person_translation_path(@person, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{native_language_name}</span></a>" +
-                "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_translation_path(@person, locale.code)}'>Delete <span class='govuk-visually-hidden'>#{native_language_name}</span></a>"),
-              format: "numeric"
+              text: tag.span("Actions", class: "govuk-visually-hidden"),
             }
-          ]
-        end
-      } %>
+          ],
+          rows: @person.non_english_translated_locales.map do |locale|
+            native_language_name = Locale.coerce(locale).native_language_name
+            [
+              {
+                text: sanitize("#{locale.native_language_name} " + link_to("(view)", @person.public_url(locale: locale.code), class: "govuk-link"))
+              },
+              {
+                text: sanitize("<a class='govuk-link' href='#{edit_admin_person_translation_path(@person, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{native_language_name}</span></a>" +
+                  "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_translation_path(@person, locale.code)}'>Delete <span class='govuk-visually-hidden'>#{native_language_name}</span></a>"),
+              }
+            ]
+          end
+        } %>
+      </div>
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "No translations."

--- a/app/views/admin/policy_groups/index.html.erb
+++ b/app/views/admin/policy_groups/index.html.erb
@@ -14,7 +14,7 @@
   } %>
 </div>
 
-<div class="app-c-govuk-table--filterable">
+<div class="app-c-govuk-table--filterable govuk-table--with-actions">
   <%= render "govuk_publishing_components/components/table", {
     filterable: true,
     head: [
@@ -26,7 +26,6 @@
       },
       {
         text: tag.span("Actions", class: "govuk-visually-hidden"),
-        format: "numeric"
       }
     ],
     rows: @policy_groups.map do |policy_group|
@@ -40,7 +39,6 @@
         {
           text: link_to(sanitize("Edit #{tag.span(policy_group.name, class: 'govuk-visually-hidden')}"), edit_admin_policy_group_path(policy_group), class: "govuk-link") +
            (link_to(sanitize("Delete #{tag.span(policy_group.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_policy_group_path(policy_group), class: "govuk-link gem-link--destructive govuk-!-margin-left-2") if can?(:delete, PolicyGroup)),
-          format: "numeric",
         }
       ]
     end

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -31,21 +31,22 @@
     <% end %>
 
     <% if @promotional_features.present? %>
-      <%= render "govuk_publishing_components/components/table", {
-        rows: @promotional_features.map do |promotional_feature|
-          [
-            {
-              text: promotional_feature.title
-            },
-            {
-              text: link_to(sanitize("View #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link govuk-!-margin-right-2") +
-                (link_to(sanitize("Rename #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link")) +
-                (link_to(sanitize("Delete #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
-              format: "numeric",
-            }
-          ]
-        end
-      } %>
+      <div class="govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          rows: @promotional_features.map do |promotional_feature|
+            [
+              {
+                text: promotional_feature.title
+              },
+              {
+                text: link_to(sanitize("View #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link govuk-!-margin-right-2") +
+                  (link_to(sanitize("Rename #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), edit_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link")) +
+                  (link_to(sanitize("Delete #{tag.span(promotional_feature.title, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_organisation_promotional_feature_path(@organisation, promotional_feature), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+              }
+            ]
+          end
+        } %>
+      </div>
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "No promotional features."

--- a/app/views/admin/sitewide_settings/index.html.erb
+++ b/app/views/admin/sitewide_settings/index.html.erb
@@ -5,33 +5,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @sitewide_settings.present? %>
-      <%= render "govuk_publishing_components/components/table", {
-        head: [
-          {
-            text: "Name"
-          },
-          {
-            text: "On/Off"
-          },
-          {
-            text: tag.span("Edit", class: "govuk-visually-hidden"),
-            format: "numeric"
-          }
-        ],
-        rows: @sitewide_settings.map do |sitewide_setting|
-          [
+      <div class="govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
             {
-              text: tag.p(sitewide_setting.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+              text: "Name"
             },
             {
-              text: sitewide_setting.human_status
+              text: "On/Off"
             },
             {
-              text: link_to(sanitize("Edit #{tag.span(sitewide_setting.name, class: "govuk-visually-hidden")}"), edit_admin_sitewide_setting_path(sitewide_setting), class: "govuk-link")
-            },
-          ]
-        end
-      } %>
+              text: tag.span("Edit", class: "govuk-visually-hidden"),
+            }
+          ],
+          rows: @sitewide_settings.map do |sitewide_setting|
+            [
+              {
+                text: tag.p(sitewide_setting.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+              },
+              {
+                text: sitewide_setting.human_status
+              },
+              {
+                text: link_to(sanitize("Edit #{tag.span(sitewide_setting.name, class: "govuk-visually-hidden")}"), edit_admin_sitewide_setting_path(sitewide_setting), class: "govuk-link")
+              },
+            ]
+          end
+        } %>
+      </div>
     <% else %>
       <%= render "components/inset_prompt",{
         description: "No sitewide settings available to configure."

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -16,36 +16,36 @@
       } %>
 
       <% if @world_location_news.non_english_translated_locales.present? %>
-        <%= render "govuk_publishing_components/components/table", {
-        first_cell_is_header: true,
-        head: [
-          {
-            text: "Locale"
-          },
-          {
-            text: sanitize("<a class='govuk-visually-hidden'>Actions</a>"),
-            format: "numeric"
-          }
-        ],
-        rows:
-          @world_location_news.non_english_translated_locales.map do |locale|
-            [
-              {
-                text: locale.native_language_name
-              },
-              {
-                text: sanitize(
-                  "<a class='govuk-link' href='#{@world_location_news.public_url(locale: locale.code)}'>View <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
+        <div class="govuk-table--with-actions">
+          <%= render "govuk_publishing_components/components/table", {
+          first_cell_is_header: true,
+          head: [
+            {
+              text: "Locale"
+            },
+            {
+              text: sanitize("<a class='govuk-visually-hidden'>Actions</a>"),
+            }
+          ],
+          rows:
+            @world_location_news.non_english_translated_locales.map do |locale|
+              [
+                {
+                  text: locale.native_language_name
+                },
+                {
+                  text: sanitize(
+                    "<a class='govuk-link' href='#{@world_location_news.public_url(locale: locale.code)}'>View <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
 
-                  "<a class='govuk-link govuk-!-margin-left-2' href='#{edit_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
+                    "<a class='govuk-link govuk-!-margin-left-2' href='#{edit_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
 
-                  "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Delete<span class='govuk-visually-hidden'>#{locale.code}</span></a>"),
+                    "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Delete<span class='govuk-visually-hidden'>#{locale.code}</span></a>"),
 
-                format: "numeric"
-              }
-            ]
-          end
-      } %>
+                }
+              ]
+            end
+          } %>
+        </div>
       <% else %>
         <p class="govuk-body">No translations</p>
       <% end %>

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -18,7 +18,6 @@
       <% if @world_location_news.non_english_translated_locales.present? %>
         <div class="govuk-table--with-actions">
           <%= render "govuk_publishing_components/components/table", {
-          first_cell_is_header: true,
           head: [
             {
               text: "Locale"
@@ -31,15 +30,12 @@
             @world_location_news.non_english_translated_locales.map do |locale|
               [
                 {
-                  text: locale.native_language_name
+                  text: tag.p(locale.native_language_name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
                 },
                 {
-                  text: sanitize(
-                    "<a class='govuk-link' href='#{@world_location_news.public_url(locale: locale.code)}'>View <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
-
-                    "<a class='govuk-link govuk-!-margin-left-2' href='#{edit_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{locale.code}</span></a>" +
-
-                    "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_world_location_news_translation_path(@world_location_news, locale.code)}'>Delete<span class='govuk-visually-hidden'>#{locale.code}</span></a>"),
+                  text: link_to(sanitize("View #{tag.span(locale.code, class: 'govuk-visually-hidden')}"), @world_location_news.public_url(locale: locale.code), class: "govuk-link") +
+                         link_to(sanitize("Edit #{tag.span(locale.code, class: 'govuk-visually-hidden')}"), edit_admin_world_location_news_translation_path(@world_location_news, locale.code), class: "govuk-link govuk-!-margin-left-2") +
+                           link_to(sanitize("Delete #{tag.span(locale.code, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_world_location_news_translation_path(@world_location_news, locale.code), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive")
 
                 }
               ]
@@ -47,24 +43,26 @@
           } %>
         </div>
       <% else %>
-        <p class="govuk-body">No translations</p>
+        <%= render "components/inset_prompt",{
+          description: "No translations."
+        } %>
       <% end %>
 
       <% if @world_location_news.missing_translations.any? %>
         <%= form_tag admin_world_location_news_translations_path(@world_location_news) do %>
           <%= render "govuk_publishing_components/components/select", {
-          id: "translation_locale",
-          name: "translation_locale",
-          label: 'Locale',
-          heading_size: 'm',
-          options: @world_location_news.missing_translations.map { |missing_trans| { text: missing_trans
-            .native_and_english_language_name, value: missing_trans.code.to_s } }
-        } %>
+            id: "translation_locale",
+            name: "translation_locale",
+            label: 'Locale',
+            heading_size: 'm',
+            options: @world_location_news.missing_translations.map { |missing_trans| { text: missing_trans
+              .native_and_english_language_name, value: missing_trans.code.to_s } }
+          } %>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Create new translation",
-          margin_bottom: 6,
-        } %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Create new translation",
+            margin_bottom: 6,
+          } %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## Description 

At the moment, we're using the 'format: "numeric"' option on the Table
Publishing Component to float actions to the right. We shouldn't really
be using an unrelated class for styling.

This commit adds styling for '.govuk-table--with-actions' and applies
it to tables with actions in place of using format numeric.

## Trello card

https://trello.com/c/K7PsPxlV/221-add-a-new-class-to-stylesheets-for-tables-with-actions-being-floated-right-and-apply-instead-of-using-numeric-formatting

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
