### PR TITLE
Create a topical event organisations sub nav tab and page

### DIFF
--- a/app/controllers/admin/topical_event_organisations_controller.rb
+++ b/app/controllers/admin/topical_event_organisations_controller.rb
@@ -15,6 +15,18 @@ class Admin::TopicalEventOrganisationsController < Admin::BaseController
     redirect_to polymorphic_path([:admin, @topical_event, :topical_event_organisations]), notice: "Lead organisations have been reordered."
   end
 
+  def toggle_lead
+    topical_event_organisation = TopicalEventOrganisation.find(params[:id])
+    lead = topical_event_organisation.lead
+    @topical_event.topical_event_organisations.find(topical_event_organisation.id).update!(
+      lead ? { lead: false, lead_ordering: nil } : { lead: true, lead_ordering: @topical_event.lead_topical_event_organisations.count },
+    )
+
+    Whitehall::PublishingApi.republish_async(@topical_event)
+
+    redirect_to polymorphic_path([:admin, @topical_event, :topical_event_organisations]), notice: "#{topical_event_organisation.organisation.name} has been assigned as a #{lead ? 'supporting' : 'lead'} organisation."
+  end
+
 private
 
   def load_topical_event

--- a/app/controllers/admin/topical_event_organisations_controller.rb
+++ b/app/controllers/admin/topical_event_organisations_controller.rb
@@ -1,0 +1,6 @@
+class Admin::TopicalEventOrganisationsController < Admin::BaseController
+  layout "design_system"
+  def index
+    @topical_event = TopicalEvent.find(params[:topical_event_id])
+  end
+end

--- a/app/controllers/admin/topical_event_organisations_controller.rb
+++ b/app/controllers/admin/topical_event_organisations_controller.rb
@@ -1,6 +1,23 @@
 class Admin::TopicalEventOrganisationsController < Admin::BaseController
+  before_action :load_topical_event
   layout "design_system"
-  def index
+  def index; end
+
+  def reorder; end
+
+  def order
+    params[:ordering].each do |topical_event_organisation_id, ordering|
+      @topical_event.topical_event_organisations.where(lead: true).find(topical_event_organisation_id).update_column(:lead_ordering, ordering)
+    end
+
+    Whitehall::PublishingApi.republish_async(@topical_event)
+
+    redirect_to polymorphic_path([:admin, @topical_event, :topical_event_organisations]), notice: "Lead organisations have been reordered."
+  end
+
+private
+
+  def load_topical_event
     @topical_event = TopicalEvent.find(params[:topical_event_id])
   end
 end

--- a/app/helpers/admin/topical_event_helper.rb
+++ b/app/helpers/admin/topical_event_helper.rb
@@ -15,6 +15,11 @@ module Admin::TopicalEventHelper
         current: current_path == url_for([:admin, topical_event]),
       },
       {
+        label: "Organisations",
+        href: [:admin, topical_event, :topical_event_organisations],
+        current: current_path == url_for([:admin, topical_event, :topical_event_organisations]),
+      },
+      {
         label: "About page",
         href: [:admin, topical_event, :topical_event_about_pages],
         current: current_path == url_for([:admin, topical_event, :topical_event_about_pages]),

--- a/app/views/admin/topical_event_organisations/_organisations_table.html.erb
+++ b/app/views/admin/topical_event_organisations/_organisations_table.html.erb
@@ -18,7 +18,7 @@
          },
          {
            text: link_to(sanitize("View #{tag.span(topical_event_organisation.organisation.name, class: "govuk-visually-hidden")}"), [:admin, topical_event_organisation.organisation], class: "govuk-link") +
-             link_to(sanitize((lead ? "Make supporting " : "Make lead ") + tag.span(topical_event_organisation.organisation.name, class: "govuk-visually-hidden")), "make_link", class: "govuk-link govuk-!-margin-left-2"),
+               link_to(sanitize((lead ? "Make supporting " : "Make lead ") + tag.span(topical_event_organisation.organisation.name, class: "govuk-visually-hidden")), toggle_lead_admin_topical_event_topical_event_organisation_path(@topical_event, topical_event_organisation), class: "govuk-link govuk-!-margin-left-2")
          }
         ]
       end

