### PR TITLE
Update org details design

### DIFF
--- a/app/components/admin/organisations/show/summary_list_component.html.erb
+++ b/app/components/admin/organisations/show/summary_list_component.html.erb
@@ -1,13 +1,13 @@
-<% if editable %>
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Edit details",
-    href: edit_admin_organisation_path(organisation),
-    secondary_solid: true,
-  } %>
-<% end %>
-
-<%= render "govuk_publishing_components/components/summary_list", {
-  heading_level: 2,
-  heading_size: "l",
-  items: rows
-} %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="gem-c-summary-list--with-image">
+      <%= render "govuk_publishing_components/components/summary_list", {
+        heading_level: 2,
+        heading_size: "l",
+        title: "Details",
+        items: rows,
+        edit: edit,
+      } %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -5,14 +5,12 @@
 
 <p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link", target: "blank" %></p>
 
-<div class="govuk-!-margin-bottom-8">
-  <%= render "components/secondary_navigation", {
-    aria_label: "Organisation navigation tabs",
-    items: secondary_navigation_tabs_items(@organisation, request.path)
-  } %>
-</div>
+<%= render "components/secondary_navigation", {
+  aria_label: "Organisation navigation tabs",
+  items: secondary_navigation_tabs_items(@organisation, request.path)
+} %>
 
 <%= render Admin::Organisations::Show::SummaryListComponent.new(
   organisation: @organisation,
   editable: can?(:edit, @organisation),
-)%>
+) %>

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -293,7 +293,7 @@ Then(/^I can see that the organisation "(.*?)" has been superseded with the orga
   visit admin_organisation_path(organisation)
 
   if using_design_system?
-    expect(page).to have_xpath("//dt[.='Superseded by']/following-sibling::dd[.='#{superseding_org_name}']")
+    expect(page).to have_xpath("//dt[.='Superseding organisation']/following-sibling::dd[.='#{superseding_org_name}']")
   else
     expect(page).to have_xpath("//th[.='Superseded by']/following-sibling::td[.='#{superseding_org_name}']")
   end

--- a/test/components/admin/organisations/show/summary_list_component_test.rb
+++ b/test/components/admin/organisations/show/summary_list_component_test.rb
@@ -4,248 +4,260 @@ require "test_helper"
 
 class Admin::Organisations::Show::SummaryListComponentTest < ViewComponent::TestCase
   include Rails.application.routes.url_helpers
+  include ApplicationHelper
 
   test "renders edit link when editable is true" do
     organisation = build_stubbed(:organisation, url: "http://parrot.org")
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:, editable: true))
 
-    assert_link("Edit details", href: edit_admin_organisation_path(organisation))
+    assert_link("Edit", href: edit_admin_organisation_path(organisation))
   end
 
   test "does not render edit link when editable is false" do
     organisation = build_stubbed(:organisation, url: "http://parrot.org")
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
 
-    assert_no_link("Edit details", href: edit_admin_organisation_path(organisation))
+    assert_no_link("Edit", href: edit_admin_organisation_path(organisation))
   end
 
   test "renders the default rows" do
-    organisation = build_stubbed(:organisation, url: "http://parrot.org")
-
-    expected_rows = [
-      {
-        key: "Type", value: "Other"
-      },
-      {
-        key: "Acronym", value: nil
-      },
-      {
-        key: "URL", value: "http://parrot.org", links: [{ href: "http://parrot.org", text: "http://parrot.org" }]
-      },
-      {
-        key: "Status on GOV.UK", value: "Live"
-      },
-      {
-        key: "Description To edit this, select the 'Corporate Information pages' tab. Click on 'About us' and edit the 'Summary' field in a new edition",
-        value: nil,
-      },
-      {
-        key: "Email address for ordering attached files in an alternative format", value: nil
-      },
-      {
-        key: "Organisation chart URL", value: nil
-      },
-      {
-        key: "Custom jobs URL", value: nil
-      },
-      {
-        key: "Sponsoring organisations", value: "None"
-      },
-      {
-        key: "Topical events", value: "None"
-      },
-      {
-        key: "Crest", value: "Single Identity"
-      },
-      {
-        key: "Brand colour", value: "None"
-      },
-      {
-        key: "Analytics identifier", value: organisation.analytics_identifier
-      },
-      {
-        key: "Featured links", value: "None"
-      },
-    ]
+    organisation = build_stubbed(:organisation)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
 
