### PR TITLE
Include the World Location(s) for a Worldwide Organisation when presenting to search

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -145,4 +145,8 @@ class WorldwideOrganisation < ApplicationRecord
 
     offices.each { |office| Whitehall::PublishingApi.republish_async(office) }
   end
+
+  def search_index
+    super.merge("world_locations" => world_locations.map(&:slug))
+  end
 end

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -218,7 +218,8 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   test "search index data for a worldwide organisation includes name, summary, the correct link and format" do
-    worldwide_organisation = create(:worldwide_organisation, content_id: "7d58b5d8-6d91-4dbb-b3e1-c2a27f131046", name: "British Embassy to Hat land", slug: "british-embassy-to-hat-land")
+    world_location = create(:world_location, slug: "narnia")
+    worldwide_organisation = create(:worldwide_organisation, content_id: "7d58b5d8-6d91-4dbb-b3e1-c2a27f131046", name: "British Embassy to Hat land", slug: "british-embassy-to-hat-land", world_locations: [world_location])
     create(:published_corporate_information_page, corporate_information_page_type: CorporateInformationPageType.find("about"), worldwide_organisation:, organisation: nil, summary: "Providing assistance to uk residents in hat land")
 
     assert_equal(
@@ -227,7 +228,8 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
         "link" => "/world/organisations/british-embassy-to-hat-land",
         "indexable_content" => "Providing assistance to uk residents in hat land",
         "format" => "worldwide_organisation",
-        "description" => "Providing assistance to uk residents in hat land" },
+        "description" => "Providing assistance to uk residents in hat land",
+        "world_locations" => %w[narnia] },
       worldwide_organisation.search_index,
     )
   end


### PR DESCRIPTION
This will allow us to use Search API to find the Worldwide Organisations that are associated with a specific World Location.

By doing this, we can then change the data source in `gds-api-adapters` meaning the Whitehall API can be deprecated.

[Trello card](https://trello.com/c/jJ0SH0N3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
