### PR TITLE
Call for Evidence email reminders

### DIFF
--- a/app/mailers/mail_notifications.rb
+++ b/app/mailers/mail_notifications.rb
@@ -91,6 +91,14 @@ class MailNotifications < ApplicationMailer
               subject: "Consultation deadline breached"
   end
 
+  def call_for_evidence_reminder(call_for_evidence, recipient_address:)
+    @title = call_for_evidence.title
+
+    view_mail template_id,
+              to: recipient_address,
+              subject: "Reminder: Call for evidence \"#{@title}\" closed 8 weeks ago"
+  end
+
   helper_method :production?
 
   def production?

--- a/app/mailers/multi_notifications.rb
+++ b/app/mailers/multi_notifications.rb
@@ -12,4 +12,11 @@ class MultiNotifications < ApplicationMailer
       mailer.consultation_deadline_passed(consultation, recipient_address: address)
     end
   end
+
+  def self.call_for_evidence_reminder(call_for_evidence, mailer: MailNotifications)
+    addresses = call_for_evidence.authors.pluck(:email).uniq
+    addresses.map do |address|
+      mailer.call_for_evidence_reminder(call_for_evidence, recipient_address: address)
+    end
+  end
 end

--- a/app/models/call_for_evidence_reminder.rb
+++ b/app/models/call_for_evidence_reminder.rb
@@ -1,0 +1,24 @@
+class CallForEvidenceReminder
+  WEEKS_FROM_CLOSE_TO_REMINDER = 8
+
+  class << self
+    def send_reminder
+      CallForEvidence.awaiting_response.closed_at_or_within_24_hours_of(WEEKS_FROM_CLOSE_TO_REMINDER.weeks.ago).each do |call_for_evidence|
+        log(call_for_evidence)
+        MultiNotifications.call_for_evidence_reminder(call_for_evidence).map(&:deliver_now)
+      end
+    end
+
+  private
+
+    def log(call_for_evidence)
+      Rails.logger.info("Sending reminder for call for evidence ##{call_for_evidence.id} '#{call_for_evidence.title}' to #{obfuscated_email_addresses(call_for_evidence)}")
+    end
+
+    def obfuscated_email_addresses(call_for_evidence)
+      call_for_evidence.authors.uniq.map { |author|
+        author.email.gsub(/^(.{2}).*(.{2})$/, '\1*****\2')
+      }.to_sentence
+    end
+  end
+end

--- a/app/views/mail_notifications/call_for_evidence_reminder.text.erb
+++ b/app/views/mail_notifications/call_for_evidence_reminder.text.erb
@@ -1,0 +1,3 @@
+This is a reminder that the call for evidence "<%= @title %>" closed 8 weeks ago and you may want to publish responses. You can do this in the Outcome section.
+
+It is optional to publish responses for a call for evidence.

--- a/lib/tasks/publisher_notifications.rake
+++ b/lib/tasks/publisher_notifications.rake
@@ -1,6 +1,7 @@
 namespace :publisher_notifications do
-  desc "Send notifications to publishers"
+  desc "Send notifications to publishers. Task is run daily. Check Cron job in Helm Charts."
   task send: :environment do
     ConsultationReminder.send_all
+    CallForEvidenceReminder.send_reminder
   end
 end

--- a/test/factories/calls_for_evidence.rb
+++ b/test/factories/calls_for_evidence.rb
@@ -53,10 +53,6 @@ FactoryBot.define do
     outcome { create(:call_for_evidence_outcome, :with_html_attachment) }
   end
 
-  factory :call_for_evidence_with_public_feedback_html_attachment, parent: :closed_call_for_evidence do
-    public_feedback { create(:consultation_public_feedback, :with_html_attachment) }
-  end
-
   factory :call_for_evidence_with_excluded_nations, parent: :call_for_evidence, traits: [:has_excluded_nations]
   factory :published_call_for_evidence_with_excluded_nations, parent: :published_call_for_evidence, traits: [:has_excluded_nations]
 end

--- a/test/functional/multi_notifications_call_for_evidence_reminders_test.rb
+++ b/test/functional/multi_notifications_call_for_evidence_reminders_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class MultiNotificationsCallForEvidenceRemindersTest < ActionMailer::TestCase
+  setup do
+    author = build(:author)
+    @call_for_evidence = create(:call_for_evidence, authors: [author, author])
+  end
+
+  test "reminder emails should contain the title text" do
+    @email = MultiNotifications.call_for_evidence_reminder(@call_for_evidence)
+    assert_includes @email.first.body.to_s, %(This is a reminder that the call for evidence "#{@call_for_evidence.title}" closed 8 weeks ago and you may want to publish responses.)
+    assert_equal 1, @email.length
+  end
+end

