### PR TITLE
Ensure correct layout renders for pages being ported to GOV.UK Design System

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -49,8 +49,8 @@ class Admin::BaseController < ApplicationController
   end
   helper_method :preview_design_system?
 
-  def render_design_system(design_system_view, legacy_view, next_release: false)
-    if preview_design_system?(next_release:)
+  def render_design_system(design_system_view, legacy_view)
+    if get_layout == "design_system"
       render design_system_view
     else
       render legacy_view

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -8,7 +8,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
     @whip_roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
     @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
 
-    render_design_system(:show, :legacy_show, next_release: false)
+    render_design_system(:show, :legacy_show)
   end
 
   def reorder_cabinet_minister_roles

--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -9,7 +9,7 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
     @paginator = @organisation.corporate_information_pages.where("state != ?", "superseded").order("corporate_information_page_type_id").page(params["page"].to_i || 1).per(100)
     @filter = FakeEditionFilter.new @paginator, "Corporate information pages", false, true
 
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index)
   end
 
   def destroy

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -5,7 +5,7 @@ class Admin::FeaturesController < Admin::BaseController
   layout :get_layout
 
   def new
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new)
   end
 
   def create
@@ -15,7 +15,7 @@ class Admin::FeaturesController < Admin::BaseController
       redirect_to admin_feature_list_path(@feature_list), notice: "The document has been saved"
     else
       flash.now[:alert] = "Unable to create feature"
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new)
     end
   end
 

--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -7,7 +7,7 @@ class Admin::GetInvolvedController < Admin::BaseController
   end
 
   def index
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index")
   end
 
   def get_layout

--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -6,7 +6,7 @@ class Admin::OffsiteLinksController < Admin::BaseController
   def new
     @offsite_link = OffsiteLink.new
 
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new)
   end
 
   def create
@@ -16,19 +16,19 @@ class Admin::OffsiteLinksController < Admin::BaseController
       flash[:notice] = "An offsite link has been created for #{@parent.name}"
       redirect_to offsite_links_path
     else
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new)
     end
   end
 
   def edit
-    render_design_system(:edit, :legacy_edit, next_release: false)
+    render_design_system(:edit, :legacy_edit)
   end
 
   def update
     if @offsite_link.update(offsite_link_params)
       redirect_to offsite_link_path(@offsite_link)
     else
-      render_design_system(:edit, :legacy_edit, next_release: false)
+      render_design_system(:edit, :legacy_edit)
     end
   end
 

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -6,7 +6,7 @@ class Admin::OrganisationsController < Admin::BaseController
   def index
     @organisations = Organisation.alphabetical
     @user_organisation = current_user.organisation
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index)
   end
 
   def new
@@ -25,7 +25,7 @@ class Admin::OrganisationsController < Admin::BaseController
   end
 
   def show
-    render_design_system(:show, :legacy_show, next_release: false)
+    render_design_system(:show, :legacy_show)
   end
 
   def people

--- a/app/controllers/admin/policy_groups_controller.rb
+++ b/app/controllers/admin/policy_groups_controller.rb
@@ -5,12 +5,12 @@ class Admin::PolicyGroupsController < Admin::BaseController
 
   def index
     @policy_groups = PolicyGroup.order(:name)
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index")
   end
 
   def new
     @policy_group = PolicyGroup.new
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -18,19 +18,19 @@ class Admin::PolicyGroupsController < Admin::BaseController
     if @policy_group.save
       redirect_to admin_policy_groups_path, notice: %("#{@policy_group.name}" created.)
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update
     if @policy_group.update(policy_group_params)
       redirect_to admin_policy_groups_path, notice: %("#{@policy_group.name}" saved.)
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -6,7 +6,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 
   def index
     @promotional_features = @organisation.promotional_features
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index")
   end
 
   def new
@@ -14,7 +14,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
     @promotional_feature.promotional_feature_items.build
     @promotional_feature.promotional_feature_items.first.links.build
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -25,16 +25,16 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
       redirect_to [:admin, @organisation, @promotional_feature], notice: "Promotional feature created"
     else
       @promotional_feature.promotional_feature_items.first.links.build if @promotional_feature.promotional_feature_items.first.links.blank?
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def show
-    render_design_system("show", "legacy_show", next_release: false)
+    render_design_system("show", "legacy_show")
   end
 
   def edit
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update

