### PR TITLE
Remove usage of legacy url path from file attachment deletion

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -32,7 +32,7 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
       Whitehall::PublishingApi.republish_async(@organisation)
       if legacy_image_url.present?
         current_legacy_image_url = @promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
-        AssetManager::AssetDeleter.call(legacy_image_url) if legacy_image_url != current_legacy_image_url
+        AssetManager::AssetDeleter.call(legacy_image_url, nil) if legacy_image_url != current_legacy_image_url
       end
 
       redirect_to_feature "Feature item updated."

--- a/app/services/asset_manager/asset_deleter.rb
+++ b/app/services/asset_manager/asset_deleter.rb
@@ -5,10 +5,17 @@ class AssetManager::AssetDeleter
     new.call(*args)
   end
 
-  def call(legacy_url_path)
-    attributes = find_asset_by(legacy_url_path)
-    return if attributes["deleted"]
+  def call(legacy_url_path, asset_manager_id)
+    if asset_manager_id
+      attributes = find_asset_by_id(asset_manager_id)
+      return if attributes["deleted"]
 
-    asset_manager.delete_asset(attributes["id"])
+      asset_manager.delete_asset(asset_manager_id)
+    else
+      attributes = find_asset_by(legacy_url_path)
+      return if attributes["deleted"]
+
+      asset_manager.delete_asset(attributes["id"])
+    end
   end
 end

--- a/app/services/asset_manager/attachment_deleter.rb
+++ b/app/services/asset_manager/attachment_deleter.rb
@@ -2,11 +2,13 @@ class AssetManager::AttachmentDeleter
   def self.call(attachment_data)
     return unless attachment_data.deleted?
 
-    delete_asset_for(attachment_data.file)
-    delete_asset_for(attachment_data.file.thumbnail) if attachment_data.pdf?
-  end
-
-  def self.delete_asset_for(uploader)
-    AssetManager::AssetDeleter.call(uploader.asset_manager_path)
+    if attachment_data.assets.empty?
+      AssetManager::AssetDeleter.call(attachment_data.file.asset_manager_path, nil)
+      AssetManager::AssetDeleter.call(attachment_data.file.thumbnail.asset_manager_path, nil) if attachment_data.pdf?
+    else
+      attachment_data.assets.each do |asset|
+        AssetManager::AssetDeleter.call(nil, asset.asset_manager_id)
+      end
+    end
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,7 +1,7 @@
 class AssetManagerDeleteAssetWorker < WorkerBase
   sidekiq_options queue: "asset_manager"
 
-  def perform(legacy_url_path)
-    AssetManager::AssetDeleter.call(legacy_url_path)
+  def perform(legacy_url_path, asset_manager_id)
+    AssetManager::AssetDeleter.call(legacy_url_path, asset_manager_id)
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -43,7 +43,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def delete
-      AssetManagerDeleteAssetWorker.perform_async(@legacy_url_path)
+      AssetManagerDeleteAssetWorker.perform_async(@legacy_url_path, nil)
     end
 
     def url

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -79,7 +79,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     legacy_url_path = promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
 
     Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
