### PR TITLE
272 create edit contact page

### DIFF
--- a/app/assets/stylesheets/admin/views/_contacts.scss
+++ b/app/assets/stylesheets/admin/views/_contacts.scss
@@ -1,0 +1,22 @@
+.app-view-contacts {
+  &__address {
+    .govuk-fieldset__legend--l {
+      margin-bottom: govuk-spacing(2);
+    }
+  }
+
+  &__phone {
+    .govuk-fieldset__legend--l {
+      margin-bottom: govuk-spacing(2);
+    }
+
+    .govuk-form-group {
+      margin-bottom: govuk-spacing(4);
+    }
+
+    .add-another__remove-button {
+      margin-top: govuk-spacing(4);
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@ $govuk-page-width: 1140px;
 
 @import "./admin/views/add-another";
 @import "./admin/views/audit-trail";
+@import "./admin/views/contacts";
 @import "./admin/views/dashboard-index";
 @import "./admin/views/document-history-tab";
 @import "./admin/views/edit-edition";

--- a/app/views/admin/contacts/_contact_type_details_form.html.erb
+++ b/app/views/admin/contacts/_contact_type_details_form.html.erb
@@ -1,8 +1,18 @@
-<div class="form-group">
-  <%= contact_form.label :contact_type_id, 'Contact type', class: "control-label" %>
-  <%= contact_form.select :contact_type_id,
-                          options_from_collection_for_select(ContactType.all, :id, :name, contact_form.object.contact_type_id),
-                          { include_blank: true },
-                          class: 'chzn-select form-control',
-                          data: { placeholder: "Choose the contact type…" } %>
-</div>
+<%
+  items = ContactType.all.map do |type|
+    {
+      value: type.id,
+      text: type.name,
+      checked: contact_form.object.contact_type_id == type.id
+    }
+  end
+%>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Contact type (required)",
+  name: "contact[contact_type_id]",
+  id: "contact_contact_type",
+  heading_size: "l",
+  error_items: errors_for(contact_form.object.errors, :contact_type),
+  items: items
+} %>

--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -1,28 +1,99 @@
-<div class="row">
-  <div class="col-md-8">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds app-view-contacts">
     <%= form_for [:admin, contactable, contact], html: {class: "well"} do |contact_form| %>
-      <%= contact_form.errors %>
-      <fieldset class="contact">
-        <%= contact_form.text_field :title %>
-        <%= contact_form.text_area :comments, rows: 2, placeholder: "Optional instructions for this contact e.g. opening hours, rules of use…" %>
-        <%= render partial: 'admin/contacts/embed_details_for_form', locals: { contact: contact_form.object } %>
-        <%= render partial: 'admin/contacts/contact_type_details_form', locals: { contact_form: contact_form } %>
-        <% if contactable.respond_to? :home_page_contacts %>
-          <p class="bold add-label-margin">Feature on home page?</p>
-          <div class="radio">
-            <% if contact.foi? %>
-              <p>Yes (in FOI section)</p>
-            <% else %>
-              <%= contact_form.labelled_radio_button('yes', :show_on_home_page, '1', checked: contactable.contact_shown_on_home_page?(contact_form.object)) %>
-              <%= contact_form.labelled_radio_button('no', :show_on_home_page, '0', checked: !contactable.contact_shown_on_home_page?(contact_form.object)) %>
-            <% end %>
-          </div>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Contact name (required)"
+        },
+        name: "contact[title]",
+        id: "contact_title",
+        heading_level: 2,
+        heading_size: "l",
+        value: contact_form.object.title,
+        error_items: errors_for(contact_form.object.errors, :title)
+      } %>
+
+      <%= render partial: 'admin/contacts/contact_type_details_form', locals: { contact_form: contact_form } %>
+
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Comments",
+          heading_level: 2,
+          heading_size: "l",
+        },
+        name: "contact[comments]",
+        id: "contact_comments",
+        hint: "Optional instructions for this contact",
+        value: contact_form.object.comments,
+        error_items: errors_for(contact_form.object.errors, :comments)
+      } %>
+
+      <% if contactable.respond_to? :home_page_contacts %>
+        <% if contact.foi? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Homepage feature",
+            font_size: "l",
+            heading_level: 2
+          } %>
+          <p class="govuk-body">Yes (in FOI section)</p>
+        <% else %>
+          <%= render "govuk_publishing_components/components/radio", {
+            heading: "Homepage feature",
+            name: "contact[show_on_home_page]",
+            id_prefix: "contact_show_on_home_page",
+            heading_level: 2,
+            heading_size: "l",
+            inline: true,
+            items: [
+              {
+                value: 1,
+                text: "Yes",
+                checked: contactable.contact_shown_on_home_page?(contact_form.object)
+              },
+              {
+                value: 0,
+                text: "No",
+                checked: !contactable.contact_shown_on_home_page?(contact_form.object)
+              }
+            ]
+          } %>
         <% end %>
