### PR TITLE
Revert "Switch rendering application for Worldwide Organisations"

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "worldwide_organisation",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -35,7 +35,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       document_type: "worldwide_organisation",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+      rendering_app: "whitehall-frontend",
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
Some worldwide organisations are showing available translations to
`placeholder` items. These 404 when followed.

https://www.gov.uk/world/organisations/department-for-business-and-trade-pakistan

The placeholder translations need deleting, but until they are, we should revert this.

Reverts alphagov/whitehall#7871