### PR TITLE
Fix issue where markup is not retained in responsibilities text area

### DIFF
--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -108,7 +108,7 @@
     },
     id: "role_responsibilities",
     name: "role[responsibilities]",
-    value: role.responsibilities_without_markup,
+    value: role.responsibilities,
     rows: 20
   } %>
 


### PR DESCRIPTION
## Description

Mark up is not being retained as the value for the `responsibilities` text area on the roles new/edit page

## Before

before save

<img width="581" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/13f352f3-5298-4efe-aa85-d71dc1fda297">

after save

<img width="621" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3c276411-60d3-4d84-a79e-e1ee292a8dd5">


## After 

before save 

<img width="581" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4c609b36-8364-4039-a065-fdcad59e7fb7">

after save

<img width="581" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/82829699-3e86-4d8e-b9d7-b0a32564b9f7">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