-        <%= render partial: 'admin/contacts/form_fields', locals: { contact_form: contact_form } %>
+      <% end %>
 
-      </fieldset>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email"
+        },
+        name: "contact[email]",
+        id: "contact_email",
+        heading_level: 2,
+        heading_size: "l",
+        value: contact_form.object.email,
+        error_items: errors_for(contact_form.object.errors, :email)
+      } %>
 
-      <%= contact_form.save_or_cancel(cancel: polymorphic_url([:admin, contact.contactable, Contact])) %>
+      <div class="govuk-!-margin-bottom-8">
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Contact form URL"
+          },
+          name: "contact[contact_form_url]",
+          id: "contact_contact_form_url",
+          heading_size: "l",
+          value: contact_form.object.contact_form_url,
+          error_items: errors_for(contact_form.object.errors, :contact_form_url)
+        } %>
+      </div>
+
+      <%= render partial: 'admin/contacts/form_fields', locals: { contact_form: contact_form } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save"
+        } %>
+
+        <%= link_to "Cancel", polymorphic_url([:admin, contact.contactable, Contact]), class:"govuk-link govuk-link--no-visited-state" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/contacts/_form_fields.html.erb
+++ b/app/views/admin/contacts/_form_fields.html.erb
@@ -1,31 +1,130 @@
-<fieldset class="contact">
-  <legend>Address</legend>
-  <%= contact_form.text_field :recipient, placeholder: "Organisation, division, team, unit or person name" %>
-  <%= contact_form.text_area :street_address, rows: 3, class: "address" %>
-  <%= contact_form.text_field :locality, placeholder: "Town or city" %>
-  <%= contact_form.text_field :region, placeholder: "State or county" %>
-  <%= contact_form.text_field :postal_code %>
+<div class="govuk-!-margin-bottom-8 app-view-contacts__address">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Address",
+    heading_level: 2,
+    heading_size: "l"
+  } do %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Recipient"
+        },
+        name: "contact[recipient]",
+        id: "contact_recipient",
+        heading_size: "m",
+        hint: "Organisation, division, team, unit or person name",
+        value: contact_form.object.recipient,
+        error_items: errors_for(contact_form.object.errors, :recipient)
+      } %>
+    </div>
 
-  <div class="form-group">
-    <%= contact_form.label :country_id, 'Country', class: "control-label" %>
-    <%= contact_form.select :country_id,
-                            options_from_collection_for_select(WorldLocation.geographical, :id, :name, contact_form.object.country_id),
-                            { include_blank: true },
-                            class: 'chzn-select form-control',
-                            data: { placeholder: "Choose the country…" } %>
-  </div>
-</fieldset>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Street address"
+        },
+        name: "contact[street_address]",
+        id: "contact_street_address",
+        heading_size: "m",
+        value: contact_form.object.street_address,
+        error_items: errors_for(contact_form.object.errors, :street_address)
+      } %>
+    </div>
 
