### PR TITLE
Ensure special characters in page title are sanitised prior to escaping

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -9,7 +9,7 @@
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Whitehall Publisher",
   environment: environment,
-  browser_title: ("Error: " unless yield(:error_summary).blank?).to_s + (yield(:page_title).presence || yield(:title)) do %>
+  browser_title: ("Error: " unless yield(:error_summary).blank?).to_s + sanitize((yield(:page_title).presence || yield(:title))) do %>
 
   <!-- This element exists to initialise the JS module that configures custom Analytics behaviour -->
   <div data-module="app-analytics"></div>


### PR DESCRIPTION
## Description 

Special chars aren't being sanitised for the page title prior to being escaped. This causes them to be rendered in the tab.

## Screenshot

### Before

<img width="185" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/72faa666-e706-4a86-8603-fe2d0cf80fa6">

### After

<img width="238" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/55f18c02-0898-4a65-a916-c10b4b2a5760">

## Trello card

https://trello.com/c/Au5IzDtE/57-render-characters-like-in-the-title-tag

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
