### PR TITLE
Add confirm destroy endpoints for office and office translations

### DIFF
--- a/app/controllers/admin/worldwide_office_translations_controller.rb
+++ b/app/controllers/admin/worldwide_office_translations_controller.rb
@@ -5,7 +5,11 @@ class Admin::WorldwideOfficeTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    "admin"
+    if action_name == "confirm_destroy"
+      "design_system"
+    else
+      "admin"
+    end
   end
 
   def create_redirect_path

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -1,6 +1,6 @@
 class Admin::WorldwideOfficesController < Admin::BaseController
   before_action :find_worldwide_organisation
-  before_action :find_worldwide_office, only: %i[edit update destroy add_to_home_page remove_from_home_page]
+  before_action :find_worldwide_office, only: %i[edit update confirm_destroy destroy add_to_home_page remove_from_home_page]
 
   def index; end
 
@@ -34,9 +34,13 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     end
   end
 
+  def confirm_destroy; end
+
   def destroy
+    title = @worldwide_office.title
+
     if @worldwide_office.destroy
-      redirect_to [:admin, @worldwide_organisation, WorldwideOffice]
+      redirect_to [:admin, @worldwide_organisation, WorldwideOffice], notice: "#{title} has been deleted"
     else
       render :edit
     end
@@ -53,6 +57,16 @@ class Admin::WorldwideOfficesController < Admin::BaseController
   end
 
 private
+
+  def get_layout
+    design_system_actions = %w[confirm_destroy]
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 
   def find_worldwide_organisation
     @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])

--- a/app/views/admin/worldwide_office_translations/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_office_translations/confirm_destroy.html.erb
@@ -1,0 +1,28 @@
+<% content_for :context, @worldwide_office.title %>
+<% content_for :page_title, "Delete #{@translation_locale.native_and_english_language_name} translation" %>
+<% content_for :title, "Delete translation" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_worldwide_organisation_worldwide_office_translation_path(@worldwide_organisation, @worldwide_office, @translation_locale), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        Are you sure you want to delete the "<%= @translation_locale.native_and_english_language_name %>" translation for "<%= @worldwide_office.title %>"?
+      </p>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-office-translations-button",
+            "track-label": "Delete"
+          }
+        } %>
+        <%= link_to("Cancel", admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/worldwide_offices/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_offices/confirm_destroy.html.erb
@@ -1,0 +1,28 @@
+<% content_for :context, @worldwide_organisation.name %>
+<% content_for :page_title, "Delete office for #{@worldwide_organisation.name}" %>
+<% content_for :title, "Delete office" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_worldwide_organisation_worldwide_office_path(@worldwide_organisation, @worldwide_office), method: :delete do %>
+      <p class="govuk-body">
+        Are you sure you want to delete "<%= @worldwide_office.title %>"
+      </p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-office-button",
+            "track-label": "Delete"
+          }
+        } %>
+        <%= link_to("Cancel", admin_worldwide_organisation_worldwide_offices_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,7 +176,9 @@ Whitehall::Application.routes.draw do
             end
             post :reorder_for_home_page, on: :collection
             resource :access_and_opening_time, path: "access_info", except: %i[index show new]
-            resources :translations, controller: "worldwide_office_translations", only: %i[create edit update destroy]
+            resources :translations, controller: "worldwide_office_translations", only: %i[create edit update destroy] do
+              get :confirm_destroy, on: :member
+            end
           end
           resources :corporate_information_pages do
             resources :translations, controller: "corporate_information_pages_translations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Whitehall::Application.routes.draw do
 
           resources :worldwide_offices, path: "offices", except: [:show] do
             member do
+              get :confirm_destroy
               post :remove_from_home_page
               post :add_to_home_page
             end

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -368,6 +368,19 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     assert_equal [office], worldwide_organisation.reload.home_page_offices
   end
 
+  test "GET :confirm_destroy calls correctly" do
+    worldwide_organisation, office = create_worldwide_organisation_and_office
+
+    get :confirm_destroy, params: {
+      worldwide_organisation_id: worldwide_organisation.id,
+      id: office.id,
+    }
+
+    assert_response :success
+    assert_equal worldwide_organisation, assigns(:worldwide_organisation)
+    assert_equal office, assigns(:worldwide_office)
+  end
+
 private
 
   def create_worldwide_organisation_and_office


### PR DESCRIPTION
## Description 

This is the first of 4 PRs that will add functionality for the offices index page. This simply adds in the confirm destroy endpoints for worldwide offices and worldwide office translations

## Screenshots

![image](https://github.com/alphagov/whitehall/assets/42515961/9c99214d-5728-442a-b013-4ce7f8911155)

![image](https://github.com/alphagov/whitehall/assets/42515961/14fc500d-fb9b-4ea4-b5fd-19406861a2e2)

## Trello card

https://trello.com/c/hM6FFPTl/321-office-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
