### PR TITLE
Remove ordered_contacts from worldwide org

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -43,7 +43,6 @@ module PublishingApi
     def links
       {
         corporate_information_pages:,
-        ordered_contacts: [],
         main_office:,
         home_page_offices:,
         primary_role_person:,

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -77,7 +77,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         worldwide_org.corporate_information_pages[4].content_id,
         worldwide_org.corporate_information_pages[5].content_id,
       ],
-      ordered_contacts: [],
       main_office: [
         worldwide_org.reload.offices.first.content_id,
       ],


### PR DESCRIPTION
Replaced with `main_office` and `home_page_offices`.

We have republished all the WorldwideOrganisation content items in production, so it should be safe to remove this link now.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
