### PR TITLE
Remove usage of legacy create_whitehall_asset when uploading file attachments

### DIFF
--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -26,6 +26,7 @@ class Admin::BulkUploadsController < Admin::BaseController
     @bulk_upload.attachments_attributes = create_params[:attachments_attributes]
     @bulk_upload.attachments.each do |attachment|
       attachment.attachment_data.attachable = @edition
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
     end
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)
@@ -42,6 +43,10 @@ private
 
   def enforce_permissions!
     enforce_permission!(:update, @edition)
+  end
+
+  def use_non_legacy_endpoints?
+    current_user.can_use_non_legacy_endpoints?
   end
 
   def create_params

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -1,0 +1,9 @@
+class AssetManagerCreateAssetWorker < WorkerBase
+  include AssetManager::ServiceHelper
+
+  sidekiq_options queue: "asset_manager"
+
+  def perform(temporary_location, model_id = nil, asset_variant = nil, draft = false, attachable_model_class, attachable_model_id, auth_bypass_ids)
+
+  end
+end

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -3,7 +3,46 @@ class AssetManagerCreateAssetWorker < WorkerBase
 
   sidekiq_options queue: "asset_manager"
 
-  def perform(temporary_location, model_id = nil, asset_variant = nil, draft = false, attachable_model_class, attachable_model_id, auth_bypass_ids)
+  def perform(temporary_location, model_id, asset_variant, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
+    return unless File.exist?(temporary_location)
 
+    file = File.open(temporary_location)
+
+    asset_options = { file:, auth_bypass_ids:, draft: }
+    authorised_user_uids = get_authorised_user_ids(attachable_model_class, attachable_model_id)
+    asset_options[:access_limited] = authorised_user_uids if authorised_user_uids
+
+    response = asset_manager.create_asset(asset_options)
+    save_asset_id_to_assets(model_id, asset_variant, response)
+
+    if asset_variant == Asset.variants[:original]
+      AttachmentData.find(model_id).uploaded_to_asset_manager!
+    end
+
+    file.close
+    FileUtils.rm(file)
+    FileUtils.rmdir(File.dirname(file))
+  end
+
+private
+
+  def get_authorised_user_ids(attachable_model_class, attachable_model_id)
+    if attachable_model_class && attachable_model_id
+      attachable_model = attachable_model_class.constantize.find(attachable_model_id)
+      if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
+        AssetManagerAccessLimitation.for(attachable_model)
+      end
+    end
+  end
+
+  def save_asset_id_to_assets(model_id, variant, response)
+    asset_manager_id = get_asset_id(response)
+    Asset.create!(asset_manager_id:, attachment_data_id: model_id, variant:)
+  end
+
+  def get_asset_id(response)
+    attributes = response.to_hash
+    url = attributes["id"]
+    url[/\/assets\/(.*)/, 1]
   end
 end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -3,7 +3,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
 
   sidekiq_options queue: "asset_manager"
 
-  def perform(file_path, legacy_url_path, model_id = nil, asset_variant = nil, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
+  def perform(file_path, legacy_url_path, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
     return unless File.exist?(file_path)
 
     file = File.open(file_path)
@@ -18,9 +18,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
       end
     end
 
-    response = asset_manager.create_whitehall_asset(asset_options)
-
-    create_asset_manager_asset(model_id, asset_variant, response)
+    asset_manager.create_whitehall_asset(asset_options)
 
     if attachable_model
       # The AttachmentData we want to set the timestamp on may not
@@ -34,24 +32,5 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
-  end
-
-private
-
-  def create_asset_manager_asset(model_id, asset_variant, response)
-    return unless model_id && asset_variant
-
-    response_id = get_asset_id(response)
-    save_asset_id_to_assets(model_id, asset_variant, response_id)
-  end
-
-  def get_asset_id(response)
-    attributes = response.to_hash
-    url = attributes["id"]
-    url[/\/assets\/(.*)/, 1]
-  end
-
-  def save_asset_id_to_assets(model_id, variant, asset_manager_id)
-    Asset.create!(asset_manager_id:, attachment_data_id: model_id, variant:)
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -26,9 +26,11 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     if should_save_an_asset?
       model_id = uploader.model.id
       asset_variant = legacy_url_path.include?("thumbnail") ? Asset.variants[:thumbnail] : Asset.variants[:original]
+      AssetManagerCreateAssetWorker.perform_async(temporary_location, model_id, asset_variant, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
+    else
+      AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, model_id, asset_variant, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
     end
 
-    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, model_id, asset_variant, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
     File.new(uploader.store_path)
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -26,9 +26,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     if should_save_an_asset?
       model_id = uploader.model.id
       asset_variant = legacy_url_path.include?("thumbnail") ? Asset.variants[:thumbnail] : Asset.variants[:original]
+      # Separating the journey based on feature flag so its easier to make future changes and also decommission old journey
       AssetManagerCreateAssetWorker.perform_async(temporary_location, model_id, asset_variant, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
     else
-      AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, model_id, asset_variant, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
+      AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
     end
 
     File.new(uploader.store_path)

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -172,7 +172,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   test "use_non_legacy_endpoints is false - POST :create triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = valid_file_attachment_params
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: }
   end
@@ -182,7 +182,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     attachment = valid_file_attachment_params
     variant = Asset.variants[:original]
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, kind_of(Integer), variant, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, kind_of(Integer), variant, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: }
   end
@@ -357,7 +357,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   test "use_non_legacy_endpoints is false - PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = create(:file_attachment, attachable: @edition)
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     put :update,
         params: {
@@ -376,7 +376,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     attachment = create(:file_attachment, attachable: @edition)
     variant = Asset.variants[:original]
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, kind_of(Integer), variant, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, kind_of(Integer), variant, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     put :update,
         params: {
@@ -447,8 +447,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
     whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf)
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), regexp_matches(/whitepaper/), anything, anything, anything, anything, anything, anything).never
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), regexp_matches(/greenpaper/), anything, anything, anything, anything, anything, anything).times(2)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), regexp_matches(/whitepaper/), anything, anything, anything, anything).never
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), regexp_matches(/greenpaper/), anything, anything, anything, anything).times(2)
 
     post :create,
          params: {
@@ -468,8 +468,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
     whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf)
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), regexp_matches(/whitepaper/), anything, anything, anything, anything, anything, anything).never
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), regexp_matches(/greenpaper/), anything, anything, anything, anything, anything, anything).times(2)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), regexp_matches(/whitepaper/), anything, anything, anything, anything).never
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), regexp_matches(/greenpaper/), anything, anything, anything, anything).times(2)
 
     put :update,
         params: {

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -49,8 +49,8 @@ class AssetManagerIntegrationTest
       end
 
       test "sends the attachment to Asset Manager" do
-        Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
-                .returns("id" => "http://asset-manager/assets/asset_manager_id")
+        Services.asset_manager.expects(:asset).with(anything).returns("id" => "http://asset-manager/assets/asset_manager_id")
+        Services.asset_manager.expects(:create_asset).with(file_matching(/#{@filename}/)).returns("id" => "http://asset-manager/assets/asset_manager_id")
 
         Sidekiq::Testing.inline! do
           @attachment.save!
@@ -58,7 +58,8 @@ class AssetManagerIntegrationTest
       end
 
       test "marks the attachment as draft in Asset Manager" do
-        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
+        Services.asset_manager.expects(:asset).with(anything).returns("id" => "http://asset-manager/assets/asset_manager_id")
+        Services.asset_manager.expects(:create_asset).with(has_entry(draft: true))
                 .returns("id" => "http://asset-manager/assets/asset_manager_id")
 
         Sidekiq::Testing.inline! do
@@ -74,10 +75,10 @@ class AssetManagerIntegrationTest
         @attachment.attachment_data.attachable = consultation
         @attachment.save!
 
-        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+        Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [user.uid]))
                 .returns("id" => "http://asset-manager/assets/asset_manager_id")
 
-        AssetManagerCreateWhitehallAssetWorker.drain
+        AssetManagerCreateAssetWorker.drain
       end
     end
   end

--- a/test/support/asset_manager_test_helpers.rb
+++ b/test/support/asset_manager_test_helpers.rb
@@ -5,4 +5,10 @@ module AssetManagerTestHelpers
       has_entry(:legacy_url_path, regexp_matches(regex)),
     )
   end
