### PR TITLE
Ensure tracking is consistent on translation pages

### DIFF
--- a/app/views/admin/person_translations/confirm_destroy.html.erb
+++ b/app/views/admin/person_translations/confirm_destroy.html.erb
@@ -12,6 +12,12 @@
         <%= render "govuk_publishing_components/components/button", {
           text: "Delete",
           destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "person-translations-button",
+            "track-label": "Delete"
+          }
         } %>
 
         <%= link_to("Cancel", admin_person_translations_path(@person), class: "govuk-link govuk-link--no-visited-state") %>

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -67,7 +67,13 @@
         } %>
 
         <%= render "govuk_publishing_components/components/button", {
-          text: "Create new translation"
+          text: "Create new translation",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "person-translations-button",
+            "track-label": "Create new translation"
+          }
         } %>
       <% end %>
     <% end %>

--- a/app/views/admin/role_translations/confirm_destroy.html.erb
+++ b/app/views/admin/role_translations/confirm_destroy.html.erb
@@ -14,6 +14,12 @@
         <%= render "govuk_publishing_components/components/button", {
           text: "Delete",
           destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "role-translations-button",
+            "track-label": "Delete"
+          }
         } %>
         <%= link_to("Cancel", admin_role_translations_path(@role), class: "govuk-link govuk-link--no-visited-state") %>
       </div>

--- a/app/views/admin/role_translations/index.html.erb
+++ b/app/views/admin/role_translations/index.html.erb
@@ -53,7 +53,13 @@
           end
         } %>
         <%= render "govuk_publishing_components/components/button", {
-          text: "Create new translation"
+          text: "Create new translation",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "role-translations-button",
+            "track-label": "Create new translation"
+          }
         } %>
       <% end %>
     <% end %>


### PR DESCRIPTION
## Description

This adds tracking to the confirm destroy and create new translation buttons for roles and person translations.

## Trello card

https://trello.com/c/kXS12mrP/288-roles-translations-index-show-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
