### PR TITLE
Fix bug with statistics_announcements form on edit page

### DIFF
--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: [:admin, statistics_announcement] do |form| %>
+<%= form_with model: statistics_announcement, url: [:admin, statistics_announcement] do |form| %>
   <%= form.hidden_field :publication_id %>
   <%= render "govuk_publishing_components/components/radio", {
     heading: "Statistics type (required)",


### PR DESCRIPTION
Currently, on the edit page, when submitted the form tries to post to `/government/admin/statistics_announcements/:id`

and blows up with this error

```
No route matches [POST] "/government/admin/statistics_announcements/earnings-and-employment-from-pay-as-you-earn-real-time-information-uk-december-2023" 

```

This is because the create endpoint lives on `/government/admin/statistics_announcements`

We can ensure the correct behaviour occurs for create and update by passing in the model to the form, it's smart enough to figure out  whether it needs to hit the POST or  PATCH endpoint based on whether the object has been persisted or if it's a new record.

i.e. 
```
if model.persisted? 
 method == :patch
else 
  method == :post
end
```
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
