### PR TITLE
Ensure link is built on unsuccessful save of promotional feature items

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -18,6 +18,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
       Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item added."
     else
+      @promotional_feature_item.links.build if @promotional_feature_item.links.blank?
       render_design_system("new", "legacy_new")
     end
   end
@@ -39,6 +40,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
       redirect_to_feature "Feature item updated."
     else
+      @promotional_feature_item.links.build if @promotional_feature_item.links.blank?
       render_design_system("edit", "legacy_edit")
     end
   end

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -43,6 +43,13 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal "Feature item added.", flash[:notice]
   end
 
+  test "POST :create re-renders new and builds link if none are present when the feature item does not save" do
+    post :create, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, promotional_feature_item: { summary: "" } }
+
+    assert_template :new
+    assert_equal 1, assigns(:promotional_feature_item).links.size
+  end
+
   test "GET :edit loads the item and its links renders the template" do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
     link = create(:promotional_feature_link, promotional_feature_item:)
@@ -112,12 +119,13 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
                   } }
   end
 
-  test "PUT :update re-renders edit if the feature item does not save" do
+  test "PUT :update re-renders edit and builds link if none are present when the feature item does not save" do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, summary: "Old summary")
     put :update, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item, promotional_feature_item: { summary: "" } }
 
     assert_template :edit
     assert_equal "Old summary", promotional_feature_item.reload.summary
+    assert_equal 1, assigns(:promotional_feature_item).links.size
   end
 
   test "DELETE :destroy deletes the promotional item and republishes the organisation to the PublishingApi" do


### PR DESCRIPTION
## Description

At the moment, on an unsuccessful save of promotional_feature_item new or edit page, a new link is not built. This causes no fields to render on the page. When you click the Add link button nothing happens as there are no fields to duplicate.

## Screenshots

### Before

<img width="392" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/cee27fd5-a5ac-409e-8ecf-197a0ca5920d">

### After

<img width="641" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7b001d39-c963-4efc-b4ee-17dca12eac91">

## Trello card

https://trello.com/c/xdadGg4B/258-adding-part-functionality-doesnt-work-when-error-message-appears

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