--- a/app/views/admin/topical_event_organisations/_organisations_table.html.erb
+++ b/app/views/admin/topical_event_organisations/_organisations_table.html.erb
@@ -1,0 +1,25 @@
+<div id=<%= lead ? "lead_organisations" : "supporting_organisations"%>>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half govuk-heading-s">
+      <%= lead ? "Lead organisations" : "Supporting organisations" %>
+    </div>
+    <div class="govuk-grid-column-one-half govuk-!-text-align-right">
+      <%= link_to sanitize("Reorder organisations #{tag.span(lead ? "lead" : "supporting", class: "govuk-visually-hidden")}"), "reorder_link", class: "govuk-link" %>
+    </div>
+  </div>
+  <div class="govuk-table--with-actions">
+    <%= render "govuk_publishing_components/components/table", {
+      first_cell_is_header: true,
+      rows: @topical_event.topical_event_organisations.where(lead: lead).map do |topical_event_organisation|
+        [{
+           text: topical_event_organisation.organisation.name,
+         },
+         {
+           text: link_to(sanitize("View #{tag.span(topical_event_organisation.organisation.name, class: "govuk-visually-hidden")}"), [:admin, topical_event_organisation.organisation], class: "govuk-link") +
+             link_to(sanitize((lead ? "Make supporting " : "Make lead ") + tag.span(topical_event_organisation.organisation.name, class: "govuk-visually-hidden")), "make_link", class: "govuk-link govuk-!-margin-left-2"),
+         }
+        ]
+      end
+    } %>
+  </div>
+</div>

--- a/app/views/admin/topical_event_organisations/_organisations_table.html.erb
+++ b/app/views/admin/topical_event_organisations/_organisations_table.html.erb
@@ -1,6 +1,6 @@
-<div id=<%= lead ? "lead_organisations" : "supporting_organisations"%>>
+<div id=<%= lead ? "lead_organisations" : "supporting_organisations"%> class="govuk-!-padding-bottom-20">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half govuk-heading-s">
+    <div class="govuk-grid-column-one-half govuk-heading-m">
       <%= lead ? "Lead organisations" : "Supporting organisations" %>
     </div>
     <% if lead && @topical_event.lead_topical_event_organisations.many? %>
@@ -9,7 +9,7 @@
       </div>
     <% end %>
   </div>