-    expected_rows.each do |row|
-      assert has_row?(row)
-    end
+    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Name"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: organisation.name
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Logo formatted name"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: organisation.logo_formatted_name
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Logo crest"
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: organisation.organisation_logo_type.title
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Type"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: organisation.type.name
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Status on GOV.UK"
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: organisation.govuk_status.titleize
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Featured link position"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "News priority"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Management team images on homepage"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: organisation.important_board_members
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__key", text: "Analytics identifier"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__value", text: organisation.analytics_identifier
   end
 
-  test "renders closed rows when org is closed" do
-    superseding_organisation = build_stubbed(:ministerial_department)
-    organisation = build_stubbed(:ministerial_department, :closed, url: "http://parrot.org", closed_at: Time.zone.now)
-    organisation.stubs(:superseding_organisations).returns([superseding_organisation])
-
-    expected_rows = [
-      {
-        key: "Organisation closed on",
-        value: "11 November 2011",
-      },
-      {
-        key: "Superseded by",
-        value: superseding_organisation.name,
-        links: [
-          {
-            href: "/government/admin/organisations/#{superseding_organisation.id}",
-            text: superseding_organisation.name,
-          },
-        ],
-      },
-    ]
+  test "renders acronym_row if the organisation has an acronym" do
+    organisation = build_stubbed(:ministerial_department, acronym: "ACRO")
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
 
-    expected_rows.each do |row|
-      assert has_row?(row)
-    end
-  end
-
-  test "renders Sponsoring organisations orgs in teh supporting orgs row when parent orgs are present" do
-    parent_organisation1 = build_stubbed(:ministerial_department)
-    parent_organisation2 = build_stubbed(:ministerial_department)
-    organisation = build_stubbed(:ministerial_department, url: "http://parrot.org")
-    organisation.stubs(:parent_organisations).returns([parent_organisation1, parent_organisation2])
-
-    expected_row = {
-      key: "Sponsoring organisations",
-      value: "#{parent_organisation1.name} and #{parent_organisation2.name}",
-      links: [
-        {
-          href: "/government/admin/organisations/#{parent_organisation1.id}",
-          text: parent_organisation1.name,
-        },
-        {
-          href: "/government/admin/organisations/#{parent_organisation2.id}",
-          text: parent_organisation2.name,
-        },
-      ],
-    }
-
-    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
-
-    assert has_row?(expected_row)
-  end
-
-  test "renders Topical events in the topical events row if present" do
-    organisation = build_stubbed(:ministerial_department, url: "http://parrot.org")
-    topical_event1 = build_stubbed(:topical_event, organisations: [organisation])
-    topical_event2 = build_stubbed(:topical_event, organisations: [organisation])
-    organisation.stubs(:topical_events).returns([topical_event1, topical_event2])
-
-    expected_row = {
-      key: "Topical events",
-      value: "#{topical_event1.name} and #{topical_event2.name}",
-      links: [
-        {
-          href: "/government/admin/topical-events/#{topical_event1.id}",
-          text: topical_event1.name,
-        },
-        {
-          href: "/government/admin/topical-events/#{topical_event2.id}",
-          text: topical_event2.name,
-        },
-      ],
-    }
-
-    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
-
-    assert has_row?(expected_row)
-  end
-
-  test "renders each social media account in a separate row if present" do
-    organisation = build_stubbed(:ministerial_department, url: "http://parrot.org")
-    social_media_account1 = build_stubbed(:social_media_account)
-    social_media_account2 = build_stubbed(:social_media_account)
-    organisation.stubs(:social_media_accounts).returns([social_media_account1, social_media_account2])
-
-    expected_rows = [
-      {
-        key: social_media_account1.social_media_service.name,
-        value: social_media_account1.url,
-        links: [
-          {
-            href: social_media_account1.url,
-            text: social_media_account1.url,
-          },
-        ],
-      },
-      {
-        key: social_media_account2.social_media_service.name,
-        value: social_media_account2.url,
-        links: [
-          {
-            href: social_media_account2.url,
-            text: social_media_account2.url,
-          },
-        ],
-      },
-    ]
-
-    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
-
-    expected_rows.each do |row|
-      assert has_row?(row)
-    end
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Acronym"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: organisation.acronym
   end
 
   test "renders brand colour in brand colour row if present" do
