### PR TITLE
Remove usage of legacy url path from file attachment updates

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -2,14 +2,14 @@ class AssetManager::AssetUpdater
   include AssetManager::ServiceHelper
 
   class AssetAlreadyDeleted < StandardError
-    def initialize(attachment_data_id, legacy_url_path)
-      super("Asset '#{legacy_url_path}' for Attachment Data #{attachment_data_id} expected not to be deleted in Asset Manager")
+    def initialize(attachment_data_id, identifier)
+      super("Asset '#{identifier}' for Attachment Data #{attachment_data_id} expected not to be deleted in Asset Manager")
     end
   end
 
   class AssetAttributesEmpty < StandardError
-    def initialize(attachment_data_id, legacy_url_path)
-      super("Attempting to update '#{legacy_url_path}' for Attachment Data #{attachment_data_id} with empty attachment attributes")
+    def initialize(attachment_data_id, identifier)
+      super("Attempting to update '#{identifier}' for Attachment Data #{attachment_data_id} with empty attachment attributes")
     end
   end
 
@@ -17,7 +17,33 @@ class AssetManager::AssetUpdater
     new.call(*args)
   end
 
-  def call(asset_data, legacy_url_path, new_attributes = {})
+  def call(asset_manager_id, asset_data, legacy_url_path, new_attributes = {})
+    if asset_manager_id
+      update_with_asset_manager_id(asset_manager_id, asset_data, new_attributes)
+    else
+      update_with_legacy_url_path(asset_data, legacy_url_path, new_attributes)
+    end
+  end
+
+private
+
+  def update_with_asset_manager_id(asset_manager_id, asset_data, new_attributes)
+    raise AssetAttributesEmpty.new(asset_data.id, asset_manager_id) if new_attributes.empty?
+
+    attributes = find_asset_by_id(asset_manager_id)
+    asset_deleted = attributes["deleted"]
+
+    if asset_deleted
+      raise AssetAlreadyDeleted.new(asset_manager_id, asset_data.id)
+    end
+
+    keys = new_attributes.keys
+    unless attributes.slice(*keys) == new_attributes.slice(*keys)
+      asset_manager.update_asset(asset_manager_id, new_attributes)
+    end
+  end
+
+  def update_with_legacy_url_path(asset_data, legacy_url_path, new_attributes)
     attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes["deleted"]
 
@@ -30,7 +56,6 @@ class AssetManager::AssetUpdater
     end
 
     keys = new_attributes.keys
-
     raise AssetAttributesEmpty.new(asset_data.id, legacy_url_path) if new_attributes.empty?
 
     unless attributes.slice(*keys) == new_attributes.slice(*keys)

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -22,15 +22,15 @@ class AssetManager::AttachmentUpdater
 
   def self.combined_updates(updates)
     grouped_updates = updates.group_by do |update|
-      [update.attachment_data, update.legacy_url_path]
+      [update.attachment_data, update.legacy_url_path, update.asset_manager_id]
     end
 
-    grouped_updates.map do |(attachment_data, legacy_url_path), updates_to_combine|
+    grouped_updates.map do |(attachment_data, legacy_url_path, asset_manager_id), updates_to_combine|
       new_attributes = updates_to_combine.each_with_object({}) do |update, hash|
         hash.merge!(update.new_attributes)
       end
 
-      Update.new(attachment_data, legacy_url_path, new_attributes)
+      Update.new(asset_manager_id, attachment_data, legacy_url_path, new_attributes)
     end
   end
 end

--- a/app/services/asset_manager/attachment_updater/access_limited_updates.rb
+++ b/app/services/asset_manager/attachment_updater/access_limited_updates.rb
@@ -5,15 +5,28 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdates
       access_limited = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
     end
 
-    Enumerator.new do |enum|
-      enum.yield AssetManager::AttachmentUpdater::Update.new(
-        attachment_data, attachment_data.file, access_limited:
-      )
-
-      if attachment_data.pdf?
+    if attachment_data.assets.empty?
+      Enumerator.new do |enum|
         enum.yield AssetManager::AttachmentUpdater::Update.new(
-          attachment_data, attachment_data.file.thumbnail, access_limited:
+          nil, attachment_data, attachment_data.file, access_limited:
         )
+
+        if attachment_data.pdf?
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            nil, attachment_data, attachment_data.file.thumbnail, access_limited:
+          )
+        end
+      end
+    else
+      # Both the file and its thumbnail are now represented by an Asset
+      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
+      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
+      Enumerator.new do |enum|
+        attachment_data.assets.each do |asset|
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            asset.asset_manager_id, attachment_data, nil, access_limited:
+          )
+        end
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/draft_status_updates.rb
+++ b/app/services/asset_manager/attachment_updater/draft_status_updates.rb
@@ -12,15 +12,28 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdates
       )
     )
 
-    Enumerator.new do |enum|
-      enum.yield AssetManager::AttachmentUpdater::Update.new(
-        attachment_data, attachment_data.file, draft:
-      )
-
-      if attachment_data.pdf?
+    if attachment_data.assets.empty?
+      Enumerator.new do |enum|
         enum.yield AssetManager::AttachmentUpdater::Update.new(
-          attachment_data, attachment_data.file.thumbnail, draft:
+          nil, attachment_data, attachment_data.file, draft:
         )
+
+        if attachment_data.pdf?
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            nil, attachment_data, attachment_data.file.thumbnail, draft:
+          )
+        end
+      end
+    else
+      # Both the file and its thumbnail are now represented by an Asset
+      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
+      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
+      Enumerator.new do |enum|
+        attachment_data.assets.each do |asset|
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            asset.asset_manager_id, attachment_data, nil, draft:
+          )
+        end
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -11,15 +11,28 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdates
                             return []
                           end
 
-    Enumerator.new do |enum|
-      enum.yield AssetManager::AttachmentUpdater::Update.new(
-        attachment_data, attachment_data.file, parent_document_url:
-      )
-
-      if attachment_data.pdf?
+    if attachment_data.assets.empty?
+      Enumerator.new do |enum|
         enum.yield AssetManager::AttachmentUpdater::Update.new(
-          attachment_data, attachment_data.file.thumbnail, parent_document_url:
+          nil, attachment_data, attachment_data.file, parent_document_url:
         )
+
+        if attachment_data.pdf?
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            nil, attachment_data, attachment_data.file.thumbnail, parent_document_url:
+          )
+        end
+      end
+    else
+      # Both the file and its thumbnail are now represented by an Asset
+      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
+      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
+      Enumerator.new do |enum|
+        attachment_data.assets.each do |asset|
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            asset.asset_manager_id, attachment_data, nil, parent_document_url:
+          )
+        end
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
+++ b/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
@@ -5,15 +5,28 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdates
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
     end
 
-    Enumerator.new do |enum|
-      enum.yield AssetManager::AttachmentUpdater::Update.new(
-        attachment_data, attachment_data.file, redirect_url:
-      )
-
-      if attachment_data.pdf?
+    if attachment_data.assets.empty?
+      Enumerator.new do |enum|
         enum.yield AssetManager::AttachmentUpdater::Update.new(
-          attachment_data, attachment_data.file.thumbnail, redirect_url:
+          nil, attachment_data, attachment_data.file, redirect_url:
         )
