### PR TITLE
Track clicks on add review date checkbox

### DIFF
--- a/app/views/admin/editions/_review_reminder_fields.html.erb
+++ b/app/views/admin/editions/_review_reminder_fields.html.erb
@@ -12,6 +12,11 @@
             label: "Set a reminder to review this content after it has been published",
             value: 1,
             checked: params[:review_reminder] == "1" || review_reminder.persisted?,
+            data_attributes: {
+              track_category: "checkbox",
+              track_label: "Set a reminder to review this content after it has been published",
+              track_action: "clicked",
+            },
             conditional: render("components/datetime_fields", {
               field_name: "review_at",
               prefix: "edition[document_attributes][review_reminder_attributes]",


### PR DESCRIPTION
## Description

We want to be able to see how many people are using this feature.

Unfortunately, the untracking module on the publishing component for when the checkbox is unchecked isn't working https://components.publishing.service.gov.uk/component-guide/checkboxes/checkboxes_with_data_attributes_and_custom_uncheck_event_category

But hopefully, this should give us a rough idea if people are at least looking at it. That in conjunction with checking the db to see if any have been created should be enough to see if people are using it.

<img width="538" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/99f35912-bb37-47d2-8037-a214c574b4ff">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
