### PR TITLE
Add choose main office endpoint in the GOV.UK Design System

### DIFF
--- a/app/assets/stylesheets/admin/views/_worldwide-organisations-choose-main-office.scss
+++ b/app/assets/stylesheets/admin/views/_worldwide-organisations-choose-main-office.scss
@@ -1,0 +1,5 @@
+.app-view-worldwide-organisations-choose-main-office__select {
+  .govuk-label--xl {
+    margin-bottom: govuk-spacing(8);
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";
 @import "./admin/views/whats-new";
+@import "./admin/views/worldwide-organisations-choose-main-office";
 
 .app-js-only {
   display: none;

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -52,6 +52,8 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
     @access_and_opening_times = @worldwide_organisation.default_access_and_opening_times
   end
 
+  def choose_main_office; end
+
   def set_main_office
     @worldwide_organisation.update!(main_office_params)
     redirect_to [:admin, @worldwide_organisation, WorldwideOffice], notice: "Main office updated successfully"
@@ -67,7 +69,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
+    design_system_actions = %w[confirm_destroy choose_main_office]
     design_system_actions += %w[index show new create edit update] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)

--- a/app/views/admin/worldwide_offices/index.html.erb
+++ b/app/views/admin/worldwide_offices/index.html.erb
@@ -30,8 +30,14 @@
     <%= render "govuk_publishing_components/components/button", {
       text: "Create new office",
       href: new_admin_worldwide_organisation_worldwide_office_path(@worldwide_organisation),
-      margin_bottom: 8,
+      margin_bottom: 6,
     } %>
+
+    <% if @worldwide_organisation.offices.many? %>
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        <%= link_to "Set main office", choose_main_office_admin_worldwide_organisation_path(@worldwide_organisation), class: "govuk-link" %>
+      </p>
+    <% end %>
   </div>
 
   <div class="govuk-grid-row">

--- a/app/views/admin/worldwide_organisations/choose_main_office.html.erb
+++ b/app/views/admin/worldwide_organisations/choose_main_office.html.erb
@@ -1,0 +1,59 @@
+<% content_for :page_title, "Set main office for #{@worldwide_organisation.name}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @worldwide_organisation)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @worldwide_organisation, url: set_main_office_admin_worldwide_organisation_path(@worldwide_organisation), method: :put do |form| %>
+      <% if @worldwide_organisation.offices.count <= 5 %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "worldwide_organisation[main_office_id]",
+          id: "worldwide_organisation_main_office_id",
+          heading: "Set main office",
+          heading_caption: @worldwide_organisation.name,
+          heading_level: 1,
+          items: @worldwide_organisation.offices.sort_by(&:title).map do |office|
+            {
+              value: office.id,
+              text: office.title,
+              checked: office == @worldwide_organisation.main_office
+            }
+          end
+        } %>
+      <% else %>
+        <div class="app-view-worldwide-organisations-choose-main-office__select govuk-!-margin-bottom-8">
+          <span class="govuk-caption-xl"><%= @worldwide_organisation.name %></span>
+
+          <%= render "govuk_publishing_components/components/select", {
+            name: "worldwide_organisation[main_office_id]",
+            id: "worldwide_organisation_main_office_id",
+            label: "Set main office",
+            full_width: true,
+            heading_size: "xl",
+            is_page_heading: true,
+            options: @worldwide_organisation.offices.sort_by(&:title).map do |office|
+              {
+                value: office.id,
+                text: office.title,
+                selected: office == @worldwide_organisation.main_office
+              }
+            end
+          } %>
+        </div>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-organisation-set-main-office-button",
+            "track-label": "Save"
+          }
+        } %>
+
+        <%= link_to "Cancel", admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), class:"govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Whitehall::Application.routes.draw do
 
         resources :worldwide_organisations do
           member do
+            get :choose_main_office
             put :set_main_office
             get :access_info
             get :confirm_destroy

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -109,17 +109,31 @@ When(/^I choose "([^"]*)" to be the main office$/) do |contact_title|
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: contact_title }).first
   visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
   click_link "Offices"
