### PR TITLE
Save assets for images

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -26,6 +26,7 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image.build_image_data(image_params["image_data"])
 
     @new_image.image_data.validate_on_image = @new_image
+    @new_image.image_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
 
     if @new_image.save
       redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.filename} successfully uploaded"
@@ -81,5 +82,9 @@ private
 
   def image_params
     params.fetch(:image, {}).permit(image_data: [:file])
+  end
+
+  def use_non_legacy_endpoints?
+    current_user.can_use_non_legacy_endpoints?
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -5,5 +5,14 @@ class Asset < ApplicationRecord
   validates :assetable, presence: true
   validates :variant, presence: true
 
-  enum variant: { original: "original".freeze, thumbnail: "thumbnail".freeze }
+  enum variant: {
+    original: "original".freeze,
+    thumbnail: "thumbnail".freeze,
+    s960: "s960".freeze,
+    s712: "s712".freeze,
+    s630: "s630".freeze,
+    s465: "s465".freeze,
+    s300: "s300".freeze,
+    s216: "s216".freeze,
+  }
 end

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -1,7 +1,7 @@
 require "mini_magick"
 
 class ImageData < ApplicationRecord
-  attr_accessor :validate_on_image
+  attr_accessor :validate_on_image, :use_non_legacy_endpoints
 
   VALID_WIDTH = 960
   VALID_HEIGHT = 640

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -24,7 +24,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     if should_save_an_asset?
       assetable_id = uploader.model.id
       assetable_type = uploader.model.class.to_s
-      asset_variant = legacy_url_path.include?("thumbnail") ? Asset.variants[:thumbnail] : Asset.variants[:original]
+      asset_variant = uploader.version_name ? Asset.variants[uploader.version_name] : Asset.variants[:original]
       asset_params = { assetable_id:, asset_variant:, assetable_type: }.deep_stringify_keys
 
       # Separating the journey based on feature flag so its easier to make future changes and also decommission old journey
@@ -78,7 +78,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
 private
 
   def should_save_an_asset?
-    uploader.model.instance_of?(AttachmentData) &&
+    (uploader.model.instance_of?(AttachmentData) || uploader.model.instance_of?(ImageData)) &&
       uploader.model.use_non_legacy_endpoints
   end
 end

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -13,13 +13,13 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
     before do
       login_as managing_editor
-      @current_user = managing_editor
       stub_publishing_api_has_linkables([], document_type: "topic")
     end
-    context "given a draft document with file attachment" do
-      let(:edition) { create(:news_article, organisations: [organisation]) }
 
-      context "updates with legacy_url_path" do
+    context "use_non_legacy_endpoints is false" do
+      context "given a draft document with file attachment" do
+        let(:edition) { create(:news_article, organisations: [organisation]) }
+
         before do
           setup_publishing_api_for(edition)
           stub_publishing_api_has_linkables([], document_type: "topic")
@@ -47,328 +47,10 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             AssetManagerAttachmentMetadataWorker.drain
           end
         end
