### PR TITLE
Add Review date functionality for a document

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -30,6 +30,7 @@ class Admin::Editions::Show::SidebarActionsComponent < ViewComponent::Base
       add_destroy_action
       add_unwithdraw_action
       add_unpublish_action
+      add_review_reminder_action
       add_view_action
       add_data_action
     end
@@ -243,6 +244,25 @@ private
           class: "govuk-link",
         )
       end
+    end
+  end
+
+  def add_review_reminder_action
+    if @edition.publicly_visible? && @edition.document.latest_edition == @edition
+      review_reminder = @edition.document.review_reminder
+      text = review_reminder.present? ? "Edit review date" : "Create new review date"
+      href = review_reminder.present? ? edit_admin_document_review_reminder_path(@edition.document, @edition.document.review_reminder) : new_admin_document_review_reminder_path(@edition.document)
+      actions << render("govuk_publishing_components/components/button", {
+        text:,
+        href:,
+        secondary_quiet: true,
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "review-reminders-button",
+          "track-label": text,
+        },
+      })
     end
   end
 

--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -250,7 +250,7 @@ private
   def add_review_reminder_action
     if @edition.publicly_visible? && @edition.document.latest_edition == @edition
       review_reminder = @edition.document.review_reminder
-      text = review_reminder.present? ? "Edit review date" : "Create new review date"
+      text = review_reminder.present? ? "Edit review date" : "Set review date"
       href = review_reminder.present? ? edit_admin_document_review_reminder_path(@edition.document, @edition.document.review_reminder) : new_admin_document_review_reminder_path(@edition.document)
       actions << render("govuk_publishing_components/components/button", {
         text:,

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -9,6 +9,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_national_exclusion_params, only: %i[create update]
+  before_action :set_creator_for_review_reminder, only: %i[create update]
   before_action :build_edition, only: %i[new create]
   before_action :detect_other_active_editors, only: %i[edit update]
   before_action :set_edition_defaults, only: :new
@@ -293,7 +294,6 @@ private
               id
               email_address
               review_at
-              creator_id
               _destroy
             ],
           },
@@ -352,6 +352,12 @@ private
   def build_nation_params(nation_id:, checked:)
     edition_params["nation_inapplicabilities_attributes"][(nation_id - 1).to_s]["excluded"] = checked ? "1" : "0"
     edition_params["nation_inapplicabilities_attributes"][(nation_id - 1).to_s]["alternative_url"] = nil unless checked
+  end
+
+  def set_creator_for_review_reminder
+    return if edition_params.dig("document_attributes", "review_reminder_attributes").blank?
+
+    edition_params["document_attributes"]["review_reminder_attributes"]["creator_id"] = current_user.id
   end
 
   def build_edition_dependencies

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -286,6 +286,18 @@ private
         ],
         nation_inapplicabilities_attributes: %i[id nation_id alternative_url excluded],
         fatality_notice_casualties_attributes: %i[id personal_details _destroy],
+        document_attributes: [
+          :id,
+          {
+            review_reminder_attributes: %i[
+              id
+              email_address
+              review_at
+              creator_id
+              _destroy
+            ],
+          },
+        ],
       },
       :auth_bypass_id,
     ]
@@ -432,6 +444,10 @@ private
       edition_params["first_published_at(3i)"] = ""
       edition_params["first_published_at(4i)"] = ""
       edition_params["first_published_at(5i)"] = ""
+    end
+
+    if params[:review_reminder].blank? && edition_params.dig("document_attributes", "review_reminder_attributes").present?
+      edition_params["document_attributes"]["review_reminder_attributes"]["_destroy"] = "1"
     end
   end
 

--- a/app/controllers/admin/review_reminders_controller.rb
+++ b/app/controllers/admin/review_reminders_controller.rb
@@ -1,0 +1,52 @@
+class Admin::ReviewRemindersController < Admin::BaseController
+  before_action :load_document
+  before_action :load_review_reminder, only: %i[edit update]
+  before_action :build_review_reminder, only: %i[new create]
+  before_action :enforce_permissions!
+  layout "design_system"
+
+  def new; end
+
+  def create
+    if @review_reminder.update(review_reminder_params)
+      redirect_to admin_edition_path(@document.latest_edition), notice: "Review date created"
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @review_reminder.update(review_reminder_params)
+      redirect_to admin_edition_path(@document.latest_edition), notice: "Review date updated"
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def load_document
+    @document = Document.friendly.find(params[:document_id])
+  end
+
+  def load_review_reminder
+    @review_reminder = @document.review_reminder
+  end
+
+  def build_review_reminder
+    @review_reminder = @document.build_review_reminder
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:update, @document.latest_edition)
+  end
+
+  def review_reminder_params
+    params
+      .require(:review_reminder)
+      .permit(:id, :email_address, :review_at)
+      .merge(creator_id: current_user.id)
+  end
+end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -171,6 +171,7 @@ module Admin::EditionsHelper
       yield(form)
       concat render("access_limiting_fields", form:, edition:)
       concat render("scheduled_publication_fields", form:, edition:)
+      concat render("review_reminder_fields", form:, review_reminder: edition.document.review_reminder)
       concat standard_edition_publishing_controls(form, edition)
     end
   end