+
+  def file_matching(_regex)
+    all_of(
+      has_entry(:file, instance_of(File)),
+    )
+  end
 end

--- a/test/unit/app/uploaders/attachment_uploader_test.rb
+++ b/test/unit/app/uploaders/attachment_uploader_test.rb
@@ -199,6 +199,7 @@ end
 
 class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
+  extend Minitest::Spec::DSL
 
   setup do
     AttachmentUploader.enable_processing = true
@@ -255,6 +256,45 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
     AssetManagerCreateWhitehallAssetWorker.drain
   end
 
+  describe "use non legacy endpoints true" do
+    test "should store an actual PNG using create asset" do
+      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+      attachment_data.save!
+      Asset.expects(:create!).twice.with(anything, anything, anything)
+      expect_thumbnail_sent_to_asset_manager_to_be_an_actual_png_using_create_asset
+      AssetManagerCreateAssetWorker.drain
+    end
+
+    test "should scale the thumbnail down proportionally to A4" do
+      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+      attachment_data.save!
+      Asset.expects(:create!).twice.with(anything, anything, anything)
+      expect_thumbnail_sent_to_asset_manager_to_be_scaled_proportionally_create_asset
+
+      AssetManagerCreateAssetWorker.drain
+    end
+
+    test "should use a generic thumbnail if conversion fails" do
+      AttachmentData.any_instance.stubs(:use_non_legacy_endpoints).returns(true)
+      AttachmentUploader.any_instance.stubs(:pdf_thumbnail_command).returns("false")
+      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+      attachment_data.save!
+      expect_fallback_thumbnail_to_be_uploaded_to_asset_manager_create_asset
+
+      AssetManagerCreateAssetWorker.drain
+    end
+
+    test "should use a generic thumbnail if conversion takes longer than 10 seconds to complete" do
+      AttachmentData.any_instance.stubs(:use_non_legacy_endpoints).returns(true)
+      AttachmentUploader.any_instance.stubs(:pdf_thumbnail_command).raises(Timeout::Error)
+      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+      attachment_data.save!
+      expect_fallback_thumbnail_to_be_uploaded_to_asset_manager_create_asset
+
+      AssetManagerCreateAssetWorker.drain
+    end
+  end
+
   def expect_fallback_thumbnail_to_be_uploaded_to_asset_manager
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with do |value|
@@ -267,6 +307,18 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
     end
   end
 
