### PR TITLE
Revert "Revert "Add presenter for World index page""

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -18,7 +18,7 @@ class WorldLocation < ApplicationRecord
   accepts_nested_attributes_for :world_location_news
   delegate :title, to: :world_location_news
 
-  after_commit :republish_embassies_index_page_to_publishing_api
+  after_commit :republish_index_pages_to_publishing_api
 
   enum world_location_type: { world_location: 1, international_delegation: 3 }
 
@@ -92,7 +92,8 @@ class WorldLocation < ApplicationRecord
   extend FriendlyId
   friendly_id
 
-  def republish_embassies_index_page_to_publishing_api
+  def republish_index_pages_to_publishing_api
     PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.new.publish(PublishingApi::WorldIndexPresenter) if I18n.locale == :en
   end
 end

--- a/app/presenters/publishing_api/world_index_presenter.rb
+++ b/app/presenters/publishing_api/world_index_presenter.rb
@@ -1,0 +1,59 @@
+module PublishingApi
+  class WorldIndexPresenter
+    attr_accessor :update_type
+
+    def initialize(update_type: nil)
+      self.update_type = update_type || "major"
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        nil,
+        title: "Help and services around the world",
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        base_path:,
+        details:,
+        document_type: "world_index",
+        public_updated_at: Time.zone.now,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "world_index",
+      )
+
+      content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def details
+      {
+        world_locations: format_locations(WorldLocation.world_location),
+        international_delegations: format_locations(WorldLocation.international_delegation),
+      }
+    end
+
+    def links
+      {}
+    end
+
+    def content_id
+      "369729ba-7776-4123-96be-2e3e98e153e1"
+    end
+
+    def base_path
+      "/world"
+    end
+
+  private
+
+    def format_locations(locations)
+      locations.map do |location|
+        {
+          name: location.name,
+          slug: location.slug,
+          active: location.active,
+        }
+      end
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,7 @@ if Government.where(name: "Test Government").blank?
   )
 end
 
+WorldLocation.skip_callback(:commit, :after, :republish_world_index_page_to_publishing_api)
 WorldLocationNews.skip_callback(:commit, :after, :publish_to_publishing_api)
 WorldLocation.skip_callback(:commit, :after, :republish_embassies_index_page_to_publishing_api)
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -93,6 +93,11 @@ namespace :publishing_api do
     task republish_embassies_index: :environment do
       PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
     end
+
+    desc "Republish the world index page to Publishing API"
+    task republish_world_index: :environment do
+      PresentPageToPublishingApi.new.publish(PublishingApi::WorldIndexPresenter)
+    end
   end
 
   namespace :patch_links do

--- a/test/integration/world_location_integration_test.rb
+++ b/test/integration/world_location_integration_test.rb
@@ -56,6 +56,13 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
     Services.publishing_api.expects(:publish).with(presenter.content_id, anything, anything)
   end
 
+  def expect_world_index_to_be_published
+    presenter = PublishingApi::WorldIndexPresenter.new
+    Services.publishing_api.expects(:put_content).once.with(presenter.content_id, has_entries(locale: "en"))
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links)
+    Services.publishing_api.expects(:publish).with(presenter.content_id, anything, anything)
+  end
+
   test "when updating, makes the correct calls to publishing api" do
     Sidekiq::Testing.inline! do
       world_location_news_without_translations = build(:world_location_news)
@@ -65,6 +72,7 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       fill_in "world_location_news_mission_statement", with: new_mission_statement
 
       expect_embassies_index_to_be_published
+      expect_world_index_to_be_published
       Services.publishing_api.expects(:put_content).once.with(world_location_news_without_translations.content_id, put_content_hash_containing("en", world_location_news_without_translations.title, new_mission_statement))
       Services.publishing_api.expects(:patch_links).with(world_location_news_without_translations.content_id, anything)
       Services.publishing_api.expects(:publish).with(world_location_news_without_translations.content_id, anything, anything)
@@ -124,6 +132,7 @@ class WorldLocationIntegrationTest < ActionDispatch::IntegrationTest
       fill_in "Title", match: :first, with: new_title
 
       PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+      PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::WorldIndexPresenter)
       Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("en", new_title, new_mission_statement))
       Services.publishing_api.expects(:put_content).once.with(@world_location_news.content_id, put_content_hash_containing("fr", @original_french_title, @original_french_mission_statement))
       Services.publishing_api.expects(:publish).at_least_once

--- a/test/unit/present_page_to_publishing_api_test.rb
+++ b/test/unit/present_page_to_publishing_api_test.rb
@@ -23,6 +23,10 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     end
   end
 
+  test "sends the world index page to publishing api" do
+    assert_content_is_presented_to_publishing_api(PublishingApi::WorldIndexPresenter)
+  end
+
   def assert_content_is_presented_to_publishing_api(presenter_class, locale: "en")
     presenter = presenter_class.new
     expected_content = presenter.content

--- a/test/unit/presenters/publishing_api/world_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_index_presenter_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
+  setup do
+    @world_location_1 = create(:world_location, name: "Location 1", slug: "location-1", active: true)
+    @world_location_2 = create(:world_location, name: "Location 2", slug: "location-2", active: false)
+    @international_delegation = create(:international_delegation, name: "Delegation", slug: "delegation", active: true)
+  end
+
+  test "presents a valid content item" do
+    expected_hash = {
+      base_path: "/world",
+      details: {
+        world_locations: [
+          {
+            name: "Location 1",
+            slug: "location-1",
+            active: true,
+          },
+          {
+            name: "Location 2",
+            slug: "location-2",
+            active: false,
+          },
+        ],
+        international_delegations: [
+          {
+            name: "Delegation",
+            slug: "delegation",
+            active: true,
+          },
+        ],
+      },
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      schema_name: "world_index",
+      document_type: "world_index",
+      title: "Help and services around the world",
+      locale: "en",
+      routes: [
+        {
+          path: "/world",
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: Time.zone.now,
+    }
+
+    expected_links = {}
+
+    presenter = PublishingApi::WorldIndexPresenter.new
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_publisher_schema(presenter.content, "world_index")
+
+    assert_equal expected_links, presenter.links
+    assert_valid_against_links_schema({ links: presenter.links }, "world_index")
+  end
+end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -119,24 +119,27 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert_equal "https://www.test.gov.uk/world/foo?cachebust=123", object.public_url(cachebust: "123")
   end
 
-  test "republishes embassies index page on creation of world location" do
+  test "republishes embassies and world index pages on creation of world location" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     create(:world_location)
   end
 
-  test "republishes embassies index page on update of world location" do
+  test "republishes embassies and world index pages on update of world location" do
     location = create(:world_location)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     location.update!(name: "new-name")
   end
 
-  test "republishes embassies index page on deletion of world location" do
+  test "republishes embassies and world index pages on deletion of world location" do
     location = create(:world_location)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     location.destroy!
   end


### PR DESCRIPTION
This reverts commit 82990b37de97447bae7e4acf67fecf1c57468f9c.

The code to present the content item for `/world` was removed during an incident (in https://github.com/alphagov/whitehall/pull/7498) as it was found there were some Worldwide Organisations that relied on `/world` being a prefix route.

That issue has now been resolved, so the content item can be reintroduced.

[Trello card](https://trello.com/c/kKxgl6AJ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
