### PR TITLE
Add helper method for organisation context blocks

### DIFF
--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -131,4 +131,8 @@ module Admin::OrganisationHelper
       topical_event.end_date.try(:to_date),
     ].compact.map { |date| l(date) }.join(" to ")
   end
+
+  def organisation_context_block(current_user, organisation)
+    current_user.organisation == organisation ? "My organisation" : "Organisation"
+  end
 end

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, @organisation.name %>
-<% content_for :context, current_user.organisation == @organisation ? "My organisation" : "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
 <% content_for :title, @organisation.name %>
 <% content_for :title_margin_bottom, 4 %>
 

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{@organisation.name}" %>
 <% content_for :title, @organisation.name %>
-<% content_for :context, current_user.organisation == @organisation ? "My organisation" : "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
 <% content_for :title_margin_bottom, 4 %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, @organisation.name %>
 <% content_for :title, @organisation.name %>
-<% content_for :context, current_user.organisation == @organisation ? "My organisation" : "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
 <% content_for :title_margin_bottom, 4 %>
 
 <p class="govuk-body">

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Organisations" %>
-<% content_for :context, current_user.organisation == @organisation ? "My organisation" : "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
 <% if can?(:create, Organisation) %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Create organisation",

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, @organisation.name %>
-<% content_for :context, current_user.organisation == @organisation ? "My organisation" : "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
 <% content_for :title, @organisation.name %>
 <% content_for :title_margin_bottom, 4 %>
 


### PR DESCRIPTION
## Description

This adds a helper method to DRY out the code for organisation pages which include the organisation secondary navigation tabs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