-    AssetManager::AssetDeleter.expects(:call).once.with(legacy_url_path)
+    AssetManager::AssetDeleter.expects(:call).once.with(legacy_url_path, nil)
 
     put :update,
         params: { organisation_id: @organisation,
@@ -103,7 +103,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
     legacy_url_path = promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
 
-    AssetManager::AssetDeleter.expects(:call).once.with(legacy_url_path)
+    AssetManager::AssetDeleter.expects(:call).once.with(legacy_url_path, nil)
 
     put :update,
         params: { organisation_id: @organisation,

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -9,72 +9,150 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
 
   describe "attachment deletion" do
     context "given a draft document with multiple file attachments" do
-      let(:managing_editor) { create(:managing_editor) }
+      context "attachments don't have assets" do
+        let(:managing_editor) { create(:managing_editor) }
 
-      let(:first_filename) { "sample.docx" }
-      let(:first_file) { File.open(path_to_attachment(first_filename)) }
-      let(:first_attachment) { build(:file_attachment, attachable: edition, file: first_file) }
-      let(:first_asset_id) { "first-asset-id" }
+        let(:first_filename) { "sample.docx" }
+        let(:first_file) { File.open(path_to_attachment(first_filename)) }
+        let(:first_attachment) { build(:file_attachment, attachable: edition, file: first_file) }
+        let(:first_asset_id) { "first-asset-id" }
 
-      let(:second_filename) { "sample.rtf" }
-      let(:second_file) { File.open(path_to_attachment(second_filename)) }
-      let(:second_attachment) { build(:file_attachment, attachable: edition, file: second_file) }
-      let(:second_asset_id) { "second-asset-id" }
+        let(:second_filename) { "sample.rtf" }
+        let(:second_file) { File.open(path_to_attachment(second_filename)) }
+        let(:second_attachment) { build(:file_attachment, attachable: edition, file: second_file) }
+        let(:second_asset_id) { "second-asset-id" }
 
-      let(:edition) { create(:news_article) }
+        let(:edition) { create(:news_article) }
 
-      before do
-        login_as(managing_editor)
-        stub_publishing_api_has_linkables([], document_type: "topic")
-        edition.attachments << first_attachment
-        edition.attachments << second_attachment
-        setup_publishing_api_for(edition)
-        stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-        stub_whitehall_asset(first_filename, id: first_asset_id)
-        stub_whitehall_asset(second_filename, id: second_asset_id)
-        first_attachment.attachment_data.uploaded_to_asset_manager!
-        second_attachment.attachment_data.uploaded_to_asset_manager!
-        edition.save!
-
-        # clear the queue of jobs resulting from test setup
-        AssetManagerAttachmentMetadataWorker.drain
-      end
-
-      context "when one attachment is deleted" do
         before do
-          visit admin_news_article_path(edition)
-          click_link "Modify attachments"
-          within row_containing(first_attachment.title) do
-            click_link "Delete"
+          login_as(managing_editor)
+          stub_publishing_api_has_linkables([], document_type: "topic")
+          edition.attachments << first_attachment
+          edition.attachments << second_attachment
+          setup_publishing_api_for(edition)
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_whitehall_asset(first_filename, id: first_asset_id)
+          stub_whitehall_asset(second_filename, id: second_asset_id)
+          first_attachment.attachment_data.uploaded_to_asset_manager!
+          second_attachment.attachment_data.uploaded_to_asset_manager!
+          edition.save!
+
+          # clear the queue of jobs resulting from test setup
+          AssetManagerAttachmentMetadataWorker.drain
+        end
+
+        context "when one attachment is deleted" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Modify attachments"
+            within row_containing(first_attachment.title) do
+              click_link "Delete"
+            end
+            click_button "Delete attachment"
+            assert_text "Attachment deleted"
           end
-          click_button "Delete attachment"
-          assert_text "Attachment deleted"
+
+          it "deletes the corresponding asset in Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
+            assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 1
+            AssetManagerAttachmentMetadataWorker.drain
+          end
+
+          it "queues one worker to delete the asset" do
+            queued_ids = AssetManagerAttachmentMetadataWorker.jobs.map { |job| job["args"].first }
+            assert_equal queued_ids, [first_attachment.attachment_data.id]
+          end
         end
 
-        it "deletes the corresponding asset in Asset Manager" do
-          Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
-          assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 1
-          AssetManagerAttachmentMetadataWorker.drain
-        end
+        context "when draft document is discarded" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Delete draft"
+            click_button "Delete"
+          end
 
-        it "queues one worker to delete the asset" do
-          queued_ids = AssetManagerAttachmentMetadataWorker.jobs.map { |job| job["args"].first }
-          assert_equal queued_ids, [first_attachment.attachment_data.id]
+          it "deletes all corresponding assets in Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
+            Services.asset_manager.expects(:delete_asset).once.with(second_asset_id)
+            assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 2
+            AssetManagerAttachmentMetadataWorker.drain
+          end
         end
       end
 
-      context "when draft document is discarded" do
+      context "attachments have assets" do
+        let(:managing_editor) { create(:managing_editor) }
+
+        let(:first_filename) { "sample.docx" }
+        let(:first_file) { File.open(path_to_attachment(first_filename)) }
+        let(:first_attachment) { build(:file_attachment, attachable: edition, file: first_file) }
+        let(:first_asset_id) { "first-asset-id" }
+
+        let(:second_filename) { "sample.rtf" }
+        let(:second_file) { File.open(path_to_attachment(second_filename)) }
+        let(:second_attachment) { build(:file_attachment, attachable: edition, file: second_file) }
+        let(:second_asset_id) { "second-asset-id" }
+
+        let(:edition) { create(:news_article) }
+
+        let(:first_asset) { Asset.new(asset_manager_id: first_asset_id, variant: Asset.variants[:original]) }
+        let(:second_asset) { Asset.new(asset_manager_id: second_asset_id, variant: Asset.variants[:original]) }
+
         before do
-          visit admin_news_article_path(edition)
-          click_link "Delete draft"
-          click_button "Delete"
+          login_as(managing_editor)
+          stub_publishing_api_has_linkables([], document_type: "topic")
+          edition.attachments << first_attachment
+          edition.attachments << second_attachment
+          setup_publishing_api_for(edition)
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+          stub_asset(first_asset_id)
+          stub_asset(second_asset_id)
+          first_attachment.attachment_data.uploaded_to_asset_manager!
+          second_attachment.attachment_data.uploaded_to_asset_manager!
+          first_attachment.attachment_data.assets = [first_asset]
+          second_attachment.attachment_data.assets = [second_asset]
+          edition.save!
+
+          # clear the queue of jobs resulting from test setup
+          AssetManagerAttachmentMetadataWorker.drain
         end
 
-        it "deletes all corresponding assets in Asset Manager" do
-          Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
-          Services.asset_manager.expects(:delete_asset).once.with(second_asset_id)
-          assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 2
-          AssetManagerAttachmentMetadataWorker.drain
+        context "when one attachment is deleted" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Modify attachments"
+            within row_containing(first_attachment.title) do
+              click_link "Delete"
+            end
+            click_button "Delete attachment"
+            assert_text "Attachment deleted"
+          end
+
+          it "deletes the corresponding asset in Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
+            assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 1
+            AssetManagerAttachmentMetadataWorker.drain
+          end
+
+          it "queues one worker to delete the asset" do
+            queued_ids = AssetManagerAttachmentMetadataWorker.jobs.map { |job| job["args"].first }
+            assert_equal queued_ids, [first_attachment.attachment_data.id]
+          end
+        end
+
+        context "when draft document is discarded" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Delete draft"
+            click_button "Delete"
+          end
+
+          it "deletes all corresponding assets in Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).once.with(first_asset_id)
+            Services.asset_manager.expects(:delete_asset).once.with(second_asset_id)
+            assert_equal AssetManagerAttachmentMetadataWorker.jobs.count, 2
+            AssetManagerAttachmentMetadataWorker.drain
+          end
         end
       end
     end
@@ -96,8 +174,15 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
     def stub_whitehall_asset(filename, attributes = {})
       url_id = "http://asset-manager/assets/#{attributes[:id]}"
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with(filename))
-        .returns(attributes.merge(id: url_id).stringify_keys)
+              .with(&ends_with(filename))
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+
+    def stub_asset(asset_manger_id, attributes = {})
+      url_id = "http://asset-manager/assets/#{asset_manger_id}"
+      Services.asset_manager.stubs(:asset)
+              .with(asset_manger_id)
+              .returns(attributes.merge(id: url_id).stringify_keys)
     end
   end
 end

--- a/test/unit/services/asset_manager/asset_deleter_test.rb
+++ b/test/unit/services/asset_manager/asset_deleter_test.rb
@@ -1,28 +1,53 @@
 require "test_helper"
 
 class AssetManager::AssetDeleterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   setup do
-    @asset_id = "asset-id"
-    @asset_url = "http://asset-manager/assets/#{@asset_id}"
+    @asset_manager_id = "asset-id"
     @legacy_url_path = "legacy-url-path"
     @worker = AssetManager::AssetDeleter.new
   end
 
-  test "deletes file from asset manager" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns("id" => @asset_id)
-    Services.asset_manager.expects(:delete_asset).with(@asset_id)
+  describe "called with legacy_url_path" do
+    test "deletes file from asset manager" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path)
+             .returns("id" => @asset_manager_id)
+      Services.asset_manager.expects(:delete_asset).with(@asset_manager_id)
 
