### PR TITLE
Topical events About Edit page to GDS

### DIFF
--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -23,7 +23,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
     if @topical_event_about_page.update(about_page_params)
       redirect_to admin_topical_event_topical_event_about_pages_path, notice: "About page saved"
     else
-      render action: "edit"
+      render_design_system(:edit, :legacy_edit)
     end
   end
 
@@ -57,7 +57,7 @@ end
 
 def get_layout
   design_system_actions = []
-  design_system_actions += %w[show] if preview_design_system?(next_release: false)
+  design_system_actions += %w[show edit] if preview_design_system?(next_release: false)
 
   if design_system_actions.include?(action_name)
     "design_system"

--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -57,7 +57,7 @@ end
 
 def get_layout
   design_system_actions = []
-  design_system_actions += %w[show edit] if preview_design_system?(next_release: false)
+  design_system_actions += %w[show edit update] if preview_design_system?(next_release: false)
 
   if design_system_actions.include?(action_name)
     "design_system"

--- a/app/views/admin/topical_event_about_pages/_form.html.erb
+++ b/app/views/admin/topical_event_about_pages/_form.html.erb
@@ -1,26 +1,54 @@
-<div class="row">
-  <section class="col-md-8">
-    <h1><%= page_title %></h1>
-
-    <p class="warning">Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.</p>
-
-    <%= form_for [@topical_event, @topical_event_about_page], url: url do |form| %>
-      <%= form.errors %>
-      <fieldset>
-        <%= form.text_field :name, required: true %>
-        <%= form.text_field :read_more_link_text, required: true %>
-      </fieldset>
-      <fieldset>
-        <%= form.text_area :summary, rows: 5, required: true %>
-        <%= form.text_area :body, rows: 20, required: true, class: "previewable", data: {
-          module: "paste-html-to-govspeak"
-        } %>
-      </fieldset>
-
-      <%= form.save_or_cancel cancel: admin_topical_event_topical_event_about_pages_path(@topical_event) %>
-    <% end %>
-  </section>
-  <div class="col-md-4">
-    <%= legacy_simple_formatting_sidebar %>
+<%= form_with model: topical_event_about_page, url: admin_topical_event_topical_event_about_pages_path(topical_event_about_page.topical_event) do |form| %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Name (required)",
+      heading_size: "l"
+    },
+    value: topical_event_about_page.name,
+    name: "topical_event_about_page[name]",
+    id: "topical_event_about_page_name",
+    error_items: errors_for(topical_event_about_page.errors, :name)
+  }
+  %>
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        text: "Read more link text (required)",
+        heading_size: "l"
+      },
+      value: topical_event_about_page.read_more_link_text,
+      name: "topical_event_about_page[read_more_link_text]",
+      error_items: errors_for(topical_event_about_page.errors, :read_more_link_text)
+    },
+    maxlength: 255,
+    id: "topical_event_about_page_read_more_link_text",
+  } %>
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      heading_size: "l",
+      text: "Summary (required)",
+    },
+    value: topical_event_about_page.summary,
+    heading_size: "l",
+    name: "topical_event_about_page[summary]",
+    id: "topical_event_about_page_summary",
+    error_items: errors_for(topical_event_about_page.errors, :summary)
+  } %>
+  <%= render "components/govspeak-editor", {
+    label: {
+      text: "Body",
+      heading_size: "l"
+    },
+    id: "topical_event_about_page_body",
+    name: "topical_event_about_page[body]",
+    value: topical_event_about_page.body,
+    rows: 20,
+    error_items: errors_for(topical_event_about_page.errors, :body)
+  } %>
+  <div class="govuk-button-group govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save"
+    } %>
+    <%= link_to("Cancel", admin_topical_events_path, class: "govuk-link") %>
   </div>
-</div>
+<% end %>

