### PR TITLE
Move roles translation edit and index pages to the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/role_translations_controller.rb
+++ b/app/controllers/admin/role_translations_controller.rb
@@ -5,13 +5,7 @@ class Admin::RoleTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy index]
-
-    if design_system_actions.include?(action_name)
-      "design_system"
-    else
-      "admin"
-    end
+    "design_system"
   end
 
   def create_redirect_path

--- a/app/controllers/admin/role_translations_controller.rb
+++ b/app/controllers/admin/role_translations_controller.rb
@@ -5,7 +5,7 @@ class Admin::RoleTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
+    design_system_actions = %w[confirm_destroy index]
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/role_translations_controller.rb
+++ b/app/controllers/admin/role_translations_controller.rb
@@ -5,7 +5,13 @@ class Admin::RoleTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    "admin"
+    design_system_actions = %w[confirm_destroy]
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
   end
 
   def create_redirect_path

--- a/app/views/admin/person_translations/edit.html.erb
+++ b/app/views/admin/person_translations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Edit translation for: #{@english_person.name}" %>
 <% content_for :title, "Edit ‘#{@translation_locale.native_language_name}(#{@translation_locale.english_language_name})’ translation for: #{@english_person.name}" %>
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_person)) %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_person, parent_class: "role")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/role_translations/confirm_destroy.html.erb
+++ b/app/views/admin/role_translations/confirm_destroy.html.erb
@@ -1,0 +1,22 @@
+<% content_for :context, @role.name %>
+<% content_for :page_title, "Delete #{@translation_locale.native_and_english_language_name} translation" %>
+<% content_for :title, "Delete translation" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_role_translation_path(@role, @translation_locale), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        Are you sure you want to delete the "<%= @translation_locale.native_and_english_language_name %>" translation for "<%= @role.name %>"?
+      </p>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", admin_role_translations_path(@role), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/role_translations/edit.html.erb
+++ b/app/views/admin/role_translations/edit.html.erb
@@ -1,16 +1,56 @@
-<% page_title "Edit translation for: #{@english_role.name}" %>
+<% content_for :page_title, "Edit translation for: #{@english_role.name}" %>
+<% content_for :title, "Edit ‘#{@translation_locale.native_language_name}(#{@translation_locale.english_language_name})’ translation for: #{@english_role.name}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_role)) %>
 
-<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_role.name %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @translated_role, as: :role, url: admin_role_translation_path(@translated_role, translation_locale) do |form| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Name (required)",
+        },
+        heading_size: "l",
+        name: "role[name]",
+        id: "role_name",
+        value: @translated_role.name,
+        error_items: errors_for(form.object.errors, :name),
+        right_to_left: @translated_role.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
 
-<div class="row">
-  <div class="col-md-8">
-    <%= form_for @translated_role, as: :role, url: admin_role_translation_path(@translated_role, translation_locale), method: :put, html: {class: 'well'} do |form| %>
-      <%= form.errors %>
+      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English name content:</h2>
+      <p class="app-view-translation__english-content govuk-body"><%= @role.name %></p>
 
-      <%= form.translated_text_field :name %>
-      <%= form.translated_text_area :responsibilities, rows: 20 %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "l",
+          text: "Responsibilities",
+        },
+        name: "role[responsibilities]",
+        id: "role_responsibilities",
+        value: @translated_role.responsibilities,
+        rows: 20,
+        error_items: errors_for(form.object.errors, :responsibilities),
+        right_to_left: @translated_role.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
 
-      <%= form.save_or_cancel cancel: admin_role_translations_path(@translated_role) %>
+      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English responsibilities content:</h2>
+      <p class="app-view-translation__english-content govuk-body"><%= @role.responsibilities %></p>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+            "track-label": "Save"
+          }
+        } %>
+
+        <%= link_to "Cancel", admin_role_translations_path(@translated_role), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/role_translations/index.html.erb
+++ b/app/views/admin/role_translations/index.html.erb
@@ -1,42 +1,61 @@
-<% page_title @role.name + " translations" %>
+<% content_for :page_title, "#{@role.name}" %>
+<% content_for :title, @role.name %>
+<% content_for :context, "Roles" %>
+<% content_for :title_margin_bottom, 4 %>
 