-<%= contact_form.text_field :email %>
-<%= contact_form.text_field :contact_form_url %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Town or city"
+        },
+        name: "contact[locality]",
+        id: "contact_locality",
+        heading_size: "m",
+        value: contact_form.object.locality,
+        error_items: errors_for(contact_form.object.errors, :locality)
+      } %>
+    </div>
 
-<fieldset class="contact_numbers js-duplicate-fields">
-  <legend>Phone numbers</legend>
-  <%= contact_form.fields_for :contact_numbers, contact_form.object.contact_numbers do |contact_number_form| %>
-    <fieldset class="contact_number well js-duplicate-fields-set">
-      <%= contact_number_form.text_field :label %>
-      <%= contact_number_form.text_field :number %>
-      <%= contact_number_form.hidden_field :_destroy, class: 'js-hidden-destroy' %>
-    </fieldset>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "State or county"
+        },
+        name: "contact[region]",
+        id: "contact_region",
+        heading_size: "m",
+        value: contact_form.object.region,
+        error_items: errors_for(contact_form.object.errors, :region)
+      } %>
+    </div>
+
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Postal code"
+        },
+        name: "contact[postal_code]",
+        id: "contact_postal_code",
+        heading_size: "m",
+        value: contact_form.object.postal_code,
+        error_items: errors_for(contact_form.object.errors, :postal_code)
+      } %>
+    </div>
+
+    <%
+      options = [{value: "", text: ""}]
+      options.concat(WorldLocation.geographical.map do |location|
+        {
+          value: location.id,
+          text: location.name,
+          selected: contact_form.object.country_id == location.id
+        }
+      end)
+    %>
+
+    <div class="govuk-!-margin-bottom-0">
+      <%= render "govuk_publishing_components/components/select", {
+        id: "contact_country_id",
+        name: "contact[country_id]",
+        label: "Country",
+        full_width: true,
+        heading_size: "m",
+        error_message: errors_for_input(contact_form.object.errors, :country_id),
+        options: options
+      } %>
+    </div>
   <% end %>
-</fieldset>
+</div>
+
+<div class="govuk-!-margin-bottom-8 app-view-contacts__phone">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Phone numbers",
+    heading_level: 2,
+    heading_size: "l",
+  } do %>
+    <div data-module="AddAnother" data-add-text="Add phone number">
+      <%= contact_form.fields_for :contact_numbers, contact_form.object.contact_numbers do |contact_number_form| %>
+        <div class=" js-duplicate-fields-set govuk-!-margin-bottom-4">
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Label"
+            },
+            name: "contact[contact_numbers_attributes][#{contact_number_form.index}][label]",
+            id: "contact_contact_numbers_attributes_#{contact_number_form.index}_label",
+            heading_size: "m",
+            value: contact_number_form.object.label
+          } %>
+
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Number"
+            },
+            name: "contact[contact_numbers_attributes][#{contact_number_form.index}][number]",
+            id: "contact_contact_numbers_attributes_#{contact_number_form.index}_number",
+            heading_size: "m",
+            value: contact_number_form.object.number
+          } %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/contacts/_legacy_contact_type_details_form.html.erb
+++ b/app/views/admin/contacts/_legacy_contact_type_details_form.html.erb
@@ -1,0 +1,8 @@
+<div class="form-group">
+  <%= contact_form.label :contact_type_id, 'Contact type', class: "control-label" %>
+  <%= contact_form.select :contact_type_id,
+                          options_from_collection_for_select(ContactType.all, :id, :name, contact_form.object.contact_type_id),
+                          { include_blank: true },
+                          class: 'chzn-select form-control',
+                          data: { placeholder: "Choose the contact type…" } %>
+</div>

