### PR TITLE
Add keyboard controls for image cropper

### DIFF
--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -21,7 +21,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.initCropper()
     }
 
-    this.setupFormListener()
+    this.$image.addEventListener('ready', function () {
+      this.initKeyboardControls()
+      this.updateAriaLabel()
+    }.bind(this))
+
+    this.$image.addEventListener('crop', function () {
+      this.updateAriaLabel()
+    }.bind(this))
+
+    this.$imageCropper.addEventListener('click', function () {
+      this.$imageCropper.focus()
+    }.bind(this))
   }
 
   ImageCropper.prototype.initCropper = function () {
@@ -51,7 +62,81 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         rotatable: false,
         scalable: false
       })
+      this.setupFormListener()
     }
+  }
+
+  ImageCropper.prototype.initKeyboardControls = function () {
+    this.$imageCropper.addEventListener('keydown', function (e) {
+      var cropBoxData = this.cropper.getCropBoxData()
+
+      switch (e.keyCode) {
+        case 37:
+          e.preventDefault()
+          cropBoxData.left -= 10
+          break
+
+        case 38:
+          e.preventDefault()
+          cropBoxData.top -= 10
+          break
+
+        case 39:
+          e.preventDefault()
+          cropBoxData.left += 10
+          break
+
+        case 40:
+          e.preventDefault()
+          cropBoxData.top += 10
+          break
+
+        case 187:
+          e.preventDefault()
+          cropBoxData.height *= 1.05
+          cropBoxData.width *= 1.05
+          break
+
+        case 189:
+          e.preventDefault()
+          cropBoxData.height /= 1.05
+          cropBoxData.width /= 1.05
+          break
+      }
+      this.cropper.setCropBoxData(cropBoxData)
+    }.bind(this))
+  }
+
+  ImageCropper.prototype.updateAriaLabel = function () {
+    var cropBoxData = this.cropper.getCropBoxData()
+    var imageData = this.cropper.getImageData()
+    var portionSelected = (cropBoxData.height * cropBoxData.width) /
+            (imageData.height * imageData.width)
+    var percentage = Math.round(portionSelected * 10) * 10
+    if (percentage === 100) {
+      this.$imageCropper.ariaLabel = 'Image to be cropped. All of the image is selected.'
+      return
+    }
+
+    var horizontalPosition = cropBoxData.left / (imageData.width - cropBoxData.width)
+    var verticalPosition = cropBoxData.top / (imageData.height - cropBoxData.height)
+
+    var positionText = ''
+    if (verticalPosition < 0.33) {
+      positionText += 'top '
+    } else if (verticalPosition > 0.67) {
+      positionText += 'bottom '
+    }
+    if (horizontalPosition < 0.33) {
+      positionText += 'left '
+    } else if (horizontalPosition > 0.67) {
+      positionText += 'right '
+    }
+
+    if (positionText === '') positionText = 'middle '
+    this.$imageCropper.ariaLabel = 'Image to be cropped. ' +
+        percentage + '% of the image, centered on the ' +
+        positionText + 'is selected.'
   }
 
   ImageCropper.prototype.setupFormListener = function () {

--- a/app/assets/stylesheets/components/_image-cropper.scss
+++ b/app/assets/stylesheets/components/_image-cropper.scss
@@ -63,6 +63,18 @@ $app-cropper-point-size: 20px;
     top: -$app-cropper-point-size / 2;
     left: -$app-cropper-point-size / 2;
   }
