### PR TITLE
UI to add a taxonomy topic email override to document collections

### DIFF
--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -1,0 +1,16 @@
+class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseController
+  before_action :load_document_collection
+  before_action :authorise_user
+
+  def edit; end
+
+private
+
+  def load_document_collection
+    @collection = DocumentCollection.find(params[:document_collection_id])
+  end
+
+  def authorise_user
+    redirect_to edit_admin_document_collection_path(@collection) unless current_user.can_edit_email_overrides?
+  end
+end

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -1,6 +1,7 @@
 class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseController
   before_action :load_document_collection
   before_action :authorise_user
+  layout "design_system"
 
   def edit; end
 

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -8,10 +8,10 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
   def update
     if user_has_selected_taxonomy_topic_emails?
       if params[:selected_taxon_content_id].blank?
-        flash["selected_taxon_content_id"] = "You must choose a topic"
+        build_flash("selected_taxon_content_id")
         return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
-      elsif params[:email_override_confirmation].blank?
-        flash["email_override_confirmation"] = "You must confirm you’re happy with the email notification settings"
+      elsif params["email_override_confirmation"].blank?
+        build_flash("email_override_confirmation")
         return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
       else
         @collection.update!(taxonomy_topic_email_override: params[:selected_taxon_content_id])
@@ -19,7 +19,7 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
     else
       @collection.update!(taxonomy_topic_email_override: nil)
     end
-    flash["notice"] = "You’ve selected the email notification settings. You cannot change these settings after the collection is published",
+    build_flash("notice")
     redirect_to edit_admin_document_collection_path(@collection)
   end
 
@@ -33,7 +33,35 @@ private
     redirect_to edit_admin_document_collection_path(@collection) unless current_user.can_edit_email_overrides?
   end
 
+  def build_flash(key)
+    flash[key] = {
+      "selected_taxon_content_id" => "You must choose a topic",
+      "email_override_confirmation" => "You must confirm you’re happy with the email notification settings",
+      "notice" => "You’ve selected the email notification settings. #{confirmation_message}. You will not be able to change these settings after you publish the collection.",
+    }[key]
+  end
+
+  def confirmation_message
+    if @collection.taxonomy_topic_email_override.present?
+      "You’ve chosen ‘Emails about the topic’ and the topic #{taxonomy_topic_email_override_title}"
+    else
+      "You’ve chosen ‘Emails about the page’"
+    end
+  end
+
   def user_has_selected_taxonomy_topic_emails?
     params[:override_email_subscriptions] == "true"
+  end
+
+  def taxonomy_topic_email_override_title
+    taxonomy_topic_content_item.fetch("title", "")
+  end
+
+  def taxonomy_topic_content_item
+    @taxonomy_topic_content_item ||= Services.publishing_api
+                                             .get_content(@collection.taxonomy_topic_email_override)
+                                             .to_h
+  rescue GdsApi::HTTPNotFound
+    {}
   end
 end

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -8,14 +8,11 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
 
   def update
     if user_has_selected_taxonomy_topic_emails?
-      if params[:selected_taxon_content_id].blank?
-        build_flash("selected_taxon_content_id")
-        return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
-      elsif params["email_override_confirmation"].blank?
-        build_flash("email_override_confirmation")
-        return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
+      if all_required_params_present?
+        @collection.update!(taxonomy_topic_email_override: params["selected_taxon_content_id"])
       else
-        @collection.update!(taxonomy_topic_email_override: params[:selected_taxon_content_id])
+        build_missing_params_flash
+        return redirect_to form_with_stored_params
       end
     else
       @collection.update!(taxonomy_topic_email_override: nil)
@@ -27,6 +24,30 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
   end
 
 private
+
+  def all_required_params_present?
+    required_params.select { |key| params[key].present? } == required_params
+  end
+
+  def required_params
+    %w[selected_taxon_content_id email_override_confirmation]
+  end
+
+  def form_with_stored_params
+    admin_document_collection_edit_email_subscription_path(@collection, params_to_store_state_of_failed_form_submission)
+  end
+
+  def build_missing_params_flash
+    missing_params = required_params.select { |required_param| params[required_param].blank? }
+    missing_params.each { |key| build_flash(key) }
+  end
+
+  def params_to_store_state_of_failed_form_submission
+    {
+      "selected_taxon_content_id" => params["selected_taxon_content_id"],
+      "override_email_subscriptions" => params["override_email_subscriptions"],
+    }
+  end
 
   def load_document_collection
     @collection = DocumentCollection.find(params[:document_collection_id])

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -4,7 +4,9 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
   before_action :authorise_user
   layout "design_system"
 
-  def edit; end
+  def edit
+    @topic_list_select_presenter = TopicListSelectPresenter.new(@collection.taxonomy_topic_email_override)
+  end
 
   def update
     if user_has_selected_taxonomy_topic_emails?

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -5,6 +5,24 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
 
   def edit; end
 
+  def update
+    if user_has_selected_taxonomy_topic_emails?
+      if params[:selected_taxon_content_id].blank?
+        flash["selected_taxon_content_id"] = "You must choose a topic"
+        return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
+      elsif params[:email_override_confirmation].blank?
+        flash["email_override_confirmation"] = "You must confirm you’re happy with the email notification settings"
+        return redirect_to admin_document_collection_edit_email_subscription_path(@collection)
+      else
+        @collection.update!(taxonomy_topic_email_override: params[:selected_taxon_content_id])
+      end
+    else
+      @collection.update!(taxonomy_topic_email_override: nil)
+    end
+    flash["notice"] = "You’ve selected the email notification settings. You cannot change these settings after the collection is published",
+    redirect_to edit_admin_document_collection_path(@collection)
+  end
+
 private
 
   def load_document_collection
@@ -13,5 +31,9 @@ private
 
   def authorise_user
     redirect_to edit_admin_document_collection_path(@collection) unless current_user.can_edit_email_overrides?
+  end
+
+  def user_has_selected_taxonomy_topic_emails?
+    params[:override_email_subscriptions] == "true"
   end
 end

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -1,4 +1,5 @@
 class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseController
+  include Admin::DocumentCollectionEmailOverrideHelper
   before_action :load_document_collection
   before_action :authorise_user
   layout "design_system"
@@ -45,7 +46,7 @@ private
 
   def confirmation_message
     if @collection.taxonomy_topic_email_override.present?
-      "You’ve chosen ‘Emails about the topic’ and the topic #{taxonomy_topic_email_override_title}"
+      "You’ve chosen ‘Emails about the topic’ and the topic #{taxonomy_topic_email_override_title(@collection)}"
     else
       "You’ve chosen ‘Emails about the page’"
     end