--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -99,6 +99,16 @@ class MailNotifications < ApplicationMailer
               subject: "Reminder: Call for evidence \"#{@title}\" closed 8 weeks ago"
   end
 
+  def review_reminder(edition, recipient_address:)
+    @title = edition.title
+    @format_name = edition.format_name
+    @link_to_summary_page = admin_edition_url(edition)
+
+    view_mail template_id,
+              to: recipient_address,
+              subject: "#{edition.format_name.capitalize} '#{edition.title}' has reached its set review date"
+  end
+
   helper_method :production?
 
   def production?

--- a/app/models/call_for_evidence.rb
+++ b/app/models/call_for_evidence.rb
@@ -154,7 +154,7 @@ class CallForEvidence < Publicationesque
   end
 
   def all_nation_applicability_selected?
-    newly_created = document.nil?
+    newly_created = document.nil? || document.new_record?
     newly_created ? false : all_nation_applicability
   end
 

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -164,7 +164,7 @@ class Consultation < Publicationesque
   end
 
   def all_nation_applicability_selected?
-    newly_created = document.nil?
+    newly_created = document.nil? || document.new_record?
     newly_created ? false : all_nation_applicability
   end
 

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -120,7 +120,7 @@ class DetailedGuide < Edition
   end
 
   def all_nation_applicability_selected?
-    newly_created = document.nil?
+    newly_created = document.nil? || document.new_record?
     newly_created ? false : all_nation_applicability
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,6 +37,8 @@ class Document < ApplicationRecord
   has_many :edition_versions, through: :editions, source: :versions
   has_many :editorial_remarks, through: :editions
 
+  has_one :review_reminder, inverse_of: :document, dependent: :destroy
+
   has_many :withdrawals,
            -> { where(unpublishing_reason_id: UnpublishingReason::Withdrawn).order(unpublished_at: :asc, id: :asc) },
            through: :editions, source: :unpublishing

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -81,7 +81,7 @@ class Document < ApplicationRecord
   end
 
   def update_slug_if_possible(new_title)
-    return if live?
+    return if live? || invalid?
 
     candidate_slug = normalize_friendly_id(new_title)
     unless candidate_slug == slug

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -47,7 +47,7 @@ class Document < ApplicationRecord
 
   after_create :ensure_document_has_a_slug
 
-  accepts_nested_attributes_for :review_reminder
+  accepts_nested_attributes_for :review_reminder, allow_destroy: true
 
   attr_accessor :sluggable_string
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -47,6 +47,8 @@ class Document < ApplicationRecord
 
   after_create :ensure_document_has_a_slug
 
+  accepts_nested_attributes_for :review_reminder
+
   attr_accessor :sluggable_string
 
   def self.live

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -107,6 +107,8 @@ class Edition < ApplicationRecord
 
   after_update :republish_topical_event_to_publishing_api
 
+  accepts_nested_attributes_for :document
+
   class UnmodifiableValidator < ActiveModel::Validator
     def validate(record)
       significant_changed_attributes(record).each do |attribute|

--- a/app/models/edition/identifiable.rb
+++ b/app/models/edition/identifiable.rb
@@ -16,10 +16,15 @@ module Edition::Identifiable
   end
 
   def ensure_presence_of_document
-    self.document ||= Document.new(
-      sluggable_string: string_for_slug,
-      content_id: SecureRandom.uuid,
-    )
+    if document.blank?
+      self.document = Document.new(
+        sluggable_string: string_for_slug,
+        content_id: SecureRandom.uuid,
+      )
+    elsif document.new_record?
+      document.sluggable_string = string_for_slug if document.slug.blank?
+      document.content_id = SecureRandom.uuid if document.content_id.blank?
+    end
   end
 
   def update_document_slug

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -73,7 +73,7 @@ class Publication < Publicationesque
   end
 
   def all_nation_applicability_selected?
-    newly_created = document.nil?
+    newly_created = document.nil? || document.new_record?
     newly_created ? false : all_nation_applicability
   end
 

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -1,0 +1,16 @@
+class ReviewReminder < ApplicationRecord
+  belongs_to :document
+  belongs_to :creator, class_name: "User"
+
+  validates :document, :creator, :review_at, :email_address, presence: true
+  validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
+  validate :review_date_cannot_be_in_the_past, if: -> { review_at.present? }
+
+private
+
+  def review_date_cannot_be_in_the_past
+    if review_at < Time.zone.today
+      errors.add(:review_at, "can't be in the past")
+    end
+  end
+end

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -6,6 +6,12 @@ class ReviewReminder < ApplicationRecord
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
   validate :review_date_cannot_be_in_the_past, if: -> { review_at.present? }
 
+  before_update :reset_reminder_sent_at_if_review_at_is_updated
+
+  def review_due?
+    Time.zone.today >= review_at
+  end
+
 private
 
   def review_date_cannot_be_in_the_past

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -6,7 +6,7 @@ class ReviewReminder < ApplicationRecord
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
   validate :review_date_cannot_be_in_the_past, if: -> { review_at.present? }
 
