### PR TITLE
Normalise locale files

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -22,14 +22,14 @@ ar:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: الملف المرفق
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: رقم ورقة الأمر الخاصة بالمرفق
         hoc_paper_number: رقم ورقة مجلس العموم
@@ -51,19 +51,19 @@ ar:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "إذا كنت تستخدم تكنولوجيا مساعدة (مثل قارئ الشاشة) وكنت بحاجة لنسخة من هذا المستند بتنسيق أيسر استخدامًا، فيُرجى التواصل معنا على البريد الإلكتروني %{email}. \nمن فضلك أخبرنا بالتنسيق الذي تحتاجه. إذا أخبرتنا بالتكنولوجيا المساعدة التي تستخدمها، فهذا سيساعدنا.\n"
@@ -89,10 +89,10 @@ ar:
       subheading: لقد وجدنا بعض المسائل المتعلقة بالارتباطات التي قد تشير إلى وجود مشكلات، وينبغي لك أن تتوخى الحذر عند إضافة الارتباطات بها
     title: ارتباطات منقطعة
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: مغلق
     closing_today: سيغلق اليوم
@@ -149,565 +149,565 @@ ar:
       written_on: 'تاريخ الكتابة:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: حول
         other: حول
-        two:
-        zero:
+        two: 
+        zero: 
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: حول خدماتنا
         other: حول خدماتنا
-        two:
-        zero:
+        two: 
+        zero: 
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: الوصول والفتح
         other: الوصول والفتح
-        two:
-        zero:
+        two: 
+        zero: 
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: سياسة المستندات المُيسَّرة
         other: سياسات المستندات المُيسَّرة
-        two:
-        zero:
+        two: 
+        zero: 
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: تنبيه
         other: التنبيهات
-        two:
-        zero:
+        two: 
+        zero: 
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: إعلان
         other: إعلانات
-        two:
-        zero:
+        two: 
+        zero: 
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: مقال مؤلَّف
         other: مقالات مؤلَّفة
-        two:
-        zero:
+        two: 
+        zero: 
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: منشور المدوَّنة
         other: منشورات المدوّنة
-        two:
-        zero:
+        two: 
+        zero: 
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: حملة
         other: حملات
-        two:
-        zero:
+        two: 
+        zero: 
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: الوظائف
         other: الوظائف
-        two:
-        zero:
+        two: 
+        zero: 
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: دراسة الحالة
         other: دراسات الحالة
-        two:
-        zero:
+        two: 
+        zero: 
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: استشارة مغلقة
         other: استشارات مغلقة
-        two:
-        zero:
+        two: 
+        zero: 
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: إجراء الشكاوى
         other: إجراءات الشكاوى
-        two:
-        zero:
+        two: 
+        zero: 
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: استشارة
         other: استشارات
-        two:
-        zero:
+        two: 
+        zero: 
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: نتيجة الاستشارة
         other: نتائج الاستشارة
-        two:
-        zero:
+        two: 
+        zero: 
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: تقرير الشركة
         other: تقارير الشركة
-        two:
-        zero:
+        two: 
+        zero: 
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: مراسلة
         other: مراسلات
-        two:
-        zero:
+        two: 
+        zero: 
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: قرار
         other: قرارات
-        two:
-        zero:
+        two: 
+        zero: 
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: توجيه
         other: توجيه
-        two:
-        zero:
+        two: 
+        zero: 
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: مجموعة
         other: مجموعات
-        two:
-        zero:
+        two: 
+        zero: 
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: مشروع النص
         other: مشاريع النصوص
-        two:
-        zero:
+        two: 
+        zero: 
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: إصدار
         other: إصدارات
-        two:
-        zero:
+        two: 
+        zero: 
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: إصدار مع موعد
         other: إصدارات مع موعد
-        two:
-        zero:
+        two: 
+        zero: 
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: المساواة والتنوع
         other: المساواة والتنوع
-        two:
-        zero:
+        two: 
+        zero: 
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: إشعار حول الوفيات
         other: إشعارات حول الوفيات
-        two:
-        zero:
+        two: 
+        zero: 
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: إصدار  حرية تداول المعلومات
         other: إصدارات حرية تداول المعلومات
-        two:
-        zero:
+        two: 
+        zero: 
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: نموذج
         other: نماذج
-        two:
-        zero:
+        two: 
+        zero: 
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: إصدار عام
         other: إصدارات عامة
-        two:
-        zero:
+        two: 
+        zero: 
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: استجابة الحكومة
         other: استجابات الحكومة
-        two:
-        zero:
+        two: 
+        zero: 
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: توجيه
         other: توجيه
-        two:
-        zero:
+        two: 
+        zero: 
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: تقييم الأثر
         other: تقييمات الأثر
-        two:
-        zero:
+        two: 
+        zero: 
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: مستورد - في انتظار النوع
         other: مستورد - في انتظار النوع
-        two:
-        zero:
+        two: 
+        zero: 
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: تقرير مستقل
         other: تقارير مستقلة
-        two:
-        zero:
+        two: 
+        zero: 
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: معاهدة دولية
         other: معاهدات دولية
-        two:
-        zero:
+        two: 
+        zero: 
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: دليل
         other: أدلة
-        two:
-        zero:
+        two: 
+        zero: 
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: خريطة
         other: خرائط
-        two:
-        zero:
+        two: 
+        zero: 
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: استفسار وسائل الإعلام
         other: استفسارات وسائل الإعلام
-        two:
-        zero:
+        two: 
+        zero: 
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: العضوية
         other: العضوية
-        two:
-        zero:
+        two: 
+        zero: 
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: الإحصاءات الوطنية
         other: الإحصاءات الوطنية
-        two:
-        zero:
+        two: 
+        zero: 
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: مقال إخباري
         other: مقالات إخبارية
-        two:
-        zero:
+        two: 
+        zero: 
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: قصة إخبارية
         other: قصص إخبارية
-        two:
-        zero:
+        two: 
+        zero: 
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: محتوى خدمات الصحة الوطنية
         other: محتوى خدمات الصحة الوطنية
-        two:
-        zero:
+        two: 
+        zero: 
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: إشعار
         other: إشعارات
-        two:
-        zero:
+        two: 
+        zero: 
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: الإحصاءات الرسمية
         other: الإحصاءات الرسمية
-        two:
-        zero:
+        two: 
+        zero: 
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: استشارة مفتوحة
         other: استشارات مفتوحة
-        two:
-        zero:
+        two: 
+        zero: 
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: بيان شفوي للبرلمان
         other: بيانات شفوية للبرلمان
-        two:
-        zero:
+        two: 
+        zero: 
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: استخدامنا للطاقة
         other: استخدامنا للطاقة
-        two:
-        zero:
+        two: 
+        zero: 
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: الحوكمة لدينا
         other: الحوكمة لدينا
-        two:
-        zero:
+        two: 
+        zero: 
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: ميثاق المعلومات الشخصية
         other: مواثيق المعلومات الشخصية
-        two:
-        zero:
+        two: 
+        zero: 
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: الالتماسات والحملات
         other: الالتماسات والحملات
-        two:
-        zero:
+        two: 
+        zero: 
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: ورقة السياسة
         other: أوراق السياسة
-        two:
-        zero:
+        two: 
+        zero: 
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: بيان صحفي
         other: بيانات صحفية
-        two:
-        zero:
+        two: 
+        zero: 
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: المشتريات
         other: المشتريات
-        two:
-        zero:
+        two: 
+        zero: 
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: مادة ترويجية
         other: مادة ترويجية
-        two:
-        zero:
+        two: 
+        zero: 
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: منشور
         other: منشورات
-        two:
-        zero:
+        two: 
+        zero: 
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: مخطط النشر
         other: مخطط النشر
-        two:
-        zero:
+        two: 
+        zero: 
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: استقطاب الموظفين
         other: استقطاب الموظفين
-        two:
-        zero:
+        two: 
+        zero: 
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: لائحة
         other: لوائح
-        two:
-        zero:
+        two: 
+        zero: 
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: الأبحاث
         other: الأبحاث
-        two:
-        zero:
+        two: 
+        zero: 
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: الخدمة
         other: الخدمات
-        two:
-        zero:
+        two: 
+        zero: 
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: استخدام وسائل التواصل الاجتماعي
         other: استخدام وسائل التواصل الاجتماعي
-        two:
-        zero:
+        two: 
+        zero: 
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: ملاحظات تحضيرية للخطاب
         other: ملاحظات تحضيرية للخطاب
-        two:
-        zero:
+        two: 
+        zero: 
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: خطاب
         other: خطابات
-        two:
-        zero:
+        two: 
+        zero: 
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: تحديث الموظفين
         other: تحديثات الموظفين
-        two:
-        zero:
+        two: 
+        zero: 
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: معيار
         other: معايير
-        two:
-        zero:
+        two: 
+        zero: 
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: بيان إلى البرلمان
         other: بيانات إلى البرلمان
-        two:
-        zero:
+        two: 
+        zero: 
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: مجموعة بيانات إحصائية
         other: مجموعات بيانات إحصائية
-        two:
-        zero:
+        two: 
+        zero: 
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: إحصائيات
         other: إحصائيات
-        two:
-        zero:
+        two: 
+        zero: 
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: التوجيه القانوني
         other: التوجيه القانوني
-        two:
-        zero:
+        two: 
+        zero: 
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: الشروط المرجعية
         other: الشروط المرجعية
-        two:
-        zero:
+        two: 
+        zero: 
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: نص
         other: نصوص
-        two:
-        zero:
+        two: 
+        zero: 
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: بيانات الشفافية
         other: بيانات الشفافية
-        two:
-        zero:
+        two: 
+        zero: 
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: مخطط اللغة الويلزية
         other: مخططات اللغة الويلزية
-        two:
-        zero:
+        two: 
+        zero: 
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: قصة إخبارية عالمية
         other: قصص إخبارية عالمية
-        two:
-        zero:
+        two: 
+        zero: 
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: بيان خطي للبرلمان
         other: بيانات خطية للبرلمان
-        two:
-        zero:
+        two: 
+        zero: 
     updated: تاريخ التحديث
   document_filters:
     world_locations:
@@ -723,71 +723,71 @@ ar:
     direction: rtl
   language_names:
     ar: العربيَّة
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: لا توجد تحديثات بعد.
     title: الأحدث
@@ -799,7 +799,7 @@ ar:
       organisation_chart: مخططنا التنظيمي
       transparency: بيانات الشفافية
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: معلومات الشركة
       corporate_reports: تقارير الشركة
@@ -816,10 +816,10 @@ ar:
   see_all:
     announcement: اطلع على جميع إعلاناتنا
     authored_article: اطلع على جميع مقالاتنا المؤلفة
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: اطلع على جميع دراسات الحالة لدينا
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: اطلع على جميع استشاراتنا المغلقة
     consultation: اطلع على جميع استشاراتنا
     consultation_outcome: اطلع على جميع نتائج استشاراتنا
@@ -842,7 +842,7 @@ ar:
     news_article: اطلع على جميع مقالاتنا الإخبارية
     news_story: اطلع على جميع قصصنا الصحفية
     notice: اطلع على جميع إشعاراتنا
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: اطلع على جميع استشاراتنا المفتوحة
     oral_statement: اطلع على جميع بياناتنا الشفوية إلى البرلمان
     policy: اطلع على جميع سياساتنا
@@ -876,30 +876,30 @@ ar:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: البحث حسب البلد أو الإقليم
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: وفد دولي
         other: وفود دولية
-        two:
-        zero:
+        two: 
+        zero: 
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: موقع عالمي
         other: مواقع عالمية
-        two:
-        zero:
+        two: 
+        zero: 
   world_news:
     uk_updates_in_country: تحديثات وأخبار وفعاليات من حكومة المملكة المتحدة في %{country}
   worldwide_organisation:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -22,14 +22,14 @@ az:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Əlavə edilmiş fayl
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Əlavənin sənəd nömrəsi
         hoc_paper_number: İcmalar palatasının sənəd nömrəsi
@@ -51,19 +51,19 @@ az:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ az:
       subheading: Biz problemləri göstərə biləcək keçidlərdə bəzi məsələlər tapmışıq, onlara qoşulan zaman ehtiyatlı olmalısınız
     title: Pozulmuş keçidlər
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Bağlıdır
     closing_today: Bu gün bağlanır
@@ -176,11 +176,11 @@ az:
         one: Bloq-post
         other: Bloq-postlar
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampaniya
         other: Kampaniyalar
@@ -191,8 +191,8 @@ az:
         one: Nümunə üzrə araşdırma
         other: Nümunə üzrə araşdırmalar
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Qapalı məsləhətləşmə
         other: Qapalı məsləhətləşmələr
@@ -275,8 +275,8 @@ az:
         one: Üzvlük
         other: Üzvlük
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Milli statistika
         other: Milli statistika
@@ -296,8 +296,8 @@ az:
         one: Rəsmi statistika
         other: Rəsmi statistika
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Açıq məsləhətləşmə
         other: Açıq məsləhətləşmələr
@@ -405,72 +405,72 @@ az:
   i18n:
     direction: ltr
   language_names:
-    ar:
+    ar: 
     az: Azeri
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Hələ yenilənmələr yoxdur.
     title: Ən son
@@ -482,7 +482,7 @@ az:
       organisation_chart: Təşkilat sxemimiz
       transparency: Məlumatla bağlı şəffaflıq
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Korporativ məlumat
       corporate_reports: Şirkətin fəaliyyəti üzrə hesabatlar
@@ -499,10 +499,10 @@ az:
   see_all:
     announcement: Bütün elanlarımıza baxın
     authored_article: Müəlliflik edilmiş bütün məqalələrimizə baxın
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Nümunə üzrə bütün araşdırmalarımıza baxın
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Bütün qapalı məsləhətləşmələrimizə baxın
     consultation: Bütün məsləhətləşmələrimizə baxın
     consultation_outcome: Bütün məsləhətləşmə nəticələrimizə baxın
@@ -525,7 +525,7 @@ az:
     news_article: Xəbərləri əks etdirən bütün məqalələrimizə baxın
     news_story: Xəbərləri əks etdirən bütün materiallarımıza baxın
     notice: Bütün bildirişlərimizə baxın
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Bütün açıq məsləhətləşmələrimizə baxın
     oral_statement: Parlamentə edilmiş bütün şifahi müraciətlərimizə baxın
     policy: Bütün siyasətlərimizə baxın
@@ -559,15 +559,15 @@ az:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Ölkəyə və ya əraziyə əsasən axtarın
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Beynəlxalq səlahiyyətin ötürülməsi

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -22,14 +22,14 @@ be:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Укладзены файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Нумар дакумента каманды дадатку
         hoc_paper_number: Нумар дакумента Палаты абшчын
@@ -51,19 +51,19 @@ be:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "Калі вы выкарыстоўваеце дапаможную праграму (напрыклад, праграму для чытання з экрана) і вам патрэбна версія гэтага дакумента ў больш даступным фармаце, то калі ласка напішыце на  электронную пошту %{email}. \nКалі ласка, скажыце нам, які фармат вам патрэбны. Нам таксама дапаможа, калі вы назавеце, якую дапаможную праграму вы выкарыстоўваеце."
@@ -89,10 +89,10 @@ be:
       subheading: Мы выявілі некаторыя праблемы са спасылкамі, якія могуць паказваць на праблемы, вам варта праяўляць асцярожнасць пры спасылках на іх
     title: Непрацуючыя спасылкі
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Закрыты
     closing_today: Зачыняецца сёння
@@ -149,403 +149,403 @@ be:
       written_on: 'Напісана:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: Пра іншых
         other: Пра іншых
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: Аб нашых паслугах
         other: Аб нашых паслугах
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Доступ і адкрыццё
         other: Доступ і адкрыццё
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Палітыка па даступных дакументаў
         other: Палітыкi па даступных дакументаў
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Апавяшчэнне
         other: Апавяшчэннi
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Аб'ява
         other: Аб'явы
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Аўтарскі артыкул
         other: Аўтарскія артыкулы
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Публікацыя ў блогу
         other: Публікацыі ў блогу
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Акцыя
         other: Акцыі
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Спецыяльнасцi
         other: спецыяльнасцi
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Тэматычнае даследаванне
         other: Тэматычныя даследаванні
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Закрытая кансультацыя
         other: Закрытыя кансультацыі
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Працэдура разгляду скаргаў
         other: Працэдуры разгляду скаргаў
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Кансультацыя
         other: Кансультацыі
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Вынік кансультацыі
         other: Вынікі кансультацыі
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Карпаратыўная справаздача
         other: Карпаратыўныя справаздачы
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Перапіска
         other: Перапіска
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Пастанова
         other: Пастановы
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Кіраўніцтва
         other: Кіраўніцтва
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Серыя
         other: Серыi
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Чарнавік
         other: Чарнавікі
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Выданне
         other: Выданнi
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Выданне з прызначэннем
         other: Выданні з прызначэннем
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Аднастайнасць і разнастайнасць
         other: Аднастайнасць і разнастайнасць
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Паведамлення аб смерці
         other: Паведамлення аб смерці
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Рэліз у межах Закона аб свабодзе інфармацыі
         other: Рэлізы ў межах Закона аб свабодзе інфармацыі
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Форма
         other: Формы
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Ўніверсальнае выданне
         other: Універсальныя выданні
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Адказ ўрада
         other: Адказы ўрада
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Кіраўніцтва
         other: Кіраўніцтва
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Ацэнка ўплыву
         other: Ацэнкі ўплыву
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: імпартавана - чаканне тыпу
         other: імпартавана - чаканне тыпу
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Незалежная справаздача
         other: Незалежныя справаздачы
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Міжнароднае пагадненне
         other: Міжнародныя пагадненнi
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Інструкцыя
         other: Інструкцыі
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Карта
         other: Карты
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Запыт медыя
         other: Запыты медыя
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Членства
         other: Членства
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Нацыянальная статыстыка
         other: Нацыянальная статыстыка
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Артыкул
         other: Артыкулы
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Навіна
         other: Навіны
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Змест NHS
         other: Змест NHS
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Паведамленне
         other: Паведамленні
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Афіцыйная статыстыка
         other: Афіцыйная статыстыка
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Адкрытая кансультацыя
         other: Адкрытыя кансультацыі
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Вусная заява ў парламенце
         other: Вусныя заявы ў парламенце
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Наша энергаспажыванне
         other: Наша энергаспажыванне
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Наша кіраванне
         other: Наша кіраванне
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Статут аб асабістай інфармацыі
         other: Статуты аб асабістай інфармацыі
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Петыцыі і акцыі
         other: Петыцыі і акцыі
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Праграмны дакумент
         other: Праграмныя дакументы
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Прэс-рэліз
         other: Прэс-рэлізы
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Пастаўка
         other: Пастаўка
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Рэкламны матэрыял
         other: Рэкламны матэрыял
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Публікацыя
         other: Публікацыі
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема публікацый
         other: Схемы публікацый
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Набор персаналу
         other: Набор персаналу
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Тэзіс
         other: Тэзісы
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Даследаванне
         other: Даследаванне
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Паслуга
         other: Паслугi
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Ужыванне сацыяльных медый
         other: Ужыванне сацыяльных медый
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Нататкі да выступу
         other: Нататкі да выступу
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Выступ
         other: Выступы
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Абнаўленне персаналу
         other: Абнаўленнi персаналу
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Стандарт
         other: Стандарты
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Заява ў парламенце
         other: Заявы ў парламенце
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Статыстычныя дадзеныя
         other: Статыстычныя дадзеныя
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Статыстыка
         other: Статыстыка
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Нарматыўныя ўказанні
         other: Заканадаўчае кіраўніцтва
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Паўнамоцтва
         other: Паўнамоцтва
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Поўны тэкст
         other: Поўныя тэксты
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Адкрытыя дадзеныя
         other: Адкрытыя дадзеныя
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема валійскай мовы
         other: Схемы валійскай мовы
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Сусветная навіна
         other: Сусветныя навіны
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Пісьмовая заява ў парламенце
         other: Пісьмовыя заявы ў парламенце
     updated: Адноўлена
@@ -562,72 +562,72 @@ be:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
+    ar: 
+    az: 
     be: Беларуская
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Ніякіх абнаўленняў пакуль няма.
     title: Апошняе
@@ -639,7 +639,7 @@ be:
       organisation_chart: Наша арганізацыйная структура
       transparency: Адкрытыя дадзеныя
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Карпаратыўная іфармацыя
       corporate_reports: Карпаратыўныя справаздачы
@@ -656,10 +656,10 @@ be:
   see_all:
     announcement: Паглядзець усе Аб'явы
     authored_article: Паглядзець усе Аўтарскія артыкулы
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Паглядзець усе Тэматычныя даследаванні
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Паглядзець усе Закрытыя кансультацыі
     consultation: Паглядзець усе Кансультацыі
     consultation_outcome: Паглядзець усе Вынікі кансультацыі
@@ -682,7 +682,7 @@ be:
     news_article: Паглядзець усе Артыкулы
     news_story: Паглядзець усе Навіны
     notice: Паглядзець усе Паведамленнi
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Паглядзець усе Адкрытыя кансультацыі
     oral_statement: Паглядзець усе Вусныя заявы ў парламенце
     policy: Паглядзець усе Напрамкі дзейнасці
@@ -716,24 +716,24 @@ be:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Пошук па краіне або тэрыторыі
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Міжнародная дэлегацыя
         other: Міжнародныя дэлегацыі
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Месцазнаходжанне ў свеце
         other: Мы ў свеце
   world_news:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -22,14 +22,14 @@ bg:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Прикаченият файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Номер на прикачения нормативен документ
         hoc_paper_number: Номер на документа на Камарата на общините
@@ -51,19 +51,19 @@ bg:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ bg:
       subheading: Открихме някои проблеми с линковете, които могат да покажат нередности, и трябва да бъдете внимателни при тяхното използване
     title: Повредени линкове
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Закрито
     closing_today: Закрито днес
@@ -175,11 +175,11 @@ bg:
         one: Публикация в блога
         other: Публикации в блога
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Кампания
         other: Кампании
@@ -190,8 +190,8 @@ bg:
         one: Казус
         other: Казуси
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Закрита консултация
         other: Закрити консултации
@@ -274,8 +274,8 @@ bg:
         one: Членство
         other: Членство
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Национална статистика
         other: Национална статистика
@@ -295,8 +295,8 @@ bg:
         one: Официална статистика
         other: Официална статистика
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Открита консултация
         other: Открити консултации
@@ -404,72 +404,72 @@ bg:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
+    ar: 
+    az: 
+    be: 
     bg: Bulgarian
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Все още няма актуализация.
     title: Последни
@@ -481,7 +481,7 @@ bg:
       organisation_chart: Нашата организационна схема
       transparency: Данни за прозрачност
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Фирмена информация
       corporate_reports: Фирмени доклади
@@ -498,10 +498,10 @@ bg:
   see_all:
     announcement: Вижте всички наши съобщения
     authored_article: Вижте всички наши авторски статии
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Вижте всички наши казуси
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Вижте всички наши закрити консултации
     consultation: Вижте всички наши консултации
     consultation_outcome: Вижте всички резултати от нашите консултации
@@ -524,7 +524,7 @@ bg:
     news_article: Вижте всички наши информационни статии
     news_story: Вижте всички наши новинарски материали
     notice: Вижте всички наши съобщения
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Вижте всички наши открити консултации
     oral_statement: Вижте всички наши устни изявления в Парламента
     policy: Вижте всички наши политики
@@ -558,15 +558,15 @@ bg:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Търсене по страна или територия
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Международна делегация

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -22,14 +22,14 @@ bn:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: সংযুক্ত নথি
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: সংযুক্ত আদেশ পত্র নম্বর
         hoc_paper_number: হাউজ অব কমন্সের পেপার নাম্বার
@@ -51,19 +51,19 @@ bn:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ bn:
       subheading: লিংকগুলোতে আমরা কিছু বিষয় পেয়েছি, যেগুলো সমস্যা নির্দেশ করতে পারে, এগুলোর সাথে লিংক করতে আপনার সতর্ক হওয়া উচিত
     title: অকার্যকর লিংকসমূহ
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: বন্ধ হয়ে গেছে
     closing_today: আজকে বন্ধ হচ্ছে
@@ -175,11 +175,11 @@ bn:
         one: ব্লগ পোস্ট
         other: ব্লগ পোস্টসমূহ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: ক্যাম্পেইন
         other: ক্যাম্পেইনসমূহ
@@ -190,8 +190,8 @@ bn:
         one: কেস স্টাডি
         other: কেস স্টাডিসমূহ
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: ক্লোজড কনসাল্টেশন
         other: ক্লোজড কনসাল্টেশন
@@ -274,8 +274,8 @@ bn:
         one: সদস্যপদ
         other: সদস্যপদ
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: জাতীয় পরিসংখ্যান
         other: জাতীয় পরিসংখ্যান
@@ -295,8 +295,8 @@ bn:
         one: দাপ্তরিক পরিসংখ্যান
         other: দাপ্তরিক পরিসংখ্যান
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: উম্মুক্ত পরামর্শ
         other: উম্মুক্ত পরামর্শসমূহ
@@ -404,72 +404,72 @@ bn:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
+    ar: 
+    az: 
+    be: 
+    bg: 
     bn: বাংলা
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: এখনও কোনো আপডেট নেই।
     title: সাম্প্রতিক
@@ -481,7 +481,7 @@ bn:
       organisation_chart: আমাদের প্রতিষ্ঠানের চার্ট
       transparency: স্বচ্ছতার তথ্য
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: কর্পোরেট তথ্য
       corporate_reports: কর্পোরেট রিপোর্টসমূহ
@@ -498,10 +498,10 @@ bn:
   see_all:
     announcement: আমাদের সকল ঘোষণা দেখুন
     authored_article: আমাদের লেখকের উৎস সহ সকল নিবন্ধ দেখুন
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: আমাদের সকল কেস স্টাডি দেখুন
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: আমাদের সকল ক্লোজড কনসাল্টেশন দেখুন
     consultation: আমাদের সকল কনসাল্টেশন দেখুন
     consultation_outcome: আমাদের সকল কনসাল্টেশনের ফলাফল দেখুন
@@ -524,7 +524,7 @@ bn:
     news_article: আমাদের সকল সংবাদপত্রের নিবন্ধ দেখুন
     news_story: আমাদের সকল সংবাদের বিষয় দেখুন
     notice: আমাদের সকল বিজ্ঞপ্তি দেখুন
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: আমাদের সকল উম্মুক্ত পরামর্শ দেখুন
     oral_statement: সংসদে আমাদের সকল মৌখিক বিবৃতি দেখুন
     policy: আমাদের সকল নীতিমালা দেখুন
@@ -558,15 +558,15 @@ bn:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: দেশ বা অঞ্চল হিসেবে অনুসন্ধান করুন
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: আন্তর্জাতিক প্রতিনিধি

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -22,14 +22,14 @@ cs:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Přiložený soubor
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Číslo příkazového papíru přílohy
         hoc_paper_number: Číslo dokumentu Dolní sněmovny
@@ -51,19 +51,19 @@ cs:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ cs:
       subheading: Zjistili jsme několik problémů s odkazy, které mohou naznačovat problémy, a proto byste měli být při odkazování na ně opatrní
     title: Poškozené odkazy
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Uzavřeno
     closing_today: Dnešní uzávěrka
@@ -152,323 +152,323 @@ cs:
       written_on: 'Napsáno dne:'
     type:
       about:
-        few:
+        few: 
         one: O stránkách
         other: O stránkách
       about_our_services:
-        few:
+        few: 
         one: O našich službách
         other: O našich službách
       access_and_opening:
-        few:
+        few: 
         one: Přístup a otevírání
         other: Přístup a otevírání
       accessible_documents_policy:
-        few:
+        few: 
         one: Politika přístupnosti dokumentů
         other: Zásady přístupnosti dokumentů
       alert:
-        few:
+        few: 
         one: Upozornění
         other: Upozornění
       announcement:
-        few:
+        few: 
         one: Oznámení
         other: Oznámení
       authored_article:
-        few:
+        few: 
         one: Autorský článek
         other: Autorské články
       blog_post:
-        few:
+        few: 
         one: Příspěvek na blogu
         other: Příspěvky na blogu
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Kampaň
         other: Kampaně
       careers:
-        few:
+        few: 
         one: Kariéra
         other: kariéra
       case_study:
-        few:
+        few: 
         one: Případová studie
         other: Případové studie
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Uzavřená konzultace
         other: Uzavřené konzultace
       complaints_procedure:
-        few:
+        few: 
         one: Postup pro podávání stížností
         other: Postupy pro podávání stížností
       consultation:
-        few:
+        few: 
         one: Konzultace
         other: Konzultace
       consultation_outcome:
-        few:
+        few: 
         one: Výsledek konzultace
         other: Výsledky konzultací
       corporate_report:
-        few:
+        few: 
         one: Podniková zpráva
         other: Podnikové zprávy
       correspondence:
-        few:
+        few: 
         one: Korespondence
         other: Korespondence
       decision:
-        few:
+        few: 
         one: Rozhodnutí
         other: Rozhodnutí
       detailed_guidance:
-        few:
+        few: 
         one: Směrnice
         other: Směrnice
       document_collection:
-        few:
+        few: 
         one: Sbírka
         other: Sbírky
       draft_text:
-        few:
+        few: 
         one: Návrh textu
         other: Návrhy textů
       edition:
-        few:
+        few: 
         one: Vydání
         other: Edice
       edition_with_appointment:
-        few:
+        few: 
         one: Vydání se schůzkou
         other: Vydání se schůzkou
       equality_and_diversity:
-        few:
+        few: 
         one: Rovnost a rozmanitost
         other: Rovnost a rozmanitost
       fatality_notice:
-        few:
+        few: 
         one: Oznámení o úmrtí
         other: Oznámení o úmrtí
       foi_release:
-        few:
+        few: 
         one: Zveřejnění informací
         other: Zveřejnění informací
       form:
-        few:
+        few: 
         one: Formulář
         other: Formuláře
       generic_edition:
-        few:
+        few: 
         one: Obecné vydání
         other: Obecné vydání
       government_response:
-        few:
+        few: 
         one: Reakce vlády
         other: Reakce vlády
       guidance:
-        few:
+        few: 
         one: Směrnice
         other: Směrnice
       impact_assessment:
-        few:
+        few: 
         one: Posouzení dopadu
         other: Posouzení dopadů
       imported:
-        few:
+        few: 
         one: importované - čekající na typ
         other: importované - čekající na typ
       independent_report:
-        few:
+        few: 
         one: Nezávislá zpráva
         other: Nezávislé zprávy
       international_treaty:
-        few:
+        few: 
         one: Mezinárodní smlouva
         other: Mezinárodní smlouvy
       manual:
-        few:
+        few: 
         one: Manuál
         other: Příručky
       map:
-        few:
+        few: 
         one: Mapa
         other: Mapy
       media_enquiries:
-        few:
+        few: 
         one: Dotaz na média
         other: Dotazy pro média
       membership:
-        few:
+        few: 
         one: Členství
         other: Členství
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Národní statistiky
         other: Národní statistiky
       news_article:
-        few:
+        few: 
         one: Zpravodajský článek
         other: Zpravodajské články
       news_story:
-        few:
+        few: 
         one: Zpravodajský příběh
         other: Zpravodajské příběhy
       nhs_content:
-        few:
+        few: 
         one: Obsah Národní zdravotní služba
         other: Obsah Národní zdravotní služba
       notice:
-        few:
+        few: 
         one: Oznámení
         other: Oznámení
       official_statistics:
-        few:
+        few: 
         one: Oficiální statistiky
         other: Oficiální statistiky
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Otevřená konzultace
         other: Otevřené konzultace
       oral_statement:
-        few:
+        few: 
         one: Ústní prohlášení pro Parlament
         other: Ústní prohlášení pro Parlament
       our_energy_use:
-        few:
+        few: 
         one: Naše spotřeba energie
         other: Naše spotřeba energie
       our_governance:
-        few:
+        few: 
         one: Naše správa
         other: Naše správa
       personal_information_charter:
-        few:
+        few: 
         one: Listina osobních údajů
         other: Listiny osobních údajů
       petitions_and_campaigns:
-        few:
+        few: 
         one: Petice a kampaně
         other: Petice a kampaně
       policy_paper:
-        few:
+        few: 
         one: Politický dokument
         other: Politické dokumenty
       press_release:
-        few:
+        few: 
         one: Tisková zpráva
         other: Tiskové zprávy
       procurement:
-        few:
+        few: 
         one: Zadávání zakázek
         other: Zadávání zakázek
       promotional:
-        few:
+        few: 
         one: Propagační materiály
         other: Propagační materiály
       publication:
-        few:
+        few: 
         one: Publikace
         other: Publikace
       publication_scheme:
-        few:
+        few: 
         one: Publikační schéma
         other: Publikační schémata
       recruitment:
-        few:
+        few: 
         one: Přijímání zaměstnanců
         other: Přijímání zaměstnanců
       regulation:
-        few:
+        few: 
         one: Nařízení
         other: nařízení
       research:
-        few:
+        few: 
         one: Výzkum
         other: Výzkum
       service:
-        few:
+        few: 
         one: Služba
         other: Služby
       social_media_use:
-        few:
+        few: 
         one: Používání sociálních médií
         other: Používání sociálních médií
       speaking_notes:
-        few:
+        few: 
         one: Poznámky k mluvení
         other: Poznámky k mluvení
       speech:
-        few:
+        few: 
         one: Projev
         other: Projevy
       staff_update:
-        few:
+        few: 
         one: Aktuální informace o zaměstnancích
         other: Aktuální informace o zaměstnancích
       standard:
-        few:
+        few: 
         one: Standardní
         other: Standardy
       statement_to_parliament:
-        few:
+        few: 
         one: Prohlášení pro Parlament
         other: Prohlášení pro Parlament
       statistical_data_set:
-        few:
+        few: 
         one: Soubor statistických údajů.
         other: Soubory statistických údajů.
       statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
       statutory_guidance:
-        few:
+        few: 
         one: Zákonné směrnice
         other: Zákonné směrnice
       terms_of_reference:
-        few:
+        few: 
         one: Podmínky zadání
         other: Podmínky zadání
       transcript:
-        few:
+        few: 
         one: Přepis
         other: Přepisy
       transparency:
-        few:
+        few: 
         one: Údaje o transparentnosti
         other: Údaje o transparentnosti
       welsh_language_scheme:
-        few:
+        few: 
         one: Schéma welšského jazyka
         other: Schémata welšského jazyka
       world_news_story:
-        few:
+        few: 
         one: Celosvětový zpravodajský příběh
         other: Celosvětové zpravodajské příběhy
       written_statement:
-        few:
+        few: 
         one: Písemné prohlášení pro Parlament
         other: Písemná prohlášení pro Parlament
     updated: aktualizováno
@@ -485,72 +485,72 @@ cs:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
     cs: Čeština
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Zatím nejsou k dispozici žádné aktualizace.
     title: Nejnovější
@@ -562,7 +562,7 @@ cs:
       organisation_chart: Naše organizační schéma
       transparency: Údaje o transparentnosti
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Firemní informace
       corporate_reports: Podnikové zprávy
@@ -579,10 +579,10 @@ cs:
   see_all:
     announcement: Podívejte se na všechna naše oznámení
     authored_article: Podívejte se na všechny naše autorské články
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Podívejte se na všechny naše případové studie
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Podívejte se na všechny naše uzavřené konzultace
     consultation: Podívejte se na všechny naše konzultace
     consultation_outcome: Podívejte se na všechny výsledky našich konzultací
@@ -605,7 +605,7 @@ cs:
     news_article: Podívejte se na všechny naše zpravodajské články
     news_story: Podívejte se na všechny naše novinky
     notice: Podívejte se na všechna naše oznámení
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Podívejte se na všechny naše otevřené konzultace
     oral_statement: Podívejte se na všechny ústní prohlášení pro Parlament
     policy: Podívejte se na všechny naše zásady
@@ -639,22 +639,22 @@ cs:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Vyhledávání podle země nebo území
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Mezinárodní delegace
         other: Mezinárodní delegace
       world_location:
