### PR TITLE
Move 1.10 pages to next release

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -38,7 +38,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -56,10 +56,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[new create edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -71,9 +71,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[reorder update_order confirm_destroy]
-    design_system_actions += %w[edit update index show new create] if preview_design_system?(next_release: false)
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/statistics_announcement_date_changes_controller.rb
+++ b/app/controllers/admin/statistics_announcement_date_changes_controller.rb
@@ -52,7 +52,7 @@ private
   end
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/statistics_announcement_tags_controller.rb
+++ b/app/controllers/admin/statistics_announcement_tags_controller.rb
@@ -44,7 +44,7 @@ private
   end
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
+++ b/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
@@ -30,7 +30,7 @@ private
   end
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -158,7 +158,7 @@ private
   end
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   def organisation
     @organisation ||= create(:organisation)

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -8,7 +8,6 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :new loads the organisation and feature and instantiates a new item and link" do
     get :new, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature }

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :index returns a 404 if the organisation is not allowed promotional" do
     organisation = create(:ministerial_department)

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -15,7 +15,6 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index with no search value renders search bar only" do
     get :index, params: { statistics_announcement_id: @official_statistics_announcement }

--- a/test/functional/admin/statistics_announcement_tags_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_tags_controller_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class Admin::StatisticsAnnouncementTagsControllerTest < ActionController::TestCase
   include TaxonomyHelper
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   setup do
     @user = login_as_preview_design_system_user(:departmental_editor)

--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -9,7 +9,6 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GDS Editor permission required to unpublish" do
     login_as :departmental_editor


### PR DESCRIPTION
## Description

This PR prepares the following controllers for release:

* Statistics announcement date changes controller
* statistics announcement publications controller
* statistics announcement tags controller
* statistics announcement unpublishings controller
* statistics announcement controller
* promotional feature items controller
* promotional feature controller
* cabinet ministers controller

## Trello
https://trello.com/c/1kHoT4im

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