--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -7,7 +7,7 @@ class Admin::RoleAppointmentsController < Admin::BaseController
     @role_appointment = role.role_appointments.build(started_at: Time.zone.today)
     @current_appointment = params[:make_current]
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -17,19 +17,19 @@ class Admin::RoleAppointmentsController < Admin::BaseController
       redirect_to edit_admin_role_path(role), notice: "Appointment created"
     else
       @current_appointment = params[:role_appointment][:make_current]
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update
     if @role_appointment.update(role_appointment_params)
       redirect_to edit_admin_role_path(@role_appointment.role), notice: "Appointment has been updated"
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 
@@ -41,7 +41,7 @@ class Admin::RoleAppointmentsController < Admin::BaseController
       redirect_to edit_admin_role_path(@role_appointment.role), notice: "Appointment has been deleted"
     else
       flash.now[:alert] = "Appointment can not be deleted"
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -6,13 +6,13 @@ class Admin::RolesController < Admin::BaseController
     @roles = Role.includes(:role_appointments, :current_people, :translations, organisations: [:translations])
                   .order("organisation_translations.name, roles.type DESC, roles.permanent_secretary DESC, role_translations.name")
 
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index")
   end
 
   def new
     @role = Role.new
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -20,21 +20,21 @@ class Admin::RolesController < Admin::BaseController
     if @role.save
       redirect_to index_or_edit_path, notice: %("#{@role.name}" created.)
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
     @role = Role.find(params[:id])
 
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update
     if @role.update(role_params)
       redirect_to index_or_edit_path, notice: %("#{@role.name}" updated.)
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 

--- a/app/controllers/admin/statistics_announcement_date_changes_controller.rb
+++ b/app/controllers/admin/statistics_announcement_date_changes_controller.rb
@@ -7,7 +7,7 @@ class Admin::StatisticsAnnouncementDateChangesController < Admin::BaseController
   def new
     @statistics_announcement_date_change = build_date_change
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -16,7 +16,7 @@ class Admin::StatisticsAnnouncementDateChangesController < Admin::BaseController
     if @statistics_announcement_date_change.save
       redirect_to [:admin, @statistics_announcement], notice: "Release date changed"
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 

--- a/app/controllers/admin/statistics_announcement_tags_controller.rb
+++ b/app/controllers/admin/statistics_announcement_tags_controller.rb
@@ -7,7 +7,7 @@ class Admin::StatisticsAnnouncementTagsController < Admin::BaseController
     @topic_taxonomy = Taxonomy::TopicTaxonomy.new
     @tag_form = TaxonomyTagForm.load(@statistics_announcement.content_id)
 
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update

--- a/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
+++ b/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
@@ -4,14 +4,14 @@ class Admin::StatisticsAnnouncementUnpublishingsController < Admin::BaseControll
   layout :get_layout
 
   def new
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
     if @statistics_announcement.update(statistics_announcement_params.merge(publishing_state: "unpublished"))
       redirect_to admin_statistics_announcements_path, notice: "Unpublished statistics announcement: #{@statistics_announcement.title}"
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -13,14 +13,14 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
   def show
     @edition_taxons = EditionTaxonsFetcher.new(@statistics_announcement.content_id).fetch
 
-    render_design_system("show", "legacy_show", next_release: false)
+    render_design_system("show", "legacy_show")
   end
 
   def new
     @statistics_announcement = build_statistics_announcement(organisation_ids: [current_user.organisation.try(:id)])
     @statistics_announcement.build_current_release_date(precision: StatisticsAnnouncementDate::PRECISION[:two_month])
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -29,12 +29,12 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
     if @statistics_announcement.save
       redirect_to [:admin, @statistics_announcement], notice: "Announcement published successfully"
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update
@@ -42,24 +42,24 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
     if @statistics_announcement.save
       redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 
   def cancel
-    render_design_system("cancel", "legacy_cancel", next_release: false)
+    render_design_system("cancel", "legacy_cancel")
   end
 
   def publish_cancellation
     if @statistics_announcement.cancel!(params[:statistics_announcement][:cancellation_reason], current_user)
       redirect_to [:admin, @statistics_announcement], notice: "Announcement has been cancelled"
     else
