### PR TITLE
Add World Location names to the details for Worldwide Organisations

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -30,6 +30,7 @@ module PublishingApi
           ordered_corporate_information_pages:,
           secondary_corporate_information_pages:,
           social_media_links:,
+          world_location_names:,
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
@@ -186,6 +187,17 @@ module PublishingApi
       return [] unless item.world_locations.any?
 
       item.world_locations.map(&:content_id)
+    end
+
+    def world_location_names
+      return [] unless item.world_locations.any?
+
+      item.world_locations.map do |world_location|
+        {
+          content_id: world_location.content_id,
+          name: world_location.name,
+        }
+      end
     end
   end
 end

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -63,6 +63,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
             title: "Our Facebook Page",
           },
         ],
+        world_location_names: [
+          {
+            content_id: worldwide_org.world_locations.first.content_id,
+            name: worldwide_org.world_locations.first.name,
+          },
+        ],
       },
       analytics_identifier: "WO123",
       update_type: "major",


### PR DESCRIPTION
In the content item for Worldwide Organisations, we are currently including a link to the world location(s) that are associated with this worldwide organisation.

However the linked content item only includes the location name in English.

We need the location to be included in the language that the page is currently being rendered in.

Therefore adding an additional item in `details` that will include the names in the correct language. We will then map these back to the `links` using the content ID.

### Example for the British Embassy Madrid
Content item for English translation of page:
```
"world_location_names": [
  {
    "name": "Spain",
    "content_id": "5e9f204e-7706-11e4-a3cb-005056011aef"
  }
],
```

Content item for Spanish translation of page:
 ```
"world_location_names": [
  {
    "name": "España",
    "content_id": "5e9f204e-7706-11e4-a3cb-005056011aef"
  }
],
```

[Trello card](https://trello.com/c/lzp59ynE)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
