### PR TITLE
Remove services and information page for MMO

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -514,7 +514,6 @@ class Organisation < ApplicationRecord
       department-for-education
       department-for-environment-food-rural-affairs
       hm-revenue-customs
-      marine-management-organisation
       natural-england
     ]
   end


### PR DESCRIPTION
Services and information pages are being retired. When an organisation is published or updated, a service and information page is created/or republished based on the inclusion of the org's slug in this [list](https://github.com/alphagov/whitehall/pull/7971/commits/240bacfa98b94b48e6fbf18f9b1f6c2a4a2a44f9). Removing MMO's slug means that we can safely un-publish its services and information page, and it won't be accidentally republished when the org page is updated.

Trello card: https://trello.com/c/aKUxfLBU/1909-archive-and-redirect-marine-management-organisation-mmo-services-and-info-page-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
