### PR TITLE
Introduce polymorphic relationship in Asset model

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,8 +1,8 @@
 class Asset < ApplicationRecord
-  belongs_to :attachment_data
+  belongs_to :assetable, polymorphic: true
 
   validates :asset_manager_id, presence: true
-  validates :attachment_data, presence: true
+  validates :assetable, presence: true
   validates :variant, presence: true
 
   enum variant: { original: "original".freeze, thumbnail: "thumbnail".freeze }

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -5,7 +5,9 @@ class AttachmentData < ApplicationRecord
   mount_uploader :file, AttachmentUploader, mount_on: :carrierwave_file
 
   has_many :attachments, -> { order(:attachable_id) }, inverse_of: :attachment_data
-  has_many :assets, inverse_of: :attachment_data
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
 
   delegate :url, :path, to: :file, allow_nil: true
 

--- a/db/migrate/20230726110128_add_polymorphic_relationship_to_assets.rb
+++ b/db/migrate/20230726110128_add_polymorphic_relationship_to_assets.rb
@@ -1,0 +1,6 @@
+class AddPolymorphicRelationshipToAssets < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :assets, :attachment_data, index: true, if_exists: true
+    add_reference :assets, :assetable, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_131507) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_110128) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
-    t.bigint "attachment_data_id", null: false
     t.string "variant", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["attachment_data_id"], name: "index_assets_on_attachment_data_id"
+    t.string "assetable_type"
+    t.bigint "assetable_id"
+    t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 
   create_table "attachment_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/unit/app/models/asset_test.rb
+++ b/test/unit/app/models/asset_test.rb
@@ -7,25 +7,28 @@ class AssetTest < ActiveSupport::TestCase
   end
 
   test "should be invalid without an asset_manager_id" do
-    asset = Asset.new(attachment_data: @attachment_data, variant: @variant)
+    asset = Asset.new(assetable: @attachment_data, variant: @variant)
 
     assert_not asset.valid?
+    assert_equal asset.errors.messages[:asset_manager_id], ["can't be blank"]
   end
 
-  test "should be invalid without an attachment_data" do
+  test "should be invalid without an assetable" do
     asset = Asset.new(asset_manager_id: "asset_manager_id", variant: @variant)
 
     assert_not asset.valid?
+    assert_equal asset.errors.messages[:assetable], ["can't be blank"]
   end
 
   test "should be invalid without a variant" do
-    asset = Asset.new(asset_manager_id: "asset_manager_id", attachment_data: @attachment_data)
+    asset = Asset.new(asset_manager_id: "asset_manager_id", assetable: @attachment_data)
 
     assert_not asset.valid?
+    assert_equal asset.errors.messages[:variant], ["can't be blank"]
   end
 
   test "should be valid if all fields present" do
-    asset = Asset.new(attachment_data: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant)
+    asset = Asset.new(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant)
 
     assert asset.valid?
   end

--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -166,6 +166,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
       AssetManagerCreateAssetWorker.drain
     end
   end
+
   describe "when use_non_legacy_endpoints is false" do
     test "should successfully create PDF and PNG thumbnail from the file_cache after a validation failure" do
       greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")
@@ -182,6 +183,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
       AssetManagerCreateWhitehallAssetWorker.drain
     end
   end
+
   test "should return nil file extension when no uploader present" do
     attachment = build(:attachment_data)
     attachment.stubs(file: nil)


### PR DESCRIPTION
Extending the Asset model's `belongs_to` relationship to be able to point to `AttachmentData`, `ImageData` etc. by introducing polymorphism.

This will enable us to store assets for all these types of attachments and replace the usage of `legacy_url_path` with `asset_manager_id(s)`.

[Trello Card](https://trello.com/c/VFrU0MLR/133-story-instead-of-createwhitehallasset-call-createasset-for-images)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
