### PR TITLE
Sidekiq Web UI integrated authenticated behind signon

### DIFF
--- a/lib/sidekiq_gds_sso_middleware.rb
+++ b/lib/sidekiq_gds_sso_middleware.rb
@@ -1,0 +1,34 @@
+require "sidekiq/web"
+
+class SidekiqGdsSsoMiddleware
+  SIDEKIQ_SIGNON_PERMISSION = "Sidekiq Admin".freeze
+
+  def self.call(...) = new(...).call
+
+  def initialize(env)
+    @env = env
+    @warden = env.fetch("warden")
+  end
+
+  def call
+    status, headers, body = authenticated_sidekiq_request
+
+    headers[Slimmer::Headers::SKIP_HEADER] = "true"
+
+    [status, headers, body]
+  end
+
+private
+
+  attr_reader :env, :warden
+
+  def authenticated_sidekiq_request
+    warden.authenticate! if !warden.authenticated? || warden.user.remotely_signed_out?
+
+    if warden.user.has_permission?(SIDEKIQ_SIGNON_PERMISSION)
+      Sidekiq::Web.call(env)
+    else
+      [403, {}, ["Forbidden - access requires the \"#{SIDEKIQ_SIGNON_PERMISSION}\" permission"]]
+    end
+  end
+end

--- a/test/unit/lib/sidekiq_gds_sso_middleware_test.rb
+++ b/test/unit/lib/sidekiq_gds_sso_middleware_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class SidekiqGdsSsoMiddlewareTest < ActiveSupport::TestCase
+  setup do
+    @user = build(:user)
+    @warden = mock("warden")
+    @warden.stubs({ authenticated?: true, user: @user })
+  end
+
+  test "it will proxy a request to sidekiq web for an authenticated user with a 'Sidekiq Admin' permission" do
+    @user.permissions = ["Sidekiq Admin"]
+    env = { "warden" => @warden }
+
+    Sidekiq::Web.expects(:call).with(env).returns([200, {}, %w[body]])
+    SidekiqGdsSsoMiddleware.call(env)
+  end
+
+  test "it will return a 403 forbidden response for an authenticated user without 'Sidekiq Admin' permission" do
+    @user.permissions = []
+
+    status, _headers, body = SidekiqGdsSsoMiddleware.call({ "warden" => @warden })
+    assert_equal(403, status)
+    assert_equal(body, ["Forbidden - access requires the \"#{SidekiqGdsSsoMiddleware::SIDEKIQ_SIGNON_PERMISSION}\" permission"])
+  end
+
+  test "it adds a header to responses to disable slimmer middleware" do
+    @user.permissions = ["Sidekiq Admin"]
+    headers = {}
+
+    Sidekiq::Web.stubs(:call).returns([200, headers, %w[body]])
+    SidekiqGdsSsoMiddleware.call({ "warden" => @warden })
+
+    assert_equal({ Slimmer::Headers::SKIP_HEADER => "true" }, headers)
+  end
+
+  test "it runs warden.authenticate! when a user is not authenticated" do
+    @warden.expects(:authenticate!)
+    @warden.stubs(:authenticated?, false)
+
+    SidekiqGdsSsoMiddleware.call({ "warden" => @warden })
+  end
+
+  test "it runs warden.authenticate! when a user is remotely signed out" do
+    @warden.expects(:authenticate!)
+    @user.remotely_signed_out = true
+
+    SidekiqGdsSsoMiddleware.call({ "warden" => @warden })
+  end
+end


### PR DESCRIPTION
This is a proof of concept to illustrate an approach we could use to integrate the Sidekiq Web user interface into GOV.UK apps, now that Sidekiq Monitoring [1] is no longer operational. It was put together after a chat with Jon Hallam about what a future without Sidekiq Monitoring might be. I'd love to receive some feedback on if people think we should go down this route.

This approach offers a number of advantages to the Sidekiq Monitoring set-up of before. This one has authentication, using Signon, where users require a "Sidekiq Admin" permission to access and thus won't require the VPN for access. It will allow post requests and thus users are able to interact with the admin interface to delete dead jobs etc. It also uses the Sidekiq code of Whitehall and won't have the issue that Sidekiq Monitoring code doesn't necessarily match the version of Sidekiq used in an app.

---

Example of successful login:
![Jul-28-2023 18-13-37](https://github.com/alphagov/whitehall/assets/282717/ceecf498-b237-4de0-8729-fed85cb6dcc5)

Example of unsuccessful login:
![Jul-28-2023 18-13-57](https://github.com/alphagov/whitehall/assets/282717/3cfa7ccf-d161-4653-9a62-3e3b2d973593)

---

I don't expect this think to be a prototype that other apps should copy. As Whitehall has frontend rendering there's a couple of extra esoteric bits of code (Slimmer and Admin host) that mean this has some app specific code. Instead I'd imagine it'd make sense if govuk_sidekiq was able to provide a class that apps could use to mount a GDS SSO ready middleware to avoid each app repeating logic. However prior to merging I expect we should move the middleware to a separate file in lib and add some tests.

There's a couple of other problems that a wider roll out of this approach would have to resolve:

1) apps that are only on the VPN without a public hostname - we'd need
   to establish a way to route a request on a public hostname to them to
   expose the Sidekiq endpoint
2) API only apps - the GDS SSO gem doesn't support session
   authentication for Rails apps that are `api_only` [2] as it didn't
   need to and that provided better errors. We may need to work out a
   way that can work with this.

Finally there's a question still on approach for testing, I'm not sure if apps should have a test for this in them (though if we have a middleware class in govuk_sidekiq that should be unit tested). I do wonder if it'd make sense to have Smokey check access to Sidekiq.

[1]: https://github.com/alphagov/sidekiq-monitoring
[2]: https://github.com/search?q=repo%3Aalphagov%2Fgds-sso%20api_only&type=code



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