-        few:
+        few: 
         one: Umístění ve světě
         other: Místa ve světě
   world_news:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -22,14 +22,14 @@ cy:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Y ffeil a atodwyd
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Rhif papur gorchymyn yr atodiad
         hoc_paper_number: Rhif papur Tŷ'r Cyffredin
@@ -51,19 +51,19 @@ cy:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ cy:
       subheading: Rydyn ni wedi canfod rhai materion gyda dolenni a allai ddangos bod problem. Dylech fod yn ofalus wrth gysylltu â nhw
     title: Dolenni wedi torri
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Wedi cau
     closing_today: Yn cau heddiw
@@ -151,565 +151,565 @@ cy:
       written_on: 'Ysgrifennwyd ar:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: Ynghylch
         other: Ynghylch
-        two:
-        zero:
+        two: 
+        zero: 
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: Am ein gwasanaethau
         other: Am ein gwasanaethau
-        two:
-        zero:
+        two: 
+        zero: 
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Mynediad ac agor
         other: Mynediad ac agor
-        two:
-        zero:
+        two: 
+        zero: 
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Polisi dogfennau hygyrch
         other: Polisïau dogfennau hygyrch
-        two:
-        zero:
+        two: 
+        zero: 
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Rhybudd
         other: Rhybuddion
-        two:
-        zero:
+        two: 
+        zero: 
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Cyhoeddiad
         other: Cyhoeddiadau
-        two:
-        zero:
+        two: 
+        zero: 
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Erthygl ag awdur wedi'i enwi
         other: Erthyglau ag awdur wedi'i enwi
-        two:
-        zero:
+        two: 
+        zero: 
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Postiad blog
         other: Postiadau blog
-        two:
-        zero:
+        two: 
+        zero: 
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymgyrch
         other: Ymgyrchoedd
-        two:
-        zero:
+        two: 
+        zero: 
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Gyrfaoedd
         other: gyrfaoedd
-        two:
-        zero:
+        two: 
+        zero: 
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Astudiaeth achos
         other: Astudiaethau achos
-        two:
-        zero:
+        two: 
+        zero: 
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymgynghoriad caeedig
         other: Ymgynghoriadau caeedig
-        two:
-        zero:
+        two: 
+        zero: 
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Gweithdrefn gwyno
         other: Gweithdrefnau cwyno
-        two:
-        zero:
+        two: 
+        zero: 
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymgynghoriad
         other: Ymgynghoriadau
-        two:
-        zero:
+        two: 
+        zero: 
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Canlyniad yr ymgynghoriad
         other: Canlyniadau'r ymgynghoriad
-        two:
-        zero:
+        two: 
+        zero: 
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Adroddiad corfforaethol
         other: Adroddiadau corfforaethol
-        two:
-        zero:
+        two: 
+        zero: 
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Gohebiaeth
         other: Gohebiaethau
-        two:
-        zero:
+        two: 
+        zero: 
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Penderfyniad
         other: Penderfyniadau
-        two:
-        zero:
+        two: 
+        zero: 
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Canllawiau
         other: Canllawiau
-        two:
-        zero:
+        two: 
+        zero: 
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Casgliad
         other: Casgliadau
-        two:
-        zero:
+        two: 
+        zero: 
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Testun drafft
         other: Testunau drafft
-        two:
-        zero:
+        two: 
+        zero: 
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Argraffiad
         other: Argraffiadau
-        two:
-        zero:
+        two: 
+        zero: 
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Argraffiad gydag apwyntiad
         other: Argraffiadau gydag apwyntiad
-        two:
-        zero:
+        two: 
+        zero: 
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Cydraddoldeb ac amrywiaeth
         other: Cydraddoldeb ac amrywiaeth
-        two:
-        zero:
+        two: 
+        zero: 
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Hysbysiad o farwolaeth
         other: Hysbysiadau o farwolaeth
-        two:
-        zero:
+        two: 
+        zero: 
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Gwybodaeth a ryddhawyd o dan FOI
         other: Gwybodaeth a ryddhawyd o dan FOI
-        two:
-        zero:
+        two: 
+        zero: 
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Ffurflen
         other: Ffurflenni
-        two:
-        zero:
+        two: 
+        zero: 
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Argraffiad generig
         other: Argraffiadau generig
-        two:
-        zero:
+        two: 
+        zero: 
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymateb y llywodraeth
         other: Ymatebion y llywodraeth
-        two:
-        zero:
+        two: 
+        zero: 
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Canllawiau
         other: Canllawiau
-        two:
-        zero:
+        two: 
+        zero: 
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Asesiad o effaith
         other: Asesiadau o effaith
-        two:
-        zero:
+        two: 
+        zero: 
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: wedi'i fewnforio - yn aros am y math
         other: wedi'i fewnforio - yn aros am y math
-        two:
-        zero:
+        two: 
+        zero: 
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Adroddiad annibynnol
         other: Adroddiadau annibynnol
-        two:
-        zero:
+        two: 
+        zero: 
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Cytuniad rhyngwladol
         other: Cytuniadau rhyngwladol
-        two:
-        zero:
+        two: 
+        zero: 
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Llawlyfr
         other: Llawlyfrau
-        two:
-        zero:
+        two: 
+        zero: 
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Map
         other: Mapiau
-        two:
-        zero:
+        two: 
+        zero: 
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymholiad gan y cyfryngau
         other: Ymholiadau gan y cyfryngau
-        two:
-        zero:
+        two: 
+        zero: 
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Aelodaeth
         other: Aelodaeth
-        two:
-        zero:
+        two: 
+        zero: 
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Ystadegau Gwladol
         other: Ystadegau Gwladol
-        two:
-        zero:
+        two: 
+        zero: 
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Erthygl newyddion
         other: Erthyglau newyddion
-        two:
-        zero:
+        two: 
+        zero: 
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Stori newyddion
         other: Straeon newyddion
-        two:
-        zero:
+        two: 
+        zero: 
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Cynnwys y GIG
         other: Cynnwys y GIG
-        two:
-        zero:
+        two: 
+        zero: 
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Hysbysiad
         other: Hysbysiadau
-        two:
-        zero:
+        two: 
+        zero: 
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Ystadegau Swyddogol
         other: Ystadegau Swyddogol
-        two:
-        zero:
+        two: 
+        zero: 
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
-        two:
-        zero:
+        few: 
+        many: 
+        one: 
+        other: 
+        two: 
+        zero: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymgynghoriad agored
         other: Ymgynghoriadau agored
-        two:
-        zero:
+        two: 
+        zero: 
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Datganiad llafar i'r Senedd
         other: Datganiadau llafar i'r Senedd
-        two:
-        zero:
+        two: 
+        zero: 
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Ein defnydd o ynni
         other: Ein defnydd o ynni
-        two:
-        zero:
+        two: 
+        zero: 
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Ein llywodraethiant
         other: Ein llywodraethiant
-        two:
-        zero:
+        two: 
+        zero: 
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Siarter gwybodaeth bersonol
         other: Siarteri gwybodaeth bersonol
-        two:
-        zero:
+        two: 
+        zero: 
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Deisebau ac ymgyrchoedd
         other: Deisebau ac ymgyrchoedd
-        two:
-        zero:
+        two: 
+        zero: 
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Papur polisi
         other: Papurau polisi
-        two:
-        zero:
+        two: 
+        zero: 
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Datganiad i'r wasg
         other: Datganiadau i'r wasg
-        two:
-        zero:
+        two: 
+        zero: 
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Caffael
         other: Caffael
-        two:
-        zero:
+        two: 
+        zero: 
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Deunydd hyrwyddo
         other: Deunyddiau hyrwyddo
-        two:
-        zero:
+        two: 
+        zero: 
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Cyhoeddiad
         other: Cyhoeddiadau
-        two:
-        zero:
+        two: 
+        zero: 
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Cynllun cyhoeddi
         other: Cynlluniau cyhoeddi
-        two:
-        zero:
+        two: 
+        zero: 
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Recriwtio
         other: Recriwtio
-        two:
-        zero:
+        two: 
+        zero: 
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Rheoliad
         other: Rheoliadau
-        two:
-        zero:
+        two: 
+        zero: 
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Ymchwil
         other: Ymchwil
-        two:
-        zero:
+        two: 
+        zero: 
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Gwasanaeth
         other: Gwasanaethau
-        two:
-        zero:
+        two: 
+        zero: 
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Defnydd o'r cyfryngau cymdeithasol
         other: Defnydd o'r cyfryngau cymdeithasol
-        two:
-        zero:
+        two: 
+        zero: 
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Nodiadau annerch
         other: Nodiadau annerch
-        two:
-        zero:
+        two: 
+        zero: 
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Anerchiad
         other: Anerchiadau
-        two:
-        zero:
+        two: 
+        zero: 
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Diweddariad staff
         other: Diweddariadau staff
-        two:
-        zero:
+        two: 
+        zero: 
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Safon
         other: Safonau
-        two:
-        zero:
+        two: 
+        zero: 
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Datganiad i'r Senedd
         other: Datganiadau i'r Senedd
-        two:
-        zero:
+        two: 
+        zero: 
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Set ddata ystadegol
         other: Setiau data ystadegol
-        two:
-        zero:
+        two: 
+        zero: 
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Ystadegau
         other: Ystadegau
-        two:
-        zero:
+        two: 
+        zero: 
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Canllawiau statudol
         other: Canllawiau statudol
-        two:
-        zero:
+        two: 
+        zero: 
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Cylch gorchwyl
         other: Cylch gorchwyl
-        two:
-        zero:
+        two: 
+        zero: 
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Trawsgrifiad
         other: Trawsgrifiadau
-        two:
-        zero:
+        two: 
+        zero: 
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Data tryloywder
         other: Data tryloywder
-        two:
-        zero:
+        two: 
+        zero: 
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Cynllun iaith Gymraeg
         other: Cynlluniau iaith Gymraeg
-        two:
-        zero:
+        two: 
+        zero: 
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Stori newyddion byd-eang
         other: Straeon newyddion byd-eang
-        two:
-        zero:
+        two: 
+        zero: 
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Datganiad ysgrifenedig i'r Senedd
         other: Datganiadau ysgrifenedig i'r Senedd
-        two:
-        zero:
+        two: 
+        zero: 
     updated: diweddarwyd
   document_filters:
     world_locations:
@@ -724,72 +724,72 @@ cy:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
     cy: Cymraeg
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Does dim diweddariadau eto.
     title: Y diweddaraf
@@ -801,7 +801,7 @@ cy:
       organisation_chart: Ein siart sefydliadol
       transparency: Data tryloywder
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Gwybodaeth gorfforaethol
       corporate_reports: Adroddiadau corfforaethol
@@ -818,10 +818,10 @@ cy:
   see_all:
     announcement: Gweld ein holl gyhoeddiadau
     authored_article: Gweld ein holl erthyglau ag awdur wedi'i enwi
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Gweld ein holl astudiaethau achos
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Gweld ein holl ymgynghoriadau caeedig
     consultation: Gweld ein holl ymgynghoriadau
     consultation_outcome: Gweld ein holl ganlyniadau o ymgynghoriadau
@@ -844,7 +844,7 @@ cy:
     news_article: Gweld ein holl erthyglau newyddion
     news_story: Gweld ein holl straeon newyddion
     notice: Gweld ein holl hysbysiadau
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Gweld ein holl ymgynghoriadau agored
     oral_statement: Gweld ein holl ddatganiadau llafar i'r Senedd
     policy: Gweld ein holl bolisïau
@@ -878,30 +878,30 @@ cy:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Chwilio yn ôl gwlad neu diriogaeth
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Dirprwyaeth ryngwladol
         other: Dirprwyaethau rhyngwladol
-        two:
-        zero:
+        two: 
+        zero: 
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Lleoliad byd-eang
         other: Lleoliadau byd-eang
-        two:
-        zero:
+        two: 
+        zero: 
   world_news:
     uk_updates_in_country: Diweddariadau, newyddion a digwyddiadau gan lywodraeth y DU yn %{country}
   worldwide_organisation:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -22,14 +22,14 @@ da:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Den vedhæftede fil
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Attachment command paper number
         hoc_paper_number: Underhusets dokument nummer
@@ -51,19 +51,19 @@ da:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ da:
       subheading: Vi har fundet nogle problemer med links, der kan indikere problemer, og du bør være forsigtig med at linke til dem
     title: Brudte links
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Luk
     closing_today: Lukning i dag
@@ -176,11 +176,11 @@ da:
         one: Blogindlæg
         other: Blogindlæg
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampagne
         other: Kampagner
@@ -191,8 +191,8 @@ da:
         one: Casestudie
         other: Casestudie
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Lukket konsultation
         other: Lukkede konsultationer
@@ -275,8 +275,8 @@ da:
         one: Medlemskab
         other: Medlemskab
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nationale statistikker
         other: Nationale statistikker
@@ -296,8 +296,8 @@ da:
         one: Officielle statistikker
         other: Officielle statistikker
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Åben konsultation
         other: Åbne konsultationer
@@ -405,72 +405,72 @@ da:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
     da: Dansk
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Der er ingen opdateringer endnu.
     title: Senest
@@ -482,7 +482,7 @@ da:
       organisation_chart: Vores organisationsdiagram
       transparency: Data om gennemsigtighed
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Virksomhedsoplysninger
       corporate_reports: Virksomhedsrapporter
@@ -499,10 +499,10 @@ da:
   see_all:
     announcement: Se alle vores meddelelser
     authored_article: Se alle vores forfattede artikler
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Se alle vores casestudier
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Se alle vores lukkede konsultationer
     consultation: Se alle vores konsultationer
     consultation_outcome: Se alle vores høringsresultater
@@ -525,7 +525,7 @@ da:
     news_article: Se alle vores nyhedsartikler
     news_story: Se alle vores nyhedshistorier
     notice: Se alle vores meddelelser
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Se alle vores lukkede konsultationer
     oral_statement: Se alle vores skriftlige erklæringer til Parlamentet
     policy: Se alle vores meddelelser
@@ -559,15 +559,15 @@ da:
       long_ordinal: "%e %B %Y%:%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Søg efter land eller område
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Internationale delegation

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -22,14 +22,14 @@ de:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Die angehängte Datei
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Anhang Anweisungspapier Nummer
         hoc_paper_number: Unterhauspapier Nummer
@@ -51,19 +51,19 @@ de:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ de:
       subheading: Wir haben einige Links gefunden, die auf Probleme hindeuten. Sie sollten bei der Verlinkung auf diese Links vorsichtig sein.
     title: Kaputte Links
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Geschlossen
     closing_today: Schließt heute
@@ -175,11 +175,11 @@ de:
         one: Blogbeitrag
         other: Blogbeiträge
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampagne
         other: Kampagnen
@@ -190,8 +190,8 @@ de:
         one: Fallstudie
         other: Fallstudien
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Abgeschlossene Beratung
         other: Abgeschlossene Beratungen
@@ -274,8 +274,8 @@ de:
         one: Mitgliedschaft
         other: Mitgliedschaft
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nationale Statistik
         other: Nationale Statistik
@@ -295,8 +295,8 @@ de:
         one: Statistiken
         other: Statistiken
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Laufende Beratung
         other: Laufende Beratungen
@@ -404,72 +404,72 @@ de:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
     de: Deutsch
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Es liegen noch keine Aktualisierungen vor.
     title: Neueste
@@ -481,7 +481,7 @@ de:
       organisation_chart: Unser Organisationsplan
       transparency: Transparenzdaten
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Unternehmensinformationen
       corporate_reports: Unternehmensberichte
@@ -498,10 +498,10 @@ de:
   see_all:
     announcement: Alle unsere Ankündigungen
     authored_article: Alle unsere Namensartikel
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Alle unsere Fallstudien
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Alle unsere abgeschlossenen Beratungen
     consultation: Alle unsere Beratungen
     consultation_outcome: Alle unsere Beratungsergebnisse
@@ -524,7 +524,7 @@ de:
     news_article: Alle unsere Nachrichtenartikel
     news_story: Alle unsere Nachrichtenberichte
     notice: Alle unsere Mitteilungen
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Alle unsere offenen Beratungen
     oral_statement: Alle unsere mündlichen Erklärungen vor dem Parlament
     policy: Alle unsere Richtlinien
@@ -558,15 +558,15 @@ de:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Nach Land oder Gebiet suchen
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Internationale Delegation

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -22,14 +22,14 @@ dr:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: فایل ضمیمه
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: شماره اوراق فرمان ضمیمه
         hoc_paper_number: مجلس اوراق عام با شماره
@@ -51,19 +51,19 @@ dr:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |-
@@ -92,10 +92,10 @@ dr:
       subheading: ما برخی موضوعات را در این لنک ها پیدا نموده ایم که ممکن است نشان دهندهء مشکلاتی باشند، در ضمیمه نمودن آنها باید احتیاط نمایید.
     title: لنک هایی تخریب شده
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: بسته شد
     closing_today: امروز بسته میشود
@@ -176,11 +176,11 @@ dr:
         one: پوست وبلاک
         other: پوست هایی وبلاگ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: کمپاین
         other: کمپاین ها
@@ -191,8 +191,8 @@ dr:
         one: مطالعهء موردی
         other: مطالعهء موردی ها
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: مشاورهء متوقف شده
         other: مشاوره هایی متوقف شده
@@ -275,8 +275,8 @@ dr:
         one: عضویت
         other: عضویت
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: آما ملی
         other: آمار ملی
@@ -296,8 +296,8 @@ dr:
         one: آمار رسمی
         other: آمار رسمی
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: مشاورهء آزاد
         other: مشاوره هایی آزاد
@@ -405,72 +405,72 @@ dr:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
     dr: دری
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: کدام آپدیتی تا هنوز موجود نیست
     title: جدیدترین ها
@@ -482,7 +482,7 @@ dr:
       organisation_chart: چارت سازمانی ما
       transparency: داده هایی شفافیت
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: اطلاعات شرکت
       corporate_reports: گزارشات شرکت
@@ -499,10 +499,10 @@ dr:
   see_all:
     announcement: تمام اعلانات ما را مشاهده نمایید
     authored_article: تمام مقالات تألیف شدهء ما را مشاهده نمایید
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: تمام مطالعات موردی مارا مشاهده نمایید
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: تمام مشاوره های تمام شدهء مارا مشاهده نمایید
     consultation: تمام مشاوره هایی ما را مشاهده نمایید
     consultation_outcome: نتایج تمام مشاوره هایی مارا مشاهده نمایید
@@ -525,7 +525,7 @@ dr:
     news_article: تمام مقلات خبری ما را مشاهده نمایید
     news_story: تمام گزارشات خبری ما را مشاهده نمایید
     notice: تمام اعلامیه هایی ما را مشاهده نمایید
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: تمام مشاوره هایی آزاد ما را مشاهده نمایید
     oral_statement: تمام بیانیه هایی شفاهی ما به پارلمان را مشاهده نمایید
     policy: تمام سیاست/خط مشی هایی ما را مشاهده نمایید
@@ -559,15 +559,15 @@ dr:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: جستجو به اساس کشور یا قلمرو
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: هیٔت بین المللی

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -22,14 +22,14 @@ el:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Το συνημμένο αρχείο
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Αριθμός συνημμένου εγγράφου εντολής
         hoc_paper_number: Αριθμός εγγράφου της Βουλής των Κοινοτήτων
@@ -51,19 +51,19 @@ el:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ el:
       subheading: Βρήκαμε ορισμένα προβλήματα με τους συνδέσμους που μπορεί να ενέχουν κίνδυνο. Θα πρέπει να είστε προσεκτικοί κατά τη σύνδεση σε αυτούς
     title: Σπασμένοι σύνδεσμοι
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Κλειστό
     closing_today: Κλείνει σήμερα
@@ -175,11 +175,11 @@ el:
         one: Ανάρτηση ιστολογίου
         other: Αναρτήσεις ιστολογίου
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Καμπάνια
         other: Καμπάνιες
@@ -190,8 +190,8 @@ el:
         one: Μελέτη περίπτωσης
         other: Μελέτες περιπτώσεων
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Κλειστή διαβούλευση
         other: Κλειστές διαβουλεύσεις
@@ -274,8 +274,8 @@ el:
         one: Ιδιότητα μέλους
         other: Ιδιότητα μέλους
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Εθνική Στατιστική Υπηρεσία
         other: Εθνική Στατιστική Υπηρεσία
@@ -295,8 +295,8 @@ el:
         one: Επίσημη Στατιστικά Στοιχεία
         other: Επίσημη Στατιστικά Στοιχεία
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Ανοιχτή διαβούλευση
         other: Ανοιχτές διαβουλεύσεις
@@ -404,72 +404,72 @@ el:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
     el: Ελληνικά
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Δεν υπάρχουν ακόμα ενημερώσεις.
     title: Πιο πρόσφατα
@@ -481,7 +481,7 @@ el:
       organisation_chart: Το οργανόγραμμα μας
       transparency: Δεδομένα διαφάνειας
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Εταιρικές πληροφορίες
       corporate_reports: Εταιρικές εκθέσεις
@@ -498,10 +498,10 @@ el:
   see_all:
     announcement: Δείτε όλες τις ανακοινώσεις
     authored_article: Δείτε όλα τα άρθρα
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Δείτε όλες τις μελέτες περιπτώσεων
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Δείτε όλες τις κλειστές διαβουλεύσεις
     consultation: Δείτε όλες τις διαβουλεύσεις
     consultation_outcome: Δείτε όλα τα αποτελέσματα της διαβούλευσης
@@ -524,7 +524,7 @@ el:
     news_article: Δείτε όλα τα άρθρα ειδήσεων
     news_story: Δείτε όλες τις ειδήσεις
     notice: Δείτε όλες τις ειδοποιήσεις
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Δείτε όλες τις ανοιχτές διαβουλεύσεις
     oral_statement: Δείτε όλες τις προφορικές δηλώσεις στη Βουλή
     policy: Δείτε όλες τις πολιτικές
@@ -558,15 +558,15 @@ el:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Αναζήτηση ανά χώρα ή περιοχή
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Διεθνής αντιπροσωπεία

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -22,14 +22,14 @@ es-419:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: El archivo adjunto
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Número del documento de pedido adjunto
         hoc_paper_number: Número del documento de la Cámara de los Comunes
@@ -51,19 +51,19 @@ es-419:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ es-419:
       subheading: Hemos encontrado algunos problemas con los enlaces que pueden indicar problemas, debe tener precaución al acceder a ellos
     title: Enlaces rotos
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Cerrado
     closing_today: Cierra hoy
@@ -176,11 +176,11 @@ es-419:
         one: Entrada del blog
         other: Entradas del blog
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campaña
         other: Campañas
@@ -191,8 +191,8 @@ es-419:
         one: Estudio de caso
         other: Estudios de caso
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Consulta restringida
         other: Consultas restringidas
@@ -275,8 +275,8 @@ es-419:
         one: Afiliación
         other: Afiliación
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Estadísticas nacionales
         other: Estadísticas nacionales
@@ -296,8 +296,8 @@ es-419:
         one: Estadísticas Oficiales
         other: Estadísticas Oficiales
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Consulta pública
         other: Consultas públicas
@@ -405,72 +405,72 @@ es-419:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
     es-419: Español de América Latina
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Aún no hay actualizaciones.
     title: Más reciente
@@ -482,7 +482,7 @@ es-419:
       organisation_chart: Nuestro organigrama
       transparency: Transparencia de datos
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Información corporativa
       corporate_reports: Informes de la empresa
@@ -499,10 +499,10 @@ es-419:
   see_all:
     announcement: Ver todos los anuncios
     authored_article: Ver todos los artículos de autoría
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Ver todos los estudios de casos
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Ver todas las consultas cerradas
     consultation: Ver todas las consultas
     consultation_outcome: Ver todos los resultados de nuestras consultas
@@ -525,7 +525,7 @@ es-419:
     news_article: Ver todos los artículos de noticias
     news_story: Ver todos los reportajes
     notice: Ver todos los avisos
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Ver todas las consultas abiertas
     oral_statement: Ver todas las declaraciones orales ante el Parlamento
     policy: Ver todas nuestras políticas
@@ -559,15 +559,15 @@ es-419:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Búsqueda por país o territorio
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Delegación internacional

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -22,14 +22,14 @@ es:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: El archivo adjunto
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Número de papel del comando de archivo adjunto
         hoc_paper_number: Número de documento de la Cámara de los Comunes
@@ -51,19 +51,19 @@ es:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: Si utiliza tecnología de asistencia (como un lector de pantalla) y necesita una versión de este documento en una formato más accesible, envíe un correo electrónico a %{email}. Díganos qué formato necesita. Para nosotros es importante saber qué tecnología de asistencia utiliza.
@@ -89,10 +89,10 @@ es:
       subheading: Hemos encontrado algunos problemas con enlaces que pueden indicar errores, debe tener cuidado al vincularse a estos
     title: Vínculos roto
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Cerrado
     closing_today: Cierre hoy
@@ -173,11 +173,11 @@ es:
         one: Entrada de blog
         other: Publicaciones del blog
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campaña
         other: Campañas
@@ -188,8 +188,8 @@ es:
         one: Caso de estudio práctico
         other: Casos de estudio práctico
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Consulta cerrada
         other: Consultas cerradas
@@ -272,8 +272,8 @@ es:
         one: Miembros
         other: Miembros
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Estadísticas - cifras nacionales
         other: Estadísticas - cifras nacionales
@@ -293,8 +293,8 @@ es:
         one: Estadísticas
         other: Estadísticas
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Consulta abierta
         other: Consultas abiertas
@@ -402,72 +402,72 @@ es:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
     es: Español
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: No hay actualizaciones
     title: Actualizaciones más recientes
@@ -479,7 +479,7 @@ es:
       organisation_chart: Nuestro organigrama
       transparency: Datos de transparencia
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Información corporativa
       corporate_reports: Informes corporativos
@@ -496,10 +496,10 @@ es:
   see_all:
     announcement: Ver toda nuestra anuncios
     authored_article: Ver toda nuestra artículos de autor
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Ver toda nuestra casos de estudio práctico
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Ver toda nuestra consultas cerradas
     consultation: Ver toda nuestra consultas
     consultation_outcome: Ver toda nuestra resultados de la consulta
@@ -522,7 +522,7 @@ es:
     news_article: Ver toda nuestra artículos
     news_story: Ver toda nuestra noticias
     notice: Ver todos nuestros avisos
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Ver toda nuestra consultas abiertas
     oral_statement: Ver toda nuestra declaraciones formuladas oralmente
     policy: Ver toda nuestra políticas
@@ -556,15 +556,15 @@ es:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Búsqueda por país o territorio
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Delegación internacional

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -22,14 +22,14 @@ et:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Lisatud fail
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Manuse käsudokumendi number
         hoc_paper_number: Alamkoja dokumendinumber
@@ -51,19 +51,19 @@ et:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ et:
       subheading: Leidsime lingidega küsitavusi, mis võivad viidata probleemidele, olge nende kasutamisel ettevaatlik
     title: Katkised lingid
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Suletud
     closing_today: Suletakse täna
@@ -175,11 +175,11 @@ et:
         one: Blogi postitus
         other: Blogi postitused
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampaania
         other: Kampaaniad
@@ -190,8 +190,8 @@ et:
         one: Juhtumiuuring
         other: Juhtumiuuringud
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Suletud konsultatsioon
         other: Suletud konsultatsioonid
@@ -274,8 +274,8 @@ et:
         one: Liikmelisus
         other: Liikmelisus
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Riiklik statistika
         other: Riiklik statistika
@@ -295,8 +295,8 @@ et:
         one: Ametlik statistika
         other: Ametlik statistika
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Avatud konsultatsioon
         other: Avatud konsultatsioonid
@@ -404,72 +404,72 @@ et:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
     et: Eesti
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Uuendusi pole veel.
     title: Viimased
@@ -481,7 +481,7 @@ et:
       organisation_chart: Meie organisatsiooni skeem
       transparency: Läbipaistvuse andmed
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Ettevõtte teave
       corporate_reports: Ettevõtte aruanded
@@ -498,10 +498,10 @@ et:
   see_all:
     announcement: Vaata kõiki meie teadaandeid
     authored_article: Vaata kõiki meie kirjutatud artikleid
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Vaata kõiki meie juhtumianalüüse
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Vaata kõiki meie suletud konsultatsioone
     consultation: Vaata kõiki meie konsultatsioone
     consultation_outcome: Vaata kõiki meie konsultatsioonitulemusi
@@ -524,7 +524,7 @@ et:
     news_article: Vaata kõiki meie uudiseartikleid
     news_story: Vaata kõiki meie uudislugusid
     notice: Vaata kõiki meie teateid
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Vaata kõiki meie avatud konsultatsioone
     oral_statement: Vaata kõiki meie suulisi avaldusi parlamendile
     policy: Vaata kõiki meie eeskirju
@@ -558,15 +558,15 @@ et:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Otsige riigi või territooriumi järgi
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Rahvusvaheline delegatsioon

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -22,14 +22,14 @@ fa:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: فایل پیوست شده
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: شماره سند فرمان پیوست
         hoc_paper_number: شماره سند مجلس عوام
@@ -51,19 +51,19 @@ fa:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ fa:
       subheading: ما در مورد برخی از لینک‌ها به مسائلی برخوردیم که ممکن است نشان دهنده وجود مشکلاتی باشند، در ارتباط با آنها باید احتیاط کنید
     title: لینک‌های خراب
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: بسته شده
     closing_today: امروز بسته شده
@@ -175,11 +175,11 @@ fa:
         one: پست وبلاگ
         other: پست‌های وبلاگ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: کمپین
         other: کمپین‌ها
@@ -190,8 +190,8 @@ fa:
         one: مطالعه موردی
         other: مطالعات موردی
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: مشاوره بسته
         other: مشاوره‌های بسته
@@ -274,8 +274,8 @@ fa:
         one: عضویت
         other: عضویت
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: آمار ملی
         other: آمار ملی
@@ -295,8 +295,8 @@ fa:
         one: آمار رسمی
         other: آمار رسمی
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: مشاوره باز
         other: مشاوره‌های باز
@@ -404,72 +404,72 @@ fa:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
     fa: فارسی
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: هنوز هیچ بروزرسانی وجود ندارد.
     title: آخرین
@@ -481,7 +481,7 @@ fa:
       organisation_chart: نمودار سازمانی ما
       transparency: داده‌های شفافیت
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: اطلاعات شرکت
       corporate_reports: گزارشات شرکتی
@@ -498,10 +498,10 @@ fa:
   see_all:
     announcement: مشاهده تمام اعلامیه‌های ما
     authored_article: مشاهده تمام مقالات تألیف شده ما
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: مشاهده تمام مطالعات موردی ما
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: مشاهده تمام مشاوره‌های بسته ما
     consultation: مشاهده تمام مشاوره‌های ما
     consultation_outcome: مشاهده تمام نتایج مشاوره‌های ما
@@ -524,7 +524,7 @@ fa:
     news_article: مشاهده تمام مقالات خبری ما
     news_story: مشاهده تمام گزارشات خبری ما
     notice: مشاهده تمام اطلاعیه‌های ما
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: مشاهده تمام مشاوره‌های باز ما
     oral_statement: مشاهده تمام بیانیه‌های شفاهی ما به پارلمان
     policy: مشاهده تمام سیاست‌های ما
@@ -558,15 +558,15 @@ fa:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: جستجو بر اساس کشور یا قلمرو
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: هیأت بین‌المللی

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -22,14 +22,14 @@ fi:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Liitetiedosto
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Liitetiedoston paperin numero
         hoc_paper_number: Alahuoneen asiakirjan numero
@@ -51,19 +51,19 @@ fi:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ fi:
       subheading: Olemme löytäneet joitakin ongelmia linkeissä, jotka voivat viitata ongelmiin, sinun on noudatettava varovaisuutta linkittämällä niihin
     title: Katkenneet linkit
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Suljettu
     closing_today: Suljetaan tänään
@@ -176,11 +176,11 @@ fi:
         one: Blogipostaus
         other: Blogiviestit
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampanja
         other: Kampanjat
@@ -191,8 +191,8 @@ fi:
         one: Tapaustutkimus
         other: Tapaustutkimuksia
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Suljettu kuuleminen
         other: Suljetut neuvottelut
@@ -275,8 +275,8 @@ fi:
         one: Jäsenyys
         other: Jäsenyys
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Kansalliset tilastot
         other: Kansalliset tilastot
@@ -296,8 +296,8 @@ fi:
         one: Viralliset tilastot
         other: Viralliset tilastot
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Avoin kuuleminen
         other: Avoimet kuulemiset
@@ -405,72 +405,72 @@ fi:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
     fi: suomi
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Ei vielä päivityksiä.
     title: Uusin
@@ -482,7 +482,7 @@ fi:
       organisation_chart: Organisaatiomme kaavio
       transparency: Avoimuustiedot
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Yritystiedot
       corporate_reports: Yritysraportit
@@ -499,10 +499,10 @@ fi:
   see_all:
     announcement: Katso kaikki ilmoituksemme
     authored_article: Katso kaikki kirjoittamamme artikkelit
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Katso kaikki tapaustutkimuksemme
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Katso kaikki suljetut konsultaatiomme
     consultation: Katso kaikki konsultaatiomme
     consultation_outcome: Katso kaikki kuulemistuloksemme
@@ -525,7 +525,7 @@ fi:
     news_article: Katso kaikki uutiset
     news_story: Katso kaikki uutisemme
     notice: Katso kaikki ilmoituksemme
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Katso kaikki avoimet neuvottelumme
     oral_statement: Katso kaikki suulliset lausuntomme parlamentille
     policy: Tutustu kaikkiin käytäntöihimme
@@ -559,15 +559,15 @@ fi:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Hae maan tai alueen mukaan
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Kansainvälinen valtuuskunta

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,14 +22,14 @@ fr:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Le fichier joint
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Numéro du document de la commande de pièce jointe
         hoc_paper_number: Numéro du document de la Chambre des Communes
@@ -51,19 +51,19 @@ fr:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |-
@@ -92,10 +92,10 @@ fr:
       subheading: Certains liens que nous avons trouvés peuvent présenter des problèmes. Nous vous recommandons de faire preuve de prudence lorsque vous établissez des liens vers ces derniers
     title: Liens brisés
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Fermé
     closing_today: Fermeture aujourd'hui
@@ -176,11 +176,11 @@ fr:
         one: Article de blog
         other: Articles de blog
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campagne
         other: Campagnes
@@ -191,8 +191,8 @@ fr:
         one: Etude de cas
         other: Etudes de cas
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Consultation fermée
         other: Consultations fermées
@@ -275,8 +275,8 @@ fr:
         one: Adhésion
         other: Adhésion
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Statistiques nationales
         other: Statistiques nationales
@@ -296,8 +296,8 @@ fr:
         one: Statistiques officielles
         other: Statistiques officielles
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Consultation ouverte
         other: Consultations ouvertes
@@ -405,72 +405,72 @@ fr:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
     fr: Français
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Aucune mise à jour n'a encore été effectuée.
     title: Récent
@@ -482,7 +482,7 @@ fr:
       organisation_chart: Notre charte organisationnelle
       transparency: Données de transparence
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informations sur l'entreprise
       corporate_reports: Rapports d'entreprise
@@ -499,10 +499,10 @@ fr:
   see_all:
     announcement: Afficher toutes nos annonces
     authored_article: Afficher toutes nos articles signés
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Afficher toutes nos etudes de cas
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Afficher toutes nos consultations fermées
     consultation: Afficher toutes nos consultations
     consultation_outcome: Afficher tous nos résultats de consultation
@@ -525,7 +525,7 @@ fr:
     news_article: Afficher tous nos articles d'actualité
     news_story: Afficher toutes nos actualités
     notice: Afficher tous nos avis
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Afficher toutes nos consultations ouvertes
     oral_statement: Afficher toutes nos déclarations orales au parlement
     policy: Afficher toutes nos politiques générales
@@ -559,15 +559,15 @@ fr:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Recherche par pays ou territoire
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Délégation internationale

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -22,14 +22,14 @@ gd:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: An comhad ceangailte
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Uimhir doiciméad Theach na dTeachtaí
         hoc_paper_number: Uimhir doiciméad Theach na dTeachtaí