+
+        if attachment_data.pdf?
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            nil, attachment_data, attachment_data.file.thumbnail, redirect_url:
+          )
+        end
+      end
+    else
+      # Both the file and its thumbnail are now represented by an Asset
+      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
+      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
+      Enumerator.new do |enum|
+        attachment_data.assets.each do |asset|
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            asset.asset_manager_id, attachment_data, nil, redirect_url:
+          )
+        end
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/update.rb
+++ b/app/services/asset_manager/attachment_updater/update.rb
@@ -13,6 +13,7 @@ class AssetManager::AttachmentUpdater::Update
 
   def call
     AssetManager::AssetUpdater.call(
+      nil,
       attachment_data,
       legacy_url_path,
       new_attributes.deep_stringify_keys,

--- a/app/services/asset_manager/attachment_updater/update.rb
+++ b/app/services/asset_manager/attachment_updater/update.rb
@@ -1,5 +1,6 @@
 class AssetManager::AttachmentUpdater::Update
-  def initialize(attachment_data, uploader_or_legacy_url_path, new_attributes)
+  def initialize(asset_manager_id, attachment_data, uploader_or_legacy_url_path, new_attributes)
+    @asset_manager_id = asset_manager_id
     @attachment_data = attachment_data
 
     @legacy_url_path = if uploader_or_legacy_url_path.respond_to?(:asset_manager_path)
@@ -13,12 +14,12 @@ class AssetManager::AttachmentUpdater::Update
 
   def call
     AssetManager::AssetUpdater.call(
-      nil,
+      asset_manager_id,
       attachment_data,
       legacy_url_path,
       new_attributes.deep_stringify_keys,
     )
   end
 
-  attr_reader :attachment_data, :legacy_url_path, :new_attributes
+  attr_reader :attachment_data, :legacy_url_path, :new_attributes, :asset_manager_id
 end

--- a/app/services/asset_manager/service_helper.rb
+++ b/app/services/asset_manager/service_helper.rb
@@ -1,7 +1,7 @@
 module AssetManager::ServiceHelper
   class AssetNotFound < StandardError
-    def initialize(legacy_url_path)
-      super("Asset '#{legacy_url_path}' is not in Asset Manager")
+    def initialize(identifier)
+      super("Asset '#{identifier}' is not in Asset Manager")
     end
   end
 
@@ -19,5 +19,11 @@ private
     attributes.merge("id" => id, "url" => url)
   rescue GdsApi::HTTPNotFound
     raise AssetNotFound, legacy_url_path
+  end
+
+  def find_asset_by_id(asset_manager_id)
+    asset_manager.asset(asset_manager_id).to_hash
+  rescue GdsApi::HTTPNotFound
+    raise AssetNotFound, asset_manager_id
   end
 end

--- a/app/workers/asset_manager_update_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_update_whitehall_asset_worker.rb
@@ -5,12 +5,12 @@ class AssetManagerUpdateWhitehallAssetWorker < WorkerBase
     model = klass.constantize.find(id)
     asset_data = GlobalID::Locator.locate(model.to_global_id)
     path = asset_data.file.asset_manager_path
-    AssetManager::AssetUpdater.call(asset_data, path, attributes)
+    AssetManager::AssetUpdater.call(nil, asset_data, path, attributes)
 
     # Update any other versions of the file (e.g. PDF thumbnail, or resized versions of an image)
     asset_versions = asset_data.file.versions.values.select(&:present?)
     asset_versions.each do |version|
-      AssetManager::AssetUpdater.call(asset_data, version.asset_manager_path, attributes)
+      AssetManager::AssetUpdater.call(nil, asset_data, version.asset_manager_path, attributes)
     end
   rescue AssetManager::ServiceHelper::AssetNotFound,
          AssetManager::AssetUpdater::AssetAlreadyDeleted,

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -9,124 +9,253 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
   describe "attachment draft status" do
     let(:filename) { "sample.docx" }
-    let(:asset_id) { "asset-id" }
+    let(:asset_manager_id) { "asset-id" }
     let(:topic_taxon) { build(:taxon_hash) }
 
-    before do
-      login_as create(:managing_editor)
-      stub_publishing_api_has_linkables([], document_type: "topic")
-      stub_whitehall_asset(filename, id: asset_id, draft: asset_initially_draft)
-    end
-
-    context "given a file attachment added after unpublishing" do
-      let(:file) { File.open(path_to_attachment(filename)) }
-      let(:attachable) { edition }
-      let(:attachment) { build(:file_attachment, attachable:, file:) }
-
+    context "updates with legacy_url_path" do
       before do
-        setup_publishing_api_for(edition)
+        login_as create(:managing_editor)
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        stub_whitehall_asset(filename, id: asset_manager_id, draft: asset_initially_draft)
       end
 
-      context "on a draft document" do
-        let(:edition) { create(:news_article) }
-        let(:asset_initially_draft) { true }
+      context "given a file attachment added after unpublishing" do
+        let(:file) { File.open(path_to_attachment(filename)) }
+        let(:attachable) { edition }
+        let(:attachment) { build(:file_attachment, attachable:, file:) }
 
-        it "marks attachment as draft in Asset Manager when document is unpublished then attachment added" do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+        before do
+          setup_publishing_api_for(edition)
+        end
 
-          visit admin_news_article_path(edition)
-          force_publish_document
-          visit admin_news_article_path(edition)
-          unpublish_document_published_in_error
+        context "on a draft document" do
+          let(:edition) { create(:news_article) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as draft in Asset Manager when document is unpublished then attachment added" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_news_article_path(edition)
+            force_publish_document
+            visit admin_news_article_path(edition)
+            unpublish_document_published_in_error
+            attachable.attachments << attachment
+            attachable.save!
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+            assert_sets_draft_status_in_asset_manager_to true
+          end
+        end
+      end
+
+      context "given a file attachment" do
+        let(:file) { File.open(path_to_attachment(filename)) }
+        let(:attachment) { build(:file_attachment, attachable:, file:) }
+        let(:attachable) { edition }
+
+        before do
+          setup_publishing_api_for(edition)
           attachable.attachments << attachment
           attachable.save!
+        end
+
+        context "on a draft document" do
+          let(:edition) { create(:news_article) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when document is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_news_article_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+
+        context "on a published document" do
+          let(:edition) { create(:published_news_article) }
+          let(:asset_initially_draft) { false }
+
+          it "does not mark attachment as draft in Asset Manager when document is unpublished" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+            visit admin_news_article_path(edition)
+            unpublish_document_published_in_error
+            refute_sets_draft_status_in_asset_manager_to true
+          end
+        end
+
+        context "on an outcome on a draft consultation" do
+          let(:edition) { create(:draft_consultation) }
+          let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+          let(:attachable) { edition.create_outcome!(outcome_attributes) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when consultation is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_consultation_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+
+        context "on a feedback on a draft consultation" do
+          let(:edition) { create(:draft_consultation) }
+          let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
+          let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when consultation is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_consultation_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+      end
+
+      context "given a policy group" do
+        let(:policy_group) { create(:policy_group) }
+        let(:asset_initially_draft) { true }
+
+        it "marks attachment as published in Asset Manager when added to policy group" do
+          visit admin_policy_group_attachments_path(policy_group)
+          add_attachment(filename)
           Attachment.last.attachment_data.uploaded_to_asset_manager!
-          assert_sets_draft_status_in_asset_manager_to true
+          assert_sets_draft_status_in_asset_manager_to false
         end
       end
     end
 
-    context "given a file attachment" do
-      let(:file) { File.open(path_to_attachment(filename)) }
-      let(:attachment) { build(:file_attachment, attachable:, file:) }
-      let(:attachable) { edition }
+    context "updates with asset_manager_id" do
+      let(:variant) { Asset.variants[:original] }
 
       before do
-        setup_publishing_api_for(edition)
-        attachable.attachments << attachment
-        attachable.save!
+        login_as create(:managing_editor)
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        stub_asset(asset_manager_id, draft: asset_initially_draft)
       end
 
-      context "on a draft document" do
-        let(:edition) { create(:news_article) }
+      context "given a file attachment added after unpublishing" do
+        let(:file) { File.open(path_to_attachment(filename)) }
+        let(:attachable) { edition }
+        let(:attachment) { build(:file_attachment, attachable:, file:) }
+
+        before do
+          setup_publishing_api_for(edition)
+        end
+
+        context "on a draft document" do
+          let(:edition) { create(:news_article) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as draft in Asset Manager when document is unpublished then attachment added" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_news_article_path(edition)
+            force_publish_document
+            visit admin_news_article_path(edition)
+            unpublish_document_published_in_error
+            attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+            attachable.attachments << attachment
+            attachable.save!
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+
+            assert_sets_draft_status_in_asset_manager_to true
+          end
+        end
+      end
+
+      context "given a file attachment" do
+        let(:file) { File.open(path_to_attachment(filename)) }
+        let(:attachment) { build(:file_attachment, attachable:, file:) }
+        let(:attachable) { edition }
+
+        before do
+          setup_publishing_api_for(edition)
+          attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+          attachable.attachments << attachment
+          attachable.save!
+        end
+
+        context "on a draft document" do
+          let(:edition) { create(:news_article) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when document is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_news_article_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+
+        context "on a published document" do
+          let(:edition) { create(:published_news_article) }
+          let(:asset_initially_draft) { false }
+
+          it "does not mark attachment as draft in Asset Manager when document is unpublished" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+            visit admin_news_article_path(edition)
+            unpublish_document_published_in_error
+            refute_sets_draft_status_in_asset_manager_to true
+          end
+        end
+
+        context "on an outcome on a draft consultation" do
+          let(:edition) { create(:draft_consultation) }
+          let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+          let(:attachable) { edition.create_outcome!(outcome_attributes) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when consultation is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_consultation_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+
+        context "on a feedback on a draft consultation" do
+          let(:edition) { create(:draft_consultation) }
+          let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
+          let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
+          let(:asset_initially_draft) { true }
+
+          it "marks attachment as published in Asset Manager when consultation is published" do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+            visit admin_consultation_path(edition)
+            force_publish_document
+            assert_sets_draft_status_in_asset_manager_to false
+          end
+        end
+      end
+
+      context "given a policy group" do
+        let(:policy_group) { create(:policy_group) }
         let(:asset_initially_draft) { true }
 
-        it "marks attachment as published in Asset Manager when document is published" do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+        it "marks attachment as published in Asset Manager when added to policy group" do
+          visit admin_policy_group_attachments_path(policy_group)
+          add_attachment(filename)
+          Attachment.last.attachment_data.assets.create!(asset_manager_id:, variant:)
+          Attachment.last.attachment_data.uploaded_to_asset_manager!
 
-          visit admin_news_article_path(edition)
-          force_publish_document
           assert_sets_draft_status_in_asset_manager_to false
         end
-      end
-
-      context "on a published document" do
-        let(:edition) { create(:published_news_article) }
-        let(:asset_initially_draft) { false }
-
-        it "does not mark attachment as draft in Asset Manager when document is unpublished" do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-          visit admin_news_article_path(edition)
-          unpublish_document_published_in_error
-          refute_sets_draft_status_in_asset_manager_to true
-        end
-      end
-
-      context "on an outcome on a draft consultation" do
-        let(:edition) { create(:draft_consultation) }
-        let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
-        let(:attachable) { edition.create_outcome!(outcome_attributes) }
-        let(:asset_initially_draft) { true }
-
-        it "marks attachment as published in Asset Manager when consultation is published" do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
-
-          visit admin_consultation_path(edition)
-          force_publish_document
-          assert_sets_draft_status_in_asset_manager_to false
-        end
-      end
-
-      context "on a feedback on a draft consultation" do
-        let(:edition) { create(:draft_consultation) }
-        let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
-        let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
-        let(:asset_initially_draft) { true }
-
-        it "marks attachment as published in Asset Manager when consultation is published" do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
-
-          visit admin_consultation_path(edition)
-          force_publish_document
-          assert_sets_draft_status_in_asset_manager_to false
-        end
-      end
-    end
-
-    context "given a policy group" do
-      let(:policy_group) { create(:policy_group) }
-      let(:asset_initially_draft) { true }
-
-      it "marks attachment as published in Asset Manager when added to policy group" do
-        visit admin_policy_group_attachments_path(policy_group)
-        add_attachment(filename)
-        Attachment.last.attachment_data.uploaded_to_asset_manager!
-        assert_sets_draft_status_in_asset_manager_to false
       end
     end
 
@@ -147,14 +276,21 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     def stub_whitehall_asset(filename, attributes = {})
       url_id = "http://asset-manager/assets/#{attributes[:id]}"
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with(filename))
-        .returns(attributes.merge(id: url_id).stringify_keys)
+              .with(&ends_with(filename))
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+
+    def stub_asset(asset_manger_id, attributes = {})
+      url_id = "http://asset-manager/assets/#{asset_manger_id}"
+      Services.asset_manager.stubs(:asset)
+              .with(asset_manger_id)
+              .returns(attributes.merge(id: url_id).stringify_keys)
     end
 
     def assert_sets_draft_status_in_asset_manager_to(draft, never: false)
       expectation = Services.asset_manager.expects(:update_asset)
-        .with(asset_id, has_entry("draft", draft))
-        .at_least_once
+                            .with(asset_manager_id, has_entry("draft", draft))
+                            .at_least_once
       expectation.never if never
       AssetManagerAttachmentMetadataWorker.drain
     end

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -12,200 +12,399 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:file) { File.open(path_to_attachment(filename)) }
     let(:attachment) { build(:file_attachment, attachable:, file:) }
     let(:attachable) { edition }
-    let(:asset_id) { "asset-id" }
+    let(:asset_manager_id) { "asset-id" }
     let(:redirect_path) { edition.public_path }
     let(:redirect_url) { edition.public_url }
     let(:topic_taxon) { build(:taxon_hash) }
 
-    before do
-      stub_publishing_api_has_linkables([], document_type: "topic")
-      login_as create(:managing_editor)
-      setup_publishing_api_for(edition)
-      attachable.attachments << attachment
-      stub_whitehall_asset(filename, id: asset_id)
-      attachable.save!
+    context "updates with legacy_url_path" do
+      before do
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        login_as create(:managing_editor)
+        setup_publishing_api_for(edition)
+        attachable.attachments << attachment
+        stub_whitehall_asset(filename, id: asset_manager_id)
+        attachable.save!
+      end
+
+      context "given a published document with file attachment" do
+        let(:edition) { create(:published_news_article) }
+
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          consolidate_document
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+
+        it "does not redirect new attachments added after a document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          unpublish_document_published_in_error
+
+          file = File.open(path_to_attachment("sample.csv"))
+          new_attachment = build(:file_attachment, attachable:, file:)
+          attachable.attachments << new_attachment
+          new_attachment.save!
+
+          refute_sets_redirect_url_in_asset_manager
+        end
+      end
+
+      context "given a published document with HTML attachment" do
+        let(:edition) { create(:published_publication, :with_html_attachment) }
+
+        it "unpublishes the HTML attachment when the document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          assert_redirected_in_publishing_api(edition.html_attachments.first.content_id, redirect_path)
+
+          unpublish_document_published_in_error
+        end
+
+        it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          consolidate_document
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+
+        it "does not redirect new attachments added after a document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          unpublish_document_published_in_error
+
+          file = File.open(path_to_attachment("sample.csv"))
+          new_attachment = build(:file_attachment, attachable:, file:)
+          attachable.attachments << new_attachment
+          new_attachment.save!
+
+          refute_sets_redirect_url_in_asset_manager
+        end
+      end
+
+      context "given a published consultation with outcome with file attachment" do
+        let(:edition) { create(:published_consultation) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+      end
+
+      context "given a published consultation with feedback with file attachment" do
+        let(:edition) { create(:published_consultation) }
+        let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
+        let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
+
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+      end
+
+      context "given an unpublished document with file attachment" do
+        let(:edition) { create(:news_article, :unpublished) }
+
+        it "resets redirect URI for attachment in Asset Manager when document is published" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+          visit admin_news_article_path(edition)
+          force_publish_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
+      end
+
+      context "given an unpublished consultation with outcome with file attachment" do
+        let(:edition) { create(:consultation, :unpublished) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+        it "resets redirect URI for attachment in Asset Manager when document is published" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+          visit admin_consultation_path(edition)
+          force_publish_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
+      end
+
+      context "given a withdrawn document with file attachment" do
+        let(:edition) { create(:news_article, :published, :withdrawn) }
+
+        it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          unwithdraw_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
+      end
+
+      context "given a withdrawn consultation with outcome with file attachment" do
+        let(:edition) { create(:consultation, :published, :withdrawn) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+        it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          unwithdraw_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
+      end
     end
 
-    context "given a published document with file attachment" do
-      let(:edition) { create(:published_news_article) }
+    context "updates with asset_manager_id" do
+      let(:variant) { Asset.variants[:original] }
 
-      it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_news_article_path(edition)
-        unpublish_document_published_in_error
-        assert_sets_redirect_url_in_asset_manager_to redirect_url
+      before do
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        login_as create(:managing_editor)
+        setup_publishing_api_for(edition)
+        attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+        attachable.attachments << attachment
+        stub_asset(asset_manager_id)
+        attachable.save!
       end
 
-      it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a published document with file attachment" do
+        let(:edition) { create(:published_news_article) }
 
-        visit admin_news_article_path(edition)
-        consolidate_document
-        assert_sets_redirect_url_in_asset_manager_to redirect_url
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          consolidate_document
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+
+        it "does not redirect new attachments added after a document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_news_article_path(edition)
+          unpublish_document_published_in_error
+
+          file = File.open(path_to_attachment("sample.csv"))
+          new_attachment = build(:file_attachment, attachable:, file:)
+          attachable.attachments << new_attachment
+          new_attachment.save!
+
+          refute_sets_redirect_url_in_asset_manager
+        end
       end
 
-      it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a published document with HTML attachment" do
+        let(:edition) { create(:published_publication, :with_html_attachment) }
 
-        visit admin_news_article_path(edition)
-        withdraw_document
-        refute_sets_redirect_url_in_asset_manager
+        it "unpublishes the HTML attachment when the document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          assert_redirected_in_publishing_api(edition.html_attachments.first.content_id, redirect_path)
+
+          unpublish_document_published_in_error
+        end
+
+        it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          consolidate_document
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
+
+        it "does not redirect new attachments added after a document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_publication_path(edition)
+          unpublish_document_published_in_error
+
+          file = File.open(path_to_attachment("sample.csv"))
+          new_attachment = build(:file_attachment, attachable:, file:)
+          attachable.attachments << new_attachment
+          new_attachment.save!
+
+          refute_sets_redirect_url_in_asset_manager
+        end
       end
 
-      it "does not redirect new attachments added after a document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a published consultation with outcome with file attachment" do
+        let(:edition) { create(:published_consultation) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-        visit admin_news_article_path(edition)
-        unpublish_document_published_in_error
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
-        file = File.open(path_to_attachment("sample.csv"))
-        new_attachment = build(:file_attachment, attachable:, file:)
-        attachable.attachments << new_attachment
-        new_attachment.save!
+          visit admin_consultation_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
 
-        refute_sets_redirect_url_in_asset_manager
-      end
-    end
+        it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
-    context "given a published document with HTML attachment" do
-      let(:edition) { create(:published_publication, :with_html_attachment) }
-
-      it "unpublishes the HTML attachment when the document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_publication_path(edition)
-        assert_redirected_in_publishing_api(edition.html_attachments.first.content_id, redirect_path)
-
-        unpublish_document_published_in_error
+          visit admin_consultation_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
       end
 
-      it "sets redirect URL for attachment in Asset Manager when document is consolidated" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a published consultation with feedback with file attachment" do
+        let(:edition) { create(:published_consultation) }
+        let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
+        let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
 
-        visit admin_publication_path(edition)
-        consolidate_document
-        assert_sets_redirect_url_in_asset_manager_to redirect_url
+        it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          unpublish_document_published_in_error
+          assert_sets_redirect_url_in_asset_manager_to redirect_url
+        end
+
+        it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          visit admin_consultation_path(edition)
+          withdraw_document
+          refute_sets_redirect_url_in_asset_manager
+        end
       end
 
-      it "does not set a redirect URI for attachment in Asset Manager when document is withdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given an unpublished document with file attachment" do
+        let(:edition) { create(:news_article, :unpublished) }
 
-        visit admin_publication_path(edition)
-        withdraw_document
-        refute_sets_redirect_url_in_asset_manager
+        it "resets redirect URI for attachment in Asset Manager when document is published" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
+
+          visit admin_news_article_path(edition)
+          force_publish_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
       end
 
-      it "does not redirect new attachments added after a document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given an unpublished consultation with outcome with file attachment" do
+        let(:edition) { create(:consultation, :unpublished) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-        visit admin_publication_path(edition)
-        unpublish_document_published_in_error
+        it "resets redirect URI for attachment in Asset Manager when document is published" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
 
-        file = File.open(path_to_attachment("sample.csv"))
-        new_attachment = build(:file_attachment, attachable:, file:)
-        attachable.attachments << new_attachment
-        new_attachment.save!
-
-        refute_sets_redirect_url_in_asset_manager
-      end
-    end
-
-    context "given a published consultation with outcome with file attachment" do
-      let(:edition) { create(:published_consultation) }
-      let(:outcome_attributes) { attributes_for(:consultation_outcome) }
-      let(:attachable) { edition.create_outcome!(outcome_attributes) }
-
-      it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_consultation_path(edition)
-        unpublish_document_published_in_error
-        assert_sets_redirect_url_in_asset_manager_to redirect_url
+          visit admin_consultation_path(edition)
+          force_publish_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
       end
 
-      it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a withdrawn document with file attachment" do
+        let(:edition) { create(:news_article, :published, :withdrawn) }
 
-        visit admin_consultation_path(edition)
-        withdraw_document
-        refute_sets_redirect_url_in_asset_manager
-      end
-    end
+        it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
-    context "given a published consultation with feedback with file attachment" do
-      let(:edition) { create(:published_consultation) }
-      let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
-      let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
-
-      it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_consultation_path(edition)
-        unpublish_document_published_in_error
-        assert_sets_redirect_url_in_asset_manager_to redirect_url
+          visit admin_news_article_path(edition)
+          unwithdraw_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
       end
 
-      it "does not set redirect URI for attachment in Asset Manager when document is withdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+      context "given a withdrawn consultation with outcome with file attachment" do
+        let(:edition) { create(:consultation, :published, :withdrawn) }
+        let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+        let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-        visit admin_consultation_path(edition)
-        withdraw_document
-        refute_sets_redirect_url_in_asset_manager
-      end
-    end
+        it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
-    context "given an unpublished document with file attachment" do
-      let(:edition) { create(:news_article, :unpublished) }
-
-      it "resets redirect URI for attachment in Asset Manager when document is published" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-        stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
-
-        visit admin_news_article_path(edition)
-        force_publish_document
-        assert_sets_redirect_url_in_asset_manager_to nil
-      end
-    end
-
-    context "given an unpublished consultation with outcome with file attachment" do
-      let(:edition) { create(:consultation, :unpublished) }
-      let(:outcome_attributes) { attributes_for(:consultation_outcome) }
-      let(:attachable) { edition.create_outcome!(outcome_attributes) }
-
-      it "resets redirect URI for attachment in Asset Manager when document is published" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-        stub_publishing_api_links_with_taxons(edition.content_id, [topic_taxon["content_id"]])
-
-        visit admin_consultation_path(edition)
-        force_publish_document
-        assert_sets_redirect_url_in_asset_manager_to nil
-      end
-    end
-
-    context "given a withdrawn document with file attachment" do
-      let(:edition) { create(:news_article, :published, :withdrawn) }
-
-      it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_news_article_path(edition)
-        unwithdraw_document
-        assert_sets_redirect_url_in_asset_manager_to nil
-      end
-    end
-
-    context "given a withdrawn consultation with outcome with file attachment" do
-      let(:edition) { create(:consultation, :published, :withdrawn) }
-      let(:outcome_attributes) { attributes_for(:consultation_outcome) }
-      let(:attachable) { edition.create_outcome!(outcome_attributes) }
-
-      it "resets redirect URI for attachment in Asset Manager when document is unwithdrawn" do
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-        visit admin_consultation_path(edition)
-        unwithdraw_document
-        assert_sets_redirect_url_in_asset_manager_to nil
+          visit admin_consultation_path(edition)
+          unwithdraw_document
+          assert_sets_redirect_url_in_asset_manager_to nil
+        end
       end
     end
 
@@ -226,34 +425,41 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     def stub_whitehall_asset(filename, attributes = {})
       url_id = "http://asset-manager/assets/#{attributes[:id]}"
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with(filename))
-        .returns(attributes.merge(id: url_id).stringify_keys)
+              .with(&ends_with(filename))
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+
+    def stub_asset(asset_manger_id, attributes = {})
+      url_id = "http://asset-manager/assets/#{asset_manger_id}"
+      Services.asset_manager.stubs(:asset)
+              .with(asset_manger_id)
+              .returns(attributes.merge(id: url_id).stringify_keys)
     end
 
     def assert_sets_redirect_url_in_asset_manager_to(redirect_url)
       Services.asset_manager.expects(:update_asset)
-        .with(asset_id, { "redirect_url" => redirect_url })
-        .at_least_once
+              .with(asset_manager_id, { "redirect_url" => redirect_url })
+              .at_least_once
       AssetManagerAttachmentRedirectUrlUpdateWorker.drain
     end
 
     def assert_redirected_in_publishing_api(content_id, redirect_path)
       Services.publishing_api.expects(:unpublish)
-        .with(
-          content_id,
-          type: "redirect",
-          alternative_path: redirect_path,
-          locale: "en",
-          allow_draft: false,
-          discard_drafts: true,
-        )
-        .once
+              .with(
+                content_id,
+                type: "redirect",
+                alternative_path: redirect_path,
+                locale: "en",
+                allow_draft: false,
+                discard_drafts: true,
+              )
+              .once
     end
 
     def refute_sets_redirect_url_in_asset_manager
       Services.asset_manager.expects(:update_asset)
-        .with(asset_id, "redirect_url" => anything)
-        .never
+              .with(asset_manager_id, "redirect_url" => anything)
+              .never
       AssetManagerAttachmentRedirectUrlUpdateWorker.drain
     end
 

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -12,79 +12,160 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     let(:filename) { "sample.docx" }
     let(:file) { File.open(path_to_attachment(filename)) }
     let(:attachment) { build(:file_attachment, title: "attachment-title", attachable: edition, file:) }
-    let(:asset_id) { "asset-id" }
+    let(:asset_manager_id) { "asset-id" }
 
     let(:replacement_filename) { "sample.rtf" }
-    let(:replacement_asset_id) { "replacement-asset-id" }
+    let(:replacement_asset_manager_id) { "replacement-asset-id" }
 
-    before do
-      create(:government)
-      login_as(managing_editor)
-      edition.attachments << attachment
-      stub_publishing_api_has_linkables([], document_type: "topic")
-      setup_publishing_api_for(edition)
-      stub_whitehall_asset(filename, id: asset_id)
-    end
+    context "updates with legacy_url_path" do
+      before do
+        create(:government)
+        login_as(managing_editor)
+        edition.attachments << attachment
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        setup_publishing_api_for(edition)
+        stub_whitehall_asset(filename, id: asset_manager_id)
+      end
 
-    context "given a draft document with a file attachment" do
-      let(:edition) { create(:news_article) }
+      context "given a draft document with a file attachment" do
+        let(:edition) { create(:news_article) }
 
-      context "when attachment is replaced" do
-        before do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          visit admin_news_article_path(edition)
-          click_link "Modify attachments"
-          within row_containing(filename) do
-            click_link "Edit"
+        context "when attachment is replaced" do
+          before do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            visit admin_news_article_path(edition)
+            click_link "Modify attachments"
+            within row_containing(filename) do
+              click_link "Edit"
+            end
+            fill_in "Title", with: "Attachment Title"
+            attach_file "Replace file", path_to_attachment(replacement_filename)
+            click_button "Save"
+            assert_text "Attachment 'Attachment Title' updated"
+
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+            stub_whitehall_asset(replacement_filename, id: replacement_asset_manager_id)
           end
-          fill_in "Title", with: "Attachment Title"
-          attach_file "Replace file", path_to_attachment(replacement_filename)
-          click_button "Save"
-          assert_text "Attachment 'Attachment Title' updated"
 
-          Attachment.last.attachment_data.uploaded_to_asset_manager!
-          stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
+          # We rely on Asset Manager to do the redirect immediately in this case,
+          # because the replacement is visible to the user.
+          it "updates replacement_id for attachment in Asset Manager" do
+            Services.asset_manager.expects(:update_asset)
+                    .at_least_once
+                    .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
+            AssetManagerAttachmentMetadataWorker.drain
+          end
         end
+      end
 
-        # We rely on Asset Manager to do the redirect immediately in this case,
-        # because the replacement is visible to the user.
-        it "updates replacement_id for attachment in Asset Manager" do
-          Services.asset_manager.expects(:update_asset)
-            .at_least_once
-            .with(asset_id, { "replacement_id" => replacement_asset_id })
-          AssetManagerAttachmentMetadataWorker.drain
+      context "given a published document with file attachment" do
+        let(:edition) { create(:published_news_article) }
+
+        context "when new draft is created and attachment is replaced" do
+          before do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_has_linkables([], document_type: "topic")
+            visit admin_news_article_path(edition)
+            click_button "Create new edition"
+            click_link "Attachments 1"
+            within row_containing(filename) do
+              click_link "Edit"
+            end
+            attach_file "Replace file", path_to_attachment(replacement_filename)
+            click_button "Save"
+            assert_text "Attachment 'attachment-title' updated"
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+            stub_whitehall_asset(replacement_filename, id: replacement_asset_manager_id)
+          end
+
+          # We rely on Asset Manager *not* to do the redirect, even though the
+          # asset is marked as replaced, because the replacement is not yet
+          # visible to the user.
+          it "updates replacement_id for attachment in Asset Manager" do
+            Services.asset_manager.expects(:update_asset)
+                    .at_least_once
+                    .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
+            AssetManagerAttachmentMetadataWorker.drain
+          end
         end
       end
     end
 
-    context "given a published document with file attachment" do
-      let(:edition) { create(:published_news_article) }
+    context "updates with asset_manager_id" do
+      let(:variant) { Asset.variants[:original] }
 
-      context "when new draft is created and attachment is replaced" do
-        before do
-          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-          stub_publishing_api_has_linkables([], document_type: "topic")
-          visit admin_news_article_path(edition)
-          click_button "Create new edition"
-          click_link "Attachments 1"
-          within row_containing(filename) do
-            click_link "Edit"
+      before do
+        create(:government)
+        login_as(managing_editor)
+        attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+        edition.attachments << attachment
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        setup_publishing_api_for(edition)
+        stub_asset(asset_manager_id)
+      end
+
+      context "given a draft document with a file attachment" do
+        let(:edition) { create(:news_article) }
+
+        context "when attachment is replaced" do
+          before do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            visit admin_news_article_path(edition)
+            click_link "Modify attachments"
+            within row_containing(filename) do
+              click_link "Edit"
+            end
+            fill_in "Title", with: "Attachment Title"
+            attach_file "Replace file", path_to_attachment(replacement_filename)
+            click_button "Save"
+            assert_text "Attachment 'Attachment Title' updated"
+
+            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:)
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+            stub_asset(replacement_asset_manager_id)
           end
-          attach_file "Replace file", path_to_attachment(replacement_filename)
-          click_button "Save"
-          assert_text "Attachment 'attachment-title' updated"
-          Attachment.last.attachment_data.uploaded_to_asset_manager!
-          stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
-        end
 
-        # We rely on Asset Manager *not* to do the redirect, even though the
-        # asset is marked as replaced, because the replacement is not yet
-        # visible to the user.
-        it "updates replacement_id for attachment in Asset Manager" do
-          Services.asset_manager.expects(:update_asset)
-            .at_least_once
-            .with(asset_id, { "replacement_id" => replacement_asset_id })
-          AssetManagerAttachmentMetadataWorker.drain
+          # We rely on Asset Manager to do the redirect immediately in this case,
+          # because the replacement is visible to the user.
+          it "updates replacement_id for attachment in Asset Manager" do
+            Services.asset_manager.expects(:update_asset)
+                    .at_least_once
+                    .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
+            AssetManagerAttachmentMetadataWorker.drain
+          end
+        end
+      end
+
+      context "given a published document with file attachment" do
+        let(:edition) { create(:published_news_article) }
+
+        context "when new draft is created and attachment is replaced" do
+          before do
+            stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+            stub_publishing_api_has_linkables([], document_type: "topic")
+            visit admin_news_article_path(edition)
+            click_button "Create new edition"
+            click_link "Attachments 1"
+            within row_containing(filename) do
+              click_link "Edit"
+            end
+            attach_file "Replace file", path_to_attachment(replacement_filename)
+            click_button "Save"
+            assert_text "Attachment 'attachment-title' updated"
+            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:)
+            Attachment.last.attachment_data.uploaded_to_asset_manager!
+            stub_asset(replacement_asset_manager_id)
+          end
+
+          # We rely on Asset Manager *not* to do the redirect, even though the
+          # asset is marked as replaced, because the replacement is not yet
+          # visible to the user.
+          it "updates replacement_id for attachment in Asset Manager" do
+            Services.asset_manager.expects(:update_asset)
+                    .at_least_once
+                    .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
+            AssetManagerAttachmentMetadataWorker.drain
+          end
         end
       end
     end
@@ -106,8 +187,15 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     def stub_whitehall_asset(filename, attributes = {})
       url_id = "http://asset-manager/assets/#{attributes[:id]}"
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with(filename))
-        .returns(attributes.merge(id: url_id).stringify_keys)
+              .with(&ends_with(filename))
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+
+    def stub_asset(asset_manger_id, attributes = {})
+      url_id = "http://asset-manager/assets/#{asset_manger_id}"
+      Services.asset_manager.stubs(:asset)
+              .with(asset_manger_id)
+              .returns(attributes.merge(id: url_id).stringify_keys)
     end
   end
 end

--- a/test/unit/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/services/asset_manager/asset_updater_test.rb
@@ -12,7 +12,7 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
     @attachment_data = FactoryBot.build(:attachment_data)
   end
 
-  describe "asset_manager_id is not present" do
+  describe "called with legacy_url_path" do
     test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
       @worker.stubs(:find_asset_by).with(@legacy_url_path)
              .returns("id" => @asset_url, "deleted" => true)
@@ -137,7 +137,7 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
     end
   end
 
-  describe "asset_manager_id is present" do
+  describe "called with asset_manager_id" do
     test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
       @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
              .returns("id" => @asset_url, "deleted" => true)

--- a/test/unit/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/services/asset_manager/asset_updater_test.rb
@@ -1,135 +1,253 @@
 require "test_helper"
 
 class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   setup do
-    @asset_id = "asset-id"
-    @asset_url = "http://asset-manager/assets/#{@asset_id}"
+    @asset_manager_id = "asset-id"
+    @asset_url = "http://asset-manager/assets/#{@asset_manager_id}"
     @legacy_url_path = "legacy-url-path"
     @worker = AssetManager::AssetUpdater.new
     @redirect_url = "https://www.test.gov.uk/example"
     @attachment_data = FactoryBot.build(:attachment_data)
   end
 
-  test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_url, "deleted" => true)
+  describe "asset_manager_id is not present" do
+    test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_url, "deleted" => true)
 
-    @attachment_data.stubs(:deleted?).returns(false)
+      @attachment_data.stubs(:deleted?).returns(false)
 
-    assert_raises(AssetManager::AssetUpdater::AssetAlreadyDeleted) do
-      @worker.call(@attachment_data, @legacy_url_path, { "draft" => false })
+      assert_raises(AssetManager::AssetUpdater::AssetAlreadyDeleted) do
+        @worker.call(nil, @attachment_data, @legacy_url_path, { "draft" => false })
+      end
+    end
+
+    test "does not update asset if no attributes are supplied" do
+      Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+              .returns("id" => @asset_url)
+      Services.asset_manager.expects(:update_asset).never
+
+      assert_raises(AssetManager::AssetUpdater::AssetAttributesEmpty) do
+        @worker.call(nil, @attachment_data, @legacy_url_path)
+      end
+    end
+
+    test "marks draft asset as published" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "draft" => true)
+      Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => false })
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "draft" => false })
+    end
+
+    test "does not mark asset as published if already published" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "draft" => false)
+      Services.asset_manager.expects(:update_asset).never
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "draft" => false })
+    end
+
+    test "mark published asset as draft" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "draft" => false)
+      Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => true })
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "draft" => true })
+    end
+
+    test "does not mark asset as draft if already draft" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "draft" => true)
+      Services.asset_manager.expects(:update_asset).never
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "draft" => true })
+    end
+
+    test "sets redirect_url on asset if not already set" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "redirect_url" => @redirect_url })
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
+    end
+
+    test "sets redirect_url on asset if already set to different value" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "redirect_url" => "#{@redirect_url}-another")
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "redirect_url" => @redirect_url })
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
+    end
+
+    test "does not set redirect_url on asset if already set" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "redirect_url" => @redirect_url)
+      Services.asset_manager.expects(:update_asset).never
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
+    end
+
+    test "marks asset as access-limited" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "access_limited" => %w[uid-1] })
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "access_limited" => %w[uid-1] })
+    end
+
+    test "does not mark asset as access-limited if already set" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "access_limited" => %w[uid-1])
+      Services.asset_manager.expects(:update_asset).never
+
+      @worker.call(nil, @attachment_data, @legacy_url_path, { "access_limited" => %w[uid-1] })
+    end
+
+    test "marks asset as replaced by another asset" do
+      replacement_legacy_url_path = "replacement-legacy-url-path"
+      replacement_id = "replacement-id"
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id)
+      @worker.stubs(:find_asset_by).with(replacement_legacy_url_path)
+             .returns("id" => replacement_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "replacement_id" => replacement_id })
+
+      attributes = { "replacement_legacy_url_path" => replacement_legacy_url_path }
+      @worker.call(nil, @attachment_data, @legacy_url_path, attributes)
+    end
+
+    test "does not mark asset as replaced if already replaced by same asset" do
+      replacement_legacy_url_path = "replacement-legacy-url-path"
+      replacement_id = "replacement-id"
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id, "replacement_id" => replacement_id)
+      @worker.stubs(:find_asset_by).with(replacement_legacy_url_path)
+             .returns("id" => replacement_id)
+      Services.asset_manager.expects(:update_asset).never
+
+      attributes = { "replacement_legacy_url_path" => replacement_legacy_url_path }
+      @worker.call(nil, @attachment_data, @legacy_url_path, attributes)
     end
   end
 
