### PR TITLE
UI improvements to role listing page

### DIFF
--- a/app/assets/stylesheets/admin/views/_roles.scss
+++ b/app/assets/stylesheets/admin/views/_roles.scss
@@ -1,0 +1,5 @@
+.app-view-roles__page-list {
+  .govuk-table__header:last-child {
+    width: 10%;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/historical-accounts-index";
 @import "./admin/views/organisations-index";
 @import "./admin/views/people";
+@import "./admin/views/roles";
 @import "./admin/views/summary";
 @import "./admin/views/take-part";
 @import "./admin/views/translation";

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -2,19 +2,19 @@
 <% content_for :title, "Roles" %>
 <% content_for :title_margin_bottom, 6 %>
 
-<%= render "govuk_publishing_components/components/button", {
-  title: "Create new role",
-  text: "Create new role",
-  href: new_admin_role_path,
-  margin_bottom: 6
-} %>
-
 <div class="govuk-!-margin-bottom-6">
   <%= render "govuk_publishing_components/components/warning_text", {
     text: "Do not create ministerial roles without consulting GDS."
   } %>
 </div>
 
+<%= render "govuk_publishing_components/components/button", {
+  title: "Create new role",
+  text: "Create new role",
+  href: new_admin_role_path,
+  margin_bottom: 6
+} %>
+<div class="app-view-roles__page-list">
 <%= render "govuk_publishing_components/components/table", {
   head: [
     {
@@ -24,52 +24,46 @@
       text: "Organistions"
     },
     {
-      text: "Role type"
-    },
-    {
       text: "Currently appointed"
     },
     {
       text: "Translations"
     },
     {
-      text: "Edit"
+      text: tag.span("Actions", class: "govuk-visually-hidden")
     },
-    {
-      text: "Delete"
-    }
   ],
   rows: @roles.map do |role|
     [
       {
-        text: role.name
+        text: tag.span(role.name, class: "govuk-!-font-weight-bold"),
       },
       {
         text: role.organisation_names
       },
       {
-        text: role.role_type.humanize
-      },
-      {
-        text: role.current_person_name
+        text:
+          if role.current_person_name.eql?("No one is assigned to this role")
+            ""
+          else
+            role.current_person_name
+          end
       },
       {
         text:
           content_tag_for(:div, role) do
-            link_to(sanitize("Manage translations#{tag.span(role.name, class: "govuk-visually-hidden")}"), admin_role_translations_path(role), title: "Manage translations of #{role.name}", class: "govuk-link")
+            link_to(sanitize("Manage #{tag.span(role.name, class: "govuk-visually-hidden")}"), admin_role_translations_path(role), title: "Manage translations of #{role.name}", class: "govuk-link")
           end
       },
       {
-        text: link_to(sanitize("Edit#{tag.span(role.name, class: "govuk-visually-hidden")}"), edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link")
+        text: link_to(sanitize("Edit #{tag.span(role.name, class: "govuk-visually-hidden")}"), edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link") +
+          if role.destroyable?
+            link_to(sanitize("Delete #{tag.span(role.name, class: "govuk-visually-hidden")}"), confirm_destroy_admin_role_path(role), class: "govuk-link govuk-link--no-visited-state gem-link--destructive govuk-!-margin-left-2")
+          else
+            ""
+          end
       },
-      {
-        text:
-            if role.destroyable?
-                link_to(sanitize("Delete#{tag.span(role.name, class: "govuk-visually-hidden")}"), confirm_destroy_admin_role_path(role), class: "govuk-link govuk-link--no-visited-state gem-link--destructive")
-            else
-              ""
-            end
-      }
     ]
-    end
+  end
 } %>
+</div>

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -56,7 +56,7 @@ end
 When(/^I appoint "(.*?)" as the "(.*?)"$/) do |person_name, role_name|
   visit admin_roles_path
 
-  click_on using_design_system? ? "Edit#{role_name}" : role_name
+  click_on using_design_system? ? "Edit #{role_name}" : role_name
   click_on using_design_system? ? "Create new appointment" : "New appointment"
   select person_name, from: "Person"
   click_on "Save"
@@ -74,7 +74,7 @@ end
 
 Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
   role = Role.last
-  click_on using_design_system? ? "Edit#{role.name}" : role.name
+  click_on using_design_system? ? "Edit #{role.name}" : role.name
   click_on using_design_system? ? "Create new appointment" : "New appointment"
   select person_name, from: "Person"
   if using_design_system?

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -22,26 +22,22 @@ class Admin::RolesControllerTest < ActionController::TestCase
       assert_select "tr:nth-child(1)" do
         assert_select "td:nth-child(1).govuk-table__cell", "ministerial-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-one and org-two"
-        assert_select "td:nth-child(3).govuk-table__cell", "Cabinet minister"
-        assert_select "td:nth-child(4).govuk-table__cell", "person-name"
+        assert_select "td:nth-child(3).govuk-table__cell", "person-name"
       end
       assert_select "tr:nth-child(2)" do
         assert_select "td:nth-child(1).govuk-table__cell", "chief-professional-officer-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-one"
-        assert_select "td:nth-child(3).govuk-table__cell", "Chief professional officer"
-        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
+        assert_select "td:nth-child(3).govuk-table__cell", ""
       end
       assert_select "tr:nth-child(3)" do
         assert_select "td:nth-child(1).govuk-table__cell", "management-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-one"
-        assert_select "td:nth-child(3).govuk-table__cell", "Permanent secretary"
-        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
+        assert_select "td:nth-child(3).govuk-table__cell", ""
       end
       assert_select "tr:nth-child(4)" do
         assert_select "td:nth-child(1).govuk-table__cell", "military-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-two"
-        assert_select "td:nth-child(3).govuk-table__cell", "Chief of staff"
-        assert_select "td:nth-child(4).govuk-table__cell", "No one is assigned to this role"
+        assert_select "td:nth-child(3).govuk-table__cell", ""
       end
     end
   end
@@ -143,7 +139,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table__body" do
       assert_select "tr:nth-child(1)" do
-        assert_select "a[href=?]", admin_role_translations_path(role), text: "Manage translations#{role.name}"
+        assert_select "a[href=?]", admin_role_translations_path(role), text: "Manage #{role.name}"
       end
     end
   end
@@ -158,10 +154,10 @@ class Admin::RolesControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table__body" do
       assert_select "tr:nth-child(1)" do
-        assert_select "a[href=?]", confirm_destroy_admin_role_path(destroyable_role), text: "Delete#{destroyable_role.name}"
+        assert_select "a[href=?]", confirm_destroy_admin_role_path(destroyable_role), text: "Delete #{destroyable_role.name}"
       end
       assert_select "tr:nth-child(2)" do
-        refute_select "a[href=?]", confirm_destroy_admin_role_path(indestructable_role), text: "Delete#{destroyable_role.name}"
+        refute_select "a[href=?]", confirm_destroy_admin_role_path(indestructable_role), text: "Delete #{destroyable_role.name}"
       end
     end
   end


### PR DESCRIPTION
This PR does the UI improvements for Role listing page.
It has the following changes.

- First column items are bold.
- Removed header for: Edit and Delete.
- Removed word “translation” from Manage translation link.
- Removed “role type” column.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/df123735-74ae-44cb-aa87-c97b8808c106)


**Trello:**
https://trello.com/c/1unFs900/234-ui-improvements-to-roles-listing-page

