### PR TITLE
Fix file attachments caching behaviour

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -108,7 +108,7 @@ private
   end
 
   def attachment_params
-    params.fetch(:attachment, {}).permit(
+    attachment_params = params.fetch(:attachment, {}).permit(
       :title,
       :locale,
       :isbn,
@@ -123,6 +123,8 @@ private
       govspeak_content_attributes: %i[id body manually_numbered_headings],
       attachment_data_attributes: %i[file to_replace_id file_cache],
     ).merge(attachable:)
+
+    clear_file_cache(attachment_params)
   end
 
   def type
@@ -204,5 +206,13 @@ private
 
   def use_non_legacy_endpoints?
     current_user.can_use_non_legacy_endpoints?
+  end
+
+  def clear_file_cache(attachment_params)
+    if attachment_params.dig(:attachment_data_attributes, :file_cache).present? && attachment_params.dig(:attachment_data_attributes, :file).present?
+      attachment_params[:attachment_data_attributes].delete(:file_cache)
+    end
+
+    attachment_params
   end
 end


### PR DESCRIPTION
When encountering a validation error on a file attachment, the current UI offers the option to also re-upload another file (or same file). When this happens, both the new file and the previous cached file get sent to the `AttachmentsController`, as part of the `attachment_data_attributes`.
Only the last file uploaded is associated with an `AttachmentData` and stored in Whitehall. Nonetheless, the Carrierwave flow gets triggered for the cached file as well, resulting in duplicated entries of the same `legacy_url_path` in Asset Manager.
Additionally, an `AttachmentDataNotFoundTransient` error is thrown by the `SetUploadedToWorker` which tries to find an `AttachmentData` with the legacy path of the cached file.

The changes in this commit remove this behaviour by dropping the `file_cache` param at the controller level, if a `file` has already been sent through.
