### PR TITLE
Add mime type validations for logo uploads

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -88,6 +88,7 @@ class TopicalEvent < ApplicationRecord
   accepts_nested_attributes_for :social_media_accounts, allow_destroy: true
 
   mount_uploader :logo, ImageUploader, mount_on: :carrierwave_image
+  validates_with ImageValidator, method: :logo, mime_types: { "image/jpeg" => /(\.jpeg|\.jpg)$/, "image/png" => /\.png$/ }, if: :logo_changed?
 
   extend FriendlyId
   friendly_id

--- a/app/validators/image_validator.rb
+++ b/app/validators/image_validator.rb
@@ -15,7 +15,7 @@ class ImageValidator < ActiveModel::Validator
   def validate(record)
     return if file_for(record).blank?
     return unless File.exist?(file_for(record).path)
-    return if file_for(record).file.content_type.match?(/svg/)
+    return if file_for(record).file.content_type.match?(/svg/) && file_for(record).model.class != TopicalEvent
 
     begin
       image = MiniMagick::Image.open file_for(record).path

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -278,4 +278,12 @@ class TopicalEventTest < ActiveSupport::TestCase
 
     assert_equal [edition2], topical_event.featurable_editions
   end
+
+  test "rejects SVG logo uploads" do
+    svg_logo = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    topical_event = build(:topical_event, logo: svg_logo)
+
+    assert_not topical_event.valid?
+    assert_equal topical_event.errors.first.full_message, "Logo is not of an allowed type"
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
[Trello ticket link](https://trello.com/c/q7A0TMov/1230-improve-topical-events-logo-upload-error-handling)
- Adds mime type validations for logo uploads on Topical Events

## Why
Uploading SVGs to the Topical Events logo field currently produces a server side error because the upload doesn't have an s300 version (due to SVG scalability). This is the version that the server is expecting. For that reason, we decided to block SVG uploads for Topical Event logos.

## Screenshots
![whitehall-admin dev gov uk_government_admin_topical-events_sexual-violence-in-conflict(iPad Pro)](https://github.com/alphagov/whitehall/assets/94846816/cc2860dd-fcd0-4322-ad16-347b65efed09)
