### PR TITLE
Fix issue with preview links showing before change note added

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -334,4 +334,12 @@ module Admin::EditionsHelper
     # Returning true from the first half of the "or" means the second half doesn't get computed.
     edition_is_a_novel?(edition) || edition_has_links?(edition)
   end
+
+  def status_text(edition)
+    if edition.unpublishing.present?
+      "#{edition.state.capitalize} (unpublished #{time_ago_in_words(edition.unpublishing.created_at)} ago)"
+    else
+      edition.state.capitalize
+    end
+  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -358,6 +358,12 @@ EXISTS (
     PUBLICLY_VISIBLE_STATES.include?(state)
   end
 
+  def versioning_completed?
+    return true unless change_note_required?
+
+    change_note.present? || minor_change
+  end
+
   # @group Overwritable permission methods
   def can_be_associated_with_topical_events?
     false

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -5,21 +5,15 @@
     </div>
 
     <div>
-      <%=
-        status_text = [@edition.state.capitalize]
-        # TODO: remove unpublishing information once we have a separate state for unpublished editions
-        status_text << "(unpublished #{time_ago_in_words(@edition.unpublishing.created_at)} ago)" if @edition.unpublishing.present?
-
-        render "govuk_publishing_components/components/summary_list", {
-          borderless: true,
-          items: [
-            { field: "Type of document", value: edition_type(@edition) },
-            { field: "Status", value: status_text.join(' ') },
-            { field: "Change type", value: @edition.minor_change? ? 'Minor' : 'Major' },
-            *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
-          ]
-        }
-      %>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        borderless: true,
+        items: [
+          { field: "Type of document", value: edition_type(@edition) },
+          { field: "Status", value: status_text(@edition) },
+          { field: "Change type", value: @edition.minor_change? ? 'Minor' : 'Major' },
+          *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
+        ]
+      } %>
     </div>
 
     <% if @edition.non_english_edition? %>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -26,7 +26,7 @@
   <%= render partial: 'admin/editions/show/main_notices', locals: { edition: @edition } %>
 
   <section class="app-view-summary__section">
-    <% if not @edition.publicly_visible? %>
+    <% if !@edition.publicly_visible? && @edition.versioning_completed? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: "Preview",
         heading_level: 2,
@@ -91,6 +91,17 @@
           <% end %>
         <% end %>
       <% end %>
+    <% elsif !@edition.publicly_visible? && !@edition.versioning_completed? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Preview",
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 3,
+      } %>
+
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "To preview this document or share a document preview, add a change note or update the change type to minor."
+      } %>
     <% end %>
   </section>
 

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -100,7 +100,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/inset_text", {
-        text: "To preview this document or share a document preview, add a change note or update the change type to minor."
+        text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
       } %>
     <% end %>
   </section>

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -47,6 +47,6 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
     get :show, params: { id: draft_edition }
 
     assert_select ".govuk-link", text: "Preview on website  (opens in new tab)", href: draft_edition.public_url(draft: true), count: 0
-    assert_select ".govuk-inset-text", text: "To preview this document or share a document preview, add a change note or update the change type to minor."
+    assert_select ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
   end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -930,6 +930,34 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
+  test "#versioning_completed? returns true if change note is not required" do
+    edition = build(:edition, change_note: nil, minor_change: false)
+    edition.stubs(:change_note_required?).returns(false)
+
+    assert edition.versioning_completed?
+  end
+
+  test "#versioning_completed? returns true when a change note is present" do
+    edition = build(:edition, change_note: "This is a change.", minor_change: false)
+    edition.stubs(:change_note_required?).returns(true)
+
+    assert edition.versioning_completed?
+  end
+
+  test "#versioning_completed? returns true when edition is minor version" do
+    edition = build(:edition, minor_change: true)
+    edition.stubs(:change_note_required?).returns(true)
+
+    assert edition.versioning_completed?
+  end
+
+  test "#versioning_completed? returns false when change note is blank and not a minor version" do
+    edition = build(:edition, change_note: nil, minor_change: false)
+    edition.stubs(:change_note_required?).returns(true)
+
+    assert_not edition.versioning_completed?
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,


### PR DESCRIPTION
## Description 

There's an issue that a few publishers have encountered where they try and share a preview link with colleagues before an edition has been saved after a new edition has been created.

This occurs in the following situation:

1. a published document exists
2. the publisher creates a new draft document
3. when they arrive on the edit page they don't add a change note or mark the version as minor.
4. they leave the edit page via exiting the browser or by clicking the cancel link.
5. they have access to preview links and the sharable preview link functionality
6. if they share a preview link it doesn't work
7. if they click the `Preview on website (opens in new tab)` link they see the previous draft 

When a draft is successfully saved, it is pushed downstream to PublishingAPI and then to Draft Content Store where it updates existing content item.

This means that until this save occurs the Draft Content Store will return the latest draft that was pushed to it. In this case that would be the draft of the now published edition.

When the user clicks the 'Preview on website (opens in new tab)' link they'll hit draft-origin, which will make the call to Draft Content Store for the latest draft for that content_id. As stated this will load the latest draft it knows about which is now out of date.

This means you can do things like add attachments and update the taxonomy of the latest draft on Whitehall, and click the preview link and none of these changes will be reflected downstream as the edition is invalid due to not having a change note or being marked as a minor version.

Additionally, the sharable preview link will continue to show, but won't work for the following reason.

- the new draft edition is created with a new auth_bypass_id
- the sharable preview link is rendered with a token which is constructed using the new draft editions auth_bypass_id
- the user takes the link
- the old auth_bypass_id lives on the old draft in the Draft Content Store
- it attempts to decrypt the token constructed with the new auth_bypass_id using the value of the old auth_bypass_id

This PR updates edition show page to only render the links to draft preview and sharable links if the change note section has been completed when it is required on an edition (not the first draft edition etc.)

## Screenshots

### Before

<img width="832" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0917a4e9-0d3b-47dd-b533-8c782247c90b">

### After 

<img width="873" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ff346e95-3ac7-440a-96ae-87af3b73dd92">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
