### PR TITLE
Update delete promotional feature title

### DIFF
--- a/app/views/admin/promotional_features/confirm_destroy.html.erb
+++ b/app/views/admin/promotional_features/confirm_destroy.html.erb
@@ -1,6 +1,6 @@
 <% content_for :context, @organisation.name %>
-<% content_for :page_title, "Delete #{@promotional_feature.title}" %>
-<% content_for :title, "Delete #{@promotional_feature.title}" %>
+<% content_for :page_title, "Delete promotional feature" %>
+<% content_for :title, "Delete promotional feature" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Description

This PR updates the title and page title for the promotional feature confirm delete page.

## Screenshot
![whitehall-admin dev gov uk_government_admin_organisations_prime-ministers-office-10-downing-street_promotional_features_51_confirm_destroy](https://github.com/alphagov/whitehall/assets/91492293/3aaeed15-c465-4dfe-b714-6d9de6ce797e)

## Trello
https://trello.com/c/UAIMSWw6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
