### PR TITLE
Pass locale into sidebar actions link

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -249,7 +249,7 @@ private
   def add_view_action
     if @edition.publicly_visible?
       actions << link_to("View on website (opens in new tab)",
-                         @edition.public_url,
+                         @edition.public_url(locale: @edition.primary_locale),
                          class: "govuk-link",
                          target: "_blank",
                          rel: "noopener",

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -22,7 +22,18 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "li", count: 3
     assert_selector "button", text: "Create new edition"
     assert_selector "a", text: "View data about page"
-    assert_selector "a", text: "View on website (opens in new tab)"
+    assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
+  end
+
+  test "actions for published edition for non-english document" do
+    current_user = build_stubbed(:user)
+    edition = create(:non_english_published_edition)
+    render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
+
+    assert_selector "li", count: 3
+    assert_selector "button", text: "Create new edition"
+    assert_selector "a", text: "View data about page"
+    assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.document.id}.cy']", text: "View on website (opens in new tab)"
   end
 
   test "actions for submitted edition" do

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -90,6 +90,8 @@ FactoryBot.define do
       after :create, &:refresh_index_if_required
     end
 
+    trait(:non_english) { primary_locale { "cy" } }
+
     trait(:force_published) do
       state { "published" }
       first_published_at { 2.days.ago }
@@ -187,6 +189,7 @@ FactoryBot.define do
   factory :submitted_edition, parent: :edition, traits: [:submitted]
   factory :rejected_edition, parent: :edition, traits: [:rejected]
   factory :published_edition, parent: :edition, traits: [:published]
+  factory :non_english_published_edition, parent: :edition, traits: %i[non_english published]
   factory :deleted_edition, parent: :edition, traits: [:deleted]
   factory :superseded_edition, parent: :edition, traits: [:superseded]
   factory :scheduled_edition, parent: :edition, traits: [:scheduled]


### PR DESCRIPTION
Fixes an issue where non-english editions weren't linking to the public site correctly from the admin interface.

Trello: https://trello.com/c/dmI3Fr77/691-5359625-5357779-translated-pages-broken-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
