### PR TITLE
Add Organisation About Page 

### DIFF
--- a/app/controllers/admin/organisations_about_controller.rb
+++ b/app/controllers/admin/organisations_about_controller.rb
@@ -1,0 +1,7 @@
+class Admin::OrganisationsAboutController < Admin::BaseController
+  layout "design_system"
+
+  def show
+    @organisation = Organisation.friendly.find(params[:id])
+  end
+end

--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -46,6 +46,11 @@ module Admin::OrganisationHelper
         current: current_path == admin_organisation_path(organisation),
       },
       {
+        label: "About",
+        href: about_admin_organisation_path(organisation),
+        current: current_path == about_admin_organisation_path(organisation),
+      },
+      {
         label: "Contacts",
         href: admin_organisation_contacts_path(organisation),
         current: current_path == admin_organisation_contacts_path(organisation),

--- a/app/views/admin/organisations_about/show.html.erb
+++ b/app/views/admin/organisations_about/show.html.erb
@@ -1,0 +1,49 @@
+<% content_for :page_title, @organisation.name %>
+<% content_for :title, @organisation.name %>
+<% content_for :context, organisation_context_block(current_user, @organisation)  %>
+<% content_for :title_margin_bottom, 4 %>
+
+<p class="govuk-body">
+  <%= view_on_website_link_for @organisation, class: "govuk-link", target: "blank" %>
+</p>
+
+<%= render "components/secondary_navigation", {
+  aria_label: "Organisation navigation tabs",
+  items: secondary_navigation_tabs_items(@organisation, request.path)
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "About",
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+    <% if @organisation.about_us.present? %>
+      <%= render "components/summary_card_component", {
+        title: "About us",
+        rows: [
+          {
+            key: "Summary",
+            value: @organisation.summary,
+          },
+          {
+            key: "Body",
+            value: simple_format(truncate(@organisation.body, length: 500)),
+          },
+        ].reject { |row| row[:value].blank? },
+        summary_card_actions: [
+          {
+            label: "View",
+            href: admin_edition_path(@organisation.about_us)
+          }
+        ],
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No about us page."
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Whitehall::Application.routes.draw do
             put :order, on: :collection
           end
           member do
+            get :about, to: "organisations_about#show", as: :about
             get "/features(.:locale)", as: "features", to: "organisations#features", constraints: { locale: valid_locales_regex }
             get :confirm_destroy
           end

--- a/test/functional/admin/organisations_about_controller_test.rb
+++ b/test/functional/admin/organisations_about_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Admin::OrganisationsAboutControllerTest < ActionController::TestCase
+  setup do
+    login_as :gds_admin
+  end
+
+  should_be_an_admin_controller
+
+  test "GET :show assings correctly" do
+    organisation = create(:organisation)
+
+    get :show, params: { id: organisation }
+
+    assert_response :success
+    assert_equal organisation, assigns(:organisation)
+  end
+end

--- a/test/unit/app/helpers/admin/organisation_helper_test.rb
+++ b/test/unit/app/helpers/admin/organisation_helper_test.rb
@@ -25,6 +25,7 @@ class Admin::OrganisationHelperTest < ActionView::TestCase
 
     expected_output = [
       { label: "Details", href: admin_organisation_path(organisation), current: false },
+      { label: "About", href: about_admin_organisation_path(organisation), current: false },
       { label: "Contacts", href: admin_organisation_contacts_path(organisation), current: false },
       { label: "Features", href: features_admin_organisation_path(organisation, locale: I18n.default_locale), current: false },
       { label: "Pages", href: admin_organisation_corporate_information_pages_path(organisation), current: true },
@@ -44,6 +45,7 @@ class Admin::OrganisationHelperTest < ActionView::TestCase
 
     expected_output = [
       { label: "Details", href: admin_organisation_path(organisation), current: true },
+      { label: "About", href: about_admin_organisation_path(organisation), current: false },
       { label: "Contacts", href: admin_organisation_contacts_path(organisation), current: false },
       { label: "Features", href: features_admin_organisation_path(organisation, locale: I18n.default_locale), current: false },
       { label: "Features (Français)", href: features_admin_organisation_path(organisation, locale: "fr"), current: false },
@@ -63,6 +65,7 @@ class Admin::OrganisationHelperTest < ActionView::TestCase
 
     expected_output = [
       { label: "Details", href: admin_organisation_path(organisation), current: false },
+      { label: "About", href: about_admin_organisation_path(organisation), current: false },
       { label: "Contacts", href: admin_organisation_contacts_path(organisation), current: false },
       { label: "Promotional features", href: admin_organisation_promotional_features_path(organisation), current: false },
       { label: "Features", href: features_admin_organisation_path(organisation, locale: I18n.default_locale), current: false },


### PR DESCRIPTION
## Description

We're moving the about us information to it's own tab for organisations. This adds the tab to the helper method responsible for rendering the organisation tabs and then adds a new endpoint which handles rendering the about page

<img width="786" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3784bafb-bf6c-41b8-a69a-8c4c90857ab6">

## Trello card

https://trello.com/c/HW4NnOjF/348-update-organisations-details-page-and-add-an-about-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
