### PR TITLE
Refactor attachment updater

### DIFF
--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -82,8 +82,6 @@ class AssetManager::AttachmentUpdater
       draft_edition.public_url(draft: true)
     elsif visible_edition.present?
       visible_edition.public_url
-    else
-      []
     end
   end
 

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -9,15 +9,26 @@ class AssetManager::AttachmentUpdater
   )
     return if attachment_data.deleted?
 
-    updates = []
+    # This logic will be eventually removed as part of cleaning up the feature flag for removing legacy_url_path
+    if attachment_data.assets.empty?
+      updates = []
 
-    updates += AccessLimitedUpdates.call(attachment_data).to_a if access_limited
-    updates += DraftStatusUpdates.call(attachment_data).to_a if draft_status
-    updates += LinkHeaderUpdates.call(attachment_data).to_a if link_header
-    updates += RedirectUrlUpdates.call(attachment_data).to_a if redirect_url
-    updates += ReplacementIdUpdates.call(attachment_data).to_a if replacement_id
+      updates += AccessLimitedUpdates.call(attachment_data).to_a if access_limited
+      updates += DraftStatusUpdates.call(attachment_data).to_a if draft_status
+      updates += LinkHeaderUpdates.call(attachment_data).to_a if link_header
+      updates += RedirectUrlUpdates.call(attachment_data).to_a if redirect_url
+      updates += ReplacementIdUpdates.call(attachment_data).to_a if replacement_id
 
-    combined_updates(updates).each(&:call)
+      combined_updates(updates).each(&:call)
+    else
+      attachment_data.assets.each do |asset|
+        asset_attributes = get_asset_attributes(attachment_data, asset, access_limited, draft_status, link_header, redirect_url, replacement_id)
+
+        next unless asset_attributes.any?
+
+        AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, asset_attributes.deep_stringify_keys)
+      end
+    end
   end
 
   def self.combined_updates(updates)
@@ -31,6 +42,66 @@ class AssetManager::AttachmentUpdater
       end
 
       Update.new(asset_manager_id, attachment_data, legacy_url_path, new_attributes)
+    end
+  end
+
+  def self.get_asset_attributes(attachment_data, asset, access_limited, draft_status, link_header, redirect_url, replacement_id)
+    new_attributes = {
+      access_limited: access_limited ? get_access_limited(attachment_data) : nil,
+      draft: draft_status ? get_draft(attachment_data) : nil,
+      parent_document_url: link_header ? get_link_header(attachment_data) : nil,
+      replacement_id: replacement_id ? get_replacement_id(attachment_data, asset) : nil,
+    }.compact
+    new_attributes.merge!(redirect_url: get_redirect_url(attachment_data)) if redirect_url
+
+    new_attributes
+  end
+
+  def self.get_access_limited(attachment_data)
+    return [] unless attachment_data.access_limited?
+
+    AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
+  end
+
+  def self.get_draft(attachment_data)
+    (
+      attachment_data.draft? &&
+        !attachment_data.unpublished? &&
+        !attachment_data.replaced?
+    ) || (
+      attachment_data.unpublished? &&
+        !attachment_data.present_at_unpublish? &&
+        !attachment_data.replaced?
+    )
+  end
+
+  def self.get_link_header(attachment_data)
+    visible_edition = attachment_data.visible_edition_for(nil)
+    draft_edition = attachment_data.draft_edition
+    if visible_edition.blank? && draft_edition
+      draft_edition.public_url(draft: true)
+    elsif visible_edition.present?
+      visible_edition.public_url
+    else
+      []
+    end
+  end
+
+  def self.get_redirect_url(attachment_data)
+    return nil unless attachment_data.unpublished? && attachment_data.present_at_unpublish?
+
+    attachment_data.unpublished_edition.unpublishing.document_url
+  end
+
+  def self.get_replacement_id(attachment_data, asset)
+    return nil unless attachment_data.replaced?
+
+    replacement = attachment_data.replaced_by
+    replacement_asset = replacement.assets.where(variant: asset.variant).first
+    if replacement_asset
+      replacement_asset.asset_manager_id
+    else
+      replacement.assets.where(variant: Asset.variants[:original]).first.asset_manager_id
     end
   end
 end

--- a/app/services/asset_manager/attachment_updater/access_limited_updates.rb
+++ b/app/services/asset_manager/attachment_updater/access_limited_updates.rb
@@ -5,28 +5,15 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdates
       access_limited = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
     end
 
-    if attachment_data.assets.empty?
-      Enumerator.new do |enum|
-        enum.yield AssetManager::AttachmentUpdater::Update.new(
-          nil, attachment_data, attachment_data.file, access_limited:
-        )
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        nil, attachment_data, attachment_data.file, access_limited:
+      )
 
-        if attachment_data.pdf?
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            nil, attachment_data, attachment_data.file.thumbnail, access_limited:
-          )
-        end
-      end
-    else
-      # Both the file and its thumbnail are now represented by an Asset
-      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
-      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
-      Enumerator.new do |enum|
-        attachment_data.assets.each do |asset|
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, access_limited:
-          )
-        end
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          nil, attachment_data, attachment_data.file.thumbnail, access_limited:
+        )
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/draft_status_updates.rb
+++ b/app/services/asset_manager/attachment_updater/draft_status_updates.rb
@@ -12,28 +12,15 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdates
       )
     )
 
-    if attachment_data.assets.empty?
-      Enumerator.new do |enum|
-        enum.yield AssetManager::AttachmentUpdater::Update.new(
-          nil, attachment_data, attachment_data.file, draft:
-        )
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        nil, attachment_data, attachment_data.file, draft:
+      )
 
