### PR TITLE
Add data attributes to track image cropping

### DIFF
--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -26,6 +26,12 @@
 
   <%= render "govuk_publishing_components/components/button", {
     text: "Upload",
-    margin_bottom: 10
+    margin_bottom: 10,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "form-button",
+      "track-action": "#{@edition.class.name.demodulize.underscore.dasherize}-button",
+      "track-label": "Upload"
+    }
   } %>
 <% end %>

--- a/app/views/admin/edition_images/crop.html.erb
+++ b/app/views/admin/edition_images/crop.html.erb
@@ -21,6 +21,12 @@
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save and continue",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "#{@edition.class.name.demodulize.underscore.dasherize}-button",
+            "track-label": "Save and continue"
+          }
         } %>
 
         <%= link_to("Cancel", admin_edition_images_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Add tracking for image upload and image crop

# Why
So that we can see how many users are uploading oversized images