@@ -51,19 +51,19 @@ gd:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ gd:
       subheading: Táimid tar éis teacht ar naisc a d'fhéadfadh lochtanna a léiriú agus molaimid duit a bheith cúramach agus tú ag nascadh leis na suíomhanna seo.
     title: Naisc bhriste
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Gnólacht
     closing_today: Dúnta inniu
@@ -151,405 +151,405 @@ gd:
       written_on: 'Scríofa i:'
     type:
       about:
-        few:
+        few: 
         one: Faoi
         other: Faoi
-        two:
+        two: 
       about_our_services:
-        few:
+        few: 
         one: Maidir lenár seirbhísí
         other: Maidir lenár seirbhísí
-        two:
+        two: 
       access_and_opening:
-        few:
+        few: 
         one: Rochtain agus oscailte
         other: Rochtain agus oscailte
-        two:
+        two: 
       accessible_documents_policy:
-        few:
+        few: 
         one: Beartas Doiciméid Inrochtana
         other: Beartas Doiciméid Inrochtana
-        two:
+        two: 
       alert:
-        few:
+        few: 
         one: Aláram
         other: Aláram
-        two:
+        two: 
       announcement:
-        few:
+        few: 
         one: Fógra
         other: Fógra
-        two:
+        two: 
       authored_article:
-        few:
+        few: 
         one: Ailt scríofa
         other: Téacsanna scríofa
-        two:
+        two: 
       blog_post:
-        few:
+        few: 
         one: Post blag
         other: Post blag
-        two:
+        two: 
       call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       campaign:
-        few:
+        few: 
         one: Gníomhaíocht
         other: Gníomhaíocht
-        two:
+        two: 
       careers:
-        few:
+        few: 
         one: Gairm
         other: Gairm
-        two:
+        two: 
       case_study:
-        few:
+        few: 
         one: Cás-staidéir
         other: Tuarascálacha staidéir
-        two:
+        two: 
       closed_call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       closed_consultation:
-        few:
+        few: 
         one: Nós imeachta comhairliúcháin dúnta
         other: Téigh i gcomhairle go príobháideach
-        two:
+        two: 
       complaints_procedure:
-        few:
+        few: 
         one: Nós imeachta gearán
         other: Nós imeachta gearán
-        two:
+        two: 
       consultation:
-        few:
+        few: 
         one: Comhairliúchán
         other: Téigh i gcomhairle
-        two:
+        two: 
       consultation_outcome:
-        few:
+        few: 
         one: Torthaí comhairliúcháin
         other: Torthaí comhairliúcháin
-        two:
+        two: 
       corporate_report:
-        few:
+        few: 
         one: Tuarascáil cuideachta
         other: Tuarascálacha cuideachta
-        two:
+        two: 
       correspondence:
-        few:
+        few: 
         one: Comhfhreagras
         other: Comhfhreagras
-        two:
+        two: 
       decision:
-        few:
+        few: 
         one: Cinneadh
         other: Cinntí
-        two:
+        two: 
       detailed_guidance:
-        few:
+        few: 
         one: Treoshuíomh
         other: Treoshuíomh
-        two:
+        two: 
       document_collection:
-        few:
+        few: 
         one: Bailiúchán
         other: Bailiúcháin
-        two:
+        two: 
       draft_text:
-        few:
+        few: 
         one: Tionscadail téacs
         other: Dréacht-téacsanna
-        two:
+        two: 
       edition:
-        few:
+        few: 
         one: Cuir in eagar
         other: Leagan
-        two:
+        two: 
       edition_with_appointment:
-        few:
+        few: 
         one: Leagan áirithinte
         other: Leagan ceapacháin
-        two:
+        two: 
       equality_and_diversity:
-        few:
+        few: 
         one: Comhionannas agus éagsúlacht
         other: Comhionannas agus éagsúlacht
-        two:
+        two: 
       fatality_notice:
-        few:
+        few: 
         one: Obituary
         other: Obituary
-        two:
+        two: 
       foi_release:
-        few:
+        few: 
         one: Preasráiteas FAITH
         other: Scaoileadh Shaoráil Faisnéise
-        two:
+        two: 
       form:
-        few:
+        few: 
         one: Foirm
         other: Foirmeacha
-        two:
+        two: 
       generic_edition:
-        few:
+        few: 
         one: Eagrán Uilíoch
         other: Leagan cineálach
-        two:
+        two: 
       government_response:
-        few:
+        few: 
         one: Freagra an Rialtais
         other: Freagraí an Rialtais
-        two:
+        two: 
       guidance:
-        few:
+        few: 
         one: Treoshuíomh
         other: Treoshuíomh
-        two:
+        two: 
       impact_assessment:
-        few:
+        few: 
         one: Anailís Tionchair
         other: Anailísí tionchair
-        two:
+        two: 
       imported:
-        few:
+        few: 
         one: allmhairithe - cineál ar feitheamh
         other: allmhairithe - cineál ar feitheamh
-        two:
+        two: 
       independent_report:
-        few:
+        few: 
         one: Tuarascálacha neamhspleácha
         other: Tuarascálacha neamhspleácha
-        two:
+        two: 
       international_treaty:
-        few:
+        few: 
         one: Conradh idirnáisiúnta
         other: Conarthaí idirnáisiúnta
-        two:
+        two: 
       manual:
-        few:
+        few: 
         one: Lámhleabhar
         other: lámhleabhar
-        two:
+        two: 
       map:
-        few:
+        few: 
         one: Roghchlár
         other: Cártaí
-        two:
+        two: 
       media_enquiries:
-        few:
+        few: 
         one: Suirbhé ar na meáin
         other: Fiosrúcháin ó na meáin
-        two:
+        two: 
       membership:
-        few:
+        few: 
         one: Staitisticí náisiúnta
         other: Staitisticí náisiúnta
-        two:
+        two: 
       modern_slavery_statement:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       national_statistics:
-        few:
+        few: 
         one: Staitisticí náisiúnta
         other: Staitisticí náisiúnta
-        two:
+        two: 
       news_article:
-        few:
+        few: 
         one: Airteagal Nuachta
         other: Airteagal Nuachta
-        two:
+        two: 
       news_story:
-        few:
+        few: 
         one: Airteagal Nuachta
         other: Nua
-        two:
+        two: 
       nhs_content:
-        few:
+        few: 
         one: Ábhar Seirbhís sláinte náisiúnta
         other: Ábhar Seirbhís sláinte náisiúnta
-        two:
+        two: 
       notice:
-        few:
+        few: 
         one: Tuairim
         other: Tuairim
-        two:
+        two: 
       official_statistics:
-        few:
+        few: 
         one: Staitisticí oifigiúla
         other: Staitisticí oifigiúla
-        two:
+        two: 
       open_call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       open_consultation:
-        few:
+        few: 
         one: Comhairliúcháin oscailte
         other: Comhairliúcháin oscailte
-        two:
+        two: 
       oral_statement:
-        few:
+        few: 
         one: Ráiteas ó bhéal don Pharlaimint
         other: Ráiteas ó bhéal don Pharlaimint
-        two:
+        two: 
       our_energy_use:
-        few:
+        few: 
         one: Ár n-ídiú fuinnimh
         other: Ár n-ídiú fuinnimh
-        two:
+        two: 
       our_governance:
-        few:
+        few: 
         one: Ár rialachas
         other: Ár rialachas
-        two:
+        two: 
       personal_information_charter:
-        few:
+        few: 
         one: Cairt Faisnéise Pearsanta
         other: Cairt Faisnéise Pearsanta
-        two:
+        two: 
       petitions_and_campaigns:
-        few:
+        few: 
         one: Achainíocha agus imeachtaí
         other: Achainíocha agus imeachtaí
-        two:
+        two: 
       policy_paper:
-        few:
+        few: 
         one: Doiciméad beartais
         other: Doiciméad beartais
-        two:
+        two: 
       press_release:
-        few:
+        few: 
         one: Preaseisiúint
         other: Preaseisiúintí
-        two:
+        two: 
       procurement:
-        few:
+        few: 
         one: Margadh oscailte
         other: Margadh oscailte
-        two:
+        two: 
       promotional:
-        few:
+        few: 
         one: Ábhar cur chun cinn
         other: Ábhar cur chun cinn
-        two:
+        two: 
       publication:
-        few:
+        few: 
         one: Foilsiú
         other: Foilseacháin
-        two:
+        two: 
       publication_scheme:
-        few:
+        few: 
         one: Córas foilsitheoireachta
         other: Córas foilsitheoireachta
-        two:
+        two: 
       recruitment:
-        few:
+        few: 
         one: Earcaíocht
         other: Earcaíocht
-        two:
+        two: 
       regulation:
-        few:
+        few: 
         one: Rialacha
         other: Rialacháin
-        two:
+        two: 
       research:
-        few:
+        few: 
         one: Taighde
         other: Taighde
-        two:
+        two: 
       service:
-        few:
+        few: 
         one: Seirbhís
         other: Seirbhísí
-        two:
+        two: 
       social_media_use:
-        few:
+        few: 
         one: Úsáid na meán sóisialta
         other: Úsáid na meán sóisialta
-        two:
+        two: 
       speaking_notes:
-        few:
+        few: 
         one: Nótaí Labhairt
         other: Nótaí Labhairt
-        two:
+        two: 
       speech:
-        few:
+        few: 
         one: óráid
         other: óráid
-        two:
+        two: 
       staff_update:
-        few:
+        few: 
         one: Nuashonrú foirne
         other: Nuashonrú foirne
-        two:
+        two: 
       standard:
-        few:
+        few: 
         one: Caighdeán
         other: Caighdeán
-        two:
+        two: 
       statement_to_parliament:
-        few:
+        few: 
         one: Ráiteas don Pharlaimint
         other: Ráitis sa Pharlaimint
-        two:
+        two: 
       statistical_data_set:
-        few:
+        few: 
         one: Tacar sonraí staidrimh
         other: Tacair sonraí staidrimh
-        two:
+        two: 
       statistics:
-        few:
+        few: 
         one: Sonraí staidrimh
         other: Sonraí staidrimh
-        two:
+        two: 
       statutory_guidance:
-        few:
+        few: 
         one: Treoir reachtúil
         other: Treoir reachtúil
-        two:
+        two: 
       terms_of_reference:
-        few:
+        few: 
         one: Téarmaí tagartha
         other: Téarmaí tagartha
-        two:
+        two: 
       transcript:
-        few:
+        few: 
         one: Tras-scríobh
         other: Athscríbhinní
-        two:
+        two: 
       transparency:
-        few:
+        few: 
         one: Sonraí trédhearcachta
         other: Sonraí trédhearcachta
-        two:
+        two: 
       welsh_language_scheme:
-        few:
+        few: 
         one: Aiste bia Breatnaise
         other: Cúrsaí Breatnaise
-        two:
+        two: 
       world_news_story:
-        few:
+        few: 
         one: Nuacht ó gach cearn den domhan
         other: Nuacht ó gach cearn den domhan
-        two:
+        two: 
       written_statement:
-        few:
+        few: 
         one: Dearbhú i scríbhinn don Pharlaimint
         other: Ráitis i scríbhinn don Pharlaimint
-        two:
+        two: 
     updated: arna chur suas
   document_filters:
     world_locations:
@@ -564,72 +564,72 @@ gd:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
     gd: Gaeilge
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Gan nuashonrú fós.
     title: le déanaí
@@ -641,7 +641,7 @@ gd:
       organisation_chart: Ár gcairt eagraíochta
       transparency: Sonraí trédhearcachta
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Faisnéis cuideachta
       corporate_reports: Tuarascálacha cuideachta
@@ -658,10 +658,10 @@ gd:
   see_all:
     announcement: Féach ar ár bhfógraí uile
     authored_article: Féach ar ár n-alt scríofa go léir
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Féach ar ár gcás-staidéir go léir
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Féach ar ár gcomhairliúcháin dúnta go léir
     consultation: Féach ar ár bhfiosrúcháin go léir
     consultation_outcome: Féach ar thorthaí uile ár gcomhairliúcháin
@@ -684,7 +684,7 @@ gd:
     news_article: Féach ar ár n-alt nuachta go léir
     news_story: Féach ar ár n-alt nuachta go léir
     notice: Féach ar ár n-athbhreithnithe go léir
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Féach ar ár gcomhairliúcháin phoiblí go léir
     oral_statement: Féach ar ár ráitis ó bhéal go léir sa Pharlaimint
     policy: Féach ar ár mbeartais go léir
@@ -718,26 +718,26 @@ gd:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Cuardaigh de réir tíre nó réigiúin
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Toscaireacht idirnáisiúnta
         other: Toscaireacht idirnáisiúnta
-        two:
+        two: 
       world_location:
-        few:
+        few: 
         one: Seasamh ar domhan
         other: Áit ar domhan
-        two:
+        two: 
   world_news:
     uk_updates_in_country: Nuashonruithe, imeachtaí agus nuacht rialtas na RA %{country}
   worldwide_organisation:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -22,14 +22,14 @@ gu:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: એટેચ કરેલ ફાઇલ
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: એટેચમેંટ આદેશ પેપર નંબર
         hoc_paper_number: હાઉસ ઓફ કૉમન્સ પેપર નંબર
@@ -51,19 +51,19 @@ gu:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ gu:
       subheading: અમને આ દસ્તાવેજમાં લિંક્સ મળેલ છે, જે તૂટેલી હોય શકે છે આ લિંક્સમાં અમને કેટલીક સમસ્યાઓ મળી આવી છે જે મુશ્કેલી તરફ ઈશારો કરતી હોઈ શકે છે. તેની સાથે જોડાતી વખતે તમારે સાવચેતી રાખવી જોઈએ
     title: તૂટેલી લિંક્સ
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: બંધ થયું
     closing_today: આજે બંધ થાય છે
@@ -175,11 +175,11 @@ gu:
         one: બ્લૉગ પોસ્ટ
         other: બ્લૉગ પોસ્ટ્સ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: ઝુંબેશ
         other: ઝુંબેશો
@@ -190,8 +190,8 @@ gu:
         one: કેસ સ્ટડી
         other: કેસ સ્ટડીઝ
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: બંધ થયેલ પરામર્શ
         other: બંધ થયેલ પરામર્શ
@@ -274,8 +274,8 @@ gu:
         one: સભ્યપદ
         other: સભ્યપદ
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: રાષ્ટ્રીય આંકડા
         other: રાષ્ટ્રીય આંકડા
@@ -295,8 +295,8 @@ gu:
         one: અધિકૃત આંકડા
         other: અધિકૃત આંકડા
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: ખુલ્લો પરામર્શ
         other: ખુલ્લા પરામર્શ
@@ -404,72 +404,72 @@ gu:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
     gu: જોર્જિયન
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: હજુ સુધી કોઈ અપડેટ્સ નથી.
     title: નવીનતમ
@@ -481,7 +481,7 @@ gu:
       organisation_chart: અમારી સંસ્થાનો ચાર્ટ
       transparency: પારદર્શિતા ડેટા
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: કોર્પોરેટ માહિતી
       corporate_reports: કોર્પોરેટ અહેવાલો
@@ -498,10 +498,10 @@ gu:
   see_all:
     announcement: અમારી તમામ ઘોષણાઓ જુઓ
     authored_article: અમારા તમામ લેખિત લેખો જુઓ
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: અમારી તમામ કેસ સ્ટડીઝ જુઓ
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: અમારા તમામ બંધ થયેલ પરામર્શ જુઓ
     consultation: અમારા તમામ પરામર્શ જુઓ
     consultation_outcome: અમારા પરામર્શના તમામ પરિણામો જુઓ
@@ -524,7 +524,7 @@ gu:
     news_article: અમારા તમામ ન્યૂઝ આર્ટિકલ્સ જુઓ
     news_story: અમારી તમામ ન્યૂઝ સ્ટોરીઝ જુઓ
     notice: અમારી તમામ સૂચનાઓ જુઓ
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: અમારા તમામ ખુલ્લા પરામર્શ જુઓ
     oral_statement: અમારા સંસદમાં કરેલ તમામ મૌખિક નિવેદનો જુઓ
     policy: અમારી બધી નીતિઓ જુઓ
@@ -558,15 +558,15 @@ gu:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: દેશ અથવા ટેરિટરીથી શોધો
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: આંતરરાષ્ટ્રીય પ્રતિનિધિમંડળ

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -22,14 +22,14 @@ he:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: הקובץ המצורף
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: מספר נייר הפקודה המצורפת
         hoc_paper_number: מספר הנייר של בית הנבחרים
@@ -51,19 +51,19 @@ he:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ he:
       subheading: 'מצאנו כמה בעיות עם קישורים שעשויים להצביע על בעיות, עליך לנקוט משנה זהירות בקישור אליהם '
     title: קישורים מנותקים
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: סגור
     closing_today: נסגר היום
@@ -176,11 +176,11 @@ he:
         one: רשומת בלוג
         other: רשומות בלוג
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: קמפיין
         other: קמפיינים
@@ -191,8 +191,8 @@ he:
         one: מקרה בוחן
         other: מקרי בוחן
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: דיון סגור
         other: דיונים סגורים
@@ -275,8 +275,8 @@ he:
         one: חברות
         other: חברות
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: סטטיסטיקה לאומית
         other: סטטיסטיקה לאומית
@@ -296,8 +296,8 @@ he:
         one: סטטיסטיקה רשמית
         other: סטטיסטיקה רשמית
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: דיון פתוח
         other: דיונים  פתוחים
@@ -405,72 +405,72 @@ he:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
     he: עברית
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: אין עדכונים נוספים.
     title: אחרון
@@ -482,7 +482,7 @@ he:
       organisation_chart: תרשים הארגון שלנו
       transparency: שקיפות מידע
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: מידע תאגידי
       corporate_reports: דו"חות משותפים
@@ -499,10 +499,10 @@ he:
   see_all:
     announcement: ראה כל הודעות
     authored_article: ראה כל מאמרים מאושרים
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: ראה כל מקרי בוחן
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: ראה כל דיונים סגורים
     consultation: ראה כל דיונים
     consultation_outcome: ראה כל תוצאות דיונים
@@ -525,7 +525,7 @@ he:
     news_article: ראה כל מאמרי חדשות
     news_story: ראה כל חדשות
     notice: ראה כל הודעות
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: ראה כל דיונים  פתוחים
     oral_statement: ראה כל הצהרות בעל פה לפרלמנט
     policy: ראה כל מדיניות
@@ -559,15 +559,15 @@ he:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: חפש לפי מדינה או שטח
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: משלחת בינלאומית

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -22,14 +22,14 @@ hi:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: संलग्न हुई फा़इल
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: अटैचमेंट कमांड पेपर नंबर
         hoc_paper_number: हाउस ऑफ कॉमन्स पेपर नंबर
@@ -51,19 +51,19 @@ hi:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ hi:
       subheading: हमें लिंक में कुछ समस्याएं मिली हैं जिनसे दिक्कतों का संकेत मिल सकता है, आपको उन्हें लिंक करते समय सावधानी बरतनी चाहिए
     title: ब्रोकन लिंक
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: बंद हो गया
     closing_today: आज बंद हो रहा है
@@ -176,11 +176,11 @@ hi:
         one: ब्लॉग पोस्ट
         other: ब्लॉग पोस्ट
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: अभियान
         other: अभियान
@@ -191,8 +191,8 @@ hi:
         one: विषय अध्ययन
         other: विषय अध्ययन
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: बंद कमरे में परामर्श
         other: बंद कमरे में परामर्श
@@ -275,8 +275,8 @@ hi:
         one: सदस्यता
         other: सदस्यता
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: राष्ट्रीय सांख्यिकी
         other: राष्ट्रीय सांख्यिकी
@@ -296,8 +296,8 @@ hi:
         one: आधिकारिक सांख्यिकी
         other: आधिकारिक सांख्यिकी
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: खुला परामर्श
         other: खुले परामर्श
@@ -405,72 +405,72 @@ hi:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
     hi: हिंदी
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: अभी तक कोई नए समाचार नहीं हैं।
     title: नवीनतम
@@ -482,7 +482,7 @@ hi:
       organisation_chart: हमारी संस्था का चार्ट
       transparency: पारदर्शिता आंकड़े
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: कारपोरेट सूचना
       corporate_reports: कॉरपोरेट विवरण
@@ -499,10 +499,10 @@ hi:
   see_all:
     announcement: देखें हमारे सभी घोषणाएं
     authored_article: देखें हमारे सभी मूल आलेख
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: देखें हमारे सभी विषय अध्ययन
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: देखें हमारे सभी बंद कमरे में परामर्श
     consultation: देखें हमारे सभी परामर्श
     consultation_outcome: देखें हमारे सभी परामर्श के नतीजे
@@ -525,7 +525,7 @@ hi:
     news_article: देखें हमारे सभी समाचार लेख
     news_story: देखें हमारे सभी समाचार कथाएं
     notice: हमारी सभी नोटिस देखें
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: देखें हमारे सभी खुले परामर्श
     oral_statement: देखें हमारे सभी संसद में मौखिक बयान
     policy: देखें हमारे सभी नीतियां
@@ -559,15 +559,15 @@ hi:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: देश या क्षेत्र से खोजें
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: अंतर्राष्ट्रीय प्रतिनिधिमंडल

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -22,14 +22,14 @@ hr:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Datoteka u privitku
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Broj papira naredbe za privitak
         hoc_paper_number: Broj papira Donjeg doma
@@ -51,19 +51,19 @@ hr:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |-
@@ -92,10 +92,10 @@ hr:
       subheading: Otkrili smo neke probleme s vezama koji mogu ukazivati na probleme. Morate biti oprezni pri povezivanju s njima
     title: Neispravni linkovi
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Zatvoreno
     closing_today: Zatvara se danas
@@ -152,323 +152,323 @@ hr:
       written_on: 'Napisano na:'
     type:
       about:
-        few:
+        few: 
         one: O nama
         other: O nama
       about_our_services:
-        few:
+        few: 
         one: O našim uslugama
         other: O našim uslugama
       access_and_opening:
-        few:
+        few: 
         one: Pristup i otvaranje
         other: Pristup i otvaranje
       accessible_documents_policy:
-        few:
+        few: 
         one: Politika pristupačnih dokumenata
         other: Politika pristupačnih dokumenata
       alert:
-        few:
+        few: 
         one: Upozorenje
         other: Upozorenja
       announcement:
-        few:
+        few: 
         one: Obavijest
         other: Obavijesti
       authored_article:
-        few:
+        few: 
         one: Autorski članak
         other: Autorski članci
       blog_post:
-        few:
+        few: 
         one: Postavka bloga
         other: Postavke bloga
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Kampanja
         other: Kampanje
       careers:
-        few:
+        few: 
         one: Karijere
         other: karijere
       case_study:
-        few:
+        few: 
         one: Studija slučaja
         other: Studije slučaja
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Zatvorena konzultacija
         other: Zatvorene konzultacije
       complaints_procedure:
-        few:
+        few: 
         one: Postupak prigovora
         other: Postupci prigovora
       consultation:
-        few:
+        few: 
         one: Konzultacija
         other: Konzultacije
       consultation_outcome:
-        few:
+        few: 
         one: Ishod konzultacija
         other: Ishodi konzultacija
       corporate_report:
-        few:
+        few: 
         one: Korporativno izvješće
         other: Korporativna izvješća
       correspondence:
-        few:
+        few: 
         one: Prepiska
         other: Prepiske
       decision:
-        few:
+        few: 
         one: Odluka
         other: Odluke
       detailed_guidance:
-        few:
+        few: 
         one: Upute
         other: Upute
       document_collection:
-        few:
+        few: 
         one: Kolekcija
         other: Kolekcije
       draft_text:
-        few:
+        few: 
         one: Nacrt teksta
         other: Nacrt tekstova
       edition:
-        few:
+        few: 
         one: Izdanje
         other: Izdanja
       edition_with_appointment:
-        few:
+        few: 
         one: Izdanje sa dogovorom
         other: Izdanja sa dogovorom
       equality_and_diversity:
-        few:
+        few: 
         one: Jednakost i raznolikost
         other: Jednakost i raznolikost
       fatality_notice:
-        few:
+        few: 
         one: Obavijest o smrtnom slučaju
         other: Obavijest o smrtnim slučajevima
       foi_release:
-        few:
+        few: 
         one: Izdanje slobode informacija
         other: Izdanja slobode informacija
       form:
-        few:
+        few: 
         one: Obrazac
         other: Obrasci
       generic_edition:
-        few:
+        few: 
         one: Opće izdanje
         other: Opća izdanja
       government_response:
-        few:
+        few: 
         one: Odgovor vlade
         other: Odgovori vlade
       guidance:
-        few:
+        few: 
         one: Upute
         other: Upute
       impact_assessment:
-        few:
+        few: 
         one: Procjena utjecaja
         other: Procjene utjecaja
       imported:
-        few:
+        few: 
         one: uvezeno - čekajući tip
         other: uvezeno - čekajući tip
       independent_report:
-        few:
+        few: 
         one: Nezavisno izvješće
         other: Nezavisna izvješća
       international_treaty:
-        few:
+        few: 
         one: Međunarodni ugovor
         other: Međunarodni ugovori
       manual:
-        few:
+        few: 
         one: Priručnik
         other: Priručnici
       map:
-        few:
+        few: 
         one: Karta
         other: Karte
       media_enquiries:
-        few:
+        few: 
         one: Medijski upit
         other: Upiti za medije
       membership:
-        few:
+        few: 
         one: Članstvo
         other: Članstvo
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Nacionalna statistika
         other: Nacionalna statistika
       news_article:
-        few:
+        few: 
         one: Novinski članak
         other: Novinski članci
       news_story:
-        few:
+        few: 
         one: Novosti
         other: Novosti
       nhs_content:
-        few:
+        few: 
         one: Sadržaj nacionalne zdravstvene službe
         other: Sadržaj nacionalne zdravstvene službe
       notice:
-        few:
+        few: 
         one: Obavijest
         other: Obavijesti
       official_statistics:
-        few:
+        few: 
         one: Službena statistika
         other: Službene statistike
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Otvorena konzultacija
         other: Otvorene konzultacije
       oral_statement:
-        few:
+        few: 
         one: Usmena izjava Parlamentu
         other: Usmene izjave Parlamentu
       our_energy_use:
-        few:
+        few: 
         one: Naša potrošnja energije
         other: Naša potrošnja energije
       our_governance:
-        few:
+        few: 
         one: Naše upravljanje
         other: Naše upravljanje
       personal_information_charter:
-        few:
+        few: 
         one: Povelja o osobnim podacima
         other: Povelje o osobnim podacima
       petitions_and_campaigns:
-        few:
+        few: 
         one: Peticije i kampanje
         other: Peticije i kampanje
       policy_paper:
-        few:
+        few: 
         one: Dokument o pravilima
         other: Dokument o pravilima
       press_release:
-        few:
+        few: 
         one: Saopćenje za javnost
         other: Saopćenja za javnost
       procurement:
-        few:
+        few: 
         one: Nabavka
         other: Nabavka
       promotional:
-        few:
+        few: 
         one: Promidžbeni materijal
         other: Promidžbeni materijal
       publication:
-        few:
+        few: 
         one: Izdanje
         other: Izdanja
       publication_scheme:
-        few:
+        few: 
         one: Shema izdanja
         other: Sheme izdanja
       recruitment:
-        few:
+        few: 
         one: Zapošljavanje
         other: Zapošljavanje
       regulation:
-        few:
+        few: 
         one: Regulacija
         other: Regulacije
       research:
-        few:
+        few: 
         one: Istraživanje
         other: Istraživanje
       service:
-        few:
+        few: 
         one: Usluga
         other: Usluge
       social_media_use:
-        few:
+        few: 
         one: Korištenje društvenih medija
         other: Korištenje društvenih medija
       speaking_notes:
-        few:
+        few: 
         one: Govorne bilješke
         other: Govorne bilješke
       speech:
-        few:
+        few: 
         one: Govor
         other: Govori
       staff_update:
-        few:
+        few: 
         one: Ažuriranje osoblja
         other: Ažuriranje osoblja
       standard:
-        few:
+        few: 
         one: Standard
         other: Standardi
       statement_to_parliament:
-        few:
+        few: 
         one: Izjava Parlamentu
         other: Izjave Parlamentu
       statistical_data_set:
-        few:
+        few: 
         one: Skup statističkih podataka
         other: Skupovi statističkih podataka
       statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
       statutory_guidance:
-        few:
+        few: 
         one: Zakonske smjernice
         other: Zakonske smjernice
       terms_of_reference:
-        few:
+        few: 
         one: Projektni zadatak
         other: Projektni zadatak
       transcript:
-        few:
+        few: 
         one: Prijepis
         other: Prijepisi
       transparency:
-        few:
+        few: 
         one: Podaci o transparentnosti
         other: Podaci o transparentnosti
       welsh_language_scheme:
-        few:
+        few: 
         one: Shema velškog jezika
         other: Sheme velškog jezika
       world_news_story:
-        few:
+        few: 
         one: Vijesti širom svijeta
         other: Vijesti širom svijeta
       written_statement:
-        few:
+        few: 
         one: Pismena izjava Parlamentu
         other: Pismene izjave Parlamentu
     updated: ažurirano
@@ -485,72 +485,72 @@ hr:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
     hr: Hrvatski
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Još nema ažuriranja.
     title: Najnoviji
@@ -562,7 +562,7 @@ hr:
       organisation_chart: Naša shema organizacije
       transparency: Podaci o transparentnosti
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Korporativne informacije
       corporate_reports: Korporativna izvješća
@@ -579,10 +579,10 @@ hr:
   see_all:
     announcement: Pogledajte sve naše obavijesti
     authored_article: Pogledajte sve naše autorske članke
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Pogledajte sve naše studije slučaja
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Pogledajte sve naše zatvorene konzultacije
     consultation: Pogledajte sve naše konzultacije
     consultation_outcome: Pogledajte sve naše rezultate konzultacija
@@ -605,7 +605,7 @@ hr:
     news_article: Pogledajte sve naše članke
     news_story: Pogledajte sve naše vijesti
     notice: Pogledajte sve naše obavijesti
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Pogledajte sve naše otvorene konzultacije
     oral_statement: Pogledajte sve naše usmene izjave Parlamentu
     policy: Pogledajte sva naša pravila
@@ -639,22 +639,22 @@ hr:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Pretražujte prema zemlji ili teritoriju
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Međunarodna delegacija
         other: Međunarodne delegacije
       world_location:
-        few:
+        few: 
         one: Svjetske lokacije
         other: Lokacije svijeta
   world_news:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -22,14 +22,14 @@ hu:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: A csatolt fájl
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: A csatolt parancsnoki papír száma
         hoc_paper_number: Angol Alsóházi lapszám
@@ -51,19 +51,19 @@ hu:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |-
@@ -91,10 +91,10 @@ hu:
       subheading: Olyan problémákat találtunk a hivatkozásokkal kapcsolatban, amelyek problémákra utalhatnak; legyen óvatos a továbbhivatkozásuk során
     title: Nem működő hivatkozások
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Lezárva
     closing_today: Ma zárul
@@ -175,11 +175,11 @@ hu:
         one: Blogbejegyzés
         other: Blogbejegyzések
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampány
         other: Kampányok
@@ -190,8 +190,8 @@ hu:
         one: Esettanulmány
         other: Esettanulmányok
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Lezárt konzultáció
         other: Lezárt konzultációk
@@ -274,8 +274,8 @@ hu:
         one: Tagság
         other: Tagság
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nemzeti statisztikák
         other: Nemzeti statisztikák
@@ -295,8 +295,8 @@ hu:
         one: Hivatalos statisztika
         other: Hivatalos statisztikák
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Nyílt konzultáció
         other: Nyílt konzultációk
@@ -404,72 +404,72 @@ hu:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
     hu: Magyar
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Még nincs frissebb változat.
     title: Legfrissebb
@@ -481,7 +481,7 @@ hu:
       organisation_chart: Szervezeti térképünk
       transparency: Átláthatósági adatok
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Vállalati adatok
       corporate_reports: Testületi beszámolók
@@ -498,10 +498,10 @@ hu:
   see_all:
     announcement: Minden bejelentés megtekintése
     authored_article: Minden publicisztika megtekintése
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Minden esettanulmány megtekintése
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Minden lezárt konzultáció megtekintése
     consultation: Minden konzultáció megtekintése
     consultation_outcome: Minden konzultációs eredmény megtekintése
@@ -524,7 +524,7 @@ hu:
     news_article: Minden cikk megtekintése
     news_story: Minden hír megtekintése
     notice: Minden értesítés megtekintése
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Minden nyílt konzultáció megtekintése
     oral_statement: Minden parlamenti felszólalás megtekintése
     policy: Minden irányelv megtekintése
@@ -558,15 +558,15 @@ hu:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Keresés ország vagy terület szerint
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Nemzetközi delegáció

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -22,14 +22,14 @@ hy:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Կցված ֆայլը
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Կցված պաշտոնական փաստաթղթի համարը
         hoc_paper_number: Համայնքների պալատի փաստաթղթի համարը
@@ -51,19 +51,19 @@ hy:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ hy:
       subheading: Մենք նկատել ենք խնդրահարույց հղումների հետ կապված որոշ խնդիրներ․ դուք պետք է զգույշ լինեք դրանց կցելու ժամանակ
     title: Չգործող հղումներ
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Ավարտվել է
     closing_today: Այսօր ավարտվում է
@@ -176,11 +176,11 @@ hy:
         one: Բլոգի գրառում
         other: Բլոգի գրառումներ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Արշավ
         other: Արշավներ
@@ -191,8 +191,8 @@ hy:
         one: Մասնավոր դեպքի ուսումնասիրություն
         other: Մասնավոր դեպքի ուսումնասիրություններ
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Փակ խորհրդակցություն
         other: Փակ խորհրդակցություններ
@@ -275,8 +275,8 @@ hy:
         one: Անդամակցություն
         other: Անդամակցություն
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Ազգային վիճակագրություն
         other: Ազգային վիճակագրություն
@@ -296,8 +296,8 @@ hy:
         one: Պաշտոնական վիճակագրություն
         other: Պաշտոնական վիճակագրություն
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Բաց խորհրդակցություն
         other: Բաց խորհրդակցություններ
@@ -405,72 +405,72 @@ hy:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
     hy: Հայերեն
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: 'Դեռևս թարմացումներ չկան:'
     title: Թարմացումներ
@@ -482,7 +482,7 @@ hy:
       organisation_chart: Մեր կազմակերպության կառուցվածքը
       transparency: Թափանցիկության տվյալներ
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Կորպորատիվ տեղեկություն
       corporate_reports: Կորպորատիվ զեկույցներ
@@ -499,10 +499,10 @@ hy:
   see_all:
     announcement: Դիտել մեր բոլոր հայտարարությունները
     authored_article: Դիտել մեր բոլոր հեղինակային հոդվածները
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Դիտել մեր բոլոր դեպքերի ուսումնասիրությունները
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Դիտել մեր բոլոր փակ խորհրդակցությունները
     consultation: Դիտել մեր բոլոր խորհրդակցությունները
     consultation_outcome: Դիտել մեր բոլոր խորհրդակցությունների արդյունքները
@@ -525,7 +525,7 @@ hy:
     news_article: Դիտել մեր բոլոր տեղեկատվական հոդվածները
     news_story: Դիտել մեր բոլոր ամսագրային հոդվածները
     notice: Դիտել մեր բոլոր ծանուցումները
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Դիտել մեր բոլոր բաց խորհրդակցությունները
     oral_statement: Դիտել խորհրդարանին ուղղված մեր բոլոր բանավոր հայտարարությունները
     policy: Դիտել մեր բոլոր քաղաքականությունները
@@ -559,15 +559,15 @@ hy:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Որոնել ըստ երկրի կամ տարածաշրջանի
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Միջազգային պատվիրակություն

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -22,14 +22,14 @@ id:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: File terlampir
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Nomor kertas perintah lampiran
         hoc_paper_number: Nomor surat House of Commons
