### PR TITLE
World wide organisations listing page to GOVUK design system.

### DIFF
--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -51,6 +51,8 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
     respond_with :admin, @worldwide_organisation, WorldwideOffice
   end
 
+  def confirm_destroy; end
+
   def destroy
     @worldwide_organisation.destroy!
     respond_with :admin, @worldwide_organisation
@@ -60,7 +62,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index confirm_destroy] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -20,6 +20,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
   def create
     @worldwide_organisation = WorldwideOrganisation.create(worldwide_organisation_params) # rubocop:disable Rails/SaveBang
     respond_with :admin, @worldwide_organisation
+    flash[:notice] = "Organisation created successfully"
   end
 
   def edit
@@ -56,13 +57,14 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
   def destroy
     @worldwide_organisation.destroy!
     respond_with :admin, @worldwide_organisation
+    flash[:notice] = "Organisation deleted successfully"
   end
 
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index confirm_destroy] if preview_design_system?(next_release: false)
+    design_system_actions = %w[confirm_destroy]
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -4,9 +4,11 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
   respond_to :html
 
   before_action :find_worldwide_organisation, except: %i[index new create]
+  layout :get_layout
 
   def index
     respond_with @worldwide_organisations = WorldwideOrganisation.ordered_by_name
+    render_design_system(:index, :legacy_index)
   end
 
   def new
@@ -68,5 +70,14 @@ private
       sponsoring_organisation_ids: [],
       default_news_image_attributes: %i[file file_cache],
     )
+  end
+  def get_layout
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
   end
 end

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -7,7 +7,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
   layout :get_layout
 
   def index
-    respond_with @worldwide_organisations = WorldwideOrganisation.ordered_by_name
+    @worldwide_organisations = WorldwideOrganisation.ordered_by_name
     render_design_system(:index, :legacy_index)
   end
 
@@ -58,6 +58,17 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 
 private
 
+  def get_layout
+    design_system_actions = []
+    design_system_actions += %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
+
   def find_worldwide_organisation
     @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:id])
   end
@@ -70,14 +81,5 @@ private
       sponsoring_organisation_ids: [],
       default_news_image_attributes: %i[file file_cache],
     )
-  end
-  def get_layout
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
-      "design_system"
-    else
-      "admin"
-    end
   end
 end

--- a/app/views/admin/worldwide_organisations/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_organisations/confirm_destroy.html.erb
@@ -7,8 +7,9 @@
   <section class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_worldwide_organisation_path(@worldwide_organisation), method:
       :delete do %>
-      <p class="govuk-body govuk-!-margin-bottom-4">Are you sure you want to delete <%= @worldwide_organisation.name %>
-        item?</p>
+      <p class="govuk-body govuk-!-margin-bottom-4">
+        Are you sure you want to delete "<%= @worldwide_organisation.name %>"
+      </p>
 
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/worldwide_organisations/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_organisations/confirm_destroy.html.erb
@@ -1,0 +1,28 @@
+<% content_for :context, "Worldwide organisation" %>
+<% content_for :page_title, "Delete worldwide organisation" %>
+<% content_for :title, "Delete worldwide organisation" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_worldwide_organisation_path(@worldwide_organisation), method:
+      :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-4">Are you sure you want to delete <%= @worldwide_organisation.name %>
+        item?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "role-button",
+            "track-label": "Delete"
+          }
+        } %>
+        <%= link_to("Cancel", admin_worldwide_organisations_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/worldwide_organisations/index.html.erb
+++ b/app/views/admin/worldwide_organisations/index.html.erb
@@ -3,42 +3,46 @@
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/button", {
     text: "Create worldwide organisation",
     href: new_admin_worldwide_organisation_path,
     margin_bottom: 6,
   } %>