-    @worker.call(@legacy_url_path)
+      @worker.call(@legacy_url_path, nil)
+    end
+
+    test "does not attempt a delete if the asset is already deleted" do
+      @worker.stubs(:find_asset_by).with(@legacy_url_path).returns(
+        "id" => @asset_manager_id,
+        "deleted" => true,
+      )
+      Services.asset_manager.expects(:delete_asset).never
+
+      @worker.call(@legacy_url_path, nil)
+    end
   end
 
-  test "does not attempt a delete if the asset is already deleted" do
-    @worker.stubs(:find_asset_by).with(@legacy_url_path).returns(
-      "id" => @asset_id,
-      "deleted" => true,
-    )
-    Services.asset_manager.expects(:delete_asset).never
+  describe "called with asset_manager_id" do
+    test "deletes file from asset manager" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+             .returns("id" => @asset_manager_id)
 
-    @worker.call(@legacy_url_path)
+      Services.asset_manager.expects(:delete_asset).with(@asset_manager_id)
+
+      @worker.call(nil, @asset_manager_id)
+    end
+
+    test "does not attempt a delete if the asset is already deleted" do
+      @worker.stubs(:find_asset_by_id).with(@asset_manager_id).returns(
+        "id" => @asset_manager_id,
+        "deleted" => true,
+      )
+
+      Services.asset_manager.expects(:delete_asset).never
+
+      @worker.call(nil, @asset_manager_id)
+    end
   end
 end

