### PR TITLE
Add Features page for organisations

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -45,13 +45,18 @@ class Admin::OrganisationsController < Admin::BaseController
 
   def features
     @feature_list = @organisation.load_or_create_feature_list(params[:locale])
+    @locale = Locale.new(params[:locale] || :en)
 
     filtering_organisation = params[:organisation] || @organisation.id
 
     filter_params = params.slice(:page, :type, :author, :title)
                           .permit!
                           .to_h
-                          .merge(state: "published", organisation: filtering_organisation)
+                          .merge(
+                            state: "published",
+                            organisation: filtering_organisation,
+                            per_page: preview_design_system?(next_release: false) ? Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE : nil,
+                          )
 
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @featurable_topical_events = TopicalEvent.active
@@ -60,7 +65,7 @@ class Admin::OrganisationsController < Admin::BaseController
     if request.xhr?
       render partial: "admin/feature_lists/legacy_search_results", locals: { feature_list: @feature_list }
     else
-      render :legacy_features
+      render_design_system(:features, :legacy_features)
     end
   end
 
@@ -88,7 +93,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index show] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index show features] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -61,7 +61,7 @@ module Admin::EditionsHelper
           {
             text: organisation.select_name,
             value: organisation.id,
-            selected: selected_organisation == organisation.id.to_s,
+            selected: selected_organisation.to_s == organisation.id.to_s,
           }
         end,
       ],
@@ -71,7 +71,7 @@ module Admin::EditionsHelper
           {
             text: organisation.select_name,
             value: organisation.id,
-            selected: selected_organisation == organisation.id.to_s,
+            selected: selected_organisation.to_s == organisation.id.to_s,
           }
         end,
       ],

--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -63,7 +63,7 @@ module Admin::OrganisationHelper
     tabs << {
       label: "Features",
       href: features_admin_organisation_path(organisation, locale: I18n.default_locale),
-      current: current_path == features_admin_organisation_path(organisation, locale: I18n.default_locale),
+      current: current_path == features_admin_organisation_path(organisation, locale: I18n.default_locale) || current_path == features_admin_organisation_path(organisation),
     }
 
     organisation.non_english_translated_locales.each do |locale|

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -1,0 +1,68 @@
+<% content_for :page_title, @organisation.name %>
+<% content_for :title, @organisation.name %>
+<% content_for :context, "Organisation" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<p class="govuk-body">
+  <%= view_on_website_link_for @organisation, url: { locale: I18n.default_locale }, class: "govuk-link" %>
+</p>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "components/secondary_navigation", {
+    aria_label: "Organisation navigation tabs",
+    items: secondary_navigation_tabs_items(@organisation, request.path)
+  } %>
+</div>
+
+<%= render "govuk_publishing_components/components/tabs", {
+  tabs: [
+    {
+      id: "currently_featured_tab",
+      label: "Currently featured",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "organisation-features-tab",
+        "track-label": "Currently featured"
+      },
+      content: render(Admin::CurrentlyFeaturedTabComponent.new(
+        features: @feature_list.features.current,
+        maximum_featured_documents: @organisation.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT
+      ))
+    },
+    {
+      id: "documents_tab",
+      label: "Documents",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "organisation-features-tab",
+        "track-label": "Documents"
+      },
+      content: render("admin/shared/featurable_editions",
+        filter: @filter,
+        paginator: @filter.editions(@feature_list.locale),
+        featurable_editions: featurable_editions_for_feature_list(@filter.editions(@feature_list.locale), @feature_list),
+        filter_by: [:title, :type, :author, :organisation],
+        anchor: "#documents_tab",
+        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable]),
+        feature_path: [:new, :admin, @feature_list, :feature],
+      ),
+    },
+    {
+      id: "non_govuk_government_links_tab",
+      label: "Non-GOV.UK government links",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "organisation-features-tab",
+        "track-label": "Non-GOV.UK government links"
+      },
+      content: render("admin/feature_lists/featureable_offsite_links",
+        model: @organisation,
+        featurable_offsite_links: featurable_offsite_links_for_feature_list(@featurable_offsite_links, @feature_list),
+        featuring_path: [:new, :admin, @feature_list, :feature],
+      ),
+    }
+  ]
+} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,9 @@ Whitehall::Application.routes.draw do
             get :people
           end
           resources :financial_reports, except: [:show]