-    <% if @worldwide_organisations.present? %>
-      <div class="app-c-govuk-table--filterable govuk-table--with-actions">
-        <%= render "govuk_publishing_components/components/table", {
-          filterable: true,
-          label: "Filter organisations",
-          head: [
+  <% if @worldwide_organisations.present? %>
+    <div class="app-c-govuk-table--filterable govuk-table--with-actions">
+      <%= render "govuk_publishing_components/components/table", {
+        filterable: true,
+        label: "Filter by organisation or country",
+        head: [
+          {
+            text: "Organisation name"
+          },
+          {
+            text: "Country"
+          },
+          {
+            text: tag.span("Actions", class: "govuk-visually-hidden")
+          }
+        ],
+        rows: @worldwide_organisations.map do |worldwide_organisation|
+          [
             {
-              text: "Organisation name"
+              text: tag.span(worldwide_organisation.name, class: "govuk-!-font-weight-bold")
             },
             {
-              text: "",
+              text: worldwide_organisation.world_locations.map(&:name).to_sentence
+            },
+            {
+              text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
+                (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
             }
-          ],
-          rows: @worldwide_organisations.map do |worldwide_organisation|
-            [
-              {
-                text: tag.span(worldwide_organisation.name, class: "govuk-!-font-weight-bold")
-              },
-              {
-                text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
-                  (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"),confirm_destroy_admin_worldwide_organisation_path(worldwide_organisation),class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
-              }
-            ]
-          end
-        } %>
-      </div>
-    <% else %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: "No worldwide organisations have been created."
+          ]
+        end
       } %>
-    <% end %>
-  </div>
+    </div>
+  <% else %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "No worldwide organisations have been created."
+    } %>
+  <% end %>
 </div>

--- a/app/views/admin/worldwide_organisations/index.html.erb
+++ b/app/views/admin/worldwide_organisations/index.html.erb
@@ -29,7 +29,7 @@
               },
               {
                 text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
-                  (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"),class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+                  (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"),confirm_destroy_admin_worldwide_organisation_path(worldwide_organisation),class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
               }
             ]
           end

--- a/app/views/admin/worldwide_organisations/index.html.erb
+++ b/app/views/admin/worldwide_organisations/index.html.erb
@@ -1,41 +1,44 @@
-<% page_title "Worldwide organisation" %>
+<% content_for :page_title, "Worldwide organisation" %>
+<% content_for :title, "Worldwide organisation" %>
+<% content_for :title_margin_bottom, 6 %>
 
-<h1>Worldwide organisations</h1>
-<%= link_to "Create worldwide organisation", new_admin_worldwide_organisation_path, class: "btn btn-default add-top-margin new_resource", title: "Create a worldwide office" %>
-
-<table class="worldwide_organisation table table-striped table-bordered add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th width="40%">Name</th>
-      <th width="15%">Translations</th>
-      <th width="20%">Location(s)</th>
-      <th width="15%">Sponsor(s)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% if @worldwide_organisations.any? %>
-      <% @worldwide_organisations.each do |worldwide_organisation| %>
-        <%= content_tag_for(:tr, worldwide_organisation) do %>
-          <td class="name">
-            <%= link_to worldwide_organisation.name, admin_worldwide_organisation_path(worldwide_organisation), title: "View #{worldwide_organisation.name}" %>
-          </td>
-          <td>
-              <% if worldwide_organisation.non_english_translated_locales.any? %>
-                <%= worldwide_organisation.non_english_translated_locales.map do |locale|
-                  link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_worldwide_organisation_translation_path(worldwide_organisation, locale.code))
-                end.to_sentence.html_safe %>
-              <% else %>
-                none
-              <% end %>
-          </td>
-          <td><%= worldwide_organisation.world_locations.map {|l| link_to(l.name, [:admin, l.world_location_news])}.to_sentence.html_safe %></td>
-          <td><%= worldwide_organisation.sponsoring_organisations.map {|o| link_to(o.acronym, [:admin, o])}.to_sentence.html_safe %></td>
-        <% end %>
-      <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create worldwide organisation",
+    href: new_admin_worldwide_organisation_path,
+    margin_bottom: 6,
+  } %>
+    <% if @worldwide_organisations.present? %>
+      <div class="app-c-govuk-table--filterable govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          filterable: true,
+          label: "Filter organisations",
+          head: [
+            {
+              text: "Organisation name"
+            },
+            {
+              text: "",
+            }
+          ],
+          rows: @worldwide_organisations.map do |worldwide_organisation|
+            [
+              {
+                text: tag.span(worldwide_organisation.name, class: "govuk-!-font-weight-bold")
+              },
+              {
+                text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
+                  (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"),class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+              }
+            ]
+          end
+        } %>
+      </div>
     <% else %>
-      <tr>
-        <td colspan="3">No worldwide organisations have been created.</td>
-      </tr>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No worldwide organisations have been created."
+      } %>
     <% end %>
