### PR TITLE
Revert "Allow AssetManagerCreateWhitehallAssetWorker to accept tempor…

### DIFF
--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -3,29 +3,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
 
   sidekiq_options queue: "asset_manager"
 
-  WITH_TEMPORARY_ASSET_RELATED_PARAMS = 8
-  EXPECTED_PARAMS = 6
-
-  def perform(*args)
-    # We eventually only run the code that is inside "perform_with_assets_params"
-    # these changes are introduced to fix a prod issue that was caused by change in
-    # arguments( decreased from 8 to 6 ) that were accepted by perform method
-    # these cause one of the job that was about to execute just before application deployment
-    # to fail. the changes are temporary.
-    if args.length == EXPECTED_PARAMS
-      perform_without_assets_params(*args)
-    elsif args.length == WITH_TEMPORARY_ASSET_RELATED_PARAMS
-      perform_with_assets_params(*args)
-    else
-      raise "invalid parameter count in sidekiq job"
-    end
-  end
-
-  def perform_without_assets_params(file_path, legacy_url_path, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
-    perform_with_assets_params(file_path, legacy_url_path, nil, nil, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
-  end
-
-  def perform_with_assets_params(file_path, legacy_url_path, _temp_asset_param = nil, _temp_another_asset_param = nil, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
+  def perform(file_path, legacy_url_path, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
     return unless File.exist?(file_path)
 
     file = File.open(file_path)


### PR DESCRIPTION
This PR is to revert the temporary fix that we introduced here [
](https://github.com/alphagov/whitehall/pull/8010)
The failing job that the above PR was introduced for is now completed hence we are reverting the changes.

This reverts commit 4392a4500ac3d6588c1cb10e07f6cb0195cf66ee.

Co-authored-by: Iris Lau  Iris.lau@digital.cabinet-office.gov.uk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