+  def expect_fallback_thumbnail_to_be_uploaded_to_asset_manager_create_asset
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/some-id")
+    Services.asset_manager.expects(:create_asset).with { |value|
+      if value[:file].path.ends_with?(".png")
+        generic_thumbnail_path = File.expand_path("app/assets/images/pub-cover.png")
+        assert_equal File.binread(generic_thumbnail_path),
+                     File.binread(value[:file].path),
+                     "Thumbnailing when PDF conversion fails should use default image."
+      end
+    }.returns("id" => "http://asset-manager/assets/some-id")
+  end
+
   def expect_thumbnail_sent_to_asset_manager_to_be_an_actual_png
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with do |value|
@@ -275,6 +327,16 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
         assert_equal "image/png", type.strip
       end
     end
+  end
+
+  def expect_thumbnail_sent_to_asset_manager_to_be_an_actual_png_using_create_asset
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/some-id")
+    Services.asset_manager.expects(:create_asset).with { |value|
+      if value[:file].path.ends_with?(".png")
+        type = `file -b --mime-type "#{value[:file].path}"`
+        assert_equal "image/png", type.strip
+      end
+    }.returns("id" => "http://asset-manager/assets/some-id")
   end
 
   def expect_thumbnail_sent_to_asset_manager_to_be_scaled_proportionally
