### PR TITLE
Add additional world location information to /world content item

### DIFF
--- a/app/presenters/publishing_api/world_index_presenter.rb
+++ b/app/presenters/publishing_api/world_index_presenter.rb
@@ -49,9 +49,13 @@ module PublishingApi
     def format_locations(locations)
       locations.map do |location|
         {
+          active: location.active,
+          analytics_identifier: location.analytics_identifier,
+          content_id: location.content_id,
+          iso2: location.iso2,
           name: location.name,
           slug: location.slug,
-          active: location.active,
+          updated_at: location.updated_at,
         }
       end
     end

--- a/test/unit/presenters/publishing_api/world_index_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_index_presenter_test.rb
@@ -2,9 +2,30 @@ require "test_helper"
 
 class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
   setup do
-    @world_location_1 = create(:world_location, name: "Location 1", slug: "location-1", active: true)
-    @world_location_2 = create(:world_location, name: "Location 2", slug: "location-2", active: false)
-    @international_delegation = create(:international_delegation, name: "Delegation", slug: "delegation", active: true)
+    @world_location_1 = create(
+      :world_location,
+      name: "Location 1",
+      slug: "location-1",
+      active: true,
+      analytics_identifier: "A1",
+      iso2: "AB",
+    )
+    @world_location_2 = create(
+      :world_location,
+      name: "Location 2",
+      slug: "location-2",
+      active: false,
+      analytics_identifier: "B2",
+      iso2: "CD",
+    )
+    @international_delegation = create(
+      :international_delegation,
+      name: "Delegation",
+      slug: "delegation",
+      active: true,
+      analytics_identifier: "C3",
+      iso2: nil,
+    )
   end
 
   test "presents a valid content item" do
@@ -13,21 +34,33 @@ class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
       details: {
         world_locations: [
           {
+            active: true,
+            analytics_identifier: "A1",
+            content_id: @world_location_1.content_id,
+            iso2: "AB",
             name: "Location 1",
             slug: "location-1",
-            active: true,
+            updated_at: @world_location_1.updated_at,
           },
           {
+            active: false,
+            analytics_identifier: "B2",
+            content_id: @world_location_2.content_id,
+            iso2: "CD",
             name: "Location 2",
             slug: "location-2",
-            active: false,
+            updated_at: @world_location_2.updated_at,
           },
         ],
         international_delegations: [
           {
+            active: true,
+            analytics_identifier: "C3",
+            content_id: @international_delegation.content_id,
+            iso2: nil,
             name: "Delegation",
             slug: "delegation",
-            active: true,
+            updated_at: @international_delegation.updated_at,
           },
         ],
       },


### PR DESCRIPTION
We are replacing the Whitehall World Location API with the content item for `/world`.

Therefore adding the additional information needed that is currently supplied by the API.

Depends on https://github.com/alphagov/publishing-api/pull/2447.

After deployment, the following rake task will need to be run in production:
```
publishing_api:republish:republish_world_index
```

[Trello card](https://trello.com/c/g4ypLS8V)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
