### PR TITLE
Fix issue with summary card component

### DIFF
--- a/app/assets/stylesheets/components/_summary-card-component.scss
+++ b/app/assets/stylesheets/components/_summary-card-component.scss
@@ -1,4 +1,4 @@
-.gem-c-summary-card-component {
+.app-c-summary-card-component {
   .govuk-summary-list__key {
     vertical-align: top;
   }


### PR DESCRIPTION
The wrong class was being applied to the stylesheet.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
