### PR TITLE
Add confirm destroy endpoint for topical events

### DIFF
--- a/app/assets/javascripts/admin/modules/add-another.js
+++ b/app/assets/javascripts/admin/modules/add-another.js
@@ -47,7 +47,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     newFields = fields.cloneNode(true)
 
     // Reset values of cloned fields
-    newFields.querySelectorAll('input, textarea').forEach(function (element) {
+    newFields.querySelectorAll('input, textarea, select').forEach(function (element) {
       element.value = ''
     })
 

--- a/app/assets/stylesheets/admin/views/_topical-events-index.scss
+++ b/app/assets/stylesheets/admin/views/_topical-events-index.scss
@@ -6,6 +6,10 @@
   width: 15%;
 }
 
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(5) {
+  width: 10%;
+}
+
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__cell:nth-child(4) {
   text-align: center;
 }

--- a/app/assets/stylesheets/admin/views/_topical-events-index.scss
+++ b/app/assets/stylesheets/admin/views/_topical-events-index.scss
@@ -1,5 +1,5 @@
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
-  width: 21%;
+  width: 22%;
 }
 
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(4) {

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -1,7 +1,7 @@
 class Admin::TopicalEventsController < Admin::BaseController
   helper_method :model_class, :model_name, :human_friendly_model_name
 
-  before_action :load_object, only: %i[show edit]
+  before_action :load_object, only: %i[show edit confirm_destroy destroy]
   before_action :build_object, only: [:new]
   before_action :build_associated_objects, only: %i[new edit]
   before_action :destroy_blank_social_media_accounts, only: %i[create update]
@@ -43,8 +43,9 @@ class Admin::TopicalEventsController < Admin::BaseController
     end
   end
 
+  def confirm_destroy; end
+
   def destroy
-    @topical_event = model_class.friendly.find(params[:id])
     @topical_event.delete!
     if @topical_event.deleted?
       redirect_to [:admin, model_class], notice: "#{human_friendly_model_name} destroyed"
@@ -72,7 +73,7 @@ class Admin::TopicalEventsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = []
+    design_system_actions = %w[confirm_destroy]
     design_system_actions += %w[show index] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -17,18 +17,23 @@ class Admin::TopicalEventsController < Admin::BaseController
     render_design_system(:index, :legacy_index)
   end
 
-  def new; end
+  def new
+    render_design_system(:new, :legacy_new)
+  end
 
   def create
     @topical_event = model_class.new(object_params)
     if @topical_event.save
       redirect_to [:admin, @topical_event], notice: "#{human_friendly_model_name} created"
     else
+      build_associated_objects
       render action: "new"
     end
   end
 
-  def edit; end
+  def edit
+    render_design_system(:edit, :legacy_edit)
+  end
 
   def update
     @topical_event = TopicalEvent.friendly.find(params[:id])
@@ -39,6 +44,7 @@ class Admin::TopicalEventsController < Admin::BaseController
         redirect_to [:admin, TopicalEvent.new], notice: "#{human_friendly_model_name} updated"
       end
     else
+      build_associated_objects
       render action: "edit"
     end
   end
@@ -74,8 +80,7 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[show index] if preview_design_system?(next_release: false)
-
+    design_system_actions += %w[show index edit update new create] if preview_design_system?(next_release: false)
     if design_system_actions.include?(action_name)
       "design_system"
     else
@@ -88,7 +93,7 @@ private
   end
 
   def build_associated_objects
-    @topical_event.social_media_accounts.build
+    @topical_event.social_media_accounts.build unless get_layout == "design_system" && @topical_event.social_media_accounts.present?
   end
 
   def destroy_blank_social_media_accounts

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -80,6 +80,7 @@ class TopicalEvent < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false } # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :description, presence: true
+  validates :summary, presence: true
   validate :start_and_end_dates
   validates :start_date, presence: true, if: ->(topical_event) { topical_event.end_date }
 

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -1,57 +1,160 @@
-<%
-  show_instantly_live_warning ||= false
-  show_consult_gds_warning ||= false
-%>
+<%= form_with model: topical_event, url: [:admin, topical_event], multipart: true do |form| %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Name (required)",
+      heading_size: "l"
+    },
+    value: topical_event.name,
+    name: "topical_event[name]",
+    id: "topical_event_name",
+    error_items: errors_for(topical_event.errors, :name)
+  } %>
 
