### PR TITLE
Fix issue with promotional feature item controller rendering templates

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -9,7 +9,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
     @promotional_feature_item = @promotional_feature.promotional_feature_items.build
     @promotional_feature_item.links.build
 
-    render_design_system("new", "legacy_new", next_release: false)
+    render_design_system("new", "legacy_new")
   end
 
   def create
@@ -18,13 +18,13 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
       Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item added."
     else
-      render_design_system("new", "legacy_new", next_release: false)
+      render_design_system("new", "legacy_new")
     end
   end
 
   def edit
     @promotional_feature_item.links.build if @promotional_feature_item.links.empty?
-    render_design_system("edit", "legacy_edit", next_release: false)
+    render_design_system("edit", "legacy_edit")
   end
 
   def update
@@ -39,7 +39,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
       redirect_to_feature "Feature item updated."
     else
-      render_design_system("edit", "legacy_edit", next_release: false)
+      render_design_system("edit", "legacy_edit")
     end
   end
 


### PR DESCRIPTION
This snuck in post the refactor of this method in https://github.com/alphagov/whitehall/pull/7778.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
