### PR TITLE
Update TagsComponent to include `Force scheduled`

### DIFF
--- a/app/components/admin/editions/tags_component.rb
+++ b/app/components/admin/editions/tags_component.rb
@@ -46,7 +46,9 @@ private
   end
 
   def state
-    if edition.force_published?
+    if edition.force_scheduled?
+      "Force scheduled"
+    elsif edition.force_published?
       "Force published"
     elsif edition.unpublishing.present? && !edition.withdrawn?
       "Unpublished"
@@ -57,7 +59,7 @@ private
 
   def colour(label)
     case label
-    when "Force published", "Link warnings"
+    when "Force published", "Link warnings", "Force scheduled"
       "govuk-tag--yellow"
     when "Draft"
       "govuk-tag--blue"

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -701,6 +701,10 @@ EXISTS (
     website_root + public_path(options)
   end
 
+  def force_scheduled?
+    force_published? && state == "scheduled"
+  end
+
 private
 
   def date_for_government

--- a/test/components/admin/editions/tags_component_test.rb
+++ b/test/components/admin/editions/tags_component_test.rb
@@ -10,6 +10,11 @@ class Admin::Editions::TagsComponentTest < ViewComponent::TestCase
       label_text: "Force published",
     },
     {
+      state: :force_scheduled,
+      expected_tag_classes: "govuk-tag govuk-tag--s govuk-tag--yellow",
+      label_text: "Force scheduled",
+    },
+    {
       state: :draft,
       expected_tag_classes: "govuk-tag govuk-tag--s govuk-tag--blue",
       label_text: "Draft",

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -125,6 +125,12 @@ FactoryBot.define do
       scheduled_publication { 7.days.from_now }
     end
 
+    trait(:force_scheduled) do
+      state { "scheduled" }
+      force_published { true }
+      scheduled_publication { 7.days.from_now }
+    end
+
     trait(:access_limited) { access_limited { true } }
 
     trait(:with_alternative_format_provider) do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -958,6 +958,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.versioning_completed?
   end
 
+  test "#force_scheduled? returns true when state is scheduled and #force_published? returns true" do
+    edition = build(:edition, :force_scheduled)
+    assert edition.force_scheduled?
+  end
+
+  test "#force_scheduled? returns false for a force published document" do
+    edition = build(:edition, :force_published)
+    assert_not edition.force_scheduled?
+  end
+
+  test "#force_scheduled? returns false for a scheduled document" do
+    edition = build(:edition, :scheduled)
+    assert_not edition.force_scheduled?
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,


### PR DESCRIPTION
## Description 

This was missed when the TagComponent was created which has led to the scheduled filter on the editions index/search page to look like it's returning force_published documents, when in reality they're force scheduled.

## Screenshots
## Before 

<img width="945" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/794f57b9-8f18-4a2a-9770-7d4b1f2a3d7d">


## After

<img width="932" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/459d00c2-fa86-4019-a40a-862f20b746b7">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