-<h1>Translations for <%= @role.name %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= view_on_website_link_for @role, class: "govuk-link" %>
+    </p>
 
-<% if @role.missing_translations.any? %>
-  <%= form_tag admin_role_translations_path(@role) do %>
-    <div class="form-group">
-      <%= label_tag :translation_locale, 'Locale' %>
-      <%= select_locale :translation_locale, @role.missing_translations, {class: 'form-control input-md-3' } %>
-    </div>
-    <%= submit_tag "Create translation", class: "btn btn-primary" %>
-  <% end %>
-<% end %>
-
-<% if @role.non_english_translated_locales.present? %>
-  <table id="role-translations" class="table table-striped table-bordered add-top-margin">
-    <thead>
-      <tr class="table-header">
-        <th>Locale</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @role.non_english_translated_locales.each do |locale| %>
-        <tr>
-          <td class="locale">
-            <%= link_to locale.native_language_name, edit_admin_role_translation_path(@role, locale.code) %>
-          </td>
-          <td class="actions">
-            <%= button_to 'Delete',
-                  admin_role_translation_path(@role, locale.code),
-                  method: :delete,
-                  class: "btn btn-danger",
-                  data: { confirm: "Are you sure you want to delete this translation?" } %>
-          </td>
-        </tr>
+    <% if @role.non_english_translated_locales.present? %>
+      <div class="govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
+            {
+              text: "Locale"
+            },
+            {
+              text: tag.span("Actions", class: "govuk-visually-hidden"),
+            }
+          ],
+          rows: @role.non_english_translated_locales.map do |locale|
+            [
+              {
+                text: locale.native_and_english_language_name
+              },
+              {
+                text: link_to(sanitize("Edit #{tag.span(locale.native_and_english_language_name, class: 'govuk-visually-hidden')}"), edit_admin_role_translation_path(@role, locale.code), class: "govuk-link") +
+                  link_to(sanitize("Delete #{tag.span(locale.native_and_english_language_name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_role_translation_path(@role, locale.code), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")
+              }
+            ]
+          end
+        } %>
+      </div>
+    <% else %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No translations."
+      } %>
+    <% end %>
+    <% if @role.missing_translations.any? %>
+      <%= form_with url: admin_role_translations_path(@role) do %>
+        <%= render "govuk_publishing_components/components/select", {
+          id: "translation_locale",
+          name: "translation_locale",
+          label: "Locale",
+          heading_size: "l",
+          options: @role.missing_translations.map do |locale|
+            {
+              value: locale.code,
+              text: Locale.coerce(locale).native_and_english_language_name,
+            }
+          end
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Create new translation"
+        } %>
       <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p class="no-content no-content-bordered">No translations</p>
-<% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,7 +305,9 @@ Whitehall::Application.routes.draw do
           resources :role_appointments, only: %i[new create edit update destroy], shallow: true do
             get :confirm_destroy, on: :member
           end
-          resources :translations, controller: "role_translations"
+          resources :translations, controller: "role_translations" do
+            get :confirm_destroy, on: :member
+          end
         end
 
         resources :world_location_news, only: %i[index edit update show] do

--- a/features/roles.feature
+++ b/features/roles.feature
@@ -37,6 +37,6 @@ Feature: Administering Roles
     When I add a new "Español" translation to the role "Her Majesty's Ambassador to Spain" with:
       | name             | Su Majestad Embajador en España           |
       | responsibilities | Retrato del Reino Unido en una buena luz. |
-    Then I should see the role translation "Español" with:
+    Then I should see the role translation "Español (Spanish)" with:
       | name             | Su Majestad Embajador en España           |
       | responsibilities | Retrato del Reino Unido en una buena luz. |

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -47,7 +47,7 @@ When(/^I add a new "([^"]*)" translation to the role "([^"]*)" with:$/) do |loca
   end
 
   select locale.native_and_english_language_name, from: "Locale"
-  click_on "Create translation"
+  click_on "Create new translation"
   fill_in "Name", with: translation["name"]
   fill_in "Responsibilities", with: translation["responsibilities"]
   click_on "Save"
@@ -96,7 +96,7 @@ end
 
 Then(/^I should see the role translation "([^"]*)" with:$/) do |locale, table|
   fields = table.rows_hash