-  before_update :reset_reminder_sent_at_if_review_at_is_updated
+  before_update :reset_reminder_sent_at, if: :review_at_changed?
 
   def review_due?
     Time.zone.today >= review_at
@@ -18,5 +18,9 @@ private
     if review_at < Time.zone.today
       errors.add(:review_at, "can't be in the past")
     end
+  end
+
+  def reset_reminder_sent_at
+    self.reminder_sent_at = nil
   end
 end

--- a/app/views/admin/editions/_review_reminder_fields.html.erb
+++ b/app/views/admin/editions/_review_reminder_fields.html.erb
@@ -1,8 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <%= form.fields_for :document do |document_form| %>
     <%= document_form.fields_for :review_reminder do |review_reminder_form| %>
-      <%= hidden_field_tag "edition[document_attributes][review_reminder_attributes][creator_id]", current_user.id %>
-
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "review_reminder",
         id: "review_reminder",

--- a/app/views/admin/editions/_review_reminder_fields.html.erb
+++ b/app/views/admin/editions/_review_reminder_fields.html.erb
@@ -1,0 +1,55 @@
+<div class="govuk-!-margin-bottom-8">
+  <%= form.fields_for :document do |document_form| %>
+    <%= document_form.fields_for :review_reminder do |review_reminder_form| %>
+      <%= hidden_field_tag "edition[document_attributes][review_reminder_attributes][creator_id]", current_user.id %>
+
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "review_reminder",
+        id: "review_reminder",
+        heading: "Review date",
+        heading_size: 'l',
+        no_hint_text: true,
+        items: [
+          {
+            label: "Set a reminder to review this content after it has been published",
+            value: 1,
+            checked: params[:review_reminder] == "1" || review_reminder.persisted?,
+            conditional: render("components/datetime_fields", {
+              field_name: "review_at",
+              prefix: "edition[document_attributes][review_reminder_attributes]",
+              date_only: true,
+              error_items: errors_for(review_reminder.errors, :review_at),
+              date_heading: "Date",
+              date_hint: "For example, 01 August 2025",
+              year: {
+                value: review_reminder.review_at&.year,
+                id: "edition_document_review_reminder_review_at_1i",
+                start_year: Time.zone.now.year,
+                end_year: Time.zone.now.year + 10,
+              },
+              month: {
+                value: review_reminder.review_at&.month,
+                id: "edition_document_review_reminder_review_at_2i",
+              },
+              day: {
+                value: review_reminder.review_at&.day,
+                id: "edition_document_review_reminder_review_at",
+              },
+            }) +
+            render("govuk_publishing_components/components/input", {
+              label: {
+                text: "Email address",
+                heading_size: "m",
+              },
+              hint: "Enter a team email or your own email address to get a review reminder",
+              name: "edition[document_attributes][review_reminder_attributes][email_address]",
+              id: "edition_document_review_reminder_email_address",
+              value: review_reminder.email_address,
+              error_items: errors_for(review_reminder.errors, :email_address),
+            })
+          }
+        ]
+      } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -5,6 +5,23 @@
     <meta name="custom-dimension:<%= key %>" content="<%= value %>">
   <% end %>
 <% end %>
+<% if @edition.document.review_reminder&.review_due? %>
+  <% content_for :banner do %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "Review reminder",
+    show_banner_title: true,
+    description: sanitize(tag.p("A review date was set for #{@edition.document.review_reminder.review_at.strftime('%-d %B %Y')}. You should review your content and either:") +
+      render("govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "update the content if it needs changing",
+          "set a new review date if the content is up to date"
+        ]
+      }))
+  } %>
+  <% end %>
+<% end %>
+
 
 <%= render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
 

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -12,6 +12,10 @@
           { field: "Status", value: status_text(@edition) },
           { field: "Change type", value: @edition.minor_change? ? 'Minor' : 'Major' },
           *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
+          {
+            field: "Review date",
+            value: @edition.document.review_reminder.present? ? @edition.document.review_reminder.review_at.strftime('%-d %B %Y') : "Not set",
+          }
         ]
       } %>
     </div>

--- a/app/views/admin/review_reminders/_form.html.erb
+++ b/app/views/admin/review_reminders/_form.html.erb
@@ -1,0 +1,51 @@
+<%= form_with model: review_reminder, url: [:admin, document, review_reminder] do |form| %>
+  <%= render("components/datetime_fields", {
+    field_name: "review_at",
+    prefix: "review_reminder",
+    date_only: true,
+    error_items: errors_for(review_reminder.errors, :review_at),
+    date_hint: "For example, 01 August 2025",
+    date_heading: "Date (required)",
+    heading_size: "l",
+    year: {
+      value: review_reminder.review_at&.year,
+      id: "review_reminder_review_at_1i",
+      start_year: Time.zone.now.year,
+      end_year: Time.zone.now.year + 10,
+    },
+    month: {
+      value: review_reminder.review_at&.month,
+      id: "review_reminder_review_at_2i",
+    },
+    day: {
+      value: review_reminder.review_at&.day,
+      id: "review_reminder_review_at",
+    },
+  }) %>
+
+  <%= render("govuk_publishing_components/components/input", {
+    label: {
+      text: "Email address (required)",
+      heading_size: "l",
+    },
+    hint: "Enter a team email or your own email address to get a review reminder",
+    name: "review_reminder[email_address]",
+    id: "review_reminder_email_address",
+    value: review_reminder.email_address,
+    error_items: errors_for(review_reminder.errors, :email_address),
+  }) %>
+
+  <div class="govuk-button-group govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "review-reminders-button",
+        "track-label": "Save"
+      }
+    } %>
+
+    <%= link_to("Cancel", admin_edition_path(@document.latest_edition), class: "govuk-link govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/admin/review_reminders/edit.html.erb
+++ b/app/views/admin/review_reminders/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Edit review date for #{@document.latest_edition.title}" %>
+<% content_for :title, "Edit review date" %>
+<% content_for :context, @document.latest_edition.title %>
+<% content_for :title_margin_bottom, 8 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @review_reminder)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", document: @document, review_reminder: @review_reminder %>
+  </div>
+</div>

