### PR TITLE
Apply design updates to person translation confirm destroy page

### DIFF
--- a/app/views/admin/person_translations/confirm_destroy.html.erb
+++ b/app/views/admin/person_translations/confirm_destroy.html.erb
@@ -1,6 +1,6 @@
 <% content_for :context, @person.name %>
-<% content_for :page_title, "Delete translation" %>
-<% content_for :title, "Delete #{@translation_locale.native_and_english_language_name} translation" %>
+<% content_for :page_title, "Delete #{@translation_locale.native_and_english_language_name} translation" %>
+<% content_for :title, "Delete translation" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -32,14 +32,14 @@
             }
           ],
           rows: @person.non_english_translated_locales.map do |locale|
-            native_language_name = Locale.coerce(locale).native_language_name
             [
               {
-                text: sanitize("#{locale.native_language_name} " + link_to("(view)", @person.public_url(locale: locale.code), class: "govuk-link"))
+                text: locale.native_and_english_language_name
               },
               {
-                text: sanitize("<a class='govuk-link' href='#{edit_admin_person_translation_path(@person, locale.code)}'>Edit <span class='govuk-visually-hidden'>#{native_language_name}</span></a>" +
-                  "<a class='govuk-link gem-link--destructive govuk-!-margin-left-2' href='#{confirm_destroy_admin_person_translation_path(@person, locale.code)}'>Delete <span class='govuk-visually-hidden'>#{native_language_name}</span></a>"),
+                text: link_to(sanitize("View #{tag.span(locale.native_and_english_language_name, class: 'govuk-visually-hidden')}"), @person.public_url(locale: locale.code), class: "govuk-link") +
+                  link_to(sanitize("Edit #{tag.span(locale.native_and_english_language_name, class: 'govuk-visually-hidden')}"), edit_admin_person_translation_path(@person, locale.code), class: "govuk-link govuk-!-margin-left-2") +
+                  link_to(sanitize("Delete #{tag.span(locale.native_and_english_language_name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_translation_path(@person, locale.code), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")
               }
             ]
           end

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -76,9 +76,11 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
     get :index, params: { person_id: person }
 
     edit_translation_path = edit_admin_person_translation_path(person, "fr")
-    view_person_path = person.public_path(locale: "fr")
-    assert_select "a[href=?]", edit_translation_path, text: "Edit Français"
-    assert_select "a[href=?]", Plek.website_root + view_person_path, text: "(view)"
+    view_person_path = person.public_url(locale: :fr)
+    confirm_destroy_url = confirm_destroy_admin_person_translation_path(person, :fr)
+    assert_select "a[href=?]", edit_translation_path, text: "Edit Français (French)"
+    assert_select "a[href=?]", view_person_path, text: "View Français (French)"
+    assert_select "a[href=?]", confirm_destroy_url, text: "Delete Français (French)"
   end
 
   view_test "index does not list the english translation" do
@@ -86,22 +88,6 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
 
     edit_translation_path = edit_admin_person_translation_path(@person, "en")
     assert_select "a[href=?]", edit_translation_path, text: "en", count: 0
-  end
-
-  view_test "index displays delete button for a translation" do
-    person = create(
-      :person,
-      biography: "She was born. She lived. She died.",
-      translated_into: {
-        fr: {
-          biography: "Elle est née. Elle a vécu. Elle est morte.",
-        },
-      },
-    )
-
-    get :index, params: { person_id: person }
-
-    assert_select ".gem-link--destructive", text: "Delete Français", href: confirm_destroy_admin_person_translation_path(@person, :fr)
   end
 
   test "create redirects to edit for the chosen language" do


### PR DESCRIPTION
## Description

Following updates and design review of organisations translations index page, it was recognised that the design for person translation confirm destroy page was inconsistent.

This PR updates the person translation confirm destroy page to maintain consistency.

## Screenshots
### Before
![whitehall-admin dev gov uk_government_admin_people_fiona-ryland_translations_ar_confirm_destroy (1)](https://github.com/alphagov/whitehall/assets/91492293/4c97ef00-d2f2-404d-835e-2385778ad6a9)

### Afterwards
![whitehall-admin dev gov uk_government_admin_people_fiona-ryland_translations_ar_confirm_destroy](https://github.com/alphagov/whitehall/assets/91492293/d7f5d56f-69cc-4aa5-83e6-85b913686b4b)

## Trello
https://trello.com/c/70gnBEan

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
