### PR TITLE
Ensure all html attachments are withdrawn when parent edition is withdrawn

### DIFF
--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -59,7 +59,7 @@ module ServiceListeners
         PublishingApiWithdrawalWorker.new.perform(
           html_attachment.content_id,
           edition.unpublishing.explanation,
-          edition.primary_locale.to_s,
+          html_attachment.locale || I18n.default_locale.to_s,
           false,
           edition.unpublishing.unpublished_at.to_s,
         )

--- a/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_html_attachments_test.rb
@@ -345,6 +345,24 @@ module ServiceListeners
           )
           call(publication)
         end
+
+        test "for a publication with a translated HTML attachment publishes a withdrawal with the expected locale for each attachment" do
+          en_attachment = build(:html_attachment)
+          cy_attachment = build(:html_attachment, locale: "cy")
+          attachments = [en_attachment, cy_attachment]
+          publication = create(:withdrawn_publication, attachments:)
+
+          attachments.each do |attachment|
+            PublishingApiWithdrawalWorker.any_instance.expects(:perform).with(
+              attachment.content_id,
+              "content was withdrawn",
+              attachment.locale || I18n.default_locale.to_s,
+              false,
+              publication.unpublishing.unpublished_at.to_s,
+            )
+          end
+          call(publication)
+        end
       end
 
       class Delete < PublishingApiHtmlAttachmentsTest


### PR DESCRIPTION
Currently, the publishing API attachments service listener iterates through the list of an edition's HTML attachments and makes a call to the publishing API to withdraw each attachment, but when making the call it uses the edition's locale. This means that attachments with a different locale value from the edition are not marked as withdrawn. This commit resolves this issue by using the attachment's locale in the publishing API call if it is available, falling back to the default system locale if the attachment locale is not specified.

See https://trello.com/c/XNjWsi1S for full bug description and screenshots of behaviour on the frontend.

Screenshot after fix taken on integration (English and Welsh are shown in the withdrawal notice but English appears first, Welsh is out of shot):
![Screenshot 2023-07-19 at 17 24 20](https://github.com/alphagov/whitehall/assets/137083285/76fbfec8-044c-485b-931d-24ba490c1b2c)