@@ -51,19 +51,19 @@ id:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ id:
       subheading: Kami menemukan masalah dengan tautan yang mungkin menandakan adanya masalah, Anda harus berhati-hati saat mengklik tautan itu
     title: Tautan terputus
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Ditutup
     closing_today: Hari ini ditutup
@@ -167,9 +167,9 @@ id:
       blog_post:
         other: Posting blog
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: Kampanye
       careers:
@@ -177,7 +177,7 @@ id:
       case_study:
         other: Studi kasus
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: Konsultasi tertutup
       complaints_procedure:
@@ -233,7 +233,7 @@ id:
       membership:
         other: Keanggotaan
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: Statistik Nasional
       news_article:
@@ -247,7 +247,7 @@ id:
       official_statistics:
         other: Statistik Resmi
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: Konsultasi terbuka
       oral_statement:
@@ -324,72 +324,72 @@ id:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
     id: Bahasa Indonesia
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Belum ada pembaruan.
     title: Terbaru
@@ -401,7 +401,7 @@ id:
       organisation_chart: Diagram organisasi kami
       transparency: Data transparansi
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informasi korporat
       corporate_reports: Laporan korporat
@@ -418,10 +418,10 @@ id:
   see_all:
     announcement: Lihat semua pengumuman kami
     authored_article: Lihat semua artikel bersumber kami
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Lihat semua studi kasus kami
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Lihat semua konsultasi tertutup kami
     consultation: Lihat semua konsultasi kami
     consultation_outcome: Lihat semua hasil konsultasi kami
@@ -444,7 +444,7 @@ id:
     news_article: Lihat semua artikel berita kami
     news_story: Lihat semua cerita berita kami
     notice: Lihat semua pemberitahuan kami
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Lihat semua konsultasi terbuka kami
     oral_statement: Lihat semua pernyataan lisan kami kepada Parlemen
     policy: Lihat semua kebijakan kami
@@ -478,15 +478,15 @@ id:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Cari menurut negara atau teritori
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: Delegasi internasional

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -22,14 +22,14 @@ is:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Skráin í viðhengi
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Skjal númer fyrirskipana í viðhengi
         hoc_paper_number: Skjal númer neðri deildar Þingsins
@@ -51,19 +51,19 @@ is:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ is:
       subheading: Við fundum vandamál með hlekki sem gætu leitt til vandræða, þú ætti að fara varlega í að tengjast þeim
     title: Óvirkir hlekkir
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Lokað
     closing_today: Lokar í dag
@@ -175,11 +175,11 @@ is:
         one: Bloggfærsla
         other: Bloggfærslur
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Herferð
         other: Herferðir
@@ -190,8 +190,8 @@ is:
         one: Ferilsathugun
         other: Ferilsathuganir
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Lokuð ráðgjöf
         other: Lokaðar ráðgjafir
@@ -274,8 +274,8 @@ is:
         one: Aðild
         other: Aðild
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Hagstofa
         other: Hagstofa
@@ -295,8 +295,8 @@ is:
         one: Opinber tölfræði
         other: Opinber tölfræði
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Opin ráðgjöf
         other: Opnar ráðgjafir
@@ -404,72 +404,72 @@ is:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
     is: Íslenska
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Það eru engar uppfærslur.
     title: Nýjasta
@@ -481,7 +481,7 @@ is:
       organisation_chart: Skipurit okkar
       transparency: Gögn um gagnsæi
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Upplýsingar um fyrirtæki
       corporate_reports: Skýrslur fyrirtækis
@@ -498,10 +498,10 @@ is:
   see_all:
     announcement: Sjá allar okkar tilkynningar
     authored_article: Sjá allar okkar samdar greinar
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Sjá allar okkar ferilsathuganir
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Sjá allar okkar lokaðar ráðgjafir
     consultation: Sjá allar okkar ráðgjafir
     consultation_outcome: Sjá allar okkar útkomur úr ráðgjöfum
@@ -524,7 +524,7 @@ is:
     news_article: Sjá allar fréttagreinar okkar
     news_story: Sjá allar fréttir okkar
     notice: Sjá allar tilkynningar okkar
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Sjá allar opnar ráðgjafir okkar
     oral_statement: Sjá allar munnlegar yfirlýsingar okkar til Þingsins
     policy: Sjá allar stefnur okkar
@@ -558,15 +558,15 @@ is:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Leita eftir landi eða landsvæði
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Alþjóðleg sendinefnd

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -22,14 +22,14 @@ it:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Il file allegato
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Numero carta comando allegato
         hoc_paper_number: Numero della carta della Camera dei Comuni
@@ -51,19 +51,19 @@ it:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ it:
       subheading: Abbiamo riscontrato alcune questioni con i collegamenti che potrebbero indicare problemi, dovresti prestare attenzione nel collegarli
     title: Collegamenti interrotti
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Chiuso
     closing_today: In chiusura oggi
@@ -176,11 +176,11 @@ it:
         one: Post sul blog
         other: Post sul blog
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campagna
         other: Campagne
@@ -191,8 +191,8 @@ it:
         one: Caso di studio
         other: Casi di studio
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Consultazione chiusa
         other: Consultazioni chiuse
@@ -275,8 +275,8 @@ it:
         one: Abbonamento
         other: Abbonamento
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Statistiche nazionali
         other: Statistiche nazionali
@@ -296,8 +296,8 @@ it:
         one: Statistiche ufficiali
         other: Statistiche ufficiali
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Consultazione aperta
         other: Consultazioni aperte
@@ -405,72 +405,72 @@ it:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
     it: Italiano
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Non ci sono ancora aggiornamenti.
     title: Ultimo
@@ -482,7 +482,7 @@ it:
       organisation_chart: Il nostro organigramma
       transparency: Dati sulla trasparenza
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informazioni aziendali
       corporate_reports: Report aziendali
@@ -499,10 +499,10 @@ it:
   see_all:
     announcement: Vedi tutti i nostri annunci
     authored_article: Vedi tutti i nostri articoli d’autore
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Vedi tutti i nostri casi di studio
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Vedi tutte le nostre consultazioni chiuse
     consultation: Vedi tutte le nostre consultazioni
     consultation_outcome: Vedi tutti i nostri esiti di consultazione
@@ -525,7 +525,7 @@ it:
     news_article: Vedi tutti i nostri articoli di notizie
     news_story: Vedi tutte le nostre storie di notizie
     notice: Vedi tutti i nostri avvisi
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Vedi tutte le nostre consultazioni aperte
     oral_statement: Vedi tutte le nostre dichiarazioni orali al Parlamento
     policy: Vedi tutte le nostre informative
@@ -559,15 +559,15 @@ it:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Cerca per stato o territorio
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Delegazione internazionale

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,14 +22,14 @@ ja:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: 添付ファイル
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: 添付勅令書類番号
         hoc_paper_number: 庶民院の書類番号
@@ -51,19 +51,19 @@ ja:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: お客様が支援技術（スクリーンリーダーなど）を使用していて、このドキュメントよりアクセスしやすい形式のバージョンが必要な場合は、必要なフォーマットや使用している支援技術を添え％{email}にEメールをお送くりください。
@@ -89,10 +89,10 @@ ja:
       subheading: リンクにいくつかの問題が見つかりました。リンクを表示する際には注意が必要です
     title: リンク切れ
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: ご利用いただけません
     closing_today: 本日は、ご利用いただけません
@@ -165,9 +165,9 @@ ja:
       blog_post:
         other: ブログ投稿
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: キャンペーン
       careers:
@@ -175,7 +175,7 @@ ja:
       case_study:
         other: ケーススタディ
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: 非公開の審議
       complaints_procedure:
@@ -231,7 +231,7 @@ ja:
       membership:
         other: メンバーシップ
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: 国家統計
       news_article:
@@ -245,7 +245,7 @@ ja:
       official_statistics:
         other: 公式統計
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: 公開審議
       oral_statement:
@@ -322,72 +322,72 @@ ja:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
     ja: 日本
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: まだ更新はありません。
     title: 最新
@@ -399,7 +399,7 @@ ja:
       organisation_chart: 組織図
       transparency: 透明度データ
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: 企業情報
       corporate_reports: 企業報告
@@ -416,10 +416,10 @@ ja:
   see_all:
     announcement: すべての発表を見る
     authored_article: すべての執筆記事を見る
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: すべてのケーススタディを見る
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: すべてのケーススタディを見る
     consultation: すべての非公開審議を見る
     consultation_outcome: すべての非公開協議結果を見る
@@ -442,7 +442,7 @@ ja:
     news_article: すべてのニュース記事を見る
     news_story: すべてのニュースストーリーを見る
     notice: すべての通知を見る
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: すべての公開審議を見る
     oral_statement: すべての議会への頭声明を見る
     policy: すべての方針を見る
@@ -476,15 +476,15 @@ ja:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: 国または地域で検索
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: 国際代表団

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -22,14 +22,14 @@ ka:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: თანდართული ფაილი
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: დანართი ბრძანების დოკუმენტის ნომერი
         hoc_paper_number: თემთა პალატის დოკუმენტის ნომერი
@@ -51,19 +51,19 @@ ka:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ ka:
       subheading: ჩვენ აღმოვაჩინეთ ხარვეზები ბმულებში, რაც შესაძლო პრობლემებზე მიანიშნებს, თქვენ ყურადღება უნდა გამოიჩინოთ მათი გამოყენებისას
     title: ხარვეზიანი ბმულები
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: დახურულია
     closing_today: იხურება დღეს
@@ -138,7 +138,7 @@ ka:
       long_ordinal: "%e %B %Y"
   document:
     contents: შემადგენლობა
-    latest:
+    latest: 
     published: გამოქვეყნებულია
     see_all: ყველას ნახვა
     speech:
@@ -176,11 +176,11 @@ ka:
         one: ბლოგ პოსტი
         other: ბლოგ პოსტები
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: კამპანია
         other: კამპანიები
@@ -191,8 +191,8 @@ ka:
         one: შემთხვევის კვლევა
         other: შემთხვევის კვლევები
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: დახურული კონსულტაცია
         other: დახურული კონსულტაციები
@@ -275,8 +275,8 @@ ka:
         one: წევრობა
         other: წევრობები
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: ეროვნული სტატისტიკა
         other: ეროვნული სტატისტიკები
@@ -296,8 +296,8 @@ ka:
         one: ოფიციალური სტატისტიკა
         other: ოფიციალური სტატისტიკები
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: ღია კონსულტაცია
         other: ღია კონსულტაციები
@@ -405,72 +405,72 @@ ka:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
     ka: ქართული
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: სიახლეები ჯერ არ ყოფილა.
     title: ბოლო
@@ -482,7 +482,7 @@ ka:
       organisation_chart: ჩვენი ორგანიზაციის ქარტია
       transparency: გამჭირვალობის მონაცემები
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: კორპორატიული ინფორმაცია
       corporate_reports: კორპორატიული ანგარიშები
@@ -499,10 +499,10 @@ ka:
   see_all:
     announcement: იხილეთ ჩვენი ყველა განცხადება
     authored_article: იხილეთ ჩვენი ყველა საავტორო სტატია
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: იხილეთ ჩვენი ყველა შემთხვევის კვლევა
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: იხილეთ ჩვენი ყველა დახურული კონსულტაცია
     consultation: იხილეთ ჩვენი ყველა კონსულტაცია
     consultation_outcome: იხილეთ ჩვენი ყველა კონსულტაციის შედეგი
@@ -525,7 +525,7 @@ ka:
     news_article: იხილეთ ჩვენი ყველა საინფორმაციო სტატია
     news_story: იხილეთ ჩვენი ყველა სიახლე
     notice: იხილეთ ჩვენი ყველა შეტყობინება
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: იხილეთ ყველა ჩვენი ღია კონსულტაცია
     oral_statement: იხილეთ ჩვენი ყველა ზეპირი განცხადება პარლამენტში
     policy: იხილეთ ჩვენი ყველა კანონი
@@ -559,15 +559,15 @@ ka:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: მოძებნეთ ქვეყნის ან ტერიტორიის მიხედვით
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: საერთაშორისო დელეგაცია

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -22,14 +22,14 @@ kk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Тіркелген файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Тіркеме пәрменінің қағаз нөмірі
         hoc_paper_number: Қауымдар палатасының саяси құжат нөмірі
@@ -51,19 +51,19 @@ kk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ kk:
       subheading: Біз сілтемелерде мәселелерді көрсетуі мүмкін кейбір ақауларды таптық, оларға сілтеме жасағанда абай болу керек
     title: Бұзылған сілтемелер
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Жабық
     closing_today: Бүгін жабылады
@@ -175,11 +175,11 @@ kk:
         one: Блог жарияланымы
         other: Блог жарияланымдары
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Науқан
         other: Науқандар
@@ -190,8 +190,8 @@ kk:
         one: Тақырыптық зерттеу
         other: Тақырыптық зерттеулер
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Жабық кеңес
         other: Жабық кеңестер
@@ -274,8 +274,8 @@ kk:
         one: Мүшелік
         other: Мүшелік
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Ұлттық статистика
         other: Ұлттық статистика
@@ -295,8 +295,8 @@ kk:
         one: Ресми статистика
         other: Ресми статистика
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Ашық кеңес
         other: Ашық кеңестер
@@ -404,72 +404,72 @@ kk:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
     kk: Қазақ
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Әлі жаңартулар жоқ.
     title: Ең соңғы
@@ -481,7 +481,7 @@ kk:
       organisation_chart: Біздің ұйым жарғысы
       transparency: Ашықтық деректері
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Корпоративтік ақпарат
       corporate_reports: Корпоративтік есептер
@@ -498,10 +498,10 @@ kk:
   see_all:
     announcement: Біздің барлық хабарландыруларды қараңыз
     authored_article: Біздің авторлық мақалалардың барлығын қараңыз
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Біздің барлық жағдайлық зерттеулерімізді қараңыз
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Біздің барлық жабық кеңестерді қараңыз
     consultation: Біздің барлық кеңестерді қараңыз
     consultation_outcome: Біздің кеңестің барлық нәтижелерін қараңыз
@@ -524,7 +524,7 @@ kk:
     news_article: Біздің барлық жаңалықтар мақалаларын қараңыз
     news_story: Біздің барлық жаңалықтар оқиғаларын қараңыз
     notice: Біздің барлық ескертулерді қараңыз
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Біздің барлық ашық кеңестерді қараңыз
     oral_statement: Парламентке біздің барлық ауызша мәлімдемелерімізді қараңыз
     policy: Біздің барлық саясаттарымызды қараңыз
@@ -558,15 +558,15 @@ kk:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Елі немесе территориясы бойынша іздеу
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Халықаралық делегация

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -22,14 +22,14 @@ ko:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: 첨부 파일
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: 첨부 명령 문서 번호
         hoc_paper_number: 하원 문서 번호
@@ -51,19 +51,19 @@ ko:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ ko:
       subheading: 링크에서 문제를 나타낼 수 있는 몇 가지 문제가 발견되었으므로, 링크할 때 주의해야 합니다
     title: 손상된 링크
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: 종결됨
     closing_today: 오늘 종결됨
@@ -167,9 +167,9 @@ ko:
       blog_post:
         other: 블로그 포스트
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: 캠페인
       careers:
@@ -177,7 +177,7 @@ ko:
       case_study:
         other: 사례 연구
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: 종결된 상담
       complaints_procedure:
@@ -233,7 +233,7 @@ ko:
       membership:
         other: 멤버십
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: 국내 통계
       news_article:
@@ -247,7 +247,7 @@ ko:
       official_statistics:
         other: 공식 통계
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: 공개 상담
       oral_statement:
@@ -324,72 +324,72 @@ ko:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
     ko: 한국어
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: 관련 내용이 아직 없습니다.
     title: 최신
@@ -401,7 +401,7 @@ ko:
       organisation_chart: 조직 차트
       transparency: 투명성 데이터
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: 기업 정보
       corporate_reports: 기업 보고서
@@ -418,10 +418,10 @@ ko:
   see_all:
     announcement: 공지 모두 둘러보기
     authored_article: 기사 모두 둘러보기
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: 케이스 스터디 모두 둘러보기
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: 비공개 협의 모두 둘러보기
     consultation: 협의 모두 둘러보기
     consultation_outcome: 협의 결과 모두 둘러보기
@@ -444,7 +444,7 @@ ko:
     news_article: 뉴스 모두 둘러보기
     news_story: 뉴스 스토리 모두 둘러보기
     notice: 공지 모두 둘러보기
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: 오픈 컨설테이션 모두 둘러보기
     oral_statement: 의회로 구두 성명 모두 둘러보기
     policy: 정책 논문 모두 둘러보기
@@ -478,15 +478,15 @@ ko:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: 국가 또는 영토로 검색하기
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: 국제 대표단

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -22,14 +22,14 @@ lt:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Pridėtas failas
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Pridėto įsakymo dokumento numeris
         hoc_paper_number: Bendruomenių rūmų dokumento numeris
@@ -51,19 +51,19 @@ lt:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: Jei norėtumėte gauti šį dokumentą kitokiu formatu (brailio, audio ar pan.), siųskite el. paštą %{email}, parašydami savo adresą, telefoną bei leidinio pavadinimą .Prašome pasakyti, kokio formato jums reikia. Mums padės, jei pasakysite, kokią pagalbinę technologiją naudojate.
@@ -89,10 +89,10 @@ lt:
       subheading: Aptikome problemų dėl nuorodų, atidarykite jas atsargiai
     title: Pažeistos nuorodos
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Pasibaigusi
     closing_today: Baigiasi šiandien
@@ -149,323 +149,323 @@ lt:
       written_on: 'Parašyta:'
     type:
       about:
-        few:
+        few: 
         one: Apie
         other: Apie
       about_our_services:
-        few:
+        few: 
         one: Apie mūsų paslaugas
         other: Apie mūsų paslaugas
       access_and_opening:
-        few:
+        few: 
         one: Prieiga ir pradžia
         other: Prieiga ir pradžia
       accessible_documents_policy:
-        few:
+        few: 
         one: Prieinama dokumentų strategija
         other: Prieinamos dokumentų strategijos
       alert:
-        few:
+        few: 
         one: Įspėjimas
         other: Šspėjimai
       announcement:
-        few:
+        few: 
         one: Pranešimas
         other: Pranešimai
       authored_article:
-        few:
+        few: 
         one: Autoriaus straipsnis
         other: Autorių straipsniai
       blog_post:
-        few:
+        few: 
         one: Tinklaraščio įrašas
         other: Tinklaraščio įrašai
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Kampanija
         other: Kampanijos
       careers:
-        few:
+        few: 
         one: Karjera
         other: karjera
       case_study:
-        few:
+        few: 
         one: Atvejo analizė
         other: Atvejų analizės
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Pasibaigusi konsultacija
         other: Pasibaigusios konsultacijos
       complaints_procedure:
-        few:
+        few: 
         one: Skundų teikimo procedūra
         other: Skundų teikimo procedūros
       consultation:
-        few:
+        few: 
         one: Konsultacija
         other: Konsultacijos
       consultation_outcome:
-        few:
+        few: 
         one: Konsultacijos rezultatas
         other: Konsultacijos rezultatai
       corporate_report:
-        few:
+        few: 
         one: Bendra ataskaita
         other: Bendros ataskaitos
       correspondence:
-        few:
+        few: 
         one: Korespondencija
         other: Korespondencija
       decision:
-        few:
+        few: 
         one: Sprendimas
         other: Sprendimai
       detailed_guidance:
-        few:
+        few: 
         one: Detalesnė informacija
         other: Detalesnė informacija
       document_collection:
-        few:
+        few: 
         one: Serijos
         other: Serijos
       draft_text:
-        few:
+        few: 
         one: Pirminis teksto variantas
         other: Pirminiai teksto variantai
       edition:
-        few:
+        few: 
         one: Leidimas
         other: Leidimai
       edition_with_appointment:
-        few:
+        few: 
         one: Leidimas su paskyrimu
         other: Leidimai su paskyrimu
       equality_and_diversity:
-        few:
+        few: 
         one: Lygybė ir įvairovė
         other: Lygybė ir įvairovė
       fatality_notice:
-        few:
+        few: 
         one: Pranešimas apie nelaimę
         other: Pranešimai apie nelaimes
       foi_release:
-        few:
+        few: 
         one: 'Informacijos laisvė: pranešimas'
         other: 'Informacijos laisvė: pranešimai'
       form:
-        few:
+        few: 
         one: Forma
         other: Formos
       generic_edition:
-        few:
+        few: 
         one: Bendras leidimas
         other: Bendri leidimai
       government_response:
-        few:
+        few: 
         one: Vyriausybės atsakas
         other: Vyriausybės atsakai
       guidance:
-        few:
+        few: 
         one: Informacija
         other: Informacija
       impact_assessment:
-        few:
+        few: 
         one: Poveikio įvertinimas
         other: Poveikio įvertinimai
       imported:
-        few:
+        few: 
         one: patalpinta - laukiama publikavimo
         other: patalpinta - laukiama publikavimo
       independent_report:
-        few:
+        few: 
         one: Nepriklausoma ataskaita
         other: Nepriklausomos ataskaitos
       international_treaty:
-        few:
+        few: 
         one: Tarptautinė sutartis
         other: Tarptautinės sutartys
       manual:
-        few:
+        few: 
         one: Vadovas
         other: Vadovai
       map:
-        few:
+        few: 
         one: Žemėlapis
         other: Žemėlapiai
       media_enquiries:
-        few:
+        few: 
         one: Žiniasklaidos užklausa
         other: Žiniasklaidos užklausos
       membership:
-        few:
+        few: 
         one: Narystė
         other: Narystė
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Statistika - nacionalinė statistika
         other: Statistika - nacionalinė statistika
       news_article:
-        few:
+        few: 
         one: Straipsnis
         other: Straipsniai
       news_story:
-        few:
+        few: 
         one: Naujiena
         other: Naujienos
       nhs_content:
-        few:
+        few: 
         one: NHS turinys
         other: NHS turinys
       notice:
-        few:
+        few: 
         one: Pranešimas
         other: Pranešimai
       official_statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Atvira konsultacija
         other: Atviros konsultacijos
       oral_statement:
-        few:
+        few: 
         one: Žodinis kreipimasis į parlamentą
         other: Žodiniai kreipimaisi į parlamentą
       our_energy_use:
-        few:
+        few: 
         one: Mūsų energijos naudojimas
         other: Mūsų energijos naudojimas
       our_governance:
-        few:
+        few: 
         one: Mūsų valdymas
         other: Mūsų valdymas
       personal_information_charter:
-        few:
+        few: 
         one: Teisė į asmens informaciją
         other: Teisė į asmens informaciją
       petitions_and_campaigns:
-        few:
+        few: 
         one: Peticijos ir kampanijos
         other: Peticijos ir kampanijos
       policy_paper:
-        few:
+        few: 
         one: Strategijos dokumentas
         other: Strategijų dokumentai
       press_release:
-        few:
+        few: 
         one: Pranešimas spaudai
         other: Pranešimai spaudai
       procurement:
-        few:
+        few: 
         one: Pirkimai
         other: Pirkimai
       promotional:
-        few:
+        few: 
         one: Reklaminė medžiaga
         other: Reklaminė medžiaga
       publication:
-        few:
+        few: 
         one: Leidinys
         other: Leidiniai
       publication_scheme:
-        few:
+        few: 
         one: Publikavimo planas
         other: Publikavimo planai
       recruitment:
-        few:
+        few: 
         one: Įdarbinimas
         other: Įdarbinimas
       regulation:
-        few:
+        few: 
         one: Reglamentas
         other: Reglamentai
       research:
-        few:
+        few: 
         one: Tyrimas ir analizė
         other: Tyrimai ir analizės
       service:
-        few:
+        few: 
         one: Paslauga
         other: Paslaugos
       social_media_use:
-        few:
+        few: 
         one: Socialinės medijos naudojimas
         other: Socialinės medijos naudojimas
       speaking_notes:
-        few:
+        few: 
         one: Kalbos santrauka
         other: Kalbos santrauka
       speech:
-        few:
+        few: 
         one: Kalba
         other: Kalbos
       staff_update:
-        few:
+        few: 
         one: Nauja informacija apie personalą
         other: Nauja informacija apie personalą
       standard:
-        few:
+        few: 
         one: Standartas
         other: Standartai
       statement_to_parliament:
-        few:
+        few: 
         one: Kreipimasis į parlamentą
         other: Kreipimaisi į parlamentą
       statistical_data_set:
-        few:
+        few: 
         one: Statistiniai duomenys
         other: Statistiniai duomenys
       statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
       statutory_guidance:
-        few:
+        few: 
         one: Įstatyminė informacija
         other: Įstatyminė informacija
       terms_of_reference:
-        few:
+        few: 
         one: Techninės užduotys
         other: Techninės užduotys
       transcript:
-        few:
+        few: 
         one: Kalbos tekstas
         other: Kalbų tekstai
       transparency:
-        few:
+        few: 
         one: Skaidrumo informacija
         other: Skaidrumo informacija
       welsh_language_scheme:
-        few:
+        few: 
         one: Valų kalbos schema
         other: Valų kalbos schemos
       world_news_story:
-        few:
+        few: 
         one: Pasaulio naujienos
         other: Pasaulio naujienos
       written_statement:
-        few:
+        few: 
         one: Rašytinis kreipimasis į parlamentą
         other: Rašytiniai kreipimaisi į parlamentą
     updated: atnaujinta
@@ -482,72 +482,72 @@ lt:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
     lt: Lietuvių
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Atnaujinimų nėra.
     title: Paskutinės
@@ -559,7 +559,7 @@ lt:
       organisation_chart: Mūsų organizacijos schema
       transparency: Skaidrumo informacija
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Korporatyvinė informacija
       corporate_reports: Korporatyvinės ataskaitos
@@ -576,10 +576,10 @@ lt:
   see_all:
     announcement: Pažiūrėkite  mūsų pranešimai
     authored_article: Pažiūrėkite  mūsų autorių straipsniai
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Pažiūrėkite  mūsų atvejų analizės
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Pažiūrėkite  mūsų pasibaigusios konsultacijos
     consultation: Pažiūrėkite  mūsų konsultacijos
     consultation_outcome: Pažiūrėkite  mūsų konsultacijos rezultatai
@@ -602,7 +602,7 @@ lt:
     news_article: Pažiūrėkite  mūsų straipsniai
     news_story: Pažiūrėkite  mūsų naujienos
     notice: Pažiūrėkite  mūsų pranešimus
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Pažiūrėkite  mūsų atviros konsultacijos
     oral_statement: Pažiūrėkite  mūsų žodiniai kreipimaisi į parlamentą
     policy: Pažiūrėkite  mūsų strategija
@@ -636,22 +636,22 @@ lt:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Ieškoti pagal šalį ar teritoriją
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Tarptautinė delegacija
         other: Tarptautinės delegacijos
       world_location:
-        few:
+        few: 
         one: Geografinė vieta
         other: Geografinės vietos
   world_news:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -22,14 +22,14 @@ lv:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Pievienotais fails
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Pievienotā Parlamentam iesniegtā dokumenta numurs
         hoc_paper_number: Pārstāvju palātas dokumenta numurs
@@ -51,19 +51,19 @@ lv:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: Lai saņemtu dokumentu citā formātā, piemēram, Braila rakstā, kā audio failu vai kā citādi, lūdzu, rakstiet uz epastu %{email} un norādiet savu adresi, telefona numuru un dokumenta nosaukumu ("%{title}")%{references}.
@@ -89,10 +89,10 @@ lv:
       subheading: Tika konstatētas problēmas ar saitēm, tāpēc ieteicams ievērot piesardzību, veidojot savienojumus uz tām
     title: Bojātas saites
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Aizvērts
     closing_today: Aizveras šodien
@@ -173,11 +173,11 @@ lv:
         one: Emuāra ziņa
         other: Emuāra ziņas
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampaņa
         other: Kampaņas
@@ -188,8 +188,8 @@ lv:
         one: Piemērs
         other: Piemēri
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Slēgta tipa konsultācija
         other: Slēgta tipa konsultācijas
@@ -272,8 +272,8 @@ lv:
         one: Dalība
         other: Dalība
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Statistika - valsts dati
         other: Statistika - valsts dati
@@ -293,8 +293,8 @@ lv:
         one: Statistika
         other: Statistika
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Atklāta konsultācija
         other: Atklātas konsultācijas
@@ -402,72 +402,72 @@ lv:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
     lv: Latviešu
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Pagaidām jaunumu nav
     title: Jaunākais
@@ -479,7 +479,7 @@ lv:
       organisation_chart: Mūsu organizācijas shēma
       transparency: Atklātība
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Korporatīvā informācija
       corporate_reports: Korporatīvie ziņojumi
@@ -496,10 +496,10 @@ lv:
   see_all:
     announcement: Skatīt visas paziņojumi
     authored_article: Skatīt visas autora raksti
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Skatīt visas piemēri
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Skatīt visas slēgta tipa konsultācijas
     consultation: Skatīt visas konsultācijas
     consultation_outcome: Skatīt visas konsultāciju rezultāti
@@ -522,7 +522,7 @@ lv:
     news_article: Skatīt visas raksti
     news_story: Skatīt visas ziņas
     notice: Skatīt visus paziņojumus
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Skatīt visas atklātas konsultācijas
     oral_statement: Skatīt visas mutiski paziņojumi parlamentam
     policy: Skatīt visas darbības jomas
@@ -556,15 +556,15 @@ lv:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Meklēt pēc valsts vai teritorijas
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Starptautiskā delegācija

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -22,14 +22,14 @@ ms:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Fail dilampirkan
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Lampiran nombor kertas perintah
         hoc_paper_number: Nombor kertas Dewan Rakyat
@@ -51,19 +51,19 @@ ms:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ ms:
       subheading: Kami menemui beberapa isu dengan pautan yang mungkin menunjukkan adanya masalah, anda harus berhati-hati semasa memaut padanya
     title: Pautan putus
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Ditutup
     closing_today: Tutup hari ini
@@ -168,9 +168,9 @@ ms:
       blog_post:
         other: Siaran blog
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: Kempen
       careers:
@@ -178,7 +178,7 @@ ms:
       case_study:
         other: Kajian kes
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: Rundingan tertutup
       complaints_procedure:
@@ -234,7 +234,7 @@ ms:
       membership:
         other: Keanggotaan
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: Statistik Nasional
       news_article:
@@ -248,7 +248,7 @@ ms:
       official_statistics:
         other: Statistik Rasmi
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: Rundingan terbuka
       oral_statement:
@@ -325,72 +325,72 @@ ms:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
     ms: Bahasa Melayu
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Belum ada kemas kini.
     title: Terkini
@@ -402,7 +402,7 @@ ms:
       organisation_chart: Carta organisasi kami
       transparency: Data ketelusan
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Maklumat korporat
       corporate_reports: Laporan korporat
@@ -419,10 +419,10 @@ ms:
   see_all:
     announcement: Lihat semua pengumuman kami
     authored_article: Lihat semua artikel ditulis penulis kami
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Lihat semua kajian kes kami
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Lihat semua rundingan tertutup kami
     consultation: Lihat semua rundingan kami
     consultation_outcome: Lihat semua hasil perundingan kami
@@ -445,7 +445,7 @@ ms:
     news_article: Lihat semua artikel berita kami
     news_story: Lihat semua berita kami
     notice: Lihat semua notis kami
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Lihat semua rundingan terbuka kami
     oral_statement: Lihat semua kenyataan lisan kami kepada Parlimen
     policy: Lihat semua dasar kami
@@ -479,15 +479,15 @@ ms:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Cari mengikut negara atau wilayah
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: Perwakilan antarabangsa

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -22,14 +22,14 @@ mt:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Il-fajl anness
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Numru tal-anness tad-dokument tal-kmand
         hoc_paper_number: Numru tad-dokument tal-House of Commons
@@ -51,19 +51,19 @@ mt:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "Jekk tuża teknoloġija assistiva (bħal qarrej ta' skrin) u għandek bżonn verżjoni ta' dan id-dokument f'format iktar aċċessibbli, jekk jogħġbok ibgħat imejl %{email}. \nJekk jogħġbok igħidilna x'format għandek bżonn.  Ser jgħinna jekk tgħidilna x'teknoloġija assistiva qed tuża'.\n"
@@ -89,10 +89,10 @@ mt:
       subheading: Sibna xi affarijiet fil-links li jistgħu jindikaw problemi, oqgħod attent meta tagħmel link magħhom
     title: Links maqsuma
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Magħluq
     closing_today: Magħluq illum
@@ -149,403 +149,403 @@ mt:
       written_on: 'Miktub f'':'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: Dwar
         other: Dwar
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: Dwar is-servizzi tagħna
         other: Dwar is-servizzi tagħna
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Aċċess u ftuħ
         other: Aċċess u ftuħ
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Politika dwar dokumenti aċċessibbli
         other: Politiċi dwar dokumenti aċċessibbli
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Twissija
         other: Twissijiet
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Avviż
         other: Avviżi
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Artiklu miktub
         other: Artikli miktuba
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Blog post
         other: Blog posts
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Kampanja
         other: Kampanji
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Karrieri
         other: karrieri
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Studju ta' Każ
         other: Studju ta' każijiet
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultazzjoni magħluqa
         other: Konsultazzjonijiet magħluqa
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Proċedura ta' ilmenti
         other: Proċeduri ta' ilmenti
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultazzjoni
         other: Konsultazzjonijiet
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Riżultat tal-konsultazzjoni
         other: Riżultati tal-konsultazzjoni
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Rapport korporattiv
         other: Rapporti korporattivi
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Korrispondenza
         other: Korrispondenzi
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Deċiżjoni
         other: Deċiżjonijiet
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Gwida
         other: Gwida
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Kollezzjoni
         other: Kollezzjonijiet
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Abbozz ta' test
         other: Abbozz ta' testijiet
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Edizzjoni
         other: Edizzjonijiet
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Edizzjoni b'appuntament
         other: Edizzjonijiet b'appuntament
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Ugwaljanza u diversità
         other: Ugwaljanza u diversità
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Avviż ta' fatalità
         other: Avviżi ta' fatalità
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Rilaxx tal-libertà għall-informazzjoni
         other: Rilaxxi tal-libertà għall-informazzjoni
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Formola
         other: Formoli
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Edizzjoni ġenerika
         other: Edizzjonijiet ġeneriċi
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Risposta tal-Gvern
         other: Risposti tal-Gvern
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Gwida
         other: Gwida
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Assessjar tal-impatt
         other: Assessjar tal-impatt
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: impurtat - tip mistenni
         other: impurtat - tip mistenni
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Rapport indipendenti
         other: Rapporti indipendenti
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Trattat internazzjonali
         other: Trattati internazzjonali
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Manwal
         other: Manwali
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Mapep
         other: Mapep
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Domanda mill-midja
         other: Domandi mill-midja
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Sħubija
         other: Sħubija
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statistiċi nazzjonali
         other: Statistiċi nazzjonali
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Artiklu b'aħbar
         other: Artiklu b'aħbarijiet
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Storja b'aħbar
         other: Stejjer b'aħbar
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Kontenut tas-Servizzi tas-Saħħa Nazzjonali (NHS)
         other: Kontenut tas-Servizzi tas-Saħħa Nazzjonali (NHS)
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Avviż
         other: Avviżi
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statistiċi uffiċjali
         other: Statistiċi uffiċjali
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultazzjoni miftuħa
         other: Konsultazzjonijiet miftuħa
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Dikjarazzjoni verbali lill-Parlament
         other: Dikjarazzjonijiet verbali lill-Parlament
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: L-użu tal-enerġija tagħna
         other: L-użu tal-enerġija tagħna
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Il-governanza tagħna
         other: Il-governanza tagħna
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Il-Karta tal-informazzjoni personali
         other: Karti tal-informazzjoni personali
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Petizzjonijiet u kampanji
         other: Petizzjonijiet u kampanji
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Dokument tal-politika
         other: Dokumenti tal-politika
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Stqarrija għall-istampa
         other: Stqarrija għall-istampa
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Akkwist
         other: Awwist
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Materjal promozzjonali
         other: Materjal promozzjonali
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Publikazzjoni
         other: Publikazzjoni
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Skema tal-publikazzjoni
         other: Skemi tal-publikazzjoni
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Reklutaġġ
         other: Reklutaġġ
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Regolament
         other: Regolamenti
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Riċerka
         other: Riċerka
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Servizz
         other: Servizzi
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Użu tal-midja soċjali
         other: Użu tal-midja soċjali
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Noti biex titkellem
         other: Noti biex titkellem
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Diskors
         other: Diskorsi
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Aġġornament tal-istaff
         other: Aġġornamenti tal-istaff
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Standard
         other: Standards
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Dikjarazzjoni lill-Parlament
         other: Dikjarazzjonijiet lill-Parlament
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Sett tad-dejta bl-istatistika
         other: Settijiet tad-dejta bl-istatistika
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statistiċi
         other: Statistiċi
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Gwida statutorja
         other: Gwida statutorja
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Termini għar-referenza
         other: Termini għar-referenza
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Traskript
         other: Transkripts
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Data għat-trasparenza
         other: Data għat-trasparenza
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Skema għall-lingwa ta' Wales
         other: Skemi għall-lingwa ta' Wales
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Storja bl-aħbarijiet minn madwar id-dinja
         other: Stejjer bl-aħbarijiet minn madwar id-dinja
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Dikjarazzjoni miktuba lill-Parlament
         other: Dikjarazzjonijiet miktuba lill-Parlament
     updated: aġġornat