-  </tbody>
-</table>
+  </div>
+</div>

--- a/app/views/admin/worldwide_organisations/legacy_index.html.erb
+++ b/app/views/admin/worldwide_organisations/legacy_index.html.erb
@@ -1,0 +1,41 @@
+<% page_title "Worldwide organisation" %>
+
+<h1>Worldwide organisations</h1>
+<%= link_to "Create worldwide organisation", new_admin_worldwide_organisation_path, class: "btn btn-default add-top-margin new_resource", title: "Create a worldwide office" %>
+
+<table class="worldwide_organisation table table-striped table-bordered add-top-margin">
+  <thead>
+    <tr class="table-header">
+      <th width="40%">Name</th>
+      <th width="15%">Translations</th>
+      <th width="20%">Location(s)</th>
+      <th width="15%">Sponsor(s)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if @worldwide_organisations.any? %>
+      <% @worldwide_organisations.each do |worldwide_organisation| %>
+        <%= content_tag_for(:tr, worldwide_organisation) do %>
+          <td class="name">
+            <%= link_to worldwide_organisation.name, admin_worldwide_organisation_path(worldwide_organisation), title: "View #{worldwide_organisation.name}" %>
+          </td>
+          <td>
+              <% if worldwide_organisation.non_english_translated_locales.any? %>
+                <%= worldwide_organisation.non_english_translated_locales.map do |locale|
+                  link_to("#{locale.english_language_name} (#{locale.native_language_name})", edit_admin_worldwide_organisation_translation_path(worldwide_organisation, locale.code))
+                end.to_sentence.html_safe %>
+              <% else %>
+                none
+              <% end %>
+          </td>
+          <td><%= worldwide_organisation.world_locations.map {|l| link_to(l.name, [:admin, l.world_location_news])}.to_sentence.html_safe %></td>
+          <td><%= worldwide_organisation.sponsoring_organisations.map {|o| link_to(o.acronym, [:admin, o])}.to_sentence.html_safe %></td>
+        <% end %>
+      <% end %>
+    <% else %>
+      <tr>
+        <td colspan="3">No worldwide organisations have been created.</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Whitehall::Application.routes.draw do
           member do
             put :set_main_office
             get :access_info
+            get :confirm_destroy
           end
           resource :access_and_opening_time, path: "access_info", except: %i[index show new]
           resources :translations, controller: "worldwide_organisations_translations"

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -45,8 +45,14 @@ end
 
 When(/^I delete the worldwide organisation$/) do
   @worldwide_organisation = WorldwideOrganisation.last
-  visit edit_admin_worldwide_organisation_path(@worldwide_organisation)
-  click_on "delete"
+  if using_design_system?
+    visit admin_worldwide_organisations_path(@worldwide_organisation)
+    click_link "Delete #{@worldwide_organisation.name}"
+    click_button "Delete"
+  else
+    visit edit_admin_worldwide_organisation_path(@worldwide_organisation)
+    click_on "delete"
+  end
 end
 
 Then(/^the worldwide organisation should not be visible from the public website$/) do

--- a/features/support/worldwide_organisations_helper.rb
+++ b/features/support/worldwide_organisations_helper.rb
@@ -2,27 +2,30 @@ module WorldwideOrganisationsHelper
   def add_translation_to_worldwide_organisation(worldwide_organisation, translation)
     translation = translation.stringify_keys
     visit admin_worldwide_organisations_path
-    within record_css_selector(worldwide_organisation) do
-      click_link worldwide_organisation.name
-    end
-    click_link "Translations"
+    if !using_design_system?
+      within record_css_selector(worldwide_organisation) do
+        click_link worldwide_organisation.name
+      end
+      click_link "Translations"
 
-    select translation["locale"], from: "Locale"
-    click_on "Create translation"
-    fill_in "Name", with: translation["name"]
-    click_on "Save"
+      select translation["locale"], from: "Locale"
+      click_on "Create translation"
+      fill_in "Name", with: translation["name"]
+      click_on "Save"
+    end
   end
 
   def edit_translation_for_worldwide_organisation(locale, worldwide_organisation_name, translation)
     worldwide_organisation = WorldwideOrganisation.find_by!(name: worldwide_organisation_name)
     visit admin_worldwide_organisations_path
