### PR TITLE
Pin Carrierwave gem at version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "addressable"
 gem "babosa"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
-gem "carrierwave"
+gem "carrierwave", "< 3" # pin at v2 to avoid breaking changes
 gem "carrierwave-i18n"
 gem "chronic"
 gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -951,7 +951,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap-kaminari-views
-  carrierwave
+  carrierwave (< 3)
   carrierwave-i18n
   chronic
   climate_control


### PR DESCRIPTION
Carrierwave version 3 introduces breaking changes which cause the Whitehall test suite to fail. It's currently unknown how much effort would be required to resolve those issues and complete the upgrade from version 2 to version 3.

There is currently [a team][1] working more broadly on refactoring and paying down tech debt relating to Whitehall's handling of file uploads, and how those files make their way to [Asset Manager][2].

Part of that work includes deciding whether Carrierwave is still the right tool for processing file uploads, or if Whitehall would be better served by something else (for example, Rails Active Storage).

The team have a [card in their backlog][3] to upgrade to Carrierwave 3 if they decide it should remain in Whitehall long term. It therefore seems appropriate to pin Carrierwave to version 2 while they carry out this work, to avoid Dependabot opening new Pull Requests with each new release of Carrierwave.

[1]: https://gds.slack.com/channels/govuk-publishing-whitehall-asset-management
[2]: https://github.com/alphagov/asset-manager
[3]: https://trello.com/c/ObuiaoJW/128-update-carrierwave-to-3x-if-needed-long-term

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
