### PR TITLE
Add call for evidence guidance

### DIFF
--- a/app/views/admin/calls_for_evidence/_form.html.erb
+++ b/app/views/admin/calls_for_evidence/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="format-advice">
-  <p class="govuk-body"><strong>Use this format for:</strong> Calls for evidence</p>
+  <p class="govuk-body"><strong>Use this format for:</strong> Calls for evidence or requests for people’s views.</p>
+  <p class="govuk-body">Do <em>not</em> use for: <%= link_to "consultations", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>. If you are not sure, ask your legal team before uploading your content.</p>
 </div>
 
 <%= standard_edition_form(edition) do |form| %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Add section on when to use call for evidence
https://trello.com/c/dj7mjSBD/1486-updating-call-for-evidence-guidance-in-use-this-for-guidance-and-email-links

# Why
To guide publishers in knowing when to use the new call for evidence document type. A link will be added when the external guidance is ready.

# Screenshot
![whitehall-admin dev gov uk_government_admin_calls-for-evidence_new(iPad Pro) (1)](https://github.com/alphagov/whitehall/assets/9594455/06ed8596-a75a-4961-b653-0d442259565f)
