### PR TITLE
Ensure statistics_announcements dates render in the correct ordering

### DIFF
--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -75,18 +75,9 @@ module Admin
     end
 
     def unfiltered_scope
-      # We are doing a "greatest n by group" query here, but on a joined model,
-      # i.e. the StatisticsAnnouncementDate, or in this case the
-      # :current_release_date, which is the most recent one. The JOINs and the
-      # GROUP combine to ensure the correct things are loaded and in the correct
-      # order.
       StatisticsAnnouncement.includes(:current_release_date, publication: :translations, organisations: :translations)
-                            .joins("INNER JOIN statistics_announcement_dates
-                              ON (statistics_announcement_dates.statistics_announcement_id = statistics_announcements.id)")
-                            .joins("LEFT OUTER JOIN statistics_announcement_dates sd2
-                              ON (sd2.statistics_announcement_id = statistics_announcements.id
-                              AND statistics_announcement_dates.created_at > sd2.created_at)")
-                            .group("statistics_announcement_dates.statistics_announcement_id")
+                            .joins(:current_release_date)
+                            .distinct
                             .page(options[:page])
                             .per(options[:per_page])
     end


### PR DESCRIPTION
## Description

There's an issue at the moment with the the ordering of statistics announcements on the index page. This is occurring due to the release date ordering not being correctly scoped to the current release date.

I've simplified this query so that it's clear what's going on, but the important thing is that it joins to the current_release_date scope and includes it in the initial query so that it's pre-loaded from the db for when future db calls are made it only returns that for the statistics_announcement_dates association.

## Before

<img width="940" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/29a63deb-14ea-4222-a20f-d3c9a6eb0e42">

## After

<img width="982" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/41216b73-5c5f-4b33-963f-8b5634aa541d">

## Trello card

https://trello.com/c/8578hcqj/335-statistic-announcements-ordering-borked

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