@@ -53,17 +54,5 @@ private
 
   def user_has_selected_taxonomy_topic_emails?
     params[:override_email_subscriptions] == "true"
-  end
-
-  def taxonomy_topic_email_override_title
-    taxonomy_topic_content_item.fetch("title", "")
-  end
-
-  def taxonomy_topic_content_item
-    @taxonomy_topic_content_item ||= Services.publishing_api
-                                             .get_content(@collection.taxonomy_topic_email_override)
-                                             .to_h
-  rescue GdsApi::HTTPNotFound
-    {}
   end
 end

--- a/app/controllers/admin/document_collection_email_subscriptions_controller.rb
+++ b/app/controllers/admin/document_collection_email_subscriptions_controller.rb
@@ -21,6 +21,8 @@ class Admin::DocumentCollectionEmailSubscriptionsController < Admin::BaseControl
     end
     build_flash("notice")
     redirect_to edit_admin_document_collection_path(@collection)
+  rescue ActiveRecord::RecordInvalid
+    redirect_to edit_admin_document_collection_path(@collection)
   end
 
 private

--- a/app/helpers/admin/document_collection_email_override_helper.rb
+++ b/app/helpers/admin/document_collection_email_override_helper.rb
@@ -1,0 +1,25 @@
+module Admin::DocumentCollectionEmailOverrideHelper
+  def taxonomy_topic_cannot_be_set?(collection)
+    collection.document.live_edition_id.present?
+  end
+
+  def has_page_level_notifications?(collection)
+    collection.taxonomy_topic_email_override.nil?
+  end
+
+  def taxonomy_topic_email_override_title(collection)
+    taxonomy_topic_content_item(collection).fetch("title", "")
+  end
+
+  def taxonomy_topic_email_override_base_path(collection)
+    taxonomy_topic_content_item(collection).fetch("base_path", "")
+  end
+
+  def taxonomy_topic_content_item(collection)
+    @taxonomy_topic_content_item ||= Services.publishing_api
+                                             .get_content(collection.taxonomy_topic_email_override)
+                                             .to_h
+  rescue GdsApi::HTTPNotFound
+    {}
+  end
+end

--- a/app/helpers/admin/document_collection_email_override_helper.rb
+++ b/app/helpers/admin/document_collection_email_override_helper.rb
@@ -22,4 +22,8 @@ module Admin::DocumentCollectionEmailOverrideHelper
   rescue GdsApi::HTTPNotFound
     {}
   end
+
+  def emails_about_this_topic_checked?(collection, params)
+    collection.taxonomy_topic_email_override.present? || (params["override_email_subscriptions"] == "true")
+  end
 end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -200,6 +200,10 @@ module Admin::EditionsHelper
       if edition.is_a?(DocumentCollection) && !edition.new_record?
         tabs["Collection documents"] = admin_document_collection_groups_path(edition)
       end
+
+      if edition.is_a?(DocumentCollection) && current_user.can_edit_email_overrides?
+        tabs["Email notifications"] = admin_document_collection_edit_email_subscription_path(edition)
+      end
     end
   end
 

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -78,11 +78,21 @@ module Admin::TabbedNavHelper
   end
 
   def document_collection_nav_items(edition, current_path)
-    {
+    collection_documents_element = {
       label: "Collections",
       href: admin_document_collection_groups_path(edition),
       current: current_path == admin_document_collection_groups_path(edition),
     }
+    email_notifications_element = {
+      label: "Email notifications",
+      href: admin_document_collection_edit_email_subscription_path(edition),
+      current: current_path == admin_document_collection_edit_email_subscription_path(edition),
+    }
+    if current_user.can_edit_email_overrides?
+      [collection_documents_element, email_notifications_element]
+    else
+      [collection_documents_element]
+    end
   end
 
   def document_collection_group_nav_items(group, current_path)

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -24,4 +24,15 @@ module ErrorsHelper
     }
     .presence
   end
+
+  def errors_from_flash(flash)
+    return nil if flash.blank?
+
+    flash.map do |array|
+      {
+        href: "##{array.first}",
+        text: array.last,
+      }
+    end
+  end
 end

--- a/app/presenters/topic_list_select_presenter.rb
+++ b/app/presenters/topic_list_select_presenter.rb
@@ -1,0 +1,84 @@
+class TopicListSelectPresenter
+  # This presenter is used to select a taxonomy topic email override for some document collections
+  #  We are only going to show the branches which the dept has told us they will need to tag to.
+  TAGGABLE_BRANCHES = [
+    "/business-and-industry",
+    "/business-tax",
+    "/childcare-parenting",
+    "/defence",
+    "/defence-and-armed-forces",
+    "/education",
+    "/employment",
+    "/environment",
+    "/government",
+    "/housing-and-local-government",
+    "/money",
+    "/regional-and-local-government",
+    "/society-and-culture",
+    "/transport",
+    "/welfare",
+    "/work",
+  ].freeze
+
+  def initialize(taxonomy_topic_email_override = nil)
+    @taxonomy_topic_email_override = taxonomy_topic_email_override
+  end
+
+  attr_reader :taxonomy_topic_email_override
+
+  def grouped_options(selected_taxon_content_id = nil)
+    branches_sorted_by_level_one_taxon_name.map do |level_one_taxon|
+      [level_one_taxon.name, sorted_transformed_descendants(level_one_taxon, selected_taxon_content_id)]
+    end
+  end
+
+private
+
+  def branches_sorted_by_level_one_taxon_name
+    topic_taxonomy.visible_branches
+    .select { |branch| TAGGABLE_BRANCHES.include?(branch.base_path) }
+    .sort_by { |branch| branch.name.downcase }
+  end
+
+  def sorted_transformed_descendants(level_one_taxon, selected_taxon_content_id)
+    transform_descendants(level_one_taxon, selected_taxon_content_id)
+    .sort_by { |s| s[:text].downcase }
+  end
+
+  def transform_descendants(level_one_taxon, selected_taxon_content_id)
+    sort_descendants(level_one_taxon).map do |child|
+      transform_taxon(child, selected_taxon_content_id)
+    end
+  end
+
+  def sort_descendants(level_one_taxon)
+    sorted_descendants = level_one_taxon.descendants.sort_by { |descendant| descendant.name.downcase }
+    [level_one_taxon, sorted_descendants].flatten
+  end
+
+  def taxon_with_ancestors(taxon)
+    ancestors_names = taxon.ancestors.map(&:name)
+    ancestor_string = ancestors_names.join(" > ")
+
+    "#{ancestor_string} > #{taxon.name} " if ancestors_names.any?
+  end
+
+  def transform_taxon(taxon, selected_taxon_content_id = nil)
+    formatted_taxon_name =
+      taxon.ancestors.present? ? taxon_with_ancestors(taxon) : taxon.name.to_s
+    {
+      text: formatted_taxon_name,
+      value: taxon.content_id,
+      selected: selected?(taxon.content_id, selected_taxon_content_id),
+    }
+  end
+
+  def selected?(content_id, selected_taxon_content_id)
+    previously_selected = selected_taxon_content_id || taxonomy_topic_email_override
+    previously_selected == content_id
+  end
+
+  def topic_taxonomy
+    @topic_taxonomy ||= Taxonomy::TopicTaxonomy.new
+  end
+end

