### PR TITLE
Add tracking to statistics announcement search button

### DIFF
--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -70,6 +70,12 @@
     <%= render "govuk_publishing_components/components/button", {
       text: "Search",
       margin_bottom: 4,
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "statistics-announcements-button",
+        "track-label": "Search"
+      }
     } %>
 
     <p class="govuk-body"><%= link_to "Reset all fields", admin_statistics_announcements_path + "?state=active", class: "govuk-link" %></p>


### PR DESCRIPTION
## Description

Following performance review of the statistics announcement listings page, a recommendation to add tracking to the search button was made.

## Trello card

https://trello.com/c/EgRz8GpE

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
