### PR TITLE
Add Worldwide Organisation About Page

### DIFF
--- a/app/controllers/admin/worldwide_organisations_about_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_about_controller.rb
@@ -1,0 +1,7 @@
+class Admin::WorldwideOrganisationsAboutController < Admin::BaseController
+  layout "design_system"
+
+  def show
+    @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:id])
+  end
+end

--- a/app/helpers/admin/worldwide_organisations_helper.rb
+++ b/app/helpers/admin/worldwide_organisations_helper.rb
@@ -18,6 +18,11 @@ module Admin::WorldwideOrganisationsHelper
         current: current_path == admin_worldwide_organisation_path(worldwide_organisation),
       },
       {
+        label: "About",
+        href: about_admin_worldwide_organisation_path(worldwide_organisation),
+        current: current_path == about_admin_worldwide_organisation_path(worldwide_organisation),
+      },
+      {
         label: "Translations",
         href: admin_worldwide_organisation_translations_path(worldwide_organisation),
         current: current_path == admin_worldwide_organisation_translations_path(worldwide_organisation),

--- a/app/views/admin/worldwide_organisations_about/show.html.erb
+++ b/app/views/admin/worldwide_organisations_about/show.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_title, @worldwide_organisation.name %>
+<% content_for :title, @worldwide_organisation.name %>
+<% content_for :context, "Worldwide organisation"  %>
+<% content_for :title_margin_bottom, 4 %>
+
+<p class="govuk-body">
+  <%= view_on_website_link_for @worldwide_organisation, class: "govuk-link", target: "blank" %>
+</p>
+
+<%= render "components/secondary_navigation", {
+  aria_label: "Organisation navigation tabs",
+  items: secondary_navigation_tabs_items(@worldwide_organisation, request.path)
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "About",
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+    <% if @worldwide_organisation.about_us.present? %>
+      <%= render "components/summary_card_component", {
+        title: "About us",
+        rows: [
+          {
+            key: "Summary",
+            value: @worldwide_organisation.summary,
+          },
+          {
+            key: "Body",
+            value: simple_format(truncate(@worldwide_organisation.body, length: 500), class: "govuk-!-margin-top-0"),
+          },
+        ].reject { |row| row[:value].blank? },
+        summary_card_actions: [
+          {
+            label: "View",
+            href: admin_edition_path(@worldwide_organisation.about_us)
+          }
+        ],
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No about us page."
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ Whitehall::Application.routes.draw do
             put :set_main_office
             get :access_info
             get :confirm_destroy
+            get :about, to: "worldwide_organisations_about#show", as: :about
           end
           resource :access_and_opening_time, path: "access_info", except: %i[index show new]
           resources :translations, controller: "worldwide_organisations_translations"

--- a/test/functional/admin/worldwide_organisations_about_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_about_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Admin::WorldwideOrganisationsAboutControllerTest < ActionController::TestCase
+  setup do
+    login_as :writer
+  end
+
+  should_be_an_admin_controller
+
+  test "GET :show assigns correctly" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    get :show, params: { id: worldwide_organisation }
+
+    assert_response :success
+    assert_equal worldwide_organisation, assigns(:worldwide_organisation)
+  end
+end

--- a/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
+++ b/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
@@ -7,6 +7,7 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
 
     expected_output = [
       { label: "Details", href: admin_worldwide_organisation_path(worldwide_organisation), current: true },
+      { label: "About", href: about_admin_worldwide_organisation_path(worldwide_organisation), current: true },
       { label: "Translations", href: admin_worldwide_organisation_translations_path(worldwide_organisation), current: false },
       { label: "Offices", href: admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation), current: false },
       { label: "Access and opening times", href: access_info_admin_worldwide_organisation_path(worldwide_organisation), current: false },

--- a/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
+++ b/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
@@ -7,7 +7,7 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
 
     expected_output = [
       { label: "Details", href: admin_worldwide_organisation_path(worldwide_organisation), current: true },
-      { label: "About", href: about_admin_worldwide_organisation_path(worldwide_organisation), current: true },
+      { label: "About", href: about_admin_worldwide_organisation_path(worldwide_organisation), current: false },
       { label: "Translations", href: admin_worldwide_organisation_translations_path(worldwide_organisation), current: false },
       { label: "Offices", href: admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation), current: false },
       { label: "Access and opening times", href: access_info_admin_worldwide_organisation_path(worldwide_organisation), current: false },


### PR DESCRIPTION
## Description

We're moving the about us information to it's own tab for worldwide organisations. This adds the tab to the helper method responsible for rendering the worldwide organisation tabs and then adds a new endpoint.

<img width="838" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/39209c97-8119-4355-af35-1d95a4e50de0">

## Trello card

https://trello.com/c/HW4NnOjF/348-update-organisations-details-page-and-add-an-about-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