-        if attachment_data.pdf?
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            nil, attachment_data, attachment_data.file.thumbnail, draft:
-          )
-        end
-      end
-    else
-      # Both the file and its thumbnail are now represented by an Asset
-      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
-      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
-      Enumerator.new do |enum|
-        attachment_data.assets.each do |asset|
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, draft:
-          )
-        end
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          nil, attachment_data, attachment_data.file.thumbnail, draft:
+        )
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -11,28 +11,15 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdates
                             return []
                           end
 
-    if attachment_data.assets.empty?
-      Enumerator.new do |enum|
-        enum.yield AssetManager::AttachmentUpdater::Update.new(
-          nil, attachment_data, attachment_data.file, parent_document_url:
-        )
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        nil, attachment_data, attachment_data.file, parent_document_url:
+      )
 
-        if attachment_data.pdf?
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            nil, attachment_data, attachment_data.file.thumbnail, parent_document_url:
-          )
-        end
-      end
-    else
-      # Both the file and its thumbnail are now represented by an Asset
-      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
-      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
-      Enumerator.new do |enum|
-        attachment_data.assets.each do |asset|
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, parent_document_url:
-          )
-        end
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          nil, attachment_data, attachment_data.file.thumbnail, parent_document_url:
+        )
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
+++ b/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
@@ -5,28 +5,15 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdates
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
     end
 
-    if attachment_data.assets.empty?
-      Enumerator.new do |enum|
-        enum.yield AssetManager::AttachmentUpdater::Update.new(
-          nil, attachment_data, attachment_data.file, redirect_url:
-        )
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        nil, attachment_data, attachment_data.file, redirect_url:
+      )
 
-        if attachment_data.pdf?
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            nil, attachment_data, attachment_data.file.thumbnail, redirect_url:
-          )
-        end
-      end
-    else
-      # Both the file and its thumbnail are now represented by an Asset
-      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
-      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
-      Enumerator.new do |enum|
-        attachment_data.assets.each do |asset|
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, redirect_url:
-          )
-        end
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          nil, attachment_data, attachment_data.file.thumbnail, redirect_url:
+        )
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater/replacement_id_updates.rb
+++ b/app/services/asset_manager/attachment_updater/replacement_id_updates.rb
@@ -4,58 +4,30 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdates
 
     replacement = attachment_data.replaced_by
 
-    if attachment_data.assets.empty?
-      Enumerator.new do |enum|
+    Enumerator.new do |enum|
+      enum.yield(
+        AssetManager::AttachmentUpdater::Update.new(
+          nil,
+          attachment_data,
+          attachment_data.file,
+          replacement_legacy_url_path: replacement.file.asset_manager_path,
+        ),
+      )
+
+      if attachment_data.pdf?
+        replacement_legacy_url_path = if replacement.pdf?
+                                        replacement.file.thumbnail.asset_manager_path
+                                      else
+                                        replacement.file.asset_manager_path
+                                      end
         enum.yield(
           AssetManager::AttachmentUpdater::Update.new(
             nil,
             attachment_data,
-            attachment_data.file,
-            replacement_legacy_url_path: replacement.file.asset_manager_path,
+            attachment_data.file.thumbnail,
+            replacement_legacy_url_path:,
           ),
         )
-
-        if attachment_data.pdf?
-          replacement_legacy_url_path = if replacement.pdf?
-                                          replacement.file.thumbnail.asset_manager_path
-                                        else
-                                          replacement.file.asset_manager_path
-                                        end
-          enum.yield(
-            AssetManager::AttachmentUpdater::Update.new(
-              nil,
-              attachment_data,
-              attachment_data.file.thumbnail,
-              replacement_legacy_url_path:,
-            ),
-          )
-        end
-      end
-    else
-      # Both the file and its thumbnail are now represented by an Asset
-      # and rely solely on the asset_manager_id rather than the legacy_url_path for updates.
-      # Therefore, it is not needed to check whether or not the Attachment is a pdf.
-      Enumerator.new do |enum|
-        attachment_data.assets.each do |asset|
-          # Update original file
-          replacement_asset = replacement.assets.where(variant: Asset.variants[:original]).first
-
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, replacement_id: replacement_asset.asset_manager_id
-          )
-
-          #   Update thumbnail
-          next unless asset.variant == Asset.variants[:thumbnail]
-
-          replacement_thumbnail = replacement.assets.where(variant: Asset.variants[:thumbnail])
-          if replacement_thumbnail.empty?
-            replacement_thumbnail = replacement.assets.where(variant: Asset.variants[:original])
-          end
-
-          enum.yield AssetManager::AttachmentUpdater::Update.new(
-            asset.asset_manager_id, attachment_data, nil, replacement_id: replacement_thumbnail.first.asset_manager_id
-          )
-        end
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/access_limited_updates_test.rb
@@ -6,191 +6,91 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
   describe AssetManager::AttachmentUpdater::AccessLimitedUpdates do
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
-    let(:update_worker) { mock("asset-manager-update-asset-worker") }
+    let(:update_service) { mock("asset-manager-update-asset-worker") }
 
-    describe "Attachment Data has no assets" do
-      around do |test|
-        AssetManager.stub_const(:AssetUpdater, update_worker) do
-          test.call
-        end
-      end
-
-      context "when attachment's attachable is access limited and the attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-
-        before do
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-
-          access_limited_object = stub("access-limited-object")
-          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
-
-          attachment_data.stubs(:access_limited?).returns(true)
-          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
-        end
-
-        it "updates the access limited state of the asset" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
-      end
-
-      context "when attachment's attachable is access limited and the attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-
-        before do
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-
-          access_limited_object = stub("access-limited-object")
-          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
-
-          attachment_data.stubs(:access_limited?).returns(true)
-          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
-        end
-
-        it "updates the access limited state of the asset and it's thumbnail" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
-      end
-
-      context "when attachment's attachable is not access limited and the attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-
-        before do
-          attachment_data.stubs(:access_limited?).returns(false)
-        end
-
-        it "updates the asset to have an empty access_limited array" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
-      end
-
-      context "when attachment's attachable is not access limited and the attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-
-        before do
-          attachment_data.stubs(:access_limited?).returns(false)
-        end
-
-        it "updates the asset to have an empty access_limited array" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
+    around do |test|
+      AssetManager.stub_const(:AssetUpdater, update_service) do
+        test.call
       end
     end
 
