### PR TITLE
Remove attachment references from calls for evidence

### DIFF
--- a/app/models/call_for_evidence_outcome.rb
+++ b/app/models/call_for_evidence_outcome.rb
@@ -8,7 +8,7 @@ class CallForEvidenceOutcome < CallForEvidenceResponse
   end
 
   def allows_attachment_references?
-    true
+    false
   end
 
   def can_have_attached_house_of_commons_papers?


### PR DESCRIPTION
This generates fields on the upload outcome page that are not in the designs for the call for evidence work.
Trello card: https://trello.com/c/vVOHXhPR/1314-add-outcomes-to-call-for-evidence-model

Before: 
![image](https://github.com/alphagov/whitehall/assets/17481621/95303d4d-9c1d-4c87-a4cd-0df8a01b6686)


After:
![image](https://github.com/alphagov/whitehall/assets/17481621/e4a49cb7-b859-4d40-9f1c-d740e8c2706a)
