### PR TITLE
Update take part pages styling

### DIFF
--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -5,31 +5,36 @@
     } %>
 
     <%= form_for take_part_page, url: [:admin, take_part_page], multipart: true do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title (required)"
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: "Title (required)",
+            heading_level: 2,
+            heading_size: "l",
+          },
+          name: "take_part_page[title]",
+          rows: 1,
+          value: form.object.title,
+          error_items: errors_for(form.object.errors, :title),
         },
-        name: "take_part_page[title]",
+        maxlength: 255,
         id: "take_part_page_title",
-        hint: "Title text should be 255 characters or fewer.",
-        heading_level: 2,
-        heading_size: "l",
-        value: form.object.title,
-        error_items: errors_for(form.object.errors, :title)
       } %>
 
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Summary (required)",
-          heading_level: 2,
-          heading_size: "l",
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: "Summary (required)",
+            heading_level: 2,
+            heading_size: "l",
+          },
+          name: "take_part_page[summary]",
+          rows: 4,
+          value: form.object.summary,
+          error_items: errors_for(form.object.errors, :summary)
         },
-        name: "take_part_page[summary]",
+        maxlength: 255,
         id: "take_part_page_summary",
-        rows: 2,
-        hint: "Summary text should be 255 characters or fewer.",
-        value: form.object.summary,
-        error_items: errors_for(form.object.errors, :summary)
       } %>
 
       <%= render "components/govspeak-editor", {
@@ -72,8 +77,7 @@
         id: "take_part_page_image_alt_text",
         value: form.object.image_alt_text
       } %>
-
-      <div class="govuk-button-group">
+      <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",
           data_attributes: {
@@ -84,7 +88,7 @@
           }
         } %>
 
-        <%= link_to "Cancel", admin_take_part_pages_path, class:"govuk-link govuk-link--no-visited-state" %>
+        <%= link_to "Cancel", admin_take_part_pages_path, class: "govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>
   </section>


### PR DESCRIPTION
This PR updates take-part-pages as per suggested styling and design specifications.
It does the following:

- It removes hint text from Title and Summary input and added character count.
- It modifies space between last the field and button as 50 px.

**Note:** Image component is still same as PF for new image component requested is still not completed.
This will be done once new image component is ready to be incorporated.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/5d6309e1-c8c6-4b10-b529-ef6d2afd4767)

![image](https://github.com/alphagov/whitehall/assets/131259138/9a510879-b527-4f40-abd8-d6dd3448a4c9)

**Trello:**
https://trello.com/c/SAfAUOhr/230-update-take-part-page-styling-and-components