@@ -289,6 +351,20 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
         assert (width == "105" || height == "140"), "geometry should be proportional scaled, but was #{geometry}"
       end
     end
+  end
+
+  def expect_thumbnail_sent_to_asset_manager_to_be_scaled_proportionally_create_asset
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/some-id")
+    Services.asset_manager.expects(:create_asset).with { |value|
+      if value[:file].path.ends_with?(".png")
+        identify_details = `identify "#{Rails.root.join("public", value[:file].path)}"`
+
+        _path, _type, geometry, _rest = identify_details.split
+        width, height = geometry.split("x")
+
+        assert (width == "105" || height == "140"), "geometry should be proportional scaled, but was #{geometry}"
+      end
+    }.returns("id" => "http://asset-manager/assets/some-id")
   end
 end
 

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+
+class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
+  setup do
+    @file = Tempfile.new("asset", Dir.mktmpdir)
+    @worker = AssetManagerCreateAssetWorker.new
+    @asset_manager_id = "asset_manager_id"
+    @organisation = FactoryBot.create(:organisation)
+    @user = FactoryBot.create(:user, organisation: @organisation, uid: "user-uid")
+    @model_id = FactoryBot.create(:attachment_data).id
+    @asset_manager_response = { "id" => "http://asset-manager/assets/#{@asset_manager_id}" }
+  end
+
+  test "upload an asset using a file object at the correct path" do
+    Services.asset_manager.expects(:create_asset).with { |args|
+      args[:file].path == @file.path
+    }.returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original])
+  end
+
+  test "marks the asset as draft if instructed" do
+    Services.asset_manager.expects(:create_asset).with(has_entry(draft: true)).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original], true)
+  end
+
+  test "removes the file after it has been successfully uploaded" do
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original])
+    assert_not File.exist?(@file.path)
+  end
+
+  test "removes the directory after it has been successfully uploaded" do
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original])
+    assert_not Dir.exist?(File.dirname(@file))
+  end
+
+  test "marks attachments belonging to consultations as access limited" do
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    attachment = FactoryBot.create(:file_attachment, attachable: consultation)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [@user.uid])).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original], true, consultation.class.to_s, consultation.id)
+  end
+
+  test "marks attachments belonging to consultation responses as access limited" do
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    response = FactoryBot.create(:consultation_outcome, consultation:)
+    attachment = FactoryBot.create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [@user.uid])).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original], true, consultation.class.to_s, consultation.id)
+  end
+
+  test "does not mark attachments belonging to policy groups as access limited" do
+    policy_group = FactoryBot.create(:policy_group)
+    attachment = FactoryBot.create(:file_attachment, attachable: policy_group)
+    attachment.attachment_data.attachable = policy_group
+
+    Services.asset_manager.expects(:create_asset).with(Not(has_key(:access_limited))).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original], true, policy_group.class.to_s, policy_group.id)
+  end
+
+  test "sends auth bypass ids to asset manager when these are passed through in the params" do
+    consultation = FactoryBot.create(:consultation)
+    response = FactoryBot.create(:consultation_outcome, consultation:)
+    attachment = FactoryBot.create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id])).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original], true, consultation.class.to_s, consultation.id, [consultation.auth_bypass_id])
+  end
+  # end
+
+  test "doesn't run if the file is missing (e.g. job ran twice)" do
+    path = @file.path
+    FileUtils.rm(@file)
+
+    Services.asset_manager.expects(:create_asset).never
+
+    @worker.perform(path, @model_id, Asset.variants[:original])
+  end
+
+  test "stores corresponding asset_manager_id for current file attachment" do
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, @model_id, Asset.variants[:original])
+
+    assert_equal 1, Asset.where(asset_manager_id: @asset_manager_id, variant: Asset.variants[:original]).count
+  end
+
+  test "updates uploaded_to_asset_manager when :original asset variant is uploaded" do
+    model_id = FactoryBot.create(:attachment_data, uploaded_to_asset_manager_at: nil).id
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, model_id, Asset.variants[:original])
+    assert_not_nil AttachmentData.find(model_id).uploaded_to_asset_manager_at
+  end
+
+  test "updates uploaded_to_asset_manager when asset variant is uploaded is not :original" do
+    model_id = FactoryBot.create(:attachment_data, uploaded_to_asset_manager_at: nil).id
+    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
+
+    @worker.perform(@file.path, model_id, Asset.variants[:thumbnail])
+    assert_nil AttachmentData.find(model_id).uploaded_to_asset_manager_at
+  end
+end

