### PR TITLE
Topical event show and about page design updates

### DIFF
--- a/app/views/admin/topical_event_about_pages/_form.html.erb
+++ b/app/views/admin/topical_event_about_pages/_form.html.erb
@@ -49,6 +49,6 @@
     <%= render "govuk_publishing_components/components/button", {
       text: "Save"
     } %>
-    <%= link_to("Cancel", admin_topical_events_path, class: "govuk-link") %>
+    <%= link_to("Cancel", admin_topical_event_topical_event_about_pages_path(topical_event_about_page.topical_event), class: "govuk-link") %>
   </div>
 <% end %>

--- a/app/views/admin/topical_event_about_pages/_form.html.erb
+++ b/app/views/admin/topical_event_about_pages/_form.html.erb
@@ -8,8 +8,7 @@
     name: "topical_event_about_page[name]",
     id: "topical_event_about_page_name",
     error_items: errors_for(topical_event_about_page.errors, :name)
-  }
-  %>
+  } %>
   <%= render "govuk_publishing_components/components/character_count", {
     textarea: {
       label: {
@@ -18,7 +17,8 @@
       },
       value: topical_event_about_page.read_more_link_text,
       name: "topical_event_about_page[read_more_link_text]",
-      error_items: errors_for(topical_event_about_page.errors, :read_more_link_text)
+      error_items: errors_for(topical_event_about_page.errors, :read_more_link_text),
+      rows: 4
     },
     maxlength: 255,
     id: "topical_event_about_page_read_more_link_text",
@@ -36,7 +36,7 @@
   } %>
   <%= render "components/govspeak-editor", {
     label: {
-      text: "Body",
+      text: "Body (required)",
       heading_size: "l"
     },
     id: "topical_event_about_page_body",

--- a/app/views/admin/topical_events/show.html.erb
+++ b/app/views/admin/topical_events/show.html.erb
@@ -21,7 +21,7 @@
   title: "Details",
   items: [
     { field: "Summary", value: @topical_event.summary },
-    { field: "Description", value: @topical_event.description },
+    { field: "Description", value: govspeak_to_html(@topical_event.description) },
     { field: "Details", value: topical_event_contents_breakdown(@topical_event) },
     { field: "Duration",
       value: ("#{@topical_event.start_date} to #{@topical_event.end_date}" if @topical_event.start_date && @topical_event.end_date)


### PR DESCRIPTION
## Description 

- Updates the cancel link to go back to the about page tab
- mark body as required on new/edit about page
- make read_more_link_text 4 rows to be consistent with other 255 character count fields introduced
- updates the description on the topical events show page to render govspeak so it's consistent with the about page


## Screenshots
### Topical events about page new/edit pages

|Before|After|
|------------|------------|
|<img width="558" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7d3eb3e7-c8a1-496b-b387-3e0d34b71bd1">|<img width="641" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/325b1768-1d3f-47b8-8a11-3e304810b7fe">|

### Topical events show page

|Before|After|
|------------|------------|
|<img width="694" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4a9cae66-fd70-42d2-903e-011b9d8f6174">|<img width="695" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a922c112-e698-43bb-b7fa-ff583538ecc3">|

## Trello cards

https://trello.com/c/3ftovxy2/332-update-form-ui-decrease-rows-add-required-tag
https://trello.com/c/IbnVpHbg/331-cancel-link-redirecting-to-wrong-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
