### PR TITLE
Stop duplicate review reminders being sent

### DIFF
--- a/app/workers/review_reminder_notifier_worker.rb
+++ b/app/workers/review_reminder_notifier_worker.rb
@@ -12,7 +12,7 @@ class ReviewReminderNotifierWorker < WorkerBase
         recipient_address: email_address,
       ).deliver_now
 
-      review_reminder.update!(reminder_sent_at: Time.zone.now)
+      review_reminder.update_columns(reminder_sent_at: Time.zone.now)
     end
   end
 end

--- a/test/unit/app/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/app/workers/review_reminder_notifier_worker_test.rb
@@ -2,8 +2,10 @@ require "test_helper"
 
 class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
   setup do
-    @edition = create(:edition)
-    @review_reminder = create(:review_reminder, document: @edition.document)
+    Timecop.travel(2.days.ago) do
+      @edition = create(:edition)
+      @review_reminder = create(:review_reminder, document: @edition.document, review_at: Time.zone.tomorrow)
+    end
   end
 
   test "calls MailNotifications#review_reminder and updates reminder_sent_at to now when reminder_sent_at is nil" do
@@ -24,7 +26,7 @@ class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
 
   test "does not call MailNotifications#review_reminder or update reminder_sent_at when reminder_sent_at is present" do
     reminder_sent_at = Time.zone.now
-    @review_reminder.update!(reminder_sent_at:)
+    @review_reminder.update_columns(reminder_sent_at:)
 
     Timecop.travel(1.day.from_now) do
       MailNotifications

--- a/test/unit/app/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/app/workers/review_reminder_notifier_worker_test.rb
@@ -2,16 +2,14 @@ require "test_helper"
 
 class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
   setup do
-    document = create(:document)
-    @review_reminder = create(:review_reminder, document:)
-    @email_address = @review_reminder.email_address
-    @editon = create(:edition, document:)
+    @edition = create(:edition)
+    @review_reminder = create(:review_reminder, document: @edition.document)
   end
 
   test "calls MailNotifications#review_reminder and updates reminder_sent_at to now when reminder_sent_at is nil" do
     MailNotifications
       .expects(:review_reminder)
-      .with(@editon, recipient_address: @email_address)
+      .with(@edition, recipient_address: @review_reminder.email_address)
       .returns(mailer = mock)
 
     mailer.expects(:deliver_now)

--- a/test/unit/app/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/app/workers/review_reminder_notifier_worker_test.rb
@@ -9,14 +9,15 @@ class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
   end
 
   test "calls MailNotifications#review_reminder and updates reminder_sent_at to now when reminder_sent_at is nil" do
+    MailNotifications
+      .expects(:review_reminder)
+      .with(@editon, recipient_address: @email_address)
+      .returns(mailer = mock)
+
+    mailer.expects(:deliver_now)
+
+    # Freeze time so we can assert against the current time without it changing
     Timecop.freeze do
-      MailNotifications
-        .expects(:review_reminder)
-        .with(@editon, recipient_address: @email_address)
-        .returns(mailer = mock)
-
-      mailer.expects(:deliver_now)
-
       ReviewReminderNotifierWorker.new.perform(@review_reminder.id)
 
       assert_equal Time.zone.now, @review_reminder.reload.reminder_sent_at


### PR DESCRIPTION
We've observed a bug in the Review Reminder feature which resulted in duplicate reminder emails being repeatedly sent to users.

### What was going wrong

The `ReviewReminderNotifierWorker` sends an email and then updates the `ReviewReminder` record to have a `reminder_sent_at` timestamp. But there's a validation rule that ensures the `review_at` date cannot be in the past, which meant the `update!` call failed with an exception and resulted in the Sidekiq job being put into the retry queue.

In turn, this meant we were sending the same reminder to users multiple times while the Sidekiq job retried (and continually failed).

### How this PR fixes it

This PR updates the worker test to expose the bug. I've then done the minimum work required to get the test passing.

Ideally I'd like to follow up with another PR to refactor some of this code – including changing the validation rules so we don't need to bypass them in this scenario.

Trello: https://trello.com/c/c5D5qVcL/1552-stop-duplicate-review-reminders-being-sent

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