-<%= form_for [:admin, topical_event] do |topical_event_form| %>
-  <%= topical_event_form.errors %>
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        text: "Summary (required)",
+        heading_size: "l"
+      },
+      value: topical_event.summary,
+      name: "topical_event[summary]",
+      rows: 4,
+      error_items: errors_for(topical_event.errors, :summary)
+    },
+    maxlength: 160,
+    id: "topical_event_summary",
+  } %>
 
-  <fieldset>
-    <%= topical_event_form.text_field :name %>
-    <%= topical_event_form.text_area :summary, rows: 3, required: true %>
-    <%= topical_event_form.text_area :description, rows: 20, class: 'previewable', data: {
-      module: "paste-html-to-govspeak"
+  <%= render "components/govspeak-editor", {
+    label: {
+      heading_size: "l",
+      text: "Description (required)",
+    },
+    value: topical_event.description,
+    heading_size: "l",
+    name: "topical_event[description]",
+    id: "topical_event_description",
+    rows: 20,
+    error_items: errors_for(topical_event.errors, :description),
+    margin_bottom: 8,
+  } %>
+
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "components/single-image-upload", {
+      title: "Logo",
+      name: "topical_event",
+      image_id: "topical_event_logo",
+      image_name: "topical_event[logo]",
+      alt_text_name: "topical_event[logo_alt_text]",
+      alt_text_id: "topical_event_logo_alt_text",
+      filename: topical_event.logo.filename,
+      page_errors: topical_event.errors.any?,
+      error_items: errors_for(topical_event.errors, :logo),
+      image_src: topical_event.logo.url,
+      image_alt: topical_event.logo_alt_text,
+      image_cache_name: "topical_event[logo_cache]",
+      image_cache: (topical_event.logo.image_cache if topical_event.logo.image_cache.present?)
     } %>
-  </fieldset>
-
-  <%= render partial: 'custom_form_fields', locals: {topical_event_form: topical_event_form} %>
-
-  <div class="row">
-    <fieldset id="organisations" class="named col-md-6">
-      <legend>Organisations</legend>
-
-      <div id="organisation_sortable">
-        <%= topical_event_form.fields_for :topical_event_organisations, topical_event.topical_event_organisations.where(lead: false) do |organisation_form| %>
-          <% organisation = organisation_form.object.organisation %>
-          <div id="<%= dom_id(organisation) %>" class="well remove-bottom-padding">
-            <%= organisation_form.text_field :lead_ordering, label_text: link_to(organisation.name, admin_organisation_path(organisation)), class: "ordering" %>
-            <%= organisation_form.text_field :lead, label_text: "#{organisation.name} is lead?", class: "lead" %>
-          </div>
-        <% end %>
-      </div>
-    </fieldset>
-
-    <fieldset id="lead_organisation_order" class="named col-md-6">
-      <legend>Lead organisations</legend>
-
-      <div id="lead_organisation_sortable">
-        <%= topical_event_form.fields_for :topical_event_organisations, topical_event.lead_topical_event_organisations do |lead_organisation_form| %>
-          <% lead_organisation = lead_organisation_form.object.organisation %>
-          <div id="<%= dom_id(lead_organisation) %>" class="well">
-            <%= lead_organisation_form.text_field :lead_ordering, label_text: link_to(lead_organisation.name, admin_organisation_path(lead_organisation)), class: "ordering" %>
-            <%= lead_organisation_form.text_field :lead, label_text: "#{lead_organisation.name} is lead?", class: "lead" %>
-          </div>
-        <% end %>
-      </div>
-    </fieldset>
   </div>
-  <p class="warning">
-    <% if show_instantly_live_warning %>
-      Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.
+
+  <div class="govuk-!-margin-bottom-8">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "Duration",
+      heading_size: "l",
+      margin_bottom: 2
+    } do %>
+      <%= render "components/datetime_fields", {
+        date_only: true,
+        prefix: "topical_event",
+        field_name: "start_date",
+        id: "topical_event_start_date",
+        heading_size: "m",
+        date_hint: "For example, 01 August 2015",
+        date_heading: "Start date",
+        margin_bottom: 2,
+        year: {
+          value: topical_event.start_date&.year
+        },
+        month: {
+          value: topical_event.start_date&.month
+        },
+        day: {
+          value: topical_event.start_date&.day,
+        },
+        error_items: errors_for(topical_event.errors, :start_date)
+      } %>
+
+      <%= render "components/datetime_fields", {
+        date_only: true,
+        prefix: "topical_event",
+        field_name: "end_date",
+        id: "topical_event_end_date",
+        heading_size: "m",
+        date_hint: "For example, 01 August 2022",
+        date_heading: "End date",
+        year: {
+          value: topical_event.end_date&.year
+        },
+        month: {
+          value: topical_event.end_date&.month
+        },
+        day: {
+          value: topical_event.end_date&.day
+        },
+      } %>
     <% end %>