--- a/app/views/admin/contacts/_legacy_form.html.erb
+++ b/app/views/admin/contacts/_legacy_form.html.erb
@@ -1,0 +1,28 @@
+<div class="row">
+  <div class="col-md-8">
+    <%= form_for [:admin, contactable, contact], html: {class: "well"} do |contact_form| %>
+      <%= contact_form.errors %>
+      <fieldset class="contact">
+        <%= contact_form.text_field :title %>
+        <%= contact_form.text_area :comments, rows: 2, placeholder: "Optional instructions for this contact e.g. opening hours, rules of use…" %>
+        <%= render partial: 'admin/contacts/embed_details_for_form', locals: { contact: contact_form.object } %>
+        <%= render partial: 'admin/contacts/legacy_contact_type_details_form', locals: { contact_form: contact_form } %>
+        <% if contactable.respond_to? :home_page_contacts %>
+          <p class="bold add-label-margin">Feature on home page?</p>
+          <div class="radio">
+            <% if contact.foi? %>
+              <p>Yes (in FOI section)</p>
+            <% else %>
+              <%= contact_form.labelled_radio_button('yes', :show_on_home_page, '1', checked: contactable.contact_shown_on_home_page?(contact_form.object)) %>
+              <%= contact_form.labelled_radio_button('no', :show_on_home_page, '0', checked: !contactable.contact_shown_on_home_page?(contact_form.object)) %>
+            <% end %>
+          </div>
+        <% end %>
+        <%= render partial: 'admin/contacts/legacy_form_fields', locals: { contact_form: contact_form } %>
+
+      </fieldset>
+
+      <%= contact_form.save_or_cancel(cancel: polymorphic_url([:admin, contact.contactable, Contact])) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/contacts/_legacy_form_fields.html.erb
+++ b/app/views/admin/contacts/_legacy_form_fields.html.erb
@@ -1,0 +1,31 @@
+<fieldset class="contact">
+  <legend>Address</legend>
+  <%= contact_form.text_field :recipient, placeholder: "Organisation, division, team, unit or person name" %>
+  <%= contact_form.text_area :street_address, rows: 3, class: "address" %>
+  <%= contact_form.text_field :locality, placeholder: "Town or city" %>
+  <%= contact_form.text_field :region, placeholder: "State or county" %>
+  <%= contact_form.text_field :postal_code %>
+
+  <div class="form-group">
+    <%= contact_form.label :country_id, 'Country', class: "control-label" %>
+    <%= contact_form.select :country_id,
+                            options_from_collection_for_select(WorldLocation.geographical, :id, :name, contact_form.object.country_id),
+                            { include_blank: true },
+                            class: 'chzn-select form-control',
+                            data: { placeholder: "Choose the country…" } %>
+  </div>
+</fieldset>
+
+<%= contact_form.text_field :email %>
+<%= contact_form.text_field :contact_form_url %>
+
+<fieldset class="contact_numbers js-duplicate-fields">
+  <legend>Phone numbers</legend>
+  <%= contact_form.fields_for :contact_numbers, contact_form.object.contact_numbers do |contact_number_form| %>
+    <fieldset class="contact_number well js-duplicate-fields-set">
+      <%= contact_number_form.text_field :label %>
+      <%= contact_number_form.text_field :number %>
+      <%= contact_number_form.hidden_field :_destroy, class: 'js-hidden-destroy' %>
+    </fieldset>
+  <% end %>
+</fieldset>

--- a/app/views/admin/contacts/edit.html.erb
+++ b/app/views/admin/contacts/edit.html.erb
@@ -1,5 +1,7 @@
-<% page_title "Contact for: #{@contact.contactable.name}" %>
-<h1>Contact for: <%= @contact.contactable.name %></h1>
-<p><%= link_to "Back to #{@contact.contactable.name}", [:admin, @contactable, Contact] %></p>
+<% content_for :page_title, "Edit contact" %>
+<% content_for :title, "Edit contact" %>
+<% content_for :context, @contact.contactable.name %>
+<% content_for :title_margin_bottom, 8 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @contact)) %>
 
 <%= render partial: "form", locals: {contact: @contact, contactable: @contactable} %>

