### PR TITLE
Ensure cancel link works on unsuccessful save for new featurings page

### DIFF
--- a/app/views/admin/topical_event_featurings/new.html.erb
+++ b/app/views/admin/topical_event_featurings/new.html.erb
@@ -56,7 +56,8 @@
         <%= link_to "Cancel",
           polymorphic_path(
             [:admin, @topical_event, :topical_event_featurings],
-            anchor: featuring_a_document? ? "documents_tab" : "non_govuk_government_links_tab"
+            anchor: featuring_a_document? ? "documents_tab" : "non_govuk_government_links_tab",
+            reload: true,
           ),
           class:"govuk-link govuk-link--no-visited-state" %>
       </div>


### PR DESCRIPTION
## Description

 Ensure cancel link works on unsuccessful save for new featurings page

When the page saves unsuccessfully the cancel link doesn't construct the link correctly. When you click it no HTTP request
is made.

This only occurs when an anchor is present. As the PATCH update resource has the same url the GET index endpoint instead of reloading the page, it simply enacts the anchors behaviour when you click on it.

As far as i can tell there's no way to force a reload without using JSor adding a query string. This isn't an ideal situation but will force a page reload when clicked.

## Trello card

https://trello.com/c/xYVJjW0f/326-cancel-button-doesnt-work-if-there-is-an-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