--- a/app/views/admin/review_reminders/new.html.erb
+++ b/app/views/admin/review_reminders/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "New review date for #{@document.latest_edition.title}" %>
+<% content_for :title, "New review date" %>
+<% content_for :context, @document.latest_edition.title %>
+<% content_for :title_margin_bottom, 8 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @review_reminder)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", document: @document, review_reminder: @review_reminder %>
+  </div>
+</div>

--- a/app/views/mail_notifications/review_reminder.text.erb
+++ b/app/views/mail_notifications/review_reminder.text.erb
@@ -1,0 +1,17 @@
+Hello,
+
+A review date for the <%= @format_name %> "<%= @title %>" has been set. The review date is today.
+
+The document for review is available in Whitehall publisher at:
+<%= @link_to_summary_page %>
+
+You should review your content and either:
+
+- update the content if it needs changing
+- set a new review date if the content is up to date
+
+The GOV.UK publishing manual has more detail:
+https://www.gov.uk/guidance/content-design/content-maintenance
+
+Best wishes
+GOV.UK publishing

--- a/app/workers/review_reminder_notifier_worker.rb
+++ b/app/workers/review_reminder_notifier_worker.rb
@@ -1,0 +1,18 @@
+class ReviewReminderNotifierWorker < WorkerBase
+  def perform(id)
+    review_reminder = ReviewReminder.find(id)
+    return if review_reminder.reminder_sent_at.present?
+
+    edition = review_reminder.document.latest_edition
+    email_address = review_reminder.email_address
+
+    ActiveRecord::Base.transaction do
+      MailNotifications.review_reminder(
+        edition,
+        recipient_address: email_address,
+      ).deliver_now
+
+      review_reminder.update!(reminder_sent_at: Time.zone.now)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,10 @@ Whitehall::Application.routes.draw do
 
         resources :users, only: %i[index show edit update]
 
+        resources :documents, only: [] do
+          resources :review_reminders, only: %i[new create edit update]
+        end
+
         resources :authors, only: [:show]
         resource :document_searches, only: [:show]
         resources :document_collections, path: "collections", except: [:index] do

--- a/db/migrate/20230703131507_create_review_reminders.rb
+++ b/db/migrate/20230703131507_create_review_reminders.rb
@@ -1,0 +1,23 @@
+class CreateReviewReminders < ActiveRecord::Migration[7.0]
+  def up
+    ## Testing a migration on integration can cause the db to get out of sync.
+    ## This ensures it drops the table if present
+    drop_table(:review_reminders, if_exists: true)
+
+    create_table :review_reminders do |t|
+      t.integer "document_id"
+      t.integer "creator_id"
+      t.string "email_address"
+      t.datetime "review_at", precision: nil
+      t.datetime "reminder_sent_at", precision: nil
+      t.datetime "created_at", precision: nil
+      t.datetime "updated_at", precision: nil
+      t.index %w[document_id], name: "index_review_reminders_on_document_id"
+      t.index %w[creator_id], name: "index_review_reminders_on_creator_id"
+    end
+  end
+
+  def down
+    drop_table :review_reminders
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_29_135717) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_131507) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "attachment_data_id", null: false
@@ -827,6 +827,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_29_135717) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
+  end
+
+  create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "document_id"
+    t.integer "creator_id"
+    t.string "email_address"
+    t.datetime "review_at", precision: nil
+    t.datetime "reminder_sent_at", precision: nil
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.index ["creator_id"], name: "index_review_reminders_on_creator_id"
+    t.index ["document_id"], name: "index_review_reminders_on_document_id"
   end
 
   create_table "role_appointments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/features/review_reminder.feature
+++ b/features/review_reminder.feature
@@ -1,0 +1,25 @@
+Feature: Review reminders
+  In order to allow publishers to maintain content
+  An editor
+  Should be able to set and edit a review date for a document
+
+  Background:
+  Given I am an editor
+
+  Scenario: Creating a new draft publication with a review date
+    When I start drafting a new publication "Standard Beard Lengths"
+    And I add a review date of "2033-1-1" and the email address "test@gmail.com" on the edit page
+    Then I should see the review date of "1 January 2033" on the edition summary page
+
+  Scenario: Creating a review date for a published publication
+    Given a published publication "Standard Beard Lengths" with a PDF attachment
+    When I click the button "Create new review date" on the edition summary page for "Standard Beard Lengths"
+    And I add a review date of "2033-1-1" and the email address "test@gmail.com"
+    Then I should see the review date of "1 January 2033" on the edition summary page
+
+  Scenario: Editing the review date for a published publication
+    Given a published publication "Standard Beard Lengths" with a PDF attachment
+    And a review reminder exists for "Standard Beard Lengths" with the date "2032-1-1"
+    When I click the button "Edit review date" on the edition summary page for "Standard Beard Lengths"
+    And I update the review date to "2033-1-1"
+    Then I should see the review date of "1 January 2033" on the edition summary page

