### PR TITLE
Remove inset component from people show page

### DIFF
--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -17,11 +17,6 @@
       aria_label: "People navigation tabs",
       items: secondary_navigation_tabs_items(@person, request.path)
     } %>
-    <% unless @person.destroyable? %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: "Note: This person cannot be deleted as they are currently assigned to a role"
-      } %>
-    <% end %>
 
     <div class="gem-c-summary-list--with-image app-view-people-details__summary_list">
       <%= render "govuk_publishing_components/components/summary_list", {

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -93,15 +93,6 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details"
   end
 
-  view_test "GET on :show renders an inset text component when user cannot be deleted" do
-    person = create(:pm)
-
-    get :show, params: { id: person }
-
-    assert_select ".gem-c-inset-text", text: "Note: This person cannot be deleted as they are currently assigned to a role"
-    assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details", count: 0
-  end
-
   view_test "editing shows form for editing a person" do
     person = create(:person, image: upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
     get :edit, params: { id: person }


### PR DESCRIPTION
## Description

This PR removes the inset text from the people details page.

## Screenshot
![whitehall-admin dev gov uk_government_admin_people_fiona-ryland](https://github.com/alphagov/whitehall/assets/91492293/db2316ff-988b-4e96-9166-2ba816a57537)

## Trello
https://trello.com/c/qXNCOPbB

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
