### PR TITLE
Add and Edit Translations page to GDS

### DIFF
--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -7,7 +7,9 @@ module TranslationControllerConcern
     helper_method :translation_locale
   end
 
-  def edit; end
+  def edit
+    render_design_system(:edit, :legacy_edit)
+  end
 
   def create
     redirect_to create_redirect_path

--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -8,7 +8,7 @@ module TranslationControllerConcern
   end
 
   def edit
-    render_design_system(:edit, :legacy_edit)
+    render :legacy_edit if get_layout == "admin" && [Organisation].include?(translatable_item.class)
   end
 
   def create

--- a/app/controllers/admin/organisation_translations_controller.rb
+++ b/app/controllers/admin/organisation_translations_controller.rb
@@ -10,7 +10,7 @@ private
 
   def get_layout
     design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index edit update] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/organisation_translations/edit.html.erb
+++ b/app/views/admin/organisation_translations/edit.html.erb
@@ -1,19 +1,69 @@
-<% page_title "Edit translation for: #{@english_organisation.name}" %>
+<% content_for :page_title, "Edit translation for: #{@english_organisation.name}" %>
+<% content_for :title, "Edit ‘#{@translation_locale.native_language_name}(#{@translation_locale.english_language_name})’ translation for: #{@english_organisation.name}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_organisation)) %>
 
-<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_organisation.name %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @translated_organisation, url: admin_organisation_translation_path(@translated_organisation, translation_locale) do |form| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Name (required)",
+        },
+        heading_size: "l",
+        name: "organisation[name]",
+        id: "organisation_name",
+        value: @translated_organisation.name,
+        error_items: errors_for(form.object.errors, :name),
+        right_to_left: @translated_organisation.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
 
-<div class="row">
-  <div class="col-md-8">
-    <%= form_for @translated_organisation, url: admin_organisation_translation_path(@translated_organisation, translation_locale), method: :put, html: {class: 'well'} do |form| %>
-      <%= form.errors %>
+      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English name
+        content:</h2>
+      <p class="app-view-translation__english-content govuk-body"><%= @organisation.name %></p>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Acronym",
+        },
+        heading_size: "l",
+        name: "organisation[acronym]",
+        id: "organisation_acronym",
+        value: @translated_organisation.acronym,
+        error_items: errors_for(form.object.errors, :acronym),
+        right_to_left: @translated_organisation.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "l",
+          text: "Logo formatted name (required)",
+        },
+        name: "organisation[logo_formatted_name]",
+        id: "organisation_logo_formatted_name",
+        value: @translated_organisation.logo_formatted_name,
+        rows: 4,
+        error_items: errors_for(form.object.errors, :logo_formatted_name),
+        right_to_left: @translated_organisation.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
 
-      <%= form.translated_text_field :name %>
-      <%= form.translated_text_field :acronym %>
-      <%= form.translated_text_area  :logo_formatted_name, rows: "4", style: "width: auto" %>
+      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
+      <p class="app-view-translation__english-content govuk-body"><%= @organisation.logo_formatted_name %></p>
 
-      <%= render 'admin/shared/legacy_featured_link_fields', form: form %>
+      <%= render 'admin/shared/featured_link_fields', form: form %>
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+            "track-label": "Save"
+          }
+        } %>
 
-      <%= form.save_or_cancel cancel: admin_organisation_translations_path(@translated_organisation) %>
+        <%= link_to "Cancel", admin_organisation_translations_path(@translated_organisation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/organisation_translations/legacy_edit.html.erb
+++ b/app/views/admin/organisation_translations/legacy_edit.html.erb
@@ -1,0 +1,19 @@
+<% page_title "Edit translation for: #{@english_organisation.name}" %>
+
+<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_organisation.name %></h1>
+
+<div class="row">
+  <div class="col-md-8">
+    <%= form_for @translated_organisation, url: admin_organisation_translation_path(@translated_organisation, translation_locale), method: :put, html: {class: 'well'} do |form| %>
+      <%= form.errors %>
+
+      <%= form.translated_text_field :name %>
+      <%= form.translated_text_field :acronym %>
+      <%= form.translated_text_area  :logo_formatted_name, rows: "4", style: "width: auto" %>
+
+      <%= render 'admin/shared/legacy_featured_link_fields', form: form %>
+
+      <%= form.save_or_cancel cancel: admin_organisation_translations_path(@translated_organisation) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/shared/_featured_link_fields.html.erb
+++ b/app/views/admin/shared/_featured_link_fields.html.erb
@@ -38,7 +38,7 @@
         heading_size: "m",
         value: featured_link_form.object.url,
         name: "#{model}[featured_links_attributes][#{featured_link_form.index}][url]",
-        id: "#{model}_featured_links[#{featured_link_form.index}]_title",
+        id: "#{model}_featured_links[#{featured_link_form.index}]_url",
       } %>
 
     <% if @translation_locale && @translation_locale.code != I18n.default_locale %>

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -55,14 +55,19 @@ When(/^I add a translation for an organisation called "([^"]*)"$/) do |organisat
   fill_in "Name", with: "Organisation Name in another language"
   fill_in "Acronym", with: "ABC"
   fill_in "Logo formatted name", with: "Organisation Name in another language"
