### PR TITLE
Fix bug with filter for topical event featurings

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -207,7 +207,7 @@ class TopicalEvent < ApplicationRecord
     end
   end
 
-  def featurable_editions
+  def featurable_editions(editions)
     editions.reject do |edition|
       topical_event_featurings.detect do |featuring|
         featuring.edition == edition

--- a/app/views/admin/topical_event_featurings/index.html.erb
+++ b/app/views/admin/topical_event_featurings/index.html.erb
@@ -42,7 +42,7 @@
       content: render("admin/shared/featurable_editions",
         filter: @filter,
         paginator: @tagged_editions,
-        featurable_editions: @topical_event.featurable_editions,
+        featurable_editions: @topical_event.featurable_editions(@tagged_editions),
         filter_by: [:title, :type, :author, :organisation],
         anchor: "#documents_tab",
         filter_action: admin_topical_event_topical_event_featurings_url(@topical_event),

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -267,7 +267,7 @@ class TopicalEventTest < ActiveSupport::TestCase
     assert_equal [offsite_link2], topical_event.featurable_offsite_links
   end
 
-  test "#featurable_editions returns associated editions that do not belong to a topical event featuring" do
+  test "#featurable_editions returns editions that do not belong to a topical event featuring" do
     topical_event = build(:topical_event)
     edition1 = build(:edition)
     edition2 = build(:edition)
@@ -276,7 +276,7 @@ class TopicalEventTest < ActiveSupport::TestCase
     topical_event.stubs(:editions).returns([edition1, edition2])
     topical_event.stubs(:topical_event_featurings).returns([topical_event_featuring])
 
-    assert_equal [edition2], topical_event.featurable_editions
+    assert_equal [edition2], topical_event.featurable_editions([edition1, edition2])
   end
 
   test "rejects SVG logo uploads" do


### PR DESCRIPTION
## Description

At the moment, this method returns all featurable editions for a topical event featurings.

This isn't actually the use case needed. What this needs to do is take a subset of editions and filter out any that belong to a topical event featuring.

This allows it to work with the paginator which only renders 15 per page.

This isn't the perfect solution as it it filters 1 out the paginator will only render 14 results, but a big refactor of the filter is beyond the scope of this piece of work. It should be something we take on post-transition though

## Screenshot

### Before 

<img width="531" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/cd1face5-c317-4adb-9a39-752e67e028e1">


### After

<img width="668" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/c11fa646-b28b-44e8-b173-a17e47422f7a">

## Trello card

https://trello.com/c/e5MmKlGd/329-filter-not-working

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