--- a/app/views/admin/document_collection_email_subscriptions/_email_override_summary_page.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_email_override_summary_page.html.erb
@@ -1,0 +1,23 @@
+<p class="govuk-body-m">
+  You cannot change the email notifications for this document collection.
+  If you have any questions about this, contact the managing editor at HMRC.
+</p>
+<p class="govuk-body-m"> Users who sign up to notifications on this document collection get an email alert when:</p>
+<% if has_page_level_notifications?(@collection) %>
+  <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: [
+      "there’s a major change to any content that’s listed on the document collection (the content items in the ‘Collection documents’ tab)",
+    "there’s a major change to the document collection itself",
+    "the page is unpublished",
+    ],
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: [
+      "there’s a major change to any content tagged to the topic #{link_to taxonomy_topic_email_override_title(@collection), taxonomy_topic_email_override_base_path(@collection)}",
+    "the page is unpublished",
+    ],
+  } %>
+<% end %>

--- a/app/views/admin/document_collection_email_subscriptions/_form.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_form.html.erb
@@ -7,7 +7,7 @@
         value: false,
         text: "Emails about this page",
         hint_text: "Users will get an email when the document collection or any of the content listed on it is updated.",
-        checked: true,
+        checked: has_page_level_notifications?(@collection),
         bold: true,
       },
       {
@@ -15,7 +15,7 @@
         text: "Emails about the topic",
         bold: true,
         hint_text: "Users will get an email when any content related to the topic is updated. You choose the topic from the topic taxonomy.",
-        checked: false,
+        checked: emails_about_this_topic_checked?(@collection, params),
         conditional: render("taxonomy_choice"),
       },
     ],

--- a/app/views/admin/document_collection_email_subscriptions/_form.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_for [:admin, @collection], url: root_path, method: "put" do |form| %>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "override_email_subscriptions",
+    id: "email_override_email_subscription_choice",
+    items: [
+      {
+        value: false,
+        text: "Emails about this page",
+        hint_text: "Users will get an email when the document collection or any of the content listed on it is updated.",
+        checked: true,
+        bold: true,
+      },
+      {
+        value: true,
+        text: "Emails about the topic",
+        bold: true,
+        hint_text: "Users will get an email when any content related to the topic is updated. You choose the topic from the topic taxonomy.",
+        checked: false,
+        conditional: render("taxonomy_choice"),
+      },
+    ],
+  } %>
+
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "update-email-subscriptions-button",
+        "track-label": "Save",
+      },
+    } %>
+    <%= link_to("Cancel", root_path, class: "govuk-link govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/admin/document_collection_email_subscriptions/_form.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @collection], url: root_path, method: "put" do |form| %>
+<%= form_for [:admin, @collection], url: admin_document_collection_update_email_subscription_path(@collection), method: "put" do |form| %>
   <%= render "govuk_publishing_components/components/radio", {
     name: "override_email_subscriptions",
     id: "email_override_email_subscription_choice",
@@ -31,6 +31,6 @@
         "track-label": "Save",
       },
     } %>
-    <%= link_to("Cancel", root_path, class: "govuk-link govuk-link--no-visited-state") %>
+    <%= link_to("Cancel", admin_document_collection_path(@collection), class: "govuk-link govuk-link--no-visited-state") %>
   </div>
 <% end %>