-  test "does not update asset if no attributes are supplied" do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns("id" => @asset_url)
-    Services.asset_manager.expects(:update_asset).never
+  describe "asset_manager_id is present" do
+    test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_url, "deleted" => true)
+      @attachment_data.stubs(:deleted?).returns(false)
 
-    assert_raises(AssetManager::AssetUpdater::AssetAttributesEmpty) do
-      @worker.call(@attachment_data, @legacy_url_path)
+      assert_raises(AssetManager::AssetUpdater::AssetAlreadyDeleted) do
+        @worker.call(@asset_manager_id, @attachment_data, nil, { "draft" => false })
+      end
     end
-  end
 
-  test "marks draft asset as published" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "draft" => true)
-    Services.asset_manager.expects(:update_asset).with(@asset_id, { "draft" => false })
+    test "does not update asset if no attributes are supplied" do
+      assert_raises(AssetManager::AssetUpdater::AssetAttributesEmpty) do
+        @worker.call(@asset_manager_id, @attachment_data, @legacy_url_path)
+      end
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "draft" => false })
-  end
+    test "marks draft asset as published" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "draft" => true)
+      Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => false })
 
-  test "does not mark asset as published if already published" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "draft" => false)
-    Services.asset_manager.expects(:update_asset).never
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "draft" => false })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "draft" => false })
-  end
+    test "does not mark asset as published if already published" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "draft" => false)
+      Services.asset_manager.expects(:update_asset).never
 
