### PR TITLE
Send access limit for organisations to publishing api

### DIFF
--- a/app/presenters/publishing_api/payload_builder/access_limitation.rb
+++ b/app/presenters/publishing_api/payload_builder/access_limitation.rb
@@ -4,8 +4,7 @@ module PublishingApi
       def self.for(item)
         return {} unless item.access_limited? && !item.publicly_visible?
 
-        users = User.where(organisation: item.organisations)
-        { access_limited: { users: users.pluck(:uid).compact } }
+        { access_limited: { organisations: item.organisations.pluck(:content_id).compact } }
       end
     end
   end

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -47,7 +47,7 @@ class AssetManager::AttachmentUpdater
 
   def self.get_asset_attributes(attachment_data, asset, access_limited, draft_status, link_header, redirect_url, replacement_id)
     new_attributes = {
-      access_limited: access_limited ? get_access_limited(attachment_data) : nil,
+      access_limited_organisation_ids: access_limited ? get_access_limited(attachment_data) : nil,
       draft: draft_status ? get_draft(attachment_data) : nil,
       parent_document_url: link_header ? get_link_header(attachment_data) : nil,
       replacement_id: replacement_id ? get_replacement_id(attachment_data, asset) : nil,

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -10,8 +10,8 @@ class AssetManagerCreateAssetWorker < WorkerBase
 
     assetable_id, assetable_type, asset_variant = asset_params.values_at("assetable_id", "assetable_type", "asset_variant")
     asset_options = { file:, auth_bypass_ids:, draft: }
-    authorised_user_uids = get_authorised_user_ids(attachable_model_class, attachable_model_id)
-    asset_options[:access_limited] = authorised_user_uids if authorised_user_uids
+    authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
+    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids
 
     response = asset_manager.create_asset(asset_options)
     save_asset_id_to_assets(assetable_id, assetable_type, asset_variant, response)
@@ -27,7 +27,7 @@ class AssetManagerCreateAssetWorker < WorkerBase
 
 private
 
-  def get_authorised_user_ids(attachable_model_class, attachable_model_id)
+  def get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
     if attachable_model_class && attachable_model_id
       attachable_model = attachable_model_class.constantize.find(attachable_model_id)
       if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -13,8 +13,8 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     if attachable_model_class && attachable_model_id
       attachable_model = attachable_model_class.constantize.find(attachable_model_id)
       if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        authorised_user_uids = AssetManagerAccessLimitation.for(attachable_model)
-        asset_options[:access_limited] = authorised_user_uids
+        organisation_ids = AssetManagerAccessLimitation.for(attachable_model)
+        asset_options[:access_limited_organisation_ids] = organisation_ids
       end
     end
 

--- a/lib/asset_manager_access_limitation.rb
+++ b/lib/asset_manager_access_limitation.rb
@@ -1,6 +1,6 @@
 class AssetManagerAccessLimitation
   def self.for(item)
     access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
-    access_limitation[:access_limited][:users]
+    access_limitation[:access_limited][:organisations]
   end
 end

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -42,7 +42,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           it "marks attachment as access limited in Asset Manager" do
             Services.asset_manager
                     .expects(:update_asset)
-                    .at_least_once.with("asset-id", has_entry("access_limited", %w[user-uid]))
+                    .at_least_once.with("asset-id", has_entry("access_limited", [organisation.content_id]))
 
             AssetManagerAttachmentMetadataWorker.drain
           end
@@ -82,7 +82,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           it "marks replacement attachment as access limited in Asset Manager" do
             Services.asset_manager.expects(:create_whitehall_asset).with do |params|
               params[:legacy_url_path] =~ /big-cheese/ &&
-                params[:access_limited] == %w[user-uid] &&
+                params[:access_limited_organisation_ids] == [organisation.content_id] &&
                 params[:auth_bypass_ids] == [edition.auth_bypass_id]
             end
 
@@ -139,7 +139,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             Services.asset_manager.expects(:create_whitehall_asset).with(
               has_entries(
                 legacy_url_path: regexp_matches(/logo\.png/),
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             )
@@ -191,14 +191,14 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             Services.asset_manager.expects(:create_whitehall_asset).with(
               has_entries(
                 legacy_url_path: regexp_matches(/greenpaper\.pdf/),
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             )
             Services.asset_manager.expects(:create_whitehall_asset).with(
               has_entries(
                 legacy_url_path: regexp_matches(/thumbnail_greenpaper\.pdf\.png/),
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             )
@@ -235,7 +235,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             Services.asset_manager.expects(:create_whitehall_asset).with(
               has_entries(
                 legacy_url_path: regexp_matches(/logo\.png/),
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             )
@@ -292,7 +292,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
             Services.asset_manager.expects(:create_asset).with(
               has_entries(
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             ).returns("id" => "http://asset-manager/assets/some-id")
@@ -315,13 +315,13 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           it "marks attachment as access limited in Asset Manager" do
             Services.asset_manager.expects(:create_asset).with(
               has_entries(
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             ).returns("id" => "http://asset-manager/assets/some-id")
             Services.asset_manager.expects(:create_asset).with(
               has_entries(
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             ).returns("id" => "http://asset-manager/assets/some-id")
@@ -353,7 +353,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             it "marks attachment as access limited in Asset Manager" do
               Services.asset_manager
                       .expects(:update_asset)
-                      .at_least_once.with(asset_manager_id, has_entry("access_limited", %w[user-uid]))
+                      .at_least_once.with(asset_manager_id, has_entry("access_limited_organisation_ids", [organisation.content_id]))
 
               AssetManagerAttachmentMetadataWorker.drain
             end
@@ -370,7 +370,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             it "unmarks attachment as access limited in Asset Manager" do
               Services.asset_manager
                       .expects(:update_asset)
-                      .at_least_once.with(asset_manager_id, has_entry("access_limited", []))
+                      .at_least_once.with(asset_manager_id, has_entry("access_limited_organisation_ids", []))
 
               AssetManagerAttachmentMetadataWorker.drain
             end
@@ -388,7 +388,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
             it "marks replacement attachment as access limited in Asset Manager" do
               Services.asset_manager.expects(:create_asset).with { |params|
-                params[:access_limited] == %w[user-uid] &&
+                params[:access_limited_organisation_ids] == [organisation.content_id] &&
                   params[:auth_bypass_ids] == [edition.auth_bypass_id]
               }.returns("id" => "http://asset-manager/assets/some-id")
 
@@ -442,7 +442,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
             Services.asset_manager.expects(:create_asset).with(
               has_entries(
-                access_limited: %w[user-uid],
+                access_limited_organisation_ids: [organisation.content_id],
                 auth_bypass_ids: [edition.auth_bypass_id],
               ),
             ).returns("id" => "http://asset-manager/assets/some-id")

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -31,13 +31,12 @@ class AssetManagerIntegrationTest
 
       test "sends the user ids of authorised users to Asset Manager" do
         organisation = FactoryBot.create(:organisation)
-        user = FactoryBot.create(:user, organisation:, uid: "user-uid")
         consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
         @attachment.attachable = consultation
         @attachment.attachment_data.attachable = consultation
         @attachment.save!
 
-        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited_organisation_ids: [organisation.content_id]))
 
         AssetManagerCreateWhitehallAssetWorker.drain
       end
@@ -69,13 +68,12 @@ class AssetManagerIntegrationTest
 
       test "sends the user ids of authorised users to Asset Manager" do
         organisation = FactoryBot.create(:organisation)
-        user = FactoryBot.create(:user, organisation:, uid: "user-uid")
         consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
         @attachment.attachable = consultation
         @attachment.attachment_data.attachable = consultation
         @attachment.save!
 
-        Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [user.uid]))
+        Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [organisation.content_id]))
                 .returns("id" => "http://asset-manager/assets/asset_manager_id")
 
         AssetManagerCreateAssetWorker.drain

--- a/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -262,11 +262,11 @@ class PublishingApi::AccessLimitedFatalityNoticeTest < ActiveSupport::TestCase
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
       @fatality_notice = create(:fatality_notice, :access_limited),
     )
-    @user = create(:user, organisation: @fatality_notice.organisations.first, uid: "booyah")
+    @organisation = @fatality_notice.organisations.first
     @presented_content = @presented_fatality_notice.content
   end
 
-  test "presents allowed users" do
-    assert_equal %w[booyah], @presented_content[:access_limited][:users]
+  test "presents allowed organisations" do
+    assert_equal [@organisation.content_id], @presented_content[:access_limited][:organisations]
   end
 end

--- a/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
@@ -5,7 +5,6 @@ module PublishingApi
     class AccessLimitationTest < ActiveSupport::TestCase
       test "returns access limitation data for the item" do
         organisation = create(:organisation)
-        user = create(:user, organisation:)
 
         stubbed_item = stub(
           access_limited?: true,
@@ -14,24 +13,11 @@ module PublishingApi
         )
         expected_hash = {
           access_limited: {
-            users: [user.uid],
+            organisations: [organisation.content_id],
           },
         }
 
         assert_equal AccessLimitation.for(stubbed_item), expected_hash
-      end
-
-      test "ignores users with no UID" do
-        organisation = create(:organisation)
-        create(:user, organisation:, uid: nil)
-
-        stubbed_item = stub(
-          access_limited?: true,
-          publicly_visible?: false,
-          organisations: [organisation],
-        )
-
-        assert_equal [], AccessLimitation.for(stubbed_item)[:access_limited][:users]
       end
 
       test "it returns an empty hash if the item is not access limited" do

--- a/test/unit/app/services/asset_manager/attachment_updater/access_limited_updates_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater/access_limited_updates_test.rb
@@ -7,6 +7,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
     let(:updater) { AssetManager::AttachmentUpdater }
     let(:attachment_data) { attachment.attachment_data }
     let(:update_service) { mock("asset-manager-update-asset-worker") }
+    let(:organisation) { FactoryBot.create(:organisation) }
 
     around do |test|
       AssetManager.stub_const(:AssetUpdater, update_service) do
@@ -22,7 +23,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
         AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
 
         access_limited_object = stub("access-limited-object")
-        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns([organisation.content_id])
 
         attachment_data.stubs(:access_limited?).returns(true)
         attachment_data.stubs(:access_limited_object).returns(access_limited_object)
@@ -30,7 +31,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the access limited state of the asset" do
         update_service.expects(:call)
-                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [organisation.content_id] })
 
         updater.call(attachment_data, access_limited: true)
       end
