### PR TITLE
Ensure values are retained on unsuccessful save for release dates

### DIFF
--- a/app/views/admin/statistics_announcement_date_changes/new.html.erb
+++ b/app/views/admin/statistics_announcement_date_changes/new.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @statistics_announcement_date_change, url: admin_statistics_announcement_changes_path(@statistics_announcement) do |form| %>
       <%= render '/admin/shared/release_date', {
-        current_release_date: @statistics_announcement_date_change.current_release_date,
+        current_release_date: @statistics_announcement_date_change,
         name_prefix: @statistics_announcement_date_change.class.name.underscore,
         id_prefix: @statistics_announcement_date_change.class.name.underscore
       } %>


### PR DESCRIPTION
## Description

At the moment, when an unsuccessful save occurs, the values the user input are overridden to the persisted values in the db.
This fixes the issue by passing the date change object in, rather than the release date object.


## Before 
update the radio button 

<img width="520" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d4f1f459-1c2f-4df2-ad38-1fd2114fc2ab">

then save 

<img width="608" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/69cb508b-6608-4062-b027-86061c821cd1">


## After

<img width="738" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0dd83e07-952f-4e32-a6c2-38cdee3610cc">

then save

<img width="723" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/df67ba38-9a5e-4a9e-9fa7-f1dc859cfaf1">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