--- a/app/views/admin/contacts/legacy_edit.html.erb
+++ b/app/views/admin/contacts/legacy_edit.html.erb
@@ -1,0 +1,5 @@
+<% page_title "Contact for: #{@contact.contactable.name}" %>
+<h1>Contact for: <%= @contact.contactable.name %></h1>
+<p><%= link_to "Back to #{@contact.contactable.name}", [:admin, @contactable, Contact] %></p>
+
+<%= render partial: "legacy_form", locals: {contact: @contact, contactable: @contactable} %>

--- a/app/views/admin/contacts/legacy_new.html.erb
+++ b/app/views/admin/contacts/legacy_new.html.erb
@@ -1,0 +1,5 @@
+<% page_title "Contact for: #{@contact.contactable.name}" %>
+<h1>New contact for: <%= @contactable.name %></h1>
+<p><%= link_to "Back to #{@contact.contactable.name}", [:admin, @contactable, Contact] %></p>
+
+<%= render partial: "legacy_form", locals: {contact: @contact, contactable: @contactable} %>

--- a/app/views/admin/contacts/new.html.erb
+++ b/app/views/admin/contacts/new.html.erb
@@ -1,5 +1,7 @@
-<% page_title "Contact for: #{@contact.contactable.name}" %>
-<h1>New contact for: <%= @contactable.name %></h1>
-<p><%= link_to "Back to #{@contact.contactable.name}", [:admin, @contactable, Contact] %></p>
+<% content_for :page_title, "Add contact" %>
+<% content_for :title, "Add contact" %>
+<% content_for :context, @contact.contactable.name %>
+<% content_for :title_margin_bottom, 8 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @contact)) %>
 
 <%= render partial: "form", locals: {contact: @contact, contactable: @contactable} %>

--- a/app/views/admin/worldwide_offices/_form.html.erb
+++ b/app/views/admin/worldwide_offices/_form.html.erb
@@ -16,7 +16,7 @@
             data: { placeholder: "Choose office type…" } %>
       </div>
       <%= render partial: 'admin/contacts/embed_details_for_form', locals: { contact: office_form.object.contact } %>
-      <%= render partial: 'admin/contacts/contact_type_details_form', locals: { contact_form: contact_form } %>
+      <%= render partial: 'admin/contacts/legacy_contact_type_details_form', locals: { contact_form: contact_form } %>
       <div class="radio">
         <p class="bold add-label-margin">Feature on home page?</p>
         <% if worldwide_organisation.is_main_office?(office_form.object) %>
@@ -48,7 +48,7 @@
         <% end %>
       </fieldset>
 
-      <%= render partial: 'admin/contacts/form_fields', locals: { contact_form: contact_form } %>
+      <%= render partial: 'admin/contacts/legacy_form_fields', locals: { contact_form: contact_form } %>
     <% end %>
   </fieldset>
 

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -16,7 +16,7 @@ When(/^I add a new office to be featured on the home page of the worldwide organ
   click_on "All"
   click_on "Add"
 
-  fill_in_contact_details(feature_on_home_page: "yes")
+  legacy_fill_in_contact_details(feature_on_home_page: "yes")
   select WorldwideOfficeType.all.sample.name, from: "Office type"
 
   click_on "Save"

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -172,7 +172,13 @@ end
 When(/^I add a new contact "([^"]*)" with address "([^"]*)"$/) do |contact_description, address|
   click_link "Contacts"
   click_link "Add"
-  fill_in_contact_details(title: contact_description, street_address: address)
+
+  if using_design_system?
+    fill_in_contact_details(title: contact_description, street_address: address)
+  else
+    legacy_fill_in_contact_details(title: contact_description, street_address: address)
+  end
+
   click_button "Save"
 end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -71,7 +71,7 @@ When(/^I add an "([^"]*)" office for the home page with address, phone number, a
 
   visit admin_worldwide_organisation_worldwide_offices_path(WorldwideOrganisation.last)
   click_link "Add"