--- a/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
@@ -4,6 +4,8 @@
   <%= render "govuk_publishing_components/components/select", {
     id: "selected_taxon_content_id",
     label: "Choose a topic from the topic taxonomy. You can only choose one.",
+    error_message: flash["selected_taxon_content_id"],
+    error_id: flash["selected_taxon_content_id"],
     options: [
       { text: "", value: "" },
       { text: "Topic One", value: "9b889c60-2191-11ee-be56-0242ac120002" },
@@ -17,6 +19,7 @@
     heading_size: "s",
     heading: "You cannot change the email notification settings after the collection is published.",
     no_hint_text: true,
+    error: flash["email_override_confirmation"],
     items: [
       {
         label: "Select this box to confirm you're happy with what you've selected.",

--- a/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
@@ -1,17 +1,13 @@
 <div>
   <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Choose the topic</h4>
-  # TODO: This is a temporary implementation of a topic taxonomy select using hardcoded values.
-  <%= render "govuk_publishing_components/components/select", {
-    id: "selected_taxon_content_id",
-    label: "Choose a topic from the topic taxonomy. You can only choose one.",
-    error_message: flash["selected_taxon_content_id"],
-    error_id: flash["selected_taxon_content_id"],
-    options: [
-      { text: "", value: "" },
-      { text: "Topic One", value: "9b889c60-2191-11ee-be56-0242ac120002" },
-      { text: "Topic Two", value: "c60-2191-11ee-be56-0242ac120002" },
-    ],
-  } %>
+  <%= render "components/select-with-search", {
+      label: "Choose a topic from the topic taxonomy. You can only choose one.",
+      error_message: flash["selected_taxon_content_id"],
+      error_id: flash["selected_taxon_content_id"],
+      id: "selected_taxon_content_id",
+      include_blank: true,
+      grouped_options: @topic_list_select_presenter.grouped_options(params["selected_taxon_content_id"]),
+      } %>
   <hr class="govuk-section-break--m">
  <%= render "govuk_publishing_components/components/checkboxes", {
     id: "email_override_confirmation",

--- a/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/_taxonomy_choice.html.erb
@@ -1,0 +1,27 @@
+<div>
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Choose the topic</h4>
+  # TODO: This is a temporary implementation of a topic taxonomy select using hardcoded values.
+  <%= render "govuk_publishing_components/components/select", {
+    id: "selected_taxon_content_id",
+    label: "Choose a topic from the topic taxonomy. You can only choose one.",
+    options: [
+      { text: "", value: "" },
+      { text: "Topic One", value: "9b889c60-2191-11ee-be56-0242ac120002" },
+      { text: "Topic Two", value: "c60-2191-11ee-be56-0242ac120002" },
+    ],
+  } %>
+  <hr class="govuk-section-break--m">
+ <%= render "govuk_publishing_components/components/checkboxes", {
+    id: "email_override_confirmation",
+    name: "email_override_confirmation",
+    heading_size: "s",
+    heading: "You cannot change the email notification settings after the collection is published.",
+    no_hint_text: true,
+    items: [
+      {
+        label: "Select this box to confirm you're happy with what you've selected.",
+        value: true,
+      },
+    ],
+  } %>
+</div>

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Email notification settings" %>
+<% content_for :title_margin_bottom, 8 %>
+<% content_for :page_class, "document-collection-email-groups edit" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1>Email notifications</h1>
+
+    <div>Choose the type of email updates users will get if they sign up for notifications.</div>
+  </div>
+</div>

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -18,8 +18,12 @@
     } %>
 
     <h2 class="govuk-heading-l">Email notifications</h2>
-    <p class="govuk-body">Choose the type of email updates users will get if they sign up for notifications.</p>
 
-    <%= render partial: "form" %>
+    <% if taxonomy_topic_cannot_be_set?(@collection) %>
+      <%= render partial: "email_override_summary_page" %>
+    <% else %>
+      <p class="govuk-body">Choose the type of email updates users will get if they sign up for notifications.</p>
+      <%= render partial: "form" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -1,7 +1,15 @@
 <% content_for :page_title, "Email notification settings" %>
 <% content_for :title_margin_bottom, 8 %>
 <% content_for :page_class, "document-collection-email-groups edit" %>
+<% errors = errors_from_flash(flash) %>
 
+  <% if errors.present? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: "There are some problems",
+    items: errors,
+  } %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -5,7 +5,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1>Email notifications</h1>
-
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation tabs",
+      items: secondary_navigation_tabs_items(@collection, request.path),
+    } %>
     <div>Choose the type of email updates users will get if they sign up for notifications.</div>
   </div>
 </div>

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -4,11 +4,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1>Email notifications</h1>
     <%= render "components/secondary_navigation", {
       aria_label: "Document navigation tabs",
       items: secondary_navigation_tabs_items(@collection, request.path),
     } %>
-    <div>Choose the type of email updates users will get if they sign up for notifications.</div>
+
+    <h2 class="govuk-heading-l">Email notifications</h2>
+    <p class="govuk-body">Choose the type of email updates users will get if they sign up for notifications.</p>
+
+    <%= render partial: "form" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Whitehall::Application.routes.draw do
             put :order, on: :collection
           end
         end
+        get "email-subscriptions" => "document_collection_email_subscriptions#edit", as: :edit_email_subscription
         post "whitehall-member" => "document_collection_group_memberships#create_whitehall_member", as: :new_whitehall_member
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Whitehall::Application.routes.draw do
           end
         end
         get "email-subscriptions" => "document_collection_email_subscriptions#edit", as: :edit_email_subscription
+        put "email-subscriptions" => "document_collection_email_subscriptions#update", as: :update_email_subscription
         post "whitehall-member" => "document_collection_group_memberships#create_whitehall_member", as: :new_whitehall_member
       end
 

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -9,7 +9,18 @@ Feature: Setting the taxonomy topic email override for a document collection
     And I select "Topic One"
     And I click the checkbox to confirm my selection.
     And I click "Save"
-    Then I am redirected to the document collection edit page.
+    Then I see the success message "You’ve selected the email notification settings. You’ve chosen ‘Emails about the topic’ and the topic Topic One. You will not be able to change these settings after you publish the collection."
+
+
+  Scenario: User cannot set the email override without checking the confirmation box.
+    Given I am a user with email override editor permissions.
+    And a draft document collection published by my organisation exists.
+    When I visit the edit document collection page
+    Then I click on the tab "Email notifications"
+    And I choose "Emails about this topic"
+    And I select "Topic One"
+    And I click "Save"
+    Then I see the error "You must confirm you’re happy with the email notification settings" prompting me to confirm my selection.
 
 
 

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -1,0 +1,10 @@
+Feature: Setting the taxonomy topic email override for a document collection
+
+  Scenario: Setting the email override.
+    Given I am a user with email override editor permissions.
+    And a draft document collection published by my organisation exists.
+    When I visit the edit document collection page
+    Then I see the tab "Email notifications"
+
+
+

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -6,10 +6,10 @@ Feature: Setting the taxonomy topic email override for a document collection
     When I visit the edit document collection page
     Then I click on the tab "Email notifications"
     And I choose "Emails about this topic"
-    And I select "Topic One"
+    And I select "Education"
     And I click the checkbox to confirm my selection.
     And I click "Save"
-    Then I see the success message "You’ve selected the email notification settings. You’ve chosen ‘Emails about the topic’ and the topic Topic One. You will not be able to change these settings after you publish the collection."
+    Then I see the success message "You’ve selected the email notification settings. You’ve chosen ‘Emails about the topic’ and the topic Education. You will not be able to change these settings after you publish the collection."
 
 
   Scenario: User cannot set the email override without checking the confirmation box.
@@ -18,7 +18,7 @@ Feature: Setting the taxonomy topic email override for a document collection
     When I visit the edit document collection page
     Then I click on the tab "Email notifications"
     And I choose "Emails about this topic"
-    And I select "Topic One"
+    And I select "Education"
     And I click "Save"
     Then I see the error "You must confirm you’re happy with the email notification settings" prompting me to confirm my selection.
 

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -4,7 +4,7 @@ Feature: Setting the taxonomy topic email override for a document collection
     Given I am a user with email override editor permissions.
     And a draft document collection published by my organisation exists.
     When I visit the edit document collection page
-    Then I see the tab "Email notifications"
+    Then I click on the tab "Email notifications"
 
 
 

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -5,6 +5,11 @@ Feature: Setting the taxonomy topic email override for a document collection
     And a draft document collection published by my organisation exists.
     When I visit the edit document collection page
     Then I click on the tab "Email notifications"
+    And I choose "Emails about this topic"
+    And I select "Topic One"
+    And I click the checkbox to confirm my selection.
+    And I click "Save"
+    Then I am redirected to the document collection edit page.
 
 
 

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -1,0 +1,16 @@
+Given(/^I am a user with email override editor permissions/) do
+  @user = build(:user, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR], organisation_slug: "gds")
+  login_as(@user)
+end
+
+And(/^a draft document collection published by my organisation exists/) do
+  @document_collection = create(:draft_document_collection)
+end
+
+When(/^I visit the edit document collection page/) do
+  visit edit_admin_document_collection_path(@document_collection)
+end
+
+Then(/^I see the tab "Email notifications/) do
+  expect(page).to have_content("Email notifications")
+end

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -14,8 +14,7 @@ end
 Then(/^I click on the tab "Email notifications/) do
   expect(page).to have_content("Email notifications")
   click_on("Email notifications")
-  expect(page).to have_content("\nEmails about this page\n")
-  expect(page).to have_content("\nEmails about the topic\n")
+  expect(page).to have_content("Choose the type of email updates users will get if they sign up for notifications.")
 end
 
 And(/^I choose "Emails about this topic"/) do
@@ -31,9 +30,16 @@ And(/^I click the checkbox to confirm my selection./) do
 end
 
 And(/^I click "Save"/) do
+  stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content})
+    .to_return(body: { base_path: "/topic-one", content_id: "9b889c60-2191-11ee-be56-0242ac120002", title: "Topic One" }.to_json)
   click_on("Save")
 end
 
-Then(/^I am redirected to the document collection edit page/) do
+Then(/^I see the success message "([^"]*)"$/) do |message|
   assert_current_path edit_admin_document_collection_path(@document_collection)
