### PR TITLE
Optimise resource usage of Link Checker batch jobs

### DIFF
--- a/app/workers/check_all_organisations_links_worker.rb
+++ b/app/workers/check_all_organisations_links_worker.rb
@@ -6,17 +6,17 @@ class CheckAllOrganisationsLinksWorker
 
   def perform
     GovukStatsd.time("link-checking-debug.check-all-organisations-worker") do
-      logger.info("[link-checking-debug][job_#{jid}]: Queuing #{organisations.count} jobs to check organisations")
-      organisations.each do |organisation|
-        CheckOrganisationLinksWorker.perform_async(organisation.id)
+      logger.info("[link-checking-debug][job_#{jid}]: Queuing #{organisation_ids.count} jobs to check organisations")
+      organisation_ids.each do |organisation_id|
+        CheckOrganisationLinksWorker.perform_async(organisation_id)
       end
-      logger.info("[link-checking-debug][job_#{jid}]: Done queuing #{organisations.count} jobs to check organisations")
+      logger.info("[link-checking-debug][job_#{jid}]: Done queuing #{organisation_ids.count} jobs to check organisations")
     end
   end
 
 private
 
-  def organisations
-    Organisation.all
+  def organisation_ids
+    @organisation_ids ||= Organisation.all.pluck(:id)
   end
 end


### PR DESCRIPTION
## What

This PR optimises resource usage in a couple of Sidekiq jobs:

- `CheckAllOrganisationsLinksWorker`
- `CheckOrganisationLinksWorker`

They should now use less memory – using [`find_each`](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each) instead of `each` to load editions in batches, and [`pluck`](https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck) to load organisations when we only need their ID.

These jobs execute [once a day at around 04:00](https://github.com/alphagov/whitehall/blob/ab98fb14d01fddd38abf79a430fb68dbcf365de8/config/sidekiq.yml#L14-L16).

## Why

We've observed repeated restarts of the Sidekiq worker containers at around the same time that these jobs run. We believe they have been exhausting the worker's available memory and getting killed due to "[Out Of Memory](https://en.wikipedia.org/wiki/Out_of_memory)" (OOM).

Sidekiq doesn't gracefully handle worker processes being killed mid-job – rather than re-queueing in-flight jobs, they seem to just get lost forever. This is [documented behaviour](https://github.com/sidekiq/sidekiq/wiki/Reliability#using-super_fetch) in the open-source version of Sidekiq that we use.

So we're hoping that, by making these jobs more memory efficient, we'll reduce the likelihood of Sidekiq jobs going missing (i.e. not completing, and not going into the retry queue). We believe this may have been the cause for a [recent incident on GOV.UK](https://docs.google.com/document/d/1y-4Skg_BJ3t8DFmAWmma0MzTqsFaGC90SQe3mX74TIU/edit) where some scheduled publications were missed.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