@@ -44,7 +45,7 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
         AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
 
         access_limited_object = stub("access-limited-object")
-        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns([organisation.content_id])
 
         attachment_data.stubs(:access_limited?).returns(true)
         attachment_data.stubs(:access_limited_object).returns(access_limited_object)
@@ -52,9 +53,9 @@ class AssetManager::AttachmentUpdater::AccessLimitedUpdatesTest < ActiveSupport:
 
       it "updates the access limited state of the asset and it's thumbnail" do
         update_service.expects(:call)
-                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => %w[user-uid] })
+                      .with(nil, attachment_data, attachment.file.asset_manager_path, { "access_limited" => [organisation.content_id] })
         update_service.expects(:call)
-                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => %w[user-uid] })
+                      .with(nil, attachment_data, attachment.file.thumbnail.asset_manager_path, { "access_limited" => [organisation.content_id] })
 
         updater.call(attachment_data, access_limited: true)
       end

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -65,7 +65,8 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         context "when attachment's attachable is access limited" do
           before do
             access_limited_object = stub("access-limited-object")
-            AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(%w[user-uid])
+            @organisation = create(:organisation)
+            AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns([@organisation.content_id])
 
             attachment_data.stubs(:access_limited?).returns(true)
             attachment_data.stubs(:access_limited_object).returns(access_limited_object)
