### PR TITLE
Revert "Revert "Switch rendering application for Worldwide Organisations""

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -35,7 +35,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       document_type: "worldwide_organisation",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "whitehall-frontend",
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
We are attempting to delete the problematic placeholder translations that prompted the original revert (https://github.com/alphagov/publishing-api/pull/2445). Following that, we should be good to switch the rendering again.

Reverts alphagov/whitehall#7885