### PR TITLE
Topical events page to GDS

### DIFF
--- a/app/assets/stylesheets/admin/views/_topical-events-index.scss
+++ b/app/assets/stylesheets/admin/views/_topical-events-index.scss
@@ -1,0 +1,15 @@
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
+  width: 21%;
+}
+
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(4) {
+  width: 15%;
+}
+
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__cell:nth-child(4) {
+  text-align: center;
+}
+
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__cell:nth-child(5) {
+  text-align: right;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/roles";
 @import "./admin/views/summary";
 @import "./admin/views/take-part";
+@import "./admin/views/topical-events-index";
 @import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";
 @import "./admin/views/whats-new";

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -14,6 +14,7 @@ class Admin::TopicalEventsController < Admin::BaseController
 
   def index
     @topical_events = model_class.order(:name)
+    render_design_system(:index, :legacy_index)
   end
 
   def new; end
@@ -72,7 +73,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[show] if preview_design_system?(next_release: false)
+    design_system_actions += %w[show index] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/helpers/admin/topical_event_helper.rb
+++ b/app/helpers/admin/topical_event_helper.rb
@@ -26,4 +26,12 @@ module Admin::TopicalEventHelper
       },
     ]
   end
+
+  def duration_row_value(topical_event)
+    if topical_event.start_date.present? && topical_event.end_date.present?
+      "#{topical_event.start_date} to #{topical_event.end_date}"
+    else
+      ""
+    end
+  end
 end

--- a/app/views/admin/historical_accounts/legacy_index.html.erb
+++ b/app/views/admin/historical_accounts/legacy_index.html.erb
@@ -1,0 +1,37 @@
+<% page_title @person.name + " historical accounts" %>
+
+<%= content_tag_for(:div, @person) do %>
+  <div class="organisation-header">
+    <h1><%= @person.name %></h1>
+    <%= view_on_website_link_for @person %>
+  </div>
+
+  <section class="organisation-details">
+    <%= tab_navigation_for(@person) %>
+
+    <% if @historical_accounts.present? %>
+    <table id="person-historical-accounts" class="table table-bordered table-striped">
+      <thead>
+        <tr class="table-header">
+          <th>Role</th>
+          <th>Summary</th>
+          <th width="20%">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render @historical_accounts, { person: @person } %>
+      </tbody>
+    </table>
+    <% else %>
+      <p class="no-content no-content-bordered">No historical accounts</p>
+    <% end %>
+
+    <nav class="form-actions">
+      <% if @person.can_have_historical_accounts? %>
+        <%= link_to 'Add an historical account', new_admin_person_historical_account_path, class: "btn btn-primary"  %>
+      <% else %>
+        <em>Note: (This person does not have any role appointments in roles that support historical accounts)</em>
+      <% end %>
+    </nav>
+  </section>
+<% end %>

--- a/app/views/admin/topical_events/index.html.erb
+++ b/app/views/admin/topical_events/index.html.erb
@@ -1,21 +1,59 @@
-<% page_title human_friendly_model_name.pluralize %>
+<% content_for :page_title, "Topical events" %>
+<% content_for :title, "Topical events" %>
+<% content_for :title_margin_bottom, 4 %>
 
-<h1><%= human_friendly_model_name.pluralize %></h1>
-<p class="warning remove-top-margin">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
-<%= link_to "Create #{human_friendly_model_name.downcase}", [:new, :admin, model_name.to_sym], class: "btn btn-default new_resource", title: "Create a #{human_friendly_model_name.downcase}" %>
+<%= render "govuk_publishing_components/components/warning_text", {
+  text: "Do not create topical events without consulting GDS. New documents will be live immediately on selecting save.",
+} %>
 
-<table class="<%= model_name %> table table-striped table-bordered add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th width="15%">Name</th>
-      <th>Summary</th>
-      <th>Description</th>
-      <th width="20%">Details</th>
-      <th width="10%">Duration</th>
-    </tr>
-  </thead>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Create topical event",
+  href: [:new, :admin, model_name.to_sym],
+  margin_bottom: 8
+} %>
+<div class="app-view-topical-events-index__table">
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "Summary",
+      },
 
