### PR TITLE
Attempt to fix flaky test

### DIFF
--- a/test/unit/models/call_for_evidence_reminder_test.rb
+++ b/test/unit/models/call_for_evidence_reminder_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
 
 class CallForEvidenceReminderTest < ActiveSupport::TestCase
-  setup { Timecop.freeze("2018/05/02 01:00:00".in_time_zone) }
+  setup do
+    Timecop.freeze("2018/05/02 01:00:00".in_time_zone)
+    ActionMailer::Base.deliveries.clear
+  end
   teardown { ActionMailer::Base.deliveries.clear }
 
   test ".send_reminder notifies authors of call for evidence reminder if today (past 24h) is exactly 8 weeks after close date without an outcome" do


### PR DESCRIPTION
Add another clear of the mailer queue in setup as it doesn't seem enough to just clear it in teardown. Existing consultation tests do it in both setup and teardown. Some questions outstanding why just teardown doesn't work. It implies there's a shared global queue for the concurrent tests, but if so the clearing of queue should also affect test flakiness but it doesn't seem to. Continue keeping an eye.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