--- a/features/review_reminder.feature
+++ b/features/review_reminder.feature
@@ -13,7 +13,7 @@ Feature: Review reminders
 
   Scenario: Creating a review date for a published publication
     Given a published publication "Standard Beard Lengths" with a PDF attachment
-    When I click the button "Create new review date" on the edition summary page for "Standard Beard Lengths"
+    When I click the button "Set review date" on the edition summary page for "Standard Beard Lengths"
     And I add a review date of "2033-1-1" and the email address "test@gmail.com"
     Then I should see the review date of "1 January 2033" on the edition summary page
 

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -1,0 +1,37 @@
+And(/^I add a review date of "([^"]*)" and the email address "([^"]*)" on the edit page$/) do |date, email|
+  click_link "Edit draft"
+  check "Set a reminder to review this content after it has been published"
+  within_conditional_reveal "Set a reminder to review this content after it has been published" do
+    fill_in_date_fields(date)
+    fill_in "Email address", with: email
+  end
+  click_button "Save and continue"
+  click_button "Update tags"
+end
+
+And(/^I add a review date of "([^"]*)" and the email address "([^"]*)"$/) do |date, email|
+  fill_in_date_fields(date)
+  fill_in "Email address (required)", with: email
+  click_button "Save"
+end
+
+Then(/^I should see the review date of "([^"]*)" on the edition summary page$/) do |date|
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: date
+end
+
+When(/^I click the button "([^"]*)" on the edition summary page for "([^"]*)"$/) do |label, title|
+  edition = Edition.find_by!(title:)
+  visit admin_edition_path(edition)
+  click_on label
+end
+
+And(/^a review reminder exists for "([^"]*)" with the date "([^"]*)"$/) do |title, date|
+  edition = Edition.find_by!(title:)
+  create(:review_reminder, document: edition.document, review_at: date)
+end
+
+And(/^I update the review date to "([^"]*)"$/) do |date|
+  fill_in_date_fields(date)
+  click_button "Save"
+end

--- a/lib/tasks/send_review_reminders.rake
+++ b/lib/tasks/send_review_reminders.rake
@@ -1,0 +1,11 @@
+desc "Send review reminder emails for when the review_at datetime has passed"
+task send_review_reminders: :environment do
+  ReviewReminder
+  .joins(document: :latest_edition)
+  .where(reminder_sent_at: nil)
+  .where("review_at < ?", Time.zone.today)
+  .where.not(document: { editions: { first_published_at: nil } })
+  .find_each do |reminder|
+    ReviewReminderNotifierWorker.perform_async(reminder.id.to_s)
+  end
+end

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -21,7 +21,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 4
     assert_selector "button", text: "Create new edition"
-    assert_selector "a", text: "Create new review date"
+    assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
   end
@@ -33,7 +33,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 4
     assert_selector "button", text: "Create new edition"
-    assert_selector "a", text: "Create new review date"
+    assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.document.id}.cy']", text: "View on website (opens in new tab)"
   end
@@ -93,7 +93,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 4
     assert_selector "a", text: "Unwithdraw"
-    assert_selector "a", text: "Create new review date"
+    assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
   end
@@ -129,7 +129,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
 
     assert_selector "li", count: 5
     assert_selector "button", text: "Create new edition"
-    assert_selector "a", text: "Create new review date"
+    assert_selector "a", text: "Set review date"
     assert_selector "a", text: "Withdraw or unpublish"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
@@ -206,7 +206,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "li", count: 5
     assert_selector "a", text: "Unwithdraw"
     assert_selector "a", text: "Edit withdrawal explanation"
-    assert_selector "a", text: "Create new review date"
+    assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
   end

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -19,8 +19,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 3
+    assert_selector "li", count: 4
     assert_selector "button", text: "Create new edition"
+    assert_selector "a", text: "Create new review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
   end
@@ -30,8 +31,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:non_english_published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 3
+    assert_selector "li", count: 4
     assert_selector "button", text: "Create new edition"
+    assert_selector "a", text: "Create new review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.document.id}.cy']", text: "View on website (opens in new tab)"
   end
@@ -89,8 +91,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:withdrawn_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 3
+    assert_selector "li", count: 4
     assert_selector "a", text: "Unwithdraw"
+    assert_selector "a", text: "Create new review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
   end
@@ -124,8 +127,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 4
+    assert_selector "li", count: 5
     assert_selector "button", text: "Create new edition"
+    assert_selector "a", text: "Create new review date"
     assert_selector "a", text: "Withdraw or unpublish"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
