### PR TITLE
Update promotional feature item confirm destroy  & promotional feature edit pages

### DIFF
--- a/app/views/admin/promotional_feature_items/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_feature_items/confirm_destroy.html.erb
@@ -1,17 +1,17 @@
-<% content_for :context, @organisation.name %>
+<% content_for :context, @promotional_feature.title %>
 <% content_for :page_title, "Delete #{@promotional_feature_item.title}" %>
-<% content_for :title, "Delete #{@promotional_feature_item.title}" %>
+<% content_for :title, "Delete promotional feature item" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_organisation_promotional_feature_item_path(@organisation, @promotional_feature, @promotional_feature_item), method:
       :delete do %>
-      <p class="govuk-body govuk-!-margin-bottom-4">Are you sure you want to
-        delete <%= @promotional_feature_item.title %>
-        item?</p>
+      <p class="govuk-body">
+        Are you sure you want to delete this promotional feature item?
+      </p>
 
-      <div class="govuk-button-group govuk-!-margin-bottom-6">
+      <div class="govuk-button-group govuk-!-margin-top-6">
         <%= render "govuk_publishing_components/components/button", {
           text: "Delete",
           destructive: true,

--- a/app/views/admin/promotional_features/edit.html.erb
+++ b/app/views/admin/promotional_features/edit.html.erb
@@ -1,6 +1,5 @@
-<% page_title "Edit #{@promotional_feature.title} promotional feature" %>
-<% content_for :page_title, "Edit #{@promotional_feature.title} promotional feature" %>
-<% content_for :title, "Edit #{@promotional_feature.title} promotional feature" %>
+<% content_for :page_title, "Rename promotional feature" %>
+<% content_for :title, "Rename promotional feature" %>
 <% content_for :context, @organisation.name %>
 <% content_for :title_margin_bottom, 8 %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @promotional_feature)) %>


### PR DESCRIPTION
## Description 

This does two things:

1. standardises the promotional feature item confirm destroy page
2. updates the title on the promotional features edit page

## Screenshots 

<img width="679" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0560dc11-4794-490b-b1dc-1156c7bfded6">

<img width="703" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0c622b57-e083-4275-b542-2a4deea93308">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
