### PR TITLE
Only filter broken links on most recent report

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -230,7 +230,8 @@ LEFT JOIN (
   ORDER BY id DESC
 ) AS latest_link_checker_api_reports
   ON latest_link_checker_api_reports.link_reportable_type = 'Edition'
- AND latest_link_checker_api_reports.link_reportable_id = editions.id",
+ AND latest_link_checker_api_reports.link_reportable_id = editions.id
+ AND latest_link_checker_api_reports.id = (SELECT MAX(id) FROM link_checker_api_reports WHERE link_checker_api_reports.link_reportable_type = 'Edition' AND link_checker_api_reports.link_reportable_id = editions.id)",
     ).where(
       "
 EXISTS (

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -224,6 +224,18 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [edition_with_broken_link, edition_with_caution_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
+  test "should only filter by the most recent broken link report" do
+    edition = create(
+      :published_publication,
+    )
+    broken_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/broken-link", status: "broken")
+    ok_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/ok-link", status: "ok")
+    create(:link_checker_api_report, batch_id: 1, link_reportable: edition, links: [broken_link])
+    create(:link_checker_api_report, batch_id: 2, link_reportable: edition, links: [ok_link])
+
+    assert_equal [], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
+  end
+
   test "should return the editions ordered by most recent first" do
     older_news_article = create(:draft_news_article, updated_at: 3.days.ago)
     newer_news_article = create(:draft_news_article, updated_at: 1.minute.ago)


### PR DESCRIPTION
At the moment, when a publisher filters the documents list for only those with broken links, an edition is included if a broken link has ever been reported.

This is incorrect as we should only be filtering on the most recent broken links report (as a link may have been fixed between runs).

This adds a condition to the query to ensure that we are only selecting the most recent report where an edition has been checked multiple times.

[Trello card](https://trello.com/c/4pbtFkdZ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