-  click_link locale
+  click_link "Edit #{locale}"
   expect(page).to have_selector("input[id=role_name][value='#{fields['name']}']")
   expect(page).to have_selector("#role_responsibilities", text: fields["responsibility"])
 end

--- a/test/functional/admin/role_translations_controller_test.rb
+++ b/test/functional/admin/role_translations_controller_test.rb
@@ -71,7 +71,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   view_test "edit indicates which language is being translated to" do
     create(:role, translated_into: [:fr])
     get :edit, params: { role_id: @role, id: "fr" }
-    assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
+    assert_select "h1", text: /Edit ‘Français\(French\)’ translation/
   end
 
   view_test "edit presents a form to update an existing translation" do
@@ -88,7 +88,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
     assert_select "form[action=?]", translation_path do
       assert_select "input[type=text][name='role[name]'][value=?]", "nom de rôle"
       assert_select "textarea[name='role[responsibilities]']", text: "responsabilités"
-      assert_select "input[type=submit][value=Save]"
+      assert_select "button[type=submit]"
     end
   end
 
@@ -107,11 +107,9 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
 
     translation_path = admin_role_translation_path(role, "ar")
     assert_select "form[action=?]", translation_path do
-      assert_select "fieldset[class='right-to-left']" do
-        assert_select "input[type=text][name='role[name]'][dir='rtl'][value=?]", "دور اسم"
-        assert_select "textarea[name='role[responsibilities]'][dir='rtl']", text: "المسؤوليات"
-      end
-      assert_select "input[type=submit][value=Save]"
+      assert_select "input[type=text][name='role[name]'][dir='rtl'][value=?]", "دور اسم"
+      assert_select "textarea[name='role[responsibilities]'][dir='rtl']", text: "المسؤوليات"
+      assert_select "button[type=submit]"
     end
   end
 
@@ -140,8 +138,9 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
                   } }
 
     translation_path = admin_role_translation_path(@role, "fr")
+
+    assert_select ".govuk-error-summary"
     assert_select "form[action=?]", translation_path do
-      assert_select ".form-errors"
       assert_select "input[type=text][name='role[name]'][value=?]", ""
       assert_select "textarea[name='role[responsibilities]']", text: "responsabilités"
     end

--- a/test/functional/admin/role_translations_controller_test.rb
+++ b/test/functional/admin/role_translations_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
         assert_select "option[value=es]", text: "Español (Spanish)"
       end
 
-      assert_select "input[type=submit]"
+      assert_select "button[type=submit]"
     end
   end
 
@@ -49,7 +49,10 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
     get :index, params: { role_id: role }
 
     edit_translation_path = edit_admin_role_translation_path(role, "fr")
-    assert_select "a[href=?]", edit_translation_path, text: "Français"
+    confirm_destroy_url = confirm_destroy_admin_role_translation_path(role, "fr")
+
+    assert_select "a[href=?]", edit_translation_path, text: "Edit Français (French)"
+    assert_select "a[href=?]", confirm_destroy_url, text: "Delete Français (French)"
   end
 
   view_test "index does not list the english translation" do
@@ -57,16 +60,6 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
 
     edit_translation_path = edit_admin_role_translation_path(@role, "en")
     assert_select "a[href=?]", edit_translation_path, text: "en", count: 0
-  end
-
-  view_test "index displays delete button for a translation" do
-    role = create(:role, translated_into: [:fr])
-
-    get :index, params: { role_id: role }
-
-    assert_select "form[action=?]", admin_role_translation_path(role, :fr) do
-      assert_select "input[type='submit'][value=?]", "Delete"
-    end
   end
 
   test "create redirects to edit for the chosen language" do


### PR DESCRIPTION
## Description

These pages were missed as part of the 1.9 release. Once merged this changes will immediately go live. These pages follow the established pattern for translation pages.

## Screenshots

<img width="654" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/fbdc331f-a702-4f30-a854-d69c0460561d">

<img width="639" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9d79c5d0-869b-492a-8f6a-df349cd44a4e">

<img width="648" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/23a31952-4c13-485c-bfc2-0f82f447a2c8">

## Trello card

https://trello.com/c/kXS12mrP/288-roles-translations-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