+
+  &:focus {
+    outline: none;
+
+    .cropper-view-box {
+      outline-width: 4px;
+    }
+
+    .cropper-point {
+      transform: scale(1.1);
+    }
+  }
 }
 
 .app-c-image-cropper__image {

--- a/app/views/admin/edition_images/crop.html.erb
+++ b/app/views/admin/edition_images/crop.html.erb
@@ -9,7 +9,7 @@
     <%= form_tag admin_edition_images_path(@edition), multipart: true do %>
       <p class="govuk-body govuk-!-margin-bottom-7 app-no-js">The image you selected needs to be cropped to fit on GOV.UK. Enable JavaScript in your browser or use an alternative browser to crop and resize the image.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-7 app-js-only">Select part of the image to use. The part you select will be resized for GOV.UK. The shape is fixed.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7 app-js-only">Use your cursor or the arrow keys and “<kbd>+</kbd>” and “<kbd>-</kbd>” to select a part of the image. The part you select will be resized for GOV.UK. The shape is fixed.</p>
 
       <%= render "components/image-cropper", {
         name: "image[image_data][file]",

--- a/app/views/components/_image-cropper.html.erb
+++ b/app/views/components/_image-cropper.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: "app-c-image-cropper", data: {module: "image-cropper", filename:, type:} do %>
+<%= tag.div class: "app-c-image-cropper", tabindex: "0", data: {module: "image-cropper", filename:, type:}, "aria-live" => "polite" do %>
   <input type="file" class="js-cropped-image-input" name="<%= name %>" hidden>
   <%= tag.div class: "app-c-image-cropper__container" do %>
     <%= tag.img class: "app-c-image-cropper__image",

--- a/spec/javascripts/components/image-cropper.spec.js
+++ b/spec/javascripts/components/image-cropper.spec.js
@@ -1,0 +1,57 @@
+describe('GOVUK.Modules.ImageCropper', () => {
+  let form, component, module
+
+  beforeEach((done) => {
+    const canvas = document.createElement('canvas')
+    canvas.setAttribute('width', 1920)
+    canvas.setAttribute('height', 1280)
+    const dataURL = canvas.toDataURL('image/png')
+
+    component = document.createElement('div')
+    component.setAttribute('data-filename', 'test.png')
+    component.setAttribute('data-type', 'image/png')
+    component.setAttribute('class', 'app-c-image-cropper')
+    component.innerHTML = `
+      <input type="file" class="js-cropped-image-input" name="image" hidden>
+      <div style="position: relative; width: 1920px; height: 1280px;">
+        <img class="app-c-image-cropper__image" src="${dataURL}"/>
+      </div>
+    `
+
+    form = document.createElement('form')
+    form.appendChild(component)
+    document.body.append(form)
+
+    // Initializing the module immediately after appending the form results in
+    // the cropper not properly reading the DOM, the following timeout prevents
+    // that from occuring.
+    window.setTimeout(() => {
+      module = new GOVUK.Modules.ImageCropper(component)
+      module.init()
+
+      const image = document.querySelector('.app-c-image-cropper__image')
+      image.addEventListener('ready', () => done())
+    }, 1)
+  })
+
+  afterEach(() => form.remove())
+
+  it('should attach an image to the input when the form is submitted', (done) => {
+    form.submit = () => {
+      const input = document.querySelector('.js-cropped-image-input')
+      expect(input.files.length).toBe(1)
+      done()
+    }
+    form.dispatchEvent(new Event('submit'))
+  })
+
+  it('should update the aria label as the selection is controlled using the keyboard', (done) => {
+    expect(document.querySelector('.app-c-image-cropper').ariaLabel).toBe('Image to be cropped. All of the image is selected.')
+    const image = document.querySelector('.app-c-image-cropper__image')
+    image.addEventListener('crop', () => {
+      expect(document.querySelector('.app-c-image-cropper').ariaLabel).toBe('Image to be cropped. 90% of the image, centered on the top left is selected.')
+      done()
+    })
+    component.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 189 }))
+  })
+})


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Add event listeners such that the image cropper can be controlled using a keyboard.
- Update the guidance to explain the controls.
- Add styles to illustrate when the cropper is focused .
- Add a live updating aria label for screenreader users.

https://github.com/alphagov/whitehall/assets/9594455/b8fbe9eb-265b-4af6-82a0-8a4d1a842503

https://trello.com/c/JDabNxHs/1255-add-keyboard-controls-for-image-cropping