-    <% if show_consult_gds_warning %>
-      Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.
+  </div>
+
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Social media accounts",
+    heading_size: "l"
+  } do %>
+    <div data-module="AddAnother" data-add-text="Add account" class="govuk-!-margin-bottom-4">
+      <%= form.fields_for :social_media_accounts do |social_media_form| %>
+        <div class="js-duplicate-fields-set">
+          <div class="govuk-!-margin-bottom-6">
+            <div class="govuk-!-margin-bottom-4">
+              <%= render "govuk_publishing_components/components/select", {
+                id: "topical_event_social_media_accounts_attributes_#{social_media_form.index}_social_media_service_id",
+                label: "Service (required)",
+                name: "topical_event[social_media_accounts_attributes][#{social_media_form.index}][social_media_service_id]",
+                heading_size: "m",
+                options: [{ text: "", value: "" }] +
+                  SocialMediaService.all.map { |social_media|
+                    {
+                      text: social_media.name,
+                      value: social_media.id,
+                      selected: social_media_form.object.social_media_service_id == social_media.id
+                    }
+                  },
+                full_width: true
+              } %>
+            </div>
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "URL (required)"
+              },
+              name: "topical_event[social_media_accounts_attributes][#{social_media_form.index}][url]",
+              id: "topical_event_social_media_accounts_attributes_#{social_media_form.index}_url",
+              value: social_media_form.object.url,
+              heading_size: "m",
+              error_items: errors_for(social_media_form.object.errors, :url)
+            } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="govuk-button-group govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save"
+    } %>
+
+    <% if @topical_event.persisted? %>
+      <%= link_to("Cancel", admin_topical_event_path(@topical_event), class: "govuk-link") %>
+    <% else %>
+      <%= link_to("Cancel", admin_topical_events_path, class: "govuk-link") %>
     <% end %>
-  </p>
-  <%= topical_event_form.save_or_cancel cancel: [:admin, topical_event] %>
+  </div>
 <% end %>

