### PR TITLE
Ensure cancel link works on unsuccessful save for new featurings page

### DIFF
--- a/app/views/admin/topical_event_featurings/new.html.erb
+++ b/app/views/admin/topical_event_featurings/new.html.erb
@@ -58,6 +58,7 @@
             [:admin, @topical_event, :topical_event_featurings],
             anchor: featuring_a_document? ? "documents_tab" : "non_govuk_government_links_tab"
           ),
+          method: :get,
           class:"govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>


### PR DESCRIPTION
## Description

For some reason when the page saves unsuccessfully the cancel link doesn't construct the link correctly. When you click it no HTTP request is made.

I'm really struggling to understand why if i'm honest as link_to should create link with a GET by default. Setting the method explicitly resolves the issue though.

## Trello card

https://trello.com/c/xYVJjW0f/326-cancel-button-doesnt-work-if-there-is-an-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
