### PR TITLE
New image uploader

### DIFF
--- a/app/models/default_news_organisation_image_data.rb
+++ b/app/models/default_news_organisation_image_data.rb
@@ -1,4 +1,4 @@
 class DefaultNewsOrganisationImageData < ApplicationRecord
-  mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
+  mount_uploader :file, FeaturedImageUploader, mount_on: :carrierwave_image
   validates :file, presence: true
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -4,7 +4,7 @@ class Feature < ApplicationRecord
   belongs_to :offsite_link
   belongs_to :feature_list
 
-  mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
+  mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
   validates :document, presence: true, unless: ->(feature) { feature.topical_event_id.present? || feature.offsite_link_id.present? }
   validates :started_at, presence: true
   validates :image, presence: true, on: :create

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,7 +1,7 @@
 class Person < ApplicationRecord
   include PublishesToPublishingApi
 
-  mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
+  mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
 
   has_many :role_appointments, -> { order(:order) }
   has_many :current_role_appointments,

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -18,7 +18,7 @@ class PromotionalFeatureItem < ApplicationRecord
 
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: ->(attributes) { attributes["url"].blank? }
 
-  mount_uploader :image, ImageUploader
+  mount_uploader :image, FeaturedImageUploader
 
   def youtube_video_id
     return if youtube_video_url.blank?

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -13,7 +13,7 @@ class TakePartPage < ApplicationRecord
 
   include PublishesToPublishingApi
 
-  mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
+  mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
 
   validates :image, presence: true, on: :create
   validates :image_alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, on: :create

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -88,8 +88,7 @@ class TopicalEvent < ApplicationRecord
   accepts_nested_attributes_for :topical_event_featurings
   accepts_nested_attributes_for :social_media_accounts, allow_destroy: true
 
-  mount_uploader :logo, ImageUploader, mount_on: :carrierwave_image
-  validates_with ImageValidator, method: :logo, mime_types: { "image/jpeg" => /(\.jpeg|\.jpg)$/, "image/png" => /\.png$/ }, if: :logo_changed?
+  mount_uploader :logo, FeaturedImageUploader, mount_on: :carrierwave_image
 
   extend FriendlyId
   friendly_id

--- a/app/models/topical_event_featuring_image_data.rb
+++ b/app/models/topical_event_featuring_image_data.rb
@@ -1,5 +1,5 @@
 class TopicalEventFeaturingImageData < ApplicationRecord
-  mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
+  mount_uploader :file, FeaturedImageUploader, mount_on: :carrierwave_image
 
   validates :file, presence: true, if: :image_changed?
   validates_with ImageValidator, size: [960, 640], if: :image_changed?

--- a/app/uploaders/featured_image_uploader.rb
+++ b/app/uploaders/featured_image_uploader.rb
@@ -1,0 +1,23 @@
+class FeaturedImageUploader < WhitehallUploader
+  include CarrierWave::MiniMagick
+
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  configure do |config|
+    config.remove_previously_stored_files_after_update = false
+    config.validate_integrity = true
+  end
+
+  version(:s960) { process resize_to_fill: [960, 640] }
+  version(:s712, from_version: :s960) { process resize_to_fill: [712, 480] }
+  version(:s630, from_version: :s960) { process resize_to_fill: [630, 420] }
+  version(:s465, from_version: :s960) { process resize_to_fill: [465, 310] }
+  version(:s300, from_version: :s960) { process resize_to_fill: [300, 195] }
+  version(:s216, from_version: :s960) { process resize_to_fill: [216, 140] }
+
+  def image_cache
+    file.file.gsub("/govuk/whitehall/carrierwave-tmp/", "") if send("cache_id").present?
+  end
+end

--- a/app/validators/image_validator.rb
+++ b/app/validators/image_validator.rb
@@ -15,7 +15,7 @@ class ImageValidator < ActiveModel::Validator
   def validate(record)
     return if file_for(record).blank?
     return unless File.exist?(file_for(record).path)
-    return if file_for(record).file.content_type.match?(/svg/) && file_for(record).model.class != TopicalEvent
+    return if file_for(record).file.content_type.match?(/svg/)
 
     begin
       image = MiniMagick::Image.open file_for(record).path

--- a/test/unit/feature_test.rb
+++ b/test/unit/feature_test.rb
@@ -42,4 +42,28 @@ class FeatureTest < ActiveSupport::TestCase
     assert feature.end!
     assert_equal Time.zone.now, feature.reload.ended_at
   end