-  <tbody>
-    <%= render @topical_events %>
-  </tbody>
-</table>
+      {
+        text: "Duration",
+      },
+      {
+        text: "Published guides",
+      },
+      {
+        text: tag.span("View", class: "govuk-visually-hidden")
+      },
+    ],
+
+    rows: @topical_events.map do |event|
+      [
+        {
+          text: tag.p(event.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
+        },
+        {
+          text: truncate(event.summary, length: 130, separator: ' '),
+        },
+
+        {
+          text: duration_row_value(event)
+        },
+
+        {
+          text: event.published_detailed_guides.count
+        },
+
+        {
+          text: link_to(sanitize("View #{tag.span(event.name, class: 'govuk-visually-hidden')}"), [:admin, event], class: "govuk-link govuk-!-margin-right-4"),
+          format: "numeric"
+        }
+      ]
+    end
+  } %>
+</div>

--- a/app/views/admin/topical_events/legacy_index.html.erb
+++ b/app/views/admin/topical_events/legacy_index.html.erb
@@ -1,0 +1,21 @@
+<% page_title human_friendly_model_name.pluralize %>
+
+<h1><%= human_friendly_model_name.pluralize %></h1>
+<p class="warning remove-top-margin">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
+<%= link_to "Create #{human_friendly_model_name.downcase}", [:new, :admin, model_name.to_sym], class: "btn btn-default new_resource", title: "Create a #{human_friendly_model_name.downcase}" %>
+
+<table class="<%= model_name %> table table-striped table-bordered add-top-margin">
+  <thead>
+    <tr class="table-header">
+      <th width="15%">Name</th>
+      <th>Summary</th>
+      <th>Description</th>
+      <th width="20%">Details</th>
+      <th width="10%">Duration</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <%= render @topical_events %>
+  </tbody>
+</table>

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -14,7 +14,11 @@ end
 Then(/^I should see the topical event "([^"]*)" in the admin interface$/) do |topical_event_name|
   topical_event = TopicalEvent.find_by!(name: topical_event_name)
   visit admin_topical_events_path(topical_event)
-  expect(page).to have_selector(record_css_selector(topical_event))
+  if using_design_system?
+    expect(page).to have_selector(".govuk-table__cell", text: topical_event)
+  else
+    expect(page).to have_selector(record_css_selector(topical_event))
+  end
 end
 
 Given(/^I'm administering a topical event$/) do

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -35,7 +35,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     assert_equal "Event description", topical_event.description
   end
 
-  view_test "GET :index lists the topical events" do
+  test "GET :index lists the topical events" do
     topical_event_c = create(:topical_event, name: "Topic C")
     topical_event_a = create(:topical_event, name: "Topic A")
     topical_event_b = create(:topical_event, name: "Topic B")
@@ -43,7 +43,13 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     get :index
 
     assert_response :success
-    assert_select "#{record_css_selector(topical_event_a)} + #{record_css_selector(topical_event_b)} + #{record_css_selector(topical_event_c)}"
+    assert_equal(assigns(:topical_events), [topical_event_a, topical_event_b, topical_event_c])
+  end
+
+  view_test "GET :index page has the View link to show page" do
+    topical_event = create(:topical_event)
+    get :index
+    assert_select "a[href=?]", admin_topical_event_path(topical_event), text: /View/
   end
 
   view_test "GET :edit renders the topical event form" do


### PR DESCRIPTION
This PR transits Topical events page to GDS.
It does the following:

- Duplicates existing index page to legacy and created new index page with GDS.
- Added design system to new index page in the controller.
- Fixed  existing feature tests and added new view test to controller.

**Screen shots:**
**Before:**
![image](https://github.com/alphagov/whitehall/assets/131259138/87f47357-23b3-4156-b40b-f982edec1e6d)

**After:**
![image](https://github.com/alphagov/whitehall/assets/131259138/9c5419a3-3cc5-48b7-a9b8-b8b30687743b)

**Trello:**

https://trello.com/c/YJb7eK7q/149-listing-page