### PR TITLE
Fix images link on document summary

### DIFF
--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -249,7 +249,7 @@
       <% if @edition.editable? %>
         <p class="govuk-body">
           <%= link_to("#{@edition.images.any? ? "Modify" : "Add"} images",
-                      admin_edition_attachments_path(@edition.id),
+                      admin_edition_images_path(@edition.id),
                       class: 'govuk-link',
                       data: {
                         module: "gem-track-click",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Change link to point to the images tab

# Why
It was incorrectly pointing to the attachments tab