--- a/app/views/admin/topical_events/_legacy_form.html.erb
+++ b/app/views/admin/topical_events/_legacy_form.html.erb
@@ -1,0 +1,57 @@
+<%
+  show_instantly_live_warning ||= false
+  show_consult_gds_warning ||= false
+%>
+
+<%= form_for [:admin, topical_event] do |topical_event_form| %>
+  <%= topical_event_form.errors %>
+
+  <fieldset>
+    <%= topical_event_form.text_field :name %>
+    <%= topical_event_form.text_area :summary, rows: 3, required: true %>
+    <%= topical_event_form.text_area :description, rows: 20, class: 'previewable', data: {
+      module: "paste-html-to-govspeak"
+    } %>
+  </fieldset>
+
+  <%= render partial: 'custom_form_fields', locals: {topical_event_form: topical_event_form} %>
+
+  <div class="row">
+    <fieldset id="organisations" class="named col-md-6">
+      <legend>Organisations</legend>
+
+      <div id="organisation_sortable">
+        <%= topical_event_form.fields_for :topical_event_organisations, topical_event.topical_event_organisations.where(lead: false) do |organisation_form| %>
+          <% organisation = organisation_form.object.organisation %>
+          <div id="<%= dom_id(organisation) %>" class="well remove-bottom-padding">
+            <%= organisation_form.text_field :lead_ordering, label_text: link_to(organisation.name, admin_organisation_path(organisation)), class: "ordering" %>
+            <%= organisation_form.text_field :lead, label_text: "#{organisation.name} is lead?", class: "lead" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+
+    <fieldset id="lead_organisation_order" class="named col-md-6">
+      <legend>Lead organisations</legend>
+
+      <div id="lead_organisation_sortable">
+        <%= topical_event_form.fields_for :topical_event_organisations, topical_event.lead_topical_event_organisations do |lead_organisation_form| %>
+          <% lead_organisation = lead_organisation_form.object.organisation %>
+          <div id="<%= dom_id(lead_organisation) %>" class="well">
+            <%= lead_organisation_form.text_field :lead_ordering, label_text: link_to(lead_organisation.name, admin_organisation_path(lead_organisation)), class: "ordering" %>
+            <%= lead_organisation_form.text_field :lead, label_text: "#{lead_organisation.name} is lead?", class: "lead" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+  <p class="warning">
+    <% if show_instantly_live_warning %>
+      Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.
+    <% end %>
+    <% if show_consult_gds_warning %>
+      Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.
+    <% end %>
+  </p>
+  <%= topical_event_form.save_or_cancel cancel: [:admin, topical_event] %>
+<% end %>

--- a/app/views/admin/topical_events/confirm_destroy.html.erb
+++ b/app/views/admin/topical_events/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @topical_event.name %>
+<% content_for :page_title, "Delete topical event" %>
+<% content_for :title, "Delete topical event" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag admin_topical_event_path(@topical_event), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete "<%= @topical_event.name %>"?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", admin_topical_events_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/topical_events/edit.html.erb
+++ b/app/views/admin/topical_events/edit.html.erb
@@ -1,18 +1,15 @@
-<% page_title "Edit " + @topical_event.name %>
+<% content_for :context, "Topical events" %>
+<% content_for :page_title, @topical_event.name %>
+<% content_for :title, @topical_event.name %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @topical_event)) %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Edit <%= human_friendly_model_name.downcase %></h1>
-    <p class="warning">Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.</p>
-    <%= render partial: "form", locals: {topical_event: @topical_event, show_instantly_live_warning: true} %>
-  </section>
-
-  <section class="sidebar col-md-4 display_heading">
-    <h1>Delete <%= human_friendly_model_name.downcase %></h1>
-    <%= button_to 'Delete',
-          [:admin, @topical_event],
-          method: :delete,
-          class: 'btn btn-danger',
-          data: { confirm: "Are you sure you want to delete: #{@topical_event} ?" } %>
-  </section>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to topical events appear instantly on the live site.",
+      margin_bottom: 6
+    } %>
+    <%= render "form", topical_event: @topical_event %>
+  </div>
 </div>

--- a/app/views/admin/topical_events/index.html.erb
+++ b/app/views/admin/topical_events/index.html.erb
@@ -28,7 +28,7 @@
         text: "Published guides",
       },
       {
-        text: tag.span("View", class: "govuk-visually-hidden")
+        text: tag.span("Actions", class: "govuk-visually-hidden")
       },
     ],
 
