### PR TITLE
Adds attributes for accessibility

### DIFF
--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -23,6 +23,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       shouldSort: false, // show options and groups in the order they were given
       itemSelectText: '',
       searchResultLimit: 100,
+      labelId: this.select.id + '_label',
       // https://fusejs.io/api/options.html
       fuseOptions: {
         ignoreLocation: true, // matches any part of the string

--- a/app/views/components/_select-with-search.html.erb
+++ b/app/views/components/_select-with-search.html.erb
@@ -13,9 +13,9 @@
 
 <%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
   <% if is_page_heading %>
-    <%= tag.h1 label_tag(id, label, class: select_helper.label_classes), class: "gem-c-title__text" %>
+    <%= tag.h1 label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label"), class: "gem-c-title__text" %>
   <% else %>
-    <%= label_tag(id, label, class: select_helper.label_classes) %>
+    <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
   <% end %>
 
   <% if select_helper.hint %>


### PR DESCRIPTION
This PR updates the aria attributes on the select-with-search component to restore some screen reader capability that was lost when this component was added (example on Consultation page shown below). The problem is that there are no linked native form elements when this component is used as the native `select`/`label` pairing is overwritten by the component which uses custom elements instead. 

In these changes a unique id value is added to the label and this is linked to the combo-box component via the `aria-labelledby` attribute. This ensures that screen-readers are able to use the label element when the combobox is in focus. 

<img width="758" alt="Screenshot 2023-06-05 at 17 23 27" src="https://github.com/alphagov/whitehall/assets/6080548/94184a2f-82b3-427a-8db9-cd65991dd81b">
