### PR TITLE
Sort World Locations in world index content item

### DIFF
--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -1,15 +1,10 @@
 module WorldLocationHelper
   def group_and_sort(locations)
-    locations.
-      # transliterate name for sorting once, we're going to use it twice:
-      map { |location| [ActiveSupport::Inflector.transliterate(location.name_without_prefix), location] }.
-      # ... 1. to sort (to avoid Côt coming after Cow) ...
-      sort_by { |transliterated_name, _location| transliterated_name }.
-      # ... 2. to group by the first letter (to avoid Éire not being in E)...
-      group_by { |transliterated_name, _location| transliterated_name.first.upcase }.
-      # then we sort the structure by the first letters
-      sort.
-      # finally we remove the sorted name from the structure
-      map { |(letter, names_and_locations)| [letter, names_and_locations.map { |_transliterated_name, location| location }] }
+    locations
+      .map { |location| [ActiveSupport::Inflector.transliterate(location.name_without_prefix), location] }
+      .sort_by { |transliterated_name, _location| transliterated_name }
+      .group_by { |transliterated_name, _location| transliterated_name.first.upcase }
+      .sort
+      .map { |(letter, names_and_locations)| [letter, names_and_locations.map { |_transliterated_name, location| location }] }
   end
 end

--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -7,4 +7,11 @@ module WorldLocationHelper
       .sort
       .map { |(letter, names_and_locations)| [letter, names_and_locations.map { |_transliterated_name, location| location }] }
   end
+
+  def sort(locations)
+    locations
+      .map { |location| [ActiveSupport::Inflector.transliterate(location.name_without_prefix), location] }
+      .sort_by { |transliterated_name, _location| transliterated_name }
+      .map { |_transliterated_name, location| location }
+  end
 end

--- a/app/presenters/publishing_api/world_index_presenter.rb
+++ b/app/presenters/publishing_api/world_index_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class WorldIndexPresenter
+    include WorldLocationHelper
+
     attr_accessor :update_type
 
     def initialize(update_type: nil)
@@ -47,7 +49,7 @@ module PublishingApi
   private
 
     def format_locations(locations)
-      locations.map do |location|
+      sort(locations).map do |location|
         {
           active: location.active,
           analytics_identifier: location.analytics_identifier,

--- a/test/unit/app/helpers/world_location_helper_test.rb
+++ b/test/unit/app/helpers/world_location_helper_test.rb
@@ -58,4 +58,45 @@ class WorldLocationHelperTest < ActionView::TestCase
       assert_equal expected_order, group_and_sort(unsorted)
     end
   end
+
+  context "#sort" do
+    test "sorts correctly where special characters are used anywhere other than the first character" do
+      world_location_1 = create(:world_location, name: "Cow")
+      world_location_2 = create(:world_location, name: "Côt")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [
+        world_location_2,
+        world_location_1,
+      ]
+
+      assert_equal expected_order, sort(unsorted)
+    end
+
+    test "sorts correctly where special characters are used as the first character" do
+      world_location_1 = create(:world_location, name: "England")
+      world_location_2 = create(:world_location, name: "Éire")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [
+        world_location_2,
+        world_location_1,
+      ]
+
+      assert_equal expected_order, sort(unsorted)
+    end
+
+    test "ignores `The` prefix when sorting" do
+      world_location_1 = create(:world_location, name: "Hungary")
+      world_location_2 = create(:world_location, name: "The Gambia")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [
+        world_location_2,
+        world_location_1,
+      ]
+
+      assert_equal expected_order, sort(unsorted)
+    end
+  end
 end

--- a/test/unit/app/helpers/world_location_helper_test.rb
+++ b/test/unit/app/helpers/world_location_helper_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class WorldLocationHelperTest < ActionView::TestCase
+  extend Minitest::Spec::DSL
+  include WorldLocationHelper
+
+  context "#group_and_sort" do
+    test "groups and sorts correctly where special characters are used anywhere other than the first character" do
+      world_location_1 = create(:world_location, name: "Cow")
+      world_location_2 = create(:world_location, name: "Côt")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [[
+        "C",
+        [
+          world_location_2,
+          world_location_1,
+        ],
+      ]]
+
+      assert_equal expected_order, group_and_sort(unsorted)
+    end
+
+    test "groups and sorts correctly where special characters are used as the first character" do
+      world_location_1 = create(:world_location, name: "England")
+      world_location_2 = create(:world_location, name: "Éire")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [[
+        "E",
+        [
+          world_location_2,
+          world_location_1,
+        ],
+      ]]
+
+      assert_equal expected_order, group_and_sort(unsorted)
+    end
+
+    test "ignores `The` prefix when sorting" do
+      world_location_1 = create(:world_location, name: "Hungary")
+      world_location_2 = create(:world_location, name: "The Gambia")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [[
+        "G",
+        [
+          world_location_2,
+        ],
+      ],
+                        [
+                          "H",
+                          [
+                            world_location_1,
+                          ],
+                        ]]
+
+      assert_equal expected_order, group_and_sort(unsorted)
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api/world_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/world_index_presenter_test.rb
@@ -2,14 +2,6 @@ require "test_helper"
 
 class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
   setup do
-    @world_location_1 = create(
-      :world_location,
-      name: "Location 1",
-      slug: "location-1",
-      active: true,
-      analytics_identifier: "A1",
-      iso2: "AB",
-    )
     @world_location_2 = create(
       :world_location,
       name: "Location 2",
@@ -17,6 +9,14 @@ class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
       active: false,
       analytics_identifier: "B2",
       iso2: "CD",
+    )
+    @world_location_1 = create(
+      :world_location,
+      name: "Location 1",
+      slug: "location-1",
+      active: true,
+      analytics_identifier: "A1",
+      iso2: "AB",
     )
     @international_delegation = create(
       :international_delegation,
@@ -28,7 +28,7 @@ class PublishingApi::WorldIndexPresenterTest < ActiveSupport::TestCase
     )
   end
 
-  test "presents a valid content item" do
+  test "presents a valid content item with locations sorted into the correct order" do
     expected_hash = {
       base_path: "/world",
       details: {


### PR DESCRIPTION
The pages consuming this data are expecting the world locations to be in alphabetical order, excluding special characters.
    
Therefore updating the presenter to sort the locations in the content item.

Also adds missing tests to the `WorldLocationHelper`.  I decided not to spend time DRY-ing up the `group_and_sort` method since this will be deleted when public rendering of the Whitehall API is switched off.

After deployment, the world index page will need to be republished.

[Trello card](https://trello.com/c/eKjf7gPC)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
