### PR TITLE
322 worldwide organisations edit translations

### DIFF
--- a/app/controllers/admin/worldwide_organisations_translations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_translations_controller.rb
@@ -6,13 +6,17 @@ class Admin::WorldwideOrganisationsTranslationsController < Admin::BaseControlle
     render_design_system(:index, :legacy_index)
   end
 
-  def edit; end
+  def edit
+    render_design_system(:edit, :legacy_edit)
+  end
+
+  def confirm_destroy; end
 
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index confirm_destroy] if preview_design_system?(next_release: false)
+    design_system_actions = %w[confirm_destroy]
+    design_system_actions += %w[index edit update] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/views/admin/worldwide_organisations_translations/edit.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/edit.html.erb
@@ -1,17 +1,42 @@
-<% page_title "Edit translation for: #{@english_worldwide_organisation.name}" %>
-<div class="row">
-  <div class="col-md-8">
-    <h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_worldwide_organisation.name %></h1>
+<% content_for :page_title, "Edit translation" %>
+<% content_for :title, "Edit translation" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @english_worldwide_organisation)) %>
 
-    <%= form_for @translated_worldwide_organisation, url: admin_worldwide_organisation_translation_path(@translated_worldwide_organisation, translation_locale), method: :put, html: {class: 'well'} do |form| %>
-      <%= form.errors %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @translated_worldwide_organisation, url: admin_worldwide_organisation_translation_path(@translated_worldwide_organisation, translation_locale), method: :put do |form| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Name (required)"
+        },
+        name: "worldwide_organisation[name]",
+        id: "worldwide_organisation_name",
+        value: @translated_worldwide_organisation.name,
+        heading_level: 2,
+        heading_size: "l",
+        error_items: errors_for(form.object.errors, :name),
+        right_to_left: @translated_worldwide_organisation.translation_locale.rtl?,
+        right_to_left_help: false
+      } %>
 
-      <%= form.translated_text_field :name %>
+      <div class="govuk-!-margin-bottom-8">
+        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
+        <p class="app-view-translation__english-content govuk-body"><%= @english_worldwide_organisation.name %></p>
+      </div>
 
-      <%= form.save_or_cancel cancel: admin_worldwide_organisation_translations_path(@english_worldwide_organisation) %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-organisation-button",
+            "track-label": "Save"
+          }
+        } %>
+
+        <%= link_to "Cancel", admin_worldwide_organisation_translations_path(@english_worldwide_organisation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
     <% end %>
-  </div>
-  <div class="col-md-4">
-    <%= legacy_simple_formatting_sidebar %>
   </div>
 </div>

--- a/app/views/admin/worldwide_organisations_translations/legacy_edit.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/legacy_edit.html.erb
@@ -1,0 +1,17 @@
+<% page_title "Edit translation for: #{@english_worldwide_organisation.name}" %>
+<div class="row">
+  <div class="col-md-8">
+    <h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_worldwide_organisation.name %></h1>
+
+    <%= form_for @translated_worldwide_organisation, url: admin_worldwide_organisation_translation_path(@translated_worldwide_organisation, translation_locale), method: :put, html: {class: 'well'} do |form| %>
+      <%= form.errors %>
+
+      <%= form.translated_text_field :name %>
+
+      <%= form.save_or_cancel cancel: admin_worldwide_organisation_translations_path(@english_worldwide_organisation) %>
+    <% end %>
+  </div>
+  <div class="col-md-4">
+    <%= legacy_simple_formatting_sidebar %>
+  </div>
+</div>

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -189,11 +189,12 @@ Then(/^I should see the language "([^"]*)" \("([^"]*)"\) for "([^"]*)" \("([^"]*
 
   if using_design_system?
     click_link "Edit #{language}"
+    expect(page).to have_content("Edit translation")
   else
     click_link language
+    expect(page).to have_content("Edit ‘#{language} (#{language_in_english})’ translation for: #{worldwide_organisation_in_english}")
   end
 
-  expect(page).to have_content("Edit ‘#{language} (#{language_in_english})’ translation for: #{worldwide_organisation_in_english}")
   expect(page).to have_field("Name", with: worldwide_organisation)
 end
 

--- a/test/functional/admin/worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_translations_controller_test.rb
@@ -70,7 +70,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   view_test "edit indicates which language is being translated to" do
     create(:worldwide_organisation, translated_into: [:fr])
     get :edit, params: { worldwide_organisation_id: @worldwide_organisation, id: "fr" }
-    assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
+    assert_select "h1", text: /Edit translation/
   end
 
   view_test "edit presents a form to update an existing translation" do
@@ -87,7 +87,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
 
     assert_select "form[action=?]", translation_path do
       assert_select "input[type=text][name='worldwide_organisation[name]'][value='Département des barbes en France']"
-      assert_select "input[type=submit][value=Save]"
+      assert_select "button", text: "Save"
     end
   end
 
@@ -97,7 +97,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
     get :edit, params: { worldwide_organisation_id: worldwide_organisation, id: "ar" }
 
     assert_select "form" do
-      assert_select "fieldset.right-to-left input[type=text][name='worldwide_organisation[name]']"
+      assert_select "input[type=text][name='worldwide_organisation[name]'][dir='rtl']"
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/ceO1UmdT/322-edit-translations-page)

Ports the "Edit translations" page of the "Worldwide organisations" section to the design system:
- Updates controller for design_system
- Updates UI for design system
- Add tracking
- Updates tests for Design System

From a design perspective the main changes form the existing implementation are: 
- Simplify the page heading to "Edit translation"
- Remove the GovSpeak sidebar as it is not possible to add markdown to the limited fields (only the organisation name) that can be edited from this page. 

| Scenario | Screenshot |
|-|-|
|Default|![Screenshot 2023-07-20 at 12 15 18](https://github.com/alphagov/whitehall/assets/6080548/181fc870-8abb-4f8e-95f6-dd85decea764)|
|With errors|![Screenshot 2023-07-20 at 12 13 06](https://github.com/alphagov/whitehall/assets/6080548/9465edd1-750d-44ba-8ee6-6d3c0af12de1)|