-      render_design_system("cancel", "legacy_cancel", next_release: false)
+      render_design_system("cancel", "legacy_cancel")
     end
   end
 
   def cancel_reason
-    render_design_system("cancel_reason", "legacy_cancel_reason", next_release: false)
+    render_design_system("cancel_reason", "legacy_cancel_reason")
   end
 
   def update_cancel_reason
@@ -67,7 +67,7 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
     if @statistics_announcement.save
       redirect_to [:admin, @statistics_announcement], notice: "Announcement updated successfully"
     else
-      render_design_system("cancel_reason", "legacy_cancel_reason", next_release: false)
+      render_design_system("cancel_reason", "legacy_cancel_reason")
     end
   end
 

--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -8,12 +8,12 @@ class Admin::TakePartPagesController < Admin::BaseController
 
   def index
     @take_part_pages = TakePartPage.in_order
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index)
   end
 
   def new
     @take_part_page = TakePartPage.new
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -21,13 +21,13 @@ class Admin::TakePartPagesController < Admin::BaseController
     if @take_part_page.save
       redirect_to [:admin, TakePartPage], notice: %(Take part page "#{@take_part_page.title}" created!)
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
     @take_part_page = TakePartPage.friendly.find(params[:id])
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update

--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -27,7 +27,7 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
     @topical_event_featuring = @topical_event.topical_event_featurings.build(edition: featured_edition, offsite_link: featured_offsite_link)
     @topical_event_featuring.build_image
 
-    render_design_system(:new, :legacy_new, next_release: false)
+    render_design_system(:new, :legacy_new)
   end
 
   def create
@@ -40,7 +40,7 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
                        end
       redirect_to polymorphic_path([:admin, @topical_event, :topical_event_featurings])
     else
-      render_design_system(:new, :legacy_new, next_release: false)
+      render_design_system(:new, :legacy_new)
     end
   end
 

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -9,7 +9,7 @@ class Admin::TopicalEventsController < Admin::BaseController
   layout :get_layout
 
   def show
-    render_design_system(:show, :show_legacy, next_release: false)
+    render_design_system(:show, :show_legacy)
   end
 
   def index

--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -4,17 +4,17 @@ class Admin::WorldLocationNewsController < Admin::BaseController
 
   def edit
     build_featured_link_if_none_present
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def show
-    render_design_system("show", "legacy_show", next_release: false)
+    render_design_system("show", "legacy_show")
   end
 
   def index
     @active_world_locations, @inactive_world_locations = WorldLocation.ordered_by_name.partition(&:active?)
 
-    render_design_system("index", "legacy_index", next_release: false)
+    render_design_system("index", "legacy_index")
   end
 
   def update
@@ -22,7 +22,7 @@ class Admin::WorldLocationNewsController < Admin::BaseController
       redirect_to [:admin, @world_location_news], notice: "World location updated successfully"
     else
       build_featured_link_if_none_present
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 
@@ -43,7 +43,7 @@ class Admin::WorldLocationNewsController < Admin::BaseController
     if request.xhr?
       render partial: "admin/feature_lists/legacy_search_results", locals: { feature_list: @feature_list }
     else
-      render_design_system("features", "legacy_features", next_release: false)
+      render_design_system("features", "legacy_features")
     end
   end
 

--- a/app/controllers/admin/world_location_news_translations_controller.rb
+++ b/app/controllers/admin/world_location_news_translations_controller.rb
@@ -3,7 +3,7 @@ class Admin::WorldLocationNewsTranslationsController < Admin::BaseController
   layout :get_layout
 
   def index
-    render_design_system(:index, :legacy_index, next_release: false)
+    render_design_system(:index, :legacy_index)
   end
 
   def destroy

--- a/test/functional/admin/access_and_opening_times_controller_test.rb
+++ b/test/functional/admin/access_and_opening_times_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET on :edit loads the organisation as accessible if worldwide_office_id is not supplied" do
     worldwide_organisation = create(:worldwide_organisation)

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   def organisation
     @organisation ||= create(:organisation)

--- a/test/functional/admin/contact_translations_controller_test.rb
+++ b/test/functional/admin/contact_translations_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "create redirects to edit for the chosen language" do
     organisation = create(:organisation)