@@ -73,9 +74,9 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
           it "updates the access limited state of all assets" do
             update_service.expects(:call)
-                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited_organisation_ids" => [@organisation.content_id] })
             update_service.expects(:call)
-                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => %w[user-uid] })
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited_organisation_ids" => [@organisation.content_id] })
 
             updater.call(attachment_data, access_limited: true)
           end
@@ -88,9 +89,9 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
           it "updates all assets to have an empty access_limited array" do
             update_service.expects(:call)
-                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "access_limited_organisation_ids" => [] })
             update_service.expects(:call)
-                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited" => [] })
+                          .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "access_limited_organisation_ids" => [] })
 
             updater.call(attachment_data, access_limited: true)
           end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -6,7 +6,6 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker = AssetManagerCreateAssetWorker.new
     @asset_manager_id = "asset_manager_id"
     @organisation = FactoryBot.create(:organisation)
-    @user = FactoryBot.create(:user, organisation: @organisation, uid: "user-uid")
     @model = FactoryBot.create(:attachment_data)
     @asset_manager_response = { "id" => "http://asset-manager/assets/#{@asset_manager_id}" }
     @asset_args = { assetable_id: @model.id, asset_variant: Asset.variants[:original], assetable_type: @model.class.to_s }.deep_stringify_keys