-  <div class="govuk-table--with-actions">
+  <div class="govuk-table--with-actions govuk-!-padding-bottom-4">
     <%= render "govuk_publishing_components/components/table", {
       first_cell_is_header: true,
       rows: @topical_event.topical_event_organisations.where(lead: lead).order(lead ? :lead_ordering : :ordering).map do |topical_event_organisation|

--- a/app/views/admin/topical_event_organisations/_organisations_table.html.erb
+++ b/app/views/admin/topical_event_organisations/_organisations_table.html.erb
@@ -3,14 +3,16 @@
     <div class="govuk-grid-column-one-half govuk-heading-s">
       <%= lead ? "Lead organisations" : "Supporting organisations" %>
     </div>
-    <div class="govuk-grid-column-one-half govuk-!-text-align-right">
-      <%= link_to sanitize("Reorder organisations #{tag.span(lead ? "lead" : "supporting", class: "govuk-visually-hidden")}"), "reorder_link", class: "govuk-link" %>
-    </div>
+    <% if lead && @topical_event.lead_topical_event_organisations.many? %>
+      <div class="govuk-grid-column-one-half govuk-!-text-align-right">
+        <%= link_to "Reorder organisations", reorder_admin_topical_event_topical_event_organisations_path(@topical_event), class: "govuk-link" %>
+      </div>
+    <% end %>
   </div>
   <div class="govuk-table--with-actions">
     <%= render "govuk_publishing_components/components/table", {
       first_cell_is_header: true,
-      rows: @topical_event.topical_event_organisations.where(lead: lead).map do |topical_event_organisation|
+      rows: @topical_event.topical_event_organisations.where(lead: lead).order(lead ? :lead_ordering : :ordering).map do |topical_event_organisation|
         [{
            text: topical_event_organisation.organisation.name,
          },

--- a/app/views/admin/topical_event_organisations/index.html.erb
+++ b/app/views/admin/topical_event_organisations/index.html.erb
@@ -19,6 +19,8 @@
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Organisations",
+  heading_level: 2,
+  font_size: "l",
   margin_bottom: @topical_event.topical_event_organisations.any? ? 6 : 0,
 } %>
 

--- a/app/views/admin/topical_event_organisations/index.html.erb
+++ b/app/views/admin/topical_event_organisations/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_topical_events_path
+  } %>
+<% end %>
+<% content_for :page_title, @topical_event.name %>
+<% content_for :title, @topical_event.name %>
+<% content_for :context, "Topical events" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<p class="govuk-body"><%= view_on_website_link_for @topical_event, class: "govuk-link" %></p>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= render "components/secondary_navigation", {
+    aria_label: "Document tabs",
+    items: secondary_navigation_tabs_items(@topical_event, request.path)
+  } %>
+</div>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Organisations",
+  margin_bottom: @topical_event.topical_event_organisations.any? ? 6 : 0,
+} %>
+
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @topical_event.lead_topical_event_organisations.any? %>
+      <%= render "organisations_table", lead: true %>
+    <% end %>
+    <% if @topical_event.topical_event_organisations.where(lead: false).any? %>
+      <%= render "organisations_table", lead: false %>
+    <% end %>
+    <% if @topical_event.topical_event_organisations.none? %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "There are no organisations associated with this topical event."
+      } %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/admin/topical_event_organisations/reorder.html.erb
+++ b/app/views/admin/topical_event_organisations/reorder.html.erb
@@ -1,8 +1,3 @@
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_topical_event_topical_event_organisations_path(@topical_event)
-  } %>
-<% end %>
 <% content_for :page_title, "Reorder lead organisations list" %>
 <% content_for :title, "Reorder lead organisations list" %>
 <% content_for :context, @topical_event.name %>

--- a/app/views/admin/topical_event_organisations/reorder.html.erb
+++ b/app/views/admin/topical_event_organisations/reorder.html.erb
@@ -1,0 +1,40 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_topical_event_topical_event_organisations_path(@topical_event)
+  } %>
+<% end %>
+<% content_for :page_title, "Reorder lead organisations list" %>
+<% content_for :title, "Reorder lead organisations list" %>
+<% content_for :context, @topical_event.name %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: order_admin_topical_event_topical_event_organisations_path(@topical_event), method: :put do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
+      <%= hidden_field_tag "lead", params[:lead] %>
+
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @topical_event.topical_event_organisations.where(lead: true).order(:lead_ordering).map do |topical_event_organisation|
+          {
+            id: topical_event_organisation.id,
+            title: topical_event_organisation.organisation.name,
+            value: topical_event_organisation.ordering
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order",
+        } %>
+
+        <%= link_to("Cancel", admin_topical_event_topical_event_organisations_path(@topical_event), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,7 @@ Whitehall::Application.routes.draw do
             put :order, on: :collection
             get :confirm_destroy, on: :member
           end
+          resources :topical_event_organisations, path: "organisations", only: %i[index]
           resources :offsite_links do
             get :confirm_destroy, on: :member
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,10 @@ Whitehall::Application.routes.draw do
             put :order, on: :collection
             get :confirm_destroy, on: :member
           end
-          resources :topical_event_organisations, path: "organisations", only: %i[index]
+          resources :topical_event_organisations, path: "organisations" do
+            get :reorder, on: :collection
+            put :order, on: :collection
+          end
           resources :offsite_links do
             get :confirm_destroy, on: :member
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Whitehall::Application.routes.draw do
           resources :topical_event_organisations, path: "organisations" do
             get :reorder, on: :collection
             put :order, on: :collection
+            get :toggle_lead, on: :member
           end
           resources :offsite_links do
             get :confirm_destroy, on: :member

--- a/features/step_definitions/topical_event_featurings_steps.rb
+++ b/features/step_definitions/topical_event_featurings_steps.rb
@@ -1,7 +1,3 @@
-And(/^a topical event called "([^"]*)" exists$/) do |name|
-  @topical_event = create(:topical_event, name:)
-end
-
 Given(/^the topical event has an offsite link with the title "([^"]*)"$/) do |title|
   create(:offsite_link, parent_type: "TopicalEvent", parent: @topical_event, title:)
 end

