### PR TITLE
Remove rake task to change Worldwide Organisations sponsor

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -32,15 +32,4 @@ namespace :data_hygiene do
       speech.save!(validate: false)
     end
   end
-
-  desc "Update all Worldwide Organisations' sponsoring organisation from FCO to FCDO"
-  task update_sponsoring_organisation_from_fco_to_fcdo: :environment do
-    fco = Organisation.find_by(slug: "foreign-commonwealth-office")
-    fcdo = Organisation.find_by(slug: "foreign-commonwealth-development-office")
-
-    Sponsorship.where(organisation: fco).each do |sponsorship|
-      sponsorship.update!(organisation: fcdo)
-      puts "#{sponsorship.worldwide_organisation.name} updated from FCO to FCDO."
-    end
-  end
 end


### PR DESCRIPTION
This task was only intended to be run once during a machinery of government change.

It was run in 2020, so can now be removed as it won't be needed again.

This reverts commit 55a73f7be7bb8ab77b06e358b6e28e5dfd5af216.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
