### PR TITLE
Revert "Remove rendering code for worldwide offices"

### DIFF
--- a/app/controllers/worldwide_offices_controller.rb
+++ b/app/controllers/worldwide_offices_controller.rb
@@ -1,0 +1,13 @@
+class WorldwideOfficesController < PublicFacingController
+  before_action :load_worldwide_organisation
+
+  def show
+    @worldwide_office = @worldwide_organisation.offices.find(params[:id])
+  end
+
+private
+
+  def load_worldwide_organisation
+    @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])
+  end
+end

--- a/app/views/worldwide_offices/show.html.erb
+++ b/app/views/worldwide_offices/show.html.erb
@@ -1,0 +1,47 @@
+<% page_title @worldwide_organisation.name %>
+<% page_class "govuk-width-container corporate-information-pages-show-worldwide-organisation" %>
+
+<%= render partial: 'worldwide_organisations/header', locals: {
+  organisation: @worldwide_organisation,
+  link_to_organisation: true,
+  object_for_translation: @worldwide_office,
+} %>
+
+<article class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <% headers = govspeak_headers(@worldwide_office.access_and_opening_times) %>
+    <% if headers.any? %>
+      <nav aria-label="Page navigation">
+        <%= render "govuk_publishing_components/components/contents_list", {
+          contents: headers.map do |header|
+              {
+                text: header.text,
+                href: "##{header.id}"
+              }
+            end,
+            underline_links: true,
+        } %>
+      </nav>
+    <% end %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: sanitize("<span class='govuk-visually-hidden'>About </span>#{@worldwide_office.title}"),
+      heading_level: 2,
+      font_size: "xl",
+      margin_bottom: 4,
+    } %>
+    <div class="contact-us govuk-clearfix">
+      <%= render partial: "contacts/organisation_contact", locals: {
+        contact: @worldwide_office.contact,
+        hide_title: true,
+      } %>
+    </div>
+
+    <div class="body">
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        govspeak_to_html(@worldwide_office.access_and_opening_times)
+      end %>
+    </div>
+  </div>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Whitehall::Application.routes.draw do
       get "/:organisation_id/office" => redirect("/world/organisations/%{organisation_id}", prefix: "")
       get "/:organisation_id/about(.:locale)", as: "about", constraints: { locale: valid_locales_regex }, to: rack_404
       get "/about/:id(.:locale)", as: "corporate_information_page", to: "corporate_information_pages#show", constraints: { locale: valid_locales_regex }
+      get "/office/:id(.:locale)", as: "worldwide_office", to: "worldwide_offices#show", constraints: { locale: valid_locales_regex }
     end
   end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -147,20 +147,17 @@ When(/^I add default access information to the worldwide organisation$/) do
   click_button "Save"
 end
 
-Then(/^I should see the default access information on the edit "([^"]*)" office page$/) do |office_name|
+Then(/^I should see the default access information on the public "([^"]*)" office page$/) do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit edit_admin_worldwide_organisation_worldwide_office_access_and_opening_time_path(worldwide_organisation, worldwide_office)
+  visit worldwide_organisation.public_path
+  within record_css_selector(worldwide_office) do
+    click_link "Access and opening times"
+  end
 
-  expect(page).to have_content("Default body information")
-end
-
-Then(/^I should see custom access information on the edit "([^"]*)" office page$/) do |office_name|
-  worldwide_organisation = WorldwideOrganisation.last
-  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
-  visit edit_admin_worldwide_organisation_worldwide_office_access_and_opening_time_path(worldwide_organisation, worldwide_office)
-
-  expect(page).to have_content("Custom body information")
+  within ".body" do
+    expect(page).to have_content("Default body information")
+  end
 end
 
 Given(/^a worldwide organisation "([^"]*)" with default access information$/) do |name|
@@ -193,6 +190,19 @@ When(/^I give "([^"]*)" custom access information$/) do |office_name|
 
   fill_in "Body", with: "Custom body information"
   click_button "Save"
+end
+
+Then(/^I should see the custom access information on the public "([^"]*)" office page$/) do |office_name|
+  worldwide_organisation = WorldwideOrganisation.last
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: office_name }).first
+  visit worldwide_organisation.public_path
+  within record_css_selector(worldwide_office) do
+    click_link "Access and opening times"
+  end
+
+  within ".body" do
+    expect(page).to have_content("Custom body information")
+  end
 end
 
 Then(/^I should see the updated default access information$/) do

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -67,8 +67,8 @@ Feature: Administering worldwide organisation
   Scenario: Adding default access information to a worldwide organisation
     Given a worldwide organisation "Department of Beards in France" with offices "Head office" and "Branch office"
     When I add default access information to the worldwide organisation
-    Then I should see the default access information on the edit "Head office" office page
-    And I should see the default access information on the edit "Branch office" office page
+    Then I should see the default access information on the public "Head office" office page
+    And I should see the default access information on the public "Branch office" office page
 
   Scenario: Editing the default access information for a worldwide organisation
     Given a worldwide organisation "Department of Beards in France" with default access information
@@ -79,8 +79,8 @@ Feature: Administering worldwide organisation
     Given a worldwide organisation "Department of Bananas" with default access information
     And the offices "Head office" and "Branch office"
     When I give "Head office" custom access information
-    Then I should see custom access information on the edit "Head office" office page
-    And I should see the default access information on the edit "Branch office" office page
+    Then I should see the custom access information on the public "Head office" office page
+    And I should see the default access information on the public "Branch office" office page
 
   Scenario: Adding a corporate information page to a worldwide organisation
     Given a worldwide organisation "Department of Beards in France"

--- a/test/functional/worldwide_offices_controller_test.rb
+++ b/test/functional/worldwide_offices_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class WorldwideOfficesControllerTest < ActionController::TestCase
+  setup do
+    @worldwide_office = create(:worldwide_office)
+  end
+
+  test "get #show loads the office and renders the show template" do
+    get :show, params: { worldwide_organisation_id: @worldwide_office.worldwide_organisation_id, id: @worldwide_office }
+
+    assert_response :success
+    assert_template :show
+    assert_equal @worldwide_office, assigns(:worldwide_office)
+    assert_equal @worldwide_office.worldwide_organisation, assigns(:worldwide_organisation)
+  end
+
+  test "does not load offices from other organisation as there may be slug clashes" do
+    assert_raise ActiveRecord::RecordNotFound do
+      get :show, params: { worldwide_organisation_id: create(:worldwide_organisation), id: @worldwide_office }
+    end
+  end
+end


### PR DESCRIPTION
We have seen errors follow the merge of this PR.

It seems like the path helper cannot create links to the associated offices anymore due to the removal of the route. Reverting so that I can investigate.

Reverts alphagov/whitehall#7738