### PR TITLE
Fix sidekiq strict args in asset manager rake tasks

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -8,7 +8,7 @@ namespace :asset_manager do
       next unless edition.respond_to?(:attachments)
 
       edition.attachments.files.each do |file_attachment|
-        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
         attachment_data_id = file_attachment.attachment_data.id
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
       end
@@ -23,7 +23,7 @@ namespace :asset_manager do
       if consultation.consultation_participation&.consultation_response_form.present?
         response_form = consultation.consultation_participation.consultation_response_form
         response_form_data_id = response_form.consultation_response_form_data.id
-        new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [consultation.auth_bypass_id] }
 
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue(
           "asset_manager_updater",
@@ -35,7 +35,7 @@ namespace :asset_manager do
 
       if consultation.outcome.present?
         consultation.outcome.attachments.files.each do |file_attachment|
-          new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+          new_attributes = { "auth_bypass_ids" => [consultation.auth_bypass_id] }
           attachment_data_id = file_attachment.attachment_data.id
           AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
         end
@@ -44,7 +44,7 @@ namespace :asset_manager do
       next if consultation.public_feedback.blank?
 
       consultation.public_feedback.attachments.files.each do |file_attachment|
-        new_attributes = { auth_bypass_ids: [consultation.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [consultation.auth_bypass_id] }
         attachment_data_id = file_attachment.attachment_data.id
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
       end
@@ -58,7 +58,7 @@ namespace :asset_manager do
     latest_draft_editions.find_each do |edition|
       edition.images.each do |image|
         image_data_id = image.image_data.id
-        new_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+        new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
         AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ImageData", image_data_id, new_attributes)
       end
     end

--- a/test/unit/lib/tasks/asset_manager_test.rb
+++ b/test/unit/lib/tasks/asset_manager_test.rb
@@ -13,7 +13,7 @@ class AssetManagerRake < ActiveSupport::TestCase
     test "updates attachments with auth_bypass_ids when its latest edition is a draft" do
       edition = create(:draft_detailed_guide)
       file_attachment = create(:file_attachment, attachable: edition)
-      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
         "asset_manager_updater",
@@ -83,7 +83,7 @@ class AssetManagerRake < ActiveSupport::TestCase
       participation = create(:consultation_participation, consultation: edition)
       consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
 
-      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
         "asset_manager_updater",
@@ -153,7 +153,7 @@ class AssetManagerRake < ActiveSupport::TestCase
       outcome = create(:consultation_outcome, consultation: edition)
       file_attachment = create(:file_attachment, attachable: outcome)
 
-      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
         "asset_manager_updater",
@@ -170,7 +170,7 @@ class AssetManagerRake < ActiveSupport::TestCase
       feedback = create(:consultation_public_feedback, consultation: edition)
       file_attachment = create(:file_attachment, attachable: feedback)
 
-      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
         "asset_manager_updater",
@@ -189,7 +189,7 @@ class AssetManagerRake < ActiveSupport::TestCase
     test "updates an image with auth_bypass_id when it is part of the latest edition which is a draft" do
       edition = create(:draft_case_study)
       image = create(:image, edition:)
-      expected_attributes = { auth_bypass_ids: [edition.auth_bypass_id] }
+      expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
       AssetManagerUpdateWhitehallAssetWorker.expects(:perform_async_in_queue).with(
         "asset_manager_updater",


### PR DESCRIPTION
Symbols were being passed in the rake task, causing it to error with `ArgumentError: Job arguments to AssetManagerUpdateWhitehallAssetWorker must be native JSON types.`

Fixed by passing strings down to the worker, which works fine as the `AssetUpdater` expect stringified keys.

Co-authored-by: Neamah al Selwi neamah.alselwi@digital.cabinet-office.gov.uk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
