### PR TITLE
Remove services and information page from MCA

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -515,7 +515,6 @@ class Organisation < ApplicationRecord
       department-for-environment-food-rural-affairs
       hm-revenue-customs
       marine-management-organisation
-      maritime-and-coastguard-agency
       natural-england
     ]
   end


### PR DESCRIPTION
Services and information pages are being retired. When an organisation is published or updated, a service and information page is created/or republished based on the inclusion of the org's slug in this [list](https://github.com/alphagov/whitehall/pull/7970/commits/e44fec578889d77ae6b49b324674a2a965abd410). Removing MCA's slug means that we can safely un-publish its services and information page, and it won't be accidentally republished when the org page is updated.

[Trello](https://trello.com/c/l3EJo0kB/1908-archive-and-redirect-the-maritime-and-coastguard-agency-mca-services-and-info-page-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
