### PR TITLE
Add blank option to offsite link type select

### DIFF
--- a/app/views/admin/offsite_links/_form.html.erb
+++ b/app/views/admin/offsite_links/_form.html.erb
@@ -29,7 +29,8 @@
     label: "Type (required)",
     error_message: errors_for_input(offsite_link.errors, :link_type),
     heading_size: "l",
-    options:  OffsiteLink::LinkTypes.all.map do |type|
+    full_width: true,
+    options: [{ text: "", value:"" }] + OffsiteLink::LinkTypes.all.map do |type|
       {
         text: type.humanize,
         value: type,

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -98,6 +98,7 @@ And(/^I create a new a non-GOV.UK link with the title "([^"]*)"$/) do |title|
 
   fill_in "Title (required)", with: title
   fill_in "Summary (required)", with: "Summary"
+  select "Alert"
   fill_in "URL (required)", with: "https://www.gov.uk/jobsearch"
 
   click_button "Save"


### PR DESCRIPTION
## Description

We're adding a blank option based on the QA/Design review of 1.11

## Screenshots

### Before

<img width="574" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/cf1ef8c7-80da-4c51-8e4e-33790e7ccbdc">

### After

<img width="692" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/69bcfb52-5d8e-4c01-a498-6cc71a1ed22f">

## Trello
https://trello.com/c/4a7skDxd

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