-    describe "Attachment Data has asset(s)" do
-      around do |test|
-        AssetManager.stub_const(:AssetUpdater, update_worker) do
-          test.call
-        end
+    context "when attachment's attachable is access limited and the attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      before do
+        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+
+        access_limited_object = stub("access-limited-object")
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+
+        attachment_data.stubs(:access_limited?).returns(true)
+        attachment_data.stubs(:access_limited_object).returns(access_limited_object)
       end
 
-      context "when attachment's attachable is access limited and the attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+      it "updates the access limited state of the asset" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
 
-        before do
-          attachment_data.assets = [asset]
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        updater.call(attachment_data, access_limited: true)
+      end
+    end
 
-          access_limited_object = stub("access-limited-object")
-          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+    context "when attachment's attachable is access limited and the attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
 
-          attachment_data.stubs(:access_limited?).returns(true)
-          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
-        end
+      before do
+        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
 
-        it "updates the access limited state of the asset" do
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+        access_limited_object = stub("access-limited-object")
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
 
-          updater.call(attachment_data, access_limited: true)
-        end
+        attachment_data.stubs(:access_limited?).returns(true)
+        attachment_data.stubs(:access_limited_object).returns(access_limited_object)
       end
 
-      context "when attachment's attachable is access limited and the attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+      it "updates the access limited state of the asset and it's thumbnail" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
 
-        before do
-          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
+        updater.call(attachment_data, access_limited: true)
+      end
+    end
 
-          access_limited_object = stub("access-limited-object")
-          AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+    context "when attachment's attachable is not access limited and the attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
-          attachment_data.stubs(:access_limited?).returns(true)
-          attachment_data.stubs(:access_limited_object).returns(access_limited_object)
-        end
-
-        it "updates the access limited state of the asset and its thumbnail" do
-          update_worker.expects(:call)
-                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
-          update_worker.expects(:call)
-                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
+      before do
+        attachment_data.stubs(:access_limited?).returns(false)
       end
 
-      context "when attachment's attachable is not access limited and the attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+      it "updates the asset to have an empty access_limited array" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
 
-        before do
-          attachment_data.assets = [asset]
-          attachment_data.stubs(:access_limited?).returns(false)
-        end
+        updater.call(attachment_data, access_limited: true)
+      end
+    end
 
-        it "updates the asset to have an empty access_limited array" do
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+    context "when attachment's attachable is not access limited and the attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
 
-          updater.call(attachment_data, access_limited: true)
-        end
+      before do
+        attachment_data.stubs(:access_limited?).returns(false)
       end
 
-      context "when attachment's attachable is not access limited and the attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+      it "updates the asset to have an empty access_limited array" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [] })
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [] })
 
-        before do
-          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
-          attachment_data.stubs(:access_limited?).returns(false)
-        end
-
-        it "updates the asset to have an empty access_limited array" do
-          update_worker.expects(:call)
-                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
-          update_worker.expects(:call)
-                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
-
-          updater.call(attachment_data, access_limited: true)
-        end
+        updater.call(attachment_data, access_limited: true)
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/draft_status_updates_test.rb
@@ -6,183 +6,92 @@ class AssetManager::AttachmentUpdater::DraftStatusUpdatesTest < ActiveSupport::T
   describe AssetManager::AttachmentUpdater::DraftStatusUpdates do
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
-    let(:update_worker) { mock("asset-manager-update-asset-worker") }
+    let(:update_service) { mock("asset-manager-update-asset-worker") }
 
     around do |test|
-      AssetManager.stub_const(:AssetUpdater, update_worker) do
+      AssetManager.stub_const(:AssetUpdater, update_service) do
         test.call
       end
     end
 
-    describe "AttachmentData has no assets" do
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-        let(:draft) { true }
+    context "when attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+      let(:draft) { true }
 
-        before do
-          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-          attachment_data.stubs(:draft?).returns(draft)
-        end
-
-        it "marks corresponding asset as draft" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
-
-          updater.call(attachment_data, draft_status: true)
-        end
+      before do
+        AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+        attachment_data.stubs(:draft?).returns(draft)
       end
 
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-        let(:draft) { true }
-        let(:unpublished) { false }
-        let(:replaced) { false }
+      it "marks corresponding asset as draft" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
 
-        before do
-          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-          attachment_data.stubs(:draft?).returns(draft)
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:replaced?).returns(replaced)
-        end
-
-        it "marks asset for attachment & its thumbnail as draft" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
-
-          updater.call(attachment_data, draft_status: true)
-        end
-
-        context "and attachment is not draft" do
-          let(:draft) { false }
-
-          it "marks corresponding assets as not draft" do
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
-
-            updater.call(attachment_data, draft_status: true)
-          end
-        end
-
-        context "and attachment is unpublished" do
-          let(:unpublished) { true }
-
-          it "marks corresponding assets as not draft even though attachment is draft" do
-            attachment_data.update!(present_at_unpublish: true)
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
-
-            updater.call(attachment_data, draft_status: true)
-          end
-        end
-
-        context "and attachment is replaced" do
-          let(:replaced) { true }
-
-          it "marks corresponding assets as not draft even though attachment is draft" do
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
-
-            updater.call(attachment_data, draft_status: true)
-          end
-        end
+        updater.call(attachment_data, draft_status: true)
       end
     end
 
