### PR TITLE
Fix broken link to corporate information pages

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -59,6 +59,6 @@ module TranslationHelper
   def t_corporate_information_page_link(organisation, slug)
     page = organisation.corporate_information_pages.for_slug(slug)
     page.extend(UseSlugAsParam)
-    link_to(t_corporate_information_page_type_link_text(page), [organisation, page], class: "govuk-link")
+    link_to(t_corporate_information_page_type_link_text(page), page.public_path(locale:), class: "govuk-link")
   end
 end


### PR DESCRIPTION
We have removed the routes corporate information pages in #7923.  However, there is a remaining path helper which is trying to build from the removed routes and is raising an `ActionView::Template::Error`.  Use the `public_path` method instead.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