--- a/test/functional/admin/contacts_controller_test.rb
+++ b/test/functional/admin/contacts_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates contact" do
     organisation = create(:organisation)

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -8,6 +8,7 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   def id_params
     { document_collection_id: @collection, group_id: @group }

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -8,6 +8,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET #index lists the groups and memberships in the collection" do
     publication = create(:publication)

--- a/test/functional/admin/financial_reports_controller_test.rb
+++ b/test/functional/admin/financial_reports_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index lists the organisation's reports" do
     report = create(:financial_report, funding: 20_000)

--- a/test/functional/admin/get_involved_controller_test.rb
+++ b/test/functional/admin/get_involved_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::GetInvolvedControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index returns ok" do
     get :index

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -9,6 +9,7 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :new should render new offsite links form" do
     get :new, params: { world_location_news_id: @world_location_news.slug }

--- a/test/functional/admin/operational_fields_controller_test.rb
+++ b/test/functional/admin/operational_fields_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
   should_require_fatality_handling_permission_to_access :operational_field, :index, :new, :edit
 
   test "index should list operational fields ordered alphabetically by name" do

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -12,6 +12,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { organisation_id: @organisation }

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   def example_organisation_attributes
     attributes_for(:organisation).except(:logo, :analytics_identifier)

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "new shows form for creating a person" do
     get :new

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -9,6 +9,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { person_id: @person }

--- a/test/functional/admin/policy_groups_controller_test.rb
+++ b/test/functional/admin/policy_groups_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index" do
     group = create(:policy_group)

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -8,6 +8,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :new loads the organisation and feature and instantiates a new item and link" do
     get :new, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature }

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index returns a 404 if the organisation is not allowed promotional" do
     organisation = create(:ministerial_department)

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "new should display a form for creating an appointment" do
     role = create(:role)

--- a/test/functional/admin/role_translations_controller_test.rb
+++ b/test/functional/admin/role_translations_controller_test.rb
@@ -9,6 +9,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { role_id: @role }

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index should display a list of roles" do
     org_one = create(:organisation, name: "org-one")

--- a/test/functional/admin/sitewide_settings_controller_test.rb
+++ b/test/functional/admin/sitewide_settings_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::SitewideSettingsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   %i[edit update].each do |action_method|
     test "#{action_method} action is not permitted to non-GDS editors" do

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates social media account" do
     worldwide_organisation = create(:worldwide_organisation)

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -15,6 +15,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index with no search value renders search bar only" do
     get :index, params: { statistics_announcement_id: @official_statistics_announcement }

--- a/test/functional/admin/statistics_announcement_tags_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_tags_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Admin::StatisticsAnnouncementTagsControllerTest < ActionController::TestCase
   include TaxonomyHelper
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   setup do
     @user = login_as_preview_design_system_user(:departmental_editor)

--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -9,6 +9,7 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GDS Editor permission required to unpublish" do
     login_as :departmental_editor

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index fetches all the take part pages in order" do
     page3 = create(:take_part_page, ordering: 3)

--- a/test/functional/admin/topical_event_featurings_controller_test.rb
+++ b/test/functional/admin/topical_event_featurings_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Admin::TopicalEventFeaturingsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   setup do
     @topical_event = create(:topical_event)

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :show lists the topical event details" do
     topical_event = create(:topical_event)