@@ -199,9 +203,10 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:withdrawn_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 4
+    assert_selector "li", count: 5
     assert_selector "a", text: "Unwithdraw"
     assert_selector "a", text: "Edit withdrawal explanation"
+    assert_selector "a", text: "Create new review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
   end

--- a/test/factories/review_reminder.rb
+++ b/test/factories/review_reminder.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :review_reminder do
+    creator
+    document
+
+    sequence :email_address do |n|
+      "creator-#{n}@example.com"
+    end
+
+    review_at { Time.zone.now + 1.day }
+  end
+end

--- a/test/factories/review_reminder.rb
+++ b/test/factories/review_reminder.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     end
 
     review_at { Time.zone.now + 1.day }
+
+    trait(:with_reminder_sent_at) do
+      reminder_sent_at { 1.day.ago }
+    end
   end
 end

--- a/test/functional/admin/review_reminders_controller_test.rb
+++ b/test/functional/admin/review_reminders_controller_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class Admin::ReviewRemindersControllerTest < ActionController::TestCase
+  include Rails.application.routes.url_helpers
+  include Admin::EditionRoutesHelper
+
+  setup do
+    login_as :gds_editor
+    @document = create(:document)
+    @edition = create(:published_edition, document: @document)
+  end
+
+  should_be_an_admin_controller
+
+  test "GET to :new renders assigns the correct values and renders the correct template" do
+    get :new, params: { document_id: @document }
+
+    assert_equal assigns(:document), @document
+    assert assigns(:review_reminder).is_a?(ReviewReminder)
+    assert_template :new
+  end
+
+  test "POST to :create with valid data creates a new review reminder" do
+    post :create,
+         params: {
+           document_id: @document,
+           review_reminder: {
+             "review_at(3i)": "7",
+             "review_at(2i)": "7",
+             "review_at(1i)": Time.zone.now.year + 1,
+             email_address: "test@gmail.com",
+           },
+         }
+
+    assert_equal "Review date created", flash[:notice]
+    assert @document.reload.review_reminder.persisted?
+    assert_redirected_to admin_edition_path(@edition)
+  end
+
+  test "POST to :create with invalid data it re-renders the new template" do
+    post :create,
+         params: {
+           document_id: @document,
+           review_reminder: {
+             "review_at(3i)": "7",
+             "review_at(2i)": "7",
+             "review_at(1i)": Time.zone.now.year + 1,
+             email_address: "",
+           },
+         }
+
+    assert_equal assigns(:document), @document
+    assert assigns(:review_reminder).is_a?(ReviewReminder)
+    assert_template :new
+  end
+
+  test "GET to :edit renders assigns the correct values and renders the correct template" do
+    review_reminder = create(:review_reminder, document: @document)
+
+    get :edit, params: { document_id: @document, id: review_reminder }
+
+    assert_equal assigns(:document), @document
+    assert_equal assigns(:review_reminder), review_reminder
+    assert_template :edit
+  end
+
+  test "PATCH to :update with valid data updates a new review reminder" do
+    review_reminder = create(:review_reminder, document: @document, email_address: "test@googlemail.com")
+
+    post :update,
+         params: {
+           document_id: @document,
+           id: review_reminder.id,
+           review_reminder: {
+             "review_at(3i)": review_reminder.review_at.day,
+             "review_at(2i)": review_reminder.review_at.month,
+             "review_at(1i)": review_reminder.review_at.year,
+             email_address: "test@gmail.com",
+           },
+         }
+
+    assert_equal "Review date updated", flash[:notice]
+    assert_equal review_reminder.reload.email_address, "test@gmail.com"
+    assert_redirected_to admin_edition_path(@edition)
+  end
+
+  test "PATCH to :update with invalid data it re-renders the new template" do
+    review_reminder = create(:review_reminder, document: @document, email_address: "test@googlemail.com")
+
+    post :update,
+         params: {
+           document_id: @document,
+           id: review_reminder.id,
+           review_reminder: {
+             "review_at(3i)": "7",
+             "review_at(2i)": "7",
+             "review_at(1i)": Time.zone.now.year + 1,
+             email_address: "",
+           },
+         }
+
+    assert_equal assigns(:document), @document
+    assert_equal assigns(:review_reminder).email_address, ""
+    assert_template :edit
+  end
+end

--- a/test/functional/notifications_review_reminder_test.rb
+++ b/test/functional/notifications_review_reminder_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class NotificationsReviewReminderTest < ActionMailer::TestCase
+  enable_url_helpers
+  include Admin::EditionRoutesHelper
+
+  setup do
+    document = create(:document)
+    @edition = create(:publication, title: "Test title", document:)
+    @title = @edition.title
+    @review_reminder = create(:review_reminder, document:)
+    @email_address = @review_reminder.email_address
+    @mail = MailNotifications.review_reminder(@edition, recipient_address: @email_address)
+  end
+
+  test "email should be sent to the correct address" do
+    assert_equal @mail.to, [@email_address]
+  end
+
+  test "email subject should include document title" do
+    assert_equal @mail.subject, "#{@edition.format_name.capitalize} '#{@edition.title}' has reached its set review date"
+  end
+
+  test "email body should include details of the document being reviwed, a link to the summary page and a link to the relevant guidance" do
+    assert @mail.body.raw_source.include?("A review date for the #{@edition.format_name} \"#{@title}\" has been set. The review date is today.")
+    assert @mail.body.raw_source.include?(admin_edition_url(@edition))
+    assert @mail.body.raw_source.include?("https://www.gov.uk/guidance/content-design/content-maintenance")
+  end
+end

