### PR TITLE
Limit the files that can be selected for image upload

### DIFF
--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -12,6 +12,7 @@
     id: "edition_images_image_data_file",
     hint: raw('Images can be JPEG, PNG, SVG or GIF files. If you are uploading more than one image, <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos">read the image guidance</a> on using unique file names.'),
     error_items: @new_image.present? ? errors_for(@new_image.errors, :"image_data.file") : nil,
+    accept: "image/png, image/jpeg, image/gif, image/svg+xml"
   } %>
 
    <%= render "govuk_publishing_components/components/details", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Limit image the file picker to only display supported file types.

# Why
Make it easier for users to choose an image of appropriate type.