-    describe "AttachmentData has asset(s)" do
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-        let(:draft) { true }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+    context "when attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+      let(:draft) { true }
+      let(:unpublished) { false }
+      let(:replaced) { false }
 
-        before do
-          attachment_data.assets = [asset]
-          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-          attachment_data.stubs(:draft?).returns(draft)
-        end
+      before do
+        AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
+        attachment_data.stubs(:draft?).returns(draft)
+        attachment_data.stubs(:unpublished?).returns(unpublished)
+        attachment_data.stubs(:replaced?).returns(replaced)
+      end
 
-        it "marks corresponding asset as draft" do
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "draft" => true })
+      it "marks asset for attachment & its thumbnail as draft" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => true })
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => true })
+
+        updater.call(attachment_data, draft_status: true)
+      end
+
+      context "and attachment is not draft" do
+        let(:draft) { false }
+
+        it "marks corresponding assets as not draft" do
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
           updater.call(attachment_data, draft_status: true)
         end
       end
 
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-        let(:draft) { true }
-        let(:unpublished) { false }
-        let(:replaced) { false }
-        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+      context "and attachment is unpublished" do
+        let(:unpublished) { true }
 
-        before do
-          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
-          AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
-          attachment_data.stubs(:draft?).returns(draft)
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:replaced?).returns(replaced)
-        end
-
-        it "marks asset for attachment & its thumbnail as draft" do
-          update_worker.expects(:call)
-                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
-          update_worker.expects(:call)
-                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
+        it "marks corresponding assets as not draft even though attachment is draft" do
+          attachment_data.update!(present_at_unpublish: true)
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
           updater.call(attachment_data, draft_status: true)
         end
+      end
 
-        context "and attachment is not draft" do
-          let(:draft) { false }
+      context "and attachment is replaced" do
+        let(:replaced) { true }
 
-          it "marks corresponding assets as not draft" do
-            update_worker.expects(:call)
-                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+        it "marks corresponding assets as not draft even though attachment is draft" do
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.asset_manager_path, { "draft" => false })
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "draft" => false })
 
-            updater.call(attachment_data, draft_status: true)
-          end
-        end
-
-        context "and attachment is unpublished" do
-          let(:unpublished) { true }
-
-          it "marks corresponding assets as not draft even though attachment is draft" do
-            attachment_data.update!(present_at_unpublish: true)
-            update_worker.expects(:call)
-                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-
-            updater.call(attachment_data, draft_status: true)
-          end
-        end
-
-        context "and attachment is replaced" do
-          let(:replaced) { true }
-
-          it "marks corresponding assets as not draft even though attachment is draft" do
-            update_worker.expects(:call)
-                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-            update_worker.expects(:call)
-                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-
-            updater.call(attachment_data, draft_status: true)
-          end
+          updater.call(attachment_data, draft_status: true)
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/link_header_updates_test.rb
@@ -9,125 +9,61 @@ class AssetManager::AttachmentUpdater::LinkHeaderUpdatesTest < ActiveSupport::Te
     let(:attachment_data) { attachment.attachment_data }
     let(:edition) { FactoryBot.create(:published_edition) }
     let(:parent_document_url) { edition.public_url }
-    let(:update_worker) { mock("asset-manager-update-worker") }
+    let(:update_service) { mock("asset-manager-update-worker") }
 
     around do |test|
-      AssetManager.stub_const(:AssetUpdater, update_worker) do
+      AssetManager.stub_const(:AssetUpdater, update_service) do
         test.call
       end
     end
 
-    describe "Attachment Data has no assets" do
-      context "when attachment doesn't belong to an edition" do
-        let(:attachment) { FactoryBot.create(:file_attachment) }
+    context "when attachment doesn't belong to an edition" do
+      let(:attachment) { FactoryBot.create(:file_attachment) }
 
-        it "does not update status of any assets" do
-          update_worker.expects(:call).never
+      it "does not update status of any assets" do
+        update_service.expects(:call).never
 
-          updater.call(attachment_data, link_header: true)
-        end
-      end
-
-      context "when attachment belongs to a draft edition" do
-        let(:edition) { FactoryBot.create(:draft_edition) }
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-        let(:parent_document_url) { edition.public_url(draft: true) }
-
-        it "sets parent_document_url for attachment using draft hostname" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
-      end
-
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-
-        it "sets parent_document_url of corresponding asset" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
-      end
-
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
-
-        it "sets parent_document_url for attachment & its thumbnail" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
+        updater.call(attachment_data, link_header: true)
       end
     end
 
-    describe "Attachment Data has asset(s)" do
-      context "when attachment doesn't belong to an edition" do
-        let(:attachment) { FactoryBot.create(:file_attachment) }
+    context "when attachment belongs to a draft edition" do
+      let(:edition) { FactoryBot.create(:draft_edition) }
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+      let(:parent_document_url) { edition.public_url(draft: true) }
 
-        it "does not update status of any assets" do
-          update_worker.expects(:call).never
+      it "sets parent_document_url for attachment using draft hostname" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
 
-          updater.call(attachment_data, link_header: true)
-        end
+        updater.call(attachment_data, link_header: true)
       end
+    end
 
-      context "when attachment belongs to a draft edition" do
-        let(:edition) { FactoryBot.create(:draft_edition) }
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-        let(:parent_document_url) { edition.public_url(draft: true) }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+    context "when attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
 
