### PR TITLE
Update the base path of the Worldwide Corporate Information about pages

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -175,13 +175,11 @@ class CorporateInformationPage < Edition
   end
 
   def base_path
-    if worldwide_organisation.present?
-      url = edition_worldwide_organisation.worldwide_organisation.base_path.to_s + "/about/#{slug}"
-      url.gsub("/about/about", "")
-    elsif organisation.present?
-      url = edition_organisation.organisation.base_path.to_s + "/about/#{slug}"
-      url.gsub("/about/about", "/about")
-    end
+    return if owning_organisation.blank?
+
+    url = owning_organisation.base_path + "/about/#{slug}"
+    url.gsub!("/about/about", "/about") if organisation.present?
+    url
   end
 
 private

--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -42,11 +42,6 @@ class EditionService
 
 private
 
-  def is_whitehall_corp_info_page?
-    edition.type == "CorporateInformationPage" &&
-      edition.rendering_app == Whitehall::RenderingApp::WHITEHALL_FRONTEND
-  end
-
   def notify!
     # reload the edition to strip the LocalisedModel, as this can
     # cause problems later with localisation.
@@ -56,8 +51,6 @@ private
   end
 
   def update_publishing_api!
-    return if is_whitehall_corp_info_page?
-
     ServiceListeners::PublishingApiPusher
       .new(edition.reload)
       .push(event: verb, options:)

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -26,8 +26,50 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     assert_not build(:corporate_information_page).previously_published
   end
 
-  test "base path is nil when neither organisation or worldwide organisation is present" do
+  test "base_path is nil when neither organisation or worldwide organisation is present" do
     corporate_information_page = create(:corporate_information_page, organisation: nil, worldwide_organisation: nil)
     assert_nil corporate_information_page.base_path
+  end
+
+  test "base_path appends the Corporate Information Page path to the associated Organisation base_path" do
+    organisation = create(:organisation)
+    corporate_information_page = create(
+      :corporate_information_page,
+      organisation:,
+    )
+
+    assert_equal "/government/organisations/#{organisation.name}/about/#{corporate_information_page.slug}", corporate_information_page.base_path
+  end
+
+  test "base_path appends /about to the associated Organisation base_path when about page" do
+    organisation = create(:organisation)
+    corporate_information_page = create(
+      :about_corporate_information_page,
+      organisation:,
+    )
+
+    assert_equal "/government/organisations/#{organisation.name}/about", corporate_information_page.base_path
+  end
+
+  test "base_path appends Corporate Information Page path to the associated WorldwideOrganisation base_path" do
+    worldwide_organisation = create(:worldwide_organisation)
+    corporate_information_page = create(
+      :corporate_information_page,
+      organisation: nil,
+      worldwide_organisation:,
+    )
+
+    assert_equal "/world/organisations/#{worldwide_organisation.name}/about/#{corporate_information_page.slug}", corporate_information_page.base_path
+  end
+
+  test "#base_path appends /about/about to WorldwideOrganisation base_path when about page" do
+    worldwide_organisation = create(:worldwide_organisation)
+    corporate_information_page = create(
+      :about_corporate_information_page,
+      organisation: nil,
+      worldwide_organisation:,
+    )
+
+    assert_equal "/world/organisations/#{worldwide_organisation.name}/about/about", corporate_information_page.base_path
   end
 end


### PR DESCRIPTION
https://trello.com/c/cxmT8SUk

The worldwide corporate information about pages differ from the organisation
corporate information about pages in that they are not rendered on a separate
page.

Currently, we attempt to prevent worldwide corporate information about pages
from being published at all. When they do get published, they raise an error as
the base_path conflicts with the existing content item for the worldwide
organisation itself.

Instead, we have decided to intentionally publish all worldwide corporate
information about pages as `placeholder` items with the base_path
`about/about`. This means we can avoid the conflicting base_path errors that
occur when they are published.

This:
- updates the base_path for corporate information pages as described above.
- Removes a guard statement that was added some time ago in an attempt to
prevent worldwide corporate information about pages from being published.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