--- a/test/unit/app/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -5,7 +5,6 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     @file = Tempfile.new("asset", Dir.mktmpdir)
     @legacy_url_path = "legacy-url-path"
     @worker = AssetManagerCreateWhitehallAssetWorker.new
-    @asset_manager_id = "asset_manager_id"
   end
 
   test "creates a whitehall asset using a file object at the correct path" do
@@ -31,7 +30,7 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
   test "marks the asset as draft if instructed" do
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
 
-    @worker.perform(@file.path, @legacy_url_path, nil, nil, true)
+    @worker.perform(@file.path, @legacy_url_path, true)
   end
 
   test "removes the file after it has been successfully uploaded" do
@@ -53,7 +52,7 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
 
-    @worker.perform(@file.path, @legacy_url_path, nil, nil, true, consultation.class.to_s, consultation.id)
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end
 
   test "marks attachments belonging to consultation responses as access limited" do
@@ -66,7 +65,7 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
 
-    @worker.perform(@file.path, @legacy_url_path, nil, nil, true, consultation.class.to_s, consultation.id)
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end
 
   test "does not mark attachments belonging to policy groups as access limited" do
@@ -78,7 +77,7 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
     Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:access_limited)))
 
-    @worker.perform(@file.path, @legacy_url_path, nil, nil, true, policy_group.class.to_s, policy_group.id)
+    @worker.perform(@file.path, @legacy_url_path, true, policy_group.class.to_s, policy_group.id)
   end
 
   test "sends auth bypass ids to asset manager when these are passed through in the params" do
@@ -89,7 +88,7 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id]))
 
-    @worker.perform(@file.path, @legacy_url_path, nil, nil, true, consultation.class.to_s, consultation.id, [consultation.auth_bypass_id])
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id, [consultation.auth_bypass_id])
   end
 
   test "doesn't run if the file is missing (e.g. job ran twice)" do
@@ -99,21 +98,5 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_whitehall_asset).never
 
     @worker.perform(path, @legacy_url_path)
-  end
-
-  test "stores corresponding asset_manager_id for current file attachment" do
-    model_id = FactoryBot.create(:attachment_data).id
-    variant = Asset.variants[:original]
-    Services.asset_manager.stubs(:create_whitehall_asset).returns("id" => "http://asset-manager/assets/#{@asset_manager_id}")
-
-    @worker.perform(@file.path, @legacy_url_path, model_id, variant)
-
-    assert_equal Asset.where(asset_manager_id: @asset_manager_id, variant:).count, 1
-  end
-
-  test "does not store asset_manager_id if there if no values provided for model_id or variant" do
-    @worker.perform(@file.path, @legacy_url_path)
-
-    assert_equal Asset.where(asset_manager_id: @asset_manager_id).count, 0
   end
 end

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -55,7 +55,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
         model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
         @uploader.stubs(:model).returns(model)
 
-        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
+        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
 
         @uploader.store!(@file)
       end
@@ -65,7 +65,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
         model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
         @uploader.stubs(:model).returns(model)
 
-        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
+        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
 
         @uploader.store!(@file)
       end
@@ -91,7 +91,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
       expected_filename = File.basename(@file.path)
       expected_path = File.join("/government/uploads/store-dir", expected_filename)
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything, anything, anything, anything, anything, anything)
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything, anything, anything, anything)
 
       @uploader.store!(@file)
     end
