### PR TITLE
Display an error message when attempting to preview invalid govspeak

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -49,6 +49,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var previewToggle = this.module.querySelector('.js-app-c-govspeak-editor__preview-button')
     var trackToggle = previewToggle.getAttribute('data-preview-toggle-tracking') === 'true'
     var preview = this.module.querySelector('.app-c-govspeak-editor__preview')
+    var error = this.module.querySelector('.app-c-govspeak-editor__error')
     var textareaWrapper = this.module.querySelector('.app-c-govspeak-editor__textarea')
     var textarea = this.module.querySelector(previewToggle.getAttribute('data-content-target'))
 
@@ -59,16 +60,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       previewToggle.innerText = previewMode ? 'Back to edit' : 'Preview'
       textareaWrapper.classList.toggle('app-c-govspeak-editor__textarea--hidden')
-      preview.classList.toggle('app-c-govspeak-editor__preview--show')
 
       if (previewMode) {
+        preview.classList.add('app-c-govspeak-editor__preview--show')
         this.getRenderedGovspeak(textarea.value, function (event) {
           var response = event.currentTarget
 
-          if (response.readyState === 4 && response.status === 200) {
-            preview.innerHTML = response.responseText
+          if (response.readyState === 4) {
+            if (response.status === 200) {
+              preview.innerHTML = response.responseText
+            }
+
+            if (response.status === 403) {
+              error.classList.add('app-c-govspeak-editor__error--show')
+              preview.classList.remove('app-c-govspeak-editor__preview--show')
+            }
           }
         })
+      } else {
+        preview.classList.remove('app-c-govspeak-editor__preview--show')
+        error.classList.remove('app-c-govspeak-editor__error--show')
       }
 
       if (trackToggle) {

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -19,3 +19,11 @@
 .app-c-govspeak-editor__preview--show {
   display: block;
 }
+
+.app-c-govspeak-editor__error {
+  display: none;
+}
+
+.app-c-govspeak-editor__error--show {
+  display: block;
+}

--- a/app/views/components/_govspeak-editor.html.erb
+++ b/app/views/components/_govspeak-editor.html.erb
@@ -1,6 +1,7 @@
 <%
   id ||= "#{name}-#{SecureRandom.hex(4)}"
   preview_id = "#{id}-preview"
+  error_id = "#{id}-error"
   label_id = "#{id}-label"
   label[:bold] ||= false
   hint ||= nil
@@ -76,5 +77,8 @@
 
   <%= tag.div class: "app-c-govspeak-editor__preview js-locale-switcher-custom", 'aria-live': "polite", id: preview_id, dir: dir do %>
     <p class="govuk-body" dir="ltr">Generating preview, please wait.</p>
+  <% end %>
+  <%= tag.div class: "app-c-govspeak-editor__error js-locale-switcher-custom", 'aria-live': "polite", id: error_id, dir: dir do %>
+    <p class="govuk-error-message" dir="ltr">There is an error in your Markdown. Select Back to edit and review your markdown.</p>
   <% end %>
 <% end %>

--- a/spec/javascripts/components/govspeak-editor.spec.js
+++ b/spec/javascripts/components/govspeak-editor.spec.js
@@ -1,4 +1,4 @@
-describe('GOVUK.Modules.GovspekEditor', function () {
+describe('GOVUK.Modules.GovspeakEditor', function () {
   var component, module
 
   beforeEach(function () {
@@ -29,10 +29,15 @@ describe('GOVUK.Modules.GovspekEditor', function () {
     var previewSection = document.createElement('div')
     previewSection.classList.add('app-c-govspeak-editor__preview')
 
+    // Error section
+    var errorSection = document.createElement('div')
+    errorSection.classList.add('app-c-govspeak-editor__error')
+
     // Append to component
     component.appendChild(previewButton)
     component.appendChild(textareaSection)
     component.appendChild(previewSection)
+    component.appendChild(errorSection)
 
     module = new GOVUK.Modules.GovspeakEditor(component)
     module.init()
@@ -56,6 +61,9 @@ describe('GOVUK.Modules.GovspekEditor', function () {
 
     expect(component.querySelectorAll('.app-c-govspeak-editor__preview').length).toEqual(1)
     expect(component.querySelector('.app-c-govspeak-editor__preview')).not.toHaveClass('app-c-govspeak-editor__preview--show')
+
+    expect(component.querySelectorAll('.app-c-govspeak-editor__error').length).toEqual(1)
+    expect(component.querySelector('.app-c-govspeak-editor__error')).not.toHaveClass('app-c-govspeak-editor__error--show')
   })
 
   it('shows preview section when button clicked', function () {
@@ -119,6 +127,34 @@ describe('GOVUK.Modules.GovspekEditor', function () {
     previewButton.dispatchEvent(new Event('click'))
 
     expect(previewSection.innerHTML).toEqual(html)
+  })
+
+  it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var previewSection = component.querySelector('.app-c-govspeak-editor__preview')
+    var errorSection = component.querySelector('.app-c-govspeak-editor__error')
+
+    jasmine.Ajax.stubRequest('/government/admin/preview', null, 'POST').andReturn({
+      status: 403,
+      contentType: 'text/html'
+    })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(errorSection.classList).toContain('app-c-govspeak-editor__error--show')
+    expect(previewSection.classList).not.toContain('app-c-govspeak-editor__preview--show')
+  })
+
+  it('hides the error message when the user returns to the editor view', function () {
+    var previewButton = component.querySelector('.js-app-c-govspeak-editor__preview-button')
+    var errorSection = component.querySelector('.app-c-govspeak-editor__error')
+
+    previewButton.innerText = 'Back to edit'
+    errorSection.classList.add('app-c-govspeak-editor__error--show')
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(errorSection.classList).not.toContain('app-c-govspeak-editor__error--show')
   })
 
   it('renders govspeak correctly with changing content', function () {


### PR DESCRIPTION
Presently, the govspeak preview endpoint on the server returns a 403 forbidden response when invalid govspeak or govspeak premitting XSS attacks is provided. This commit handles the 403 response by displaying an error to the user asking them to ensure the provided govspeak is valid. The error message is removed when the user returns to edit the govspeak.

Link to trello ticket: https://trello.com/c/CHKJCYDu

Here's the initial govspeak editor component. Note the dangerous script markup in the textarea:

![Screenshot 2023-06-20 at 14 29 20](https://github.com/alphagov/whitehall/assets/137083285/7e0283b8-cb59-4310-baaf-d466d12d3b1d)

When we attempt to preview the content, we will now see:

![Screenshot 2023-06-20 at 14 29 34](https://github.com/alphagov/whitehall/assets/137083285/9ec95808-dcd0-450c-8410-7aa6b3062d65)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
