### PR TITLE
Change edit to view links for world location news index page

### DIFF
--- a/app/views/admin/world_location_news/_world_location_table.html.erb
+++ b/app/views/admin/world_location_news/_world_location_table.html.erb
@@ -13,7 +13,7 @@
         text: "Translations"
       },
       {
-        text: tag.span("Edit", class: "govuk-visually-hidden")
+        text: tag.span("View", class: "govuk-visually-hidden")
       }
     ],
     rows:
@@ -41,7 +41,7 @@
               end
           },
           {
-            text: link_to(sanitize("Edit#{tag.span(world_location.name, class: "govuk-visually-hidden")}"), [:admin, world_location.world_location_news], class: "govuk-link")
+            text: link_to(sanitize("View#{tag.span(world_location.name, class: "govuk-visually-hidden")}"), [:admin, world_location.world_location_news], class: "govuk-link")
           }
         ]
       end


### PR DESCRIPTION
## Description

This PR updates the links in the world location news page from edit to view.

## Screenshot
![whitehall-admin dev gov uk_government_admin_world_location_news (1)](https://github.com/alphagov/whitehall/assets/91492293/f7277362-a6e6-4cff-82fe-471071bb3b73)


## Trello
https://trello.com/c/cNXVVFdo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