-      end
-
-      context "updates with asset_manager_id" do
-        let(:asset_manager_id) { "asset-id" }
-        let(:variant) { Asset.variants[:original] }
-
-        before do
-          setup_publishing_api_for(edition)
-          stub_publishing_api_has_linkables([], document_type: "topic")
-
-          add_file_attachment("logo.png", to: edition)
-          edition.attachments[0].attachment_data.assets.create!(asset_manager_id:, variant:)
-          edition.attachments[0].attachment_data.uploaded_to_asset_manager!
-          edition.save!
-
-          stub_asset(asset_manager_id, draft: true)
-        end
-
-        context "when document is marked as access limited in Whitehall" do
-          before do
-            visit edit_admin_news_article_path(edition)
-            check "Limit access to producing organisations prior to publication"
-            click_button "Save"
-            assert_text "The document has been saved"
-          end
-
-          it "marks attachment as access limited in Asset Manager" do
-            Services.asset_manager
-                    .expects(:update_asset)
-                    .at_least_once.with(asset_manager_id, has_entry("access_limited", %w[user-uid]))
-
-            AssetManagerAttachmentMetadataWorker.drain
-          end
-        end
-      end
-    end
-
-    context "given a draft document with an image uploader" do
-      let(:edition) { create(:draft_case_study) }
-
-      before do
-        setup_publishing_api_for(edition)
-
-        stub_whitehall_asset("minister-of-funk.960x640.jpg", id: "asset-id", draft: true)
-
-        visit admin_case_study_path(edition)
-        click_link "Edit draft"
-        click_link "Images"
-        attach_file "image[image_data][file]", path_to_attachment("minister-of-funk.960x640.jpg")
-        click_button "Upload"
-      end
-
-      # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
-      it "sends an image to asset manager with the case study's auth_bypass_id" do
-        Services.asset_manager.expects(:create_whitehall_asset).at_least_once.with(
-          has_entry(auth_bypass_ids: [edition.auth_bypass_id]),
-        )
-
-        AssetManagerCreateWhitehallAssetWorker.drain
-      end
-    end
-
-    context "given an access-limited draft document when user does not have use_non_legacy_endpoints permission" do
-      # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
-
-      before do
-        setup_publishing_api_for(edition)
-      end
-
-      context "when an attachment is added to the draft document" do
-        before do
-          visit admin_news_article_path(edition)
-          click_link "Add attachments"
-          click_link "Upload new file attachment"
-          fill_in "Title", with: "asset-title"
-          attach_file "File", path_to_attachment("logo.png")
-          click_button "Save"
-          assert_text "Attachment 'asset-title' uploaded"
-        end
-
-        it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
-          Services.asset_manager.expects(:create_whitehall_asset).with(
-            has_entries(
-              legacy_url_path: regexp_matches(/logo\.png/),
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          )
-          AssetManagerCreateWhitehallAssetWorker.drain
-        end
-      end
-
-      context "given an edition with an html attachment" do
-        let(:edition) { create(:publication, :policy_paper) }
-
-        before do
-          setup_publishing_api_for(edition)
-          visit admin_publication_path(edition)
-          click_link "Modify attachments"
-          click_link "Add new HTML attachment"
-          fill_in "Title", with: "html-attachment"
-          fill_in "Body", with: "some html content"
-        end
-
-        it "sends an html attachment to publishing api with its edition's auth_bypass_id" do
-          Services.publishing_api.expects(:put_content)
-                  .with(anything, has_entries(title: edition.title))
-          Services.publishing_api.expects(:put_content)
-                  .with(anything, has_entries(title: edition.attachments.first.title))
-
-          Services.publishing_api.expects(:put_content).at_least_once
-                  .with(anything, has_entries(
-                                    title: "html-attachment",
-                                    auth_bypass_ids: [edition.auth_bypass_id],
-                                  ))
-
-          click_button "Save"
-        end
-      end
-
-      context "when bulk uploaded to draft document" do
-        before do
-          visit admin_news_article_path(edition)
-          click_link "Add attachments"
-          click_link "Bulk upload from Zip file"
-          attach_file "Zip file", path_to_attachment("sample_attachment.zip")
-          click_button "Upload zip"
-          fill_in "Title", with: "file-title"
-          click_button "Save"
-          assert find("li a", text: "greenpaper.pdf")
-        end
-
-        it "marks attachment as access limited in Asset Manager" do
-          Services.asset_manager.expects(:create_whitehall_asset).with(
-            has_entries(
-              legacy_url_path: regexp_matches(/greenpaper\.pdf/),
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          )
-          Services.asset_manager.expects(:create_whitehall_asset).with(
-            has_entries(
-              legacy_url_path: regexp_matches(/thumbnail_greenpaper\.pdf\.png/),
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          )
-
-          AssetManagerCreateWhitehallAssetWorker.drain
-        end
-      end
-    end
-
-    context "given an access-limited draft document when user has use_non_legacy_endpoints permission" do
-      # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
-
-      before do
-        setup_user_with_required_permission
-        setup_publishing_api_for(edition)
-      end
-
-      context "when an attachment is added to the draft document" do
-        before do
-          visit admin_news_article_path(edition)
-          click_link "Add attachments"
-          click_link "Upload new file attachment"
-          fill_in "Title", with: "asset-title"
-          attach_file "File", path_to_attachment("logo.png")
-          click_button "Save"
-          assert_text "Attachment 'asset-title' uploaded"
-        end
-
-        it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
-          Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          ).returns("id" => "http://asset-manager/assets/some-id")
-          AssetManagerCreateAssetWorker.drain
-        end
-      end
-
-      context "when bulk uploaded to draft document" do
-        before do
-          setup_user_with_required_permission
-          visit admin_news_article_path(edition)
-          click_link "Add attachments"
-          click_link "Bulk upload from Zip file"
-          attach_file "Zip file", path_to_attachment("sample_attachment.zip")
-          click_button "Upload zip"
-          fill_in "Title", with: "file-title"
-          click_button "Save"
-          assert find("li a", text: "greenpaper.pdf")
-        end
-        it "marks attachment as access limited in Asset Manager" do
-          Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          ).returns("id" => "http://asset-manager/assets/some-id")
-          Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          ).returns("id" => "http://asset-manager/assets/some-id")
-
-          AssetManagerCreateAssetWorker.drain
-        end
-      end
-    end
-
-    context "given a consultation when user does not have use_non_legacy_endpoints permission" do
-      # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
-      let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
-      let!(:outcome) { edition.create_outcome!(outcome_attributes) }
-
-      before do
-        setup_publishing_api_for(edition)
-        stub_publishing_api_has_linkables([], document_type: "topic")
-      end
-
-      context "when an attachment is added to the consultation's outcome" do
-        before do
-          visit admin_consultation_path(edition)
-          click_link "Edit draft"
-          click_link "Final outcome"
-          click_link "Upload new file attachment"
-          fill_in "Title", with: "asset-title"
-          attach_file "File", path_to_attachment("logo.png")
-          click_button "Save"
-          assert_text "Attachment 'asset-title' uploaded"
-        end
-
-        it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
-          Services.asset_manager.expects(:create_whitehall_asset).with(
-            has_entries(
-              legacy_url_path: regexp_matches(/logo\.png/),
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          )
-          AssetManagerCreateWhitehallAssetWorker.drain
-        end
-      end
-
-      it "sends a consultation form to asset manager with the consultation's auth_bypass_id" do
-        visit admin_consultation_path(edition)
-        click_link "Edit draft"
-        name_of_form_uploader = "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]"
-        fill_in "edition[consultation_participation_attributes][consultation_response_form_attributes][title]", with: "Consultation response form"
-        attach_file name_of_form_uploader, path_to_attachment("simple.pdf")
-        click_button "Save"
-
-        # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
-        Services.asset_manager.expects(:create_whitehall_asset).with(
-          has_entries(
-            legacy_url_path: regexp_matches(/simple\.pdf/),
-            auth_bypass_ids: [edition.auth_bypass_id],
-          ),
-        )
-
-        AssetManagerCreateWhitehallAssetWorker.drain
-      end
-    end
-
-    context "given a consultation when user has use_non_legacy_endpoints permission" do
-      # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
-      let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
-      let!(:outcome) { edition.create_outcome!(outcome_attributes) }
-
-      before do
-        setup_user_with_required_permission
-        setup_publishing_api_for(edition)
-        stub_publishing_api_has_linkables([], document_type: "topic")
-      end
-
-      context "when an attachment is added to the consultation's outcome" do
-        before do
-          visit admin_consultation_path(edition)
-          click_link "Edit draft"
-          click_link "Final outcome"
-          click_link "Upload new file attachment"
-          fill_in "Title", with: "asset-title"
-          attach_file "File", path_to_attachment("logo.png")
-          click_button "Save"
-          assert_text "Attachment 'asset-title' uploaded"
-        end
-
-        it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
-          Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited: %w[user-uid],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
-          ).returns("id" => "http://asset-manager/assets/some-id")
-          AssetManagerCreateAssetWorker.drain
-        end
-      end
-    end
-
-    context "given an access-limited draft document with file attachment" do
-      let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
-
-      context "updates with legacy_url_path" do
-        before do
-          setup_publishing_api_for(edition)
-          stub_publishing_api_has_linkables([], document_type: "topic")
-
-          add_file_attachment("logo.png", to: edition)
-          edition.attachments[0].attachment_data.uploaded_to_asset_manager!
-
-          stub_whitehall_asset("logo.png", id: "asset-id", draft: true)
-        end
 
         context "when document is unmarked as access limited in Whitehall" do