-    organisation = build_stubbed(:ministerial_department, url: "http://parrot.org", organisation_brand_colour_id: 2)
-
-    expected_row = {
-      key: "Brand colour",
-      value: "Cabinet Office",
-    }
+    organisation = build_stubbed(:ministerial_department, organisation_brand_colour_id: 2)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
 
-    assert has_row?(expected_row)
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Brand colour"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: organisation.organisation_brand_colour.title
   end
 
-  test "renders featured links in featured links row if present" do
+  test "renders default news image row if the organisation has a default news image" do
+    news_image = build_stubbed(:default_news_organisation_image_data)
+    organisation = build_stubbed(:ministerial_department, default_news_image: news_image)
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Default news image"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value img[src='#{news_image.file.url(:s300)}']"
+  end
+
+  test "renders url_row if the organisation has a url" do
     organisation = build_stubbed(:ministerial_department, url: "http://parrot.org")
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Organisation’s URL"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "http://parrot.org"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__actions a[href='#{organisation.url}']", text: /View/
+  end
+
+  test "renders alternative_format_contact_email_row if the organisation has an alternative_format_contact_email" do
+    organisation = build_stubbed(:ministerial_department, alternative_format_contact_email: "test@email.com")
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Accessible formats request email"
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: organisation.alternative_format_contact_email
+  end
+
+  test "renders correct closed rows when org is closed and there is 1 superseding organisation" do
+    superseding_organisation = build_stubbed(:ministerial_department)
+    organisation = build_stubbed(:ministerial_department, :closed, closed_at: Time.zone.now)
+    organisation.stubs(:superseding_organisations).returns([superseding_organisation])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 11
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Reason for closure"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: organisation.govuk_closed_status
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Organisation closed on"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: "11 November 2011"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__key", text: "Superseding organisation"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__value", text: superseding_organisation.name
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__actions a[href='#{superseding_organisation.public_url}']", text: /View/
+  end
+
+  test "renders correct rows when closed and there are 2 superseding organisation" do
+    superseding_organisation1 = build_stubbed(:ministerial_department)
+    superseding_organisation2 = build_stubbed(:ministerial_department)
+    organisation = build_stubbed(:ministerial_department, :closed, closed_at: Time.zone.now)
+    organisation.stubs(:superseding_organisations).returns([superseding_organisation1, superseding_organisation2])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 12
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__key", text: "Superseding organisation 1"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__value", text: superseding_organisation1.name
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__actions a[href='#{superseding_organisation1.public_url}']", text: /View/
+    assert_selector ".govuk-summary-list__row:nth-child(9) .govuk-summary-list__key", text: "Superseding organisation 2"
+    assert_selector ".govuk-summary-list__row:nth-child(9) .govuk-summary-list__value", text: superseding_organisation2.name
+    assert_selector ".govuk-summary-list__row:nth-child(9) .govuk-summary-list__actions a[href='#{superseding_organisation2.public_url}']", text: /View/
+  end
+
+  test "renders organisation_chart_url_row if the organisation has an organisation_chart_url" do
+    organisation = build_stubbed(:ministerial_department, organisation_chart_url: "organisation@chart.com")
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Organisation chart URL"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: organisation.organisation_chart_url
+  end
+
+  test "renders recruitment_url_row if the organisation has an recruitment_url" do
+    organisation = build_stubbed(:ministerial_department, custom_jobs_url: "custom@jobs.com")
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Recruitment URL"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: organisation.custom_jobs_url
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{organisation.custom_jobs_url}']", text: /View/
+  end
+
+  test "renders political_row if the organisation has been marked as political" do
+    organisation = build_stubbed(:ministerial_department, political: true)
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Publishes content associated with the current government"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "Yes"
+  end
+
+  test "renders Sponsoring organisations row correctly when one parent org is present" do
+    parent_organisation = build_stubbed(:ministerial_department)
+    organisation = build_stubbed(:ministerial_department)
+    organisation.stubs(:parent_organisations).returns([parent_organisation])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Sponsoring organisation"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: parent_organisation.name
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{parent_organisation.public_url}']", text: /View/
+  end
+
+  test "renders Sponsoring organisations rows correctly when multiple parent orgs are present" do
+    parent_organisation1 = build_stubbed(:ministerial_department)
+    parent_organisation2 = build_stubbed(:ministerial_department)
+    organisation = build_stubbed(:ministerial_department)
+    organisation.stubs(:parent_organisations).returns([parent_organisation1, parent_organisation2])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 10
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Sponsoring organisation 1"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: parent_organisation1.name
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{parent_organisation1.public_url}']", text: /View/
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Sponsoring organisation 2"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: parent_organisation2.name
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions a[href='#{parent_organisation2.public_url}']", text: /View/
+  end
+
+  test "renders topical_events_row correctly when one parent org is present" do
+    topical_event = build_stubbed(:topical_event)
+    organisation = build_stubbed(:ministerial_department)
+    organisation.stubs(:topical_events).returns([topical_event])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Topical event"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: topical_event.name
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{topical_event.public_url}']", text: /View/
+  end
+
+  test "renders topical_events_rows correctly when multiple topical events are present" do
+    topical_event1 = build_stubbed(:topical_event)
+    topical_event2 = build_stubbed(:topical_event)
+    organisation = build_stubbed(:ministerial_department)
+    organisation.stubs(:topical_events).returns([topical_event1, topical_event2])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 10
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Topical event 1"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: topical_event1.name
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{topical_event1.public_url}']", text: /View/
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Topical event 2"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: topical_event2.name
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions a[href='#{topical_event2.public_url}']", text: /View/
+  end
+
+  test "renders featured_link correctly when one featured link is present" do
+    featured_link = build_stubbed(:featured_link)
+    organisation = build_stubbed(:ministerial_department)
+    organisation.stubs(:featured_links).returns([featured_link])
+
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Featured link"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: featured_link.title
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions a[href='#{featured_link.url}']", text: /View/
+  end
+
+  test "renders featured_links correctly when multiple featured links are present" do
     featured_link1 = build_stubbed(:featured_link)
