### PR TITLE
Remove grid row div wrapper

### DIFF
--- a/app/views/admin/worldwide_organisations/index.html.erb
+++ b/app/views/admin/worldwide_organisations/index.html.erb
@@ -2,53 +2,51 @@
 <% content_for :title, "Worldwide organisation" %>
 <% content_for :title_margin_bottom, 6 %>
 
-<div class="govuk-grid-row">
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Create worldwide organisation",
-    href: new_admin_worldwide_organisation_path,
-    margin_bottom: 6,
-    data_attributes: {
-      module: "gem-track-click",
-      "track-category": "form-button",
-      "track-action": "worldwide-organisation-button",
-      "track-label": "Create worldwide organisation"
-    }
-  } %>
-  <% if @worldwide_organisations.present? %>
-    <div class="app-c-govuk-table--filterable govuk-table--with-actions">
-      <%= render "govuk_publishing_components/components/table", {
-        filterable: true,
-        label: "Filter by organisation or country",
-        head: [
+<%= render "govuk_publishing_components/components/button", {
+  text: "Create worldwide organisation",
+  href: new_admin_worldwide_organisation_path,
+  margin_bottom: 6,
+  data_attributes: {
+    module: "gem-track-click",
+    "track-category": "form-button",
+    "track-action": "worldwide-organisation-button",
+    "track-label": "Create worldwide organisation"
+  }
+} %>
+<% if @worldwide_organisations.present? %>
+  <div class="app-c-govuk-table--filterable govuk-table--with-actions">
+    <%= render "govuk_publishing_components/components/table", {
+      filterable: true,
+      label: "Filter by organisation or country",
+      head: [
+        {
+          text: "Organisation name"
+        },
+        {
+          text: "Country"
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden")
+        }
+      ],
+      rows: @worldwide_organisations.map do |worldwide_organisation|
+        [
           {
-            text: "Organisation name"
+            text: tag.span(worldwide_organisation.name, class: "govuk-!-font-weight-bold")
           },
           {
-            text: "Country"
+            text: worldwide_organisation.world_locations.map(&:name).to_sentence
           },
           {
-            text: tag.span("Actions", class: "govuk-visually-hidden")
+            text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
+              (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
           }
-        ],
-        rows: @worldwide_organisations.map do |worldwide_organisation|
-          [
-            {
-              text: tag.span(worldwide_organisation.name, class: "govuk-!-font-weight-bold")
-            },
-            {
-              text: worldwide_organisation.world_locations.map(&:name).to_sentence
-            },
-            {
-              text: link_to(sanitize("View #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link govuk-!-margin-right-2") +
-                (link_to(sanitize("Delete #{tag.span(worldwide_organisation.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_worldwide_organisation_path(worldwide_organisation), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
-            }
-          ]
-        end
-      } %>
-    </div>
-  <% else %>
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: "No worldwide organisations have been created."
+        ]
+      end
     } %>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "No worldwide organisations have been created."
+  } %>
+<% end %>


### PR DESCRIPTION
## Description

This PR aligns the title, button and table margin on the left of the worldwide organisations listing page.

## Screenshot
![whitehall-admin dev gov uk_government_admin_worldwide_organisations](https://github.com/alphagov/whitehall/assets/91492293/1edadb59-0e84-4d9e-881a-fc7b1e812064)

## Trello
https://trello.com/c/pV5v4pEn

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
