### PR TITLE
Link draft attachments to their parent document

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -139,6 +139,15 @@ class AttachmentData < ApplicationRecord
     draft_attachable.is_a?(Edition) ? draft_attachable : nil
   end
 
+  def draft_attachment
+    attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable&.draft? }
+  end
+
+  def draft_edition
+    draft_attachable = draft_attachment&.attachable
+    draft_attachable.is_a?(Edition) ? draft_attachable : nil
+  end
+
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -1,9 +1,15 @@
 class AssetManager::AttachmentUpdater::LinkHeaderUpdates
   def self.call(attachment_data)
     visible_edition = attachment_data.visible_edition_for(nil)
-    return [] if visible_edition.blank?
+    draft_edition = attachment_data.draft_edition
 
-    parent_document_url = visible_edition.public_url
+    parent_document_url = if visible_edition.blank? && draft_edition
+                            draft_edition.public_url(draft: true)
+                          elsif visible_edition.present?
+                            visible_edition.public_url
+                          else
+                            return []
+                          end
 
     Enumerator.new do |enum|
       enum.yield AssetManager::AttachmentUpdater::Update.new(

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -20,8 +20,22 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
     context "when attachment doesn't belong to an edition" do
       let(:attachment) { FactoryBot.create(:file_attachment) }
 
-      it "does not update draft status of any assets" do
+      it "does not update status of any assets" do
         update_worker.expects(:call).never
+
+        updater.call(attachment_data, link_header: true)
+      end
+    end
+
+    context "when attachment belongs to a draft edition" do
+      let(:edition) { FactoryBot.create(:draft_edition) }
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+      let(:parent_document_url) { edition.public_url(draft: true) }
+
+      it "sets parent_document_url for attachment using draft hostname" do
+        update_worker.expects(:call)
+          .with(attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
 
         updater.call(attachment_data, link_header: true)
       end


### PR DESCRIPTION
Asset Manager has a concept of linking assets to their parent document. We use this URL in the CSV Previews to retrieve the metadata about the parent document.

At the moment, Whitehall only sends the parent document URL for live assets.

This extends that to send the parent document URL for draft assets too. Doing this will allow us to offer previews of draft CSV files to users.

[Trello card](https://trello.com/c/y2vagYMl)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
