### PR TITLE
Ensure connected document view link goes to publication show page

### DIFF
--- a/app/views/admin/statistics_announcements/show/_main.html.erb
+++ b/app/views/admin/statistics_announcements/show/_main.html.erb
@@ -91,7 +91,7 @@
         </div>
         <div class="govuk-grid-column-one-quarter">
           <p class="govuk-body govuk-!-text-align-right">
-            <%= link_to("View", admin_statistics_announcement_publication_index_path(@statistics_announcement),
+            <%= link_to("View", admin_edition_path(@statistics_announcement.publication),
                         class: "govuk-link") %>
           </p>
         </div>

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -123,7 +123,7 @@ Then(/^I should see that the announcement is linked to the publication$/) do
     expect(page).to_not have_link("Add existing document", href: admin_statistics_announcement_publication_index_path(@statistics_announcement))
     expect(page).to_not have_link("create new document", href: new_admin_publication_path(statistics_announcement_id: @statistics_announcement))
     expect(page).to have_content(@statistics_publication.title.to_s)
-    expect(page).to have_link("View", href: admin_statistics_announcement_publication_index_path(@statistics_announcement))
+    expect(page).to have_link("View", href: admin_edition_path(@statistics_publication))
   else
     expect(page).to have_content(
       "Announcement connected to draft document #{@statistics_publication.title}",


### PR DESCRIPTION
## Description

This should go to the publication summary page, not the connect document page

## Screenshot of affected link

<img width="595" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/59270746-ff0a-4ea1-83f0-6d0be44eeefd">

## Trello card 

https://trello.com/c/2e7kYkZk/281-broken-link-when-trying-to-view-document

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
