### PR TITLE
Add rake task to republish worldwide orgs

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -53,6 +53,11 @@ namespace :publishing_api do
       Organisation.find_by!(slug: args[:slug]).publish_to_publishing_api
     end
 
+    desc "Republish a worldwide organisation to the Publishing API"
+    task :worldwide_organisation_by_slug, [:slug] => :environment do |_, args|
+      WorldwideOrganisation.find_by!(slug: args[:slug]).publish_to_publishing_api
+    end
+
     desc "Republish a person to the Publishing API"
     task :person_by_slug, [:slug] => :environment do |_, args|
       Person.find_by!(slug: args[:slug]).publish_to_publishing_api

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -83,6 +83,16 @@ class PublishingApiRake < ActiveSupport::TestCase
       end
     end
 
+    describe "#worldwide_organisation_by_slug" do
+      let(:task) { Rake::Task["publishing_api:republish:worldwide_organisation_by_slug"] }
+
+      test "Republishes worldwide organisation by slug" do
+        record = create(:worldwide_organisation)
+        WorldwideOrganisation.any_instance.expects(:publish_to_publishing_api)
+        capture_io { task.invoke(record.slug) }
+      end
+    end
+
     describe "#person_by_slug" do
       let(:task) { Rake::Task["publishing_api:republish:person_by_slug"] }
 


### PR DESCRIPTION
Since the rendering of worldwide organisations has been moved out of whitehall we may need to republish a single worldwide organisation to publishing API. 

Creating this rake task should make this easier to do.