--- a/features/step_definitions/topical_event_organisations_steps.rb
+++ b/features/step_definitions/topical_event_organisations_steps.rb
@@ -38,6 +38,10 @@ Then(/^the lead organisations should be in the following order:$/) do |expected_
   end
 end
 
+And(/^I make "([^"]*)" a (lead|supporting) organisation$/) do |name, organisation_type|
+  click_link "Make #{organisation_type} #{name}"
+end
+
 Then(/^I can see a "([^"]*)" success notice$/) do |message|
   expect(find(".gem-c-success-alert__message").text).to eq message
 end

--- a/features/step_definitions/topical_event_organisations_steps.rb
+++ b/features/step_definitions/topical_event_organisations_steps.rb
@@ -9,6 +9,35 @@ end
 
 Then(/^I can see the (lead|supporting) organisation with the name "([^"]*)"$/) do |organisation_type, name|
   within "##{organisation_type}_organisations" do
-    expect(find("table th:first").text).to eq name
+    organisations = all("table th").map(&:text)
+    expect(organisations).to include name
   end
+end
+
+And(/^I set the order of (lead|supporting) organisations to:$/) do |organisation_type, organisations_order|
+  within "##{organisation_type}_organisations" do
+    click_link "Reorder organisations"
+  end
+
+  organisations_order.hashes.each do |hash|
+    topical_event_organisation = @topical_event.topical_event_organisations.where(lead: organisation_type == "lead").select { |f| f.organisation.name == hash[:name] }.first
+    fill_in "ordering[#{topical_event_organisation.id}]", with: hash[:order]
+  end
+
+  click_button "Update order"
+end
+
+Then(/^the lead organisations should be in the following order:$/) do |expected_organisations_order|
+  within "#lead_organisations" do
+    actual_organisations_order = all("table th").map(&:text)
+
+    expected_organisations_order.hashes.each_with_index do |hash, index|
+      topical_event_organisation = @topical_event.topical_event_organisations.where(lead: true).select { |f| f.organisation.name == hash[:name] }.first
+      expect(topical_event_organisation.organisation.name).to eq(actual_organisations_order[index])
+    end
+  end
+end
+
+Then(/^I can see a "([^"]*)" success notice$/) do |message|
+  expect(find(".gem-c-success-alert__message").text).to eq message
 end

--- a/features/step_definitions/topical_event_organisations_steps.rb
+++ b/features/step_definitions/topical_event_organisations_steps.rb
@@ -1,0 +1,14 @@
+And(/^the topical event has a (lead|supporting) organisation called "([^"]*)"$/) do |organisation_type, name|
+  organisation = create(:organisation, name:)
+  @topical_event_organisation = create(:topical_event_organisation, organisation:, topical_event: @topical_event, lead: organisation_type == "lead")
+end
+
+When(/^I visit the topical event organisations index page$/) do
+  visit admin_topical_event_topical_event_organisations_path(@topical_event)
+end
+
+Then(/^I can see the (lead|supporting) organisation with the name "([^"]*)"$/) do |organisation_type, name|
+  within "##{organisation_type}_organisations" do
+    expect(find("table th:first").text).to eq name
+  end
+end

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -1,3 +1,7 @@
+And(/^a topical event called "([^"]*)" exists$/) do |name|
+  @topical_event = create(:topical_event, name:)
+end
+
 Given(/^a topical event called "(.*?)" with summary "([^"]*)" and description "(.*?)"$/) do |name, summary, description|
   @topical_event = create(:topical_event, name:, summary:, description:)
   stub_topical_event_in_content_store(name)

