### PR TITLE
Add additional fields to Worldwide Office presenter

### DIFF
--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -19,6 +19,8 @@ module PublishingApi
       content.merge!(
         details: {
           access_and_opening_times:,
+          services:,
+          type: item.worldwide_office_type.name,
         },
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
@@ -49,6 +51,15 @@ module PublishingApi
       return if item.access_and_opening_times.blank?
 
       Whitehall::GovspeakRenderer.new.govspeak_to_html(item.access_and_opening_times)
+    end
+
+    def services
+      item.services.map do |service|
+        {
+          title: service.name,
+          type: service.service_type.name,
+        }
+      end
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -7,7 +7,8 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
 
   test "presents a Worldwide Office ready for adding to the publishing API" do
     access_and_opening_times = "## About us\r\n\r\nVisit our [profile page](https://www.gov.uk/government/world/organisations/british-consulate-general-atlanta)"
-    worldwide_office = create(:worldwide_office, access_and_opening_times:)
+    worldwide_office = build(:worldwide_office, access_and_opening_times:)
+    worldwide_office_service = create(:worldwide_office_worldwide_service, worldwide_office:)
     public_path = worldwide_office.public_path
 
     expected_hash = {
@@ -23,6 +24,13 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
       redirects: [],
       details: {
         access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_office.access_and_opening_times),
+        services: [
+          {
+            title: worldwide_office_service.worldwide_service.name,
+            type: worldwide_office_service.worldwide_service.service_type.name,
+          },
+        ],
+        type: worldwide_office.worldwide_office_type.name,
       },
       update_type: "major",
     }


### PR DESCRIPTION
We are migrating the Worldwide Organisations API away from Whitehall and into content items.

Therefore we need to include some missing fields in the Worldwide Office content item that was previously included in the API.

[Trello card](https://trello.com/c/jJ0SH0N3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
