### PR TITLE
Topical event  about new page to design system. .

### DIFF
--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -7,7 +7,8 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
   layout :get_layout
 
   def new
-    @topical_event_about_page = TopicalEventAboutPage.new
+    @topical_event_about_page = TopicalEventAboutPage.new(topical_event: @topical_event)
+    render_design_system(:new, :legacy_new)
   end
 
   def create
@@ -15,7 +16,7 @@ class Admin::TopicalEventAboutPagesController < Admin::BaseController
     if @topical_event_about_page.save
       redirect_to admin_topical_event_topical_event_about_pages_path, notice: "About page created"
     else
-      render action: "new"
+      render_design_system("new", "legacy_new")
     end
   end
 
@@ -57,7 +58,7 @@ end
 
 def get_layout
   design_system_actions = []
-  design_system_actions += %w[show edit update] if preview_design_system?(next_release: false)
+  design_system_actions += %w[show new edit update create] if preview_design_system?(next_release: false)
 
   if design_system_actions.include?(action_name)
     "design_system"

--- a/app/views/admin/topical_event_about_pages/edit.html.erb
+++ b/app/views/admin/topical_event_about_pages/edit.html.erb
@@ -1,5 +1,6 @@
-<% content_for :page_title, "Edit page about #{@topical_event.name}" %>
-<% content_for :title, "Edit page about #{@topical_event.name}" %>
+<% content_for :context, "#{@topical_event.name}" %>
+<% content_for :page_title, "Edit about page" %>
+<% content_for :title, "Edit about page" %>
 <% content_for :title_margin_bottom, 6 %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @topical_event_about_page)) %>
 <div class="govuk-grid-row">

--- a/app/views/admin/topical_event_about_pages/legacy_new.html.erb
+++ b/app/views/admin/topical_event_about_pages/legacy_new.html.erb
@@ -1,0 +1,2 @@
+<% content_for :page_title, "Create page about #{@topical_event.name}" %>
+<%= render partial: 'legacy_form', locals: { page_title: "Create page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event) } %>

--- a/app/views/admin/topical_event_about_pages/new.html.erb
+++ b/app/views/admin/topical_event_about_pages/new.html.erb
@@ -1,1 +1,24 @@
-<%= render partial: 'legacy_form', locals: { page_title: "Create page about #{@topical_event.name}", url: admin_topical_event_topical_event_about_pages_path(@topical_event) } %>
+<% content_for :context, "#{@topical_event.name}" %>
+<% content_for :page_title, "New about page" %>
+<% content_for :title, "New about page" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @topical_event_about_page)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to topical events appear instantly on the live site."
+    } %>
+    <%= render "form", topical_event_about_page: @topical_event_about_page %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/tabs", {
+      tabs: [
+        {
+          id: "govspeak_tab",
+          label: "Help",
+          content: simple_formatting_sidebar
+        },
+      ]
+    } %>
+  </div>
+</div>

--- a/test/functional/admin/topical_event_about_pages_controller_test.rb
+++ b/test/functional/admin/topical_event_about_pages_controller_test.rb
@@ -27,9 +27,9 @@ class Admin::TopicalEventAboutPagesControllerTest < ActionController::TestCase
   end
 
   view_test "GET edit shows the form for editing an about page" do
-    about = create(:topical_event_about_page, topical_event: @topical_event)
+    create(:topical_event_about_page, topical_event: @topical_event)
     get :edit, params: { topical_event_id: @topical_event.to_param }
-    assert_select ".govuk-form-group", text: /#{about.summary}/
+    assert_select 'textarea[name*="summary"]'
   end
 
   test "PUT update saves changes to the about page" do


### PR DESCRIPTION
This PR transits new topical event about page to gds.
It does the following.

- Duplicates existing new topical event about page to legacy.
- Added design system logic to the controller.
- Created new topical event about page.
- Fixed the existing tests.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/973852b4-c0db-49d7-98fb-a694bcd91ee2)
![image](https://github.com/alphagov/whitehall/assets/131259138/69608d7b-018c-463e-bfd4-9e177c4e2c9a)
![image](https://github.com/alphagov/whitehall/assets/131259138/8bfb8c9f-c5ea-4cf4-8f6c-3d880123cf28)

**With errors:**
![image](https://github.com/alphagov/whitehall/assets/131259138/9ca1b3a7-45c1-43c9-9f78-6c6b4b5c25e1)

**With success message:**
![image](https://github.com/alphagov/whitehall/assets/131259138/7c0f54f2-a70a-48a2-acd1-69fac09cc52a)

**Trello:**
https://trello.com/c/lOEiufQ0/271-new-about-page
