### PR TITLE
Fix rebuild taxonomy cache command

### DIFF
--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -3,7 +3,7 @@ require "redis-lock"
 namespace :taxonomy do
   desc "Rebuild the taxonomy cache"
   task rebuild_cache: [:environment] do
-    Redis.new.lock("rebuild_taxonomy_cache_worker_lock", life: 10.minutes, acquire: 1) do
+    Redis.new.lock("rebuild_taxonomy_cache_worker_lock", life: 10, acquire: 1) do
       Rails.logger.info "Scheduling taxonomy cache rebuild"
       RebuildTaxonomyCacheWorker.perform_async
     end


### PR DESCRIPTION
The mlanett-redis-lock gem API has never, as far as I can see, accepted a duration for the life option. Without this fix, the command resulted in a `Unsupported command argument type: ActiveSupport::Duration` error

I briefly attempted writing a test for this but it seemed very high effort for uncertain value. I'm not sure how to mock the publishing API adapter for this case or if it would even be possible, and the classes that handle the rebuild have their own tests, so I've decided against it.