### PR TITLE
Fix bug where worldwide orgs and world locations errors don't link

### DIFF
--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -2,8 +2,9 @@
 
 <% cache_if edition.world_location_ids.empty?, "#{taggable_world_locations_cache_digest}-design-system" do %>
   <%= render "components/autocomplete", {
-    id: "edition_world_location_ids",
+    id: "edition_world_locations",
     name: "edition[world_location_ids][]",
+    error_items: errors_for(edition.errors, :world_locations),
     label: {
       text: "World locations" + "#{' (required)' if required}",
       heading_size: "m",

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -2,8 +2,9 @@
 
 <% cache_if edition.worldwide_organisation_ids.empty?, "#{taggable_worldwide_organisations_cache_digest}-design-system" do %>
   <%= render "components/autocomplete", {
-    id: "edition_worldwide_organisation_ids",
+    id: "edition_worldwide_organisations",
     name: "edition[worldwide_organisation_ids][]",
+    error_items: errors_for(edition.errors, :worldwide_organisations),
     label: {
       text:  "Worldwide organisations" + "#{' (required)' if required}",
       heading_size: "m",

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1072,9 +1072,9 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "label[for=edition_worldwide_organisation_ids]", text: "Worldwide organisations"
+          assert_select "label[for=edition_worldwide_organisations]", text: "Worldwide organisations"
 
-          assert_select "#edition_worldwide_organisation_ids" do |elements|
+          assert_select "#edition_worldwide_organisations" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_worldwide_organisations(
               element: elements.first,
@@ -1105,9 +1105,9 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
-          assert_select "label[for=edition_worldwide_organisation_ids]", text: "Worldwide organisations"
+          assert_select "label[for=edition_worldwide_organisations]", text: "Worldwide organisations"
 
-          assert_select "#edition_worldwide_organisation_ids" do |elements|
+          assert_select "#edition_worldwide_organisations" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_worldwide_organisations(
               element: elements.first,

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -9,8 +9,8 @@ module AdminEditionWorldLocationsBehaviour
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "label[for=edition_world_location_ids]", text: "World locations"
-          assert_select "#edition_world_location_ids" do |elements|
+          assert_select "label[for=edition_world_locations]", text: "World locations"
+          assert_select "#edition_world_locations" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_world_locations(
               element: elements.first,
@@ -41,9 +41,9 @@ module AdminEditionWorldLocationsBehaviour
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
-          assert_select "label[for=edition_world_location_ids]", text: "World locations"
+          assert_select "label[for=edition_world_locations]", text: "World locations"
 
-          assert_select "#edition_world_location_ids" do |elements|
+          assert_select "#edition_world_locations" do |elements|
             assert_equal 1, elements.length
             assert_data_attributes_for_world_locations(
               element: elements.first,


### PR DESCRIPTION
## Description

Some fields on the edit editionhave the wrong id and attribute being passed into the error items object so errors aren't linking correctly.

## Screenshots

<img width="368" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/aebd3e44-edd5-4e0b-ae02-1d8b31117c59">

### Before 

<img width="445" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/b58d72dc-b3bb-4f1e-b218-60f7b1a88246">">

### After 

<img width="459" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/5e56be0a-7d3c-4a36-83eb-90d07bda5271">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
