### PR TITLE
Make sure HTML attachment content remains intact

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -5,8 +5,7 @@ class HtmlAttachment < Attachment
 
   has_one :govspeak_content,
           autosave: true,
-          inverse_of: :html_attachment,
-          dependent: :destroy
+          inverse_of: :html_attachment
 
   before_validation :clear_slug_if_non_english_locale
 

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -1,13 +1,14 @@
 require "test_helper"
 
 class HtmlAttachmentTest < ActiveSupport::TestCase
-  test "associated govspeak content is deleted with the html attachment" do
+  test "when HTML attachment is soft deleted, the associated Govspeak content remains intact" do
     attachment = create(:html_attachment)
-    govspeak_content = attachment.govspeak_content
 
-    attachment.destroy!
+    attachment.destroy! # this is a 'soft' delete
+    attachment.reload
 
-    assert_not GovspeakContent.exists?(govspeak_content.id)
+    assert attachment.deleted?
+    assert attachment.govspeak_content.present?
   end
 
   test "#deep_clone deep clones the HTML attachment, body, content_id and slug" do


### PR DESCRIPTION
Editions and their associated attachments get 'soft deleted' when users click the 'Discard draft' button.

However, a misconfiguration meant that the GovspeakContent record associated with HtmlAttachments was being 'hard deleted' (i.e. permanently deleted) when the associated attachment was only 'soft deleted'.

This has resulted in HTML attachment content being unrecoverable when attempting to restore editions that have been accidentally deleted by users.

GovspeakContent records will no longer be deleted when their associated HtmlAttachment is 'soft deleted'.

---

Trello: https://trello.com/c/59ripNXi/1289-discarding-a-draft-edition-causes-govspeakcontent-to-be-hard-deleted

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
