### PR TITLE
Update designs for new/edit role pages

### DIFF
--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -1,140 +1,143 @@
-<%= form_for role, as: :role, url: role_url_for(role) do |form| %>
-    <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Role title (required)",
-          heading_size: "m"
-        },
-        value: role.name,
-        name: "role[name]",
-        id: "role_name",
-        type: "text",
-        error_items: errors_for(role.errors, :name)
-    }
-    %>
-
-    <%= render "govuk_publishing_components/components/select", {
-      id: "role_type",
-      label: "Role type (required)",
-      heading_size: "m",
-      name: "role[role_type]",
-      options:
-        [{ value: nil, text: nil }] + role_type_options.map do |group, name_vs_type|
-          name_vs_type.map do |name, type|
-            {
-              text: name,
-              value: type,
-              selected: role.role_type == type
-            }
-          end
-        end.flatten,
-      error_message: errors_for_input(role.errors, :type)
-    } %>
-
-    <%= render "components/autocomplete", {
-      id: "role_organisation_ids",
+<%= form_with model: role, as: :role, url: role_url_for(role) do |form| %>
+  <%= render "govuk_publishing_components/components/input", {
       label: {
-        text: "Organisations",
-        heading_size: "m"
+        text: "Role title (required)",
+        heading_size: "l"
       },
-      name: "role[organisation_ids][]",
-      select: {
-        options:  options_from_collection_for_select(Organisation.with_translations(:en), 'id', 'select_name', role.organisation_ids),
-        multiple: true
-      }
-    } %>
+      value: role.name,
+      name: "role[name]",
+      id: "role_name",
+      error_items: errors_for(role.errors, :name)
+  }
+  %>
 
-    <%= render "govuk_publishing_components/components/select", {
-      id: "role_whip_organisation_id",
-      label: "Whip Organisation",
-      heading_size: "m",
-      name: "role[whip_organisation_id]",
-      options: ([nil] + Whitehall::WhipOrganisation.all).map do |whip_organisation|
+  <%= render "govuk_publishing_components/components/select", {
+    id: "role_type",
+    label: "Role type (required)",
+    heading_size: "l",
+    name: "role[role_type]",
+    full_width: true,
+    options:
+      [{ value: nil, text: nil }] + role_type_options.map do |group, name_vs_type|
+        name_vs_type.map do |name, type|
           {
-            text: whip_organisation&.label,
-            value: whip_organisation&.id,
-            selected: whip_organisation&.id == role.whip_organisation_id
+            text: name,
+            value: type,
+            selected: role.role_type == type
           }
         end
-    } %>
+      end.flatten,
+    error_message: errors_for_input(role.errors, :type)
+  } %>
 
-    <%= render "govuk_publishing_components/components/select", {
-      id: "role_role_payment_type_id",
-      label: "Payment options",
-      heading_size: "m",
-      name: "role[role_payment_type_id]",
-      options: ([nil] + RolePaymentType.all).map do |role_payment_type|
+  <%= render "components/autocomplete", {
+    id: "role_organisation_ids",
+    label: {
+      text: "Organisations",
+      heading_size: "l"
+    },
+    name: "role[organisation_ids][]",
+    select: {
+      options:  options_from_collection_for_select(Organisation.with_translations(:en), 'id', 'select_name', role.organisation_ids),
+      multiple: true
+    }
+  } %>
+
+  <%= render "govuk_publishing_components/components/select", {
+    id: "role_whip_organisation_id",
+    label: "Whip Organisation",
+    heading_size: "l",
+    name: "role[whip_organisation_id]",
+    full_width: true,
+    options: ([nil] + Whitehall::WhipOrganisation.all).map do |whip_organisation|
         {
-          text: role_payment_type&.name,
-          value: role_payment_type&.id,
-          selected: role.role_payment_type_id == role_payment_type&.id
+          text: whip_organisation&.label,
+          value: whip_organisation&.id,
+          selected: whip_organisation&.id == role.whip_organisation_id
         }
       end
-    } %>
+  } %>
 