@@ -45,7 +44,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     attachment = FactoryBot.create(:file_attachment, attachable: consultation)
     attachment.attachment_data.attachable = consultation
 
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [@user.uid])).returns(@asset_manager_response)
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
 
     @worker.perform(@file.path, @asset_args, true, consultation.class.to_s, consultation.id)
   end
@@ -56,7 +55,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     attachment = FactoryBot.create(:file_attachment, attachable: response)
     attachment.attachment_data.attachable = consultation
 
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited: [@user.uid])).returns(@asset_manager_response)
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
 
     @worker.perform(@file.path, @asset_args, true, consultation.class.to_s, consultation.id)
   end

--- a/test/unit/app/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -45,25 +45,23 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
   test "marks attachments belonging to consultations as access limited" do
     organisation = FactoryBot.create(:organisation)
-    user = FactoryBot.create(:user, organisation:, uid: "user-uid")
     consultation = FactoryBot.create(:consultation, organisations: [organisation], access_limited: true)
     attachment = FactoryBot.create(:file_attachment, attachable: consultation)
     attachment.attachment_data.attachable = consultation
 
-    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited_organisation_ids: [organisation.content_id]))
 
     @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end
 
   test "marks attachments belonging to consultation responses as access limited" do
     organisation = FactoryBot.create(:organisation)
-    user = FactoryBot.create(:user, organisation:, uid: "user-uid")
     consultation = FactoryBot.create(:consultation, organisations: [organisation], access_limited: true)
     response = FactoryBot.create(:consultation_outcome, consultation:)
     attachment = FactoryBot.create(:file_attachment, attachable: response)
     attachment.attachment_data.attachable = consultation
 
-    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited_organisation_ids: [organisation.content_id]))
 
     @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end

--- a/test/unit/lib/asset_manager_access_limitation_test.rb
+++ b/test/unit/lib/asset_manager_access_limitation_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class AssetManagerAccessLimitationTest < ActiveSupport::TestCase
   test "delegates to PublishingApi::PayloadBuilder::AccessLimitation to ask for users that can access item" do
     edition = FactoryBot.build(:edition)
-    access_limitation = { access_limited: { users: %w[uid-1] } }
+    access_limitation = { access_limited: { organisations: %w[org-1] } }
     PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
-    assert_equal %w[uid-1], AssetManagerAccessLimitation.for(edition)
+    assert_equal %w[org-1], AssetManagerAccessLimitation.for(edition)
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/QcQlBpuq/1231-fix-bug-on-access-limiting-for-accounts-created-after-it-was-sent-to-the-publishing-api)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
