### PR TITLE
Prepare release 1.9

### DIFF
--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -11,7 +11,7 @@ class Admin::GetInvolvedController < Admin::BaseController
   end
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/policy_groups_controller.rb
+++ b/app/controllers/admin/policy_groups_controller.rb
@@ -45,7 +45,7 @@ class Admin::PolicyGroupsController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -58,10 +58,7 @@ private
   end
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[new create edit update destroy confirm_destroy] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -84,10 +84,7 @@ private
   end
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index confirm_destroy edit update new create] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -62,10 +62,7 @@ class Admin::TakePartPagesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[new create index edit update confirm_destroy update_order] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -78,8 +78,7 @@ private
   end
 
   def get_layout
-    design_system_actions = %w[show index edit update features]
-    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/world_location_news_translations_controller.rb
+++ b/app/controllers/admin/world_location_news_translations_controller.rb
@@ -53,8 +53,7 @@ private
   end
 
   def get_layout
-    design_system_actions = %w[edit create update index confirm_destroy]
-    if preview_design_system?(next_release: false) && design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/views/admin/world_location_news_translations/edit.html.erb
+++ b/app/views/admin/world_location_news_translations/edit.html.erb
@@ -75,8 +75,8 @@
 
             <%= link_to("cancel", admin_world_location_news_translations_path(@world_location_news), class: "govuk-link") %>
           </div>
-        </div>
-      </div>
+        <% end %>
+      <% end %>
     </div>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/test/functional/admin/get_involved_controller_test.rb
+++ b/test/functional/admin/get_involved_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::GetInvolvedControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index returns ok" do
     get :index

--- a/test/functional/admin/policy_groups_controller_test.rb
+++ b/test/functional/admin/policy_groups_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index" do
     group = create(:policy_group)

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "new should display a form for creating an appointment" do
     role = create(:role)

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::RolesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index should display a list of roles" do
     org_one = create(:organisation, name: "org-one")

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index fetches all the take part pages in order" do
     page3 = create(:take_part_page, ordering: 3)

--- a/test/functional/admin/world_location_news_controller_test.rb
+++ b/test/functional/admin/world_location_news_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::WorldLocationNewsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "should return active and inactive world locations in alphabetical order" do
     active = [

--- a/test/functional/admin/world_location_news_translations_controller_test.rb
+++ b/test/functional/admin/world_location_news_translations_controller_test.rb
@@ -12,7 +12,6 @@ class Admin::WorldLocationNewsTranslationsControllerTest < ActionController::Tes
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { world_location_news_id: @world_location }

--- a/test/integration/world_location_integration_test.rb
+++ b/test/integration/world_location_integration_test.rb
@@ -10,9 +10,9 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
 
   before do
     organisation = create(:organisation)
-    managing_editor = create(:managing_editor, organisation:, uid: "user-uid")
+    @managing_editor = create(:managing_editor, organisation:, uid: "user-uid")
 
-    login_as managing_editor
+    login_as @managing_editor
   end
 
   setup do
@@ -115,6 +115,22 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "when updating a world location news with translations, does not make any calls to search api with design system" do
+    @managing_editor.permissions << "Preview next release"
+
+    Sidekiq::Testing.inline! do
+      visit admin_world_location_news_path(@world_location_news)
+      click_link "Translations"
+      click_link "Edit fr"
+      new_mission_statement = "un mission différent"
+      fill_in "world_location_news_mission_statement", with: new_mission_statement
+
+      Whitehall::FakeRummageableIndex.any_instance.expects(:add).never
+
+      click_on "Save"
+    end
+  end
+
   test "when updating the english news page, other translations retains their original values" do
     Sidekiq::Testing.inline! do
       visit edit_admin_world_location_news_path(@world_location_news)
@@ -139,6 +155,27 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       visit admin_world_location_news_path(@world_location_news)
       click_link "Translations"
       click_link "Français"
+      new_mission_statement = "un mission différent"
+      fill_in "world_location_news_mission_statement", with: new_mission_statement
+      new_title = "un titre différent"
+      fill_in "Title", with: new_title
+
+      PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+      Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("en", @original_english_title, @original_english_mission_statement))
+      Services.publishing_api.expects(:put_content).at_least_once.with(@world_location_news.content_id, put_content_hash_containing("fr", new_title, new_mission_statement))
+      Services.publishing_api.expects(:publish).at_least_once
+
+      click_on "Save"
+    end
+  end
+
+  test "when updating a non-english news page, the english version retains its original values with design system" do
+    @managing_editor.permissions << "Preview next release"
+
+    Sidekiq::Testing.inline! do
+      visit admin_world_location_news_path(@world_location_news)
+      click_link "Translations"
+      click_link "Edit fr"
       new_mission_statement = "un mission différent"
       fill_in "world_location_news_mission_statement", with: new_mission_statement
       new_title = "un titre différent"


### PR DESCRIPTION
## Description

This moves pages from the following controllers into the next release 

- World location news
- World location news translation
- Roles
- Get involved
- Role appointments
- Take part pages
- Policy groups

We forced the override to run in all envs and duplicated some integration tests that were missed while porting.

## Trello card 

https://trello.com/c/QLHVuXpF/243-prepare-release-19


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