+  expect(page).to have_content(message)
+end
+
+Then(/^I see the error "([^"]*)" prompting me to confirm my selection./) do |error_message|
+  expect(page).to have_content(error_message)
 end

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -17,3 +17,23 @@ Then(/^I click on the tab "Email notifications/) do
   expect(page).to have_content("\nEmails about this page\n")
   expect(page).to have_content("\nEmails about the topic\n")
 end
+
+And(/^I choose "Emails about this topic"/) do
+  page.choose(name: "override_email_subscriptions", option: "true")
+end
+
+And(/^I select "([^"]*)"$/) do |topic_label|
+  select topic_label, from: "selected_taxon_content_id"
+end
+
+And(/^I click the checkbox to confirm my selection./) do
+  check("email_override_confirmation-0")
+end
+
+And(/^I click "Save"/) do
+  click_on("Save")
+end
+
+Then(/^I am redirected to the document collection edit page/) do
+  assert_current_path edit_admin_document_collection_path(@document_collection)
+end

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -11,6 +11,9 @@ When(/^I visit the edit document collection page/) do
   visit edit_admin_document_collection_path(@document_collection)
 end
 
-Then(/^I see the tab "Email notifications/) do
+Then(/^I click on the tab "Email notifications/) do
   expect(page).to have_content("Email notifications")
+  click_on("Email notifications")
+  expect(page).to have_content("\nEmails about this page\n")
+  expect(page).to have_content("\nEmails about the topic\n")
 end

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -12,6 +12,7 @@ When(/^I visit the edit document collection page/) do
 end
 
 Then(/^I click on the tab "Email notifications/) do
+  stub_taxonomy_data
   expect(page).to have_content("Email notifications")
   click_on("Email notifications")
   expect(page).to have_content("Choose the type of email updates users will get if they sign up for notifications.")
@@ -22,7 +23,7 @@ And(/^I choose "Emails about this topic"/) do
 end
 
 And(/^I select "([^"]*)"$/) do |topic_label|
-  select topic_label, from: "selected_taxon_content_id"
+  select topic_label, from: :selected_taxon_content_id
 end
 
 And(/^I click the checkbox to confirm my selection./) do
@@ -31,7 +32,7 @@ end
 
 And(/^I click "Save"/) do
   stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content})
-    .to_return(body: { base_path: "/topic-one", content_id: "9b889c60-2191-11ee-be56-0242ac120002", title: "Topic One" }.to_json)
+  .to_return(body: { base_path: "/education", content_id: "root", title: "Education" }.to_json)
   click_on("Save")
 end
 

--- a/lib/taxonomy/topic_taxonomy.rb
+++ b/lib/taxonomy/topic_taxonomy.rb
@@ -18,9 +18,11 @@ module Taxonomy
     end
 
     def visible_taxons
-      @visible_taxons = branches.select(
-        &:visible_to_departmental_editors
-      ).flat_map(&:taxon_list)
+      @visible_taxons = visible_branches.flat_map(&:taxon_list)
+    end
+
+    def visible_branches
+      @visible_branches ||= branches.select(&:visible_to_departmental_editors)
     end
 
   private

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -5,6 +5,13 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
     @collection = create(:document_collection, :with_group)
     @user_with_permission = create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
     @user_without_permission = create(:writer)
+    @selected_taxon_content_id = "9b889c60-2191-11ee-be56-0242ac120002"
+    @put_params = {
+      document_collection_id: @collection.id,
+      override_email_subscriptions: "true",
+      selected_taxon_content_id: @selected_taxon_content_id,
+      email_override_confirmation: "true",
+    }
     login_as @user_without_permission
   end
 
@@ -20,6 +27,58 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
   test "GET #edit redirects to the edit page when the user does not have permission" do
     login_as @user_without_permission
     get :edit, params: { document_collection_id: @collection.id }
-    assert_redirected_to admin_document_collection_path(@collection)
+    assert_redirected_to edit_admin_document_collection_path(@collection)
+  end
+
+  test "PUT #edit successfully updates a document collection when the user has permission" do
+    login_as @user_with_permission
+    put :update, params: @put_params
+    @collection.reload
+
+    assert_equal @collection.taxonomy_topic_email_override, @selected_taxon_content_id
+    assert_redirected_to edit_admin_document_collection_path(@collection)
+  end
+
+  test "PUT #edit does not update a document collection when the user does not have permission" do
+    login_as @user_without_permission
+    put :update, params: @put_params
+    @collection.reload
+
+    assert_nil @collection.taxonomy_topic_email_override
+    assert_redirected_to edit_admin_document_collection_path(@collection)
+  end
+
+  test "PUT #edit does not update a document collection when the confirmation field is not present" do
+    login_as @user_with_permission
+    put :update, params: @put_params.reject { |k| k == :email_override_confirmation }
+    @collection.reload
+
+    assert_nil @collection.taxonomy_topic_email_override
+    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection)
+  end
+
+  test "PUT #edit does not update a document collection when the selected_taxon_content_id field is not present" do
+    login_as @user_with_permission
+    put :update, params: @put_params.reject { |k| k == :selected_taxon_content_id }
+    @collection.reload
+
+    assert_nil @collection.taxonomy_topic_email_override
+    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection)
+  end
+
+  test "PUT #edit successfully updates taxonomy topic override of a draft document collection" do
+    login_as @user_with_permission
+    collection = create(:draft_document_collection, taxonomy_topic_email_override: @selected_taxon_content_id)
+
+    params = {
+      document_collection_id: collection.id,
+      override_email_subscriptions: "false",
+    }
+
+    put(:update, params:)
+    collection.reload
+
+    assert_nil collection.taxonomy_topic_email_override
+    assert_redirected_to edit_admin_document_collection_path(collection)
   end
 end

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -54,8 +54,10 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
     put :update, params: @put_params.reject { |k| k == :email_override_confirmation }
     @collection.reload
 