+          let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
+
           before do
             visit edit_admin_news_article_path(edition)
             uncheck "Limit access to producing organisations prior to publication"
@@ -386,30 +68,316 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
         end
 
         context "when attachment is replaced" do
-          context "with user not having USE_NON_LEGACY_ENDPOINTS permission" do
-            before do
-              visit admin_news_article_path(edition)
-              click_link "Modify attachments"
-              click_link "Edit"
-              attach_file "Replace file", path_to_attachment("big-cheese.960x640.jpg")
-              click_button "Save"
-              assert_text "Attachment 'logo.png' updated"
+          let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
+
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Modify attachments"
+            click_link "Edit"
+            attach_file "Replace file", path_to_attachment("big-cheese.960x640.jpg")
+            click_button "Save"
+            assert_text "Attachment 'logo.png' updated"
+          end
+
+          it "marks replacement attachment as access limited in Asset Manager" do
+            Services.asset_manager.expects(:create_whitehall_asset).with do |params|
+              params[:legacy_url_path] =~ /big-cheese/ &&
+                params[:access_limited] == %w[user-uid] &&
+                params[:auth_bypass_ids] == [edition.auth_bypass_id]
             end
 
-            it "marks replacement attachment as access limited in Asset Manager" do
-              Services.asset_manager.expects(:create_whitehall_asset).with do |params|
-                params[:legacy_url_path] =~ /big-cheese/ &&
-                  params[:access_limited] == %w[user-uid] &&
-                  params[:auth_bypass_ids] == [edition.auth_bypass_id]
-              end
+            AssetManagerCreateWhitehallAssetWorker.drain
+          end
+        end
+      end
 
