### PR TITLE
Remove comment from routes file

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,6 @@ Whitehall::Application.routes.draw do
     end
   end
 
-  # Routes rendered by Whitehall to the public under the /government scope (specified in lib/whitehall.rb under the `router_prefix` method)
   scope Whitehall.router_prefix, shallow_path: Whitehall.router_prefix do
     root to: redirect("/", prefix: ""), via: :get, as: :main_root
 


### PR DESCRIPTION
All public routes under `/government` have been removed. It appears this comment remained, but in the wrong place.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