-    featured_link2 = build_stubbed(:featured_link, title: "An example service 2", url: "https://www.gov.uk/example/service2")
+    featured_link2 = build_stubbed(:featured_link)
+    organisation = build_stubbed(:ministerial_department)
     organisation.stubs(:featured_links).returns([featured_link1, featured_link2])
 
-    expected_row = {
-      key: "Featured links",
-      value: "  \n      An example service\n      An example service 2\n",
-      links: [
-        {
-          href: featured_link1.url,
-          text: featured_link1.title,
-        },
-        {
-          href: featured_link2.url,
-          text: featured_link2.title,
-        },
-      ],
-    }
+    render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
+
+    assert_selector ".govuk-summary-list__row", count: 10
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Featured link 1"
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: featured_link1.title
+    assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions a[href='#{featured_link1.url}']", text: /View/
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__key", text: "Featured link 2"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__value", text: featured_link2.title
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__actions a[href='#{featured_link2.url}']", text: /View/
+  end
+
+  test "renders foi_exempt_row if the organisation is exempt from FOI requests" do
+    organisation = build_stubbed(:ministerial_department, foi_exempt: true)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))
 
-    assert has_row?(expected_row)
-  end
-
-  def has_row?(row)
-    assert_selector ".govuk-summary-list__row" do
-      assert_selector ".govuk-summary-list__key", text: row[:key]
-      assert_selector ".govuk-summary-list__value", text: row[:value]
-    end
-    assert_links(row)
-  end
-
-  def assert_links(row)
-    return true if row[:links].blank?
-
-    row[:links].all? do |link|
-      assert_selector ".govuk-summary-list__value", text: row[:value] do
-        assert_link(link[:text], href: link[:href])
-      end
-    end
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__key", text: "Exempt from Freedom of Information requests"
+    assert_selector ".govuk-summary-list__row:nth-child(8) .govuk-summary-list__value", text: "Yes"
   end
 end


### PR DESCRIPTION
## Description 

This PR does a few things:

- moves edit button into edit link in summary list component on org show page
- adds "Details" h2 to the summary list component
- removes description row which will now live in the about tab
- adds rows for every field in the edit page in the same order
- splits multiple assoications (sponsoring orgs, featured link etc. to 1 per row)
- adds view link actions instead of links being embedded in value column
- removes empty rows

## Screenshots 

### Before 

<img width="747" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3feedf4c-fb51-4757-8720-3cc879f43dcc">

### After

<img width="519" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/230cec3b-668d-4d7d-9467-9efa12dfb2ab">

## Trello card

https://trello.com/c/HW4NnOjF/348-update-organisations-details-page-and-add-an-about-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
