### PR TITLE
Design updates for WorldLocation pages

### DIFF
--- a/app/views/admin/shared/_featured_link_fields.html.erb
+++ b/app/views/admin/shared/_featured_link_fields.html.erb
@@ -14,9 +14,9 @@
   text: "Only the first #{visible_links} links will be shown on the public site."
 } %>
 
-<div data-module="AddAnother" data-add-text="Add another featured link" class="govuk-!-margin-bottom-4">
+<div data-module="AddAnother" data-add-text="Add another featured link">
   <%= form.fields_for :featured_links do |featured_link_form| %>
-    <div class="js-duplicate-fields-set govuk-!-margin-top-4">
+    <div class="js-duplicate-fields-set govuk-!-margin-bottom-6">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Title"

--- a/app/views/admin/world_location_news/_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_world_location_table.html.erb
@@ -4,9 +4,6 @@
   <%= render "govuk_publishing_components/components/table", {
     head: [
       {
-        text: "Type"
-      },
-      {
         text: "Location"
       },
       {
@@ -16,17 +13,14 @@
         text: "Translations"
       },
       {
-        text: "Edit"
+        text: tag.span("Edit", class: "govuk-visually-hidden")
       }
     ],
     rows:
       world_locations.map do |world_location|
         [
           {
-            text: world_location.display_type
-          },
-          {
-            text: world_location.name
+            text: tag.p(world_location.name, class: "govuk-!-font-weight-bold govuk-!-margin-0"),
           },
           {
             text:
@@ -43,7 +37,7 @@
                   link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_world_location_news_translation_path(world_location, locale.code), class: "govuk-link")
                 end.to_sentence)
               else
-                "none"
+                ""
               end
           },
           {

--- a/app/views/admin/world_location_news/edit.html.erb
+++ b/app/views/admin/world_location_news/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Edit " + @world_location_news.name %>
-<% content_for :title, "Edit " + @world_location_news.name %>
-<% content_for :context, "World location" %>
+<% content_for :title, "Edit details" %>
+<% content_for :context, @world_location_news.name %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :error_summary,
   render(Admin::ErrorSummaryComponent.new(
@@ -61,14 +61,14 @@
           } %>
         <% end %>
 
-        <%= render "govuk_publishing_components/components/title", {
-          context: @world_location_news.name,
-          title: "Featured links"
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Featured links",
+          font_size: "l"
         } %>
 
         <%= render 'admin/shared/featured_link_fields', form: form %>
 
-        <div class="govuk-button-group govuk-!-margin-top-6">
+        <div class="govuk-button-group govuk-!-margin-top-8">
           <%= render "govuk_publishing_components/components/button", {
             text: "Save",
             data_attributes: {

--- a/app/views/admin/world_location_news/index.html.erb
+++ b/app/views/admin/world_location_news/index.html.erb
@@ -2,16 +2,17 @@
 <% content_for :title, "World location news" %>
 
 <%= render "govuk_publishing_components/components/tabs", {
+  panel_border: false,
   tabs: [
     {
       id: "active_tab",
       label: "Active",
-      content: render(partial: "world_location_table", locals: {world_locations: @active_world_locations, error_message: "No active world location news."})
+      content: render("world_location_table", world_locations: @active_world_locations, error_message: "No active world location news.")
     },
     {
       id: "inactive_tab",
       label: "Inactive",
-      content: render(partial: "world_location_table", locals: {world_locations: @inactive_world_locations, error_message: "No inactive world location news."})
+      content: render("world_location_table", world_locations: @inactive_world_locations, error_message: "No inactive world location news.")
     }
   ]
 } %>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, @world_location_news.name %>
-<% content_for :context, "Details" %>
+<% content_for :context, "World location news" %>
 <% content_for :title, @world_location_news.name %>
 <% content_for :title_margin_bottom, 4 %>
 
@@ -12,13 +12,43 @@
       aria_label: "World location news navigation tabs",
       items: secondary_navigation_tabs_items(@world_location_news, request.path)
     } %>
-    <div class="govuk-!-margin-bottom-4">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Edit",
-        secondary_solid: true,
-        href: [:edit, :admin, @world_location_news]
-      } %>
-    </div>
-    <%= govspeak_to_html @world_location_news.mission_statement %>
+
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "Details",
+      items: [
+        {
+          field: "Type",
+          value: @world_location_news.world_location.display_type,
+        },
+        {
+          field: "Title",
+          value: @world_location_news.title,
+        },
+        {
+          field: "Mission statement",
+          value: @world_location_news.mission_statement,
+        },
+        {
+          field: "Active",
+          value: @world_location_news.world_location.active? ? "Yes" : "",
+        },
+        @world_location_news.featured_links.each_with_index.map do |featured_link, index|
+          [
+            {
+              field: "Featured link #{index + 1} title",
+              value: featured_link.title,
+            },
+            {
+              field: "Featured link #{index + 1} URL",
+              value: featured_link.url,
+            }
+          ]
+        end
+      ].flatten.reject { |row| row[:value].blank? },
+      edit: {
+        href: [:edit, :admin, @world_location_news],
+        link_text: "Edit",
+      }
+    } %>
   </div>
 </div>


### PR DESCRIPTION
## Description 

Design changes for the world location index page post 1.9 review

- remove type column
- bold world location name (1st column)
- use visually hidden text for edit column head
- show empty cell when no translations are present
- remove panel border on tabs so styling doesn't break on smaller resolutions

Show page

- Use summary list component for details

Edit page

- Update context and title
- Reduce size of featured link 
- Fix margin

## Screenshots

### Before

<img width="768" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a3bb6401-dfc1-4dbc-aeca-aad96eb91b2c">

### After

<img width="772" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/26e5a113-139a-45fa-8280-d4e2a7471d70">

### Before

<img width="543" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/90c383df-83c6-41f3-aeda-73372e723d6b">

### After

<img width="568" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/353f4fce-6b71-4cd3-9b7e-c758cf2066b1">

### Before

<img width="518" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3a2fa0de-839b-4524-892d-c214441101dc">

### After

<img width="633" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/744fdf90-33ce-4db5-91bc-5d3edc991f35">

## Trello card 

https://trello.com/c/bAxHukAN/236-update-component-with-summary-list

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
