### PR TITLE
Topical events about page to gds

### DIFF
--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -29,7 +29,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
 
   def show
     @topical_event_about_page = @topical_event.topical_event_about_page
-    render_design_system(:show, :legacy_show, next_release: false)
+    render_design_system(:show, :legacy_show)
   end
 
   def model_name
@@ -40,7 +40,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
     model_name.humanize
   end
 
-  private
+private
 
   def find_topical_event
     @topical_event = TopicalEvent.friendly.find(params[:topical_event_id])

--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -4,6 +4,8 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
 
   helper_method :model_name, :human_friendly_model_name
 
+  layout :get_layout
+
   def new
     @topical_event_about_page = TopicalEventAboutPage.new
   end
@@ -27,6 +29,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
 
   def show
     @topical_event_about_page = @topical_event.topical_event_about_page
+    render_design_system(:show, :legacy_show, next_release: false)
   end
 
   def model_name
@@ -37,7 +40,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
     model_name.humanize
   end
 
-private
+  private
 
   def find_topical_event
     @topical_event = TopicalEvent.friendly.find(params[:topical_event_id])
@@ -49,5 +52,16 @@ private
 
   def about_page_params
     params.require(:topical_event_about_page).permit(:body, :name, :summary, :read_more_link_text)
+  end
+end
+
+def get_layout
+  design_system_actions = []
+  design_system_actions += %w[show] if preview_design_system?(next_release: false)
+
+  if design_system_actions.include?(action_name)
+    "design_system"
+  else
+    "admin"
   end
 end

--- a/app/helpers/admin/topical_event_helper.rb
+++ b/app/helpers/admin/topical_event_helper.rb
@@ -6,4 +6,24 @@ module Admin::TopicalEventHelper
       "Features" => url_for([:admin, topical_event, :topical_event_featurings]),
     }
   end
+
+  def topical_events_nav_items(topical_event, current_path)
+    [
+      {
+        label: "Details",
+        href: [:admin, topical_event],
+        current: current_path == url_for([:admin, topical_event]),
+      },
+      {
+        label: "About page",
+        href: [:admin, topical_event, :topical_event_about_pages],
+        current: current_path == url_for([:admin, topical_event, :topical_event_about_pages]),
+      },
+      {
+        label: "Features",
+        href: [:admin, topical_event, :topical_event_featurings],
+        current: current_path == url_for([:admin, topical_event, :topical_event_featurings]),
+      },
+    ]
+  end
 end

--- a/app/views/admin/topical_event_about_pages/_form.html.erb
+++ b/app/views/admin/topical_event_about_pages/_form.html.erb
@@ -17,7 +17,7 @@
         } %>
       </fieldset>
 
-      <%= form.save_or_cancel cancel: admin_topical_event_topical_event_about_pages_path(@topical_event, @topical_event_about_page) %>
+      <%= form.save_or_cancel cancel: admin_topical_event_topical_event_about_pages_path(@topical_event) %>
     <% end %>
   </section>
   <div class="col-md-4">

--- a/app/views/admin/topical_event_about_pages/legacy_show.html.erb
+++ b/app/views/admin/topical_event_about_pages/legacy_show.html.erb
@@ -1,0 +1,37 @@
+<% page_title "Read more about #{@topical_event.name}" %>
+
+<% content_for :current_tab do %>
+  <% if @topical_event_about_page.present? %>
+    <table class="<%= model_name %> table">
+      <tr>
+        <th>Name</th>
+        <td class="name"><%= @topical_event_about_page.name %></td>
+      </tr>
+      <tr>
+        <th>Read more link text</th>
+        <td class="read-more-link-text"><%= @topical_event_about_page.read_more_link_text %></td>
+      </tr>
+      <tr>
+        <th>Summary</th>
+        <td class="summary"><%= @topical_event_about_page.summary %></td>
+      </tr>
+      <tr>
+        <th width="20%">Body</th>
+        <td class="body"><%= govspeak_to_html(@topical_event_about_page.body) %></td>
+      </tr>
+    </table>
+
+    <div class="form-actions">
+      <%= link_to "Edit", [:edit, :admin, @topical_event, :topical_event_about_pages], class: "btn btn-lg btn-primary"%>
+    </div>
+  <% else %>
+    <p>
+      <%= @topical_event.name %> doesn’t yet have a page showing more information about it.
+    </p>
+    <div class="form-actions">
+      <%= link_to 'Create', new_admin_topical_event_topical_event_about_pages_path, class: 'btn btn-lg btn-primary' %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= render partial: "admin/topical_events/tab_wrapper", locals: { model: @topical_event } %>

--- a/app/views/admin/topical_event_about_pages/show.html.erb
+++ b/app/views/admin/topical_event_about_pages/show.html.erb
@@ -1,37 +1,58 @@
-<% page_title "Read more about #{@topical_event.name}" %>
-
-<% content_for :current_tab do %>
-  <% if @topical_event_about_page.present? %>
-    <table class="<%= model_name %> table">
-      <tr>
-        <th>Name</th>
-        <td class="name"><%= @topical_event_about_page.name %></td>
-      </tr>
-      <tr>
-        <th>Read more link text</th>
-        <td class="read-more-link-text"><%= @topical_event_about_page.read_more_link_text %></td>
-      </tr>
-      <tr>
-        <th>Summary</th>
-        <td class="summary"><%= @topical_event_about_page.summary %></td>
-      </tr>
-      <tr>
-        <th width="20%">Body</th>
-        <td class="body"><%= govspeak_to_html(@topical_event_about_page.body) %></td>
-      </tr>
-    </table>
-
-    <div class="form-actions">
-      <%= link_to "Edit", [:edit, :admin, @topical_event, :topical_event_about_pages], class: "btn btn-lg btn-primary"%>
-    </div>
-  <% else %>
-    <p>
-      <%= @topical_event.name %> doesn’t yet have a page showing more information about it.
-    </p>
-    <div class="form-actions">
-      <%= link_to 'Create', new_admin_topical_event_topical_event_about_pages_path, class: 'btn btn-lg btn-primary' %>
-    </div>
-  <% end %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_topical_events_path
+  } %>
 <% end %>