--- a/features/topical_event_organisations.feature
+++ b/features/topical_event_organisations.feature
@@ -1,0 +1,16 @@
+@design-system-only
+Feature:
+  As an Editor.
+  I want to be able to view and manage topical_event_organisations.
+  So that I can order organisations and designate as lead or supporting.
+
+  Background:
+    Given I am a GDS admin
+    And a topical event called "Really topical" exists
+    And the topical event has a lead organisation called "Lead organisation"
+    And the topical event has a supporting organisation called "Supporting organisation"
+
+  Scenario: View topical event organisations
+    When I visit the topical event organisations index page
+    Then I can see the lead organisation with the name "Lead organisation"
+    And I can see the supporting organisation with the name "Supporting organisation"

--- a/features/topical_event_organisations.feature
+++ b/features/topical_event_organisations.feature
@@ -14,3 +14,16 @@ Feature:
     When I visit the topical event organisations index page
     Then I can see the lead organisation with the name "Lead organisation"
     And I can see the supporting organisation with the name "Supporting organisation"
+
+  Scenario: Reorder lead organisations
+    Given the topical event has a lead organisation called "Another lead organisation"
+    When I visit the topical event organisations index page
+    And I set the order of lead organisations to:
+      | name                      | order |
+      | Lead organisation         | 1     |
+      | Another lead organisation | 0     |
+    Then I can see a "Lead organisations have been reordered." success notice
+    And the lead organisations should be in the following order:
+      | name                      |
+      | Another lead organisation |
+      | Lead organisation         |

--- a/features/topical_event_organisations.feature
+++ b/features/topical_event_organisations.feature
@@ -27,3 +27,15 @@ Feature:
       | name                      |
       | Another lead organisation |
       | Lead organisation         |
+
+  Scenario: Make lead organisation
+    When I visit the topical event organisations index page
+    And I make "Supporting organisation" a lead organisation
+    Then I can see a "Supporting organisation has been assigned as a lead organisation." success notice
+    And I can see the lead organisation with the name "Supporting organisation"
+
+  Scenario: Make supporting organisation
+    When I visit the topical event organisations index page
+    And I make "Lead organisation" a supporting organisation
+    Then I can see a "Lead organisation has been assigned as a supporting organisation." success notice
+    And I can see the supporting organisation with the name "Lead organisation"

--- a/test/functional/admin/topical_event_organisations_controller_test.rb
+++ b/test/functional/admin/topical_event_organisations_controller_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Admin::TopicalEventOrganisationsControllerTest < ActionController::TestCase
+  should_be_an_admin_controller
+
+  setup do
+    @topical_event = create(:topical_event)
+    login_as_preview_design_system_user :writer
+  end
+
+  view_test "GET :index renders headings and links" do
+    get :index, params: { topical_event_id: @topical_event }
+
+    assert_template :index
+    assert_response :success
+    assert_select "a[href=?]", admin_topical_events_path, text: "Back"
+    assert_select "h1", @topical_event.name
+    assert_select "a[href=?]", @topical_event.public_url({ cachebust: Time.zone.now.getutc.to_i }), text: "View on website"
+    assert_select "a[href=?]", admin_topical_event_topical_event_organisations_path(@topical_event), text: "Organisations"
+  end
+
+  view_test "GET :index renders lead organisations only" do
+    lead_topical_event_organisations = create_list(:topical_event_organisation, 2, topical_event: @topical_event, lead: true)
+    get :index, params: { topical_event_id: @topical_event }
+
+    check_topical_event_organisations(lead_topical_event_organisations, "lead")
+    refute_select "#supporting_organisations"
+  end
+
+  view_test "GET :index renders lead supporting organisations only" do
+    supporting_topical_event_organisations = create_list(:topical_event_organisation, 2, topical_event: @topical_event)
+    get :index, params: { topical_event_id: @topical_event }
+
+    check_topical_event_organisations(supporting_topical_event_organisations, "supporting")
+    refute_select "#lead_organisations"
+  end
+
+  view_test "GET :index renders no organisations banner" do
+    get :index, params: { topical_event_id: @topical_event }
+
+    assert_template :index
+    assert_response :success
+    assert_select ".govuk-inset-text", "There are no organisations associated with this topical event."
+  end
+
+  def check_topical_event_organisations(topical_event_organisations, type)
+    assert_select "##{type}_organisations" do
+      assert_select ".govuk-heading-s", "#{type.capitalize} organisations"
+      assert_select "a[href=?]", "reorder_link", text: "Reorder organisations #{type}"
+      topical_event_organisations.each do |topical_event_organisation|
+        assert_select "th", topical_event_organisation.organisation.name
+        assert_select "a[href=?]", admin_organisation_path(topical_event_organisation.organisation), text: "View #{topical_event_organisation.organisation.name}"
+        assert_select "a[href=?]", "make_link", text: "Make #{type == 'lead' ? 'supporting' : 'lead'} #{topical_event_organisation.organisation.name}"
+      end
+    end
+  end
+end