--- a/test/unit/services/asset_manager/attachment_deleter_test.rb
+++ b/test/unit/services/asset_manager/attachment_deleter_test.rb
@@ -21,18 +21,59 @@ class AssetManager::AttachmentDeleterTest < ActiveSupport::TestCase
         attachment_data.stubs(:deleted?).returns(deleted)
       end
 
-      context "when attachment data is not a PDF" do
-        let(:file) { File.open(fixture_path.join("sample.rtf")) }
+      context "attachment_data has no associated assets" do
+        context "when attachment data is not a PDF" do
+          let(:file) { File.open(fixture_path.join("sample.rtf")) }
 
-        context "and attachment data is deleted" do
-          let(:deleted) { true }
+          context "and attachment data is deleted" do
+            let(:deleted) { true }
 
-          it "deletes corresponding asset in Asset Manager" do
-            delete_worker.expects(:call)
-              .with(attachment_data.file.asset_manager_path)
+            it "deletes corresponding asset in Asset Manager" do
+              delete_worker.expects(:call)
+                           .with(attachment_data.file.asset_manager_path, nil)
 
-            worker.call(attachment_data)
+              worker.call(attachment_data)
+            end
           end
+
+          context "and attachment data is not deleted" do
+            let(:deleted) { false }
+
+            it "does not delete any assets from Asset Manager" do
+              delete_worker.expects(:call).never
+
+              assert AssetManagerDeleteAssetWorker.jobs.empty?
+            end
+          end
+        end
+
+        context "when attachment data is a PDF" do
+          let(:file) { File.open(fixture_path.join("simple.pdf")) }
+
+          context "and attachment data is deleted" do
+            let(:deleted) { true }
+
+            it "deletes attachment & thumbnail asset in Asset Manager" do
+              delete_worker.expects(:call)
+                           .with(attachment_data.file.asset_manager_path, nil)
+              delete_worker.expects(:call)
+                           .with(attachment_data.file.thumbnail.asset_manager_path, nil)
+
+              worker.call(attachment_data)
+            end
+          end
+        end
+      end
+
+      context "attachment_data has associated assets" do
+        let(:file) { File.open(fixture_path.join("simple.pdf")) }
+        let(:original_file_id) { "original_file_id" }
+        let(:variant_file_id) { "variant_file_id" }
+        let(:original_asset) { Asset.new(asset_manager_id: original_file_id, variant: Asset.variants[:original]) }
+        let(:variant_asset) { Asset.new(asset_manager_id: variant_file_id, variant: Asset.variants[:thumbnail]) }
+
+        before do
+          attachment_data.assets = [original_asset, variant_asset]
         end
 
         context "and attachment data is not deleted" do