@@ -99,7 +99,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
       @uploader.assets_protected = true
 
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, true, anything, anything, anything)
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, true, anything, anything, anything)
 
       @uploader.store!(@file)
     end
@@ -107,7 +107,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
       @uploader.assets_protected = false
 
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, false, anything, anything, anything)
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, false, anything, anything, anything)
 
       @uploader.store!(@file)
     end
@@ -116,13 +116,13 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
       @uploader.stubs(:model).returns(model)
 
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
 
       @uploader.store!(@file)
     end
 
     test "calls worker with nil model_id and asset_variant" do
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, nil, nil, anything, anything)
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, anything, anything)
 
       @uploader.store!(@file)
     end
@@ -186,7 +186,6 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
       @uploader.store!(@file)
     end
-
   end
 end
 

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -23,71 +23,6 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     FileUtils.remove_dir(Whitehall.asset_manager_tmp_dir, true)
   end
 
-  test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with do |actual_path, _|
-      uploaded_file_name = File.basename(@file.path)
-      expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
-      actual_path =~ expected_path
-    end
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job and sets the legacy url path to the location that it would have been stored on disk" do
-    @uploader.store_dir = "store-dir"
-
-    expected_filename = File.basename(@file.path)
-    expected_path = File.join("/government/uploads/store-dir", expected_filename)
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything, anything, anything, anything, anything, anything)
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
-    @uploader.assets_protected = false
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, false, anything, anything, anything)
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
-    @uploader.assets_protected = true
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, true, anything, anything, anything)
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job and passes through the model class and id and auth_bypass_id if if the model responds to attachable" do
-    model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
-    @uploader.stubs(:model).returns(model)
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to images" do
-    model = build(:image_data)
-    model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
-    @uploader.stubs(:model).returns(model)
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
-
-    @uploader.store!(@file)
-  end
-
-  test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to consultation_response_form" do
-    model = ConsultationResponseFormData.new
-    model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
-    @uploader.stubs(:model).returns(model)
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
-
-    @uploader.store!(@file)
-  end
-
   test "store! returns an asset manager file" do
     AssetManagerCreateWhitehallAssetWorker.stubs(:perform_async)
 
@@ -113,62 +48,145 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     storage = Whitehall::AssetManagerStorage.new(@uploader)
     assert_equal file, storage.retrieve!("identifier")
   end
-
-  describe "invokes worker with necessary arguments to create an asset record" do
-    context "attachment is a file" do
-      setup do
-        @model = create(:attachment_data)
-        @uploader.stubs(:model).returns(@model)
-      end
-
-      context "use_non_legacy_endpoints permission is true" do
-        setup do
-          @model.use_non_legacy_endpoints = true
-        end
-
-        test "calls worker with model_id and default origin asset_variant" do
-          variant = Asset.variants[:original]
-
-          AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, @model.id, variant, anything, anything, anything, anything)
-
-          @uploader.store!(@file)
-        end
-
-        test "calls worker with model_id and variant/thumbnail asset_variant" do
-          variant = Asset.variants[:thumbnail]
-          @uploader.stubs(:store_path).returns("asset-path/thumbnail_file_name")
-
-          AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, @model.id, variant, anything, anything, anything, anything)
-
-          @uploader.store!(@file)
-        end
-      end
-
-      context "use_non_legacy_endpoints permission is false" do
-        setup do
-          @model.use_non_legacy_endpoints = false
-        end
-
-        test "calls worker with nil model_id and asset_variant" do
-          AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, nil, nil, anything, anything)
-
-          @uploader.store!(@file)
-        end
-      end
-    end
-
-    context "attachment is not a file" do
-      setup do
-        model = create(:image_data)
+  describe "when use_non_legacy_endpoints permission is false and uploader model is not an AttachmentData" do
+    context "uploader.model.instance_of?(AttachmentData) is false" do
+      test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to images" do
+        model = build(:image_data)
+        model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
         @uploader.stubs(:model).returns(model)
+
+        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
+
+        @uploader.store!(@file)
       end
 
