### PR TITLE
Add calls for evidence to the document filter

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -156,6 +156,7 @@ module Whitehall
   def self.edition_classes
     [
       CaseStudy,
+      CallForEvidence,
       Consultation,
       CorporateInformationPage,
       DetailedGuide,


### PR DESCRIPTION
Adding calls for evidence to the list of document types that can be filtered on the document index page

Before:
![Screenshot 2023-06-28 at 11 54 45](https://github.com/alphagov/whitehall/assets/17481621/1880ace0-9317-4afc-8281-1ead269ae4de)


After: 
![Screenshot 2023-06-28 at 12 02 04](https://github.com/alphagov/whitehall/assets/17481621/7a433e2c-6c98-4188-8348-e9aec243c1a6)