@@ -50,7 +50,8 @@
         },
 
         {
-          text: link_to(sanitize("View #{tag.span(event.name, class: 'govuk-visually-hidden')}"), [:admin, event], class: "govuk-link govuk-!-margin-right-4"),
+          text: link_to(sanitize("View #{tag.span(event.name, class: 'govuk-visually-hidden')}"), [:admin, event], class: "govuk-link") +
+            tag.span(link_to(sanitize("Delete #{tag.span(event.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_topical_event_path(event),class: "govuk-link govuk-!-margin-left-2 gem-link--destructive")),
           format: "numeric"
         }
       ]

--- a/app/views/admin/topical_events/legacy_edit.html.erb
+++ b/app/views/admin/topical_events/legacy_edit.html.erb
@@ -1,0 +1,18 @@
+<% page_title "Edit " + @topical_event.name %>
+
+<div class="row">
+  <section class="col-md-8">
+    <h1>Edit <%= human_friendly_model_name.downcase %></h1>
+    <p class="warning">Warning: changes to <%= human_friendly_model_name.downcase %>s appear instantly on the live site.</p>
+    <%= render partial: "legacy_form", locals: {topical_event: @topical_event, show_instantly_live_warning: true} %>
+  </section>
+
+  <section class="sidebar col-md-4 display_heading">
+    <h1>Delete <%= human_friendly_model_name.downcase %></h1>
+    <%= button_to 'Delete',
+          [:admin, @topical_event],
+          method: :delete,
+          class: 'btn btn-danger',
+          data: { confirm: "Are you sure you want to delete: #{@topical_event} ?" } %>
+  </section>
+</div>

--- a/app/views/admin/topical_events/legacy_new.html.erb
+++ b/app/views/admin/topical_events/legacy_new.html.erb
@@ -1,0 +1,8 @@
+<% page_title "New policy area" %>
+<div class="row">
+  <div class="col-md-8">
+    <h1>New <%= human_friendly_model_name.downcase %></h1>
+    <p class="warning">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
+    <%= render partial: "legacy_form", locals: {topical_event: @topical_event, show_consult_gds_warning: true} %>
+  </div>
+</div>

--- a/app/views/admin/topical_events/new.html.erb
+++ b/app/views/admin/topical_events/new.html.erb
@@ -1,8 +1,15 @@
-<% page_title "New policy area" %>
-<div class="row">
-  <div class="col-md-8">
-    <h1>New <%= human_friendly_model_name.downcase %></h1>
-    <p class="warning">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS. New documents will be live immediately on selecting save.</p>
-    <%= render partial: "form", locals: {topical_event: @topical_event, show_consult_gds_warning: true} %>
+<% content_for :context, "Topical events" %>
+<% content_for :page_title, "New topical event" %>
+<% content_for :title, "New topical event" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @topical_event)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: "Changes to topical events appear instantly on the live site.",
+      margin_bottom: 6
+    } %>
+    <%= render "form", topical_event: @topical_event %>
   </div>
 </div>

--- a/app/views/components/_single-image-upload.html.erb
+++ b/app/views/components/_single-image-upload.html.erb
@@ -5,13 +5,19 @@
   image_src ||= nil
   image_alt ||= nil
   image_cache ||= nil
+  title ||= "Image (required)"
+  alt_text_name ||= "#{name}[image_alt_text]"
+  alt_text_id ||= "#{id}_image_alt_text"
+  image_name ||= "#{name}[image]"
+  image_id ||= "#{id}_image"
+  image_cache_name ||= "#{name}[image_cache]"
 
   root_classes = %w(app-c-single-image-upload govuk-form-group)
 %>
 
 <%= tag.div class: root_classes, data: data_attributes do %>
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Image (required)",
+    text: title,
     font_size: "l",
     margin_bottom: 3
   } %>
@@ -25,7 +31,7 @@
     } %>
 
     <% if page_errors %>
-      <%= hidden_field_tag "#{name}[image_cache]", image_cache %>
+      <%= hidden_field_tag image_cache_name, image_cache %>
       <p class="govuk-body"><strong>File name: </strong><%= filename %></p>
       <p class="govuk-body"><strong>Alt text: </strong><%= image_alt == "" ? "None" : image_alt %></p>
     <% else %>
@@ -54,9 +60,9 @@
       text: image_label,
       heading_size: label_size
     },
-    name: "#{name}[image]",
+    name: image_name,
     hint: "Images must be 960px by 640px",
-    id: "#{id}_image",
+    id: image_id,
     value: image_src,
     error_items: error_items
   } %>
@@ -65,8 +71,8 @@
     label: {
       text: "Image description (alt text)"
     },
-    name: "#{name}[image_alt_text]",
-    id: "#{id}_image_alt_text",
+    name: alt_text_name,
+    id: alt_text_id,
     value: image_alt
   } %>
 <% end %>

--- a/app/views/components/docs/single-image-upload.yml
+++ b/app/views/components/docs/single-image-upload.yml
@@ -17,6 +17,20 @@ examples:
     data:
       id: single-image-upload
       name: single-image-upload