-  test "mark published asset as draft" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "draft" => false)
-    Services.asset_manager.expects(:update_asset).with(@asset_id, { "draft" => true })
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "draft" => false })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "draft" => true })
-  end
+    test "mark published asset as draft" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "draft" => false)
+      Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => true })
 
-  test "does not mark asset as draft if already draft" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "draft" => true)
-    Services.asset_manager.expects(:update_asset).never
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "draft" => true })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "draft" => true })
-  end
+    test "does not mark asset as draft if already draft" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "draft" => true)
+      Services.asset_manager.expects(:update_asset).never
 
-  test "sets redirect_url on asset if not already set" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id)
-    Services.asset_manager.expects(:update_asset)
-      .with(@asset_id, { "redirect_url" => @redirect_url })
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "draft" => true })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
-  end
+    test "sets redirect_url on asset if not already set" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "redirect_url" => @redirect_url })
 
-  test "sets redirect_url on asset if already set to different value" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "redirect_url" => "#{@redirect_url}-another")
-    Services.asset_manager.expects(:update_asset)
-      .with(@asset_id, { "redirect_url" => @redirect_url })
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "redirect_url" => @redirect_url })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
-  end
+    test "sets redirect_url on asset if already set to different value" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "redirect_url" => "#{@redirect_url}-another")
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "redirect_url" => @redirect_url })
 
