### PR TITLE
Use active verb for fieldset legend when scheduling publication

### DIFF
--- a/app/views/admin/editions/_scheduled_publication_fields.html.erb
+++ b/app/views/admin/editions/_scheduled_publication_fields.html.erb
@@ -4,7 +4,7 @@
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "scheduled_publication_active",
     id: "scheduled_publication_active",
-    heading: "Scheduled publication",
+    heading: "Schedule publication",
     heading_size: 'l',
     error_items: errors_for(edition.errors, :scheduled_publication_active),
     no_hint_text: true,


### PR DESCRIPTION
## Description

This really annoys Mike 😂 

## Before 

<img width="403" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a4b6b66a-5a21-4a20-883e-a40ecc083065">

## After 

<img width="496" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/559440a2-a74b-4b4d-b566-6dd7a1cb781f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
