### PR TITLE
Make financial reports header large

### DIFF
--- a/app/views/admin/financial_reports/index.html.erb
+++ b/app/views/admin/financial_reports/index.html.erb
@@ -18,6 +18,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Financial Reports",
+      font_size: "l",
       margin_bottom: 6
     } %>
 


### PR DESCRIPTION
## Description

This PR updates the size of the Financial Reports header on the organisation page to large.

## Screenshot
![whitehall-admin dev gov uk_government_admin_organisations_cabinet-office_financial_reports](https://github.com/alphagov/whitehall/assets/91492293/e19228b2-ce1f-4e8f-bdc9-bb7243075175)

## Trello
https://trello.com/c/UvQqRhbV

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