-  within record_css_selector(worldwide_office) do
-    click_button "Set as main office"
+  if using_design_system?
+    click_link "Set main office"
+    choose contact_title
+    click_button "Save"
+  else
+    within record_css_selector(worldwide_office) do
+      click_button "Set as main office"
+    end
   end
 end
 
 Then(/^the "([^"]*)" should be marked as the main office$/) do |contact_title|
   admin_worldwide_organisation_worldwide_offices_path(WorldwideOrganisation.last)
 
-  office_container = page.find("h3", text: contact_title).ancestor(".worldwide_office")
-  within office_container do
-    expect(page).to have_content("(Main office)")
+  if using_design_system?
+    within ".app-vc-worldwide-offices-index-office-summary-card-component", match: :first do
+      expect(page).to have_content contact_title
+      assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Main office"
+      assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "Yes"
+    end
+  else
+    office_container = page.find("h3", text: contact_title).ancestor(".worldwide_office")
+    within office_container do
+      expect(page).to have_content("(Main office)")
+    end
   end
 end
 

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -46,7 +46,6 @@ Feature: Administering worldwide organisation
     When I create a new worldwide organisation "Department of Beards in France" in "France"
     Then I should see the worldwide location name "France" on the worldwide organisation page
 
-  @design-system-wip
   Scenario: Choosing the main office for a worldwide organisation with multiple offices
     Given a worldwide organisation "Department of Beards in France" with offices "Head office" and "Branch office"
     When I choose "Branch office" to be the main office

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -71,6 +71,35 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
 
+  test "GET :choose_main_office calls correctly" do
+    organisation = create(:worldwide_organisation)
+
+    get :choose_main_office, params: { id: organisation.id }
+
+    assert_response :success
+    assert_equal organisation, assigns(:worldwide_organisation)
+  end
+
+  view_test "GET :choose_main_office uses radios when 5 or less offices exist" do
+    organisation = create(:worldwide_organisation)
+    5.times { create(:worldwide_office, worldwide_organisation: organisation) }
+
+    get :choose_main_office, params: { id: organisation.id }
+
+    assert_select ".govuk-radios"
+    refute_select "select#worldwide_organisation_main_office_id"
+  end
+
+  view_test "GET :choose_main_office uses a select when 6 or more offices exist" do
+    organisation = create(:worldwide_organisation)
+    6.times { create(:worldwide_office, worldwide_organisation: organisation) }
+
+    get :choose_main_office, params: { id: organisation.id }
+
+    assert_select "select#worldwide_organisation_main_office_id"
+    refute_select ".govuk-radios"
+  end
+
   test "setting the main office" do
     offices = [create(:worldwide_office), create(:worldwide_office)]
     worldwide_organisation = create(:worldwide_organisation, offices:)

--- a/test/support/controller_test_helpers.rb
+++ b/test/support/controller_test_helpers.rb
@@ -2,7 +2,7 @@ module ControllerTestHelpers
   extend ActiveSupport::Concern
 
   module ClassMethods
-    LAYOUT_ALWAYS_DESIGN_SYSTEM = %w[reorder update_order confirm_destroy].freeze
+    LAYOUT_ALWAYS_DESIGN_SYSTEM = %w[reorder update_order confirm_destroy choose_main_office].freeze
 
     def should_be_an_admin_controller
       test "should be an admin controller" do


### PR DESCRIPTION
## Description 

This follows on from: 

1. https://github.com/alphagov/whitehall/pull/8032 - adds the confirm destroy worldwide offices and worldwide office translation endpoints
2. https://github.com/alphagov/whitehall/pull/8033 - adds the worldwide offices index page
3. https://github.com/alphagov/whitehall/pull/8034 - adds the reorder office page

This PR adds a new endpoint where the user can choose which office they want to be their main office. When a ww org has more than 1 office, the `Set main office` link appears.

When you follow this link you can choose/select your main office.

- when 6 or more offices exist, we use a select
- when 5 or less we use a radio button

## Screenshots 

![image](https://github.com/alphagov/whitehall/assets/42515961/7724885d-b181-447f-a1ce-5b254b13ca3e)

![image](https://github.com/alphagov/whitehall/assets/42515961/6e334707-6076-47ce-812e-f3f518bb2a3e)


## Trello card

https://trello.com/c/hM6FFPTl/321-office-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
