### PR TITLE
Add tracking to tabs on feature and featuring pages

### DIFF
--- a/app/views/admin/topical_event_featurings/index.html.erb
+++ b/app/views/admin/topical_event_featurings/index.html.erb
@@ -19,6 +19,12 @@
     {
       id: "currently_featured_tab",
       label: "Currently featured",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "topical-event-featuring-tab",
+        "track-label": "Currently featured"
+      },
       content: render(Admin::CurrentlyFeaturedTabComponent.new(
         featurings: @topical_event_featurings,
         maximum_featured_documents: 5
@@ -27,6 +33,12 @@
     {
       id: "documents_tab",
       label: "Documents",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "topical-event-featuring-tab",
+        "track-label": "Documents"
+      },
       content: render("admin/shared/featurable_editions",
         filter: @filter,
         paginator: @tagged_editions,
@@ -40,6 +52,12 @@
     {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "topical-event-featuring-tab",
+        "track-label": "Non-GOV.UK government links"
+      },
       content: render("admin/feature_lists/featureable_offsite_links",
         model: @topical_event,
         featurable_offsite_links: @topical_event.featurable_offsite_links,

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -19,6 +19,12 @@
     {
       id: "currently_featured_tab",
       label: "Currently featured",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "world-location-news-features-tab",
+        "track-label": "Currently featured"
+      },
       content: render(Admin::CurrentlyFeaturedTabComponent.new(
         features: @feature_list.features.current,
         maximum_featured_documents: @world_location_news.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT
@@ -27,6 +33,12 @@
     {
       id: "documents_tab",
       label: "Documents",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "world-location-news-features-tab",
+        "track-label": "Documents"
+      },
       content: render("admin/shared/featurable_editions",
         filter: @filter,
         paginator: @filter.editions(@feature_list.locale),
@@ -40,6 +52,12 @@
     {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "world-location-news-features-tab",
+        "track-label": "Non-GOV.UK government links"
+      },
       content: render("admin/feature_lists/featureable_offsite_links",
         model: @world_location_news,
         featurable_offsite_links: featurable_offsite_links_for_feature_list(@featurable_offsite_links, @feature_list),


### PR DESCRIPTION
## Description 

We've been asked to do additional tracking to the tabs on the features and topical event featuring pages to see how users interact with the page.

## Events

<img width="289" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/aed504de-0c1f-487c-acb3-4b59c8fa11e7">

<img width="363" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2c3a40e8-cb42-42d4-b900-867ab02dbf61">

<img width="319" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/f25b7f8a-f0ac-48e4-bfe0-a40203e47f80">

<img width="459" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d5e87642-e273-40e2-bbdd-0f93ac1c9218">

<img width="361" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ff9b1c8d-e939-49d1-82be-2f622af03c2b">

<img width="340" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8b9a3e12-e49c-442d-8234-892de27b0be8">

## Trello card

https://trello.com/c/XlTdRBmm/166-add-tracking-to-tabs-on-the-features-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