--- a/test/models/review_reminder_test.rb
+++ b/test/models/review_reminder_test.rb
@@ -59,4 +59,12 @@ class ReviewReminderTest < ActiveSupport::TestCase
     reminder = build(:review_reminder, review_at: 1.day.from_now)
     assert_not reminder.review_due?
   end
+
+  test "it resets reminder_sent_at when the review_at date is changed" do
+    reminder = create(:review_reminder, :with_reminder_sent_at)
+
+    reminder.update!(review_at: Time.zone.now + 10.days)
+
+    assert_nil reminder.reload.reminder_sent_at
+  end
 end

--- a/test/models/review_reminder_test.rb
+++ b/test/models/review_reminder_test.rb
@@ -44,4 +44,19 @@ class ReviewReminderTest < ActiveSupport::TestCase
     reminder = build(:review_reminder, email_address: "not a real email @ address . com")
     assert_not reminder.valid?
   end
+
+  test "#review_due? returns true when review_at is in the past" do
+    reminder = build(:review_reminder, review_at: 1.day.ago)
+    assert reminder.review_due?
+  end
+
+  test "#review_due? returns true when review_at is today" do
+    reminder = build(:review_reminder, review_at: Time.zone.today)
+    assert reminder.review_due?
+  end
+
+  test "#review_due? returns false when review_at is in the future" do
+    reminder = build(:review_reminder, review_at: 1.day.from_now)
+    assert_not reminder.review_due?
+  end
 end

--- a/test/models/review_reminder_test.rb
+++ b/test/models/review_reminder_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ReviewReminderTest < ActiveSupport::TestCase
+  test "is associated with a document" do
+    document = build(:document)
+    reminder = build(:review_reminder, document:)
+
+    assert_equal reminder.document, document
+  end
+
+  test "is associated with a creator" do
+    creator = build(:user)
+    reminder = build(:review_reminder, creator:)
+
+    assert_equal reminder.creator, creator
+  end
+
+  test "is invalid without a creator" do
+    reminder = build(:review_reminder, creator: nil)
+    assert_not reminder.valid?
+  end
+
+  test "is invalid without a document" do
+    reminder = build(:review_reminder, document: nil)
+    assert_not reminder.valid?
+  end
+
+  test "is invalid without a review_at datetime" do
+    reminder = build(:review_reminder, review_at: nil)
+    assert_not reminder.valid?
+  end
+
+  test "is invalid if review_at is in the past" do
+    reminder = build(:review_reminder, review_at: 1.day.ago)
+    assert_not reminder.valid?
+  end
+
+  test "is invalid without an email_address" do
+    reminder = build(:review_reminder, email_address: nil)
+    assert_not reminder.valid?
+  end
+
+  test "is invalid with an invalid email_address" do
+    reminder = build(:review_reminder, email_address: "not a real email @ address . com")
+    assert_not reminder.valid?
+  end
+end

--- a/test/unit/call_for_evidence_test.rb
+++ b/test/unit/call_for_evidence_test.rb
@@ -437,7 +437,9 @@ class CallForEvidenceTest < ActiveSupport::TestCase
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:call_for_evidence)
+    unsaved_publication_with_document = build(:call_for_evidence, document: build(:document))
     assert_not unsaved_publication.all_nation_applicability_selected?
+    assert_not unsaved_publication_with_document.all_nation_applicability_selected?
   end
 
   test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -495,7 +495,9 @@ class ConsultationTest < ActiveSupport::TestCase
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:consultation)
+    unsaved_publication_with_document = build(:consultation, document: build(:document))
     assert_not unsaved_publication.all_nation_applicability_selected?
+    assert_not unsaved_publication_with_document.all_nation_applicability_selected?
   end
 
   test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -266,7 +266,9 @@ class DetailedGuideTest < ActiveSupport::TestCase
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:detailed_guide)
+    unsaved_publication_with_document = build(:detailed_guide, document: build(:document))
     assert_not unsaved_publication.all_nation_applicability_selected?
+    assert_not unsaved_publication_with_document.all_nation_applicability_selected?
   end
 
   test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do

--- a/test/unit/edition/identifiable_test.rb
+++ b/test/unit/edition/identifiable_test.rb
@@ -19,6 +19,14 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
     assert publication.document.content_id.present?
   end
 
+  test "should generate a content_id and slug on a document when present" do
+    document = build(:document, content_id: nil, slug: nil)
+    publication = build(:publication, document:)
+    publication.valid?
+    assert publication.document.content_id.present?
+    assert publication.document.slug.present?
+  end
+
   test "should not allow the same slug to be used again for the same document type" do
     same_title = "same-title"
     publication1 = create(:publication, title: same_title)

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -170,7 +170,9 @@ class PublicationTest < ActiveSupport::TestCase
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:publication)
+    unsaved_publication_with_document = build(:publication, document: build(:document))
     assert_not unsaved_publication.all_nation_applicability_selected?