@@ -41,22 +82,18 @@ class AssetManager::AttachmentDeleterTest < ActiveSupport::TestCase
           it "does not delete any assets from Asset Manager" do
             delete_worker.expects(:call).never
 
+            worker.call(attachment_data)
+
             assert AssetManagerDeleteAssetWorker.jobs.empty?
           end
         end
-      end
-
-      context "when attachment data is a PDF" do
-        let(:file) { File.open(fixture_path.join("simple.pdf")) }
 
         context "and attachment data is deleted" do
           let(:deleted) { true }
 
           it "deletes attachment & thumbnail asset in Asset Manager" do
-            delete_worker.expects(:call)
-              .with(attachment_data.file.asset_manager_path)
-            delete_worker.expects(:call)
-              .with(attachment_data.file.thumbnail.asset_manager_path)
+            delete_worker.expects(:call).with(nil, original_file_id)
+            delete_worker.expects(:call).with(nil, variant_file_id)
 
             worker.call(attachment_data)
           end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -180,7 +180,7 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
   end
 
   test "queues the call to delete the asset from asset manager" do
-    AssetManagerDeleteAssetWorker.expects(:perform_async).with(@asset_url_path)
+    AssetManagerDeleteAssetWorker.expects(:perform_async).with(@asset_url_path, nil)
 
     @file.delete
   end

--- a/test/unit/workers/asset_manager_delete_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_delete_asset_worker_test.rb
@@ -4,11 +4,12 @@ class AssetManagerDeleteAssetWorkerTest < ActiveSupport::TestCase
   setup do
     @legacy_url_path = "legacy-url-path"
     @worker = AssetManagerDeleteAssetWorker.new
+    @asset_manager_id = "asset_manager_id"
   end
 
   test "it calls AssetManager::AssetDeleter" do
-    AssetManager::AssetDeleter.expects(:call).with(@legacy_url_path)
+    AssetManager::AssetDeleter.expects(:call).with(@legacy_url_path, @asset_manager_id)
 
-    @worker.perform(@legacy_url_path)
+    @worker.perform(@legacy_url_path, @asset_manager_id)
   end
 end


### PR DESCRIPTION
Following the [PR on file attachment updates](https://github.com/alphagov/whitehall/pull/7883), this piece of work handles the deletion of file attachments. 

There are a few different flows around asset deletion, all calling `AssetDeleter` one way or another. The scope for these changes is file attachments. Images and logos will be dealt with in future cards. For file attachments, the updates are triggered by the `MetadataWorker` -> `AttachmentDeleter` -> `AssetDeleter`.

The approach here is similar to the one in the updates PR, checking for the existence assets (the new `Asset` model) on the current `AttachmentData` to decide whether to use `asset_manager_id` (if assets are present) or `legacy_url_path`. 
The intention is to have the two flows coexist until the old one can be safely removed. The creation of new assets remains behind the `Use non legacy endpoints` user permission which is not yet enabled in production.

[Trello card](https://trello.com/c/AE0rfUJZ/96-story-use-assetmanagerid-for-deleting-a-file-attachment)
