### PR TITLE
Ensure sidebar actions render with correct styling

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.html.erb
+++ b/app/components/admin/editions/show/sidebar_actions_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-view-edition-summary__sidebar-actions">
+<div class="app-view-summary__sidebar-actions">
   <%= render "govuk_publishing_components/components/list", {
     extra_spacing: true,
     items: actions

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -51,7 +51,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:superseded_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_no_selector "app-view-edition-summary__sidebar-actions"
+    assert_no_selector "app-view-summary__sidebar-actions"
   end
 
   test "actions for scheduled edition" do
@@ -160,7 +160,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:superseded_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_no_selector "app-view-edition-summary__sidebar-actions"
+    assert_no_selector "app-view-summary__sidebar-actions"
   end
 
   test "actions for scheduled edition as managing editor" do

--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -17,7 +17,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: draft_edition }
 
-    assert_select ".app-view-edition-summary__sidebar-actions" do
+    assert_select ".app-view-summary__sidebar-actions" do
       assert_select "a[href=?]", confirm_destroy_admin_edition_path(draft_edition), text: "Delete draft"
     end
   end
@@ -28,7 +28,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: submitted_edition }
 
-    assert_select ".app-view-edition-summary__sidebar-actions" do
+    assert_select ".app-view-summary__sidebar-actions" do
       assert_select "a[href=?]", confirm_destroy_admin_edition_path(submitted_edition), text: "Delete draft"
     end
   end
@@ -39,7 +39,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
 
     get :show, params: { id: published_edition }
 
-    refute_select ".app-view-edition-summary__sidebar-actions input[name='_method'][type='hidden'][value='delete']"
+    refute_select ".app-view-summary__sidebar-actions input[name='_method'][type='hidden'][value='delete']"
   end
 
   view_test "show does not display the delete button for superseded editions" do


### PR DESCRIPTION
## Description

The class name for sidebar actions wasn't updated as part of the refactor that pulled styling into a shared stylesheet.

## Screenshot 

### Before 

<img width="717" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9bf042dc-5b78-4468-b847-7eabc243697d">

### After 

<img width="638" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ba077d35-a974-47c1-84eb-7c38fcc6d77e">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