+    selected = { override_email_subscriptions: "true", selected_taxon_content_id: @selected_taxon_content_id }
+
     assert_nil @collection.taxonomy_topic_email_override
-    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection)
+    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection, selected)
   end
 
   test "PUT #edit does not update a document collection when the selected_taxon_content_id field is not present" do
@@ -63,14 +65,15 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
     put :update, params: @put_params.reject { |k| k == :selected_taxon_content_id }
     @collection.reload
 
+    selected = { override_email_subscriptions: "true" }
+
     assert_nil @collection.taxonomy_topic_email_override
-    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection)
+    assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection, selected)
   end
 
   test "PUT #edit does not update taxonomy topic override of a published document collection" do
     login_as @user_with_permission
     collection = create(:published_document_collection, taxonomy_topic_email_override: "a-uuid")
-
     put :update, params: @put_params.merge(document_collection_id: collection.id)
     assert_redirected_to edit_admin_document_collection_path(collection)
 

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionController::TestCase
   setup do
-    @collection = create(:document_collection, :with_group)
+    @collection = create(:draft_document_collection, :with_group)
     @user_with_permission = create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
     @user_without_permission = create(:writer)
     @selected_taxon_content_id = "9b889c60-2191-11ee-be56-0242ac120002"
@@ -65,6 +65,17 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
 
     assert_nil @collection.taxonomy_topic_email_override
     assert_redirected_to admin_document_collection_edit_email_subscription_path(@collection)
+  end
+
+  test "PUT #edit does not update taxonomy topic override of a published document collection" do
+    login_as @user_with_permission
+    collection = create(:published_document_collection, taxonomy_topic_email_override: "a-uuid")
+
+    put :update, params: @put_params.merge(document_collection_id: collection.id)
+    assert_redirected_to edit_admin_document_collection_path(collection)
+
+    collection.reload
+    assert_equal "a-uuid", collection.taxonomy_topic_email_override
   end
 
   test "PUT #edit successfully updates taxonomy topic override of a draft document collection" do

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -1,11 +1,12 @@
 require "test_helper"
 
 class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
   setup do
     @collection = create(:draft_document_collection, :with_group)
     @user_with_permission = create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
     @user_without_permission = create(:writer)
-    @selected_taxon_content_id = "9b889c60-2191-11ee-be56-0242ac120002"
+    @selected_taxon_content_id = root_taxon_content_id
     @put_params = {
       document_collection_id: @collection.id,
       override_email_subscriptions: "true",
@@ -13,7 +14,8 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
       email_override_confirmation: "true",
     }
     login_as @user_without_permission
-    stub_publishing_api_has_item(content_id: "9b889c60-2191-11ee-be56-0242ac120002", title: "Topic One")
+    stub_publishing_api_has_item(content_id: root_taxon_content_id, title: root_taxon["title"])
+    stub_taxonomy_with_all_taxons
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionController::TestCase
+  setup do
+    @collection = create(:document_collection, :with_group)
+    @user_with_permission = create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
+    @user_without_permission = create(:writer)
+    login_as @user_without_permission
+  end
+
+  should_be_an_admin_controller
+
+  view_test "GET #edit renders successfully when the user has the relevant permission" do
+    login_as @user_with_permission
+    get :edit, params: { document_collection_id: @collection.id }
+    assert_response :ok
+    assert_select "div", /Choose the type of email updates users will get if they sign up for notifications./
+  end
+
+  test "GET #edit redirects to the edit page when the user does not have permission" do
+    login_as @user_without_permission
+    get :edit, params: { document_collection_id: @collection.id }
+    assert_redirected_to admin_document_collection_path(@collection)
+  end
+end

--- a/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
+++ b/test/functional/admin/document_collection_email_subscriptions_controller_test.rb
@@ -13,6 +13,7 @@ class Admin::DocumentCollectionEmailSubscriptionsControllerTest < ActionControll
       email_override_confirmation: "true",
     }
     login_as @user_without_permission
+    stub_publishing_api_has_item(content_id: "9b889c60-2191-11ee-be56-0242ac120002", title: "Topic One")
   end
 
   should_be_an_admin_controller

--- a/test/integration/document_collection_email_override_test.rb
+++ b/test/integration/document_collection_email_override_test.rb
@@ -8,7 +8,7 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
   include TaxonomyHelper
 
   describe "adding an email override" do
-    let(:document_collection) { create(:document_collection) }
+    let(:document_collection) { create(:draft_document_collection) }
 
     context "as a user with the email override editor permission" do
       let(:user_with_permission_to_override) { create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR]) }
@@ -50,6 +50,21 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
         click_button("Save")
         document_collection.reload
         assert_nil document_collection.taxonomy_topic_email_override
+      end
+
+      it "shows the user a summary page if the document collection is in an unmodifiable state" do
+        published_collection = create(:published_document_collection)
+        taxons = { "title" => "Foo", "base_path" => "/foo", "content_id" => "123asd", "phase" => "live" }
+        links = { "meets_user_needs" => %w[123] }
+        stub_publishing_api_expanded_links_with_taxons(published_collection.content_id, [taxons])
+        stub_publishing_api_has_links({ content_id: published_collection.content_id, links: })
+
+        visit edit_admin_document_collection_path(published_collection)
+        click_button "Create new edition"
+        click_link "Email notifications"
+
+        assert page.has_no_field?("override_email_subscriptions")
+        assert page.has_content?("You cannot change the email notifications for this document collection.")
       end
     end
 

