### PR TITLE
Increases heading size in Social Media Accounts tab

### DIFF
--- a/app/views/admin/social_media_accounts/index.html.erb
+++ b/app/views/admin/social_media_accounts/index.html.erb
@@ -14,6 +14,7 @@
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Social media accounts",
+  font_size: "l",
   margin_bottom: 6,
 } %>
 


### PR DESCRIPTION
This PR increases the size of the heading under the "Social media accounts" tab of the "Worldwide organisations" page to be consistent with other equivalent headings and with the design pattern for such elements. 

|Current|Updated in this PR|
|-|-|
|![Screenshot 2023-07-14 at 15 51 07](https://github.com/alphagov/whitehall/assets/6080548/8e3805af-77ee-4644-ae32-1073a3ce4ab7)|![Screenshot 2023-07-14 at 15 50 58](https://github.com/alphagov/whitehall/assets/6080548/89e64c9e-6f33-41b3-9c0f-ff91dbbceb48)|