+    assert_not unsaved_publication_with_document.all_nation_applicability_selected?
   end
 
   test "#all_nation_applicability_selected? responds to all_nation_applicability once created" do

--- a/test/unit/tasks/send_review_reminders_test.rb
+++ b/test/unit/tasks/send_review_reminders_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "rake"
+
+class ResluggingTest < ActiveSupport::TestCase
+  teardown do
+    Sidekiq::Worker.clear_all
+  end
+
+  test "it calls the ReviewReminderNotifierWorker with the correct review_reminders" do
+    document1 = create(:document)
+    create(:published_edition, document: document1)
+    review_reminder_to_be_sent = build(:review_reminder, document: document1, review_at: Time.zone.now - 1.day)
+    review_reminder_to_be_sent.save!(validate: false)
+
+    document2 = create(:document)
+    create(:published_edition, document: document2)
+    review_reminder_with_future_review_at = create(:review_reminder, document: document2, review_at: Time.zone.now + 1.day)
+
+    document3 = create(:document)
+    create(:published_edition, document: document3)
+    review_reminder_with_sent_reminder = create(:review_reminder, :with_reminder_sent_at, document: document3)
+
+    document4 = create(:document)
+    create(:edition, document: document4)
+    review_reminder_with_no_published_editions = build(:review_reminder, document: document4, review_at: Time.zone.now - 1.day)
+    review_reminder_with_no_published_editions.save!(validate: false)
+
+    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_to_be_sent.id.to_s).once
+    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_future_review_at.id.to_s).never
+    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_sent_reminder.id.to_s).never
+    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_no_published_editions.id.to_s).never
+
+    Rake.application.invoke_task "send_review_reminders"
+  end
+end

--- a/test/unit/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/workers/review_reminder_notifier_worker_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
+  setup do
+    document = create(:document)
+    @review_reminder = create(:review_reminder, document:)
+    @email_address = @review_reminder.email_address
+    @editon = create(:edition, document:)
+  end
+
+  test "calls MailNotifications#review_reminder and updates reminder_sent_at to now when reminder_sent_at is nil" do
+    Timecop.freeze do
+      MailNotifications
+        .expects(:review_reminder)
+        .with(@editon, recipient_address: @email_address)
+        .returns(mailer = mock)
+
+      mailer.expects(:deliver_now)
+
+      ReviewReminderNotifierWorker.new.perform(@review_reminder.id)
+
+      assert_equal Time.zone.now, @review_reminder.reload.reminder_sent_at
+    end
+  end
+
+  test "does not call MailNotifications#review_reminder or update reminder_sent_at when reminder_sent_at is present" do
+    reminder_sent_at = Time.zone.now
+    @review_reminder.update!(reminder_sent_at:)
+
+    Timecop.travel(1.day.from_now) do
+      MailNotifications
+        .expects(:review_reminder)
+        .never
+
+      ReviewReminderNotifierWorker.new.perform(@review_reminder.id)
+
+      assert_equal reminder_sent_at, @review_reminder.reload.reminder_sent_at
+    end
+  end
+end


### PR DESCRIPTION
## Description 

For gift week we're adding in basic functionality to allow Publishers to set a date where they'll receive an email reminder that their content needs to be reviewed. This PR adds this functionality.

In scope for this piece of work

- ability to add a review date to a draft edition on the edit edition page
- ability to add and edit a review date for live editions on the edition summary page
- a banner on the summary page that shows when the deadline has passed
- information on the summary page which informs publishers when the review date is
- build an email which will be sent as a reminder
- build a rake task which will run daily via a cron job which emails reminders to publishers when the review date has passed and a reminder hasn't already been sent

out of scope:
worrying about any additional complexity such as
- follow up chaser emails
- any sort of state which allows users to acknowledge that they've checked the content and are happy with it

The banner will continue to show unless 1 of two things happen:

1. they update the review date to a date in the future
2. they create a draft edition and remove the review date

The review reminder belongs to the document, so it will remain when new editions are created. It will only go away if explicitly removed.

## Guidance for review

Very much recommend reviewing per commit

I'll probably break this down into at least two, but likely more PRs before release, but i think it'll be easier to get preliminary feedback of it when people can see the full context.

## Cron job PR on Helm 

https://github.com/alphagov/govuk-helm-charts/pull/1205/commits

## Screenshots

### Email 

**this now says "for the publication"**

<img width="701" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4a03673c-76a5-4ae0-af6b-7537c3fae619">


### Edit edition page 

<img width="674" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ed26ef53-4469-44ba-8fde-b146555bc04c">

### Summary page

<img width="708" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8cd4d8a6-3316-48ae-8809-3b97ad9b13e7">

<img width="699" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/206593f9-fd0b-4d28-be7f-6bbd821aefa3">

<img width="669" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/145aceb8-a2c7-404b-827e-75ca7d76616f">


### New page

<img width="730" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/953470a9-a5a3-48d6-a8d3-f75b02f1fe7e">


### Edit page

<img width="801" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/50947da2-f380-482e-80cd-938e40b18628">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