--- a/app/views/admin/topical_event_about_pages/_legacy_form.html.erb
+++ b/app/views/admin/topical_event_about_pages/_legacy_form.html.erb
@@ -1,0 +1,26 @@
+<div class="row">
+  <section class="col-md-8">
+    <h1><%= page_title %></h1>
+
+    <p class="warning">Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.</p>
+
+    <%= form_for [@topical_event, @topical_event_about_page], url: url do |form| %>
+      <%= form.errors %>
+      <fieldset>
+        <%= form.text_field :name, required: true %>
+        <%= form.text_field :read_more_link_text, required: true %>
+      </fieldset>
+      <fieldset>
+        <%= form.text_area :summary, rows: 5, required: true %>
+        <%= form.text_area :body, rows: 20, required: true, class: "previewable", data: {
+          module: "paste-html-to-govspeak"
+        } %>
+      </fieldset>
+
+      <%= form.save_or_cancel cancel: admin_topical_event_topical_event_about_pages_path(@topical_event) %>
+    <% end %>
+  </section>
+  <div class="col-md-4">
+    <%= legacy_simple_formatting_sidebar %>
+  </div>
+</div>

--- a/app/views/admin/topical_event_about_pages/edit.html.erb
+++ b/app/views/admin/topical_event_about_pages/edit.html.erb
@@ -1,1 +1,23 @@
-<%= render partial: 'form', locals: { page_title: "Edit page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event, @topical_event_about_page) } %>
+<% content_for :page_title, "Edit page about #{@topical_event.name}" %>
+<% content_for :title, "Edit page about #{@topical_event.name}" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @topical_event_about_page)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to topical events appear instantly on the live site."
+    } %>
+    <%= render "form", topical_event_about_page: @topical_event_about_page %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/tabs", {
+      tabs: [
+        {
+          id: "govspeak_tab",
+          label: "Help",
+          content: simple_formatting_sidebar
+        },
+      ]
+    } %>
+  </div>
+</div>

--- a/app/views/admin/topical_event_about_pages/legacy_edit.html.erb
+++ b/app/views/admin/topical_event_about_pages/legacy_edit.html.erb
@@ -1,1 +1,2 @@
-<%= render partial: 'form', locals: { page_title: "Edit page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event, @topical_event_about_page) } %>
+<% content_for :page_title, "Edit page about #{@topical_event.name}" %>
+<%= render partial: 'legacy_form', locals: { page_title: "Edit page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event, @topical_event_about_page) } %>

--- a/app/views/admin/topical_event_about_pages/legacy_edit.html.erb
+++ b/app/views/admin/topical_event_about_pages/legacy_edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'form', locals: { page_title: "Edit page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event, @topical_event_about_page) } %>

--- a/app/views/admin/topical_event_about_pages/new.html.erb
+++ b/app/views/admin/topical_event_about_pages/new.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'form', locals: { page_title: "Create page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event) } %>
+<%= render partial: 'legacy_form', locals: { page_title: "Create page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event) } %>

--- a/test/functional/admin/topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/topical_event_about_pages_controller_test.rb
@@ -29,7 +29,7 @@ class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
   view_test "GET edit shows the form for editing an about page" do
     about = create(:topical_event_about_page, topical_event: @topical_event)
     get :edit, params: { topical_event_id: @topical_event.to_param }
-    assert_select 'textarea[name*="summary"]', text: /#{about.summary}/
+    assert_select ".govuk-form-group", text: /#{about.summary}/
   end
 
   test "PUT update saves changes to the about page" do


### PR DESCRIPTION
This PR transits topical events about edit page to gds.
It does the following:

- Duplicated old edit and form files to legacy and updated controller with design system.
- Added new edit html for topical events about edit page.

**Screen shots:**

![image](https://github.com/alphagov/whitehall/assets/131259138/acf6cf3b-17d3-406e-99d4-12b84767c2d2)

![image](https://github.com/alphagov/whitehall/assets/131259138/16a9c1da-e229-462a-906b-1e9d941aadb0)

![image](https://github.com/alphagov/whitehall/assets/131259138/8f591b8b-30d4-419c-9af8-d29704e6612e)
![image](https://github.com/alphagov/whitehall/assets/131259138/79ef06ad-e0bc-42e6-b202-841480f637b9)

**No About page scenario:**
![image](https://github.com/alphagov/whitehall/assets/131259138/52b3f308-cf9f-470e-a0bc-d416d9e0ea20)

**Trello:**
https://trello.com/c/HjFFamct/152-edit-about-page