+<% content_for :context, "Topical events" %>
+<% content_for :page_title, "Read more about #{@topical_event.name}" %>
+<% content_for :title, @topical_event.name %>
+<% content_for :title_margin_bottom, 4 %>
 
-<%= render partial: "admin/topical_events/tab_wrapper", locals: { model: @topical_event } %>
+<p class="govuk-body"><%= view_on_website_link_for @topical_event, class: "govuk-link" %></p>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "components/secondary_navigation", {
+    aria_label: "Topical Events tabs",
+    items: topical_events_nav_items(@topical_event, request.path)
+  } %>
+</div>
+<% if @topical_event_about_page.present? %>
+  <%= render "govuk_publishing_components/components/summary_list", {
+    title: "About page",
+    items: [
+      {
+        field: "Name",
+        value: @topical_event_about_page.name,
+      },
+      {
+        field: "Read more link text",
+        value: @topical_event_about_page.read_more_link_text,
+      },
+      {
+        field: "Summary",
+        value: @topical_event_about_page.summary,
+      },
+      {
+        field: "Body",
+        value: govspeak_to_html(@topical_event_about_page.body),
+      }
+    ],
+    edit: {
+      href: [:edit, :admin, @topical_event, :topical_event_about_pages],
+      link_text: "Edit",
+    }
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "About page",
+    margin_bottom: 6
+  } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create new about page",
+    href: new_admin_topical_event_topical_event_about_pages_path
+
+  } %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "There is no about page associated with this topical event."
+  } %>
+<% end %>

--- a/app/views/admin/topical_events/show.html.erb
+++ b/app/views/admin/topical_events/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_topical_events_path
+  } %>
+<% end %>
+<% content_for :context, "Topical events" %>
 <% content_for :page_title, @topical_event.name %>
 <% content_for :title, @topical_event.name %>
 <% content_for :title_margin_bottom, 4 %>
@@ -7,21 +13,7 @@
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
     aria_label: "Topical Events tabs",
-    items: [
-      {
-        label: "Details",
-        href: [:admin, @topical_event],
-        current: true,
-      },
-      {
-        label: "About page",
-        href: [:admin, @topical_event, :topical_event_about_pages]
-      },
-      {
-        label: "Features",
-        href: [:admin, @topical_event, :topical_event_featurings]
-      }
-    ]
+    items: topical_events_nav_items(@topical_event, request.path)
   } %>
 </div>
 

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -25,7 +25,11 @@ end
 
 When(/^I add a page of information about the event$/) do
   click_link "About page"
-  click_link "Create"
+  if using_design_system?
+    click_link "Create new about page"
+  else
+    click_link "Create"
+  end
   fill_in "Name", with: "Page about the event"
   fill_in "Read more link text", with: "Read more about this event"
   fill_in "Summary", with: "Summary"

--- a/test/functional/admin/legacy_topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/legacy_topical_event_about_pages_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
+class Admin::LegacyTopicalEventAboutPagesControllerTest < ActionController::TestCase
   tests Admin::TopicalEventAboutPagesController
   def setup
     login_as :user

--- a/test/functional/admin/legacy_topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/legacy_topical_event_about_pages_controller_test.rb
@@ -1,9 +1,10 @@
 require "test_helper"
 
 class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
+  tests Admin::TopicalEventAboutPagesController
   def setup
+    login_as :user
     @topical_event = create(:topical_event)
-    login_as_preview_design_system_user(:writer)
   end
 
   view_test "GET show prompts user to create an about page" do

--- a/test/functional/admin/topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/topical_event_about_pages_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
     get :show, params: { topical_event_id: @topical_event.to_param }
     assert_response :success
     assert_select "h1", @topical_event.name
-    assert_select "p", /doesn’t yet have a page/
+    assert_select ".govuk-inset-text", "There is no about page associated with this topical event."
   end
 
   view_test "GET new allows user to enter copy for new about page" do


### PR DESCRIPTION
This PR transits topical events about page to GDS.
It does the following

- Duplicated topical events about page controller and show page to legacy.
- Added new show page with design system.
- Updated topical events details page with back link and caption.
- Added helper method for topical events nav items.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/f3096e07-feff-4b4e-b130-0c8976b25dcc)

![image](https://github.com/alphagov/whitehall/assets/131259138/5b0e31f9-5f91-4ccf-82a3-786994cb4c81)
<img width="1679" alt="Screenshot 2023-06-08 at 12 40 59" src="https://github.com/alphagov/whitehall/assets/131259138/6d6d9f09-e9d5-4b57-9a2e-1c32adbb6080">


**Trello:**
https://trello.com/c/jnDUJnRu/153-about-page