--- a/test/functional/admin/topical_event_organisations_controller_test.rb
+++ b/test/functional/admin/topical_event_organisations_controller_test.rb
@@ -60,7 +60,6 @@ class Admin::TopicalEventOrganisationsControllerTest < ActionController::TestCas
 
     assert_template :reorder
     assert_response :success
-    assert_select "a[href=?]", admin_topical_event_topical_event_organisations_path(@topical_event), text: "Back"
     assert_select "h1", "Reorder lead organisations list"
     assert_select ".gem-c-reorderable-list", count: 1
     assert_select ".gem-c-reorderable-list__item", count: 2
@@ -115,7 +114,7 @@ class Admin::TopicalEventOrganisationsControllerTest < ActionController::TestCas
 
   def check_topical_event_organisations(topical_event_organisations, type)
     assert_select "##{type}_organisations" do
-      assert_select ".govuk-heading-s", "#{type.capitalize} organisations"
+      assert_select ".govuk-heading-m", "#{type.capitalize} organisations"
       topical_event_organisations.each do |topical_event_organisation|
         assert_select "th", topical_event_organisation.organisation.name
         assert_select "a[href=?]", admin_organisation_path(topical_event_organisation.organisation), text: "View #{topical_event_organisation.organisation.name}"


### PR DESCRIPTION
## Description

This PR creates an organisations sub nav tab and page for Topical Events using the GOV.UK Design System.

It does the following:

1. Adds topical events organisations index page
2. Adds a reorder topical event organisations page
3. Adds a toggle lead of topical event organisations route

## Screenshots
### Before
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_edit](https://github.com/alphagov/whitehall/assets/91492293/d39c1bc4-6c1f-4d76-9213-2c028de09753)

### After
#### On landing
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations (5)](https://github.com/alphagov/whitehall/assets/91492293/066fc886-11d9-42a1-9bd5-1b83647a9d91)

#### Make supporting (and only one lead organisation - with no reorder link)
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations (6)](https://github.com/alphagov/whitehall/assets/91492293/e476a7b0-d454-4099-b4f6-655a30e4131f)

#### Supporting organisations only
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations (7)](https://github.com/alphagov/whitehall/assets/91492293/80e91995-b109-459e-b08f-50e2382a29ae)

#### Lead organisations only (and make lead message)
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations (8)](https://github.com/alphagov/whitehall/assets/91492293/343fd6ec-d42e-43d5-9f5a-5167d222ab5f)

#### Reorder lead organisations page
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations_reorder (1)](https://github.com/alphagov/whitehall/assets/91492293/74e6effb-d60a-446f-95c6-78ef811c6b73)

#### Organisations after reodering
![whitehall-admin dev gov uk_government_admin_topical-events_afghanistan-uk-government-response_organisations (9)](https://github.com/alphagov/whitehall/assets/91492293/16271d80-6717-47af-b070-6225b9000982)

### Trello
https://trello.com/c/vJibQOQM

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
