### PR TITLE
Add reorder offices endpoint

### DIFF
--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -37,6 +37,10 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     end
   end
 
+  def reorder
+    @reorderable_offices = @worldwide_organisation.home_page_offices
+  end
+
   def confirm_destroy; end
 
   def destroy
@@ -62,7 +66,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
+    design_system_actions = %w[confirm_destroy reorder]
     design_system_actions += %w[index] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)

--- a/app/views/admin/worldwide_offices/index.html.erb
+++ b/app/views/admin/worldwide_offices/index.html.erb
@@ -47,7 +47,7 @@
       <% if @worldwide_organisation.home_page_offices.many? %>
         <div class="govuk-grid-column-one-third">
           <p class="govuk-body govuk-!-text-align-right">
-            <%= link_to "Reorder", "#", class: "govuk-link" %>
+            <%= link_to "Reorder", reorder_admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), class: "govuk-link" %>
           </p>
         </div>
       <% end %>

--- a/app/views/admin/worldwide_offices/reorder.html.erb
+++ b/app/views/admin/worldwide_offices/reorder.html.erb
@@ -1,0 +1,27 @@
+<% content_for :context, @worldwide_organisation.name %>
+<% content_for :page_title, "Reorder offices" %>
+<% content_for :title, "Reorder offices" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with url: [:reorder_for_home_page, :admin, @worldwide_organisation, WorldwideOffice] do %>
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @reorderable_offices.map do |office|
+          {
+            id: office.id,
+            title: office.title,
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+
+        <%= link_to("Cancel", admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Whitehall::Application.routes.draw do
               post :remove_from_home_page
               post :add_to_home_page
             end
+            get :reorder, on: :collection
             post :reorder_for_home_page, on: :collection
             resource :access_and_opening_time, path: "access_info", except: %i[index show new]
             resources :translations, controller: "worldwide_office_translations", only: %i[create edit update destroy] do

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -383,6 +383,23 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     assert_equal office, assigns(:worldwide_office)
   end
 
+  test "GET :reorder calls correctly" do
+    worldwide_organisation = create_worldwide_organisation_with_main_office
+    office1 = create(:worldwide_office, worldwide_organisation:)
+    office2 = create(:worldwide_office, worldwide_organisation:)
+
+    worldwide_organisation.add_office_to_home_page!(office1)
+    worldwide_organisation.add_office_to_home_page!(office2)
+
+    get :reorder, params: {
+      worldwide_organisation_id: worldwide_organisation.id,
+    }
+
+    assert_response :success
+    assert_equal worldwide_organisation, assigns(:worldwide_organisation)
+    assert_equal [office1, office2], assigns(:reorderable_offices)
+  end
+
 private
 
   def create_worldwide_organisation_and_office


### PR DESCRIPTION
## Description

This follows on from: 

1. https://github.com/alphagov/whitehall/pull/8032 - adds the confirm destroy worldwide offices and worldwide office translation endpoints
2. https://github.com/alphagov/whitehall/pull/8033 - adds the worldwide offices index page

This PR adds the ability to reorder the offices. This only reorders offices that are:

1. not the main office
2. are shown on the ww orgs homepage

The reorder link only shows when there are 2 or more offices shown on the homepage (not including the main office)

## Screenshots 

![image](https://github.com/alphagov/whitehall/assets/42515961/feab6bb7-0b89-489e-8404-3fda42511c1a)

## Trello card

https://trello.com/c/hM6FFPTl/321-office-page


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
