### PR TITLE
Switch the rendering of worldwide CIPs to government-frontend

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -155,11 +155,7 @@ class CorporateInformationPage < Edition
   end
 
   def rendering_app
-    if worldwide_organisation.present?
-      Whitehall::RenderingApp::WHITEHALL_FRONTEND
-    else
-      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-    end
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
   def previously_published

--- a/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
@@ -27,7 +27,7 @@ module PublishingApi::WorldwideCorporateInformationPagePresenterTest
           document_type: corporate_information_page.display_type_key,
           locale: "en",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           public_updated_at: corporate_information_page.updated_at,
           routes: [{ path: public_path, type: "exact" }],
           redirects: [],


### PR DESCRIPTION
https://trello.com/c/RbQUlEqp

Following the work to add a new content item
(https://github.com/alphagov/publishing-api/pull/2399) and move over the
rendering of the worldwide corporate information pages
(https://github.com/alphagov/government-frontend/pull/2824), we can switch the
rendering of all of these pages to government-frontend.

This includes the "about us" CIPs, which are published as placeholder content
items (see #7844), these now show a 404 page as desired.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