-  test "does not set redirect_url on asset if already set" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "redirect_url" => @redirect_url)
-    Services.asset_manager.expects(:update_asset).never
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "redirect_url" => @redirect_url })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "redirect_url" => @redirect_url })
-  end
+    test "does not set redirect_url on asset if already set" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "redirect_url" => @redirect_url)
+      Services.asset_manager.expects(:update_asset).never
 
-  test "marks asset as access-limited" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id)
-    Services.asset_manager.expects(:update_asset)
-      .with(@asset_id, { "access_limited" => %w[uid-1] })
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "redirect_url" => @redirect_url })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "access_limited" => %w[uid-1] })
-  end
+    test "marks asset as access-limited" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "access_limited" => %w[uid-1] })
 
-  test "does not mark asset as access-limited if already set" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "access_limited" => %w[uid-1])
-    Services.asset_manager.expects(:update_asset).never
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "access_limited" => %w[uid-1] })
+    end
 
-    @worker.call(@attachment_data, @legacy_url_path, { "access_limited" => %w[uid-1] })
-  end
+    test "does not mark asset as access-limited if already set" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "access_limited" => %w[uid-1])
+      Services.asset_manager.expects(:update_asset).never
 
-  test "marks asset as replaced by another asset" do
-    replacement_legacy_url_path = "replacement-legacy-url-path"
-    replacement_id = "replacement-id"
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id)
-    @worker.stubs(:find_asset_by).with(replacement_legacy_url_path)
-      .returns("id" => replacement_id)
-    Services.asset_manager.expects(:update_asset)
-      .with(@asset_id, { "replacement_id" => replacement_id })
+      @worker.call(@asset_manager_id, @attachment_data, nil, { "access_limited" => %w[uid-1] })
+    end
 
-    attributes = { "replacement_legacy_url_path" => replacement_legacy_url_path }
-    @worker.call(@attachment_data, @legacy_url_path, attributes)
-  end
+    test "marks asset as replaced by another asset" do
+      replacement_id = "replacement-id"
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:update_asset)
+              .with(@asset_manager_id, { "replacement_id" => replacement_id })
 
-  test "does not mark asset as replaced if already replaced by same asset" do
-    replacement_legacy_url_path = "replacement-legacy-url-path"
-    replacement_id = "replacement-id"
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id, "replacement_id" => replacement_id)
-    @worker.stubs(:find_asset_by).with(replacement_legacy_url_path)
-      .returns("id" => replacement_id)
-    Services.asset_manager.expects(:update_asset).never
+      attributes = { "replacement_id" => replacement_id }
+      @worker.call(@asset_manager_id, @attachment_data, nil, attributes)
+    end
 