-        it "sets parent_document_url for attachment using draft hostname" do
-          attachment_data.assets = [asset]
+      it "sets parent_document_url of corresponding asset" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
 
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
+        updater.call(attachment_data, link_header: true)
       end
+    end
 
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+    context "when attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
 
-        it "sets parent_document_url of corresponding asset" do
-          attachment_data.assets = [asset]
+      it "sets parent_document_url for attachment & its thumbnail" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "parent_document_url" => parent_document_url })
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "parent_document_url" => parent_document_url })
 
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
-      end
-
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
-        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
-
-        it "sets parent_document_url for attachment & its thumbnail" do
-          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
-
-          update_worker.expects(:call)
-                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
-          update_worker.expects(:call)
-                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
-
-          updater.call(attachment_data, link_header: true)
-        end
+        updater.call(attachment_data, link_header: true)
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/redirect_url_updates_test.rb
@@ -10,127 +10,64 @@ class AssetManager::AttachmentUpdater::RedirectUrlUpdatesTest < ActiveSupport::T
     let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
     let(:redirect_url) { unpublished_edition.public_url }
     let(:unpublished) { true }
-    let(:update_worker) { mock("asset-manager-update-asset-worker") }
+    let(:update_service) { mock("asset-manager-update-asset-worker") }
 
     around do |test|
-      AssetManager.stub_const(:AssetUpdater, update_worker) do
+      AssetManager.stub_const(:AssetUpdater, update_service) do
         test.call
       end
     end
 
-    describe "Attachment Data has no assets" do
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+    context "when attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
-        before do
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:present_at_unpublish?).returns(true)
-          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-        end
-
-        it "updates redirect URL of corresponding asset" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
-
-          updater.call(attachment_data, redirect_url: true)
-        end
+      before do
+        attachment_data.stubs(:unpublished?).returns(unpublished)
+        attachment_data.stubs(:present_at_unpublish?).returns(true)
+        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
       end
 
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+      it "updates redirect URL of corresponding asset" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
 
-        before do
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:present_at_unpublish?).returns(true)
-          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-        end
-
-        it "updates redirect URL of asset for attachment & its thumbnail" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
-
-          updater.call(attachment_data, redirect_url: true)
-        end
-
-        context "and attachment is not unpublished" do
-          let(:unpublished) { false }
-          let(:unpublished_edition) { nil }
-
-          it "resets redirect URL of asset for attachment & its thumbnail" do
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
-
-            updater.call(attachment_data, redirect_url: true)
-          end
-        end
+        updater.call(attachment_data, redirect_url: true)
       end
     end
 
-    describe "Attachment Data has asset(s)" do
-      context "when attachment is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-        let(:asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
+    context "when attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
 
-        before do
-          attachment_data.assets = [asset]
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:present_at_unpublish?).returns(true)
-          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-        end
-
-        it "updates redirect URL of corresponding asset" do
-          update_worker.expects(:call)
-                       .with(asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
-
-          updater.call(attachment_data, redirect_url: true)
-        end
+      before do
+        attachment_data.stubs(:unpublished?).returns(unpublished)
+        attachment_data.stubs(:present_at_unpublish?).returns(true)
+        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+        AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
       end
 
-      context "when attachment is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-        let(:pdf_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:pdf_thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
+      it "updates redirect URL of asset for attachment & its thumbnail" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => redirect_url })
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => redirect_url })
 
-        before do
-          attachment_data.assets = [pdf_asset, pdf_thumbnail_asset]
-          attachment_data.stubs(:unpublished?).returns(unpublished)
-          attachment_data.stubs(:present_at_unpublish?).returns(true)
-          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-          AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
-        end
+        updater.call(attachment_data, redirect_url: true)
+      end
 
-        it "updates redirect URL of asset for attachment & its thumbnail" do
-          update_worker.expects(:call)
-                       .with(pdf_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
-          update_worker.expects(:call)
-                       .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
+      context "and attachment is not unpublished" do
+        let(:unpublished) { false }
+        let(:unpublished_edition) { nil }
+
+        it "resets redirect URL of asset for attachment & its thumbnail" do
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.asset_manager_path, { "redirect_url" => nil })
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "redirect_url" => nil })
 
           updater.call(attachment_data, redirect_url: true)
