### PR TITLE
Fix call for evidence path

### DIFF
--- a/app/models/call_for_evidence.rb
+++ b/app/models/call_for_evidence.rb
@@ -167,7 +167,7 @@ class CallForEvidence < Publicationesque
   end
 
   def base_path
-    "/government/calls_for_evidence/#{slug}"
+    "/government/calls-for-evidence/#{slug}"
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,7 @@ Whitehall::Application.routes.draw do
           end
         end
 
-        resources :calls_for_evidence, except: [:index] do
+        resources :calls_for_evidence, path: "calls-for-evidence", except: [:index] do
           resource :outcome, controller: "call_for_evidence_responses", type: "CallForEvidenceOutcome", except: %i[new destroy]
         end
 

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -169,7 +169,7 @@ module Whitehall
   end
 
   def self.edition_route_path_segments
-    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages]
+    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence]
   end
 
   def self.analytics_format(format)

--- a/test/unit/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -187,12 +187,12 @@ module PublishingApi::CallForEvidencePresenterTest
     end
 
     test "it presents the base_path if locale is :en" do
-      assert_equal "/government/calls_for_evidence/call-for-evidence-title", presented_content[:base_path]
+      assert_equal "/government/calls-for-evidence/call-for-evidence-title", presented_content[:base_path]
     end
 
     test "it presents the base_path with locale if non-english" do
       with_locale("it") do
-        assert_equal "/government/calls_for_evidence/call-for-evidence-title.it", presented_content[:base_path]
+        assert_equal "/government/calls-for-evidence/call-for-evidence-title.it", presented_content[:base_path]
       end
     end
 


### PR DESCRIPTION
We had a mismatch in our code of whether the admin paths for call for evidence should have hyphens or underscores.

This PR sets the path for calls for evidence to be '/calls-for-evidence' to ensure it is standardised.