--- a/test/functional/admin/world_location_news_controller_test.rb
+++ b/test/functional/admin/world_location_news_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::WorldLocationNewsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "should return active and inactive world locations in alphabetical order" do
     active = [

--- a/test/functional/admin/world_location_news_translations_controller_test.rb
+++ b/test/functional/admin/world_location_news_translations_controller_test.rb
@@ -12,6 +12,7 @@ class Admin::WorldLocationNewsTranslationsControllerTest < ActionController::Tes
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { world_location_news_id: @world_location }

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "post create creates worldwide office" do
     worldwide_organisation = create(:worldwide_organisation)

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   test "shows a list of worldwide organisations" do
     organisation = create(:worldwide_organisation)

--- a/test/functional/admin/worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_translations_controller_test.rb
@@ -11,6 +11,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { worldwide_organisation_id: @worldwide_organisation }

--- a/test/support/controller_test_helpers.rb
+++ b/test/support/controller_test_helpers.rb
@@ -2,6 +2,8 @@ module ControllerTestHelpers
   extend ActiveSupport::Concern
 
   module ClassMethods
+    LAYOUT_ALWAYS_DESIGN_SYSTEM = %w[reorder update_order confirm_destroy].freeze
+
     def should_be_an_admin_controller
       test "should be an admin controller" do
         assert @controller.is_a?(Admin::BaseController), "the controller should be an admin controller"
@@ -11,6 +13,21 @@ module ControllerTestHelpers
     def should_be_a_public_facing_controller
       test "should be a public facing controller" do
         assert @controller.is_a?(PublicFacingController), "the controller should be a public facing controller"
+      end
+    end
+
+    def should_render_bootstrap_implementation_with_preview_next_release
+      test "should render the admin layout when the user has 'Preview next release' permission" do
+        return unless @controller.class.private_method_defined?(:get_layout)
+
+        user = login_as(:writer)
+        user.permissions << "Preview next release"
+
+        # Get all non-inherited controller actions and test they use the admin layout.
+        @controller.class.instance_methods(false).map(&:to_s).reject { |action| LAYOUT_ALWAYS_DESIGN_SYSTEM.include?(action) }.each do |action|
+          @controller.action_name = action
+          assert_equal "admin", @controller.send(:get_layout), "#{@controller.class}##{action} is not rendering the admin layout"
+        end
       end
     end
 

--- a/test/support/controller_test_helpers.rb
+++ b/test/support/controller_test_helpers.rb
@@ -8,12 +8,6 @@ module ControllerTestHelpers
       end
     end
 
-    def legacy_should_be_an_admin_controller
-      test "should be an admin controller" do
-        assert @controller.is_a?(Admin::BaseController), "the controller should be an admin controller"
-      end
-    end
-
     def should_be_a_public_facing_controller
       test "should be a public facing controller" do
         assert @controller.is_a?(PublicFacingController), "the controller should be a public facing controller"
@@ -21,17 +15,6 @@ module ControllerTestHelpers
     end
 
     def should_require_fatality_handling_permission_to_access(edition_type, *actions)
-      test "requires the ability to handle fatalities to access" do
-        edition = create(edition_type) # rubocop:disable Rails/SaveBang
-        login_as :writer
-        actions.each do |action|
-          get action, params: { id: edition.id }
-          assert_response 403
-        end
-      end
-    end
-
-    def legacy_should_require_fatality_handling_permission_to_access(edition_type, *actions)
       test "requires the ability to handle fatalities to access" do
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
         login_as :writer


### PR DESCRIPTION
## Description

We've had an issue a few times where we've accidentally rendered atemplate built in the GOV.UK Design System with the Bootstrap layout. This is due to pages accidentally being moved into the next release.

This PR couples view rendering with the get_layout method in each controller that conditionally renders the view. If `get_layout` returns `design_system` that is passed downstream to the `preview_design_system?` method.

It then adds a shared test to all admin controllers that still need to be ported to the GOV.UK Design System.

This test checks whether the `get_layout` method is defined on the controller. If not then the test returns as we can be confident it's rendering the `admin` layout

If defined, it creates a user with the "Preview next release" permission, then iterates through each non-inherited controller
action (new create edit update etc.) and checks that get_layout returns "admin".

Once pages are moved into the next release the test will fail and it can be removed.

## Where this doesn't work

If we try to break releases into smaller sections where only some of a controllers actions are going out in a release this wouldn't work as it iterates through all the controller actions. I've manually added exceptions for actions we know are always in the design system (reorder confirm destroy etc.), but if for example a new page was meant to be in the design system in 1. controller but the edit page wasn't, it wouldn't work.

We could adapt this to take an arg which filters out some actions etc. down the line.

This shouldn't be an issue though as all our future releases involve releasing full sections so all the controller actions should port to using the design system at the same time.

## Screenshot of failure

When i moved the roles index action into the design system layout i get this error

<img width="1409" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/97d46a0c-ad28-4e6f-9456-2b5f574b7e30">


## Trello card 

https://trello.com/c/0DVQgb9L/241-add-test-which-ensures-that-views-have-use-the-correct-layout

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
