### PR TITLE
Updated What's New for Review Dates

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,28 +1,22 @@
 en:
   admin:
     feedback:
-      show_banner: true
-    whats_new:
       show_banner: false
+    whats_new:
+      show_banner: true
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 22 June 2023
+      last_updated: Last updated 18 July 2023
       introduction:
         heading: Our roadmap
         body_govspeak: |
           This quarter we are focussing on:
-          
-          - moving Whitehall to the design system
-          - updating images
-          - exploring the use of a new content type for consultations
-  
-          Next quarter we plan to:
-          
+
           - finish our work on the design system
           - explore how to improve the editor journey when creating or editing a draft
           - review how you navigate in Whitehall, as well as add document collections
-  
+
           ### Take part in user research
 
           You can [sign up to take part in Whitehall Publisher user research](https://docs.google.com/forms/d/e/1FAIpQLSci1Ff7YGLWnvDiuaoAVKzSO06q32kgjVYnSX9A5Kf7jliLaQ/viewform). If you cannot access Google Forms, email <publishing-service-research@digital.cabinet-office.gov.uk>. Once you’ve signed up, you could be invited to feedback on new features and designs, user interviews or test products.
@@ -31,6 +25,16 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: Review dates and email reminders on all content types
+            area: Creating and updating documents
+            type: new
+            date: 18 July 2023
+            body_govspeak: |
+              When creating a document, there is a now a review dates section. You can find this under 'Schedule publication.'
+
+              Setting a review date is optional, but it allows you, or your team, to receive an email reminder when content needs to be reviewed.
+
+              You can also edit and manage a review date from the document summary screen.
           - heading: New page for uploading and managing images
             area: Creating and updating documents
             type: change
@@ -58,7 +62,7 @@ en:
             date: 2 February 2023
             body_govspeak: |
               History and notes have been merged into a single history tab on the edition summary page. Internal notes will be shown alongside a document’s history.
-              
+
               ‘Remarks’ or ‘editorial remarks’ are now known as ‘internal notes’.
           - heading: Edition summary page and worldwide tagging move to the Design System
             area: Creating and updating documents
@@ -66,7 +70,7 @@ en:
             date: 2 February 2023
             body_govspeak: |
               The edition summary page (where you can do things like previewing, history and notes, submitting for 2i or publishing) and worldwide tagging have moved to use the GOV.UK Design System.
-              
+
       guidance:
         heading: Publishing guidance, updates and support
         body_govspeak: |
@@ -75,7 +79,7 @@ en:
           - [how to publish content on GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk)
           - [planning, writing and managing content](https://www.gov.uk/guidance/content-design)
           - [how to contact the Government Digital Service (GDS) to request or report something](https://www.gov.uk/guidance/contact-the-government-digital-service)
-          
+
           The [GOV.UK style guide](https://www.gov.uk/guidance/style-guide) covers style, spelling and grammar conventions for content published on GOV.UK.
-          
+
           Read the [Inside GOV.UK blog](https://insidegovuk.blog.gov.uk/) for updates about GOV.UK.


### PR DESCRIPTION
### Context 

This PR updates the roadmap and what's new section, for review dates functionality.

It turns off the feedback banner, and adds the 'What's new banner' with the new information for review dates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