--- a/test/functional/multi_notifications_consultation_reminders_test.rb
+++ b/test/functional/multi_notifications_consultation_reminders_test.rb
@@ -1,10 +1,9 @@
 require "test_helper"
 
-class NotificationsConsultationRemindersTest < ActionMailer::TestCase
+class MultiNotificationsConsultationRemindersTest < ActionMailer::TestCase
   setup do
-    @consultation = build(:consultation)
     author = build(:author)
-    @consultation.update!(authors: [author, author])
+    @consultation = create(:consultation, authors: [author, author])
   end
 
   test "reminder emails should contain the title text and weeks remaining" do

--- a/test/unit/models/call_for_evidence_reminder_test.rb
+++ b/test/unit/models/call_for_evidence_reminder_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class CallForEvidenceReminderTest < ActiveSupport::TestCase
+  setup { Timecop.freeze("2018/05/02 01:00:00".in_time_zone) }
+  teardown { ActionMailer::Base.deliveries.clear }
+
+  test ".send_reminder notifies authors of call for evidence reminder if today (past 24h) is exactly 8 weeks after close date without an outcome" do
+    calls_for_evidence = [
+      create_call_for_evidence(closing_at: "2018/03/06 01:01:00".in_time_zone),
+      create_call_for_evidence(closing_at: "2018/03/06 02:30:00".in_time_zone),
+      create_call_for_evidence(closing_at: "2018/03/06 23:45:00".in_time_zone),
+      create_call_for_evidence(closing_at: "2018/03/07 00:30:00".in_time_zone),
+      create_call_for_evidence(closing_at: "2018/03/07 01:00:00".in_time_zone),
+    ]
+
+    CallForEvidenceReminder.send_reminder
+
+    assert_equal 5, ActionMailer::Base.deliveries.size
+
+    calls_for_evidence.each do |call_for_evidence|
+      assert ActionMailer::Base.deliveries.any? do |email|
+        email.to.sort == call_for_evidence.authors.map(&:email).sort &&
+          email.subject.includes?("Reminder: Call for evidence") &&
+          email.body.includes?(call_for_evidence.title)
+      end
+    end
+  end
+
+  test ".send_reminder doesn't send notifications for calls for evidence if today (past 24h) is before 8 weeks after closing date" do
+    create_call_for_evidence(closing_at: "2018/03/06 00:30:00".in_time_zone)
+    create_call_for_evidence(closing_at: "2018/03/06 01:00:00".in_time_zone)
+    CallForEvidenceReminder.send_reminder
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  test ".send_reminder doesn't send notifications for calls for evidence if today (past 24h) is after 8 weeks after closing date" do
+    create_call_for_evidence(closing_at: "2018/03/07 01:01:00".in_time_zone)
+    create_call_for_evidence(closing_at: "2018/03/07 02:00:00".in_time_zone)
+    CallForEvidenceReminder.send_reminder
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  test ".send_reminder doesn't send notifications for calls for evidence if today (24h) is exactly 8 weeks after close but have an outcome" do
+    create_call_for_evidence(closing_at: "2018/03/06 23:45:00".in_time_zone, responded: true)
+    CallForEvidenceReminder.send_reminder
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  def create_call_for_evidence(closing_at:, responded: false)
+    type = responded ? :call_for_evidence_with_outcome : :call_for_evidence
+    FactoryBot.create(type, :published, opening_at: 10.months.ago, closing_at:)
+  end
+end

--- a/test/unit/tasks/publisher_notifications_test.rb
+++ b/test/unit/tasks/publisher_notifications_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "rake"
+
+class PublisherNotificationsRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown { task.reenable }
+
+  describe "#publisher_notifications:send" do
+    let(:task) { Rake::Task["publisher_notifications:send"] }
+
+    test "sends consultation reminders" do
+      ConsultationReminder.expects(:send_all).once
+      task.invoke
+    end
+
+    test "sends call for evidence reminders" do
+      CallForEvidenceReminder.expects(:send_reminder).once
+      task.invoke
+    end
+  end
+end


### PR DESCRIPTION
After a Call For Evidence document is closed, at 8 weeks, we would like to send an email reminder to remind the user to publish the response. Since it is optional for Call For Evidence to have a response, we don't need to send anything after the initial reminder.

There is an existing daily job that runs and sends publisher notification emails for consultation reminders. We can reuse this to also send CFE Reminders. Cron job is set to run daily and config can be found for each environment in Helm Charts. For more info about emails, read the email_delivery.md docs

Guidance link is <Placeholder> for now while we are still working on it.

https://trello.com/c/VVJx9AY0/1313-implement-1-reminder-email-at-8-weeks-for-call-for-evidence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
