### PR TITLE
Ignore case when sorting world locations

### DIFF
--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -11,7 +11,7 @@ module WorldLocationHelper
   def sort(locations)
     locations
       .map { |location| [ActiveSupport::Inflector.transliterate(location.name_without_prefix), location] }
-      .sort_by { |transliterated_name, _location| transliterated_name }
+      .sort_by { |transliterated_name, _location| transliterated_name.downcase }
       .map { |_transliterated_name, location| location }
   end
 end

--- a/test/unit/app/helpers/world_location_helper_test.rb
+++ b/test/unit/app/helpers/world_location_helper_test.rb
@@ -98,5 +98,18 @@ class WorldLocationHelperTest < ActionView::TestCase
 
       assert_equal expected_order, sort(unsorted)
     end
+
+    test "ignores case when sorting" do
+      world_location_1 = create(:world_location, name: "UK Mission to ASEAN")
+      world_location_2 = create(:world_location, name: "UK and the Commonwealth")
+      unsorted = [world_location_1, world_location_2]
+
+      expected_order = [
+        world_location_2,
+        world_location_1,
+      ]
+
+      assert_equal expected_order, sort(unsorted)
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/ii6IgWnk

The consumers of the world location content item rely on the data being correctly sorted (#8002).

However, case is currently not being ignored which means that lowercase characters come after all uppercase characters. For example, "UK and the Commonwealth" is incorrectly sorted to be after "UK Mission to ASEAN".

This updates the sort to ignore case.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