@@ -562,72 +562,72 @@ mt:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
     mt: Malti
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Għad m'hemmx aġġornamenti.
     title: L-iktar riċenti
@@ -639,7 +639,7 @@ mt:
       organisation_chart: Iċ-chart organizzatorja tagħna
       transparency: Data għat-trasparenza
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informazzjoni korporattiva
       corporate_reports: Raporti korporattivi
@@ -656,10 +656,10 @@ mt:
   see_all:
     announcement: Ara l-avviżi tagħna kollha
     authored_article: Ara l-artikli tagħna kollha li ktibna
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Ara l-istudji dwar il-każi tagħna kollha
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Ara l-konsultazzjonijiet magħluqa tagħna kollha
     consultation: Ara l-konsultazzjonijiet tagħna kollha
     consultation_outcome: Ara r-riżultati tal-konsultazzjoni tagħna
@@ -682,7 +682,7 @@ mt:
     news_article: Ara l-artikli bl-aħbarijiet tagħna kollha
     news_story: Ara l-istejjer bl-aħbarijiet tagħna kollha
     notice: Ara l-avviżi tagħna kollha
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Ara l-konsultazzjonijiet miftuħa tagħna kollha
     oral_statement: Ara d-dikjarazzjonijiet verbali tagħna kollha lill-Parlament
     policy: Ara l-politiki tagħna kollha
@@ -716,24 +716,24 @@ mt:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Fittex permezz tal-pajjiż jew territorju
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Delegazzjoni internazzjonali
         other: Delegazzjonijiet internazzjonali
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Post fid-dinja
         other: Postijiet fid-dinja
   world_news:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -22,14 +22,14 @@ ne:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: संलग्न फाइल
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: संलग्न आदेश पृष्ठ संख्या
         hoc_paper_number: हाउस अफ कमन्स पृष्ठ संख्या
@@ -51,19 +51,19 @@ ne:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ ne:
       subheading: हामीले लिंकहरू सँग केहि समस्याहरु भएको थाहा पाएका छौं, तपाईं उनीहरुलाई जोड्ने कार्य गर्दा सावधानी अपनाउनु पर्छ
     title: काम नगर्ने लिंक
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: बन्द
     closing_today: आज बन्द हुँदैछ
@@ -175,11 +175,11 @@ ne:
         one: ब्लग पोस्ट
         other: ब्लग पोस्टहरू
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: अभियान
         other: अभियानहरु
@@ -190,8 +190,8 @@ ne:
         one: मामिला अध्ययन
         other: मामिला अध्ययनहरू
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: बन्द परामर्श
         other: बन्द परामर्शहरू
@@ -274,8 +274,8 @@ ne:
         one: सदस्यता
         other: सदस्यता
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: राष्ट्रिय तथ्याङ्क
         other: राष्ट्रिय तथ्याङ्क
@@ -295,8 +295,8 @@ ne:
         one: आधिकारिक तथ्याङ्क
         other: आधिकारिक तथ्याङ्क
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: खुला परामर्श
         other: खुला परामर्शहरू
@@ -404,72 +404,72 @@ ne:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
     ne: नेपाली
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: अहिले सम्म कुनै अद्यावधिक छैन।
     title: पछिल्लो
@@ -481,7 +481,7 @@ ne:
       organisation_chart: हाम्रो सङ्गठनको तालिका
       transparency: पारदर्शिता जानकारी
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: निगम जानकारी
       corporate_reports: निगम प्रतिवेदनहरू
@@ -498,10 +498,10 @@ ne:
   see_all:
     announcement: हाम्रा सबै घोषणाहरु हेर्नुहोस्
     authored_article: हाम्रो सबै लेखिएको लेखहरू हेर्नुहोस्
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: हाम्रो सबै मामिलाहरू अध्ययन हेर्नुहोस्
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: हाम्रो सबै बन्द परामर्शहरू हेर्नुहोस्
     consultation: हाम्रो सबै परामर्शहरू हेर्नुहोस्
     consultation_outcome: हाम्रो सबै परामर्श परिणामहरु हेर्नुहोस्
@@ -524,7 +524,7 @@ ne:
     news_article: हाम्रो सबै समाचार लेखहरू हेर्नुहोस्
     news_story: हाम्रा सबै समाचार कथाहरु हेर्नुहोस्
     notice: हाम्रा सबै सूचनाहरु हेर्नुहोस्
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: हाम्रो सबै खुला परामर्शहरू हेर्नुहोस्
     oral_statement: हाम्रो सबै संसदमा मौखिक वक्तव्यहरू हेर्नुहोस्
     policy: हाम्रा सबै नीतिहरु हेर्नुहोस्
@@ -558,15 +558,15 @@ ne:
       long_ordinal: "%e %B %Y %l: %M %P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: देश वा क्षेत्रको नामले खोज
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: अन्तर्राष्ट्रिय प्रतिनिधिमण्डल

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -22,14 +22,14 @@ nl:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Het bijgevoegde bestand
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Nummer van het bijgevoegde document
         hoc_paper_number: Nummer Lagerhuisdocument
@@ -51,19 +51,19 @@ nl:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "Als u ondersteunende technologie gebruikt (zoals een schermlezer) en een\r\nversie van dit document in een meer toegankelijk formaat nodig heeft, stuur dan een e-mail naar %{email}.\r\nVertel ons welk formaat u nodig hebt. Het zal ons helpen als u zegt welke ondersteunende technologie u gebruikt.\r\n"
@@ -89,10 +89,10 @@ nl:
       subheading: We hebben enkele problemen gevonden met links die op problemen kunnen wijzen, wees daarom voorzichtig met het linken naar deze links
     title: Gebroken links
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Gesloten
     closing_today: Sluiting vandaag
@@ -173,11 +173,11 @@ nl:
         one: Blog bericht
         other: Blog berichten
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campagne
         other: Campagnes
@@ -188,8 +188,8 @@ nl:
         one: Casestudy
         other: Casestudies
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Gesloten consultatie
         other: Gesloten consultaties
@@ -272,8 +272,8 @@ nl:
         one: Lidmaatschap
         other: Lidmaatschap
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nationale Statistieken
         other: Nationale Statistieken
@@ -293,8 +293,8 @@ nl:
         one: Officiële statistieken
         other: Officiële statistieken
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Openbare raadpleging
         other: Openbare raadplegingen
@@ -402,72 +402,72 @@ nl:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
     nl: Nederlands
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Er zijn nog geen updates.
     title: Laatste
@@ -479,7 +479,7 @@ nl:
       organisation_chart: Ons organigram
       transparency: Transparantiegegevens
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Bedrijfsinformatie
       corporate_reports: Bedrijfsrapporten
@@ -496,10 +496,10 @@ nl:
   see_all:
     announcement: Bekijk al onze aankondigingen
     authored_article: Bekijk al onze geschreven artikelen
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Bekijk al onze case studies
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Bekijk al onze gesloten consultaties
     consultation: Bekijk al onze raadplegingen
     consultation_outcome: Bekijk alle uitkomsten van onze raadplegingen
@@ -522,7 +522,7 @@ nl:
     news_article: Bekijk al onze nieuwsartikelen
     news_story: Bekijk al onze nieuwsberichten
     notice: Bekijk al onze aankondigingen
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Bekijk al onze openbare raadplegingen
     oral_statement: Bekijk al onze mondelinge verklaringen aan het Parlement
     policy: Bekijk al ons beleid
@@ -556,15 +556,15 @@ nl:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Zoeken op land of gebied
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Internationale delegatie

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -22,14 +22,14 @@
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Den vedlagte filen
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Vedleggskommandopapirnummer
         hoc_paper_number: Skrivnummer i Underhuset
@@ -51,19 +51,19 @@
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@
       subheading: Vi har funnet noen uregelmessigheter med lenker som kan indikere problemer. Du bør være forsiktig når du lenker til dem
     title: Brutte koblinger
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Lukket
     closing_today: Stenger i dag
@@ -176,11 +176,11 @@
         one: Blogginnlegg
         other: Blogginnlegg
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampanje
         other: Kampanjer
@@ -191,8 +191,8 @@
         one: Casestudie
         other: Casestudier
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Lukket konsultasjon
         other: Lukkede konsultasjoner
@@ -275,8 +275,8 @@
         one: Medlemskap
         other: Medlemskap
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nasjonal statistikk
         other: Nasjonal statistikk
@@ -296,8 +296,8 @@
         one: Offisiell statistikk
         other: Offisiell statistikk
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Åpen konsultasjon
         other: Åpne konsultasjoner
@@ -405,72 +405,72 @@
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
     'no': norsk
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Det er ingen oppdateringer ennå.
     title: Siste
@@ -482,7 +482,7 @@
       organisation_chart: Vårt organisasjonskart
       transparency: Åpenhetstsdata
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Bedriftsinformasjon
       corporate_reports: Bedriftsrapporter
@@ -499,10 +499,10 @@
   see_all:
     announcement: Se alle våre kunngjøringer
     authored_article: Se alle våre forfatterartikler
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Se alle våre casestudier
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Se alle våre lukkede konsultasjoner
     consultation: Se alle våre konsultasjoner
     consultation_outcome: Se alle våre konsultasjonsresultater
@@ -525,7 +525,7 @@
     news_article: Se alle våre nyhetsartikler
     news_story: Se alle våre nyhetshistorier
     notice: Se alle våre oppslag
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Se alle våre åpne konsultasjoner
     oral_statement: Se alle våre muntlige uttalelser til Stortinget
     policy: Se alle retningslinjene våre
@@ -559,15 +559,15 @@
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Søk etter land eller territorium
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Internasjonal delegasjon

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -22,14 +22,14 @@ pa-pk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: اٹیچمینٹ فائل
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: اٹیچمینٹ کمانڈ پیپر نمبر
         hoc_paper_number: ہاؤس آف کامننز پیپر نمبر
@@ -51,19 +51,19 @@ pa-pk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: اگر تُسی مدد گارٹیکنالوجی نوں استعمال کردے او ( جیویں کہ اک سکرین ریڈر) تے تہانوں ایس دستاویز دے ترجمے دی لوڑ اے جہیڑا اک بوہت پہنچ والی شکل وچ ہوئے گا، برائے مہربانی ای میل کریں {email}% برائے مہربانی سانوں ایہ دسو کہ تہانوں کس شکل دی لوڑ اے۔ ایس توں سانوں مدد ملے گی کہ تسی کس طراں دی مددگار ٹیکنالوجی استعمال کردے او۔
@@ -89,10 +89,10 @@ pa-pk:
       subheading: سانوں ایناں لنکس دے بارے کجھ مشکلاں دا پتہ لگیا جو کہ مشکلاں دا اشارہ کردا اے، تہانوں ایندے نال جوڑن لئی احتیاط کرن دی لوڑ اے
     title: ٹُٹے ہوئے لنک
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: بند ہویا
     closing_today: اج بند ہو ریئا اے
@@ -128,7 +128,7 @@ pa-pk:
         staff_update: نوکراں دیاں خبراں تے معلومات
         statistics: ایندے اعدادو شمار {organisation_name}%
         terms_of_reference: حوالے دیاں شرطاں
-        welsh_language_scheme:
+        welsh_language_scheme: 
   date:
     formats:
       default: "%d %B %Y"
@@ -173,11 +173,11 @@ pa-pk:
         one: بلاگ پوسٹ
         other: بلاگ پوسٹس
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: مہم
         other: مہمات
@@ -188,8 +188,8 @@ pa-pk:
         one: کیس دا مطالعہ
         other: کیس دا مطالعہ
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: بند مشورہ
         other: بند مشورے
@@ -272,8 +272,8 @@ pa-pk:
         one: ممبری
         other: ممبری
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: قومی اعدادوشمار
         other: قومی اعدادوشمار
@@ -293,8 +293,8 @@ pa-pk:
         one: سرکاری اعدادو شمار
         other: سرکاری اعدادو شمار
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: کُھلا مشورہ
         other: کُھلے مشورے
@@ -402,72 +402,72 @@ pa-pk:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
     pa-pk: پنجابی شاہ مُکھی
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: ہون تک کوئی تازہ ترین حال دا پتہ نئیں لگیا
     title: تازہ ترین
@@ -479,7 +479,7 @@ pa-pk:
       organisation_chart: ساڈے ادارے دا چارٹ
       transparency: شفافیت دی معلومات
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: کاروبار دی معلومات
       corporate_reports: کاروبار دیاں خبراں
@@ -496,10 +496,10 @@ pa-pk:
   see_all:
     announcement: ساڈے سارے اعلانات ویکھو
     authored_article: ساڈے سارے لکھے ہوئے مضمون ویکھو
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: سادے سارے کیس نوں ویکھو
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: ساڈی ساری ختم ہوئی مشاورت ویکھو
     consultation: ساڈی ساری مشاورت ویکھو
     consultation_outcome: ساڈی ساری مشاور ت دے نتیجے ویکھو
@@ -522,7 +522,7 @@ pa-pk:
     news_article: ساڈے سارے خبراں دے مضمون ویکھو
     news_story: ساڈیاں ساریاں خبراں دیاں کہانیاں ویکھو
     notice: ساڈے سارے نوٹسز ویکھو
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: ساڈی ساری کُھلی مشاورت ویکھو
     oral_statement: ساڈے سارے قومی مجلس دے سامنے بیان ویکھو
     policy: ساڈی ساری حکمت عملی ویکھو
@@ -556,15 +556,15 @@ pa-pk:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: مُلک یا علاقے توں لبھو
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: بین الاقوامی وفد

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -22,14 +22,14 @@ pa:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: ਨੱਥੀ ਕੀਤੀ ਫਾਈਲ
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: ਅਟੈਚਮੈਂਟ ਕਮਾਂਡ ਪੇਪਰ ਨੰਬਰ
         hoc_paper_number: ਹਾਊਸ ਆਫ ਕਾਮਨਜ਼ ਪੇਪਰ ਨੰਬਰ
@@ -51,19 +51,19 @@ pa:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ pa:
       subheading: ਸਾਨੂੰ ਲਿੰਕਾਂ ਦੇ ਨਾਲ ਕੁਝ ਸਮੱਸਿਆਵਾਂ ਮਿਲੀਆਂ ਹਨ ਜੋ ਸਮੱਸਿਆਵਾਂ ਦਾ ਸੰਕੇਤ ਦੇ ਸਕਦੀਆਂ ਹਨ, ਤੁਹਾਨੂੰ ਉਹਨਾਂ ਨਾਲ ਜੋੜਨ ਵਿੱਚ ਸਾਵਧਾਨੀ ਵਰਤਣੀ ਚਾਹੀਦੀ ਹੈ
     title: ਟੁੱਟੇ ਲਿੰਕ
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: ਬੰਦ
     closing_today: ਅੱਜ ਬੰਦ
@@ -176,11 +176,11 @@ pa:
         one: ਬਲੌਗ ਪੋਸਟ
         other: ਬਲੌਗ ਪੋਸਟਾਂ
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: ਮੁਹਿੰਮ
         other: ਮੁਹਿੰਮਾਂ
@@ -191,8 +191,8 @@ pa:
         one: ਕੇਸ ਅਧਿਐਨ
         other: ਕੇਸ ਅਧਿਐਨ
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: ਬੰਦ ਸਲਾਹ -ਮਸ਼ਵਰਾ
         other: ਬੰਦ ਸਲਾਹ ਮਸ਼ਵਰੇ
@@ -275,8 +275,8 @@ pa:
         one: ਮੈਂਬਰਸ਼ਿਪ
         other: ਮੈਂਬਰਸ਼ਿਪ
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: ਰਾਸ਼ਟਰੀ ਅੰਕੜੇ
         other: ਰਾਸ਼ਟਰੀ ਅੰਕੜੇ
@@ -296,8 +296,8 @@ pa:
         one: ਅਧਿਕਾਰਤ ਅੰਕੜੇ
         other: ਅਧਿਕਾਰਤ ਅੰਕੜੇ
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: ਖੁੱਲ੍ਹਾ ਸਲਾਹ-ਮਸ਼ਵਰਾ
         other: ਖੁੱਲ੍ਹੇ ਸਲਾਹ-ਮਸ਼ਵਰੇ
@@ -405,72 +405,72 @@ pa:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
     pa: ਪੰਜਾਬੀ ਗੁਰਮੁਖੀ
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: ਅਜੇ ਕੋਈ ਅਪਡੇਟ ਨਹੀਂ ਹਨ।
     title: ਨਵੀਨਤਮ
@@ -482,7 +482,7 @@ pa:
       organisation_chart: ਸਾਡਾ ਸੰਗਠਨ ਚਾਰਟ
       transparency: ਪਾਰਦਰਸ਼ਤਾ ਡਾਟਾ
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: ਕਾਰਪੋਰੇਟ ਜਾਣਕਾਰੀ
       corporate_reports: ਕਾਰਪੋਰੇਟ ਰਿਪੋਰਟਾਂ
@@ -499,10 +499,10 @@ pa:
   see_all:
     announcement: ਸਾਡੀਆਂ ਸਾਰੀਆਂ ਘੋਸ਼ਣਾਵਾਂ ਵੇਖੋ
     authored_article: ਸਾਡੇ ਸਾਰੇ ਲੇਖਕ ਲੇਖ ਵੇਖੋ
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: ਸਾਡੇ ਸਾਰੇ ਕੇਸ ਅਧਿਐਨ ਵੇਖੋ
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: ਸਾਡੇ ਸਾਰੇ ਬੰਦ ਕੀਤੇ ਸਲਾਹ ਮਸ਼ਵਰੇ ਵੇਖੋ
     consultation: ਸਾਡੀਆਂ ਸਾਰੀਆਂ ਸਲਾਹ ਮਸ਼ਵਰੇ ਵੇਖੋ
     consultation_outcome: ਸਾਡੇ ਸਾਰੇ ਸਲਾਹ -ਮਸ਼ਵਰੇ ਦੇ ਨਤੀਜੇ ਵੇਖੋ
@@ -525,7 +525,7 @@ pa:
     news_article: ਸਾਡੇ ਸਾਰੇ ਖਬਰ ਲੇਖ ਵੇਖੋ
     news_story: ਸਾਡੀਆਂ ਸਾਰੀਆਂ ਖ਼ਬਰਾਂ ਵੇਖੋ
     notice: ਸਾਡੇ ਸਾਰੇ ਨੋਟਿਸ ਵੇਖੋ
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: ਸਾਡੇ ਸਾਰੇ ਖੁੱਲੇ ਸਲਾਹ ਮਸ਼ਵਰੇ ਵੇਖੋ
     oral_statement: ਸੰਸਦ ਨੂੰ ਸਾਡੇ ਸਾਰੇ ਜ਼ਬਾਨੀ ਬਿਆਨ ਵੇਖੋ
     policy: ਸਾਡੀਆਂ ਸਾਰੀਆਂ ਨੀਤੀਆਂ ਵੇਖੋ
@@ -559,15 +559,15 @@ pa:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: ਦੇਸ਼ ਜਾਂ ਖੇਤਰ ਦੁਆਰਾ ਖੋਜ ਕਰੋ
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: ਅੰਤਰਰਾਸ਼ਟਰੀ ਵਫਦ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -22,14 +22,14 @@ pl:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Załączony plik
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Numer dokumentu w załączniku
         hoc_paper_number: Numer dokumentu w Izbie Gmin
@@ -51,19 +51,19 @@ pl:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "Aby otrzymać ten dokument w innym formacie, np. w alfabecie Braille'a. \nw formacie audio lub w innym rodzaju pliku prosimy wysłać email na adres %{email}.\n\n"
@@ -89,10 +89,10 @@ pl:
       subheading: Wykryliśmy kilka problemów z linkami. Zachowaj ostrożność podczas łączenia się z nimi.
     title: Uszkodzone linki
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Zamknięte
     closing_today: Zamknięcie dziś
@@ -149,403 +149,403 @@ pl:
       written_on: 'Napisany w dniu:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: O nas
         other: O nas
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: O naszych usługach
         other: O naszych usługach
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Dostęp i otwieranie
         other: Dostęp i otwieranie
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Polityka dot. dostępności dokumentów
         other: Polityki dot. dostępności dokumentów
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Alert
         other: Alerty
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Ogłoszenie
         other: Ogłoszenia
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Dokument utworzony przez
         other: Dokumenty utworzone przez
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Wpis na blogu
         other: Wpisy na blogu
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Kampania
         other: Kampanie
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Kariera
         other: kariera
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Studium przypadku
         other: Studia przypadku
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultacja zamknięta
         other: Konsultacje zamknięte
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Procedura składania skarg
         other: Procedury składania skarg
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultacja
         other: Konsultacje
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Wynik konsultacji
         other: Wyniki konsultacji
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Raport korporacyjny
         other: Raporty korporacyjne
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Korespondencja
         other: Korespondencje
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Decyzja
         other: Decyzje
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Szczegółowe wskazówki
         other: Szczegółowe wskazówki
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Seria
         other: Serie
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Tekst roboczy
         other: Teksty robocze
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Wydanie
         other: Wydania
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Wydanie po uzgodnieniu terminu
         other: Wydania po uzgodnieniu terminu
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Równość i różnorodność
         other: Równość i różnorodność
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Informacja o śmierci
         other: Informacje o śmierci
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Informacja zgodnie z ustawą o wolnosci informacji
         other: Informacje zgodnie z ustawą o wolności informacji
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Formularz
         other: Formularze
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Wydanie ogólne
         other: Wydania ogólne
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Odpowiedź rządu
         other: Odpowiedzi rządu
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Wskazówki
         other: Wskazówki
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Ocena oddziaływania
         other: Oceny oddziaływania
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: Zaimportowany - oczekuje typu
         other: Zaimportowany - oczekuje typu
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Niezależny raport
         other: Niezależne raporty
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Traktat międzynarodowy
         other: Traktaty międzynarodowe
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Instrukcja
         other: Instrukcje
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Mapa
         other: Mapy
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Zapytanie do mediów
         other: Zapytania do mediów
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Członkostwo
         other: Członkostwo
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statystyki - statystyki narodowe
         other: Statystyki - statystyki narodowe
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Artykuł prasowy
         other: Artykuły prasowe
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Aktualności
         other: Aktualności
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Treść dot. Narodowej Służby Zdrowia
         other: Treść dot. Narodowej Służby Zdrowia
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Powiadomienie
         other: Powiadomienia
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statystyki
         other: Statystyki
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Konsultacje otwarte
         other: Konsultacje otwarte
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Ustne oświadczenie przed parlamentem
         other: Ustne oświadczenia przed parlamentem
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Nasze zużycie energii
         other: Nasze zużycie energii
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Nasz system zarządzania
         other: Nasz system zarządzania
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Statut dot. danych osobowych
         other: Statut dot. danych osobowych
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Petycje i kampanie
         other: Petycje i kampanie
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Dokument programowy
         other: Dokumenty programowe
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Informacja prasowa
         other: Informacje prasowe
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Zamówienia
         other: Zamówienia
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Materiał promocyjny
         other: Materiał promocyjny
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Publikacja
         other: Publikacje
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: System publikacji
         other: Systemy publikacji
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Rekrutacja
         other: Rekrutacja
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Rozporządzenie
         other: Rozporządzenia
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Badania
         other: Badania
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Usługa
         other: Usługi
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Korzystanie z mediów społecznościowych
         other: Korzystanie z mediów społecznościowych
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Notatki do prelekcji
         other: Notatki do prelekcji
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Przemówienie
         other: Przemówienia
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Aktualizacja informacji o personelu
         other: Aktualizacje informacji o personelu
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Standard
         other: Standardy
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Wystapienie przed parlamentem
         other: Wystapienia przed parlamentem
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Zestaw danych statystycznych
         other: Zestawy danych statystycznych
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Statystyki
         other: Statystyki
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Wytyczne ustawowe
         other: Wytyczne ustawowe
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Zakres zadań
         other: Zakres zadań
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Transkrypcja
         other: Transkrypcje
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Dane o transparentności
         other: Dane o transparentności
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Program języka walijskiego
         other: Programy języka walijskiego
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Wiadomość ze świata
         other: Wiadomości ze świata
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Pisemne oświadczenie przed parlamentem
         other: Pisemne oświadczenia przed parlamentem
     updated: Zaktualizowany
@@ -562,72 +562,72 @@ pl:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
     pl: Polski
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Aktualizacje nie są jeszcze dostępne.
     title: Najnowsze
@@ -639,7 +639,7 @@ pl:
       organisation_chart: Nasza struktura organizacyjna
       transparency: Dane o transparentności
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informacje korporacyjne
       corporate_reports: Sprawozdania korporacyjne
@@ -656,10 +656,10 @@ pl:
   see_all:
     announcement: Zobacz wszystkie nasze ogłoszenia
     authored_article: Zobacz wszystkie nasze dokumenty utworzone przez
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Zobacz wszystkie nasze studia przypadku
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Zobacz wszystkie nasze konsultacje zamknięte
     consultation: Zobacz wszystkie nasze konsultacje
     consultation_outcome: Zobacz wszystkie nasze wyniki konsultacji
@@ -682,7 +682,7 @@ pl:
     news_article: Zobacz wszystkie nasze artykuły prasowe
     news_story: Zobacz wszystkie nasze aktualności
     notice: Zobacz wszystkie nasze powiadomienia
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Zobacz wszystkie nasze konsultacje otwarte
     oral_statement: Zobacz wszystkie nasze ustne oświadczenia przed parlamentem
     policy: Zobacz wszystkie nasze polityki
@@ -716,24 +716,24 @@ pl:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Wyszukiwanie według kraju lub terytorium
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Delegacja międzynarodowa
         other: Delegacje międzynarodowe
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Lokalizacja na świecie
         other: Lokalizacje na świecie
   world_news:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -22,14 +22,14 @@ ps:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: ضمیمه شوې فایل
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: د ضمیمې قوماندې کاغذ شمیره
         hoc_paper_number: د ولسي جرګې د کاغذ شمیره
@@ -51,19 +51,19 @@ ps:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ ps:
       subheading: موږ د لینکونو سره ځینې مسلې موندلي چې ممکن ستونزې په ګوته کړي ، تاسو باید د دوی سره وصل کیدو کې احتیاط وکړئ
     title: مات شوي لینکونه
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: تړل شوی
     closing_today: نن ورځ تړل
@@ -176,11 +176,11 @@ ps:
         one: د بلاګ پوسټ
         other: د بلاګ پوسټونه
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: کمپاین
         other: کمپاینونه
@@ -191,8 +191,8 @@ ps:
         one: د قضیې مطالعه
         other: د قضیې مطالعات
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: تړلې مشوره
         other: تړلې مشورې
@@ -275,8 +275,8 @@ ps:
         one: غړیتوب
         other: غړیتوب
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: ملي احصایې
         other: ملي احصایې
@@ -296,8 +296,8 @@ ps:
         one: رسمي احصایې
         other: رسمي احصایې
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: خلاص مشوره
         other: مشورې خلاص کړئ
@@ -405,72 +405,72 @@ ps:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
     ps: جرمني
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: تراوسه کوم تازه معلومات نشته.
     title: وروستی
@@ -482,7 +482,7 @@ ps:
       organisation_chart: زموږ د سازمان چارټ
       transparency: د شفافیت ډاټا
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: د شرکت معلومات
       corporate_reports: د شرکت راپورونه
@@ -499,10 +499,10 @@ ps:
   see_all:
     announcement: زموږ ټول اعلانونه وګورئ
     authored_article: زموږ ټولې لیکل شوې مقالې وګورئ
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: زموږ ټولې قضیې مطالعات وګورئ
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: زموږ ټولې تړلې مشورې وګورئ
     consultation: زموږ ټولې مشورې وګورئ
     consultation_outcome: زموږ د مشورې ټولې پایلې وګورئ
@@ -525,7 +525,7 @@ ps:
     news_article: زموږ ټولې خبري مقالې وګورئ
     news_story: زموږ ټول خبرونه وګورئ
     notice: زموږ ټول خبرتیاوې وګورئ
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: زموږ ټولې خلاصې مشورې وګورئ
     oral_statement: پارلمان ته زموږ ټولې شفاهي څرګندونې وګورئ
     policy: زموږ ټولې پالیسۍ وګورئ
@@ -559,15 +559,15 @@ ps:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: د هیواد یا سیمې له مخې لټون
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: نړیوال پلاوی

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -22,14 +22,14 @@ pt:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: O ficheiro anexo
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Número de papel de comando do anexo
         hoc_paper_number: Número de papel da Câmara dos Comuns
@@ -51,19 +51,19 @@ pt:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ pt:
       subheading: Encontrámos alguns problemas com links que podem indicar dificuldades – deve ter cautela ao estabelecer ligações com elas
     title: Links desfeitos
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Fechado
     closing_today: Encerra hoje
@@ -176,11 +176,11 @@ pt:
         one: Publicação no blogue
         other: Publicações no blogue
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Campanha
         other: Campanhas
@@ -191,8 +191,8 @@ pt:
         one: Estudo de caso
         other: Estudos de caso
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Consulta encerrada
         other: Consultas encerradas
@@ -275,8 +275,8 @@ pt:
         one: Adesão
         other: Adesão
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Estatísticas Nacionais
         other: Estatísticas Nacionais
@@ -296,8 +296,8 @@ pt:
         one: Estatísticas Oficiais
         other: Estatísticas Oficiais
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Consulta aberta
         other: Consultas abertas
@@ -405,72 +405,72 @@ pt:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
     pt: Português
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Ainda não há atualizações.
     title: Mais recentes
@@ -482,7 +482,7 @@ pt:
       organisation_chart: O nosso organigrama
       transparency: Dados de transparência
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informações da empresa
       corporate_reports: Relatórios empresariais
@@ -499,10 +499,10 @@ pt:
   see_all:
     announcement: Ver todos os nossos anúncios
     authored_article: Ver todos os nossos artigos de autor
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Ver todos os nossos estudos de caso
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Ver todas as nossas consultas encerradas
     consultation: Ver todas as nossas consultas
     consultation_outcome: Ver todos os resultados da nossa consulta
@@ -525,7 +525,7 @@ pt:
     news_article: Ver todos os nossos artigos noticiosos
     news_story: Ver todas as nossas reportagens
     notice: Ver todos os nossos avisos
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Ver todas as nossas consultas abertas
     oral_statement: Ver todas as nossas declarações orais ao Parlamento
     policy: Ver todas as nossas políticas
@@ -559,15 +559,15 @@ pt:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Pesquisa por país ou território
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Delegação internacional

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -22,14 +22,14 @@ ro:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Fișierul atașat
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Număr document comandă atașament
         hoc_paper_number: Numărul documentului de la Camera Comunelor
@@ -51,19 +51,19 @@ ro:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ ro:
       subheading: Am găsit niște erori la linkuri ce pot indica probleme, trebuie să le urmați cu atenție
     title: Linkuri rupte
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Închis
     closing_today: Se închide astăzi
@@ -151,323 +151,323 @@ ro:
       written_on: 'Scris pe:'
     type:
       about:
-        few:
+        few: 
         one: Despre
         other: Despre
       about_our_services:
-        few:
+        few: 
         one: Despre serviciile noastre
         other: Despre serviciile noastre
       access_and_opening:
-        few:
+        few: 
         one: Acces și deschidere
         other: Acces și deschidere
       accessible_documents_policy:
-        few:
+        few: 
         one: Politica privind documentele accesibile
         other: Politicile privind documentele accesibile
       alert:
-        few:
+        few: 
         one: Alertă
         other: Alerte
       announcement:
-        few:
+        few: 
         one: Anunț
         other: Anunțuri
       authored_article:
-        few:
+        few: 
         one: Articol publicat
         other: Articole publicate
       blog_post:
-        few:
+        few: 
         one: Postare pe blog
         other: Postări pe blog
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Campanie
         other: Campanii
       careers:
-        few:
+        few: 
         one: Cariere
         other: cariere
       case_study:
-        few:
+        few: 
         one: Studiu de caz
         other: Studii de caz
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Consultație închisă
         other: Consultații închise
       complaints_procedure:
-        few:
+        few: 
         one: Procedură de reclamație
         other: Proceduri de reclamație
       consultation:
-        few:
+        few: 
         one: Consultație
         other: Consultații
       consultation_outcome:
-        few:
+        few: 
         one: Rezultatul consultației
         other: Rezultatele consultației
       corporate_report:
-        few:
+        few: 
         one: Raport de companie
         other: Rapoarte de companie
       correspondence:
-        few:
+        few: 
         one: Corespondență
         other: Corespondențe
       decision:
-        few:
+        few: 
         one: Decizie
         other: Decizii
       detailed_guidance:
-        few:
+        few: 
         one: Orientări
         other: Orientări
       document_collection:
-        few:
+        few: 
         one: Colecție
         other: Colecții
       draft_text:
-        few:
+        few: 
         one: Proiect de text
         other: Proiecte de text
       edition:
-        few:
+        few: 
         one: Ediție
         other: Ediții
       edition_with_appointment:
-        few:
+        few: 
         one: Ediție cu programare
         other: Ediții cu programare
       equality_and_diversity:
-        few:
+        few: 
         one: Egalitate și diversitate
         other: Egalitate și diversitate
       fatality_notice:
-        few:
+        few: 
         one: Notificare accident mortal
         other: Notificări accident mortal
       foi_release:
-        few:
+        few: 
         one: Document eliberat privind libertatea informației
         other: Documente eliberate privind libertatea informației
       form:
-        few:
+        few: 
         one: Formular
         other: Formulare
       generic_edition:
-        few:
+        few: 
         one: Ediție generică
         other: Ediții generice
       government_response:
-        few:
+        few: 
         one: Răspunsul guvernului
         other: Răspunsurile guvernului
       guidance:
-        few:
+        few: 
         one: Orientări
         other: Orientări
       impact_assessment:
-        few:
+        few: 
         one: Evaluarea impactului
         other: Evaluările impactului
       imported:
-        few:
+        few: 
         one: importat - se așteaptă tipul
         other: importat - se așteaptă tipul
       independent_report:
-        few:
+        few: 
         one: Raport independent
         other: Rapoarte independente
       international_treaty:
-        few:
+        few: 
         one: Tratat internațional
         other: Tratate internaționale
       manual:
-        few:
+        few: 
         one: Manual
         other: Manuale
       map:
-        few:
+        few: 
         one: Hartă
         other: Hărți
       media_enquiries:
-        few:
+        few: 
         one: Investigație în mass-media
         other: Investigații în mass-media
       membership:
-        few:
+        few: 
         one: Abonament
         other: Abonament
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Statistică națională
         other: Statistică națională
       news_article:
-        few:
+        few: 
         one: Articol de știri
         other: Articole de știri
       news_story:
-        few:
+        few: 
         one: Reportaj de știri
         other: Reportaje de știri
       nhs_content:
-        few:
+        few: 
         one: Conținut NHS
         other: Conținut NHS
       notice:
-        few:
+        few: 
         one: Notificare
         other: Notificări
       official_statistics:
-        few:
+        few: 
         one: Statistică oficială
         other: Statistică oficială
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Consultație deschisă
         other: Consultație deschise
       oral_statement:
-        few:
+        few: 
         one: Expunere orală către Parlament
         other: Expuneri orale către Parlament
       our_energy_use:
-        few:
+        few: 
         one: Consumul nostru de energie
         other: Consumul nostru de energie
       our_governance:
-        few:
+        few: 
         one: Guvernarea noastră
         other: Guvernarea noastră
       personal_information_charter:
-        few:
+        few: 
         one: Carta informațiilor cu caracter personal
         other: Cartele informațiilor cu caracter personal
       petitions_and_campaigns:
-        few:
+        few: 
         one: Petiții și campanii
         other: Petiții și campanii
       policy_paper:
-        few:
+        few: 
         one: Document de politică
         other: Documente de politică
       press_release:
-        few:
+        few: 
         one: Comunicat de presă
         other: Comunicate de presă
       procurement:
-        few:
+        few: 
         one: Achiziții
         other: Achiziții
       promotional:
-        few:
+        few: 
         one: Material promoțional
         other: Material promoțional
       publication:
-        few:
+        few: 
         one: Publicație
         other: Publicații
       publication_scheme:
-        few:
+        few: 
         one: Schemă de publicare
         other: Scheme de publicare
       recruitment:
-        few:
+        few: 
         one: Angajare
         other: Angajare
       regulation:
-        few:
+        few: 
         one: Reglementare
         other: Reglementări
       research:
-        few:
+        few: 
         one: Cercetare
         other: Cercetare
       service:
-        few:
+        few: 
         one: Serviciu
         other: Servicii
       social_media_use:
-        few:
+        few: 
         one: Utilizarea rețelelor de socializare
         other: Utilizarea rețelelor de socializare
       speaking_notes:
-        few:
+        few: 
         one: Note de discuție
         other: Note de discuție
       speech:
-        few:
+        few: 
         one: Discurs
         other: Discursuri
       staff_update:
-        few:
+        few: 
         one: Actualizare personal
         other: Actualizări personal
       standard:
-        few:
+        few: 
         one: Standard
         other: Standarde
       statement_to_parliament:
-        few:
+        few: 
         one: Declarație către Parlament
         other: Declarații către Parlament
       statistical_data_set:
-        few:
+        few: 
         one: Set de date statistice
         other: Seturi de date statistice
       statistics:
-        few:
+        few: 
         one: Statistici
         other: Statistici
       statutory_guidance:
-        few:
+        few: 
         one: Orientări privind dispozițiile legale
         other: Orientări privind dispozițiile legale
       terms_of_reference:
-        few:
+        few: 
         one: Termeni de referință
         other: Termeni de referință
       transcript:
-        few:
+        few: 
         one: Transcriere
         other: Transcrieri
       transparency:
-        few:
+        few: 
         one: Date privind transparența
         other: Date privind transparența
       welsh_language_scheme:
-        few:
+        few: 
         one: Schema limbii galeze
         other: Schemele limbii galeze
       world_news_story:
-        few:
+        few: 
         one: Reportaj de știri global
         other: Reportaje de știri globale
       written_statement:
-        few:
+        few: 
         one: Declarație scrisă către Parlament
         other: Declarații scrise către Parlament
     updated: actualizat
@@ -484,72 +484,72 @@ ro:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
     ro: Română
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Nu există încă actualizări
     title: Cele mai recente
@@ -561,7 +561,7 @@ ro:
       organisation_chart: Graficul nostru organizațional
       transparency: Date privind transparența
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informații despre corporație
       corporate_reports: Rapoarte de companie
@@ -578,10 +578,10 @@ ro:
   see_all:
     announcement: Vedeți toate anunțurile noastre
     authored_article: Vedeți toate articolele noastre publicate
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Vedeți toate studiile noastre de caz
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Vedeți toate consultațiile noastre închise
     consultation: Vedeți toate consultațiile noastre
     consultation_outcome: Vedeți toate rezultatele consultațiilor noastre
@@ -604,7 +604,7 @@ ro:
     news_article: Vedeți toate articolele noastre de știri
     news_story: Vedeți toate reportajele noastre de știri
     notice: Vedeți toate notificările noastre
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Vedeți toate consultațiile noastre deschise
     oral_statement: Vedeți toate expunerile noastre orale către Parlament
     policy: Vedeți toate politicile noastre
@@ -638,22 +638,22 @@ ro:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Căutați după țară sau teritoriu
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Delegare internațională
         other: Delegări internaționale
       world_location:
-        few:
+        few: 
         one: Locație pe glob
         other: Locații pe glob
   world_news:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -22,14 +22,14 @@ ru:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Прикрепленный файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Номер прикрепляемого командного документа
         hoc_paper_number: Номер документа Палаты общин
@@ -51,19 +51,19 @@ ru:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: "Если вы используете вспомогательные технологии (например, программу чтения с экрана), \nи вам нужна версия этого документа в более доступном формате, отправьте \nписьмо по адресу электронной почты %{email}.\nВ нем укажите, какой формат вам нужен. Хорошо было бы, если бы вы также указали, какие вспомогательные технологии вы используете.\n"
@@ -89,10 +89,10 @@ ru:
       subheading: Мы обнаружили неполадки, связанные со ссылками, которые могут указывать на наличие проблем. Будьте осторожны при подключении к ним
     title: Недействительные ссылки
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Закрыто
     closing_today: День закрытия
@@ -149,403 +149,403 @@ ru:
       written_on: 'Написано:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: О нас
         other: О нас
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: О наших услугах
         other: Он наших услугах
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Доступ и открытие
         other: Доступ и открытие
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Политика доступности документов
         other: Политики доступности документов
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Оповещение
         other: Оповещения
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Объявление
         other: Объявления
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Авторская статья
         other: Авторские статьи
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Запись в блоге
         other: Записи в блоге
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Кампания
         other: Кампании
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Карьера
         other: карьера
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Ситуационное исследование
         other: Ситуационные исследования
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Закрытая консультация
         other: Закрытые консультации
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Процедура подачи жалоб
         other: Процедуры подачи жалоб
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Консультация
         other: Консультации
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Результат консультации
         other: Результаты консультаций
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Корпоративный отчет
         other: Корпоративные отчеты
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Корреспонденция
         other: Корреспонденция
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Решение
         other: Решения
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Руководство
         other: Руководство
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Коллекция
         other: Коллекции
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Проект текста
         other: Проект текстов
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Издание
         other: Издания
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Издание с назначением
         other: Издания с назначением
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Равенство и разнообразие
         other: Равенство и разнообразие
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Уведомление о смертельном исходе
         other: Уведомления о смертельном исходе
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Публикация о свободном распространении информации
         other: Публикации о свободном распространении информации
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Форма
         other: Формы
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Типовое издание
         other: Типовые издания
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Ответ правительства
         other: Ответы правительства
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Руководство
         other: Руководство
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Оценка воздействия
         other: Оценки воздействия
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: импортировано - тип ожидания
         other: импортировано - тип ожидания
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Независимый доклад
         other: Независимые доклады
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Международный договор
         other: Международные договоры
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Руководство
         other: Руководства
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Карта
         other: Карты
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Отдел по связям со СМИ
         other: Отделы по связам по СМИ
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Членство
         other: Членство
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Национальная статистика
         other: Национальная статистика
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Новостная статья
         other: Новостные статьи
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Новостной сюжет
         other: Новостные сюжеты
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Контент Национальной службы здравоохранения
         other: Контент Национальной службы здравоохранения
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Уведомление
         other: Уведомления
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Официальная статистика
         other: Официальная статистика
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Открытая консультация
         other: Открытые консультации
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Устное заявление Парламенту
         other: Устные заявления Парламенту
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Использование нами энергии
         other: Использование нами энергии
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Наше управление
         other: Наше управление
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Чартер личной информации
         other: Чартеры личной информации
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Петиции и кампании
         other: Петиции и кампании
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Директивный документ
         other: Директивные документы
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Пресс-релиз
         other: Пресс-релизы
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Материально-техническое снабжение
         other: Материально-техническое снабжение
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Рекламный материал
         other: Рекламные материалы
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Публикация
         other: Публикации
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема публикации
         other: Схемы публикации
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Набор персонала
         other: Набор персонала
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Распорядительный документ
         other: Распорядительные документы
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Исследования
         other: Исследования
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Услуга
         other: Услуги
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Использование социальных сетей
         other: Использование социальных сетей
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Тезисы выступления
         other: Тезисы выступления
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Текст выступления
         other: Тексты выступлений
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Обновление персонала
         other: Обновления персонала
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Стандарт
         other: Стандарты
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Заявление Парламенту
         other: Заявления Парламенту
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Набор статистических данных
         other: Наборы статистических данных
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Статистика
         other: Статистика
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Официальные рекомендации
         other: Официальные рекомендации
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Акт о полномочиях
         other: Акт о полномочиях
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Текст
         other: Тексты
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Прозрачность данных
         other: Прозрачность данных
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема уэльского языка
         other: Схемы уэльского языка
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Мировая новость
         other: Мировые новости
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Письменное заявление Парламенту
         other: Письменные заявления Парламенту
     updated: обновлено
@@ -562,72 +562,72 @@ ru:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
     ru: Русский
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Обновлений нет.
     title: Последние новости
@@ -639,7 +639,7 @@ ru:
       organisation_chart: Хартия нашей организации
       transparency: Данные о прозрачности
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Корпоративная информация
       corporate_reports: Корпоративные отчеты
@@ -656,10 +656,10 @@ ru:
   see_all:
     announcement: Посмотреть все наши объявления
     authored_article: Посмотреть все наши авторские статьи
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Посмотреть все наши ситуационные исследования
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Посмотреть все наши закрытые консультации
     consultation: Посмотреть все наши консультации
     consultation_outcome: Посмотреть все наши результаты консультаций
@@ -682,7 +682,7 @@ ru:
     news_article: Посмотреть все наши новостные статьи
     news_story: Посмотреть все наши новостные сюжеты
     notice: Посмотреть все наши уведомления
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Посмотреть все наши открытые консультации
     oral_statement: Посмотреть все наши устные заявления Парламенту
     policy: Посмотреть все наши политики
@@ -716,24 +716,24 @@ ru:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Поиск по стране или территории
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Международная делегация
         other: Международные делегации
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Место нахождения в мире
         other: Места нахождения в мире
   world_news:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -22,14 +22,14 @@ si:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: අමුණා ඇති ගොනුව
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: ඇමුණුම් විධාන පත්‍රිකා අංකය
         hoc_paper_number: මහජන මන්ත්‍රී මණ්ඩල පත්‍රිකා අංකය
@@ -51,19 +51,19 @@ si:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ si:
       subheading: ප්‍රශ්න පෙන්විය හැකි සබැඳි වල ගැටළු ඇති බව අපි සොයා ගෙන ඇත, ඔබ ඒවාට සම්බන්ධ වීමේදී ප්රවේශම් විය යුතුය
     title: කැඩුණු සබැඳි
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: වසා ඇත
     closing_today: අද දින වසා දැමේ
@@ -175,11 +175,11 @@ si:
         one: බ්ලොග් පළ කිරීම
         other: බ්ලොග් පළ කිරීම්
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: ව්යාපාරය
         other: ව්යාපාර
@@ -190,8 +190,8 @@ si:
         one: සිද්ධි අධ්යයනය
         other: සිද්ධි අධ්යයන
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: සංවෘත උපදේශනය
         other: සංවෘත උපදේශන
@@ -274,8 +274,8 @@ si:
         one: සාමාජිකත්වය
         other: සාමාජිකත්වය
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: ජාතික සංඛ්යාලේඛන
         other: ජාතික සංඛ්යාලේඛන
@@ -295,8 +295,8 @@ si:
         one: නිල සංඛ්යාලේඛන
         other: නිල සංඛ්යාලේඛන
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: විවෘත උපදේශනය
         other: විවෘත උපදේශන
@@ -404,72 +404,72 @@ si:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
     si: සිංහල
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: තවම යාවත්කාලීන කිසිවක් නොමැත.
     title: නවතම
@@ -481,7 +481,7 @@ si:
       organisation_chart: අපේ සංවිධාන සටහන
       transparency: විනිවිදභාව දත්ත
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: ආයතනික තොරතුරු
       corporate_reports: ආයතනික වාර්තා
@@ -498,10 +498,10 @@ si:
   see_all:
     announcement: අපේ සියලු නිවේදන බලන්න
     authored_article: අපේ සියලුම රචනා කළ ලිපි බලන්න
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: අපේ සියලු සිද්ධි අධ්යයන බලන්න
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: අපේ සියලු සංවෘත උපදේශන බලන්න
     consultation: අපේ සියලු උපදේශන බලන්න
     consultation_outcome: අපේ සියලු උපදේශන ප්‍රතිඵල බලන්න
@@ -524,7 +524,7 @@ si:
     news_article: අපේ සියලු පුවත් ලිපි බලන්න
     news_story: අපේ සියලු පුවත් කථා බලන්න
     notice: අපේ සියලු දැන්වීම් බලන්න
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: අපේ සියලු විවෘත උපදේශන බලන්න
     oral_statement: අපේ පාර්ලිමේන්තුවට කළ ප්‍රකාශන සියල්ල බලන්න
     policy: අපේ සියලු ප්රතිපත්ති බලන්න
@@ -558,15 +558,15 @@ si:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: රට හෝ භූමිය අනුව සොයන්න
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: ජාත්යන්තර නියෝජිත පිරිස

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -22,14 +22,14 @@ sk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Pripojený súbor
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Číslo príkazu na pripojenie papiera
         hoc_paper_number: Číslo dokumentu Dolnej snemovne
@@ -51,19 +51,19 @@ sk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ sk:
       subheading: Zistili sme niekoľko problémov s odkazmi, ktoré môžu naznačovať problémy, preto by ste mali byť pri odkazovaní na ne opatrní.
     title: Nefunkčné odkazy
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Zatvorené
     closing_today: Uzatvára sa dnes
@@ -152,323 +152,323 @@ sk:
       written_on: 'Napísané dňa:'
     type:
       about:
-        few:
+        few: 
         one: Informácie
         other: Informácie
       about_our_services:
-        few:
+        few: 
         one: O našich službách
         other: O našich službách
       access_and_opening:
-        few:
+        few: 
         one: Prístup a prevádzka
         other: Prístup a prevádzka
       accessible_documents_policy:
-        few:
+        few: 
         one: Politika prístupnosti dokumentov
         other: Politiky prístupnosti dokumentov
       alert:
-        few:
+        few: 
         one: Upozornenie
         other: Upozornenia
       announcement:
-        few:
+        few: 
         one: Oznámenie
         other: Oznámenia
       authored_article:
-        few:
+        few: 
         one: Autor článku
         other: Autorské články
       blog_post:
-        few:
+        few: 
         one: Príspevok na blogu
         other: Príspevky na blogu
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Kampaň
         other: Kampane
       careers:
-        few:
+        few: 
         one: Kariéra
         other: kariéra
       case_study:
-        few:
+        few: 
         one: Prípadová štúdia
         other: Prípadové štúdie
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Uzavretá konzultácia
         other: Uzavreté konzultácie
       complaints_procedure:
-        few:
+        few: 
         one: Postup podávania sťažností
         other: Postupy podávania sťažností
       consultation:
-        few:
+        few: 
         one: Konzultácia
         other: Konzultácie
       consultation_outcome:
-        few:
+        few: 
         one: Výsledok konzultácie
         other: Výsledky konzultácie
       corporate_report:
-        few:
+        few: 
         one: Podniková správa
         other: Podnikové správy
       correspondence:
-        few:
+        few: 
         one: Korešpondencia
         other: Korešpondencie
       decision:
-        few:
+        few: 
         one: Rozhodnutie
         other: Rozhodnutia
       detailed_guidance:
-        few:
+        few: 
         one: Poradenstvo
         other: Poradenstvo
       document_collection:
-        few:
+        few: 
         one: Zbierka
         other: Zbierky
       draft_text:
-        few:
+        few: 
         one: Návrh textu
         other: Návrhy textov
       edition:
-        few:
+        few: 
         one: Vydanie
         other: Vydania
       edition_with_appointment:
-        few:
+        few: 
         one: Vydanie s dohodnutým termínom
         other: Vydania s dohodnutým termínom
       equality_and_diversity:
-        few:
+        few: 
         one: Rovnosť a rozmanitosť
         other: Rovnosť a rozmanitosť
       fatality_notice:
-        few:
+        few: 
         one: Oznámenie o úmrtí
         other: Oznámenia o úmrtí
       foi_release:
-        few:
+        few: 
         one: Zverejnenie slobody informácií
         other: Zverejnenia slobody informácií
       form:
-        few:
+        few: 
         one: Formulár
         other: Formuláre
       generic_edition:
-        few:
+        few: 
         one: Všeobecné vydanie
         other: Všeobecné vydania
       government_response:
-        few:
+        few: 
         one: Odpoveď vlády
         other: Odpovede vlády
       guidance:
-        few:
+        few: 
         one: Poradenstvo
         other: Poradenstvo
       impact_assessment:
-        few:
+        few: 
         one: Posúdenie vplyvu
         other: Posúdenia vplyvu
       imported:
-        few:
+        few: 
         one: importované - čaká sa na typ
         other: importované - čaká sa na typ
       independent_report:
-        few:
+        few: 
         one: Nezávislá správa
         other: Nezávislé správy
       international_treaty:
-        few:
+        few: 
         one: Medzinárodná zmluva
         other: Medzinárodné zmluvy
       manual:
-        few:
+        few: 
         one: Príručka
         other: Príručky
       map:
-        few:
+        few: 
         one: Mapa
         other: Mapy
       media_enquiries:
-        few:
+        few: 
         one: Požiadavka na médiá
         other: Požiadavky na médiá
       membership:
-        few:
+        few: 
         one: Členstvo
         other: Členstvo
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Národné štatistiky
         other: Národné štatistiky
       news_article:
-        few:
+        few: 
         one: Spravodajský článok
         other: Spravodajské články
       news_story:
-        few:
+        few: 
         one: Spravodajský príbeh
         other: Spravodajské príbehy
       nhs_content:
-        few:
+        few: 
         one: Obsah NHS
         other: Obsah NHS
       notice:
-        few:
+        few: 
         one: Oznámenie
         other: Oznámenia
       official_statistics:
-        few:
+        few: 
         one: Oficiálne štatistiky
         other: Oficiálne štatistiky
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Otvorená konzultácia
         other: Otvorené konzultácie
       oral_statement:
-        few:
+        few: 
         one: Ústne vyhlásenie pred Parlamentom
         other: Ústne vyhlásenia pred Parlamentom
       our_energy_use:
-        few:
+        few: 
         one: Naše využívanie energie
         other: Naše využívanie energie
       our_governance:
-        few:
+        few: 
         one: Naše riadenie
         other: Naše riadenie
       personal_information_charter:
-        few:
+        few: 
         one: Charta osobných údajov
         other: Charty osobných údajov
       petitions_and_campaigns:
-        few:
+        few: 
         one: Petície a kampane
         other: Petície a kampane
       policy_paper:
-        few:
+        few: 
         one: Strategický dokument
         other: Strategické dokumenty
       press_release:
-        few:
+        few: 
         one: Tlačová správa
         other: Tlačové správy
       procurement:
-        few:
+        few: 
         one: Obstarávanie
         other: Obstarávanie
       promotional:
-        few:
+        few: 
         one: Propagačné materiály
         other: Propagačné materiály
       publication:
-        few:
+        few: 
         one: Publikácia
         other: Publikácie
       publication_scheme:
-        few:
+        few: 
         one: Systém zverejňovania
         other: Publikačné schémy
       recruitment:
-        few:
+        few: 
         one: Nábor
         other: Nábor
       regulation:
-        few:
+        few: 
         one: Nariadenie
         other: Nariadenia
       research:
-        few:
+        few: 
         one: Výskum
         other: Výskum
       service:
-        few:
+        few: 
         one: Služba
         other: Služby
       social_media_use:
-        few:
+        few: 
         one: Používanie sociálnych médií
         other: Používanie sociálnych médií
       speaking_notes:
-        few:
+        few: 
         one: Poznámky k prejavu
         other: Poznámky k prejavu
       speech:
-        few:
+        few: 
         one: Prejav
         other: Prejay
       staff_update:
-        few:
+        few: 
         one: Aktualizácia zamestnancov
         other: Aktualizácie zamestnancov
       standard:
-        few:
+        few: 
         one: Štandard
         other: Štandardy
       statement_to_parliament:
-        few:
+        few: 
         one: Vyhlásenie pre Parlament
         other: Vyhlásenia pre Parlament
       statistical_data_set:
-        few:
+        few: 
         one: Súbor štatistických údajov
         other: Súbory štatistických údajov
       statistics:
-        few:
+        few: 
         one: Štatistiky
         other: Štatistiky
       statutory_guidance:
-        few:
+        few: 
         one: Zákonné usmernenia
         other: Zákonné usmernenia
       terms_of_reference:
-        few:
+        few: 
         one: Referenčné podmienky
         other: Referenčné podmienky
       transcript:
-        few:
+        few: 
         one: Prepis
         other: Prepisy
       transparency:
-        few:
+        few: 
         one: Údaje o transparentnosti
         other: Údaje o transparentnosti
       welsh_language_scheme:
-        few:
+        few: 
         one: Program vo waleskom jazyku
         other: Programy vo waleskom jazyku
       world_news_story:
-        few:
+        few: 
         one: Celosvetové spravodajstvo
         other: Celosvetové spravodajstvo
       written_statement:
-        few:
+        few: 
         one: Písomné vyhlásenie pre Parlament
         other: Písomné vyhlásenia pre Parlament
     updated: aktualizované
@@ -485,72 +485,72 @@ sk:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
     sk: Slovensky
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Zatiaľ nie sú k dispozícii žiadne aktualizácie.
     title: Najnovšie
@@ -562,7 +562,7 @@ sk:
       organisation_chart: Naša organizačná schéma
       transparency: Údaje o transparentnosti
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Firemné informácie
       corporate_reports: Podnikové správy
@@ -579,10 +579,10 @@ sk:
   see_all:
     announcement: Pozrite si všetky naše oznámenia
     authored_article: Pozrite si všetky naše autorské články
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Pozrite si všetky naše prípadové štúdie
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Pozrite si všetky naše uzavreté konzultácie
     consultation: Pozrite si všetky naše konzultácie
     consultation_outcome: Pozrite si všetky výsledky našich konzultácií
@@ -605,7 +605,7 @@ sk:
     news_article: Pozrite si všetky naše novinové články
     news_story: Pozrite si všetky naše novinky
     notice: Pozrite si všetky naše oznámenia
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Pozrite si všetky naše otvorené konzultácie
     oral_statement: Pozrite si všetky naše ústne vyhlásenia v Parlamente
     policy: Pozrite si všetky naše zásady
@@ -639,22 +639,22 @@ sk:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Vyhľadávanie podľa krajiny alebo územia
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Medzinárodná delegácia
         other: Medzinárodné delegácie
       world_location:
-        few:
+        few: 
         one: Umiestnenie vo svete
         other: Svetové lokality
   world_news:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -22,14 +22,14 @@ sl:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Pripeta datoteka
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Številka dokumenta, predstavljenega parlamentu v prilogi
         hoc_paper_number: Številka dokumenta britanskega parlamenta
@@ -51,19 +51,19 @@ sl:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ sl:
       subheading: Našli smo nekaj težav s povezavami, ki lahko kažejo na težave. Pri povezovanju z njimi bodite previdni
     title: Prekinjene povezave
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Zaprto
     closing_today: Zapira se danes
@@ -152,405 +152,405 @@ sl:
       written_on: 'Napisano dne:'
     type:
       about:
-        few:
+        few: 
         one: O
         other: O
-        two:
+        two: 
       about_our_services:
-        few:
+        few: 
         one: O naših storitvah
         other: O naših storitvah
-        two:
+        two: 
       access_and_opening:
-        few:
+        few: 
         one: Dostop in odpiranje
         other: Dostop in odpiranje
-        two:
+        two: 
       accessible_documents_policy:
-        few:
+        few: 
         one: Politika dostopnih dokumentov
         other: Politike dostopnih dokumentov
-        two:
+        two: 
       alert:
-        few:
+        few: 
         one: Opozorilo
         other: Opozorila
-        two:
+        two: 
       announcement:
-        few:
+        few: 
         one: Razglas
         other: Razglasi
-        two:
+        two: 
       authored_article:
-        few:
+        few: 
         one: Avtorski članek
         other: Avtorski članki
-        two:
+        two: 
       blog_post:
-        few:
+        few: 
         one: Prispevek na blogu
         other: Prispevki na blogu
-        two:
+        two: 
       call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       campaign:
-        few:
+        few: 
         one: Kampanja
         other: Kampanje
-        two:
+        two: 
       careers:
-        few:
+        few: 
         one: Kariera
         other: Kariere
-        two:
+        two: 
       case_study:
-        few:
+        few: 
         one: Študija primera
         other: Študije primera
-        two:
+        two: 
       closed_call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       closed_consultation:
-        few:
+        few: 
         one: Tesno posvetovanje
         other: Tesna posvetovanja
-        two:
+        two: 
       complaints_procedure:
-        few:
+        few: 
         one: Pritožbeni postopek
         other: Pritožbeni postopki
-        two:
+        two: 
       consultation:
-        few:
+        few: 
         one: Posvetovanje
         other: Posvetovanja
-        two:
+        two: 
       consultation_outcome:
-        few:
+        few: 
         one: Rezultat posvetovanja
         other: Rezultati posvetovanja
-        two:
+        two: 
       corporate_report:
-        few:
+        few: 
         one: Poročilo podjetja
         other: Poročila podjetja
-        two:
+        two: 
       correspondence:
-        few:
+        few: 
         one: Korespondenca
         other: Korespondenca
-        two:
+        two: 
       decision:
-        few:
+        few: 
         one: Odločitev
         other: Odločitve
-        two:
+        two: 
       detailed_guidance:
-        few:
+        few: 
         one: Smernice
         other: Smernice
-        two:
+        two: 
       document_collection:
-        few:
+        few: 
         one: Zbirka
         other: Zbirke
-        two:
+        two: 
       draft_text:
-        few:
+        few: 
         one: Osnutek besedila
         other: Osnutki besedila
-        two:
+        two: 
       edition:
-        few:
+        few: 
         one: Izdaja
         other: Izdaje
-        two:
+        two: 
       edition_with_appointment:
-        few:
+        few: 
         one: Izdaja s srečanjem
         other: Izdaje s srečanjem
-        two:
+        two: 
       equality_and_diversity:
-        few:
+        few: 
         one: Enakopravnost in raznolikost
         other: Enakopravnost in raznolikost
-        two:
+        two: 
       fatality_notice:
-        few:
+        few: 
         one: Obvestilo o smrti
         other: Obvestila o smrti
-        two:
+        two: 
       foi_release:
-        few:
+        few: 
         one: Izjava o svobodi informacij
         other: Izjave o svobodi informacij
-        two:
+        two: 
       form:
-        few:
+        few: 
         one: Oblika
         other: Oblike
-        two:
+        two: 
       generic_edition:
-        few:
+        few: 
         one: Generična izdaja
         other: Generične izdaje
-        two:
+        two: 
       government_response:
-        few:
+        few: 
         one: Odziv vlade
         other: Odzivi vlade
-        two:
+        two: 
       guidance:
-        few:
+        few: 
         one: Smernice
         other: Smernice
-        two:
+        two: 
       impact_assessment:
-        few:
+        few: 
         one: Presoja vpliva
         other: Presoje vpliva
-        two:
+        two: 
       imported:
-        few:
+        few: 
         one: uvoženo − vrsta čakanja
         other: uvoženo − vrsta čakanja
-        two:
+        two: 
       independent_report:
-        few:
+        few: 
         one: neodvisno poročilo
         other: neodvisna poročila
-        two:
+        two: 
       international_treaty:
-        few:
+        few: 
         one: mednarodni sporazum
         other: mednarodni sporazumi
-        two:
+        two: 
       manual:
-        few:
+        few: 
         one: Priročnik
         other: Priročniki
-        two:
+        two: 
       map:
-        few:
+        few: 
         one: Zemljevid
         other: Zemljevidi
-        two:
+        two: 
       media_enquiries:
-        few:
+        few: 
         one: Vprašanje medijev
         other: Vprašanja medijev
-        two:
+        two: 
       membership:
-        few:
+        few: 
         one: Članstvo
         other: Članstvo
-        two:
+        two: 
       modern_slavery_statement:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       national_statistics:
-        few:
+        few: 
         one: Državna statistika
         other: Državna statistika
-        two:
+        two: 
       news_article:
-        few:
+        few: 
         one: Časopisni članek
         other: Časopisni članki
-        two:
+        two: 
       news_story:
-        few:
+        few: 
         one: Časopisna zgodba
         other: Časopisne zgodbe
-        two:
+        two: 
       nhs_content:
-        few:
+        few: 
         one: Vsebina Državne zdravstvene službe
         other: Vsebina Državne zdravstvene službe
-        two:
+        two: 
       notice:
-        few:
+        few: 
         one: Obvestilo
         other: Obvestila
-        two:
+        two: 
       official_statistics:
-        few:
+        few: 
         one: Uradna statistika
         other: Uradna statistika
-        two:
+        two: 
       open_call_for_evidence:
-        few:
-        one:
-        other:
-        two:
+        few: 
+        one: 
+        other: 
+        two: 
       open_consultation:
-        few:
+        few: 
         one: Odprto posvetovanje
         other: Odprto posvetovanje
-        two:
+        two: 
       oral_statement:
-        few:
+        few: 
         one: Ustna izjava za parlament
         other: Ustne izjave za parlament
-        two:
+        two: 
       our_energy_use:
-        few:
+        few: 
         one: Naša poraba energije
         other: Naša poraba energije
-        two:
+        two: 
       our_governance:
-        few:
+        few: 
         one: Naše upravljanje
         other: Naše upravljanje
-        two:
+        two: 
       personal_information_charter:
-        few:
+        few: 
         one: Listina o osebnih podatkih
         other: Listine o osebnih podatkih
-        two:
+        two: 
       petitions_and_campaigns:
-        few:
+        few: 
         one: Peticije in kampanje
         other: Peticije in kampanje
-        two:
+        two: 
       policy_paper:
-        few:
+        few: 
         one: Politični dokument
         other: Politični dokumenti
-        two:
+        two: 
       press_release:
-        few:
+        few: 
         one: Sporočilo za javnost
         other: Sporočila za javnost
-        two:
+        two: 
       procurement:
-        few:
+        few: 
         one: Javno naročilo
         other: Javna naročila
-        two:
+        two: 
       promotional:
-        few:
+        few: 
         one: Promocijsko gradivo
         other: Promocijsko gradivo
-        two:
+        two: 
       publication:
-        few:
+        few: 
         one: Publikacija
         other: Publikacije
-        two:
+        two: 
       publication_scheme:
-        few:
+        few: 
         one: Shema publikacij
         other: Sheme publikacij
-        two:
+        two: 
       recruitment:
-        few:
+        few: 
         one: Zaposlovanje
         other: Zaposlovanje
-        two:
+        two: 
       regulation:
-        few:
+        few: 
         one: Uredba
         other: Uredbe
-        two:
+        two: 
       research:
-        few:
+        few: 
         one: Raziskava
         other: Raziskave
-        two:
+        two: 
       service:
-        few:
+        few: 
         one: Storitev
         other: Storitve
-        two:
+        two: 
       social_media_use:
-        few:
+        few: 
         one: Uporaba družabnih omrežij
         other: Uporaba družabnih omrežij
-        two:
+        two: 
       speaking_notes:
-        few:
+        few: 
         one: Točke za govor
         other: Točke za govor
-        two:
+        two: 
       speech:
-        few:
+        few: 
         one: Govor
         other: Govori
-        two:
+        two: 
       staff_update:
-        few:
+        few: 
         one: Posodobitev osebja
         other: Posodobitve osebja
-        two:
+        two: 
       standard:
-        few:
+        few: 
         one: Standard
         other: Standardi
-        two:
+        two: 
       statement_to_parliament:
-        few:
+        few: 
         one: Izjava parlamentu
         other: Izjave parlamentu
-        two:
+        two: 
       statistical_data_set:
-        few:
+        few: 
         one: Statistični podatkovni niz
         other: Statistični podatkovni nizi
-        two:
+        two: 
       statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
-        two:
+        two: 
       statutory_guidance:
-        few:
+        few: 
         one: Zakonski napotki
         other: Zakonski napotki
-        two:
+        two: 
       terms_of_reference:
-        few:
+        few: 
         one: Obseg pristojnosti
         other: Obseg pristojnosti
-        two:
+        two: 
       transcript:
-        few:
+        few: 
         one: Prepis
         other: Prepisi
-        two:
+        two: 
       transparency:
-        few:
+        few: 
         one: Podatki o preglednosti
         other: Podatki o preglednosti
-        two:
+        two: 
       welsh_language_scheme:
-        few:
+        few: 
         one: Valižanski jezikovni sistem
         other: Valižanski jezikovni sistemi
-        two:
+        two: 
       world_news_story:
-        few:
+        few: 
         one: Novica s sveta
         other: Novice s celega sveta
-        two:
+        two: 
       written_statement:
-        few:
+        few: 
         one: Pisna izjava za parlament
         other: Pisne izjave za parlament
-        two:
+        two: 
     updated: posodobljeno
   document_filters:
     world_locations:
@@ -565,72 +565,72 @@ sl:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
     sl: Slovenščina
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Posodobitve še niso na voljo.
     title: Najnovejše
@@ -642,7 +642,7 @@ sl:
       organisation_chart: Naša organizacijska shema
       transparency: Podatki o preglednosti
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informacije o podjetju
       corporate_reports: Poročila podjetja
@@ -659,10 +659,10 @@ sl:
   see_all:
     announcement: Oglejte si vse naše razglase
     authored_article: Oglejte si vse naše avtorske članke
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Oglejte si naše študije primerov
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Oglejte si vsa naša tesna posvetovanja
     consultation: Oglejte si vsa naša posvetovanja
     consultation_outcome: Oglejte si vse rezultate naših posvetovanj
@@ -685,7 +685,7 @@ sl:
     news_article: Oglejte si vse naše časopisne članke
     news_story: Oglejte si vse naše časopisne zgodbe
     notice: Oglejte si vsa naša obvestila
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Oglejte si vsa naša odprta posvetovanja
     oral_statement: Oglejte si vse naše ustne izjave za parlament
     policy: Oglejte si vsa naša politike
@@ -719,26 +719,26 @@ sl:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Išči po državah ali ozemljih
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Mednarodna delegacija
         other: Mednarodne delegacije
-        two:
+        two: 
       world_location:
-        few:
+        few: 
         one: Lokacija na svetu
         other: Lokacije po svetu
-        two:
+        two: 
   world_news:
     uk_updates_in_country: Posodobitve, novice in dogodki britanske vlade v %{country}
   worldwide_organisation:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -22,14 +22,14 @@ so:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Faylka lifaaqa
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Lifaaqa lambarka warqada amarka
         hoc_paper_number: lambarka warqada guriga Commons
@@ -51,19 +51,19 @@ so:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ so:
       subheading: Waxaan helnay arimaha qaar linkiyadooda kaasoo dhib muujinaya, waa inaad ka taxadartaa marka aad ka codsanayso linki iyaga
     title: Linkiyada la jabsaday
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Xidhan
     closing_today: Xidhan maanta
@@ -175,11 +175,11 @@ so:
         one: Qoraalka boga
         other: Qoraalada boga
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Xayaysiiska
         other: Xayaysiisyada
@@ -190,8 +190,8 @@ so:
         one: Daraasad
         other: Daraasado
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Latalin Xidhan
         other: Latalino xidhan
@@ -274,8 +274,8 @@ so:
         one: Xubinimada
         other: Xubinimada
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Tirokoobka qaranka
         other: Tirokoobka qaranka
