### PR TITLE
Fix broken links filter on documents search page

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -236,7 +236,7 @@ EXISTS (
   SELECT 1
   FROM link_checker_api_report_links
   WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
-    AND link_checker_api_report_links.status != 'ok'
+    AND link_checker_api_report_links.status IN ('broken', 'caution')
 )",
     )
   end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -200,21 +200,28 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "should filter by broken links" do
-    edition_with_broken_links = create(
+    edition_with_broken_link = create(
       :published_publication,
-      body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A bad link](https://www.gov.uk/bad-link)",
     )
-    edition = create(
+    edition_with_caution_link = create(
       :published_publication,
-      body: "[Good](https://www.gov.uk/good-link)",
     )
-    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
-    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
-    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
-    create(:link_checker_api_report, batch_id: 1, link_reportable: edition_with_broken_links, links: [bad_link, another_bad_link])
-    create(:link_checker_api_report, batch_id: 2, link_reportable: edition, links: [good_link])
+    edition_with_ok_link = create(
+      :published_publication,
+    )
+    edition_with_pending_link = create(
+      :published_publication,
+    )
+    broken_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/broken-link", status: "broken")
+    caution_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/caution-link", status: "caution")
+    ok_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/ok-link", status: "ok")
+    pending_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/pending-link", status: "pending")
+    create(:link_checker_api_report, batch_id: 1, link_reportable: edition_with_broken_link, links: [broken_link])
+    create(:link_checker_api_report, batch_id: 2, link_reportable: edition_with_caution_link, links: [caution_link])
+    create(:link_checker_api_report, batch_id: 3, link_reportable: edition_with_ok_link, links: [ok_link])
+    create(:link_checker_api_report, batch_id: 4, link_reportable: edition_with_pending_link, links: [pending_link])
 
-    assert_equal [edition_with_broken_links], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions
+    assert_equal [edition_with_broken_link, edition_with_caution_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
   test "should return the editions ordered by most recent first" do


### PR DESCRIPTION
## Description

At the moment, this filter isn't working correctly. Some link reports have links in a pending state. As the SQL is only checking that all the links are in the "ok" state, any edition with a "pending" link is being returned.

This updates the SQL to explicitly check whether the link report has a link with a "broken" or "caution" status.

## Screenshots

### Before

<img width="739" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/adb36bcb-a1e6-4c8f-a52f-5d26336f1d3a">

### After 

<img width="535" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/f394ba5b-bac8-47e9-870e-6388f3126001">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
