### PR TITLE
Replace edit details with edit on people details page

### DIFF
--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -55,7 +55,7 @@
         ].reject { |row| row[:value].blank? },
         edit: {
           href: [:edit, :admin, @person],
-          link_text: "Edit details",
+          link_text: "Edit",
         },
         delete: {
           href: (confirm_destroy_admin_person_path(@person) if @person.destroyable?),

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -89,7 +89,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "OBE"
     assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Biography"
     assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "He is the PM."
-    assert_select ".govuk-summary-list__actions-list a[href='#{edit_admin_person_path(person)}']", text: /Edit details/
+    assert_select ".govuk-summary-list__actions-list a[href='#{edit_admin_person_path(person)}']", text: /Edit Details/
     assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details"
   end
 


### PR DESCRIPTION
## Description

This PR updates the Edit link text on the people details page.

## Screenshot
![whitehall-admin dev gov uk_government_admin_people_fiona-ryland (3)](https://github.com/alphagov/whitehall/assets/91492293/0c93a077-26f5-4dc7-90f4-652c82144342)

## Trello
https://trello.com/c/ROhb9MJo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
