### PR TITLE
Publish worldwide corporate information about pages as redirects

### DIFF
--- a/app/presenters/publishing_api/redirect_presenter.rb
+++ b/app/presenters/publishing_api/redirect_presenter.rb
@@ -1,0 +1,38 @@
+module PublishingApi
+  class RedirectPresenter
+    attr_accessor :item, :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      {
+        locale: I18n.locale.to_s,
+        base_path: item.public_path(locale: I18n.locale),
+        document_type: "redirect",
+        schema_name: "redirect",
+        redirects:,
+        publishing_app: Whitehall::PublishingApp::WHITEHALL,
+        update_type:,
+      }
+    end
+
+    def links
+      {}
+    end
+
+  private
+
+    def redirects
+      [{
+        path: item.public_path(locale: I18n.locale),
+        type: "exact",
+        destination: item.api_presenter_redirect_to,
+      }]
+    end
+  end
+end

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -51,6 +51,17 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     assert_equal "/government/organisations/#{organisation.name}/about", corporate_information_page.base_path
   end
 
+  test "base_path appends /about to the associated Worldwide Organisation base_path when about page" do
+    worldwide_organisation = create(:worldwide_organisation)
+    corporate_information_page = create(
+      :about_corporate_information_page,
+      organisation: nil,
+      worldwide_organisation:,
+    )
+
+    assert_equal "/world/organisations/#{worldwide_organisation.name}/about", corporate_information_page.base_path
+  end
+
   test "base_path appends Corporate Information Page path to the associated WorldwideOrganisation base_path" do
     worldwide_organisation = create(:worldwide_organisation)
     corporate_information_page = create(
@@ -62,7 +73,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     assert_equal "/world/organisations/#{worldwide_organisation.name}/about/#{corporate_information_page.slug}", corporate_information_page.base_path
   end
 
-  test "#base_path appends /about/about to WorldwideOrganisation base_path when about page" do
+  test "api_presenter_redirect_to returns the base_path of the owning Worldwide Organisation for about us pages" do
     worldwide_organisation = create(:worldwide_organisation)
     corporate_information_page = create(
       :about_corporate_information_page,
@@ -70,7 +81,17 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
       worldwide_organisation:,
     )
 
-    assert_equal "/world/organisations/#{worldwide_organisation.name}/about/about", corporate_information_page.base_path
+    assert_equal "/world/organisations/#{worldwide_organisation.name}", corporate_information_page.api_presenter_redirect_to
+  end
+
+  test "api_presenter_redirect_to returns a #{RuntimeError} when not a Worldwide Organisation about page" do
+    organisation = create(:organisation)
+    corporate_information_page = create(
+      :about_corporate_information_page,
+      organisation:,
+    )
+
+    assert_raises(RuntimeError, "only worldwide about pages should redirect") { corporate_information_page.api_presenter_redirect_to }
   end
 
   test "republishes owning organisation after commit when present" do

--- a/test/unit/app/presenters/publishing_api/redirect_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/redirect_presenter_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class PublishingApi::RedirectPresenterTest < ActiveSupport::TestCase
+  def present(...)
+    PublishingApi::RedirectPresenter.new(...)
+  end
+
+  test "presents an item as a redirect to the publishing API" do
+    item = create(
+      :corporate_information_page,
+      :published,
+      organisation: nil,
+      worldwide_organisation: create(:worldwide_organisation),
+      corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
+    )
+
+    expected_hash = {
+      locale: "en",
+      publishing_app: "whitehall",
+      redirects: [{
+        path: item.base_path,
+        type: "exact",
+        destination: item.api_presenter_redirect_to,
+      }],
+      update_type: "major",
+      base_path: item.base_path,
+      document_type: "redirect",
+      schema_name: "redirect",
+    }
+
+    presented_item = present(item)
+
+    assert_equal item.content_id, presented_item.content_id
+    assert_equal expected_hash, presented_item.content
+    assert_equal presented_item.links, {}
+    assert_valid_against_publisher_schema(presented_item.content, "redirect")
+  end
+
+  test "presents an item as a redirect to publishing API when translated" do
+    I18n.with_locale(:ar) do
+      item = create(
+        :corporate_information_page,
+        :published,
+        organisation: nil,
+        worldwide_organisation: create(:worldwide_organisation),
+        corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
+      )
+
+      expected_hash = {
+        locale: "ar",
+        publishing_app: "whitehall",
+        redirects: [{
+          path: item.public_path(locale: I18n.locale),
+          type: "exact",
+          destination: item.api_presenter_redirect_to,
+        }],
+        update_type: "major",
+        base_path: item.public_path(locale: I18n.locale),
+        document_type: "redirect",
+        schema_name: "redirect",
+      }
+
+      presented_item = present(item)
+
+      assert_equal item.content_id, presented_item.content_id
+      assert_equal expected_hash, presented_item.content
+      assert_equal presented_item.links, {}
+      assert_valid_against_publisher_schema(presented_item.content, "redirect")
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/app/presenters/publishing_api_presenters_test.rb
@@ -149,7 +149,7 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     )
   end
 
-  test ".presenter_for returns a GenericEditionPresenter for an " \
+  test ".presenter_for returns a RedirectPresenter for an " \
     "AboutUs CorporateInformationPage belonging to an WorldwideOrganisation" do
     presenter = PublishingApiPresenters
       .presenter_for(
@@ -162,7 +162,7 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
       )
 
     assert_equal(
-      PublishingApi::GenericEditionPresenter,
+      PublishingApi::RedirectPresenter,
       presenter.class,
     )
   end


### PR DESCRIPTION
https://trello.com/c/En4l42d7

Worldwide corporate information about pages aren't rendered, instead they are
surfaced in the body of the owning worldwide organisation.

There have been various attempts to devise a strategy for these pages.
Currently, they are published with the `schema_name` of
`placeholder_corporate_information_page` at the path
`world/organisation/:organisation_id/about/about`.

Unfortunately, anywhere in Whitehall that links to the base path of these pages
now 404s. Instead, we should redirect to the worldwide organisation itself.

This:
- Updates the base path of worldwide corporate
  information pages to
  `world/organisation/:organisation_id/about` to
  match the non-worldwide
  organisation corporate information pages.
- Adds a generic presenter for a redirect.
- Publishes worldwide corporate information pages as
  redirects.

This means any worldwide corporate information about pages will now live at
`world/organisation/:organisation_id/about`. When we republish these content
items, Pulishing API will create additional redirect from each
`world/organisation/:organisation_id/about/about` to
`world/organisation/:organisation_id/about` as well.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