--- a/test/integration/document_collection_email_override_test.rb
+++ b/test/integration/document_collection_email_override_test.rb
@@ -12,23 +12,22 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
 
     context "as a user with the email override editor permission" do
       let(:user_with_permission_to_override) { create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR]) }
-      let(:taxon_content_id) { "9b889c60-2191-11ee-be56-0242ac120002" }
       before do
         login_as(user_with_permission_to_override)
+        stub_taxonomy_with_all_taxons
       end
 
       it "updates the taxonomy topic email override" do
-        stub_publishing_api_has_item(content_id: taxon_content_id, title: "Topic one")
-
+        stub_publishing_api_has_item(content_id: root_taxon_content_id, title: root_taxon["title"])
         visit edit_admin_document_collection_path(document_collection)
         click_link "Email notifications"
 
         page.choose("Emails about the topic")
-        select "Topic One", from: "selected_taxon_content_id"
+        select root_taxon["title"], from: "selected_taxon_content_id"
         page.check("Select this box to confirm you're happy with what you've selected.")
         click_button("Save")
         document_collection.reload
-        assert_equal document_collection.taxonomy_topic_email_override, taxon_content_id
+        assert_equal document_collection.taxonomy_topic_email_override, root_taxon_content_id
       end
 
       it "does not update taxonomy topic email if confirmation button is unchecked" do
@@ -36,7 +35,7 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
         click_link "Email notifications"
 
         page.choose("Emails about the topic")
-        select "Topic One", from: "selected_taxon_content_id"
+        select root_taxon["title"], from: "selected_taxon_content_id"
         click_button("Save")
         document_collection.reload
         assert_nil document_collection.taxonomy_topic_email_override
@@ -54,7 +53,7 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
 
       it "shows the user a summary page if the document collection is in an unmodifiable state" do
         published_collection = create(:published_document_collection)
-        taxons = { "title" => "Foo", "base_path" => "/foo", "content_id" => "123asd", "phase" => "live" }
+        taxons = { "title" => "Foo", "base_path" => "/foo", "content_id" => "123asd" }
         links = { "meets_user_needs" => %w[123] }
         stub_publishing_api_expanded_links_with_taxons(published_collection.content_id, [taxons])
         stub_publishing_api_has_links({ content_id: published_collection.content_id, links: })

--- a/test/integration/document_collection_email_override_test.rb
+++ b/test/integration/document_collection_email_override_test.rb
@@ -12,12 +12,14 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
 
     context "as a user with the email override editor permission" do
       let(:user_with_permission_to_override) { create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR]) }
-
+      let(:taxon_content_id) { "9b889c60-2191-11ee-be56-0242ac120002" }
       before do
         login_as(user_with_permission_to_override)
       end
 
       it "updates the taxonomy topic email override" do
+        stub_publishing_api_has_item(content_id: taxon_content_id, title: "Topic one")
+
         visit edit_admin_document_collection_path(document_collection)
         click_link "Email notifications"
 
@@ -26,7 +28,7 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
         page.check("Select this box to confirm you're happy with what you've selected.")
         click_button("Save")
         document_collection.reload
-        assert_equal document_collection.taxonomy_topic_email_override, "9b889c60-2191-11ee-be56-0242ac120002"
+        assert_equal document_collection.taxonomy_topic_email_override, taxon_content_id
       end
 
       it "does not update taxonomy topic email if confirmation button is unchecked" do

--- a/test/integration/document_collection_email_override_test.rb
+++ b/test/integration/document_collection_email_override_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+require "capybara/rails"
+
+class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+  include TaxonomyHelper
+
+  describe "adding an email override" do
+    let(:document_collection) { create(:document_collection) }
+
+    context "as a user with the email override editor permission" do
+      let(:user_with_permission_to_override) { create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR]) }
+
+      before do
+        login_as(user_with_permission_to_override)
+      end
+
+      it "updates the taxonomy topic email override" do
+        visit edit_admin_document_collection_path(document_collection)
+        click_link "Email notifications"
+
+        page.choose("Emails about the topic")
+        select "Topic One", from: "selected_taxon_content_id"
+        page.check("Select this box to confirm you're happy with what you've selected.")
+        click_button("Save")
+        document_collection.reload
+        assert_equal document_collection.taxonomy_topic_email_override, "9b889c60-2191-11ee-be56-0242ac120002"
+      end
+
+      it "does not update taxonomy topic email if confirmation button is unchecked" do
+        visit edit_admin_document_collection_path(document_collection)
+        click_link "Email notifications"
+
+        page.choose("Emails about the topic")
+        select "Topic One", from: "selected_taxon_content_id"
+        click_button("Save")
+        document_collection.reload
+        assert_nil document_collection.taxonomy_topic_email_override
+      end
+
+      it "does not update taxonomy topic email if topic is not selected" do
+        visit edit_admin_document_collection_path(document_collection)
+        click_link "Email notifications"
+
+        page.choose("Emails about the topic")
+        click_button("Save")
+        document_collection.reload
+        assert_nil document_collection.taxonomy_topic_email_override
+      end
+    end
+
+    context "as a user without the email override editor permission" do
+      let(:user_without_permission_to_override) { create(:writer) }
+
+      before do
+        login_as(user_without_permission_to_override)
+      end
+
+      it "the tab to edit the taxonomy topic email override is not visible" do
+        visit edit_admin_document_collection_path(document_collection)
+        assert page.has_no_link?("Email notifications")
+      end
+
+      it "visiting the edit email url directly redirects the user with a permission error" do
+        visit admin_document_collection_edit_email_subscription_path(document_collection)
+
+        assert_equal page.current_path, edit_admin_document_collection_path(document_collection)
+      end
+    end
+  end
+end

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -5,6 +5,14 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     []
   end
 
+  def current_user
+    @user
+  end
+
+  setup do
+    @user = create(:user)
+  end
+
   test "warn_about_lack_of_contacts_in_body? says no if the edition is not a news article" do
     (Edition.descendants - [NewsArticle] - NewsArticle.descendants).each do |not_a_news_article|
       assert_not warn_about_lack_of_contacts_in_body?(not_a_news_article.new)
@@ -32,6 +40,16 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     assert_not_includes default_edition_tabs(document_collection).keys, "Collection documents"
     document_collection = create(:document_collection)
     assert_includes default_edition_tabs(document_collection).keys, "Collection documents"
