### PR TITLE
Remove extra about page for British Indian Ocean Territory

### DIFF
--- a/db/data_migration/20230628134346_remove_extra_about_page_for_british_indian_ocean_territory.rb
+++ b/db/data_migration/20230628134346_remove_extra_about_page_for_british_indian_ocean_territory.rb
@@ -1,0 +1,4 @@
+worldwide_organisation = WorldwideOrganisation.find_by(slug: "british-indian-ocean-territory")
+cip = worldwide_organisation.corporate_information_pages.find(&:force_published?)
+
+Whitehall.edition_services.deleter(cip).perform!


### PR DESCRIPTION
We have recently updated the base_path for the "about us" worldwide corporate information pages. 

Because of this, we have seen a bunch of `UnpublishableInstanceError`s for this particular worldwide organisation as it has two "about us" pages and therefore two of the same base_paths. The "about us" page that is not in use has very minor changes (compared to the one that is) and we have decided as a team that it can be removed.

We plan to do further work to identify where other worldwide organisations have multiples of the same type of CIP, including adding validation where it is missing so that this issue can be prevented in future.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
