### PR TITLE
Add captions and standardise confirm destroy pages

### DIFF
--- a/app/views/admin/policy_groups/confirm_destroy.html.erb
+++ b/app/views/admin/policy_groups/confirm_destroy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, @policy_group.name %>
+<% content_for :context, "Groups" %>
 <% content_for :page_title, "Delete group" %>
 <% content_for :title, "Delete group" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/admin/take_part_pages/confirm_destroy.html.erb
+++ b/app/views/admin/take_part_pages/confirm_destroy.html.erb
@@ -1,11 +1,11 @@
-<% content_for :context, @take_part_page.title %>
+<% content_for :context, "Get involved" %>
 <% content_for :page_title, "Delete take part page" %>
 <% content_for :title, "Delete take part page" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this page?</p>
+    <p class="govuk-body govuk-!-margin-bottom-8">Are you sure you want to delete "<%= @take_part_page.title %>"?</p>
 
     <%= form_tag [:admin, :take_part_page], id: @take_part_page_to_change, method: :delete do %>
       <div class="govuk-button-group">


### PR DESCRIPTION
## Description

This updates the captions to be in line with the other pages.

It also updates the copy to on the take part page to use the same pattern as other pages.

## Screenshots

<img width="534" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2a85294c-1df8-4653-a1d4-fafe8c4d7a01">

<img width="403" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e720a725-0f2f-47ca-b528-92db38f68564">

## Trello card

https://trello.com/c/JxBCFr0I/265-design-updates-update-ia
https://trello.com/c/CJp7VGru/264-update-caption-for-groups

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