-              AssetManagerCreateWhitehallAssetWorker.drain
+      context "given a draft document with an image attachment" do
+        let(:edition) { create(:draft_case_study) }
+
+        before do
+          setup_publishing_api_for(edition)
+
+          stub_whitehall_asset("minister-of-funk.960x640.jpg", id: "asset-id", draft: true)
+
+          visit admin_case_study_path(edition)
+          click_link "Edit draft"
+          click_link "Images"
+          attach_file "image[image_data][file]", path_to_attachment("minister-of-funk.960x640.jpg")
+          click_button "Upload"
+        end
+
+        # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
+        it "sends an image to asset manager with the case study's auth_bypass_id" do
+          Services.asset_manager.expects(:create_whitehall_asset).at_least_once.with(
+            has_entry(auth_bypass_ids: [edition.auth_bypass_id]),
+          )
+
+          AssetManagerCreateWhitehallAssetWorker.drain
+        end
+      end
+
+      context "given an access-limited draft document" do
+        # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
+        let(:edition) { create(:news_article, organisations: [organisation], access_limited: true) }
+
+        before do
+          setup_publishing_api_for(edition)
+        end
+
+        context "when a file attachment is added to the draft document" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Add attachments"
+            click_link "Upload new file attachment"
+            fill_in "Title", with: "asset-title"
+            attach_file "File", path_to_attachment("logo.png")
+            click_button "Save"
+            assert_text "Attachment 'asset-title' uploaded"
+          end
+
+          it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
+            Services.asset_manager.expects(:create_whitehall_asset).with(
+              has_entries(
+                legacy_url_path: regexp_matches(/logo\.png/),
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            )
+            AssetManagerCreateWhitehallAssetWorker.drain
+          end
+        end
+
+        context "given an edition with an html attachment" do
+          let(:edition) { create(:publication, :policy_paper) }
+
+          before do
+            setup_publishing_api_for(edition)
+            visit admin_publication_path(edition)
+            click_link "Modify attachments"
+            click_link "Add new HTML attachment"
+            fill_in "Title", with: "html-attachment"
+            fill_in "Body", with: "some html content"
+          end
+
+          it "sends an html attachment to publishing api with its edition's auth_bypass_id" do
+            Services.publishing_api.expects(:put_content)
+                    .with(anything, has_entries(title: edition.title))
+            Services.publishing_api.expects(:put_content)
+                    .with(anything, has_entries(title: edition.attachments.first.title))
+
+            Services.publishing_api.expects(:put_content).at_least_once
+                    .with(anything, has_entries(
+                                      title: "html-attachment",
+                                      auth_bypass_ids: [edition.auth_bypass_id],
+                                    ))
+
+            click_button "Save"
+          end
+        end
+
+        context "when bulk uploaded to draft document" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Add attachments"
+            click_link "Bulk upload from Zip file"
+            attach_file "Zip file", path_to_attachment("sample_attachment.zip")
+            click_button "Upload zip"
+            fill_in "Title", with: "file-title"
+            click_button "Save"
+            assert find("li a", text: "greenpaper.pdf")
+          end
+
+          it "marks attachment as access limited in Asset Manager" do
+            Services.asset_manager.expects(:create_whitehall_asset).with(
+              has_entries(
+                legacy_url_path: regexp_matches(/greenpaper\.pdf/),
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            )
+            Services.asset_manager.expects(:create_whitehall_asset).with(
+              has_entries(
+                legacy_url_path: regexp_matches(/thumbnail_greenpaper\.pdf\.png/),
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            )
+
+            AssetManagerCreateWhitehallAssetWorker.drain
+          end
+        end
+      end
+
+      context "given a consultation" do
+        # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
+        let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
+        let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+        let!(:outcome) { edition.create_outcome!(outcome_attributes) }
+
+        before do
+          setup_publishing_api_for(edition)
+          stub_publishing_api_has_linkables([], document_type: "topic")
+        end
+
+        context "when an attachment is added to the consultation's outcome" do
+          before do
+            visit admin_consultation_path(edition)
+            click_link "Edit draft"
+            click_link "Final outcome"
+            click_link "Upload new file attachment"
+            fill_in "Title", with: "asset-title"
+            attach_file "File", path_to_attachment("logo.png")
+            click_button "Save"
+            assert_text "Attachment 'asset-title' uploaded"
+          end
+
+          it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
+            Services.asset_manager.expects(:create_whitehall_asset).with(
+              has_entries(
+                legacy_url_path: regexp_matches(/logo\.png/),
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            )
+            AssetManagerCreateWhitehallAssetWorker.drain
+          end
+        end
+
+        it "sends a consultation form to asset manager with the consultation's auth_bypass_id" do
+          visit admin_consultation_path(edition)
+          click_link "Edit draft"
+          name_of_form_uploader = "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]"
+          fill_in "edition[consultation_participation_attributes][consultation_response_form_attributes][title]", with: "Consultation response form"
+          attach_file name_of_form_uploader, path_to_attachment("simple.pdf")
+          click_button "Save"
+
+          # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
+          Services.asset_manager.expects(:create_whitehall_asset).with(
+            has_entries(
+              legacy_url_path: regexp_matches(/simple\.pdf/),
+              auth_bypass_ids: [edition.auth_bypass_id],
+            ),
+          )
+
+          AssetManagerCreateWhitehallAssetWorker.drain
+        end
+      end
+    end
+
+    context "use_non_legacy_endpoints is true" do
+      before do
+        @current_user = managing_editor
+        setup_user_with_required_permission
+        stub_publishing_api_has_linkables([], document_type: "topic")
+        setup_publishing_api_for(edition)
+      end
+
+      context "given a draft news article" do
+        let(:edition) { create(:news_article, organisations: [organisation], access_limited:) }
+        let(:access_limited) { true }
+        let(:asset_manager_id) { "asset-id" }
+        let(:variant) { Asset.variants[:original] }
+
+        context "when an attachment is added to the draft document" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Add attachments"
+            click_link "Upload new file attachment"
+            fill_in "Title", with: "asset-title"
+            attach_file "File", path_to_attachment("logo.png")
+            click_button "Save"
+            assert_text "Attachment 'asset-title' uploaded"
+          end
+
+          it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
+            Services.asset_manager.expects(:create_asset).with(
+              has_entries(
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            ).returns("id" => "http://asset-manager/assets/some-id")
+            AssetManagerCreateAssetWorker.drain
+          end
+        end
+
+        context "when bulk uploaded to draft document" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Add attachments"
+            click_link "Bulk upload from Zip file"
+            attach_file "Zip file", path_to_attachment("sample_attachment.zip")
+            click_button "Upload zip"
+            fill_in "Title", with: "file-title"
+            click_button "Save"
+            assert find("li a", text: "greenpaper.pdf")
+          end
+
+          it "marks attachment as access limited in Asset Manager" do
+            Services.asset_manager.expects(:create_asset).with(
+              has_entries(
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            ).returns("id" => "http://asset-manager/assets/some-id")
+            Services.asset_manager.expects(:create_asset).with(
+              has_entries(
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            ).returns("id" => "http://asset-manager/assets/some-id")
+
+            AssetManagerCreateAssetWorker.drain
+          end
+        end
+
+        context "with a file attachment" do
+          before do
+            stub_asset(asset_manager_id, draft: true)
+
+            add_file_attachment("logo.png", to: edition)
+            edition.attachments[0].attachment_data.assets.create!(asset_manager_id:, variant:)
+            edition.attachments[0].attachment_data.uploaded_to_asset_manager!
+            edition.save!
+          end
+
+          context "when document is marked as access limited in Whitehall" do
+            let(:access_limited) { false }
+
+            before do
+              visit edit_admin_news_article_path(edition)
+              check "Limit access to producing organisations prior to publication"
+              click_button "Save"
+              assert_text "The document has been saved"
+            end
+
+            it "marks attachment as access limited in Asset Manager" do
+              Services.asset_manager
+                      .expects(:update_asset)
+                      .at_least_once.with(asset_manager_id, has_entry("access_limited", %w[user-uid]))
+
+              AssetManagerAttachmentMetadataWorker.drain
             end
           end
 
-          context "with user having USE_NON_LEGACY_ENDPOINTS permission" do
+          context "when document is unmarked as access limited in Whitehall" do
             before do
-              @current_user.permissions << User::Permissions::USE_NON_LEGACY_ENDPOINTS
+              visit edit_admin_news_article_path(edition)
+              uncheck "Limit access to producing organisations prior to publication"
+              click_button "Save"
+              assert_text "The document has been saved"
+            end
+
+            it "unmarks attachment as access limited in Asset Manager" do
+              Services.asset_manager
+                      .expects(:update_asset)
+                      .at_least_once.with(asset_manager_id, has_entry("access_limited", []))
+
+              AssetManagerAttachmentMetadataWorker.drain
+            end
+          end
+
+          context "when attachment is replaced" do
+            before do
               visit admin_news_article_path(edition)
               click_link "Modify attachments"
               click_link "Edit"
@@ -430,36 +398,55 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
         end
       end
 
-      context "updates with asset_manager_id" do
-        let(:asset_manager_id) { "asset-id" }
-        let(:variant) { Asset.variants[:original] }
+      context "given a draft case study with an image attachment" do
+        let(:edition) { create(:draft_case_study) }
 
         before do
-          setup_publishing_api_for(edition)
-          stub_publishing_api_has_linkables([], document_type: "topic")
+          stub_asset("minister-of-funk.960x640.jpg", id: "asset-id", draft: true)
 
-          add_file_attachment("logo.png", to: edition)
-
-          edition.attachments[0].attachment_data.assets.create!(asset_manager_id:, variant:)
-          edition.attachments[0].attachment_data.uploaded_to_asset_manager!
-
-          stub_asset(asset_manager_id, draft: true)
+          visit admin_case_study_path(edition)
+          click_link "Edit draft"
+          click_link "Images"
+          attach_file "image[image_data][file]", path_to_attachment("minister-of-funk.960x640.jpg")
+          click_button "Upload"
         end
 
-        context "when document is unmarked as access limited in Whitehall" do
+        # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
+        it "sends an image to asset manager with the document's auth_bypass_id" do
+          Services.asset_manager.expects(:create_asset).at_least_once.with(
+            has_entry(auth_bypass_ids: [edition.auth_bypass_id]),
+          ).returns("id" => "http://asset-manager/assets/asset-id")
+
+          AssetManagerCreateAssetWorker.drain
+        end
+      end
+
+      context "given an access limited draft consultation" do
+        # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
+        let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
+        let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+        let!(:outcome) { edition.create_outcome!(outcome_attributes) }
+
+        context "when an attachment is added to the consultation's outcome" do
           before do
-            visit edit_admin_news_article_path(edition)
-            uncheck "Limit access to producing organisations prior to publication"
+            visit admin_consultation_path(edition)
+            click_link "Edit draft"
+            click_link "Final outcome"
+            click_link "Upload new file attachment"
+            fill_in "Title", with: "asset-title"
+            attach_file "File", path_to_attachment("logo.png")
             click_button "Save"
-            assert_text "The document has been saved"
+            assert_text "Attachment 'asset-title' uploaded"
           end
 
-          it "unmarks attachment as access limited in Asset Manager" do
-            Services.asset_manager
-                    .expects(:update_asset)
-                    .at_least_once.with(asset_manager_id, has_entry("access_limited", []))
-
-            AssetManagerAttachmentMetadataWorker.drain
+          it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
+            Services.asset_manager.expects(:create_asset).with(
+              has_entries(
+                access_limited: %w[user-uid],
+                auth_bypass_ids: [edition.auth_bypass_id],
+              ),
+            ).returns("id" => "http://asset-manager/assets/some-id")
+            AssetManagerCreateAssetWorker.drain
           end
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -264,6 +264,10 @@ class ActionDispatch::IntegrationTest
     login_as(create(:user, name: "user-name", email: "user@example.com"))
   end
 
+  def login_as_use_non_legacy_endpoints_user(role, organisation = nil)
+    login_as(create(role, :with_use_non_legacy_endpoints, name: "user-name", email: "user@example.com", organisation:))
+  end
+
   def logout
     GDS::SSO.test_user = nil
     super

--- a/test/unit/app/uploaders/attachment_uploader_test.rb
+++ b/test/unit/app/uploaders/attachment_uploader_test.rb
@@ -257,17 +257,18 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   end
 
   describe "use non legacy endpoints true" do
-    test "should store an actual PNG using create asset" do
-      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
-      attachment_data.save!
+    test "should store an actual PNG as thumbnail" do
+      AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+
       Asset.expects(:create!).twice.with(anything, anything, anything)
       expect_thumbnail_sent_to_asset_manager_to_be_an_actual_png_using_create_asset
+
       AssetManagerCreateAssetWorker.drain
     end
 
     test "should scale the thumbnail down proportionally to A4" do
-      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
-      attachment_data.save!
+      AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+
       Asset.expects(:create!).twice.with(anything, anything, anything)
       expect_thumbnail_sent_to_asset_manager_to_be_scaled_proportionally_create_asset
 
@@ -275,20 +276,18 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
     end
 
     test "should use a generic thumbnail if conversion fails" do
-      AttachmentData.any_instance.stubs(:use_non_legacy_endpoints).returns(true)
       AttachmentUploader.any_instance.stubs(:pdf_thumbnail_command).returns("false")
-      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
-      attachment_data.save!
+      AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+
       expect_fallback_thumbnail_to_be_uploaded_to_asset_manager_create_asset
 
       AssetManagerCreateAssetWorker.drain
     end
 
     test "should use a generic thumbnail if conversion takes longer than 10 seconds to complete" do
-      AttachmentData.any_instance.stubs(:use_non_legacy_endpoints).returns(true)
       AttachmentUploader.any_instance.stubs(:pdf_thumbnail_command).raises(Timeout::Error)
-      attachment_data = AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
-      attachment_data.save!
+      AttachmentData.create!(file: file_fixture("two-pages-with-content.pdf"), use_non_legacy_endpoints: true)
+
       expect_fallback_thumbnail_to_be_uploaded_to_asset_manager_create_asset
 
       AssetManagerCreateAssetWorker.drain

--- a/test/unit/app/uploaders/image_uploader_test.rb
+++ b/test/unit/app/uploaders/image_uploader_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ImageUploaderTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
+  extend Minitest::Spec::DSL
 
   setup do
     ImageUploader.enable_processing = true
@@ -20,50 +21,93 @@ class ImageUploaderTest < ActiveSupport::TestCase
     assert_equal %w[jpg jpeg gif png svg], uploader.extension_allowlist
   end
 
-  test "should send correctly resized versions of a bitmap image to asset manager" do
-    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
-
-    Services.asset_manager.stubs(:create_whitehall_asset)
-    Services.asset_manager.expects(:create_whitehall_asset).with do |value|
-      image_path = value[:file].path
-      assert_image_has_correct_size image_path
+  describe "use_non_legacy_endpoints is false" do
+    setup do
+      image_data = FactoryBot.create(:image_data)
+      @uploader = ImageUploader.new(image_data, "mounted-as")
     end
 
-    Sidekiq::Testing.inline! do
-      @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+    test "should send correctly resized versions of a bitmap image to asset manager" do
+      Services.asset_manager.stubs(:create_whitehall_asset)
+      Services.asset_manager.expects(:create_whitehall_asset).with do |value|
+        image_path = value[:file].path
+        assert_image_has_correct_size image_path
+      end
+
+      Sidekiq::Testing.inline! do
+        @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+      end
+    end
+
+    test "should store uploads in a directory that persists across deploys" do
+      assert_match %r{^system}, @uploader.store_dir
+    end
+
+    test "should store all the versions of a bitmap image in asset manager" do
+      Services.asset_manager.stubs(:create_whitehall_asset)
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s960_minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s712_minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s630_minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s465_minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s300_minister-of-funk.960x640.jpg/))
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s216_minister-of-funk.960x640.jpg/))
+
+      Sidekiq::Testing.inline! do
+        @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+      end
+    end
+
+    test "should store the original version only of a svg image in asset manager" do
+      Services.asset_manager.stubs(:create_whitehall_asset)
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))
+
+      Sidekiq::Testing.inline! do
+        @uploader.store!(upload_fixture("images/test-svg.svg", "image/svg+xml"))
+      end
     end
   end
 
-  test "should store uploads in a directory that persists across deploys" do
-    uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
-    assert_match %r{^system}, uploader.store_dir
-  end
+  describe "use_non_legacy_endpoints is true" do
+    test "should send correctly resized versions of a bitmap image to asset manager" do
+      create(:image_data, use_non_legacy_endpoints: true)
 
-  test "should store all the versions of a bitmap image in asset manager" do
-    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
+      Services.asset_manager.expects(:create_asset).with { |value|
+        image_path = value[:file].path
+        assert_image_has_correct_size image_path
+      }.times(7).returns("id" => "http://asset-manager/assets/some-id")
 
-    Services.asset_manager.stubs(:create_whitehall_asset)
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s960_minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s712_minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s630_minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s465_minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s300_minister-of-funk.960x640.jpg/))
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s216_minister-of-funk.960x640.jpg/))
-
-    Sidekiq::Testing.inline! do
-      @uploader.store!(upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"))
+      AssetManagerCreateAssetWorker.drain
     end
-  end
 
-  test "should store the original version only of a svg image in asset manager" do
-    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
+    test "should store uploads in a directory that persists across deploys" do
+      image_data = build(:image_data, use_non_legacy_endpoints: true)
+      @uploader = ImageUploader.new(image_data, "mounted-as")
 
-    Services.asset_manager.stubs(:create_whitehall_asset)
-    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))
+      assert_match %r{^system}, @uploader.store_dir
+    end
 
