### PR TITLE
Stringify keys in EditionAuthBypassUpdater

### DIFF
--- a/app/services/edition_auth_bypass_updater.rb
+++ b/app/services/edition_auth_bypass_updater.rb
@@ -22,7 +22,7 @@ private
   def update_file_attachments(edition)
     return unless edition.respond_to?(:attachments) && edition.attachments.files.present?
 
-    new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+    new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
     edition.attachments.files.each do |file_attachment|
       attachment_data_id = file_attachment.attachment_data.id
@@ -33,7 +33,7 @@ private
   def update_image_attachments(edition)
     edition.images.each do |image|
       image_data_id = image.image_data.id
-      new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
       AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ImageData", image_data_id, new_attributes)
     end
   end
@@ -44,14 +44,14 @@ private
     if edition.consultation_participation&.consultation_response_form.present?
       response_form = edition.consultation_participation.consultation_response_form
       response_form_data_id = response_form.consultation_response_form_data.id
-      new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ConsultationResponseFormData", response_form_data_id, new_attributes)
     end
 
     if edition.outcome.present?
       edition.outcome.attachments.files.each do |file_attachment|
-        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
         attachment_data_id = file_attachment.attachment_data.id
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
       end
@@ -59,7 +59,7 @@ private
 
     if edition.public_feedback.present?
       edition.public_feedback.attachments.files.each do |file_attachment|
-        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
         attachment_data_id = file_attachment.attachment_data.id
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
       end

--- a/test/unit/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/services/editon_auth_bypass_updater_test.rb
@@ -35,7 +35,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       file_attachment = create(:file_attachment, attachable: edition)
 
       SecureRandom.stubs(uuid: uid)
-      expected_attributes = { auth_bypass_ids: [uid] }
+      expected_attributes = { "auth_bypass_ids" => [uid] }
 
       service = EditionAuthBypassUpdater.new(
         edition:,
@@ -58,7 +58,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       image = create(:image, edition:)
 
       SecureRandom.stubs(uuid: uid)
-      expected_attributes = { auth_bypass_ids: [uid] }
+      expected_attributes = { "auth_bypass_ids" => [uid] }
 
       service = EditionAuthBypassUpdater.new(
         edition:,
@@ -99,7 +99,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
 
       SecureRandom.stubs(uuid: uid)
-      expected_attributes = { auth_bypass_ids: [uid] }
+      expected_attributes = { "auth_bypass_ids" => [uid] }
 
       service = EditionAuthBypassUpdater.new(
         edition:,
@@ -123,7 +123,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       file_attachment = create(:file_attachment, attachable: outcome)
 
       SecureRandom.stubs(uuid: uid)
-      expected_attributes = { auth_bypass_ids: [uid] }
+      expected_attributes = { "auth_bypass_ids" => [uid] }
 
       service = EditionAuthBypassUpdater.new(
         edition:,
@@ -147,7 +147,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       file_attachment = create(:file_attachment, attachable: feedback)
 
       SecureRandom.stubs(uuid: uid)
-      expected_attributes = { auth_bypass_ids: [uid] }
+      expected_attributes = { "auth_bypass_ids" => [uid] }
 
       service = EditionAuthBypassUpdater.new(
         edition:,


### PR DESCRIPTION
## Description

I'm currently looking into an issue with shareable previews. I noticed that during generation of a new token the page was erroring out. Looking at sentry i saw the following issue https://govuk.sentry.io/issues/3908333761/?environment=integration&project=202259&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

Sidekiq is blowing up when a new shareable preview link is generated which has images or attachments. This is due to an arg being passed using a hash with symbols rather than strings. Stringifying the keys resolves this issue.

## Zendesk ticket

https://govuk.zendesk.com/agent/tickets/5359777
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