-        end
-
-        context "and attachment is not unpublished" do
-          let(:unpublished) { false }
-          let(:unpublished_edition) { nil }
-
-          it "resets redirect URL of asset for attachment & its thumbnail" do
-            update_worker.expects(:call)
-                         .with(pdf_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
-            update_worker.expects(:call)
-                         .with(pdf_thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
-
-            updater.call(attachment_data, redirect_url: true)
-          end
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/replacement_id_updates_test.rb
@@ -5,186 +5,91 @@ class AssetManager::AttachmentUpdater::ReplacementIdUpdatesTest < ActiveSupport:
 
   describe AssetManager::AttachmentUpdater::ReplacementIdUpdates do
     let(:updater) { AssetManager::AttachmentUpdater }
-    let(:update_worker) { mock("asset-manager-update-asset-worker") }
+    let(:update_service) { mock("asset-manager-update-asset-worker") }
 
     around do |test|
-      AssetManager.stub_const(:AssetUpdater, update_worker) do
+      AssetManager.stub_const(:AssetUpdater, update_service) do
         test.call
       end
     end
 
-    describe "Attachment Data has no assets" do
-      context "when attachment data is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-        let(:replacement) { AttachmentData.create!(file: sample_docx) }
-        let(:key) { "replacement_legacy_url_path" }
-        let(:attributes) { { key => replacement.file.asset_manager_path } }
+    context "when attachment data is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+      let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+      let(:replacement) { AttachmentData.create!(file: sample_docx) }
+      let(:key) { "replacement_legacy_url_path" }
+      let(:attributes) { { key => replacement.file.asset_manager_path } }
 
-        it "updates replacement ID of corresponding asset" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
+      it "updates replacement ID of corresponding asset" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
 
-          updater.call(attachment_data, replacement_id: true)
-        end
+        updater.call(attachment_data, replacement_id: true)
+      end
+    end
+
+    context "when attachment does not have a replacement" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
+
+      it "does not update asset manager" do
+        update_service.expects(:call).never
+
+        updater.call(attachment_data, replacement_id: true)
+      end
+    end
+
+    context "when attachment data is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
+      let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
+      let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
+      let(:key) { "replacement_legacy_url_path" }
+      let(:replacement_url_path) { replacement.file.asset_manager_path }
+      let(:attributes) { { key => replacement_url_path } }
+      let(:replacement_thumbnail_url_path) { replacement.file.thumbnail.asset_manager_path }
+      let(:thumbnail_attributes) { { key => replacement_thumbnail_url_path } }
+
+      it "updates replacement ID of asset for attachment & its thumbnail" do
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
+        update_service.expects(:call)
+                      .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+
+        updater.call(attachment_data, replacement_id: true)
       end
 
-      context "when attachment does not have a replacement" do
+      context "but replacement is not a PDF" do
         let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
-
-        it "does not update asset manager" do
-          update_worker.expects(:call).never
-
-          updater.call(attachment_data, replacement_id: true)
-        end
-      end
-
-      context "when attachment data is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
-        let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
-        let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
-        let(:key) { "replacement_legacy_url_path" }
-        let(:replacement_url_path) { replacement.file.asset_manager_path }
-        let(:attributes) { { key => replacement_url_path } }
-        let(:replacement_thumbnail_url_path) { replacement.file.thumbnail.asset_manager_path }
-        let(:thumbnail_attributes) { { key => replacement_thumbnail_url_path } }
+        let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+        let(:thumbnail_attributes) { { key => replacement_url_path } }
 
         it "updates replacement ID of asset for attachment & its thumbnail" do
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
-          update_worker.expects(:call)
-                       .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
+          update_service.expects(:call)
+                        .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
           updater.call(attachment_data, replacement_id: true)
-        end
-
-        context "but replacement is not a PDF" do
-          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-          let(:replacement) { AttachmentData.create!(file: sample_rtf) }
-          let(:thumbnail_attributes) { { key => replacement_url_path } }
-
-          it "updates replacement ID of asset for attachment & its thumbnail" do
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment_data.file.asset_manager_path, attributes)
-            update_worker.expects(:call)
-                         .with(nil, attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
-
-            updater.call(attachment_data, replacement_id: true)
-          end
-        end
-      end
-
-      context "when attachment is not synced with asset manager" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-        let(:replacement) { AttachmentData.create!(file: sample_docx) }
-
-        before do
-          update_worker.expects(:call)
-                       .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
-        end
-
-        it "raises a AssetNotFound error" do
-          assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
-            updater.call(attachment_data, replacement_id: true)
-          end
         end
       end
     end
 
-    describe "Attachment Data has asset(s)" do
-      context "when attachment data being updated is not a PDF" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-        let(:replacement) { AttachmentData.create!(file: sample_docx) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-        let(:attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
-        let(:original_asset) { Asset.new(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original]) }
-        let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id", variant: Asset.variants[:original]) }
+    context "when attachment is not synced with asset manager" do
+      let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+      let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+      let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+      let(:replacement) { AttachmentData.create!(file: sample_docx) }
 
-        it "updates replacement ID of corresponding asset" do
-          attachment_data.assets = [original_asset]
-          replacement.assets = [replacement_original_asset]
-
-          update_worker.expects(:call)
-                       .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
-
-          updater.call(attachment_data, replacement_id: true)
-        end
+      before do
+        update_service.expects(:call)
+                      .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
       end
 
-      context "when attachment does not have a replacement" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
-
-        it "does not update asset manager" do
-          update_worker.expects(:call).never
-
+      it "raises a AssetNotFound error" do
+        assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
           updater.call(attachment_data, replacement_id: true)
-        end
-      end
-
-      context "when attachment data being updated is a PDF" do
-        let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
-        let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
-        let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
-        let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
-        let(:attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
-        let(:thumbnail_attributes) { { "replacement_id" => replacement_thumbnail_asset.asset_manager_id } }
-        let(:original_asset) { Asset.new(asset_manager_id: "asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:thumbnail_asset) { Asset.new(asset_manager_id: "asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
-        let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id_1", variant: Asset.variants[:original]) }
-        let(:replacement_thumbnail_asset) { Asset.new(asset_manager_id: "replacement_asset_manager_id_2", variant: Asset.variants[:thumbnail]) }
-
-        it "and replacement is a pdf - updates replacement ID of asset for attachment & its thumbnail" do
-          attachment_data.assets = [original_asset, thumbnail_asset]
-          replacement.assets = [replacement_original_asset, replacement_thumbnail_asset]
-
-          update_worker.expects(:call)
-                       .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
-          update_worker.expects(:call)
-                       .with(thumbnail_asset.asset_manager_id, attachment_data, nil, thumbnail_attributes)
-
-          updater.call(attachment_data, replacement_id: true)
-        end
-
-        context "but replacement is not a PDF" do
-          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-          let(:replacement) { AttachmentData.create!(file: sample_rtf) }
-
-          it "updates replacement ID of asset for attachment & its thumbnail" do
-            attachment_data.assets = [original_asset, thumbnail_asset]
-            replacement.assets = [replacement_original_asset]
-
-            update_worker.expects(:call)
-                         .with(original_asset.asset_manager_id, attachment_data, nil, attributes)
-            update_worker.expects(:call)
-                         .with(thumbnail_asset.asset_manager_id, attachment_data, nil, attributes)
-
-            updater.call(attachment_data, replacement_id: true)
-          end
-        end
-      end
-
-      context "when attachment is not synced with asset manager" do
-        let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
-        let(:replacement) { AttachmentData.create!(file: sample_docx) }
-
-        before do
-          update_worker.expects(:call)
-                       .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
-        end
-
-        it "raises a AssetNotFound error" do
-          assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
-            updater.call(attachment_data, replacement_id: true)
-          end
         end
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater_test.rb
@@ -9,21 +9,48 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
     let(:attachment) { FactoryBot.create(:file_attachment, file:) }
     let(:attachment_data) { attachment.attachment_data }
 
-    it "groups updates together" do
-      AssetManager::AssetUpdater.expects(:call).once
-
-      subject.call(attachment_data, redirect_url: true, draft_status: true)
-    end
-
-    context "when the attachment has been deleted" do
-      before do
-        attachment.delete
-      end
-
-      it "does not update the asset" do
-        AssetManager::AssetUpdater.expects(:call).never
+    context "AttachmentData has no assets" do
+      it "groups updates together" do
+        AssetManager::AssetUpdater.expects(:call).once
 
         subject.call(attachment_data, redirect_url: true, draft_status: true)
+      end
+
+      context "when the attachment has been deleted" do
+        before do
+          attachment.delete
+        end
+
+        it "does not update the asset" do
+          AssetManager::AssetUpdater.expects(:call).never
+
+          subject.call(attachment_data, redirect_url: true, draft_status: true)
+        end
+      end
+    end
+
+    context "AttachmentData has assets" do
+      before do
+        attachment_data.assets.create!(asset_manager_id: "first_asset_id", variant: Asset.variants[:original])
+        attachment_data.assets.create!(asset_manager_id: "second_asset_id", variant: Asset.variants[:thumbnail])
+      end
+
+      it "groups updates together based on asset ID" do
+        AssetManager::AssetUpdater.expects(:call).twice
+
+        subject.call(attachment_data, redirect_url: true, draft_status: true)
+      end
+
+      context "when the attachment has been deleted" do
+        before do
+          attachment.delete
+        end
+
+        it "does not update the asset" do
+          AssetManager::AssetUpdater.expects(:call).never
+
+          subject.call(attachment_data, redirect_url: true, draft_status: true)
+        end
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater_test.rb
@@ -4,16 +4,17 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   describe AssetManager::AttachmentUpdater do
-    let(:subject) { AssetManager::AttachmentUpdater }
-    let(:file) { File.open(fixture_path.join("sample.rtf")) }
-    let(:attachment) { FactoryBot.create(:file_attachment, file:) }
+    let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
 
     context "AttachmentData has no assets" do
+      let(:file) { File.open(fixture_path.join("sample.rtf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file:) }
+
       it "groups updates together" do
         AssetManager::AssetUpdater.expects(:call).once
 
-        subject.call(attachment_data, redirect_url: true, draft_status: true)
+        updater.call(attachment_data, redirect_url: true, draft_status: true)
       end
 
       context "when the attachment has been deleted" do
@@ -24,21 +25,28 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         it "does not update the asset" do
           AssetManager::AssetUpdater.expects(:call).never
 
-          subject.call(attachment_data, redirect_url: true, draft_status: true)
+          updater.call(attachment_data, redirect_url: true, draft_status: true)
         end
       end
     end
 
     context "AttachmentData has assets" do
-      before do
-        attachment_data.assets.create!(asset_manager_id: "first_asset_id", variant: Asset.variants[:original])
-        attachment_data.assets.create!(asset_manager_id: "second_asset_id", variant: Asset.variants[:thumbnail])
+      let(:update_service) { mock("asset-manager-update-asset-worker") }
+      let(:simple_pdf) { File.open(fixture_path.join("simple.pdf")) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+      let(:original) { Asset.variants[:original] }
+      let(:thumbnail) { Asset.variants[:thumbnail] }
+      let(:original_asset) { Asset.new(asset_manager_id: "original_asset_manager_id", variant: original) }
+      let(:thumbnail_asset) { Asset.new(asset_manager_id: "thumbnail_asset_manager_id", variant: thumbnail) }
+
+      around do |test|
+        AssetManager.stub_const(:AssetUpdater, update_service) do
+          test.call
+        end
       end
 
-      it "groups updates together based on asset ID" do
-        AssetManager::AssetUpdater.expects(:call).twice
-
-        subject.call(attachment_data, redirect_url: true, draft_status: true)
+      before do
+        attachment_data.assets = [original_asset, thumbnail_asset]
       end
 
       context "when the attachment has been deleted" do
@@ -49,7 +57,254 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         it "does not update the asset" do
           AssetManager::AssetUpdater.expects(:call).never
 
-          subject.call(attachment_data, redirect_url: true, draft_status: true)
+          updater.call(attachment_data, redirect_url: true, draft_status: true)
+        end
+      end
+
+      describe "access limited updates" do
+        context "when attachment's attachable is access limited" do
+          before do
+            access_limited_object = stub("access-limited-object")
+            AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+
+            attachment_data.stubs(:access_limited?).returns(true)
+            attachment_data.stubs(:access_limited_object).returns(access_limited_object)
+          end
+
+          it "updates the access limited state of all assets" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+
+            updater.call(attachment_data, access_limited: true)
+          end
+        end
+
+        context "when attachment's attachable is not access limited" do
+          before do
+            attachment_data.stubs(:access_limited?).returns(false)
+          end
+
+          it "updates all assets to have an empty access_limited array" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+
+            updater.call(attachment_data, access_limited: true)
+          end
+        end
+      end
+
+      describe "draft status updates" do
+        let(:draft) { true }
+        let(:unpublished) { false }
+        let(:replaced) { false }
+
+        before do
+          attachment_data.stubs(:draft?).returns(draft)
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:replaced?).returns(replaced)
+        end
+
+        it "marks corresponding assets as draft" do
+          update_service.expects(:call)
+                        .with(original_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
+          update_service.expects(:call)
+                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => true })
+
+          updater.call(attachment_data, draft_status: true)
+        end
+
+        context "and attachment is not draft" do
+          let(:draft) { false }
+
+          it "marks corresponding assets as not draft" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is unpublished" do
+          let(:unpublished) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            attachment_data.update!(present_at_unpublish: true)
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+
+        context "and attachment is replaced" do
+          let(:replaced) { true }
+
+          it "marks corresponding assets as not draft even though attachment is draft" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
+
+            updater.call(attachment_data, draft_status: true)
+          end
+        end
+      end
+
+      describe "link header updates" do
+        let(:edition) { FactoryBot.create(:published_edition) }
+        let(:parent_document_url) { edition.public_url }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+
+        context "when attachment doesn't belong to an edition" do
+          let(:attachment) { FactoryBot.create(:file_attachment) }
+
+          it "does not update status of any assets" do
+            update_service.expects(:call).never
+
+            updater.call(attachment_data, link_header: true)
+          end
+        end
+
+        context "when attachment belongs to a draft edition" do
+          let(:draft_edition) { FactoryBot.create(:draft_edition) }
+          let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: draft_edition) }
+          let(:parent_document_url) { draft_edition.public_url(draft: true) }
+
+          it "sets parent_document_url for attachment using draft hostname" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+            updater.call(attachment_data, link_header: true)
+          end
+        end
+
+        context "when edition is published" do
+          it "sets parent_document_url for all assets" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+            updater.call(attachment_data, link_header: true)
+          end
+        end
+      end
+
+      describe "redirect url updates" do
+        let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
+        let(:redirect_url) { unpublished_edition.public_url }
+        let(:unpublished) { true }
+
+        before do
+          attachment_data.stubs(:unpublished?).returns(unpublished)
+          attachment_data.stubs(:present_at_unpublish?).returns(true)
+          attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+        end
+
+        it "updates redirect URL for all assets" do
+          update_service.expects(:call)
+                        .with(original_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
+          update_service.expects(:call)
+                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => redirect_url })
+
+          updater.call(attachment_data, redirect_url: true)
+        end
+
+        context "and attachment is not unpublished" do
+          let(:unpublished) { false }
+          let(:unpublished_edition) { nil }
+
+          it "resets redirect URL for all assets" do
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "redirect_url" => nil })
+
+            updater.call(attachment_data, redirect_url: true)
+          end
+        end
+      end
+
+      describe "replacement ID updates" do
+        context "when attachment does not have a replacement" do
+          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+          let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
+
+          it "does not update asset manager" do
+            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original)
+            update_service.expects(:call).never
+
+            updater.call(attachment_data, replacement_id: true)
+          end
+        end
+
+        context "when attachment data being updated has multiple assets" do
+          let(:whitepaper_pdf) { File.open(fixture_path.join("whitepaper.pdf")) }
+          let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
+          let(:replacement_attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
+          let(:replacement_thumbnail_attributes) { { "replacement_id" => replacement_thumbnail_asset.asset_manager_id } }
+          let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_original_asset_manager_id", variant: original) }
+          let(:replacement_thumbnail_asset) { Asset.new(asset_manager_id: "replacement_thumbnail_asset_manager_id", variant: thumbnail) }
+
+          before do
+            attachment_data.replaced_by = replacement
+          end
+
+          it "and replacement has multiple assets - updates with matching replacement IDs based on asset variant" do
+            replacement.assets = [replacement_original_asset, replacement_thumbnail_asset]
+
+            update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, replacement_attributes)
+            update_service.expects(:call)
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, replacement_thumbnail_attributes)
+
+            updater.call(attachment_data, replacement_id: true)
+          end
+
+          context "but replacement has one asset" do
+            let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+            let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+
+            it "updates all assets (of attachment to be updated) with original asset ID of replacement attachment" do
+              replacement.assets = [replacement_original_asset]
+
+              update_service.expects(:call)
+                            .with(original_asset.asset_manager_id, attachment_data, nil, replacement_attributes)
+              update_service.expects(:call)
+                            .with(thumbnail_asset.asset_manager_id, attachment_data, nil, replacement_attributes)
+
+              updater.call(attachment_data, replacement_id: true)
+            end
+          end
+        end
+
+        context "when attachment is not synced with asset manager" do
+          let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+          let(:sample_docx) { File.open(fixture_path.join("sample.docx")) }
+          let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+          let(:replacement) { AttachmentData.create!(file: sample_docx) }
+
+          it "raises a AssetNotFound error" do
+            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original)
+            replacement.assets.create!(asset_manager_id: "replacement_asset_manager_id", variant: original)
+
+            update_service.expects(:call)
+                          .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))
+
+            assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
+              updater.call(attachment_data, replacement_id: true)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Now that the Asset model has been introduced to manage how whitehall talks to asset manager, it is also easier to group and fire updates.

Whereas before additional checks were required to ascertain which variants an attachment can potentially have, the Asset model now provides that out of the box. This enables cleaner logic around asset manipulation.

[Trello card](https://trello.com/c/IKTNJyCF/97-story-use-asset-manager-id-when-updating-attachment-states-from-a-rake-task)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
