### PR TITLE
Add virus checking placeholder to list of public rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Whitehall is deployed in two modes:
 
 - CSV Preview pages: [https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview)
 
+### Static Content
+
+- Virus checking placeholder: [https://www.gov.uk/government/placeholder](https://www.gov.uk/government/placeholder)
+
 ### World Information
 
 - Help and services around the world: [https://www.gov.uk/world](https://www.gov.uk/world)


### PR DESCRIPTION
We weren't aware of this page, so adding it to the list of content still rendered by Whitehall for visibility.

[Trello card](https://trello.com/c/81j2sbeq/710-move-rendering-of-https-wwwgovuk-government-placeholder-out-of-whitehall)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