+
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    feature = build(:feature, image: svg_image)
+
+    assert_not feature.valid?
+    assert_includes feature.errors.map(&:full_message), "Image You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    feature = build(:feature, image: non_image_file)
+
+    assert_not feature.valid?
+    assert_includes feature.errors.map(&:full_message), "Image You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    feature = build(:feature, image: jpg_image)
+
+    assert feature
+    assert_empty feature.errors
+  end
 end

--- a/test/unit/featured_image_uploader_test.rb
+++ b/test/unit/featured_image_uploader_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class FeaturedImageUploaderTest < ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+  setup { FeaturedImageUploader.enable_processing = true }
+  teardown { FeaturedImageUploader.enable_processing = false }
+
+  test "uses the asset manager and quarantined file storage engine" do
+    assert_equal Whitehall::AssetManagerStorage, FeaturedImageUploader.storage
+  end
+
+  test "should only allow JPG, GIF, PNG images" do
+    uploader = FeaturedImageUploader.new
+    assert_equal %w[jpg jpeg gif png], uploader.extension_allowlist
+  end
+
+  test "should send correctly resized versions of a bitmap image to asset manager" do
+    @uploader = FeaturedImageUploader.new(FactoryBot.create(:person), "mounted-as")
+
+    Services.asset_manager.stubs(:create_whitehall_asset)
+    Services.asset_manager.expects(:create_whitehall_asset).with do |value|
+      image_path = value[:file].path
+      assert_image_has_correct_size(image_path)
+    end
+
+    Sidekiq::Testing.inline! do
+      @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+    end
+  end
+
+  test "should store uploads in a directory that persists across deploys" do
+    uploader = FeaturedImageUploader.new(Person.new(id: 1), "mounted-as")
+    assert_match %r{^system}, uploader.store_dir
+  end
+
+  test "should store all the versions of a bitmap image in asset manager" do
+    @uploader = FeaturedImageUploader.new(FactoryBot.create(:person), "mounted-as")
+
+    Services.asset_manager.stubs(:create_whitehall_asset)
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s960_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s712_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s630_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s465_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s300_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s216_minister-of-funk.960x640.jpg/))
+
+    Sidekiq::Testing.inline! do
+      @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+    end
+  end
+
+private
+
+  def assert_image_has_correct_size(asset_path)
+    filename = File.basename(asset_path)
+
+    expected_sizes = {
+      "minister-of-funk.960x640.jpg" => [960, 640],
+      "s960_minister-of-funk.960x640.jpg" => [960, 640],
+      "s712_minister-of-funk.960x640.jpg" => [712, 480],
+      "s630_minister-of-funk.960x640.jpg" => [630, 420],
+      "s465_minister-of-funk.960x640.jpg" => [465, 310],
+      "s300_minister-of-funk.960x640.jpg" => [300, 195],
+      "s216_minister-of-funk.960x640.jpg" => [216, 140],
+    }
+
+    width, height = expected_sizes[filename]
+    image = MiniMagick::Image.open(asset_path)
+    assert_equal width, image[:width], "#{expected_sizes[filename].join('x')} image version should be #{width}px wide, but was #{image[:width]}"
+    assert_equal height, image[:height], "#{expected_sizes[filename].join('x')} image version should be #{height}px high, but was #{image[:height]}"
+  end
+end

--- a/test/unit/models/default_news_organisation_image_data_test.rb
+++ b/test/unit/models/default_news_organisation_image_data_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+class DefaultNewsOrganisationImageDataTest < ActiveSupport::TestCase
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    default_image_data = build(:default_news_organisation_image_data, file: svg_image)
+
+    assert_not default_image_data.valid?
+    assert_includes default_image_data.errors.map(&:full_message), "File You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    default_image_data = build(:default_news_organisation_image_data, file: non_image_file)
+
+    assert_not default_image_data.valid?
+    assert_includes default_image_data.errors.map(&:full_message), "File You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    default_image_data = build(:default_news_organisation_image_data, file: jpg_image)
+
+    assert default_image_data
+    assert_empty default_image_data.errors
+  end
+end

--- a/test/unit/models/topical_event_featuring_image_data_test.rb
+++ b/test/unit/models/topical_event_featuring_image_data_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class TopicalEventFeaturingImageDataTest < ActiveSupport::TestCase
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    image_data = build(:topical_event_featuring_image_data, file: svg_image)
+
+    assert_not image_data.valid?
+    assert_includes image_data.errors.map(&:full_message), "File You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    topical_event_featuring_image_data = build(:topical_event_featuring_image_data, file: non_image_file)
+
+    assert_not topical_event_featuring_image_data.valid?
+    assert_includes topical_event_featuring_image_data.errors.map(&:full_message), "File You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    topical_event_featuring_image_data = build(:topical_event_featuring_image_data, file: jpg_image)
+
+    assert topical_event_featuring_image_data
+    assert_empty topical_event_featuring_image_data.errors
+  end
+end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -233,4 +233,28 @@ class PersonTest < ActiveSupport::TestCase
 
     assert_equal "Prime Minister and Big Cheese", person.current_role_appointments_title
   end
