### PR TITLE
Fix ability to edit translation documents

### DIFF
--- a/lib/present_page_to_publishing_api.rb
+++ b/lib/present_page_to_publishing_api.rb
@@ -1,9 +1,8 @@
 class PresentPageToPublishingApi
   def publish(presenter_class)
     payload = presenter_class.new
-
     Services.publishing_api.put_content(payload.content_id, payload.content)
     Services.publishing_api.patch_links(payload.content_id, links: payload.links)
-    Services.publishing_api.publish(payload.content_id, nil)
+    Services.publishing_api.publish(payload.content_id, nil, locale: payload.content[:locale])
   end
 end

--- a/test/integration/world_location_integration_test.rb
+++ b/test/integration/world_location_integration_test.rb
@@ -53,7 +53,7 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
     presenter = PublishingApi::EmbassiesIndexPresenter.new
     Services.publishing_api.expects(:put_content).with(presenter.content_id, presenter.content)
     Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
-    Services.publishing_api.expects(:publish).with(presenter.content_id, anything)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, anything, anything)
   end
 
   test "when updating, makes the correct calls to publishing api" do

--- a/test/unit/lib/present_page_to_publishing_api_test.rb
+++ b/test/unit/lib/present_page_to_publishing_api_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class PresentPageToPublishingApiTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "#publish" do
+    it "should update content, patch links and publish new document" do
+      I18n.with_locale(:cy) do
+        presenter = PublishingApi::HowGovernmentWorksPresenter.new
+        Services.publishing_api.expects(:put_content).with(presenter.content_id, presenter.content)
+        Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
+        Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale: "cy")
+        PresentPageToPublishingApi.new.publish(presenter.class)
+      end
+    end
+  end
+end

--- a/test/unit/present_page_to_publishing_api_test.rb
+++ b/test/unit/present_page_to_publishing_api_test.rb
@@ -23,7 +23,7 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
 
     Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content)
     Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
-    Services.publishing_api.expects(:publish).with(presenter.content_id, nil)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale: "en")
 
     PresentPageToPublishingApi.new.publish(presenter_class)
   end


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/EfvXj4b5/1378-bug-fix-editing-featured-links-for-translations)

Previously, locale was not added to the publishing API publish command, meaning the default english document is loaded, and attempting to publish an already published document returns an error 409 unable to publish already published document. With the fix, publish command should be able to load the correct document with the previous draft created in the PUT command.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