@@ -295,8 +295,8 @@ so:
         one: Tirokoobka rasmiga ah
         other: Tirokoobka rasmiga ah
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Latalin furan
         other: Latalino furan
@@ -404,72 +404,72 @@ so:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
     so: Soomaali
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Wali wax cusub ma jiraan.
     title: Ugu dambeeyay
@@ -481,7 +481,7 @@ so:
       organisation_chart: Jaantuska ururkayaga
       transparency: Xog daah furan
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Macluumaadka shirkada
       corporate_reports: Warbixinaha shirkada
@@ -498,10 +498,10 @@ so:
   see_all:
     announcement: Eeg dhamaan ku dhawaaqisahayaga
     authored_article: Eeg dhamaan qoraalaada la ogalyahay
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Eeg dhamaan cilmi baadhisahayaga
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Eeg dhamaan latilinahayaga dhaw
     consultation: Eeg dhamaan la talinahayaga oo dhan
     consultation_outcome: Eeg dhamaan maxsuulada la talinahayaga oo dhan
@@ -524,7 +524,7 @@ so:
     news_article: Eeg dhamaan qoraalaada wararka
     news_story: Eeg dhamaan sheekoyinkayaga wararka
     notice: Eeg dhamaan ogaysiisyadaya
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Eeg dhamaan latilinahayaga furan
     oral_statement: Eeg dhammaan hadalada aan afka u sheegnay ee Baarlamaanka
     policy: Eeg dhamaan siyaasadahayaga
@@ -558,15 +558,15 @@ so:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Ku raadi dalka ama dhulka
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Wafti caalami ah

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -22,14 +22,14 @@ sq:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Skedari i bashkangjitur
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Numri i letrës së komandës së bashkëngjitjes
         hoc_paper_number: Numri i letrës së Dhomës së Komuneve
@@ -51,19 +51,19 @@ sq:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ sq:
       subheading: Ne kemi gjetur disa çështje me lidhjet që mund të tregojnë probleme, duhet të jeni të kujdesshëm në lidhjen me to
     title: Lidhje të prishura
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Mbyllur
     closing_today: Mbyllet sot
@@ -176,11 +176,11 @@ sq:
         one: Postim blogu
         other: Postime blogu
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Fushatë
         other: Fushata
@@ -191,8 +191,8 @@ sq:
         one: Rast studimi
         other: Raste studimesh
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Konsultim i mbyllur
         other: Konsultime të mbyllura
@@ -275,8 +275,8 @@ sq:
         one: Anëtarësi
         other: Anëtarësi
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Statistika kombëtare
         other: Statistika kombëtare
@@ -296,8 +296,8 @@ sq:
         one: Statistikat Zyrtare
         other: Statistikat Zyrtare
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Konsultim i hapur
         other: Konsultime të hapura
@@ -405,72 +405,72 @@ sq:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
     sq: Shqip
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Ende nuk ka përditësime.
     title: Më të fundit
@@ -482,7 +482,7 @@ sq:
       organisation_chart: Tabela e organizimit tonë
       transparency: Të dhënat e transparencës
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Informacioni i korporatës
       corporate_reports: Raportet e korporatës
@@ -499,10 +499,10 @@ sq:
   see_all:
     announcement: Shihni të gjitha njoftimet tona
     authored_article: Shihni të gjithë artikujt tanë të shkruar
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Shihni të gjitha studimet tona të rasteve
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Shihni të gjitha konsultimet tona të mbyllura
     consultation: Shihni të gjitha konsultimet tona
     consultation_outcome: Shihni të gjitha rezultatet e konsultimit tonë
@@ -525,7 +525,7 @@ sq:
     news_article: Shihni të gjitha artikujt tanë të lajmeve
     news_story: Shihni të gjitha ngjarjet
     notice: Shihni të gjitha njoftimet tona
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Shihni të gjitha konsultimet tona të hapura
     oral_statement: Shihni të gjitha deklaratat tona verbale në Parlament
     policy: Shihni të gjitha politikat tona
@@ -559,15 +559,15 @@ sq:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Kërkoni sipas vendit ose territorit
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Delegacion ndërkombëtar

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -22,14 +22,14 @@ sr:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Priložena datoteka
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Broj priloženog komandnog dokumenta
         hoc_paper_number: Broj dokumenta Donjeg doma skupštine
@@ -51,19 +51,19 @@ sr:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ sr:
       subheading: Pronašli smo neke nedoumice sa vezama koji možda ukazuju probleme, budite oprezni pri praćenju veza
     title: Prekinute veze
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Zatvoreno
     closing_today: Zatvara se danas
@@ -152,323 +152,323 @@ sr:
       written_on: 'Napisano:'
     type:
       about:
-        few:
+        few: 
         one: Informacije
         other: Informacije
       about_our_services:
-        few:
+        few: 
         one: O našim uslugama
         other: O našim uslugama
       access_and_opening:
-        few:
+        few: 
         one: Pristup i radno vreme
         other: Pristup i radno vreme
       accessible_documents_policy:
-        few:
+        few: 
         one: Politika o pristupačnim dokumentima
         other: Politike o pristupačnim dokumentima
       alert:
-        few:
+        few: 
         one: Upozorenje
         other: Upozorenja
       announcement:
-        few:
+        few: 
         one: Najava
         other: Najave
       authored_article:
-        few:
+        few: 
         one: Autorski članak
         other: Autorski članci
       blog_post:
-        few:
+        few: 
         one: Objava na blogu
         other: Objave na blogu
       call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       campaign:
-        few:
+        few: 
         one: Kampanja
         other: Kampanje
       careers:
-        few:
+        few: 
         one: Zaposlenje
         other: zaposlenje
       case_study:
-        few:
+        few: 
         one: Studija slučaja
         other: Studije slučaja
       closed_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       closed_consultation:
-        few:
+        few: 
         one: Zatvorena konsultacija
         other: Zatvorene konsultacije
       complaints_procedure:
-        few:
+        few: 
         one: Postupak žalbe
         other: Postupci žalbe
       consultation:
-        few:
+        few: 
         one: Konsultacija
         other: Konsultacije
       consultation_outcome:
-        few:
+        few: 
         one: Ishod konsultacija
         other: Ishodi konsultacija
       corporate_report:
-        few:
+        few: 
         one: Organizacioni izveštaj
         other: Organizacioni izveštaji
       correspondence:
-        few:
+        few: 
         one: Prepiska
         other: Prepiske
       decision:
-        few:
+        few: 
         one: Odluka
         other: Odluke
       detailed_guidance:
-        few:
+        few: 
         one: Detaljno uputstvo
         other: Detaljno uputstvo
       document_collection:
-        few:
+        few: 
         one: Kolekcija
         other: Kolekcije
       draft_text:
-        few:
+        few: 
         one: Radna verzija teksta
         other: Radne verzije teksta
       edition:
-        few:
+        few: 
         one: Izdanje
         other: Izdanja
       edition_with_appointment:
-        few:
+        few: 
         one: Izdanje sa terminom
         other: Izdanje sa terminima
       equality_and_diversity:
-        few:
+        few: 
         one: Jednakost i raznolikost
         other: Jednakost i raznolikost
       fatality_notice:
-        few:
+        few: 
         one: Obaveštenje o smrtnim slučajevima
         other: Obaveštenja o smrtnim slučajevima
       foi_release:
-        few:
+        few: 
         one: Odgovor na zahtev za pristup informacijama od javnog značaja
         other: Odgovori na zahteve za pristup informacijama od javnog značaja
       form:
-        few:
+        few: 
         one: Formular
         other: Obrasci
       generic_edition:
-        few:
+        few: 
         one: Generičko izdanje
         other: Generička izdanja
       government_response:
-        few:
+        few: 
         one: Odgovor vlade
         other: Odgovori vlade
       guidance:
-        few:
+        few: 
         one: Detaljno uputstvo
         other: Detaljno uputstvo
       impact_assessment:
-        few:
+        few: 
         one: Procena efekta
         other: Procene efekata
       imported:
-        few:
+        few: 
         one: uvezeno – utvrđivanje tipa
         other: uvezeno – utvrđivanje tipa
       independent_report:
-        few:
+        few: 
         one: Nezavisni izveštaj
         other: Nezavisni izveštaji
       international_treaty:
-        few:
+        few: 
         one: Međunarodni sporazum
         other: Međunarodni sporazumi
       manual:
-        few:
+        few: 
         one: Priručnik
         other: Priručnici
       map:
-        few:
+        few: 
         one: Mapa
         other: Mape
       media_enquiries:
-        few:
+        few: 
         one: Upit za medije
         other: Upiti za medije
       membership:
-        few:
+        few: 
         one: Članstvo
         other: Članstvo
       modern_slavery_statement:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       national_statistics:
-        few:
+        few: 
         one: Državna statistika
         other: Državna statistika
       news_article:
-        few:
+        few: 
         one: Članak vesti
         other: Članci vesti
       news_story:
-        few:
+        few: 
         one: Vest
         other: Vesti
       nhs_content:
-        few:
+        few: 
         one: Sadržaj Nacionalne zdravstvene službe
         other: Sadržaj Nacionalne zdravstvene službe
       notice:
-        few:
+        few: 
         one: Obaveštenje
         other: Obaveštenja
       official_statistics:
-        few:
+        few: 
         one: Zvanična statistika
         other: Zvanična statistika
       open_call_for_evidence:
-        few:
-        one:
-        other:
+        few: 
+        one: 
+        other: 
       open_consultation:
-        few:
+        few: 
         one: Otvorena konsultacija
         other: Otvorene konsultacije
       oral_statement:
-        few:
+        few: 
         one: Usmeno obraćanje Parlamentu
         other: Usmena obraćanja Parlamentu
       our_energy_use:
-        few:
+        few: 
         one: Potrošnja energije
         other: Potrošnja energije
       our_governance:
-        few:
+        few: 
         one: Upravljanje
         other: Upravljanje
       personal_information_charter:
-        few:
+        few: 
         one: Deklaracija o ličnim podacima
         other: Deklaracije o ličnim podacima
       petitions_and_campaigns:
-        few:
+        few: 
         one: Peticije i kampanje
         other: Peticije i kampanje
       policy_paper:
-        few:
+        few: 
         one: Predlog politike
         other: Predlozi politike
       press_release:
-        few:
+        few: 
         one: Saopštenje za medije
         other: Saopštenja za štampu
       procurement:
-        few:
+        few: 
         one: Nabavka
         other: Nabavka
       promotional:
-        few:
+        few: 
         one: Promotivni materijal
         other: Promotivni materijal
       publication:
-        few:
+        few: 
         one: Publikacija
         other: Publikacije
       publication_scheme:
-        few:
+        few: 
         one: Shema publikacije
         other: Sheme publikacije
       recruitment:
-        few:
+        few: 
         one: Angažovanje
         other: Angažovanje
       regulation:
-        few:
+        few: 
         one: Propis
         other: Propisi
       research:
-        few:
+        few: 
         one: Istraživanje
         other: Istraživanje
       service:
-        few:
+        few: 
         one: Usluga
         other: Usluge
       social_media_use:
-        few:
+        few: 
         one: Korišćenje društvenih medija
         other: Korišćenje društvenih medija
       speaking_notes:
-        few:
+        few: 
         one: Teze za govor
         other: Teze za govor
       speech:
-        few:
+        few: 
         one: Govor
         other: Govori
       staff_update:
-        few:
+        few: 
         one: Ažuriranje osoblja
         other: Ažuriranja osoblja
       standard:
-        few:
+        few: 
         one: Standard
         other: Standardi
       statement_to_parliament:
-        few:
+        few: 
         one: Obraćanje Parlamentu
         other: Obraćanja Parlamentu
       statistical_data_set:
-        few:
+        few: 
         one: Set statističkih podataka
         other: Setovi statističkih podataka
       statistics:
-        few:
+        few: 
         one: Statistika
         other: Statistika
       statutory_guidance:
-        few:
+        few: 
         one: Zakonska uputstva
         other: Zakonska uputstva
       terms_of_reference:
-        few:
+        few: 
         one: Projektni zadatak
         other: Projektni zadatak
       transcript:
-        few:
+        few: 
         one: Transkript
         other: Transkripti
       transparency:
-        few:
+        few: 
         one: Podaci o transparentnosti
         other: Podaci o transparentnosti
       welsh_language_scheme:
-        few:
+        few: 
         one: Shema na velškom jeziku
         other: Sheme na velškom jeziku
       world_news_story:
-        few:
+        few: 
         one: Globalna vest
         other: Globalne vesti
       written_statement:
-        few:
+        few: 
         one: Pismena predstavka Parlamentu
         other: Pismene predstavke Parlamentu
     updated: ažurirano
@@ -485,72 +485,72 @@ sr:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
     sr: srpski
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Još nema novosti.
     title: Najnovije
@@ -562,7 +562,7 @@ sr:
       organisation_chart: Naš organizacioni dijagram
       transparency: Podaci o transparentnosti
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Poslovni podaci
       corporate_reports: Organizacioni izveštaji
@@ -579,10 +579,10 @@ sr:
   see_all:
     announcement: Pogledajte sva naša saopštenja
     authored_article: Pogledajte sve naše autorske članke
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Pogledajte sve naše studije slučajeva
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Pogledajte sve naše zatvorene konsultacije
     consultation: Pogledajte sve naše konsultacije
     consultation_outcome: Pogledajte sve naše ishode konsultacija
@@ -605,7 +605,7 @@ sr:
     news_article: Pogledajte sve naše članke vesti
     news_story: Pogledajte sve naše vesti
     notice: Pogledajte sva naša obaveštenja
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Pogledajte sve naše otvorene konsultacije
     oral_statement: Pogledajte sva naša usmena obraćanja Parlamentu
     policy: Pogledajte sve naše politike
@@ -639,22 +639,22 @@ sr:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Pretraga po zemlji ili teritoriji
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
+        few: 
         one: Međunarodna delegacija
         other: Međunarodne delegacije
       world_location:
-        few:
+        few: 
         one: Globalna lokacija
         other: Globalne lokacije
   world_news:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -22,14 +22,14 @@ sv:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Den bifogade filen
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Bilagans kommandopappersnummer
         hoc_paper_number: Underhusets dokumentnummer
@@ -51,19 +51,19 @@ sv:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -92,10 +92,10 @@ sv:
       subheading: Vi har hittat några problem med länkar som kan tyda på problem, du bör vara försiktig när du länkar till dem
     title: Trasiga länkar
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Stängd
     closing_today: Stänger idag
@@ -176,11 +176,11 @@ sv:
         one: Blogginlägg
         other: Blogginlägg
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampanj
         other: Kampanjer
@@ -191,8 +191,8 @@ sv:
         one: Fallstudier
         other: Fallstudier
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Slutet samråd
         other: Slutna samråd
@@ -275,8 +275,8 @@ sv:
         one: Medlemskap
         other: Medlemskap
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Nationell statistik
         other: Nationell statistik
@@ -296,8 +296,8 @@ sv:
         one: Officiell statistik
         other: Officiell statistik
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Öppet samråd
         other: Öppna samråd
@@ -405,72 +405,72 @@ sv:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
     sv: Svensk
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Det finns inga uppdateringar ännu.
     title: Senaste
@@ -482,7 +482,7 @@ sv:
       organisation_chart: Vårt organisationsschema
       transparency: Uppgifter om öppenhet
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Företagsinformation
       corporate_reports: Företagsrapporter
@@ -499,10 +499,10 @@ sv:
   see_all:
     announcement: Se alla våra tillkännagivanden
     authored_article: Se alla våra författade artiklar
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Se alla våra fallstudier
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Se alla våra avslutade samråd
     consultation: Se alla våra samråd
     consultation_outcome: Se alla våra samrådsresultat
@@ -525,7 +525,7 @@ sv:
     news_article: Se alla våra nyhetsartiklar
     news_story: Se alla våra nyheter
     notice: Se alla våra meddelanden
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Se alla våra öppna samråd
     oral_statement: Se alla våra muntliga uttalanden inför parlamentet
     policy: Se all vår politik
@@ -559,15 +559,15 @@ sv:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Sök efter land eller område
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Internationell delegation

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -22,14 +22,14 @@ sw:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Faili iliyoambatishwa
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Nambari ya hati ya amri ya kiambatisho
         hoc_paper_number: Nambari ya hati ya House of Commons
@@ -51,19 +51,19 @@ sw:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ sw:
       subheading: Tumepata matatizo kwenye viungo ambayo huenda yanaashiria hatari, unapaswa kutahadhari unapovibofya
     title: Viungo ambavyo havijakamilika
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Imefungwa
     closing_today: Inafungwa leo
@@ -175,11 +175,11 @@ sw:
         one: Chapisho kwenye blogu
         other: Machapisho kwenye blogu
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampeni
         other: Kampeni
@@ -190,8 +190,8 @@ sw:
         one: Uchunguzi kifani
         other: Uchunguzi kifani
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Mashauriano ya watu wachache
         other: Mashauriano ya watu wachache
@@ -274,8 +274,8 @@ sw:
         one: Uanachama
         other: Uanachama
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Takwimu za Kitaifa
         other: Takwimu za Kitaifa
@@ -295,8 +295,8 @@ sw:
         one: Takwimu Rasmi
         other: Takwimu Rasmi
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Mashauriano ya watu wengi
         other: Mashauriano ya watu wengi
@@ -404,72 +404,72 @@ sw:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
     sw: Kiswahili
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Bado hakuna masasisho.
     title: Habari mpya
@@ -481,7 +481,7 @@ sw:
       organisation_chart: Chati ya shirika letu
       transparency: Data ya uwazi
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Maelezo ya shirika
       corporate_reports: Ripoti za shirika
@@ -498,10 +498,10 @@ sw:
   see_all:
     announcement: Angalia matangazo yetu yote
     authored_article: Angalia makala yetu yote yaliyo na maelezo ya mwandishi
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Angalia uchunguzi kifani wetu wote
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Angalia mashauriano yetu yote ya watu wachache
     consultation: Angalia mashauriano yetu yote
     consultation_outcome: Angalia matokeo ya mashauriano yetu yote
@@ -524,7 +524,7 @@ sw:
     news_article: Angalia makala yetu yote ya habari
     news_story: Angalia taarifa zetu zote za habari
     notice: Angalia notisi zetu zote
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Angalia mashauriano yetu yote ya watu wengi
     oral_statement: Angalia taarifa zetu za matamshi kwa Bunge
     policy: Angalia sera zetu zote
@@ -558,15 +558,15 @@ sw:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Tafuta kulingana na nchi au eneo
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Ujumbe wa kimataifa

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -22,14 +22,14 @@ ta:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: இணைக்கப்பட்ட கோப்பு
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: இணைப்பு கட்டளை ஆவண எண்
         hoc_paper_number: கீழ்ச்சபை ஆவண எண்
@@ -51,19 +51,19 @@ ta:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ ta:
       subheading: பிரச்சினைகளைச் சுட்டிக்காட்டக்கூடிய இணைப்புகளுடன் சில பிரச்சினைகளைக் கண்டறிந்துள்ளோம். அவற்றைத் தொடர்வதில் கவனமாய் இருக்கவும்
     title: முறிந்த இணைப்புகள்
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: மூடப்பட்டது
     closing_today: இன்று மூடப்படுகிறது
@@ -175,11 +175,11 @@ ta:
         one: வலைப்பூப் பதிவு
         other: வலைப்பூப் பதிவுகள்
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: பிரச்சாரம்
         other: பிரச்சாரங்கள்
@@ -190,8 +190,8 @@ ta:
         one: நிகழ்வு ஆய்வு
         other: நிகழ்வு ஆய்வுகள்
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: மூடிய கலந்தாய்வு
         other: மூடிய கலந்தாய்வுகள்
@@ -274,8 +274,8 @@ ta:
         one: உறுப்பினர் நிலை
         other: உறுப்பினர் நிலை
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: தேசிய புள்ளியியல்
         other: தேசிய புள்ளியியல்
@@ -295,8 +295,8 @@ ta:
         one: அதிகாரப்பூர்வ புள்ளியியல்
         other: அதிகாரப்பூர்வ புள்ளியியல்
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: திறந்த கலந்தாலோசனை
         other: திறந்த கலந்தாலோசனைகள்
@@ -404,72 +404,72 @@ ta:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
     ta: தமிழ்
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: எந்த புதுப்பித்தல்களும் இல்லை.
     title: சமீபத்தியது
@@ -481,7 +481,7 @@ ta:
       organisation_chart: எங்கள் அமைப்பு வரைபடம்
       transparency: வெளிப்படையான தரவு
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: குழுமத் தகவல்கள்
       corporate_reports: குழும அறிக்கைகள்
@@ -498,10 +498,10 @@ ta:
   see_all:
     announcement: எங்கள் அனைத்து அறிவிப்புகளையும் காண்க
     authored_article: எங்கள் அனைத்து எழுதப்பட்ட கட்டுரைகளையும் காண்க
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: எங்கள் அனைத்து நிகழ்வு ஆய்வுகளையும் காண்க
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: எங்கள் அனைத்து மூடிய கலந்தாலோசனைகளையும் காண்க
     consultation: எங்கள் அனைத்து கலந்தாலோசனைகளையும் காண்க
     consultation_outcome: எங்கள் அனைத்து கலந்தாலோசனை பலன்களையும் காண்க
@@ -524,7 +524,7 @@ ta:
     news_article: எங்கள் அனைத்து செய்திக் கட்டுரைகளையும் காண்க
     news_story: எங்கள் அனைத்து செய்திகளையும் காண்க
     notice: எங்கள் அனைத்து அறிவிப்புகளையும் காண்க
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: எங்கள் அனைத்து திறந்த கலந்தாலோசனைகளையும் காண்க
     oral_statement: எங்கள் அனைத்து நாடாளுமன்றத்துக்கான வாய்வழி அறிவிப்புகளையும் காண்க
     policy: எங்கள் அனைத்து கொள்கைகளையும் காண்க
@@ -558,15 +558,15 @@ ta:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: நாடு அல்லது பிரதேசம் வாரியாகத் தேடு
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: சர்வதேச தூதுக்குழு

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -22,14 +22,14 @@ th:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: เอกสารแนบ
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: เลขที่เอกสารคำสั่งแนบ
         hoc_paper_number: เลขที่เอกสารสภาสามัญ
@@ -51,19 +51,19 @@ th:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ th:
       subheading: เราพบประเด็นบางอย่างเกี่ยวกับลิงก์ที่อาจบ่งชี้ว่าลิงก์นี้มีปัญหา คุณควรใช้ความระมัดระวังในการเปิดลิงก์เหล่านั้น
     title: ลิงค์ใช้ไม่ได้
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: ปิดแล้ว
     closing_today: กำลังปิดวันนี้
@@ -167,9 +167,9 @@ th:
       blog_post:
         other: โพสต์บล็อก
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: การรณรงค์
       careers:
@@ -177,7 +177,7 @@ th:
       case_study:
         other: กรณีศึกษา
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: การให้คำปรึกษาที่ปิดแล้ว
       complaints_procedure:
@@ -233,7 +233,7 @@ th:
       membership:
         other: สมาชิก
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: สถิติแห่งชาติ
       news_article:
@@ -247,7 +247,7 @@ th:
       official_statistics:
         other: สถิติของราชการ
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: การให้คำปรึกษาที่เปิดอยู่
       oral_statement:
@@ -324,72 +324,72 @@ th:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
     th: ไทย
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: ยังไม่มีการปรับปรุง
     title: ล่าสุด
@@ -401,7 +401,7 @@ th:
       organisation_chart: แผนผังองค์กรของเรา
       transparency: ข้อมูลความโปร่งใส
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: ข้อมูลองค์กร
       corporate_reports: รายงานของบริษัท
@@ -418,10 +418,10 @@ th:
   see_all:
     announcement: ดูประกาศทั้งหมดของเรา
     authored_article: ดูบทความโดยผู้เขียนทั้งหมดของเรา
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: ดูกรณีศึกษาทั้งหมดของเรา
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: ดูการให้คำปรึกษาที่ปิดแล้วทั้งหมดของเรา
     consultation: ดูการให้คำปรึกษาที่ปิดแล้วทั้งหมดของเรา
     consultation_outcome: ดูผลลัพธ์จากการให้คำปรึกษาทั้งหมดของเรา
@@ -444,7 +444,7 @@ th:
     news_article: ดูบทความข่าวทั้งหมดของเรา
     news_story: ดูเนื้อหาข่าวทั้งหมดของเรา
     notice: ดูประกาศทั้งหมดของเรา
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: ดูการให้คำปรึกษาที่เปิดอยู่ทั้งหมดของเรา
     oral_statement: ดูแถลงการณ์ด้วยวาจาต่อรัฐสภาทั้งหมดของเรา
     policy: ดูนโยบายทั้งหมดของเรา
@@ -478,15 +478,15 @@ th:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: ค้นหาด้วยประเทศหรือดินแดน
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: คณะผู้แทนระหว่างประเทศ

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -22,14 +22,14 @@ tk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Goşulan faýl
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Goşundy buýruk kagyz belgisi
         hoc_paper_number: Jemgyýetçilik palatasy kagyz belgisi
@@ -51,19 +51,19 @@ tk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ tk:
       subheading: Biz baglanyşyklara degişli käbir meseleleri ýüze çykardyk, olardan peýdalanylanda seresap bolmaly
     title: Döwülen baglanyşyklar
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Ýapyk
     closing_today: Şu gün ýapylýar
@@ -175,11 +175,11 @@ tk:
         one: Blog ýazgysy
         other: Blog ýazgylary
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kompaniýa
         other: Kompaniýalar
@@ -190,8 +190,8 @@ tk:
         one: Ýagdaý seljermesi
         other: Ýagdaý seljermeleri
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Ýapyk maslahat
         other: Ýapyk maslahatlar
@@ -274,8 +274,8 @@ tk:
         one: Agzalyk
         other: Agzalyk
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Milli statistika
         other: Milli statistika
@@ -295,8 +295,8 @@ tk:
         one: Resmi statistika
         other: Resmi statistika
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Açyk maslahat
         other: Açyk maslahatlar
@@ -404,72 +404,72 @@ tk:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
     tk: Türkmen
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Heniz täzelenmeler ýok.
     title: Iň täze
@@ -481,7 +481,7 @@ tk:
       organisation_chart: Guramamyzyň diagrammasy
       transparency: Aç-açanlyk maglumatlar
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Korporatiw maglumatlar
       corporate_reports: Korperatiw hasabatlar
@@ -498,10 +498,10 @@ tk:
   see_all:
     announcement: Biziň ähli bildirişlerimize serediň
     authored_article: Biziň ähli ygtyýarlandyrylan statýalarymyza serediň
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Biziň ähli ýagdaý seljermelerimize serediň
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Biziň ähli ýapyk maslahatlarymyza serediň
     consultation: Biziň ähli maslahatlarymyza serediň
     consultation_outcome: Biziň ähli maslahat netijelerimize serediň
@@ -524,7 +524,7 @@ tk:
     news_article: Biziň ähli habar makalalarymyza serediň
     news_story: Biziň ähli habarlarymyza serediň
     notice: Biziň ähli belliklerimize serediň
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Biziň ähli açyk maslahatlarymyza serediň
     oral_statement: Biziň ähli Mejlise edilen dilden beýanlarymyza serediň
     policy: Biziň ähli syýasatymyza serediň
@@ -558,15 +558,15 @@ tk:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Döwlet ýa-da territoriýa boýunça gözlemek
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Halkara delegasiýa

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -22,14 +22,14 @@ tr:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Ekli dosya
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Ek komutu evrak numarası
         hoc_paper_number: Avam Kamarası evrak numarası
@@ -51,19 +51,19 @@ tr:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ tr:
       subheading: Linklerde problem göstergesi olabilecek bazı sorunlar bulduk, bunlara bağlantı kurarken dikkatli olmalısınız
     title: Kırık linkler
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Kapatılan
     closing_today: Bugün kapanıyor
@@ -175,11 +175,11 @@ tr:
         one: Blog gönderisi
         other: Blog gönderileri
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Kampanya
         other: Kampanyalar
@@ -190,8 +190,8 @@ tr:
         one: Vaka incelemesi
         other: Vaka incelemeleri
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Kapalı danışma
         other: Kapalı danışmalar
@@ -274,8 +274,8 @@ tr:
         one: Üyelik
         other: Üyelik
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Ulusal İstatistikler
         other: Ulusal İstatistikler
@@ -295,8 +295,8 @@ tr:
         one: Resmi İstatistikler
         other: Resmi İstatistikler
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Açık danışma
         other: Açık danışmalar
@@ -404,72 +404,72 @@ tr:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
     tr: Türkçe
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Henüz hiç güncelleme yok.
     title: En güncel
@@ -481,7 +481,7 @@ tr:
       organisation_chart: Kuruluş şemamız
       transparency: Şeffaflık verileri
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Kurumsal bilgiler
       corporate_reports: Kurumsal raporlar
@@ -498,10 +498,10 @@ tr:
   see_all:
     announcement: Tüm duyurularımıza bakın
     authored_article: Tüm yazar makalelerimize bakın
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Tüm vaka incelemelerimize bakın
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Tüm tamamlanan danışmalarımıza bakın
     consultation: Tüm danışmalarımıza bakın
     consultation_outcome: Tüm danışma sonuçlarımıza bakın
@@ -524,7 +524,7 @@ tr:
     news_article: Tüm haber makalelerimize bakın
     news_story: Tüm haber hikayelerimize bakın
     notice: Tüm bildirimlerimize bakın
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Tüm tamamlanan danışmalarımıza bakın
     oral_statement: Parlamentoya tüm sözlü açıklamalarımıza bakın
     policy: Tüm politikalarımıza bakın
@@ -558,15 +558,15 @@ tr:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Ülkeye veya bölgeye göre arama yapın
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Uluslararası delegasyon

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -22,14 +22,14 @@ uk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Доданий файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Номер додатку директивного документу
         hoc_paper_number: Номер документу Палати громад
@@ -51,19 +51,19 @@ uk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ uk:
       subheading: Ми виявили деякі розбіжності посилань, які можуть вказувати на проблеми, тому слід бути обережними, посилаючись на них
     title: Порушені посилання
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Закрито
     closing_today: Закривається сьогодні
@@ -151,403 +151,403 @@ uk:
       written_on: 'Написано:'
     type:
       about:
-        few:
-        many:
+        few: 
+        many: 
         one: Інформація
         other: Інформація
       about_our_services:
-        few:
-        many:
+        few: 
+        many: 
         one: Про наші послуги
         other: Про наші послуги
       access_and_opening:
-        few:
-        many:
+        few: 
+        many: 
         one: Доступ і відкриття
         other: Доступ і відкриття
       accessible_documents_policy:
-        few:
-        many:
+        few: 
+        many: 
         one: Політика щодо доступних документів
         other: Політика щодо доступних документів
       alert:
-        few:
-        many:
+        few: 
+        many: 
         one: Сповіщення
         other: Сповіщення
       announcement:
-        few:
-        many:
+        few: 
+        many: 
         one: Оголошення
         other: Оголошення
       authored_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Авторська стаття
         other: Авторські статті
       blog_post:
-        few:
-        many:
+        few: 
+        many: 
         one: Допис у блозі
         other: Дописи в блозі
       call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       call_for_evidence_outcome:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       campaign:
-        few:
-        many:
+        few: 
+        many: 
         one: Кампанія
         other: Кампанії
       careers:
-        few:
-        many:
+        few: 
+        many: 
         one: Кар'єра
         other: Кар'єра
       case_study:
-        few:
-        many:
+        few: 
+        many: 
         one: Аналіз ситуації
         other: Аналізи ситуації
       closed_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       closed_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Закрита консультація
         other: Закриті консультації
       complaints_procedure:
-        few:
-        many:
+        few: 
+        many: 
         one: Процедура подання скарг
         other: Процедури подання скарг
       consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Консультація
         other: Консультації
       consultation_outcome:
-        few:
-        many:
+        few: 
+        many: 
         one: Результат консультації
         other: Результати консультації
       corporate_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Звіт про діяльність корпорації
         other: Звіти про діяльність корпорації
       correspondence:
-        few:
-        many:
+        few: 
+        many: 
         one: Кореспонденція
         other: Кореспонденція
       decision:
-        few:
-        many:
+        few: 
+        many: 
         one: Рішення
         other: Рішення
       detailed_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Керівництво
         other: Керівництво
       document_collection:
-        few:
-        many:
+        few: 
+        many: 
         one: Збір
         other: Збір
       draft_text:
-        few:
-        many:
+        few: 
+        many: 
         one: Проєкт тексту
         other: Проєкт текстів
       edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Видання
         other: Видання
       edition_with_appointment:
-        few:
-        many:
+        few: 
+        many: 
         one: Видання із домовленістю
         other: Видання із домовленістю
       equality_and_diversity:
-        few:
-        many:
+        few: 
+        many: 
         one: Рівність і різноманітність
         other: Рівність і різноманітність
       fatality_notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Повідомлення про нещасний випадок зі смертельним наслідком
         other: Повідомлення про нещасний випадок зі смертельним наслідком
       foi_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Випуск закону про свободу інформації
         other: Випуски закону про свободу інформації
       form:
-        few:
-        many:
+        few: 
+        many: 
         one: Форма
         other: Форми
       generic_edition:
-        few:
-        many:
+        few: 
+        many: 
         one: Загальне видання
         other: Загальні видання
       government_response:
-        few:
-        many:
+        few: 
+        many: 
         one: Відповідь уряду
         other: Відповіді уряду
       guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Керівництво
         other: Керівництво
       impact_assessment:
-        few:
-        many:
+        few: 
+        many: 
         one: Оцінка впливу
         other: Оцінки впливу
       imported:
-        few:
-        many:
+        few: 
+        many: 
         one: імпортовано - тип в очікуванні
         other: імпортовано - тип в очікуванні
       independent_report:
-        few:
-        many:
+        few: 
+        many: 
         one: Незалежний звіт
         other: Незалежні звіти
       international_treaty:
-        few:
-        many:
+        few: 
+        many: 
         one: Міжнародний договір
         other: Міжнародні договори
       manual:
-        few:
-        many:
+        few: 
+        many: 
         one: Керівництво
         other: Керівництва
       map:
-        few:
-        many:
+        few: 
+        many: 
         one: Карта
         other: Карти
       media_enquiries:
-        few:
-        many:
+        few: 
+        many: 
         one: Запит ЗМІ
         other: Запит ЗМІ
       membership:
-        few:
-        many:
+        few: 
+        many: 
         one: Членство
         other: Членство
       modern_slavery_statement:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       national_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Національна статистика
         other: Національна статистика
       news_article:
-        few:
-        many:
+        few: 
+        many: 
         one: Новини
         other: Новини
       news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Сюжет новин
         other: Сюжети новин
       nhs_content:
-        few:
-        many:
+        few: 
+        many: 
         one: Зміст Національної служби з охорони здоров'я
         other: Зміст Національної служби з охорони здоров'я
       notice:
-        few:
-        many:
+        few: 
+        many: 
         one: Повідомлення
         other: Повідомлення
       official_statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Офіційна статистика
         other: Офіційна статистика
       open_call_for_evidence:
-        few:
-        many:
-        one:
-        other:
+        few: 
+        many: 
+        one: 
+        other: 
       open_consultation:
-        few:
-        many:
+        few: 
+        many: 
         one: Відкрита консультація
         other: Відкриті консультації
       oral_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Усна заява до Парламенту
         other: Усні заяви до Парламенту
       our_energy_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Наше енергоспоживання
         other: Наше енергоспоживання
       our_governance:
-        few:
-        many:
+        few: 
+        many: 
         one: Наше управління
         other: Наше управління
       personal_information_charter:
-        few:
-        many:
+        few: 
+        many: 
         one: Статут з персональних даних
         other: Статути з персональних даних
       petitions_and_campaigns:
-        few:
-        many:
+        few: 
+        many: 
         one: Петиції та кампанії
         other: Петиції та кампанії
       policy_paper:
-        few:
-        many:
+        few: 
+        many: 
         one: Програмний документ
         other: Програмні документи
       press_release:
-        few:
-        many:
+        few: 
+        many: 
         one: Пресреліз
         other: Пресрелізи
       procurement:
-        few:
-        many:
+        few: 
+        many: 
         one: Закупівлі
         other: Закупівлі
       promotional:
-        few:
-        many:
+        few: 
+        many: 
         one: Рекламний матеріал
         other: Рекламний матеріал
       publication:
-        few:
-        many:
+        few: 
+        many: 
         one: Публікація
         other: Публікації
       publication_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема публікації
         other: Схеми публікації
       recruitment:
-        few:
-        many:
+        few: 
+        many: 
         one: Прийом на роботу
         other: Прийом на роботу
       regulation:
-        few:
-        many:
+        few: 
+        many: 
         one: Норма
         other: Норми
       research:
-        few:
-        many:
+        few: 
+        many: 
         one: Дослідження
         other: Дослідження
       service:
-        few:
-        many:
+        few: 
+        many: 
         one: Послуга
         other: Послуги
       social_media_use:
-        few:
-        many:
+        few: 
+        many: 
         one: Використання соціальних медіа
         other: Використання соціальних медіа
       speaking_notes:
-        few:
-        many:
+        few: 
+        many: 
         one: Тези виступу
         other: Тези виступу
       speech:
-        few:
-        many:
+        few: 
+        many: 
         one: Виступ
         other: Виступи
       staff_update:
-        few:
-        many:
+        few: 
+        many: 
         one: Оновлення щодо персоналу
         other: Оновлення щодо персоналу
       standard:
-        few:
-        many:
+        few: 
+        many: 
         one: Стандарт
         other: Стандарти
       statement_to_parliament:
-        few:
-        many:
+        few: 
+        many: 
         one: Заява до Парламенту
         other: Заяви до Парламенту
       statistical_data_set:
-        few:
-        many:
+        few: 
+        many: 
         one: Набір статистичних даних
         other: Набори статистичних даних
       statistics:
-        few:
-        many:
+        few: 
+        many: 
         one: Статистика
         other: Статистика
       statutory_guidance:
-        few:
-        many:
+        few: 
+        many: 
         one: Нормативне керівництво
         other: Нормативне керівництво
       terms_of_reference:
-        few:
-        many:
+        few: 
+        many: 
         one: Сфера компетенції
         other: Сфера компетенції
       transcript:
-        few:
-        many:
+        few: 
+        many: 
         one: Стенограма
         other: Стенограми
       transparency:
-        few:
-        many:
+        few: 
+        many: 
         one: Дані прозорості
         other: Дані прозорості
       welsh_language_scheme:
-        few:
-        many:
+        few: 
+        many: 
         one: Схема валлійської мови
         other: Схеми валлійської мови
       world_news_story:
-        few:
-        many:
+        few: 
+        many: 
         one: Сюжет міжнародних новин
         other: Сюжети міжнародних новин
       written_statement:
-        few:
-        many:
+        few: 
+        many: 
         one: Письмова заява до Парламенту
         other: Письмові заяви до Парламенту
     updated: оновлено
@@ -564,72 +564,72 @@ uk:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
     uk: Українська
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Оновлення поки немає.
     title: Останні
@@ -641,7 +641,7 @@ uk:
       organisation_chart: Структурна схема нашої організації
       transparency: Дані прозорості
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Корпоративна інформація
       corporate_reports: Звіти про діяльність корпорації
@@ -658,10 +658,10 @@ uk:
   see_all:
     announcement: Перегляньте всі наші оголошення
     authored_article: Перегляньте всі наші авторські статті
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Перегляньте всі наші аналізи ситуацій
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Перегляньте всі наші закриті консультації
     consultation: Перегляньте всі наші консультації
     consultation_outcome: Перегляньте всі результати наших консультацій
@@ -684,7 +684,7 @@ uk:
     news_article: Перегляньте всі наші авторські статті
     news_story: Перегляньте всі наші сюжети новин
     notice: Перегляньте всі наші повідомлення
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Перегляньте всі наші відкриті консультації
     oral_statement: Перегляньте всі наші усні заяви до парламенту
     policy: Перегляньте всі наші політики
@@ -718,24 +718,24 @@ uk:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Пошук за країною чи територією
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        few:
-        many:
+        few: 
+        many: 
         one: Міжнародна делегація
         other: Міжнародні делегації
       world_location:
-        few:
-        many:
+        few: 
+        many: 
         one: Світова локація
         other: Світові локації
   world_news:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -22,14 +22,14 @@ ur:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: منسلک کردہ فائل
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: منسلکہ کے حکم کا صفحہ نمبر
         hoc_paper_number: ہاؤس آف کامنز کا صفحہ نمبر
@@ -51,19 +51,19 @@ ur:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ ur:
       subheading: ہمیں لنکس کے ساتھ کچھ درپیش مسائل کے بارے میں معلوم ہوا ہے جو کہ مسائل کی نشاندہی کر سکتے ہیں، آپ کو انہیں مربوط کرنے وقت احتیاط برتنی چاہیئے
     title: ٹوٹے ہوئے لنکس
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: بند
     closing_today: آج بند ہونا ہے۔
@@ -175,11 +175,11 @@ ur:
         one: بلاگ پوسٹ
         other: بلاگ پوسٹس
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: مہم
         other: مہمات
@@ -190,8 +190,8 @@ ur:
         one: کیس اسٹڈی
         other: کیس اسٹڈیز
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: محدود مشاورت
         other: محدود مشاورتیں
@@ -274,8 +274,8 @@ ur:
         one: ممبرشپ
         other: ممبرشپ
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: قومی شماریات
         other: قومی شماریات
@@ -295,8 +295,8 @@ ur:
         one: سرکاری شماریات
         other: سرکاری شماریات
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: آزاد مشاورت
         other: آزاد مشاورت
@@ -404,72 +404,72 @@ ur:
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
     ur: اردو
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: ابھی تک کوئی اپ ڈیٹس نہیں ہیں۔
     title: تازہ ترین
@@ -481,7 +481,7 @@ ur:
       organisation_chart: ہماری تنظیم کا چارٹ
       transparency: شفافیت کا ڈیٹا
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: کارپوریٹ معلومات
       corporate_reports: کارپوریٹ رپورٹس
@@ -498,10 +498,10 @@ ur:
   see_all:
     announcement: ہمارے تمام اعلانات دکھائیں
     authored_article: ہمارے تمام مصنف کے نام کے ساتھ لکھے مضامین دیکھیں
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: ہماری تمام کیس اسٹڈیز دیکھیں
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: ہماری تمام محدود مشاورتیں دیکھیں
     consultation: ہماری تمام مشاورتیں دیکھیں
     consultation_outcome: ہماری تمام مشاورتوں کے نتائج دیکھیں
@@ -524,7 +524,7 @@ ur:
     news_article: ہمارے تمام خبروں کے مضامین دیکھیں
     news_story: ہماری تمام خبروں کی کہانیاں دیکھیں
     notice: ہمارے تمام نوٹسز دیکھیں
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: ہماری تمام آزاد مشاورتیں دیکھیں
     oral_statement: ہمارے تمام پارلیمان کے لیے زبانی بیانات دیکھیں
     policy: ہماری تمام پالیسیاں دیکھیں
@@ -558,15 +558,15 @@ ur:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: ملک یا خطے کے لحاظ سے تلاش کریں
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: عالمی وفد

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -22,14 +22,14 @@ uz:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Илова қилинган файл
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Илова қилинган буйруқнинг рақами
         hoc_paper_number: Жамоат Палатасининг ҳужжат рақами
@@ -51,19 +51,19 @@ uz:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ uz:
       subheading: Биз томондан бузилишга кўрсатиши мумкин бўлган ҳаволаларга тааллуқли маълум муаммолар аниқланди. Сизга улар орқали ўтишда эҳтиёткорликка риоя қилиш лозим бўлади
     title: шикастланган ҳаволалар
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Ёпиқ
     closing_today: Бугун ёпилади
@@ -175,11 +175,11 @@ uz:
         one: Блог хабари
         other: Блог хабарлари
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
         one: Кампания
         other: Кампаниялар
@@ -190,8 +190,8 @@ uz:
         one: Ҳолатлар таҳлили
         other: Ҳолатларнинг таҳлиллари
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
         one: Ёпиқ маслаҳат
         other: Ёпиқ маслаҳатлар
@@ -274,8 +274,8 @@ uz:
         one: Аъзолик
         other: Аъзолик
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
         one: Миллий статистика
         other: Миллий статистика
@@ -295,8 +295,8 @@ uz:
         one: Расмий статистик маълумотлар
         other: Расмий статистик маълумотлар
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
         one: Очиқ маслаҳат
         other: Очиқ маслаҳатлар
@@ -404,72 +404,72 @@ uz:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
     uz: Ўзбекча
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Янгиланишлар мавжуд эмас.
     title: Энг сўнгги
@@ -481,7 +481,7 @@ uz:
       organisation_chart: Ташкилий тузилмани бизнинг схемамиз
       transparency: Очиқликка оид маълумотлар
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Корпоратив маълумот
       corporate_reports: Корпорация фаолияти тўғрисида ҳисоботлар
@@ -498,10 +498,10 @@ uz:
   see_all:
     announcement: Бизнинг барча эълонларимизни кўринг
     authored_article: Бизнинг барча муаллифлик мақолаларимизни кўринг
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Бизнинг барча ҳолатни ўрганилишларимизни кўринг
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Бизнинг барча ёпиқ маслаҳатларимизни кўринг
     consultation: Бизнинг барча маслаҳатларимизни кўринг
     consultation_outcome: Бизнинг барча маслаҳатларимиз натижаларини кўринг
@@ -524,7 +524,7 @@ uz:
     news_article: Бизнинг барча янги мақолаларимизни кўринг
     news_story: Бизнинг барча янгиликларимизни кўринг
     notice: Бизнинг барча хабарномаларимизни кўринг
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Бизнинг барча очиқ маслаҳатларимизни кўринг
     oral_statement: Бизнинг барча парламентга оғзаки баёнотларимизни кўринг
     policy: Бизнинг барча дастурларимизни кўринг
@@ -558,15 +558,15 @@ uz:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Мамлакат ёки минтақа бўйича излаш
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         one: Халқаро делегация

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -22,14 +22,14 @@ vi:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Tệp đính kèm
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: Số văn kiện lệnh đính kèm
         hoc_paper_number: Số văn kiện của Hạ viện
@@ -51,19 +51,19 @@ vi:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ vi:
       subheading: Chúng tôi đã tìm thấy một số vấn đề với các liên kết có thể là dấu hiệu cho thấy sự cố, bạn nên thận trọng khi truy cập các liên kết đó
     title: Liên kết đã hỏng
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: Đã đóng
     closing_today: Đóng hôm nay
@@ -167,9 +167,9 @@ vi:
       blog_post:
         other: Bài viết trên blog
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: Chiến dịch
       careers:
@@ -177,7 +177,7 @@ vi:
       case_study:
         other: Nghiên cứu điển hình
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: Tham vấn kín
       complaints_procedure:
@@ -233,7 +233,7 @@ vi:
       membership:
         other: Tư cách thành viên
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: Thống kê Quốc gia
       news_article:
@@ -247,7 +247,7 @@ vi:
       official_statistics:
         other: Thống kê Chính thức
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: Tham vấn mở
       oral_statement:
@@ -324,72 +324,72 @@ vi:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
     vi: Tiếng Việt
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    yi: 
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: Chưa có cập nhật.
     title: Mới nhất
@@ -401,7 +401,7 @@ vi:
       organisation_chart: Sơ đồ tổ chức của chúng tôi
       transparency: Dữ liệu về tính minh bạch
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: Thông tin doanh nghiệp
       corporate_reports: Báo cáo của doanh nghiệp
@@ -418,10 +418,10 @@ vi:
   see_all:
     announcement: Xem tất cả các thông báo của chúng tôi
     authored_article: Xem tất cả các bài viết có tác giả của chúng tôi
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: Xem tất cả các nghiên cứu điển hình của chúng tôi
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: Xem tất cả các buổi tham vấn kín của chúng tôi
     consultation: Xem tất cả các buổi tham vấn của chúng tôi
     consultation_outcome: Xem tất cả các kết quả tham vấn của chúng tôi
@@ -444,7 +444,7 @@ vi:
     news_article: Xem tất cả các bài báo của chúng tôi
     news_story: Xem tất cả các bài phóng sự của chúng tôi
     notice: Xem tất cả các thông báo của chúng tôi
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: Xem tất cả các buổi tham vấn mở của chúng tôi
     oral_statement: Xem tất cả các tuyên bố bằng lời của chúng tôi trước Nghị viện
     policy: Xem tất cả các chính sách của chúng tôi
@@ -478,15 +478,15 @@ vi:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: Tìm kiếm theo quốc gia hoặc lãnh thổ
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: Phái đoàn quốc tế

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -3,589 +3,589 @@ yi:
   activerecord:
     attributes:
       attachment:
-        hoc_paper_number:
-        isbn:
-        unnumbered_hoc_paper:
+        hoc_paper_number: 
+        isbn: 
+        unnumbered_hoc_paper: 
       attachment_data:
-        file:
+        file: 
       corporate_information_page/corporate_information_page_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
-        file:
+        file: 
       edition:
-        nation_inapplicabilities:
+        nation_inapplicabilities: 
       policy_group/policy_group_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/consultation_response_attachments/attachment/attachment_data:
-        file:
+        file: 
     nested_attachment_data_field_names:
-      file:
+      file: 
     nested_attachment_field_names:
-      command_paper_number:
-      hoc_paper_number:
-      isbn:
-      title:
-      unique_reference:
-      unnumbered_hoc_paper:
+      command_paper_number: 
+      hoc_paper_number: 
+      isbn: 
+      title: 
+      unique_reference: 
+      unnumbered_hoc_paper: 
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
-      full_help_html:
-      intro:
-      request_a_different_format:
+      full_help_html: 
+      intro: 
+      request_a_different_format: 
     csv:
-      cannot_preview:
-      download:
-      truncated_message:
+      cannot_preview: 
+      download: 
+      truncated_message: 
     headings:
-      order_a_copy:
-      order_a_copy_full:
-      published:
-      reference:
-      unnumbered_command_paper:
-      unnumbered_hoc_paper:
+      order_a_copy: 
+      order_a_copy_full: 
+      published: 
+      reference: 
+      unnumbered_command_paper: 
+      unnumbered_hoc_paper: 
     opendocument:
-      help_html:
+      help_html: 
   broken_links:
     broken:
-      subheading:
+      subheading: 
     caution:
-      subheading:
-    title:
+      subheading: 
+    title: 
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   contact:
-    access_and_opening_times:
-    contact_form:
-    email:
+    access_and_opening_times: 
+    contact_form: 
+    email: 
   corporate_information_page:
     type:
       link_text:
-        welsh_language_scheme:
+        welsh_language_scheme: 
       title:
-        about:
-        about_our_services:
-        access_and_opening:
-        accessible_documents_policy:
-        complaints_procedure:
-        equality_and_diversity:
-        media_enquiries:
-        membership:
-        modern_slavery_statement:
-        our_energy_use:
-        our_governance:
-        personal_information_charter:
-        petitions_and_campaigns:
-        procurement:
-        publication_scheme:
-        recruitment:
-        research:
-        social_media_use:
-        staff_update:
-        statistics:
-        terms_of_reference:
-        welsh_language_scheme:
+        about: 
+        about_our_services: 
+        access_and_opening: 
+        accessible_documents_policy: 
+        complaints_procedure: 
+        equality_and_diversity: 
+        media_enquiries: 
+        membership: 
+        modern_slavery_statement: 
+        our_energy_use: 
+        our_governance: 
+        personal_information_charter: 
+        petitions_and_campaigns: 
+        procurement: 
+        publication_scheme: 
+        recruitment: 
+        research: 
+        social_media_use: 
+        staff_update: 
+        statistics: 
+        terms_of_reference: 
+        welsh_language_scheme: 
   date:
     formats:
-      default:
-      long_ordinal:
+      default: 
+      long_ordinal: 
   document:
-    contents:
-    latest:
-    published:
-    see_all:
+    contents: 
+    latest: 
+    published: 
+    see_all: 
     speech:
       author_title:
-        minister:
-        speaker:
-      delivered_on:
+        minister: 
+        speaker: 
+      delivered_on: 
       delivery_title:
-        minister:
-        speaker:
-      written_on:
+        minister: 
+        speaker: 
+      written_on: 
     type:
       about:
-        one:
-        other:
+        one: 
+        other: 
       about_our_services:
-        one:
-        other:
+        one: 
+        other: 
       access_and_opening:
-        one:
-        other:
+        one: 
+        other: 
       accessible_documents_policy:
-        one:
-        other:
+        one: 
+        other: 
       alert:
-        one:
-        other:
+        one: 
+        other: 
       announcement:
-        one:
-        other:
+        one: 
+        other: 
       authored_article:
-        one:
-        other:
+        one: 
+        other: 
       blog_post:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       call_for_evidence_outcome:
-        one:
-        other:
+        one: 
+        other: 
       campaign:
-        one:
-        other:
+        one: 
+        other: 
       careers:
-        one:
-        other:
+        one: 
+        other: 
       case_study:
-        one:
-        other:
+        one: 
+        other: 
       closed_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       closed_consultation:
-        one:
-        other:
+        one: 
+        other: 
       complaints_procedure:
-        one:
-        other:
+        one: 
+        other: 
       consultation:
-        one:
-        other:
+        one: 
+        other: 
       consultation_outcome:
-        one:
-        other:
+        one: 
+        other: 
       corporate_report:
-        one:
-        other:
+        one: 
+        other: 
       correspondence:
-        one:
-        other:
+        one: 
+        other: 
       decision:
-        one:
-        other:
+        one: 
+        other: 
       detailed_guidance:
-        one:
-        other:
+        one: 
+        other: 
       document_collection:
-        one:
-        other:
+        one: 
+        other: 
       draft_text:
-        one:
-        other:
+        one: 
+        other: 
       edition:
-        one:
-        other:
+        one: 
+        other: 
       edition_with_appointment:
-        one:
-        other:
+        one: 
+        other: 
       equality_and_diversity:
-        one:
-        other:
+        one: 
+        other: 
       fatality_notice:
-        one:
-        other:
+        one: 
+        other: 
       foi_release:
-        one:
-        other:
+        one: 
+        other: 
       form:
-        one:
-        other:
+        one: 
+        other: 
       generic_edition:
-        one:
-        other:
+        one: 
+        other: 
       government_response:
-        one:
-        other:
+        one: 
+        other: 
       guidance:
-        one:
-        other:
+        one: 
+        other: 
       impact_assessment:
-        one:
-        other:
+        one: 
+        other: 
       imported:
-        one:
-        other:
+        one: 
+        other: 
       independent_report:
-        one:
-        other:
+        one: 
+        other: 
       international_treaty:
-        one:
-        other:
+        one: 
+        other: 
       manual:
-        one:
-        other:
+        one: 
+        other: 
       map:
-        one:
-        other:
+        one: 
+        other: 
       media_enquiries:
-        one:
-        other:
+        one: 
+        other: 
       membership:
-        one:
-        other:
+        one: 
+        other: 
       modern_slavery_statement:
-        one:
-        other:
+        one: 
+        other: 
       national_statistics:
-        one:
-        other:
+        one: 
+        other: 
       news_article:
-        one:
-        other:
+        one: 
+        other: 
       news_story:
-        one:
-        other:
+        one: 
+        other: 
       nhs_content:
-        one:
-        other:
+        one: 
+        other: 
       notice:
-        one:
-        other:
+        one: 
+        other: 
       official_statistics:
-        one:
-        other:
+        one: 
+        other: 
       open_call_for_evidence:
-        one:
-        other:
+        one: 
+        other: 
       open_consultation:
-        one:
-        other:
+        one: 
+        other: 
       oral_statement:
-        one:
-        other:
+        one: 
+        other: 
       our_energy_use:
-        one:
-        other:
+        one: 
+        other: 
       our_governance:
-        one:
-        other:
+        one: 
+        other: 
       personal_information_charter:
-        one:
-        other:
+        one: 
+        other: 
       petitions_and_campaigns:
-        one:
-        other:
+        one: 
+        other: 
       policy_paper:
-        one:
-        other:
+        one: 
+        other: 
       press_release:
-        one:
-        other:
+        one: 
+        other: 
       procurement:
-        one:
-        other:
+        one: 
+        other: 
       promotional:
-        one:
-        other:
+        one: 
+        other: 
       publication:
-        one:
-        other:
+        one: 
+        other: 
       publication_scheme:
-        one:
-        other:
+        one: 
+        other: 
       recruitment:
-        one:
-        other:
+        one: 
+        other: 
       regulation:
-        one:
-        other:
+        one: 
+        other: 
       research:
-        one:
-        other:
+        one: 
+        other: 
       service:
-        one:
-        other:
+        one: 
+        other: 
       social_media_use:
-        one:
-        other:
+        one: 
+        other: 
       speaking_notes:
-        one:
-        other:
+        one: 
+        other: 
       speech:
-        one:
-        other:
+        one: 
+        other: 
       staff_update:
-        one:
-        other:
+        one: 
+        other: 
       standard:
-        one:
-        other:
+        one: 
+        other: 
       statement_to_parliament:
-        one:
-        other:
+        one: 
+        other: 
       statistical_data_set:
-        one:
-        other:
+        one: 
+        other: 
       statistics:
-        one:
-        other:
+        one: 
+        other: 
       statutory_guidance:
-        one:
-        other:
+        one: 
+        other: 
       terms_of_reference:
-        one:
-        other:
+        one: 
+        other: 
       transcript:
-        one:
-        other:
+        one: 
+        other: 
       transparency:
-        one:
-        other:
+        one: 
+        other: 
       welsh_language_scheme:
-        one:
-        other:
+        one: 
+        other: 
       world_news_story:
-        one:
-        other:
+        one: 
+        other: 
       written_statement:
-        one:
-        other:
-    updated:
+        one: 
+        other: 
+    updated: 
   document_filters:
     world_locations:
-      all:
-      label:
-      no_locations_filter:
+      all: 
+      label: 
+      no_locations_filter: 
   fatality_notice:
-    british_fatalities:
-    none_added:
+    british_fatalities: 
+    none_added: 
   feeds:
-    latest_activity:
+    latest_activity: 
   i18n:
     direction: rtl
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
     yi: יידיש
-    zh:
-    zh-hk:
-    zh-tw:
+    zh: 
+    zh-hk: 
+    zh-tw: 
   latest_feed:
-    no_updates:
-    title:
+    no_updates: 
+    title: 
   organisation:
     corporate_information:
-      access_our_info:
-      jobs:
-      jobs_and_contacts:
-      organisation_chart:
-      transparency:
+      access_our_info: 
+      jobs: 
+      jobs_and_contacts: 
+      organisation_chart: 
+      transparency: 
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
-      corporate_information:
-      corporate_reports:
+      corporate_information: 
+      corporate_reports: 
     support:
-      administered_by:
-      agencies_and_public_bodies:
-      part_of:
-      public_body:
-      works_with:
+      administered_by: 
+      agencies_and_public_bodies: 
+      part_of: 
+      public_body: 
+      works_with: 
     type:
-      courts_and_tribunals:
+      courts_and_tribunals: 
   roles:
-    unassigned:
+    unassigned: 
   see_all:
-    announcement:
-    authored_article:
-    call_for_evidence:
-    call_for_evidence_outcome:
-    case_study:
-    closed_call_for_evidence:
-    closed_consultation:
-    consultation:
-    consultation_outcome:
-    corporate_report:
-    correspondence:
-    decision:
-    detailed_guidance:
-    document_collection:
-    draft_text:
-    fatality_notice:
-    foi_release:
-    form:
-    government_response:
+    announcement: 
+    authored_article: 
+    call_for_evidence: 
+    call_for_evidence_outcome: 
+    case_study: 
+    closed_call_for_evidence: 
+    closed_consultation: 
+    consultation: 
+    consultation_outcome: 
+    corporate_report: 
+    correspondence: 
+    decision: 
+    detailed_guidance: 
+    document_collection: 
+    draft_text: 
+    fatality_notice: 
+    foi_release: 
+    form: 
+    government_response: 
     guidance: גיידאַנס
-    impact_assessment:
-    imported:
-    international_treaty:
-    map:
-    national_statistics:
-    news_article:
-    news_story:
-    notice:
-    open_call_for_evidence:
-    open_consultation:
-    oral_statement:
-    policy:
-    policy_paper:
-    press_release:
-    promotional:
-    publication:
-    regulation:
-    research:
-    speaking_notes:
-    speech:
-    statement_to_parliament:
-    statistical_data_set:
-    statistics:
-    statutory_guidance:
-    transcript:
-    transparency:
-    written_statement:
+    impact_assessment: 
+    imported: 
+    international_treaty: 
+    map: 
+    national_statistics: 
+    news_article: 
+    news_story: 
+    notice: 
+    open_call_for_evidence: 
+    open_consultation: 
+    oral_statement: 
+    policy: 
+    policy_paper: 
+    press_release: 
+    promotional: 
+    publication: 
+    regulation: 
+    research: 
+    speaking_notes: 
+    speech: 
+    statement_to_parliament: 
+    statistical_data_set: 
+    statistics: 
+    statutory_guidance: 
+    transcript: 
+    transparency: 
+    written_statement: 
   support:
-    download:
-    field_of_operation:
-    fields_of_operation:
+    download: 
+    field_of_operation: 
+    fields_of_operation: 
     pagination:
-      next_html:
-      next_page:
-      previous_html:
-      previous_page:
-    part_of_collection:
+      next_html: 
+      next_page: 
+      previous_html: 
+      previous_page: 
+    part_of_collection: 
   time:
     formats:
-      long_ordinal:
+      long_ordinal: 
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
-      search:
+      search: 
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
-        one:
-        other:
+        one: 
+        other: 
       world_location:
-        one:
-        other:
+        one: 
+        other: 
   world_news:
-    uk_updates_in_country:
+    uk_updates_in_country: 
   worldwide_organisation:
     corporate_information:
-      about_our_services_html:
-      personal_information_charter_html:
-      publication_scheme_html:
-      social_media_use_html:
-      welsh_language_scheme_html:
-    find_out_more:
+      about_our_services_html: 
+      personal_information_charter_html: 
+      publication_scheme_html: 
+      social_media_use_html: 
+      welsh_language_scheme_html: 
+    find_out_more: 
     headings:
-      contact_us:
-      corporate_information:
-      follow_us:
-      our_people:
-    location:
-    part_of:
+      contact_us: 
+      corporate_information: 
+      follow_us: 
+      our_people: 
+    location: 
+    part_of: 

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -22,14 +22,14 @@ zh-hk:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: 隨附檔案
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: 附件指令文件編號
         hoc_paper_number: 下議院文書編號
@@ -51,19 +51,19 @@ zh-hk:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ zh-hk:
       subheading: 我們發現部份可能表明問題的連結，您在使用這些連結瀏覽網站時應加以注意
     title: 破損之連結
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: 已關閉
     closing_today: 今日關閉
@@ -167,9 +167,9 @@ zh-hk:
       blog_post:
         other: 網誌發佈內容
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: 活動
       careers:
@@ -177,7 +177,7 @@ zh-hk:
       case_study:
         other: 案例研究
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: 專屬諮詢
       complaints_procedure:
@@ -233,7 +233,7 @@ zh-hk:
       membership:
         other: 會員資格
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: 國家統計數據
       news_article:
@@ -247,7 +247,7 @@ zh-hk:
       official_statistics:
         other: 統計資料
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: 公開諮詢
       oral_statement:
@@ -324,72 +324,72 @@ zh-hk:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
     zh-hk: 中文
-    zh-tw:
+    zh-tw: 
   latest_feed:
     no_updates: 目前暫無更新。
     title: 最新消息
@@ -418,10 +418,10 @@ zh-hk:
   see_all:
     announcement: 查閱我們所有的其他公告
     authored_article: 查閱我們所有的其他撰寫文章
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: 查閱我們所有的其他案例研究
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: 查閱我們所有的其他專屬諮詢
     consultation: 查閱我們所有的其他諮詢
     consultation_outcome: 查閱我們所有的其他諮詢結果
@@ -444,7 +444,7 @@ zh-hk:
     news_article: 查閱我們所有的其他新聞
     news_story: 查閱我們所有的其他新聞
     notice: 查閱我們所有的其他通知
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: 查閱我們所有的其他公開諮詢
     oral_statement: 查閱我們所有的提交國會的其他口頭聲明
     policy: 查閱我們所有的其他政策
@@ -478,15 +478,15 @@ zh-hk:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: 按國家或地區搜尋
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: 國際代表

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -22,14 +22,14 @@ zh-tw:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: 附件
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: 附件命令文件編號
         hoc_paper_number: 下議院文件編碼
@@ -51,19 +51,19 @@ zh-tw:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ zh-tw:
       subheading: 我們發現了一些可能表明存在問題的連結問題，你在應謹慎連結。
     title: 連結損壞
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: 關閉
     closing_today: 今日關閉
@@ -167,9 +167,9 @@ zh-tw:
       blog_post:
         other: 部落格文章
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: 活動
       careers:
@@ -177,7 +177,7 @@ zh-tw:
       case_study:
         other: 案例分析
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: 非公開協商
       complaints_procedure:
@@ -233,7 +233,7 @@ zh-tw:
       membership:
         other: 會員資格
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: 國家統計
       news_article:
@@ -247,7 +247,7 @@ zh-tw:
       official_statistics:
         other: 官方統計
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: 公開諮詢
       oral_statement:
@@ -324,71 +324,71 @@ zh-tw:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
+    zh: 
+    zh-hk: 
     zh-tw: 繁體中文
   latest_feed:
     no_updates: 尚未更新
@@ -418,10 +418,10 @@ zh-tw:
   see_all:
     announcement: 查看我們所有公告
     authored_article: 查看我們所有授權文章
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: 查看我們所有案例分析
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: 查看我們所有未公開諮詢
     consultation: 查看我們所有諮詢
     consultation_outcome: 查看我們所有諮詢結果
@@ -444,7 +444,7 @@ zh-tw:
     news_article: 查看我們所有新聞文章
     news_story: 查看我們所有新聞報導
     notice: 查看我們所有通知
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: 查看我們所有公開諮詢
     oral_statement: 查看我們所有對議會的口頭聲明
     policy: 查看我們所有政策
@@ -478,15 +478,15 @@ zh-tw:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: 按國家或地區搜索
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: 國際代表團

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -22,14 +22,14 @@ zh:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: 附件文件
       response/call_for_evidence_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
+        command_paper_number: 
+        hoc_paper_number: 
+        isbn: 
+        title: 
+        unique_reference: 
+        unnumbered_hoc_paper: 
       response/call_for_evidence_response_attachments/attachment/attachment_data:
-        file:
+        file: 
       response/consultation_response_attachments/attachment:
         command_paper_number: 附件命令文件编号
         hoc_paper_number: 下议院文件编号
@@ -51,19 +51,19 @@ zh:
   admin:
     whats_new:
       guidance:
-        body_govspeak:
-        heading:
+        body_govspeak: 
+        heading: 
       introduction:
-        body_govspeak:
-        heading:
-      last_updated:
+        body_govspeak: 
+        heading: 
+      last_updated: 
       recent_changes:
-        heading:
-        updates:
-      summary:
-      title:
+        heading: 
+        updates: 
+      summary: 
+      title: 
       upcoming_changes:
-        heading:
+        heading: 
   attachment:
     accessibility:
       full_help_html: |
@@ -91,10 +91,10 @@ zh:
       subheading: 我们已经发现一些链接的问题，这可能表明存在问题，您应该在链接到它们时小心
     title: 被破坏的链接
   call_for_evidence:
-    closed:
-    closing_today:
-    closing_tomorrow:
-    days_left:
+    closed: 
+    closing_today: 
+    closing_tomorrow: 
+    days_left: 
   consultation:
     closed: 关闭
     closing_today: 今天关闭
@@ -167,9 +167,9 @@ zh:
       blog_post:
         other: 博客帖子
       call_for_evidence:
-        other:
+        other: 
       call_for_evidence_outcome:
-        other:
+        other: 
       campaign:
         other: 活动
       careers:
@@ -177,7 +177,7 @@ zh:
       case_study:
         other: 案例研究
       closed_call_for_evidence:
-        other:
+        other: 
       closed_consultation:
         other: 封闭咨询
       complaints_procedure:
@@ -233,7 +233,7 @@ zh:
       membership:
         other: 会员身份
       modern_slavery_statement:
-        other:
+        other: 
       national_statistics:
         other: 国家统计局
       news_article:
@@ -247,7 +247,7 @@ zh:
       official_statistics:
         other: 官方统计
       open_call_for_evidence:
-        other:
+        other: 
       open_consultation:
         other: 公开协商
       oral_statement:
@@ -324,72 +324,72 @@ zh:
   i18n:
     direction: ltr
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
+    ar: 
+    az: 
+    be: 
+    bg: 
+    bn: 
+    cs: 
+    cy: 
+    da: 
+    de: 
+    dr: 
+    el: 
+    en: 
+    es: 
+    es-419: 
+    et: 
+    fa: 
+    fi: 
+    fr: 
+    gd: 
+    gu: 
+    he: 
+    hi: 
+    hr: 
+    hu: 
+    hy: 
+    id: 
+    is: 
+    it: 
+    ja: 
+    ka: 
+    kk: 
+    ko: 
+    lt: 
+    lv: 
+    ms: 
+    mt: 
+    ne: 
+    nl: 
+    'no': 
+    pa: 
+    pa-pk: 
+    pl: 
+    ps: 
+    pt: 
+    ro: 
+    ru: 
+    si: 
+    sk: 
+    sl: 
+    so: 
+    sq: 
+    sr: 
+    sv: 
+    sw: 
+    ta: 
+    th: 
+    tk: 
+    tr: 
+    uk: 
+    ur: 
+    uz: 
+    vi: 
+    yi: 
     zh: 中文
-    zh-hk:
-    zh-tw:
+    zh-hk: 
+    zh-tw: 
   latest_feed:
     no_updates: 尚未更新。
     title: 最新
@@ -401,7 +401,7 @@ zh:
       organisation_chart: 我们的组织机构图
       transparency: 透明度数据
     embassies:
-      find_an_embassy_title:
+      find_an_embassy_title: 
     headings:
       corporate_information: 公司信息
       corporate_reports: 公司报告
@@ -418,10 +418,10 @@ zh:
   see_all:
     announcement: 查看我们的全部公告
     authored_article: 查看我们的全部撰写文章
-    call_for_evidence:
-    call_for_evidence_outcome:
+    call_for_evidence: 
+    call_for_evidence_outcome: 
     case_study: 查看我们的全部案例研究
-    closed_call_for_evidence:
+    closed_call_for_evidence: 
     closed_consultation: 看看我们的全部封闭咨询
     consultation: 查看我们的全部咨询
     consultation_outcome: 查看我们的全部咨询结果
@@ -444,7 +444,7 @@ zh:
     news_article: 查看我们的全部新闻文章
     news_story: 查看我们的全部新闻故事
     notice: 查看我们的全部通知
-    open_call_for_evidence:
+    open_call_for_evidence: 
     open_consultation: 看看我们的全部开放咨询
     oral_statement: 查看我们的全部议会口头声明
     policy: 查看我们的全部政策
@@ -478,15 +478,15 @@ zh:
       long_ordinal: "%e %B %Y %l:%M%P"
   world_location:
     content:
-      complete_list:
-      find_out:
-      heading:
-      list_link:
+      complete_list: 
+      find_out: 
+      heading: 
+      list_link: 
     headings:
       search: 按国家或地区搜索
     search_description:
-      international_delegation:
-      world_location:
+      international_delegation: 
+      world_location: 
     type:
       international_delegation:
         other: 国际代表处


### PR DESCRIPTION
Running an i18n-tasks task to remove specific unused keys resulted in a much larger diff than expected, because i18n decides to do normalisation at the same time.

Let's re-normalise ALL the things to have a clean baseline.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
