### PR TITLE
Add task to publish Worldwide Corporate Information Pages

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -254,6 +254,16 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
+    desc "Republish all published Worldwide CorporateInformationPages"
+    task worldwide_corporate_information_pages: :environment do
+      worldwide_corporate_information_pages = CorporateInformationPage.joins(:worldwide_organisation).where(state: "published")
+      puts "Enqueueing #{worldwide_corporate_information_pages.count} Worldwide CorporateInformationPages"
+      worldwide_corporate_information_pages.each do |corporate_information_page|
+        PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", corporate_information_page.document_id, true)
+      end
+      puts "Finished enqueueing Worldwide CorporateInformationPages for Publishing API"
+    end
+
     desc "Republish all documents of a given organisation"
     task :by_organisation, [:organisation_slug] => :environment do |_, args|
       org = Organisation.find_by(slug: args[:organisation_slug])

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -344,6 +344,33 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#worldwide_corporate_information_pages" do
+      let(:task) { Rake::Task["publishing_api:bulk_republish:worldwide_corporate_information_pages"] }
+
+      test "republishes published worldwide corporate information pages (including about pages)" do
+        create(
+          :published_worldwide_organisation_corporate_information_page,
+          corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
+        )
+
+        create(
+          :published_worldwide_organisation_corporate_information_page,
+          corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id,
+        )
+
+        create(:corporate_information_page, :draft, worldwide_organisation: create(:worldwide_organisation), organisation: nil)
+
+        create(
+          :published_corporate_information_page,
+          corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id,
+        )
+
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).twice
+
+        capture_io { task.invoke }
+      end
+    end
+
     describe "#by_organisation" do
       let(:org) { create(:organisation) }
       let(:task) { Rake::Task["publishing_api:bulk_republish:by_organisation"] }


### PR DESCRIPTION
> **Note**
> The plan is to run this following the merge of [this PR](https://github.com/alphagov/whitehall/pull/7844) to make sure that the base_path changes work as expected. We would then run this a second time once [this PR](https://github.com/alphagov/whitehall/pull/7789) is merged

We are currently moving the rendering of the Worldwide Corporate Information Pages away from Whitehall. As part of this, we will need to republish all of the content items.

This adds a task to do so, as the existing task to republish all Corporate Information Pages takes some time.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
