### PR TITLE
Revert "Switch the rendering of worldwide CIPs to government-frontend"

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -155,7 +155,11 @@ class CorporateInformationPage < Edition
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    if worldwide_organisation.present?
+      Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    else
+      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    end
   end
 
   def previously_published

--- a/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
@@ -27,7 +27,7 @@ module PublishingApi::WorldwideCorporateInformationPagePresenterTest
           document_type: corporate_information_page.display_type_key,
           locale: "en",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           public_updated_at: corporate_information_page.updated_at,
           routes: [{ path: public_path, type: "exact" }],
           redirects: [],


### PR DESCRIPTION
We haven't yet handled RTL direction translations. I'm fairly confident that there are no translations of RTL languages currently for worldwide CIPs, but reverting until we have fixed.

Reverts alphagov/whitehall#7867