### PR TITLE
Add images to document summary

### DIFF
--- a/app/assets/stylesheets/admin/views/_summary.scss
+++ b/app/assets/stylesheets/admin/views/_summary.scss
@@ -27,6 +27,10 @@
   }
 }
 
+.app-view-summary__tag {
+  margin-left: govuk-spacing(1);
+}
+
 .app-view-summary__section--attachments .govuk-table__cell {
   overflow-wrap: break-word;
   word-break: break-word;

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -237,6 +237,48 @@
     </section>
   <% end %>
 
+  <% if @edition.allows_image_attachments? %>
+    <section class="app-view-summary__section app-view-summary__section--attachments">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Images",
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 3,
+      } %>
+
+      <% if @edition.editable? %>
+        <p class="govuk-body">
+          <%= link_to("#{@edition.images.any? ? "Modify" : "Add"} images",
+                      admin_edition_attachments_path(@edition.id),
+                      class: 'govuk-link',
+                      data: {
+                        module: "gem-track-click",
+                        "track-category": "button-clicked",
+                        "track-action": "#{@edition.model_name.singular.dasherize}-button",
+                        "track-label": "Modify images",
+                      }) %>
+        </p>
+      <% end %>
+
+      <% if @edition.images.any? %>
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
+            {
+              text: "Filename"
+            }
+          ],
+          rows: @edition.images.map do | image |
+            [
+              { text: sanitize("#{image.filename} #{tag.span("Lead image", class: 'govuk-tag app-view-summary__tag') if @edition.is_a? Edition::FirstImagePulledOut and image == @edition.images.first}") },
+            ]
+          end
+        } %>
+      <% else %>
+        <p class="govuk-body">No images for this document</p>
+      <% end %>
+    </section>
+  <% end %>
+
   <% if @edition.allows_attachments? %>
     <section class="app-view-summary__section app-view-summary__section--attachments">
       <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Display images in the document summary in a table above attachments with filenames and a tag for the lead image.

https://trello.com/c/7xzNFJFk/1326-add-images-to-document-summary

# Why
This makes images more consistent with attachments and is a step towards the document summary page acting as an editing hub.

# Screenshot
![whitehall-admin dev gov uk_government_admin_case-studies_1374131(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/7feeae3e-f2b1-4e12-a436-c8686c54fce6)
