### PR TITLE
Ensure columns are static when links are focussed on topical event index page

### DIFF
--- a/app/assets/stylesheets/admin/views/_topical-events-index.scss
+++ b/app/assets/stylesheets/admin/views/_topical-events-index.scss
@@ -1,3 +1,11 @@
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(1) {
+  width: 20%;
+}
+
+.app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(2) {
+  width: 31%;
+}
+
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
   width: 22%;
 }
@@ -7,7 +15,7 @@
 }
 
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__header:nth-child(5) {
-  width: 10%;
+  width: 12%;
 }
 
 .app-view-topical-events-index__table .govuk-table__row .govuk-table__cell:nth-child(4) {

--- a/app/views/admin/topical_events/index.html.erb
+++ b/app/views/admin/topical_events/index.html.erb
@@ -11,8 +11,10 @@
   href: [:new, :admin, model_name.to_sym],
   margin_bottom: 8
 } %>
-<div class="app-view-topical-events-index__table">
+<div class="app-view-topical-events-index__table govuk-table--with-actions app-c-govuk-table--filterable">
   <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: "Filter topical events",
     head: [
       {
         text: "Name"
@@ -31,7 +33,6 @@
         text: tag.span("Actions", class: "govuk-visually-hidden")
       },
     ],
-
     rows: @topical_events.map do |event|
       [
         {
@@ -52,7 +53,6 @@
         {
           text: link_to(sanitize("View #{tag.span(event.name, class: 'govuk-visually-hidden')}"), [:admin, event], class: "govuk-link") +
             tag.span(link_to(sanitize("Delete #{tag.span(event.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_topical_event_path(event),class: "govuk-link govuk-!-margin-left-2 gem-link--destructive")),
-          format: "numeric"
         }
       ]
     end


### PR DESCRIPTION
## Description 

When you focus the view link the column width changes. This PR updates does 2 things.

1. adds a search filter to the table (have consulted with Nik)
2. makes the table layout fixed


<img width="917" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4aa0ec05-5f34-4f82-9137-34c923e42417">


## Trello card

https://trello.com/c/0NdfmDeJ/333-weird-jump-when-view-link-on-focus

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
