### PR TITLE
Cleanup nested documents collections

### DIFF
--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -1,6 +1,4 @@
 class DocumentCollectionGroupMembership < ApplicationRecord
-  BANNED_DOCUMENT_TYPES = %w[DocumentCollection].freeze
-
   belongs_to :document,
              inverse_of: :document_collection_group_memberships,
              optional: true
@@ -13,7 +11,6 @@ class DocumentCollectionGroupMembership < ApplicationRecord
   before_create :assign_ordering
 
   validates :document_collection_group, presence: true
-  validate :document_is_of_allowed_type, if: -> { document.present? }
   validate :presence_of_document_or_non_whitehall_link
 
   def content_id
@@ -30,12 +27,6 @@ private
                       maximum = memberships.maximum(:ordering)
                       maximum.nil? ? 0 : maximum + 1
                     end
-  end
-
-  def document_is_of_allowed_type
-    if document && BANNED_DOCUMENT_TYPES.include?(document.document_type)
-      errors.add(:document, "cannot be a #{document.humanized_document_type}")
-    end
   end
 
   def presence_of_document_or_non_whitehall_link

--- a/app/services/draft_document_collection_builder.rb
+++ b/app/services/draft_document_collection_builder.rb
@@ -90,11 +90,7 @@ private
   end
 
   def permissable_whitehall_document(content_id)
-    document = Document.find_by(content_id:)
-
-    return if document&.document_type == "DocumentCollection"
-
-    document
+    Document.find_by(content_id:)
   end
 
   def build_document_group_membership(document, group)

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -27,12 +27,6 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     assert_match %r{couldn't find.*blah}, flash[:alert]
   end
 
-  test "POST #create_whitehall_member handles invalid DocumentCollectionGroupMemberships" do
-    collection_document = create(:document, document_type: "DocumentCollection")
-    post :create_whitehall_member, params: id_params.merge(document_id: collection_document.id)
-    assert_match %r{Document cannot be a document collection}, flash[:alert]
-  end
-
   test "POST #create_non_whitehall_member adds a non-whitehall document to a group and redirects" do
     stub_publishing_api_has_lookups("/government/news/test" => "51ac4247-fd92-470a-a207-6b852a97f2db")
     res = stub_publishing_api_has_item(

--- a/test/unit/app/models/document_collection_group_membership_test.rb
+++ b/test/unit/app/models/document_collection_group_membership_test.rb
@@ -65,9 +65,4 @@ class DocumentCollectionGroupMembershipTest < ActiveSupport::TestCase
   test "is invalid without a document_collection_group" do
     assert_not build(:document_collection_group_membership, document_collection_group: nil).valid?
   end
-
-  test "is invalid when document is a document collection" do
-    membership = build(:document_collection_group_membership, document: create(:document_collection).document)
-    assert_not membership.valid?
-  end
 end

--- a/test/unit/app/services/draft_document_collection_builder_test.rb
+++ b/test/unit/app/services/draft_document_collection_builder_test.rb
@@ -45,8 +45,7 @@ class DraftDocumentCollectionBuilderTest < ActiveSupport::TestCase
 
     # Document collections
     document_collection_member = document_collection_group_memberships.third
-    document_collection_link = DocumentCollectionNonWhitehallLink.find_by(base_path: document_collection_content_item[:base_path])
-    assert_equal document_collection_member.non_whitehall_link_id, document_collection_link.id
+    assert_equal document_collection_member.document.content_id, document_collection_content_id
   end
 
   test "#perform! will not add unpublished documents to a document collection group membership" do


### PR DESCRIPTION
## Description

There's currently a workaround to add document collections to a DocumentCollectionGroup that a large group of users have used to circumvent this validation.

Instead of directly attaching the document, users attach other collections as ‘external links’.

This is documented in this card
https://trello.com/c/RKMn2oIs/55-nested-document-collections-are-not-allowed-but-they-exist

We've decided that we should just remove this validation as it doesn't seem to be causing any massive issues.

## Trello card

https://trello.com/c/RKMn2oIs/55-nested-document-collections-are-not-allowed-but-they-exist

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
