### PR TITLE
Make title text bold in the search results partial

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -29,7 +29,7 @@
         filter.editions.map do |edition|
           [
              {
-               text: index_table_title_row(edition)
+               text: tag.span(index_table_title_row(edition), class: "govuk-!-font-weight-bold")
              },
              {
                text: tag.p("#{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-0") +


### PR DESCRIPTION
## Description

The goal of this PR was to make the title fields of the corporate information pages page for organisations and worldwide organisations bold.

This has been achieved through making title fields of the search results partial bold. Which should standardise the bold formatting for all document search results tables.

## Screenshot
![whitehall-admin dev gov uk_government_admin_organisations_cabinet-office_corporate_information_pages](https://github.com/alphagov/whitehall/assets/91492293/176a764f-e490-4eb9-95b4-935300ca6ed7)

## Trello
https://trello.com/c/6LGaTX18

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