-    attributes = { "replacement_legacy_url_path" => replacement_legacy_url_path }
-    @worker.call(@attachment_data, @legacy_url_path, attributes)
+    test "does not mark asset as replaced if already replaced by same asset" do
+      replacement_id = "replacement-id"
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id, "replacement_id" => replacement_id)
+      Services.asset_manager.expects(:update_asset).never
+
+      attributes = { "replacement_id" => replacement_id }
+      @worker.call(@asset_manager_id, @attachment_data, nil, attributes)
+    end
   end
 end

--- a/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
@@ -30,7 +30,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the access limited state of the asset" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
 
         updater.call(attachment_data, access_limited: true)
       end
@@ -52,9 +52,9 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the access limited state of the asset and it's thumbnail" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
+          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
 
         updater.call(attachment_data, access_limited: true)
       end
@@ -70,7 +70,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the asset to have an empty access_limited array" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
 
         updater.call(attachment_data, access_limited: true)
       end
@@ -86,9 +86,9 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the asset to have an empty access_limited array" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
+          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
 
         updater.call(attachment_data, access_limited: true)
       end

--- a/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
@@ -8,89 +8,189 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
     let(:attachment_data) { attachment.attachment_data }
     let(:update_worker) { mock("asset-manager-update-asset-worker") }
 
-    around do |test|
-      AssetManager.stub_const(:AssetUpdater, update_worker) do
-        test.call
+    describe "Attachment Data has no assets" do
+      around do |test|
+        AssetManager.stub_const(:AssetUpdater, update_worker) do
+          test.call
+        end
+      end
+
+      context "when attachment's attachable is access limited and the attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+        before do
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+
+          access_limited_object = stub("access-limited-object")
+          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+
+          attachment_data.stubs(:access_limited?).returns(true)
+          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+        end
+
+        it "updates the access limited state of the asset" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
+      end
+
+      context "when attachment's attachable is access limited and the attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+        before do
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+
+          access_limited_object = stub("access-limited-object")
+          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+
+          attachment_data.stubs(:access_limited?).returns(true)
+          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+        end
+
+        it "updates the access limited state of the asset and it's thumbnail" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
+      end
+
+      context "when attachment's attachable is not access limited and the attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+        before do
+          attachment_data.stubs(:access_limited?).returns(false)
+        end
+
+        it "updates the asset to have an empty access_limited array" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
+      end
+
+      context "when attachment's attachable is not access limited and the attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+        before do
+          attachment_data.stubs(:access_limited?).returns(false)
+        end
+
+        it "updates the asset to have an empty access_limited array" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
       end
     end
 
-    context "when attachment's attachable is access limited and the attachment is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-
-      before do
-        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-
-        access_limited_object = stub("access-limited-object")
-        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
-
-        attachment_data.stubs(:access_limited?).returns(true)
-        attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+    describe "Attachment Data has asset(s)" do
+      around do |test|
+        AssetManager.stub_const(:AssetUpdater, update_worker) do
+          test.call
+        end
       end
 
-      it "updates the access limited state of the asset" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+      context "when attachment's attachable is access limited and the attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-        updater.call(attachment_data, access_limited: true)
-      end
-    end
+        before do
+          attachment_data.assets = [asset]
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
 
-    context "when attachment's attachable is access limited and the attachment is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+          access_limited_object = stub("access-limited-object")
+          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
 
-      before do
-        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+          attachment_data.stubs(:access_limited?).returns(true)
+          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+        end
 
-        access_limited_object = stub("access-limited-object")
-        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+        it "updates the access limited state of the asset" do
+          update_worker.expects(:call)
+                       .with(asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
 
-        attachment_data.stubs(:access_limited?).returns(true)
-        attachment_data.stubs(:access_limited_object).returns(access_limited_object)
-      end
-
-      it "updates the access limited state of the asset and it's thumbnail" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
-
-        updater.call(attachment_data, access_limited: true)
-      end
-    end
-
-    context "when attachment's attachable is not access limited and the attachment is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-
-      before do
-        attachment_data.stubs(:access_limited?).returns(false)
+          updater.call(attachment_data, access_limited: true)
+        end
       end
 
-      it "updates the asset to have an empty access_limited array" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+      context "when attachment's attachable is access limited and the attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
 
-        updater.call(attachment_data, access_limited: true)
+        before do
+          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+
+          access_limited_object = stub("access-limited-object")
+          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+
+          attachment_data.stubs(:access_limited?).returns(true)
+          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+        end
+
+        it "updates the access limited state of the asset and its thumbnail" do
+          update_worker.expects(:call)
+                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+          update_worker.expects(:call)
+                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
       end
-    end
 
-    context "when attachment's attachable is not access limited and the attachment is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+      context "when attachment's attachable is not access limited and the attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-      before do
-        attachment_data.stubs(:access_limited?).returns(false)
+        before do
+          attachment_data.assets = [asset]
+          attachment_data.stubs(:access_limited?).returns(false)
+        end
+
+        it "updates the asset to have an empty access_limited array" do
+          update_worker.expects(:call)
+                       .with(asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
       end
 
-      it "updates the asset to have an empty access_limited array" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
+      context "when attachment's attachable is not access limited and the attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
 
-        updater.call(attachment_data, access_limited: true)
+        before do
+          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
+          attachment_data.stubs(:access_limited?).returns(false)
+        end
+
+        it "updates the asset to have an empty access_limited array" do
+          update_worker.expects(:call)
+                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+          update_worker.expects(:call)
+                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+
+          updater.call(attachment_data, access_limited: true)
+        end
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
@@ -26,7 +26,7 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
 
       it "marks corresponding asset as draft" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
 
         updater.call(attachment_data, draft_status: true)
       end
@@ -48,9 +48,9 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
 
       it "marks asset for attachment & its thumbnail as draft" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
+          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
 
         updater.call(attachment_data, draft_status: true)
       end
@@ -60,9 +60,9 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
 
         it "marks corresponding assets as not draft" do
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
           updater.call(attachment_data, draft_status: true)
         end
@@ -74,9 +74,9 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
         it "marks corresponding assets as not draft even though attachment is draft" do
           attachment_data.update!(present_at_unpublish: true)
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
           updater.call(attachment_data, draft_status: true)
         end
@@ -87,9 +87,9 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
 
         it "marks corresponding assets as not draft even though attachment is draft" do
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
           updater.call(attachment_data, draft_status: true)
         end

--- a/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
@@ -14,84 +14,175 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
       end
     end
 
-    context "when attachment is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-      let(:draft) { true }
+    describe "AttachmentData has no assets" do
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+        let(:draft) { true }
 
-      before do
-        AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-        attachment_data.stubs(:draft?).returns(draft)
+        before do
+          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+          attachment_data.stubs(:draft?).returns(draft)
+        end
+
+        it "marks corresponding asset as draft" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+
+          updater.call(attachment_data, draft_status: true)
+        end
       end
 
-      it "marks corresponding asset as draft" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+        let(:draft) { true }
+        let(:unpublished) { false }
+        let(:replaced) { false }
 
-        updater.call(attachment_data, draft_status: true)
+        before do
+          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+          attachment_data.stubs(:draft?).returns(draft)
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:replaced?).returns(replaced)
+        end
+
+        it "marks asset for attachment & its thumbnail as draft" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
+
+          updater.call(attachment_data, draft_status: true)
+        end
+
+        context "and attachment is not draft" do
+          let(:draft) { false }
+
+          it "marks corresponding assets as not draft" do
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is unpublished" do
+          let(:unpublished) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            attachment_data.update!(present_at_unpublish: true)
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is replaced" do
+          let(:replaced) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
       end
     end
 
-    context "when attachment is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-      let(:draft) { true }
-      let(:unpublished) { false }
-      let(:replaced) { false }
+    describe "AttachmentData has asset(s)" do
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+        let(:draft) { true }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-      before do
-        AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-        attachment_data.stubs(:draft?).returns(draft)
-        attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:replaced?).returns(replaced)
-      end
+        before do
+          attachment_data.assets = [asset]
+          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+          attachment_data.stubs(:draft?).returns(draft)
+        end
 
-      it "marks asset for attachment & its thumbnail as draft" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
-
-        updater.call(attachment_data, draft_status: true)
-      end
-
-      context "and attachment is not draft" do
-        let(:draft) { false }
-
-        it "marks corresponding assets as not draft" do
+        it "marks corresponding asset as draft" do
           update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
-          update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+                       .with(asset.asset_manager_id, attachment_data, nil, { "draft" => true })
 
           updater.call(attachment_data, draft_status: true)
         end
       end
 
-      context "and attachment is unpublished" do
-        let(:unpublished) { true }
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+        let(:draft) { true }
+        let(:unpublished) { false }
+        let(:replaced) { false }
+        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
 
-        it "marks corresponding assets as not draft even though attachment is draft" do
-          attachment_data.update!(present_at_unpublish: true)
+        before do
+          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
+          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+          attachment_data.stubs(:draft?).returns(draft)
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:replaced?).returns(replaced)
+        end
+
+        it "marks asset for attachment & its thumbnail as draft" do
           update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
           update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
 
           updater.call(attachment_data, draft_status: true)
         end
-      end
 
-      context "and attachment is replaced" do
-        let(:replaced) { true }
+        context "and attachment is not draft" do
+          let(:draft) { false }
 
-        it "marks corresponding assets as not draft even though attachment is draft" do
-          update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
-          update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
+          it "marks corresponding assets as not draft" do
+            update_worker.expects(:call)
+                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
 
-          updater.call(attachment_data, draft_status: true)
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is unpublished" do
+          let(:unpublished) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            attachment_data.update!(present_at_unpublish: true)
+            update_worker.expects(:call)
+                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is replaced" do
+          let(:replaced) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            update_worker.expects(:call)
+                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_worker.expects(:call)
+                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -35,7 +35,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
 
       it "sets parent_document_url for attachment using draft hostname" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
 
         updater.call(attachment_data, link_header: true)
       end
@@ -47,7 +47,7 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
 
       it "sets parent_document_url of corresponding asset" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
 
         updater.call(attachment_data, link_header: true)
       end
