### PR TITLE
Link main and home page offices for worldwide orgs

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -43,7 +43,9 @@ module PublishingApi
     def links
       {
         corporate_information_pages:,
-        ordered_contacts:,
+        ordered_contacts: [],
+        main_office:,
+        home_page_offices:,
         primary_role_person:,
         secondary_role_person:,
         office_staff:,
@@ -60,10 +62,16 @@ module PublishingApi
       Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body) || ""
     end
 
-    def ordered_contacts
-      return [] unless item.offices.any?
+    def main_office
+      return [] unless item.main_office
 
-      item.offices.map(&:contact).map(&:content_id)
+      [item.main_office.content_id]
+    end
+
+    def home_page_offices
+      return [] unless item.home_page_offices.any?
+
+      item.home_page_offices.map(&:content_id)
     end
 
     def primary_role_person

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -77,9 +77,11 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         worldwide_org.corporate_information_pages[4].content_id,
         worldwide_org.corporate_information_pages[5].content_id,
       ],
-      ordered_contacts: [
-        worldwide_org.reload.offices.first.contact.content_id,
+      ordered_contacts: [],
+      main_office: [
+        worldwide_org.reload.offices.first.content_id,
       ],
+      home_page_offices: [],
       primary_role_person: [
         ambassador.content_id,
       ],


### PR DESCRIPTION
In order to keep the current behaviour from whitehall, we need the worldwide organisation content item to have the information about which office, if any, is the main office, and which offices to show on the home page of the organisation.

Worldwide offices have their own content item, and some of the data (such as the `public_url` of the office to be shown when the main office has access and opening times) belong to the office rather than to its contact. So we have linked the offices rather than skipping directly to the contacts' `content_id`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
