### PR TITLE
Revert "Revert "Switch the rendering of worldwide CIPs to government-frontend""

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -155,11 +155,7 @@ class CorporateInformationPage < Edition
   end
 
   def rendering_app
-    if worldwide_organisation.present?
-      Whitehall::RenderingApp::WHITEHALL_FRONTEND
-    else
-      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-    end
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
   def previously_published

--- a/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
@@ -27,7 +27,7 @@ module PublishingApi::WorldwideCorporateInformationPagePresenterTest
           document_type: corporate_information_page.display_type_key,
           locale: "en",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           public_updated_at: corporate_information_page.updated_at,
           routes: [{ path: public_path, type: "exact" }],
           redirects: [],


### PR DESCRIPTION
We have now made sure RTL transalated pages are rendered correctly (see https://github.com/alphagov/government-frontend/pull/2843), so we now want to release this

Reverts alphagov/whitehall#7880