### PR TITLE
Prepare release 1.11

### DIFF
--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -54,12 +54,12 @@ private
   def about_page_params
     params.require(:topical_event_about_page).permit(:body, :name, :summary, :read_more_link_text)
   end
-end
 
-def get_layout
-  if preview_design_system?(next_release: true)
-    "design_system"
-  else
-    "admin"
+  def get_layout
+    if preview_design_system?(next_release: true)
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/controllers/admin/topical_event_about_pages_controller.rb
+++ b/app/controllers/admin/topical_event_about_pages_controller.rb
@@ -57,10 +57,7 @@ private
 end
 
 def get_layout
-  design_system_actions = []
-  design_system_actions += %w[show new edit update create] if preview_design_system?(next_release: false)
-
-  if design_system_actions.include?(action_name)
+  if preview_design_system?(next_release: true)
     "design_system"
   else
     "admin"

--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -82,10 +82,7 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[new create index reorder confirm_destroy] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -79,9 +79,7 @@ class Admin::TopicalEventsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[show index edit update new create] if preview_design_system?(next_release: false)
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/test/functional/admin/operational_fields_controller_test.rb
+++ b/test/functional/admin/operational_fields_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
   should_require_fatality_handling_permission_to_access :operational_field, :index, :new, :edit
 
   test "index should list operational fields ordered alphabetically by name" do

--- a/test/functional/admin/sitewide_settings_controller_test.rb
+++ b/test/functional/admin/sitewide_settings_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::SitewideSettingsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   %i[edit update].each do |action_method|
     test "#{action_method} action is not permitted to non-GDS editors" do

--- a/test/functional/admin/topical_event_featurings_controller_test.rb
+++ b/test/functional/admin/topical_event_featurings_controller_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class Admin::TopicalEventFeaturingsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   setup do
     @topical_event = create(:topical_event)

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :show lists the topical event details" do
     topical_event = create(:topical_event)


### PR DESCRIPTION
## Description

This updates the get_layout methods in the controllers to include these controllers in the next release and removes the test to ensure they render the admin layout for a user with the "Preview next release" permission.

I've then run all the tests with the `preview_design_system?` permission overriden and checked that all test failures are either: 

- legacy tests
- have already been duplicated and the user has been given the "Preview design system" permission
- the override has been set back to only work in non-test ENVs.

<img width="512" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/403079d4-7740-4505-9841-4b69cd1e9d66">

only legacy tests and the ones which check the admin template is rendered ☝️ 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
