### PR TITLE
Update README to reflect publicly rendered pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@ Whitehall is deployed in two modes:
 
 ## Live examples (public facing frontend)
 
-### Static Content
-
-- Virus checking placeholder: [https://www.gov.uk/government/placeholder](https://www.gov.uk/government/placeholder)
-
 ### World Information
 
 - Help and services around the world: [https://www.gov.uk/world](https://www.gov.uk/world)
-- Worldwide Organisation pages: [https://www.gov.uk/world/organisations/british-embassy-paris](https://www.gov.uk/world/organisations/british-embassy-paris)
 
 ## Running the Application
 


### PR DESCRIPTION
The virus checking placeholder and Worldwide Organisations are now rendered by other applications.

Therefore removing them from the list of example pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
