### PR TITLE
Update What's new / Phase banner with new message

### DIFF
--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -4,7 +4,7 @@
 <%if t('admin.whats_new.show_banner') %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "What's new",
-      message: sanitize("Improvements to uploading and managing images -
+      message: sanitize("New review date functionality -
         #{
           link_to(
             "read more about the changes",


### PR DESCRIPTION
Pull request to update the text shown on the phase banner.

The current banner is showing 

<img width="1071" alt="Screenshot 2023-07-18 at 12 57 17" src="https://github.com/alphagov/whitehall/assets/55087909/87ec3993-d034-4558-997b-76f757c01cf6">

This replaces the text so that it says: 

New review date functionality 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