@@ -59,9 +59,9 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
 
       it "sets parent_document_url for attachment & its thumbnail" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
+          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
 
         updater.call(attachment_data, link_header: true)
       end

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -17,53 +17,117 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
       end
     end
 
-    context "when attachment doesn't belong to an edition" do
-      let(:attachment) { FactoryBot.create(:file_attachment) }
+    describe "Attachment Data has no assets" do
+      context "when attachment doesn't belong to an edition" do
+        let(:attachment) { FactoryBot.create(:file_attachment) }
 
-      it "does not update status of any assets" do
-        update_worker.expects(:call).never
+        it "does not update status of any assets" do
+          update_worker.expects(:call).never
 
-        updater.call(attachment_data, link_header: true)
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment belongs to a draft edition" do
+        let(:edition) { FactoryBot.create(:draft_edition) }
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+        let(:parent_document_url) { edition.public_url(draft: true) }
+
+        it "sets parent_document_url for attachment using draft hostname" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+
+        it "sets parent_document_url of corresponding asset" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+
+        it "sets parent_document_url for attachment & its thumbnail" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
       end
     end
 
-    context "when attachment belongs to a draft edition" do
-      let(:edition) { FactoryBot.create(:draft_edition) }
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-      let(:parent_document_url) { edition.public_url(draft: true) }
+    describe "Attachment Data has asset(s)" do
+      context "when attachment doesn't belong to an edition" do
+        let(:attachment) { FactoryBot.create(:file_attachment) }
 
-      it "sets parent_document_url for attachment using draft hostname" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+        it "does not update status of any assets" do
+          update_worker.expects(:call).never
 
-        updater.call(attachment_data, link_header: true)
+          updater.call(attachment_data, link_header: true)
+        end
       end
-    end
 
-    context "when attachment is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+      context "when attachment belongs to a draft edition" do
+        let(:edition) { FactoryBot.create(:draft_edition) }
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+        let(:parent_document_url) { edition.public_url(draft: true) }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-      it "sets parent_document_url of corresponding asset" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+        it "sets parent_document_url for attachment using draft hostname" do
+          attachment_data.assets = [asset]
 
-        updater.call(attachment_data, link_header: true)
+          update_worker.expects(:call)
+                       .with(asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
       end
-    end
 
-    context "when attachment is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-      it "sets parent_document_url for attachment & its thumbnail" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
+        it "sets parent_document_url of corresponding asset" do
+          attachment_data.assets = [asset]
 
-        updater.call(attachment_data, link_header: true)
+          update_worker.expects(:call)
+                       .with(asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+
+        it "sets parent_document_url for attachment & its thumbnail" do
+          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
+
+          update_worker.expects(:call)
+                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+          update_worker.expects(:call)
+                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
@@ -18,56 +18,119 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
       end
     end
 
-    context "when attachment is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+    describe "Attachment Data has no assets" do
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
-      before do
-        attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:present_at_unpublish?).returns(true)
-        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        before do
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:present_at_unpublish?).returns(true)
+          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        end
+
+        it "updates redirect URL of corresponding asset" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+
+          updater.call(attachment_data, redirect_url: true)
+        end
       end
 
-      it "updates redirect URL of corresponding asset" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
 
-        updater.call(attachment_data, redirect_url: true)
+        before do
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:present_at_unpublish?).returns(true)
+          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        end
+
+        it "updates redirect URL of asset for attachment & its thumbnail" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
+
+          updater.call(attachment_data, redirect_url: true)
+        end
+
+        context "and attachment is not unpublished" do
+          let(:unpublished) { false }
+          let(:unpublished_edition) { nil }
+
+          it "resets redirect URL of asset for attachment & its thumbnail" do
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
+
+            updater.call(attachment_data, redirect_url: true)
+          end
+        end
       end
     end
 
-    context "when attachment is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+    describe "Attachment Data has asset(s)" do
+      context "when attachment is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
 
-      before do
-        attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:present_at_unpublish?).returns(true)
-        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-      end
+        before do
+          attachment_data.assets = [asset]
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:present_at_unpublish?).returns(true)
+          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        end
 
-      it "updates redirect URL of asset for attachment & its thumbnail" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
-
-        updater.call(attachment_data, redirect_url: true)
-      end
-
-      context "and attachment is not unpublished" do
-        let(:unpublished) { false }
-        let(:unpublished_edition) { nil }
-
-        it "resets redirect URL of asset for attachment & its thumbnail" do
+        it "updates redirect URL of corresponding asset" do
           update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
-          update_worker.expects(:call)
-            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
+                       .with(asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
 
           updater.call(attachment_data, redirect_url: true)
+        end
+      end
+
+      context "when attachment is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+
+        before do
+          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:present_at_unpublish?).returns(true)
+          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        end
+
+        it "updates redirect URL of asset for attachment & its thumbnail" do
+          update_worker.expects(:call)
+                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
+          update_worker.expects(:call)
+                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
+
+          updater.call(attachment_data, redirect_url: true)
+        end
+
+        context "and attachment is not unpublished" do
+          let(:unpublished) { false }
+          let(:unpublished_edition) { nil }
+
+          it "resets redirect URL of asset for attachment & its thumbnail" do
+            update_worker.expects(:call)
+                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
+            update_worker.expects(:call)
+                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
+
+            updater.call(attachment_data, redirect_url: true)
+          end
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
@@ -31,7 +31,7 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
 
       it "updates redirect URL of corresponding asset" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
 
         updater.call(attachment_data, redirect_url: true)
       end
@@ -50,9 +50,9 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
 
       it "updates redirect URL of asset for attachment & its thumbnail" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+          .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
         update_worker.expects(:call)
-          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
+          .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
 
         updater.call(attachment_data, redirect_url: true)
       end
@@ -63,9 +63,9 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
 
         it "resets redirect URL of asset for attachment & its thumbnail" do
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
+            .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
           update_worker.expects(:call)
-            .with(attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
+            .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
 
           updater.call(attachment_data, redirect_url: true)
         end

--- a/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
@@ -13,83 +13,178 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdatesTest < ActiveSupport:
       end
     end
 
-    context "when attachment data is not a PDF" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-      let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-      let(:replacement) { AttachmentData.create!(file: sample_docx) }
-      let(:key) { "replacement_legacy_url_path" }
-      let(:attributes) { { key => replacement.file.asset_manager_path } }
-
-      it "updates replacement ID of corresponding asset" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
-
-        updater.call(attachment_data, replacement_id: true)
-      end
-    end
-
-    context "when attachment does not have a replacement" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
-
-      it "does not update asset manager" do
-        update_worker.expects(:call).never
-
-        updater.call(attachment_data, replacement_id: true)
-      end
-    end
-
-    context "when attachment data is a PDF" do
-      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-      let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
-      let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
-      let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
-      let(:key) { "replacement_legacy_url_path" }
-      let(:replacement_url_path) { replacement.file.asset_manager_path }
-      let(:attributes) { { key => replacement_url_path } }
-      let(:replacement_thumbnail_url_path) { replacement.file.thumbnail.asset_manager_path }
-      let(:thumbnail_attributes) { { key => replacement_thumbnail_url_path } }
-
-      it "updates replacement ID of asset for attachment & its thumbnail" do
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
-        update_worker.expects(:call)
-          .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
-
-        updater.call(attachment_data, replacement_id: true)
-      end
-
-      context "but replacement is not a PDF" do
+    describe "Attachment Data has no assets" do
+      context "when attachment data is not a PDF" do
         let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:replacement) { AttachmentData.create!(file: sample_rtf) }
-        let(:thumbnail_attributes) { { key => replacement_url_path } }
+        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+        let(:replacement) { AttachmentData.create!(file: sample_docx) }
+        let(:key) { "replacement_legacy_url_path" }
+        let(:attributes) { { key => replacement.file.asset_manager_path } }
 
-        it "updates replacement ID of asset for attachment & its thumbnail" do
+        it "updates replacement ID of corresponding asset" do
           update_worker.expects(:call)
-            .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
-          update_worker.expects(:call)
-            .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+                       .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
 
           updater.call(attachment_data, replacement_id: true)
         end
       end
-    end
 
-    context "when attachment is not synced with asset manager" do
-      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-      let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-      let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-      let(:replacement) { AttachmentData.create!(file: sample_docx) }
+      context "when attachment does not have a replacement" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
 
-      before do
-        update_worker.expects(:call)
-          .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
+        it "does not update asset manager" do
+          update_worker.expects(:call).never
+
+          updater.call(attachment_data, replacement_id: true)
+        end
       end
 
-      it "raises a AssetNotFound error" do
-        assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
+      context "when attachment data is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
+        let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
+        let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
+        let(:key) { "replacement_legacy_url_path" }
+        let(:replacement_url_path) { replacement.file.asset_manager_path }
+        let(:attributes) { { key => replacement_url_path } }
+        let(:replacement_thumbnail_url_path) { replacement.file.thumbnail.asset_manager_path }
+        let(:thumbnail_attributes) { { key => replacement_thumbnail_url_path } }
+
+        it "updates replacement ID of asset for attachment & its thumbnail" do
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
+          update_worker.expects(:call)
+                       .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+
           updater.call(attachment_data, replacement_id: true)
