### PR TITLE
Remove auto-publishing of retired service and info pages

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -513,16 +513,10 @@ class Organisation < ApplicationRecord
       charity-commission
       department-for-education
       department-for-environment-food-rural-affairs
-      driver-and-vehicle-standards-agency
-      environment-agency
-      high-speed-two-limited
-      highways-england
       hm-revenue-customs
       marine-management-organisation
       maritime-and-coastguard-agency
-      medicines-and-healthcare-products-regulatory-agency
       natural-england
-      planning-inspectorate
     ]
   end
 


### PR DESCRIPTION
Collections is responsible for rendering organisation pages. [Some orgs are allowed](https://github.com/alphagov/collections/blob/main/app/presenters/organisations/header_presenter.rb#L113-L120) to have a link to a services and information page in the header of their org page. 

We are currently retiring service and information pages, and so far we have removed the link from the following pages:

- Highways England https://github.com/alphagov/collections/pull/3166
- MHRA https://github.com/alphagov/collections/pull/3213
- High Speed Two Limited https://github.com/alphagov/collections/pull/3188
- DVSA https://github.com/alphagov/collections/pull/3188
- Planning Inspectorate https://github.com/alphagov/collections/pull/3165
- Environment Agency https://github.com/alphagov/collections/pull/3170

Once the link is removed, we can then redirect the page. But the final step in their retirement is to remove the same orgs from the list held in whitehall. So that they are no long republished [every time the org page is updated](https://github.com/alphagov/whitehall/blob/122a847b5422a795486bc77a6d96417f19955575/app/controllers/admin/organisations_controller.rb#L80)

### Future work 
- Remove Charity Commission from this list once I get the go ahead from content folks.
- Remove service and information code once all the pages have been retired. But until then, we need to manually keep the lists in sync.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
[trello](https://trello.com/c/VmtNAPb5/1874-remove-auto-publishing-of-dvsa-planning-inspectorate-and-environment-agency-service-and-information-pages-and-maybe-some-others)