### PR TITLE
Fix URLs for CSV Previews

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -8,7 +8,7 @@ module AttachmentsHelper
   end
 
   def preview_path_for_attachment(attachment)
-    "/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
+    "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
   end
 
   def block_attachments(attachments = [],

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -60,7 +60,7 @@ private
 
   def preview_url
     if csv? && attachable.is_a?(Edition)
-      Plek.asset_root + "/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/#{filename}/preview"
+      Plek.asset_root + "/government/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/#{filename}/preview"
     end
   end
 


### PR DESCRIPTION
Part of the path was missed when this was added in https://github.com/alphagov/whitehall/pull/7825.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