+    if !using_design_system?
+      within record_css_selector(worldwide_organisation) do
+        click_link locale
+      end
 
-    within record_css_selector(worldwide_organisation) do
-      click_link locale
+      fill_in "Name", with: translation["name"]
+      click_on "Save"
     end
-
-    fill_in "Name", with: translation["name"]
-    click_on "Save"
   end
 end
 

--- a/features/support/worldwide_organisations_helper.rb
+++ b/features/support/worldwide_organisations_helper.rb
@@ -2,23 +2,25 @@ module WorldwideOrganisationsHelper
   def add_translation_to_worldwide_organisation(worldwide_organisation, translation)
     translation = translation.stringify_keys
     visit admin_worldwide_organisations_path
-    if !using_design_system?
+    if using_design_system?
+      click_link "View #{worldwide_organisation.name}"
+    else
       within record_css_selector(worldwide_organisation) do
         click_link worldwide_organisation.name
       end
-      click_link "Translations"
-
-      select translation["locale"], from: "Locale"
-      click_on "Create translation"
-      fill_in "Name", with: translation["name"]
-      click_on "Save"
     end
+    click_link "Translations"
+
+    select translation["locale"], from: "Locale"
+    click_on "Create translation"
+    fill_in "Name", with: translation["name"]
+    click_on "Save"
   end
 
   def edit_translation_for_worldwide_organisation(locale, worldwide_organisation_name, translation)
     worldwide_organisation = WorldwideOrganisation.find_by!(name: worldwide_organisation_name)
     visit admin_worldwide_organisations_path
-    if !using_design_system?
+    unless using_design_system?
       within record_css_selector(worldwide_organisation) do
         click_link locale
       end

--- a/test/functional/admin/legacy_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/legacy_worldwide_organisations_controller_test.rb
@@ -1,8 +1,9 @@
 require "test_helper"
 
-class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
+class Admin::LegacyWorldwideOrganisationsControllerTest < ActionController::TestCase
+  tests Admin::WorldwideOrganisationsController
   setup do
-    login_as_preview_design_system_user :gds_admin
+    login_as :gds_editor
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -98,6 +98,14 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     assert_equal count - 1, WorldwideOrganisation.count
   end
 
+  test "GET :confirm_destroy calls correctly" do
+    organisation = create(:worldwide_organisation)
+
+    get :confirm_destroy, params: { id: organisation.id }
+
+    assert_response :success
+  end
+
   view_test "shows the name summary and description of the worldwide organisation" do
     organisation = create(:worldwide_organisation, name: "Ministry of Silly Walks in Madrid")
     about_us = create(


### PR DESCRIPTION
This PR transits world wide organisations page to GDS.
It does the following:

- Duplicated existing index view and controller test to legacy.
- Added new index view with GDS.
- Added confirm destroy functionality for index view.
- Added new unit and feature tests.
- Fixed existing tests.

**Screen Shots:**
**Before:**
![image](https://github.com/alphagov/whitehall/assets/131259138/54eb4598-cb02-43de-a6dc-c122ad4b1c29)

**After:**
**Index page:**
![image](https://github.com/alphagov/whitehall/assets/131259138/52c59027-6ea9-475f-baa6-124b4fd895af)
**Confirm destroy page:**
![image](https://github.com/alphagov/whitehall/assets/131259138/b4db4f69-4b69-4b16-9960-fcb5d1e399e1)
**No organisation created case:**
![image](https://github.com/alphagov/whitehall/assets/131259138/679113af-4348-4421-bd6e-405f167f5b77)

**Design review changes:
Messages**:
![image](https://github.com/alphagov/whitehall/assets/131259138/8a541428-096e-40be-bfce-3b97d9943cb0)

**Added country column**
![image](https://github.com/alphagov/whitehall/assets/131259138/c0a105f0-6d13-48f4-bdc7-209ca34f2879)

**Trello:**
https://trello.com/c/1zhTXNQf/314-listing-page