+
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    person = build(:person, image: svg_image)
+
+    assert_not person.valid?
+    assert_includes person.errors.map(&:full_message), "Image You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    person = build(:person, image: non_image_file)
+
+    assert_not person.valid?
+    assert_includes person.errors.map(&:full_message), "Image You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    person = build(:person, image: jpg_image)
+
+    assert person
+    assert_empty person.errors
+  end
 end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -297,18 +297,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal([{ path: "/courts-tribunals/court-at-mid-wicket", type: "exact" }], presented_item.content[:routes])
   end
 
-  test "present default news image url only when image is SVG" do
-    news_image = create(
-      :default_news_organisation_image_data,
-      file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")),
-    )
-    organisation = create(:organisation, default_news_image: news_image)
-    presented_item = present(organisation)
-    expected_hash = { url: news_image.file.url }
-
-    assert_equal expected_hash, presented_item.content[:details][:default_news_image]
-  end
-
   test "presents the display type of an offsite link" do
     organisation = create(
       :court,

--- a/test/unit/promotional_feature_item_test.rb
+++ b/test/unit/promotional_feature_item_test.rb
@@ -76,6 +76,30 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
     end
   end
 
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    promotional_feature = build(:promotional_feature_item, image: svg_image)
+
+    assert_not promotional_feature.valid?
+    assert_includes promotional_feature.errors.map(&:full_message), "Image You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    promotional_feature_item = build(:promotional_feature_item, image: non_image_file)
+
+    assert_not promotional_feature_item.valid?
+    assert_includes promotional_feature_item.errors.map(&:full_message), "Image You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    promotional_feature_item = build(:promotional_feature_item, image: jpg_image)
+
+    assert promotional_feature_item
+    assert_empty promotional_feature_item.errors
+  end
+
 private
 
   def string_of_length(length)

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -218,5 +218,29 @@ class TakePartPageTest < ActiveSupport::TestCase
     assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", object.public_url(cachebust: "123")
   end
 
+  test "rejects SVG logo uploads" do
+    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
+    take_part_page = build(:take_part_page, image: svg_image)
+
+    assert_not take_part_page.valid?
+    assert_includes take_part_page.errors.map(&:full_message), "Image You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    take_part_page = build(:take_part_page, image: non_image_file)
+
+    assert_not take_part_page.valid?
+    assert_includes take_part_page.errors.map(&:full_message), "Image You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    take_part_page = build(:take_part_page, image: jpg_image)
+
+    assert take_part_page
+    assert_empty take_part_page.errors
+  end
+
   should_not_accept_footnotes_in :body
 end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -284,6 +284,22 @@ class TopicalEventTest < ActiveSupport::TestCase
     topical_event = build(:topical_event, logo: svg_logo)
 
     assert_not topical_event.valid?
-    assert_equal topical_event.errors.first.full_message, "Logo is not of an allowed type"
+    assert_equal topical_event.errors.first.full_message, "Logo You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "rejects non-image file uploads" do
+    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
+    topical_event = build(:topical_event, logo: non_image_file)
+
+    assert_not topical_event.valid?
+    assert_includes topical_event.errors.map(&:full_message), "Logo You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+  end
+
+  test "accepts valid image uploads" do
+    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
+    topical_event = build(:topical_event, logo: jpg_image)
+
+    assert topical_event
+    assert_empty topical_event.errors
   end
 end


### PR DESCRIPTION
This new image uploader is used for featured images (including Lead Images, Person Images, Featured Images) and hence do not allow SVG file uploads.

Most non-inline images currently use ImageUploader, but only ever send a specific size over to publishing API, resulting in an error or some other unexpected behaviour when SVGs are uploaded.
The logic required to add SVG blocking using in conjunction with the other ImageUploader and also managing error messages seemed overly complex as compared to adding another uploader for these types of Featured Images which encompasses the resizing as well as the extension blocking and its validation messages.

SVGs should be used for graphs and charts and not as person images, featured images, and lead images, so we have introduced a new uploader to support this type of images.

https://trello.com/c/ZjWXXW93/1438-add-wrong-file-type-errors-to-topical-events-logo-uploads

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