+  with_custom_title:
+    data:
+      id: single-image-upload-with-title
+      name: ingle-image-upload-with-title
+      title: Custom title
+  with_custom_name_fields:
+    data:
+      id: single-image-upload-with-title
+      name: ingle-image-upload-with-title
+      alt_text_name: klass[logo_alt_text]
+      alt_text_id: klass_logo_alt_text
+      image_name: klass[logo]
+      image_id: klass_logo
+      image_cache_name: klass[logo_cache]
   with_error:
     data:
       id: single-image-upload-with-error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Whitehall::Application.routes.draw do
           resources :offsite_links do
             get :confirm_destroy, on: :member
           end
+          get :confirm_destroy, on: :member
         end
 
         resources :worldwide_organisations do

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -56,9 +56,14 @@ Then(/^I should see the about page is updated$/) do
 end
 
 Then(/^I should be able to delete the topical event "([^"]*)"$/) do |name|
-  topical_event = TopicalEvent.find_by!(name:)
-  visit admin_topical_event_path(topical_event)
-  click_on "Edit"
+  if using_design_system?
+    visit admin_topical_events_path
+    click_link "Delete #{name}" if using_design_system?
+  else
+    topical_event = TopicalEvent.find_by!(name:)
+    visit admin_topical_event_path(topical_event)
+    click_on "Edit"
+  end
 
   expect { click_button "Delete" }.to change(TopicalEvent, :count).by(-1)
 end

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -10,8 +10,19 @@ module TopicalEventsHelper
     click_link "Create topical event"
     fill_in "Name", with: options[:name] || "topic-name"
     fill_in "Description", with: options[:description] || "topic-description"
-    select_date (options[:start_date] || 1.day.ago.to_s), from: "Start Date"
-    select_date (options[:end_date] || 1.month.from_now.to_s), from: "End Date"
+    fill_in "Summary", with: options[:description] || "topic-summary"
+    if using_design_system?
+      within "#topical_event_start_date" do
+        fill_in_date_fields(options[:start_date] || 1.day.ago.to_s)
+      end
+      within "#topical_event_end_date" do
+        fill_in_date_fields(options[:end_date] || 1.month.from_now.to_s)
+      end
+    else
+      select_date (options[:start_date] || 1.day.ago.to_s), from: "Start Date"
+      select_date (options[:end_date] || 1.month.from_now.to_s), from: "End Date"
+    end
+
     click_button "Save"
 
     stub_topical_event_in_content_store(options[:name])

--- a/test/functional/admin/legacy_topical_events_controller_test.rb
+++ b/test/functional/admin/legacy_topical_events_controller_test.rb
@@ -26,7 +26,7 @@ class Admin::LegacyTopicalEventsControllerTest < ActionController::TestCase
 
   test "POST :create saves the topical event" do
     assert_difference("TopicalEvent.count") do
-      post :create, params: { topical_event: { name: "Event", description: "Event description" } }
+      post :create, params: { topical_event: { name: "Event", description: "Event description", summary: "Event description" } }
     end
 
     assert_response :redirect

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -68,6 +68,15 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     assert_equal "New name", topical_event.reload.name
   end
 
+  test "GET :confirm_destroy calls correctly" do
+    topical_event = create(:topical_event)
+
+    get :confirm_destroy, params: { id: topical_event.id }
+
+    assert_response :success
+    assert_equal topical_event, assigns(:topical_event)
+  end
+
   test "DELETE :destroy deletes the topical event" do
     topical_event = create(:topical_event)
     delete :destroy, params: { id: topical_event }

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   test "POST :create saves the topical event" do
     assert_difference("TopicalEvent.count") do
-      post :create, params: { topical_event: { name: "Event", description: "Event description" } }
+      post :create, params: { topical_event: { name: "Event", description: "Event description", summary: "Event summary" } }
     end
 
     assert_response :redirect