-      test "calls worker with nil model_id and asset_variant" do
-        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, nil, nil, anything, anything)
+      test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to consultation_response_form" do
+        model = ConsultationResponseFormData.new
+        model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
+        @uploader.stubs(:model).returns(model)
+
+        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, nil, nil, [@auth_bypass_id])
 
         @uploader.store!(@file)
       end
     end
+  end
+  describe "when use_non_legacy_endpoints permission is false and uploader model is AttachmentData" do
+    setup do
+      model = build(:attachment_data)
+      model.stubs(:use_non_legacy_endpoints).returns(false)
+      @uploader.stubs(:model).returns(model)
+    end
+    test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with do |actual_path, _|
+        uploaded_file_name = File.basename(@file.path)
+        expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
+        actual_path =~ expected_path
+      end
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and sets the legacy url path to the location that it would have been stored on disk" do
+      @uploader.store_dir = "store-dir"
+
+      expected_filename = File.basename(@file.path)
+      expected_path = File.join("/government/uploads/store-dir", expected_filename)
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything, anything, anything, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
+      @uploader.assets_protected = true
+
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, true, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
+      @uploader.assets_protected = false
+
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, false, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and passes through the model class and id and auth_bypass_id if the model responds to attachable" do
+      model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
+      @uploader.stubs(:model).returns(model)
+
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
+
+      @uploader.store!(@file)
+    end
+
+    test "calls worker with nil model_id and asset_variant" do
+      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, nil, nil, nil, nil, anything, anything)
+
+      @uploader.store!(@file)
+    end
+  end
+
+  describe "when use_non_legacy_endpoints permission is true and uploader model is AttachmentData" do
+    setup do
+      model = build(:attachment_data)
+      model.stubs(:use_non_legacy_endpoints).returns(true)
+      model.id = 1
+      @uploader.stubs(:model).returns(model)
+    end
+    test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
+      AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, _|
+        uploaded_file_name = File.basename(@file.path)
+        expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
+        actual_path =~ expected_path
+      end
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
+      @uploader.assets_protected = true
+
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, true, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
+      @uploader.assets_protected = false
+
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, false, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "creates a sidekiq job and passes through the model class and id and auth_bypass_id if the model responds to attachable" do
+      model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
+      model.stubs(:use_non_legacy_endpoints).returns(true)
+      @uploader.stubs(:model).returns(model)
+
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
+
+      @uploader.store!(@file)
+    end
+
+    test "calls worker with model_id and default origin asset_variant" do
+      variant = Asset.variants[:original]
+
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, @uploader.model.id, variant, anything, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
+    test "calls worker with model_id and variant/thumbnail asset_variant" do
+      variant = Asset.variants[:thumbnail]
+      @uploader.stubs(:store_path).returns("asset-path/thumbnail_file_name")
+
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, @uploader.model.id, variant, anything, anything, anything, anything)
+
+      @uploader.store!(@file)
+    end
+
   end
 end
 


### PR DESCRIPTION
These changes are part of a larger epic to remove the use of legacy_url_path from whitehall and the associated legacy endpoints from asset-manager and gds-api-adapters.

As a part of these changes, we want to introduce the use of `post_multipart("#{base_url}/assets", asset: asset)` instead of `post_multipart("#{base_url}/whitehall_assets", asset: asset)`. We want whitehall to only use the non-legacy /create endpoint so that it can be consistent with other publishing apps.

These changes are inside a new worker `app/workers/asset_manager_create_asset_worker.rb` and the call to this worker depends on the state of feature flag inside `lib/whitehall/asset_manager_storage.rb`. When the feature flag `use_non_legacy_endpoints` is false then journey will fallback to the old endpoint inside "app/workers/asset_manager_create_whitehall_asset_worker.rb".

Where applicable, the tests are split in a "feature flag on/off" manner to enable easy removal of flag. 

[trello](https://trello.com/c/gEZMTUQW/66-story-instead-of-createwhitehallasset-call-createasset-for-fileattachments)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