+        end
+
+        context "but replacement is not a PDF" do
+          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+          let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+          let(:thumbnail_attributes) { { key => replacement_url_path } }
+
+          it "updates replacement ID of asset for attachment & its thumbnail" do
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
+            update_worker.expects(:call)
+                         .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+
+            updater.call(attachment_data, replacement_id: true)
+          end
+        end
+      end
+
+      context "when attachment is not synced with asset manager" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+        let(:replacement) { AttachmentData.create!(file: sample_docx) }
+
+        before do
+          update_worker.expects(:call)
+                       .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
+        end
+
+        it "raises a AssetNotFound error" do
+          assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
+            updater.call(attachment_data, replacement_id: true)
+          end
+        end
+      end
+    end
+
+    describe "Attachment Data has asset(s)" do
+      context "when attachment data being updated is not a PDF" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+        let(:replacement) { AttachmentData.create!(file: sample_docx) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+        let(:attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
+        let(:original_asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+        let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id", variant: Asset.variants[:original]) }
+
+        it "updates replacement ID of corresponding asset" do
+          attachment_data.assets = [original_asset]
+          replacement.assets = [replacement_original_asset]
+
+          update_worker.expects(:call)
+                       .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
+
+          updater.call(attachment_data, replacement_id: true)
+        end
+      end
+
+      context "when attachment does not have a replacement" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
+
+        it "does not update asset manager" do
+          update_worker.expects(:call).never
+
+          updater.call(attachment_data, replacement_id: true)
+        end
+      end
+
+      context "when attachment data being updated is a PDF" do
+        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+        let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
+        let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
+        let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
+        let(:attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
+        let(:thumbnail_attributes) { { "replacement_id" => replacement_thumbnail_asset.asset_manager_id } }
+        let(:original_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+        let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id_1", variant: Asset.variants[:original]) }
+        let(:replacement_thumbnail_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+
+        it "and replacement is a pdf - updates replacement ID of asset for attachment & its thumbnail" do
+          attachment_data.assets = [original_asset, thumbnail_asset]
+          replacement.assets = [replacement_original_asset, replacement_thumbnail_asset]
+
+          update_worker.expects(:call)
+                       .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
+          update_worker.expects(:call)
+                       .with(thumbnail_asset.asset_manager_id, attachment_data, nil, thumbnail_attributes)
+
+          updater.call(attachment_data, replacement_id: true)
+        end
+
+        context "but replacement is not a PDF" do
+          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+          let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+
+          it "updates replacement ID of asset for attachment & its thumbnail" do
+            attachment_data.assets = [original_asset, thumbnail_asset]
+            replacement.assets = [replacement_original_asset]
+
+            update_worker.expects(:call)
+                         .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
+            update_worker.expects(:call)
+                         .with(thumbnail_asset.asset_manager_id, attachment_data, nil, attributes)
+
+            updater.call(attachment_data, replacement_id: true)
+          end
+        end
+      end
+
+      context "when attachment is not synced with asset manager" do
+        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+        let(:replacement) { AttachmentData.create!(file: sample_docx) }
+
+        before do
+          update_worker.expects(:call)
+                       .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
+        end
+
+        it "raises a AssetNotFound error" do
+          assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
+            updater.call(attachment_data, replacement_id: true)
+          end
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
@@ -23,7 +23,7 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdatesTest < ActiveSupport:
 
       it "updates replacement ID of corresponding asset" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
+          .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
 
         updater.call(attachment_data, replacement_id: true)
       end
@@ -53,9 +53,9 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdatesTest < ActiveSupport:
 
       it "updates replacement ID of asset for attachment & its thumbnail" do
         update_worker.expects(:call)
-          .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
+          .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
         update_worker.expects(:call)
-          .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+          .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
         updater.call(attachment_data, replacement_id: true)
       end
@@ -67,9 +67,9 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdatesTest < ActiveSupport:
 
         it "updates replacement ID of asset for attachment & its thumbnail" do
           update_worker.expects(:call)
-            .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
+            .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
           update_worker.expects(:call)
-            .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+            .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
           updater.call(attachment_data, replacement_id: true)
         end

--- a/test/unit/services/asset_manager/service_helper_test.rb
+++ b/test/unit/services/asset_manager/service_helper_test.rb
@@ -1,47 +1,80 @@
 require "test_helper"
 
 class AssetManager::ServiceHelperTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   setup do
-    @asset_id = "asset-id"
-    @asset_url = "http://asset-manager/assets/#{@asset_id}"
+    @asset_manager_id = "asset-id"
+    @asset_url = "http://asset-manager/assets/#{@asset_manager_id}"
     @legacy_url_path = "legacy-url-path"
     @worker = Object.new
     @worker.extend(AssetManager::ServiceHelper)
   end
 
-  test "returns attributes including asset ID" do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response("id" => @asset_url))
+  describe "find_asset_by" do
+    test "returns attributes including asset ID" do
+      Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+              .returns(gds_api_response("id" => @asset_url))
 
-    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+      attributes = @worker.send(:find_asset_by, @legacy_url_path)
 
-    assert_equal @asset_id, attributes["id"]
+      assert_equal @asset_manager_id, attributes["id"]
+    end
+
+    test "returns attributes including asset URL" do
+      Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+              .returns(gds_api_response("id" => @asset_url))
+
+      attributes = @worker.send(:find_asset_by, @legacy_url_path)
+
+      assert_equal @asset_url, attributes["url"]
+    end
+
+    test "returns other attributes" do
+      Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+              .returns(gds_api_response("id" => @asset_url, "key" => "value"))
+
+      attributes = @worker.send(:find_asset_by, @legacy_url_path)
+
+      assert_equal "value", attributes["key"]
+    end
+
+    test "raises AssetNotFound when an asset is not available" do
+      Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+              .raises(GdsApi::HTTPNotFound.new(404))
+
+      assert_raises AssetManager::ServiceHelper::AssetNotFound do
+        @worker.send(:find_asset_by, @legacy_url_path)
+      end
+    end
   end
 
-  test "returns attributes including asset URL" do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response("id" => @asset_url))
+  describe "find_asset_by_id" do
+    test "returns attributes including asset URL" do
+      Services.asset_manager.stubs(:asset).with(@asset_manager_id)
+              .returns(gds_api_response("id" => @asset_url))
 
-    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+      response = @worker.send(:find_asset_by_id, @asset_manager_id)
 
-    assert_equal @asset_url, attributes["url"]
-  end
+      assert_equal @asset_url, response["id"]
+    end
 
-  test "returns other attributes" do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response("id" => @asset_url, "key" => "value"))
+    test "returns other attributes" do
+      Services.asset_manager.stubs(:asset).with(@asset_manager_id)
+              .returns(gds_api_response("id" => @asset_url, "key" => "value"))
 
-    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+      attributes = @worker.send(:find_asset_by_id, @asset_manager_id)
 
-    assert_equal "value", attributes["key"]
-  end
+      assert_equal "value", attributes["key"]
+    end
 
-  test "raises AssetNotFound when an asset is not available" do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .raises(GdsApi::HTTPNotFound.new(404))
+    test "raises AssetNotFound when an asset is not available" do
+      Services.asset_manager.stubs(:asset).with(@asset_manager_id)
+              .raises(GdsApi::HTTPNotFound.new(404))
 
-    assert_raises AssetManager::ServiceHelper::AssetNotFound do
-      @worker.send(:find_asset_by, @legacy_url_path)
+      assert_raises AssetManager::ServiceHelper::AssetNotFound do
+        @worker.send(:find_asset_by_id, @asset_manager_id)
+      end
     end
   end
 

--- a/test/unit/workers/asset_manager_update_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_whitehall_asset_worker_test.rb
@@ -11,7 +11,7 @@ class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     attachment_data = FactoryBot.create(:attachment_data, file: File.open(Rails.root.join("test/fixtures/sample.csv")))
     expected_legacy_url_path = expected_legacy_url("attachment_data", attachment_data.id, "sample.csv")
 
-    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with(nil, attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
 
     AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, @auth_bypass_id_attributes)
     AssetManagerUpdateWhitehallAssetWorker.drain
@@ -22,8 +22,8 @@ class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     expected_legacy_url_path = expected_legacy_url("attachment_data", attachment_data.id, "greenpaper.pdf")
     expected_legacy_url_thumbnail_path = expected_legacy_url("attachment_data", attachment_data.id, "thumbnail_greenpaper.pdf.png")
 
-    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
-    AssetManager::AssetUpdater.expects(:call).with(attachment_data, expected_legacy_url_thumbnail_path, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with(nil, attachment_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with(nil, attachment_data, expected_legacy_url_thumbnail_path, @auth_bypass_id_attributes)
 
     AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, @auth_bypass_id_attributes)
     AssetManagerUpdateWhitehallAssetWorker.drain
@@ -41,7 +41,7 @@ class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
       s216_minister-of-funk.960x640.jpg
     ].each do |filename|
       path = expected_legacy_url("image_data", image_data.id, filename)
-      AssetManager::AssetUpdater.expects(:call).with(image_data, path, @auth_bypass_id_attributes).once
+      AssetManager::AssetUpdater.expects(:call).with(nil, image_data, path, @auth_bypass_id_attributes).once
     end
 
     AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ImageData", image_data.id, @auth_bypass_id_attributes)
@@ -52,7 +52,7 @@ class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     response_form = FactoryBot.create(:consultation_response_form)
     form_data = response_form.consultation_response_form_data
     expected_legacy_url_path = expected_legacy_url("consultation_response_form_data", form_data.id, "two-pages.pdf")
-    AssetManager::AssetUpdater.expects(:call).with(form_data, expected_legacy_url_path, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with(nil, form_data, expected_legacy_url_path, @auth_bypass_id_attributes)
 
     AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ConsultationResponseFormData", form_data.id, @auth_bypass_id_attributes)
     AssetManagerUpdateWhitehallAssetWorker.drain


### PR DESCRIPTION
These changes are part of a larger epic to remove the use of `legacy_url_path` from `whitehall` and the associated legacy endpoints from `asset-manager` and `gds-api-adapters`.

This first slice of changes is replacing the `GET` calls to the legacy `/whitehall_assets/:legacy_url_path` with calls to `/assets/:id ` (non-legacy endpoints used by other publishing apps). In the as-is, the legacy call returns the asset's document ID which is then used for all subsequent calls to delete, update etc. We want `whitehall` to use only the non-legacy `/show` endpoint thus also removing this redundant translation step and the usage of `legacy_url_path` (eventually). Most of the required changes are around the various attachment updaters that support this flow.

Preliminary work around saving asset manager ID in a new Asset model has been done [in this PR](https://github.com/alphagov/whitehall/pull/7882).

Whilst the changes for saving the ID are behind a user permission, the changes in this PR check for the existence of `assets` on the associated `AttachmentData` to select whether the old or new flow should be used. The flows will co-exist until the migration work is laid out and user permission can be removed. 

Where applicable, the tests are split in a "feature flag on/feature flag off" manner to enable easy removal of flag. The expected behaviour has also been manually tested in the integration environment.

[Trello card](https://trello.com/c/aAYQVYMG/69-story-use-assetmanagerid-for-updating-file-attachments)
[RFC](https://docs.google.com/document/d/1YLsnqhu0BNNCnHJa62yHr_BbyYJS8pIWTRFZKcIezwI/edit#heading=h.3m6qxrmo17ls)
[ADR](https://github.com/alphagov/whitehall/blob/adr-0002-new-asset-model/docs/adr/0002-new-asset-model.md)