-    Sidekiq::Testing.inline! do
-      @uploader.store!(upload_fixture("images/test-svg.svg", "image/svg+xml"))
+    test "should store all the versions of a bitmap image in asset manager" do
+      expected_file_names = %w[minister-of-funk.960x640.jpg s960_minister-of-funk.960x640.jpg s712_minister-of-funk.960x640.jpg s630_minister-of-funk.960x640.jpg s465_minister-of-funk.960x640.jpg s300_minister-of-funk.960x640.jpg s216_minister-of-funk.960x640.jpg]
+      create(:image_data, use_non_legacy_endpoints: true)
+
+      Services.asset_manager.stubs(:create_asset).with { |params|
+        file = params[:file].path.split("/").last
+        assert expected_file_names.include?(file)
+      }.times(7).returns("id" => "http://asset-manager/assets/some-id")
+
+      AssetManagerCreateAssetWorker.drain
+    end
+
+    test "should store only the original version of a svg image in asset manager" do
+      svg = upload_fixture("images/test-svg.svg", "image/svg+xml")
+      ImageData.create!(file: svg, use_non_legacy_endpoints: true)
+
+      Services.asset_manager.stubs(:create_asset).with { |params|
+        assert params[:file].path.split("/").last == "test-svg.svg"
+      }.once.returns("id" => "http://asset-manager/assets/some-id")
+
+      AssetManagerCreateAssetWorker.drain
     end
   end
 


### PR DESCRIPTION
Introduced additional variants to the Asset model, to cover all Carrierwave sizes for images. When the Carrierwave flow gets triggered, corresponding assets are now saved for the original image and each of its variants.

Co-authored-by: Neamah al Selwi neamah.alselwi@digital.cabinet-office.gov.uk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