+  end
+
+  test "default_edition_tabs includes email notifications tab when the user has the appropriate permission" do
+    document_collection = create(:document_collection)
+
+    @user = create(:user)
+    assert_not_includes default_edition_tabs(document_collection).keys, "Email notifications"
+
+    @user = create(:user, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
+    assert_includes default_edition_tabs(document_collection).keys, "Email notifications"
   end
 
   test "#admin_author_filter_options excludes disabled users" do

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -4,6 +4,14 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
   include Rails.application.routes.url_helpers
   include Admin::EditionRoutesHelper
 
+  def current_user
+    @user
+  end
+
+  setup do
+    @user = create(:user)
+  end
+
   test "#secondary_navigation_tabs_items for persisted consultations with no attachments" do
     consultation = build_stubbed(:consultation)
 
@@ -121,6 +129,31 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         label: "Collections",
         href: admin_document_collection_groups_path(document_collection),
         current: true,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(document_collection, admin_document_collection_groups_path(document_collection))
+  end
+
+  test "#secondary_navigation_tabs_items contains email notifications tab when the current user has the relevant permission" do
+    document_collection = build_stubbed(:document_collection)
+    @user = create(:user, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
+
+    expected_output = [
+      {
+        label: "Document",
+        href: edit_admin_edition_path(document_collection),
+        current: false,
+      },
+      {
+        label: "Collections",
+        href: admin_document_collection_groups_path(document_collection),
+        current: true,
+      },
+      {
+        label: "Email notifications",
+        href: admin_document_collection_edit_email_subscription_path(document_collection),
+        current: false,
       },
     ]
 

--- a/test/unit/app/helpers/errors_helper_test.rb
+++ b/test/unit/app/helpers/errors_helper_test.rb
@@ -7,6 +7,7 @@ class ErrorsHelperTest < ActionView::TestCase
     @object_with_unrelated_errors = ErrorTestObject.new("title", nil)
     @object_with_errors.validate
     @object_with_unrelated_errors.validate
+    @flash = ActionDispatch::Flash::FlashHash.new
   end
 
   test "#errors_for_input returns nil when there are no error messages" do
@@ -39,6 +40,22 @@ class ErrorsHelperTest < ActionView::TestCase
 
   test "#errors_for does not return an empty string when object has unrelated error" do
     assert_nil errors_for(@object_with_unrelated_errors.errors, :title)
+  end
+
+  test "#errors_from_flash returns nil if flash has no errors" do
+    assert_nil errors_from_flash(@flash)
+  end
+
+  test "#errors_from_flash returns formatted items" do
+    @flash[:my_attribute] = "My message"
+
+    expected_output = [
+      {
+        href: "#my_attribute",
+        text: "My message",
+      },
+    ]
+    assert_equal expected_output, errors_from_flash(@flash)
   end
 
   class ErrorTestObject

--- a/test/unit/app/presenters/topic_list_select_presenter_test.rb
+++ b/test/unit/app/presenters/topic_list_select_presenter_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class TopicListSelectPresenterTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
+  test ".grouped_options returns subtopics grouped by their parent topic" do
+    stub_taxonomy_with_all_taxons
+    #  this stubs a taxonomy with three taxons [Education, About your organisation, Parenting]
+    # only Education and Parenting branches are taggable, so About your organisation is hidden
+    #  from the select
+
+    expected = [
+      [
+        "Education",
+        [
+          {
+            text: "Education",
+            value: root_taxon_content_id,
+            selected: false,
+          },
+          {
+            text: "Education > School Curriculum ",
+            value: grandparent_taxon_content_id,
+            selected: false,
+          },
+          {
+            text: "Education > School Curriculum > Primary curriculum, key stage 1 ",
+            value: parent_taxon_content_id,
+            selected: false,
+          },
+          {
+            text: "Education > School Curriculum > Primary curriculum, key stage 1 > Tests ",
+            value: child_taxon_content_id,
+            selected: false,
+          },
+        ],
+      ],
+      [
+        "Parenting",
+        [
+          {
+            text: "Parenting",
+            value: draft_taxon_1_content_id,
+            selected: false,
+          },
+        ],
+      ],
+    ]
+
+    document_collection = create(:draft_document_collection)
+
+    result = TopicListSelectPresenter.new(document_collection).grouped_options
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
Contains work done by @BeckaL and @hannako 

## What
Add a new tab to the document collection edit view, to all publishers (with a special signon permission), to set a taxonomy_topic_email_override field on their document collection. 

|<img width="865" alt="Screenshot 2023-08-04 at 21 57 30" src="https://github.com/alphagov/whitehall/assets/17908089/21df38b9-8b8f-4b83-852b-02c80b7e533e">|<img width="829" alt="Screenshot 2023-08-04 at 22 00 32" src="https://github.com/alphagov/whitehall/assets/17908089/7a689851-b6e8-4d59-93d3-36eed9646aee">|
--------| -------|

Example content item created from using this UI on integration to publish a collection:

<img width="1204" alt="content_item" src="https://github.com/alphagov/whitehall/assets/17908089/5f74c9d9-6b30-416e-88e8-6015a0db3988">


## Why
We (Homepage and Navigation Team) are retiring specialist topic pages i.e. we are redirecting all specialist topics to other pieces of content on GOV.UK and then removing support for specialist topics from the code base. One dept would like their specialist topics redirected to document collections, but they want the email signup button on those document collection pages to behave differently:

- Normal document_collection pages have a single page notification button that allows the user to subscribe to notifications on that document, and the collection of documents belonging to that document. 
- Document collections that have a taxonomy_topic_email_override field will have a email signup link instead, that allows the user to subscribe to notifications on that taxonomy topic instead. A much broader subscription that meets the needs of their users better.

## How

- If a user with email_override_editor permissions is editing a draft document collection, there will be an additional tab visible
- Selecting Emails about this page sets an taxonomy_topic_email_override value of `nil`, which on the frontend will result in the page getting a standard single page notification button
- Selecting Emails about this topic, and choosing a taxonomy topic, will store the content id of the taxon on the model, and when formatted for publishing API, the field will be added to the content _item's `links`.

Related PR's upon which this work depends:

- [PR to update document collection schema](https://github.com/alphagov/publishing-api/pull/2440)
- [PR to add new field to the document collection model](https://github.com/alphagov/whitehall/pull/8056)
- [PR to add new field to the links for publishing API](https://github.com/alphagov/whitehall/pull/8057)

## Future work
Once this feature has been used by the department to publish their collection pages, we will:
- Remove the form to set the override. 
- Users will only be able to see the summary page

[Trello](https://trello.com/c/WYDeGPe6/1894-publishers-can-add-an-emailsignupoverride-to-document-collections-published-from-whitehall-l)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
