### PR TITLE
Fixed promotional feature edit page redirection issue

### DIFF
--- a/app/views/admin/promotional_features/edit.html.erb
+++ b/app/views/admin/promotional_features/edit.html.erb
@@ -5,7 +5,7 @@
 <% content_for :title_margin_bottom, 8 %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @promotional_feature)) %>
 
-<%= form_with url: [:admin, @promotional_feature.organisation, @promotional_feature] do |form| %>
+<%= form_with model: @promotional_feature,url: [:admin, @promotional_feature.organisation, @promotional_feature] do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
This PF fixes the redirection error for promotional feature edit page after when click on "Update name" button.

Screen shots:
Before:
![image](https://github.com/alphagov/whitehall/assets/131259138/bf938620-39b7-4bc9-81f6-b5a44d0bcedd)
![image](https://github.com/alphagov/whitehall/assets/131259138/a38e6f44-32ca-437f-84b4-e57d5bba06d8)

After : 
![image](https://github.com/alphagov/whitehall/assets/131259138/04f7ec8b-090a-4fe5-b128-5d42452f5cba)

**Trello:**
https://trello.com/c/N8MRPBOy
https://trello.com/c/2jeyp0uN/283-fix-promotional-feature-edit-page-redirection-error