-
-  within ".featured-links" do
-    expect(page).to have_content("English: Top task 1")
-    expect(page).to have_content("English: http://mainstream.co.uk")
+  if using_design_system?
     fill_in "Title", with: "Top task 1 in another language"
+    expect(page).to have_field("organisation_featured_links[0]_title"), with: "Top task 1 in another language"
     fill_in "URL", with: "http://mainstream.wales"
+    expect(page).to have_field("organisation_featured_links[0]_url"), with: "http://mainstream.co.uk"
+  else
+    within ".featured-links" do
+      expect(page).to have_content("English: Top task 1")
+      expect(page).to have_content("English: http://mainstream.co.uk")
+      fill_in "Title", with: "Top task 1 in another language"
+      fill_in "URL", with: "http://mainstream.wales"
+    end
   end
-
   click_button "Save"
 end
 

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -66,7 +66,9 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   view_test "edit indicates which language is being translated to" do
     create(:organisation, translated_into: [:fr])
     get :edit, params: { organisation_id: @organisation, id: "fr" }
-    assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
+    assert_select ".govuk-grid-row" do
+      assert_select "h1", text: "Edit ‘Français(French)’ translation for: #{@organisation.name}"
+    end
   end
 
   view_test "edit presents a form to update an existing translation" do
@@ -86,10 +88,11 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     translation_path = admin_organisation_translation_path(organisation, "fr")
 
     assert_select "form[action=?]", translation_path do
-      assert_select "input[type=text][name='organisation[name]'][value='Afrolasie']"
-      assert_select "input[type=text][name='organisation[acronym]'][value='AFRO']"
-      assert_select "textarea[name='organisation[logo_formatted_name]']", text: "Afrolasie"
-      assert_select "input[type=submit][value=Save]"
+      assert_select ".govuk-form-group" do
+        assert_select "input[type=text][name='organisation[acronym]'][value='AFRO']"
+        assert_select "textarea[name='organisation[logo_formatted_name]']", text: "Afrolasie"
+      end
+      assert_select ".gem-c-button", text: "Save"
     end
   end
 
@@ -99,12 +102,11 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     get :edit, params: { organisation_id: organisation, id: "ar" }
 
     translation_path = admin_organisation_translation_path(organisation, "ar")
-
     assert_select "form[action=?]", translation_path do
-      assert_select "fieldset[class='right-to-left']" do
+      assert_select ".govuk-form-group" do
         assert_select "input[type=text][name='organisation[name]'][dir='rtl'][value='الناس']"
       end
-      assert_select "input[type=submit][value=Save]"
+      assert_select ".gem-c-button", text: "Save"
     end
   end
 


### PR DESCRIPTION
This PR transits edit and new translations pages for an organisation to govuk design system.
It does the following:

- Duplicated the existing edit html page to legacy and updated the controller.
- Added new and edit page for translation using GOV UK design system.
- Fixed the controller test and feature tests.
- Corrected the existing featured link partial file for url id field.

**Screen shots:**
![image](https://github.com/alphagov/whitehall/assets/131259138/573a4284-b088-4d3a-8b77-0cc0da86ea6b)
![image](https://github.com/alphagov/whitehall/assets/131259138/73a2334f-2e64-4220-8013-f386991b481b)

**Trello:**
https://trello.com/c/9QoFofXu/275-add-edit-translations

