### PR TITLE
Fix bug with world news story organisation values not being cleared

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -58,6 +58,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (subtypeSelect.value === worldNewsArticleTypeId) {
       ministersDiv.classList.add('app-view-edit-edition__appointment-fields--hidden')
       organisationsDiv.classList.add('app-view-edit-edition__organisation-fields--hidden')
+      organisationsDiv.querySelectorAll('select').forEach(function (select) {
+        select.value = ''
+      })
     } else {
       worldOrganisationDiv.classList.add('app-view-edit-edition__world-organisation-fields--hidden')
     }

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -44,12 +44,15 @@ describe('GOVUK.Modules.EditionForm', function () {
       editionForm.init()
     })
 
-    it('should hide the ministers and organisation fields on page load', function () {
+    it('should hide the ministers field & reset and hide the organisation fields on page load', function () {
       var ministersFields = form.querySelector('.app-view-edit-edition__appointment-fields')
       var organisationFields = form.querySelector('.app-view-edit-edition__organisation-fields')
 
       expect(ministersFields.classList).toContain('app-view-edit-edition__appointment-fields--hidden')
       expect(organisationFields.classList).toContain('app-view-edit-edition__organisation-fields--hidden')
+      organisationFields.querySelectorAll('select').forEach(function (select) {
+        expect(select.value).toBe('')
+      })
     })
 
     it('should reset & hide the locale & world location fields, and show the organisation and ministers fields when WorldNewsStory is deselected', function () {


### PR DESCRIPTION
## Description

You can replicate this bug with the following:

1. Make a new story, fill out the required fields and save
2. Change the news story to be world news story and save without updating any other fields
3. You see an error that you need to add a worldwide organisation and world location
4. Update the worldwide organisation and world location
5. You see an error that you can't tag a world news story to an organisation, please remove organisation (but you have no way of doing this task as the field is not displayed)

This only occurs on an unsuccessful save occurs. This is because lead and supporting organisations are grabbed from the database each time the page is reloaded. They don't live on the edition itself.

We can get round this by manually clearing the organisation fields select values on page load when the NewsArticle is a World News Story.

## Video

https://github.com/alphagov/whitehall/assets/42515961/6f40c9d5-5628-4773-b70a-ce75ece0f4dc

## Trello card

https://trello.com/c/G7fZNOuB/356-bug-worldwide-news-story-not-able-to-tag-organisation

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
