### PR TITLE
Allow option to layout to make the title, error summary and banner full width

### DIFF
--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @filter.page_title %>
 <% content_for :title, @filter.page_title %>
+<% content_for :page_full_width, true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -1,11 +1,12 @@
 <% content_for :page_title, @filter.title %>
 <% content_for :title, @filter.title %>
 <% content_for :title_margin_bottom, 0 %>
+<% content_for :page_full_width, true %>
 <% content_for :banner, render("banner", show_banner: show_unlinked_announcements_warning?, count: unlinked_announcements_count, filter: @filter) %>
 
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= render 'warning' %>
 
     <%= render "govuk_publishing_components/components/button", {
@@ -33,4 +34,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -47,15 +47,17 @@
         </div>
       <% end %>
 
+      <% column_width = yield(:page_full_width).present? ? "full" : "two-thirds" %>
+
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-<%= column_width %>">
           <%= yield(:error_summary) %>
         </div>
       </div>
 
       <% if yield(:error_summary).blank? %>
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-grid-column-<%= column_width %>">
             <%= yield(:banner) %>
           </div>
         </div>
@@ -63,7 +65,7 @@
 
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-grid-column-<%= column_width %>">
             <%= render "govuk_publishing_components/components/title", {
               context: yield(:context),
               title: yield(:title),
@@ -71,9 +73,12 @@
               margin_bottom: yield(:title_margin_bottom).present? ? yield(:title_margin_bottom).to_i : nil,
             } %>
           </div>
-          <div class="govuk-grid-column-one-third app-grid-column--align-right">
-            <%= yield(:title_side) %>
-          </div>
+
+          <% if yield(:page_full_width).blank? %>
+            <div class="govuk-grid-column-one-third app-grid-column--align-right">
+              <%= yield(:title_side) %>
+            </div>
+          <% end %>
         </div>
       <% end %>
       <%= yield %>


### PR DESCRIPTION
## Description

Some of our pages are built in full width. When this is the case, the title, error summary and banners should render in full width so the pages look consistent.

This adds this functionality to the design_system layout and applies it in the statistics_announcements index page.

## Screenshots

### Before 

<img width="956" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4554c4b3-6228-4ffd-86c3-64d753a08aa1">

<img width="918" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/1a222478-967b-4c66-8293-22435dd3c8ae">


### After

<img width="862" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/b932ec26-c656-4400-83a6-231d78885bab">

<img width="966" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/de5933d5-a2a3-4ad1-b22e-2ae10dc6eef1">

## Trello card 

https://trello.com/c/ADFHcASv/285-option-for-headers-components-title-insets-notifications-to-be-full-width

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