-          resources :offsite_links
+          resources :offsite_links do
+            get :confirm_destroy, on: :member
+          end
         end
         resources :corporate_information_pages, only: [] do
           resources :attachments, except: [:show] do

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -27,7 +27,7 @@ Feature: Administering Organisations
     When I add the offsite link "Offsite Thing" of type "Alert" to the organisation "Ministry of Pop"
     Then I should see the edit offsite link "Offsite Thing" on the "Ministry of Pop" organisation page
 
-  @javascript
+  @javascript @bootstrap-only
   Scenario: Filtering items to feature on an organisation page
     Given an organisation and some documents exist
     When I go to the organisation feature page

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -89,11 +89,22 @@ end
 When(/^I add the offsite link "(.*?)" of type "(.*?)" to the organisation "(.*?)"$/) do |title, type, organisation_name|
   organisation = Organisation.find_by!(name: organisation_name)
   visit features_admin_organisation_path(organisation)
-  click_link "Create a non-GOV.UK government link"
-  fill_in :offsite_link_title, with: title
-  select type, from: "offsite_link_link_type"
-  fill_in :offsite_link_summary, with: "summary"
-  fill_in :offsite_link_url, with: "http://gov.uk"
+
+  if using_design_system?
+    click_link "Create new link"
+
+    fill_in "Title (required)", with: title
+    select type, from: "offsite_link_link_type"
+    fill_in "Summary (required)", with: "Summary"
+    fill_in "URL (required)", with: "https://www.gov.uk/jobsearch"
+  else
+    click_link "Create a non-GOV.UK government link"
+    fill_in :offsite_link_title, with: title
+    select type, from: "offsite_link_link_type"
+    fill_in :offsite_link_summary, with: "summary"
+    fill_in :offsite_link_url, with: "http://gov.uk"
+  end
+
   click_button "Save"
 end
 
@@ -108,11 +119,17 @@ Then(/^there should not be an organisation called "([^"]*)"$/) do |name|
 end
 
 Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" organisation page$/) do |title, organisation_name|
-  organisation = Organisation.find_by!(name: organisation_name)
-  offsite_link = OffsiteLink.find_by!(title:)
-  visit admin_organisation_path(organisation)
-  click_link "Features"
-  expect(page).to have_link(title, href: edit_admin_organisation_offsite_link_path(organisation.slug, offsite_link.id))
+  if using_design_system?
+    within "#non_govuk_government_links_tab" do
+      expect(find("table td:first").text).to eq title
+    end
+  else
+    organisation = Organisation.find_by!(name: organisation_name)
+    offsite_link = OffsiteLink.find_by!(title:)
+    visit admin_organisation_path(organisation)
+    click_link "Features"
+    expect(page).to have_link(title, href: edit_admin_organisation_offsite_link_path(organisation.slug, offsite_link.id))
+  end
 end
 
 def navigate_to_organisation(page_name)

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -451,7 +451,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     get :features, params: { id: organisation, locale: "en" }
     assert_response :success
 
-    selected_organisation = css_select('#organisation option[selected="selected"]')
+    selected_organisation = css_select('#organisation_filter option[selected="selected"]')
     assert_equal selected_organisation.text, organisation.name
   end
 

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -480,6 +480,6 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     create(:feature_list, locale: :en, featurable: organisation, features: [first_feature])
     get :features, params: { id: organisation }
 
-    assert_match(/Please note that you can only feature a maximum of 6 documents.*/, response.body)
+    assert_match(/A maximum of 6 documents will be featured on GOV.UK.*/, response.body)
   end
 end


### PR DESCRIPTION
## Description

This reuses the functionality build in previous PRs to add the organisation#features page in the GOV.UK Design System.  It adds 3 tabs, currently featured, documents and offsite links.

It also adds a confirm destroy endpoint for offsite links. The reorder endpoint has already been setup.

## Screenshots

<img width="532" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/86bbfea6-6e1b-4665-88a9-c25e76c374d2">

<img width="564" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8cec1cb7-9a04-430e-be70-0792beadf176">

<img width="464" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e81cfed3-7933-46d3-8d67-37ee27a12fb7">

## Trello card 

https://trello.com/c/6agml0rk/256-currently-featured

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
