### PR TITLE
Provide publishers with published date on reorder features pages

### DIFF
--- a/app/components/admin/features/featured_documents_table_component.rb
+++ b/app/components/admin/features/featured_documents_table_component.rb
@@ -3,6 +3,7 @@
 class Admin::Features::FeaturedDocumentsTableComponent < ViewComponent::Base
   include Admin::EditionRoutesHelper
   include Admin::OrganisationHelper
+  include Admin::FeaturesHelper
 
   attr_reader :caption, :features
 
@@ -62,20 +63,8 @@ private
 
   def published_row(feature)
     {
-      text: published_at(feature),
+      text: feature_published_on(feature),
     }
-  end
-
-  def published_at(feature)
-    if feature.document&.live_edition.present?
-      localize(feature.document.live_edition.major_change_published_at.to_date)
-    elsif feature.topical_event.present?
-      topical_event_dates_string(feature.topical_event)
-    elsif feature.offsite_link.present?
-      (localize(feature.offsite_link.date.to_date) if feature.offsite_link.date) || ""
-    else
-      ""
-    end
   end
 
   def actions_row(feature)

--- a/app/components/admin/topical_events/featurings/featured_documents_table_component.rb
+++ b/app/components/admin/topical_events/featurings/featured_documents_table_component.rb
@@ -2,6 +2,7 @@
 
 class Admin::TopicalEvents::Featurings::FeaturedDocumentsTableComponent < ViewComponent::Base
   include Admin::EditionRoutesHelper
+  include Admin::TopicalEventFeaturingsHelper
 
   attr_reader :caption, :featurings
 
@@ -45,16 +46,8 @@ private
 
   def published_row(featuring)
     {
-      text: published_at(featuring),
+      text: featuring_published_on(featuring),
     }
-  end
-
-  def published_at(featuring)
-    if featuring.offsite?
-      (localize(featuring.offsite_link.date.to_date) if featuring.offsite_link.date) || ""
-    else
-      localize(featuring.edition.major_change_published_at.to_date)
-    end
   end
 
   def actions_row(featuring)

--- a/app/helpers/admin/features_helper.rb
+++ b/app/helpers/admin/features_helper.rb
@@ -16,4 +16,16 @@ module Admin::FeaturesHelper
       end
     end
   end
+
+  def feature_published_on(feature)
+    if feature.document&.live_edition.present?
+      localize(feature.document.live_edition.major_change_published_at.to_date)
+    elsif feature.topical_event.present?
+      topical_event_dates_string(feature.topical_event)
+    elsif feature.offsite_link.present?
+      (localize(feature.offsite_link.date.to_date) if feature.offsite_link.date) || ""
+    else
+      ""
+    end
+  end
 end

--- a/app/helpers/admin/topical_event_featurings_helper.rb
+++ b/app/helpers/admin/topical_event_featurings_helper.rb
@@ -1,0 +1,9 @@
+module Admin::TopicalEventFeaturingsHelper
+  def featuring_published_on(featuring)
+    if featuring.offsite?
+      (localize(featuring.offsite_link.date.to_date) if featuring.offsite_link.date) || ""
+    else
+      localize(featuring.edition.major_change_published_at.to_date)
+    end
+  end
+end

--- a/app/views/admin/feature_lists/reorder.html.erb
+++ b/app/views/admin/feature_lists/reorder.html.erb
@@ -16,6 +16,7 @@
           {
             id: feature.id,
             title: feature,
+            description: feature_published_on(feature).present? ? "Published: #{feature_published_on(feature)}" : nil,
           }
         end
       } %>

--- a/app/views/admin/topical_event_featurings/reorder.html.erb
+++ b/app/views/admin/topical_event_featurings/reorder.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= form_with url: order_admin_topical_event_topical_event_featurings_path(@topical_event), method: :put do %>
       <%= render "govuk_publishing_components/components/hint", {
         text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
@@ -16,6 +16,7 @@
           {
             id: featuring.id,
             title: featuring.title,
+            description: featuring_published_on(featuring).present? ? "Published: #{featuring_published_on(featuring)}" : nil
           }
         end
       } %>


### PR DESCRIPTION
## Description

We've had some feedback that publishers are struggling to reorder features when the features are translations. As we now reorder on a separate page they have less information as they've lost the published date. They were previously relying on this to reorder as they often don't speak the language

Adds it for:
- feature lists
- topical event featurings

## Screenshots

### Before

<img width="876" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/2bebca5f-3984-4321-9f91-50d6d84587d8">

### After 

<img width="843" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/16314360-b64c-4bf2-b49d-adbf38fc9e68">

## Trello card

https://trello.com/c/m1q3646w/259-5361477-unable-to-work-out-which-translation-to-feature-foreign-commonwealth-and-development-office-fcdo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
