### PR TITLE
Add section break to search results partial

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -6,6 +6,8 @@
     <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
 <% end %>
 
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <% if filter.editions.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No documents found</p>
 <% else %>


### PR DESCRIPTION
## Description

This PR adds a section break to the search results, as raised as part of the commercial info pages update.

## Screenshot
![whitehall-admin dev gov uk_government_admin_organisations_cabinet-office_corporate_information_pages (1)](https://github.com/alphagov/whitehall/assets/91492293/c2af278f-9702-47cc-b04f-fac32280a0ee)

## Trello
https://trello.com/c/6LGaTX18
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