-  fill_in_contact_details(title: description, feature_on_home_page: "yes")
+  legacy_fill_in_contact_details(title: description, feature_on_home_page: "yes")
   select WorldwideOfficeType.all.sample.name, from: "Office type"
 
   check service1.name

--- a/features/support/contact_helper.rb
+++ b/features/support/contact_helper.rb
@@ -11,6 +11,32 @@ module ContactHelper
       feature_on_home_page: "yes",
       contact_type: "General",
     }.merge(contact_details)
+    fill_in "Contact name", with: contact_details[:title]
+    fill_in "Street address", with: contact_details[:street_address]
+    fill_in "Postal code", with: contact_details[:postal_code]
+    fill_in "Email", with: contact_details[:email]
+    fill_in "Label", with: contact_details[:phone_number_label]
+    fill_in "Number", with: contact_details[:phone_number]
+    select contact_details[:country], from: "Country"
+    # allow passing in nil to say - don't try to choose the feature on
+    # home page? setting; maybe because it's the first office for a world
+    # org, or because it's an FOI contact for a normal org.
+    choose contact_details[:home_page_feature] unless contact_details[:home_page_feature].nil?
+    choose contact_details[:contact_type]
+  end
+
+  def legacy_fill_in_contact_details(contact_details = {})
+    contact_details = {
+      title: "Our shiny new office",
+      street_address: "address1\naddress2",
+      postal_code: "12345-123",
+      email: "foo@bar.com",
+      country: WorldLocation.first.name,
+      phone_number_label: "Main phone number",
+      phone_number: "+22 (0) 111 111-111",
+      feature_on_home_page: "yes",
+      contact_type: "General",
+    }.merge(contact_details)
     fill_in "Title", with: contact_details[:title]
     fill_in "Street address", with: contact_details[:street_address]
     fill_in "Postal code", with: contact_details[:postal_code]

--- a/test/functional/admin/legacy_contacts_controller_test.rb
+++ b/test/functional/admin/legacy_contacts_controller_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-class Admin::ContactsControllerTest < ActionController::TestCase
+class Admin::LegacyContactsControllerTest < ActionController::TestCase
+  tests Admin::ContactsController
+
   setup do
-    login_as_preview_design_system_user(:departmental_editor)
+    login_as :departmental_editor
   end
 
   should_be_an_admin_controller


### PR DESCRIPTION
[Trello](https://trello.com/c/N19YqzZw/272-create-edit-contact-page)

This ports the Create and Edit contacts pages to the design system:
- Updates controller
- Updates controller tests
- Updates views/partials for New and Edit pages
- Adds error messaging
- Updates references to partials used in other views
- Updates tests

I am not convinced I have taken the best approach to updating the tests so that they pass for the design system - there are partials shared in other views and a shared helper in the test that made this a bit tricky - so if that could be looked at that would be good. 

Screenshots below. 

|Create|Edit|
|-|-|
| ![Screenshot 2023-06-20 at 17 34 05](https://github.com/alphagov/whitehall/assets/6080548/14832724-fd2e-48e2-b61f-ea1cee004982) | ![Screenshot 2023-06-20 at 17 50 23](https://github.com/alphagov/whitehall/assets/6080548/f32e6dd3-6091-4625-9c9c-e609654fe1a6) |
|with phone numbers expanded||
| ![Screenshot 2023-06-20 at 17 38 07](https://github.com/alphagov/whitehall/assets/6080548/b8c13ac2-6f11-460b-9742-648c61e555ee) ||
|with errors||
| ![Screenshot 2023-06-20 at 17 43 08](https://github.com/alphagov/whitehall/assets/6080548/107aa75f-6b23-49b8-8762-dca482dbc431) | ![Screenshot 2023-06-20 at 17 55 41](https://github.com/alphagov/whitehall/assets/6080548/2bbf2d4c-4c41-4bde-a48d-947274cbc420) |