### PR TITLE
Switch rendering application for Worldwide Organisations

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -35,7 +35,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       document_type: "worldwide_organisation",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "whitehall-frontend",
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
These were rendered by Whitehall, they are now rendered by Government Frontend.

[Trello card](https://trello.com/c/yGefHr3x)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