--- a/test/unit/call_for_evidence_test.rb
+++ b/test/unit/call_for_evidence_test.rb
@@ -332,7 +332,7 @@ class CallForEvidenceTest < ActiveSupport::TestCase
   test "can associate calls for evidence with topical events" do
     call_for_evidence = create(:call_for_evidence)
     assert call_for_evidence.can_be_associated_with_topical_events?
-    assert topical_event = call_for_evidence.topical_events.create!(name: "Test", description: "Test")
+    assert topical_event = call_for_evidence.topical_events.create!(name: "Test", description: "Test", summary: "Test")
     assert_equal [call_for_evidence], topical_event.calls_for_evidence
   end
 

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -372,7 +372,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "can associate consultations with topical events" do
     consultation = create(:consultation)
     assert consultation.can_be_associated_with_topical_events?
-    assert topical_event = consultation.topical_events.create!(name: "Test", description: "Test")
+    assert topical_event = consultation.topical_events.create!(name: "Test", description: "Test", summary: "Test")
     assert_equal [consultation], topical_event.consultations
   end
 

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -72,7 +72,7 @@ class DetailedGuideTest < ActiveSupport::TestCase
   test "can be associated with topical events" do
     detailed_guide = create(:detailed_guide)
     assert detailed_guide.can_be_associated_with_topical_events?
-    assert topical_event = detailed_guide.topical_events.create!(name: "Test", description: "Test")
+    assert topical_event = detailed_guide.topical_events.create!(name: "Test", description: "Test", summary: "Test")
     assert_equal [detailed_guide], topical_event.detailed_guides
   end
 

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -10,7 +10,7 @@ class NewsArticleTest < ActiveSupport::TestCase
   test "can associate news articles with topical events" do
     news_article = create(:news_article)
     assert news_article.can_be_associated_with_topical_events?
-    assert topical_event = news_article.topical_events.create!(name: "Test", description: "Test")
+    assert topical_event = news_article.topical_events.create!(name: "Test", description: "Test", summary: "Test")
     assert_equal [news_article], topical_event.news_articles
   end
 

--- a/test/unit/presenters/document_export_presenter_test.rb
+++ b/test/unit/presenters/document_export_presenter_test.rb
@@ -350,7 +350,7 @@ class DocumentExportPresenterTest < ActiveSupport::TestCase
 
   test "includes topical events details" do
     edition = create(:news_article)
-    edition.topical_events.create!(name: "Super important event", description: "Not that important")
+    edition.topical_events.create!(name: "Super important event", description: "Not that important", summary: "Not important")
     topical_event = edition.topical_events.last
 
     result = DocumentExportPresenter.new(edition.document).as_json

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -121,7 +121,7 @@ class PublicationTest < ActiveSupport::TestCase
   test "can associate publications with topical events" do
     publication = create(:publication)
     assert publication.can_be_associated_with_topical_events?
-    assert topical_event = publication.topical_events.create!(name: "Test", description: "Test")
+    assert topical_event = publication.topical_events.create!(name: "Test", description: "Test", summary: "Test")
     assert_equal [publication], topical_event.publications
   end
 

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -129,7 +129,7 @@ class SpeechTest < ActiveSupport::TestCase
 
   test "can associate a speech with a topical event" do
     speech = create(:speech)
-    speech.topical_events << TopicalEvent.new(name: "foo", description: "bar")
+    speech.topical_events << TopicalEvent.new(name: "foo", description: "bar", summary: "test")
     assert speech.can_be_associated_with_topical_events?
     assert_equal 1, speech.topical_events.size
   end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -13,6 +13,11 @@ class TopicalEventTest < ActiveSupport::TestCase
     assert_not topical_event.valid?
   end
 
+  test "should be invalid without a summary" do
+    topical_event = build(:topical_event, summary: nil)
+    assert_not topical_event.valid?
+  end
+
   test "should be current when created" do
     topical_event = build(:topical_event)
     assert_equal "current", topical_event.state


### PR DESCRIPTION
## Description

We've lost the ability to delete a topical event while porting this section to the GOV.UK Design System.

This adds in a delete link to the index page which links to a confirm delete page.

## Screenshots

<img width="897" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/bcd90e63-439c-49eb-ad57-47726afc4982">

<img width="554" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ce1bd28e-a51a-4329-add5-9f864e118d01">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