-    <%= render "govuk_publishing_components/components/select", {
-      id: "role_attends_cabinet_type_id",
-      label: "Attends cabinet options",
-      heading_size: "m",
-      name: "role[attends_cabinet_type_id]",
-      options: ([nil] + RoleAttendsCabinetType.all).map do |role_attends_cabinet_type|
-        {
-          text: role_attends_cabinet_type&.name,
-          value: role_attends_cabinet_type&.id,
-          selected: role.attends_cabinet_type_id == role_attends_cabinet_type&.id
-        }
-      end
-    } %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: "role_role_payment_type_id",
+    label: "Payment options",
+    heading_size: "l",
+    name: "role[role_payment_type_id]",
+    full_width: true,
+    options: ([nil] + RolePaymentType.all).map do |role_payment_type|
+      {
+        text: role_payment_type&.name,
+        value: role_payment_type&.id,
+        selected: role.role_payment_type_id == role_payment_type&.id
+      }
+    end
+  } %>
 
-    <%= render "components/autocomplete", {
-      id: "role_worldwide_organisation_ids",
-      label: {
-        text: "Worldwide organisations",
-        heading_size: "m"
-      },
-      name: "role[worldwide_organisation_ids][]",
-      select: {
-        options:  options_from_collection_for_select(WorldwideOrganisation.all, 'id', 'name', role.worldwide_organisation_ids),
-        multiple: true
+  <%= render "govuk_publishing_components/components/select", {
+    id: "role_attends_cabinet_type_id",
+    label: "Attends cabinet options",
+    heading_size: "l",
+    name: "role[attends_cabinet_type_id]",
+    full_width: true,
+    options: ([nil] + RoleAttendsCabinetType.all).map do |role_attends_cabinet_type|
+      {
+        text: role_attends_cabinet_type&.name,
+        value: role_attends_cabinet_type&.id,
+        selected: role.attends_cabinet_type_id == role_attends_cabinet_type&.id
+      }
+    end
+  } %>
+
+  <%= render "components/autocomplete", {
+    id: "role_worldwide_organisation_ids",
+    label: {
+      text: "Worldwide organisations",
+      heading_size: "l"
+    },
+    name: "role[worldwide_organisation_ids][]",
+    select: {
+      options:  options_from_collection_for_select(WorldwideOrganisation.all, 'id', 'name', role.worldwide_organisation_ids),
+      multiple: true
+    }
+  } %>
+
+  <%= render "components/govspeak-editor", {
+    label: {
+      text: "Responsibilities",
+      heading_size: "l"
+    },
+    id: "role_responsibilities",
+    name: "role[responsibilities]",
+    value: role.responsibilities_without_markup,
+    rows: 20
+  } %>
+
+  <div class="govuk-button-group govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save",
+      name: "save",
+      value: "Save",
+      type: "submit",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+        "track-label": "Save"
       }
     } %>
-
-    <%= render "components/govspeak-editor", {
-      label: {
-        text: "Responsibilities",
-        heading_size: "m"
-      },
-      id: "role_responsibilities",
-      name: "role[responsibilities]",
-      value: role.responsibilities_without_markup,
-      rows: 20
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save and continue",
+      name: "save_and_continue",
+      value: "Save and continue",
+      type: "submit",
+      secondary_solid: true,
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+        "track-label": "Save and continue"
+      }
     } %>
-
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        name: "save",
-        value: "Save",
-        type: "submit",
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "form-button",
-          "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
-          "track-label": "Save"
-        }
-      } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save and continue",
-        name: "save_and_continue",
-        value: "Save and continue",
-        type: "submit",
-        secondary_solid: true,
-        data_attributes: {
-          module: "gem-track-click",
-          "track-category": "form-button",
-          "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
-          "track-label": "Save and continue"
-        }
-      } %>
-      <%= link_to("Cancel", admin_roles_path, class: "govuk-link") %>
-    </div>
+    <%= link_to("Cancel", admin_roles_path, class: "govuk-link") %>
+  </div>
 <% end %>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -8,9 +8,7 @@
     <%= render "govuk_publishing_components/components/warning_text", {
       text: "Changes to roles appear instantly on the live site."
     } %>
-    <%= render "form", {
-       role: @role
-    } %>
+    <%= render "form", role: @role %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/tabs", {


### PR DESCRIPTION
## Description

These changes came out of the 1.9 design review

- make heading size l
- fix indentation
- make selects full width
- 50px between last field and button


## Screenshots

## Before

<img width="570" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/34e65a4f-6593-40f4-ae89-84dfd2516b10">


## After

<img width="572" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/cdb92c3e-4262-4a9d-b47e-72041af00a57">

## Trello card

https://trello.com/c/lWBpTkLR/235-updates-to-ui-for-new-edit-role

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
