### PR TITLE
Update fields of operation table

### DIFF
--- a/app/views/admin/operational_fields/index.html.erb
+++ b/app/views/admin/operational_fields/index.html.erb
@@ -13,7 +13,7 @@
       <%= render "govuk_publishing_components/components/table", {
         head: [
           {
-            text: "Name"
+            text: "Location"
           },
           {
             text: tag.span("Actions", class: "govuk-visually-hidden"),
@@ -23,7 +23,7 @@
           @operational_fields.map do |operational_field|
             [
               {
-                text: operational_field.name,
+                text: tag.span(operational_field.name, class: "govuk-!-font-weight-bold"),
               },
               {
                 text: sanitize("<a href='#{edit_admin_operational_field_path(operational_field)}' class='govuk-link'>Edit<span class='govuk-visually-hidden'> #{operational_field.name}</span></a>"),


### PR DESCRIPTION
## Description

This PR updates the fields of operation table with;
* heading to Location
* Location fields are bold

## Screenshot
![whitehall-admin dev gov uk_government_admin_operational_fields](https://github.com/alphagov/whitehall/assets/91492293/a6f3dea1-2978-4522-9ee5-04b70993add3)

## Trello
https://trello.com/c/cP2XruiV

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
