### PR TITLE
Add topical events tabs to organisation features page

### DIFF
--- a/app/helpers/admin/features_helper.rb
+++ b/app/helpers/admin/features_helper.rb
@@ -7,6 +7,14 @@ module Admin::FeaturesHelper
     end
   end
 
+  def featurable_topical_events_for_feature_list(featurable_topical_events, feature_list)
+    @featurable_topical_events_for_feature_list ||= featurable_topical_events.reject do |topical_event|
+      feature_list.features.current.detect do |feature|
+        feature.topical_event == topical_event
+      end
+    end
+  end
+
   def featurable_editions_for_feature_list(editions, feature_list)
     @featurable_editions_for_feature_list ||= editions.reject do |edition|
       localised_edition = LocalisedModel.new(edition, feature_list.locale)

--- a/app/views/admin/feature_lists/_featureable_topical_events.html.erb
+++ b/app/views/admin/feature_lists/_featureable_topical_events.html.erb
@@ -1,0 +1,44 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Feature topical events",
+  margin_bottom: 6,
+} %>
+
+<% if featurable_topical_events.any? %>
+  <p class="govuk-heading-s govuk-!-margin-bottom-3">
+    <%= pluralize(number_with_delimiter(featurable_topical_events.count), "document") %>
+  </p>
+
+  <div class="app-view-features-offsite-links__table govuk-table--with-actions">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title"
+        },
+        {
+          text: "Published/duration",
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden"),
+        }
+      ],
+      rows: featurable_topical_events.map do |topical_event|
+        [
+          {
+            text: tag.p(topical_event.name, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
+          },
+          {
+            text: "#{l(topical_event.start_date.to_date)} to #{l(topical_event.end_date.to_date)}",
+          },
+          {
+            text: link_to(sanitize("Edit #{tag.span(topical_event.name, class: "govuk-visually-hidden")}"), polymorphic_url([:edit, :admin, topical_event]), class: "govuk-link") +
+                    link_to(sanitize("Feature #{tag.span(topical_event.name, class: "govuk-visually-hidden")}"), polymorphic_url([:new, :admin, feature_list, :feature], topical_event_id: topical_event.id), class: 'govuk-link govuk-!-margin-left-2'),
+          }
+        ]
+      end
+    } %>
+  </div>
+<% else %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "There are currently no featurable topical events."
+  } %>
+<% end %>

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -56,6 +56,20 @@
       ),
     },
     {
+      id: "topical_events_tab",
+      label: "Topical events",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "organisation-topical-events-tab",
+        "track-label": "Topical events"
+      },
+      content: render("admin/feature_lists/featureable_topical_events",
+        feature_list: @feature_list,
+        featurable_topical_events: featurable_topical_events_for_feature_list(@featurable_topical_events, @feature_list),
+      ),
+    },
+    {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",
       tab_data_attributes: {

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -27,6 +27,13 @@ Feature: Administering Organisations
     When I add the offsite link "Offsite Thing" of type "Alert" to the organisation "Ministry of Pop"
     Then I should see the edit offsite link "Offsite Thing" on the "Ministry of Pop" organisation page
 
+  @design-system-only
+  Scenario: Featuring a topical event for an organisation
+    When an active topical event called "Super topical" exists
+    And I visit the the organisation feature page for "Ministry of Pop"
+    And I feature "Super topical"
+    Then I see that "Super topical" has been featured
+
   @javascript @bootstrap-only
   Scenario: Filtering items to feature on an organisation page
     Given an organisation and some documents exist

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -336,3 +336,13 @@ Then(/^the roles should be in the following order:$/) do |roles|
     expect(hash[:name]).to eq(role_names[index])
   end
 end
+
+Given(/^an active topical event called "([^"]*)" exists$/) do |name|
+  @topical_event = create(:topical_event, :active, name:)
+end
+
+And(/^I visit the the organisation feature page for "([^"]*)"$/) do |name|
+  organisation = Organisation.find_by!(name:)
+  visit admin_organisation_path(organisation)
+  click_link "Features"
+end


### PR DESCRIPTION
## Description

This was missed when I ported over the org features page by accident. I've added a feature test as this should be tested.


## Screenshots

<img width="938" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9da8ca72-09b1-4b35-aa56-9fb4e3a405a6">

<img width="883" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/02704605-fb88-44a0-9d2a-f24b1609d5c5">

## Trello card

https://trello.com/c/fZSJEfR0/487-add-topical-events-tab-to-organisation-features-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
