### PR TITLE
Updated excluded nations heading to show it's required

### DIFF
--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -10,7 +10,7 @@
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "edition[all_nation_applicability][]",
   id: "edition_nation_inapplicabilities",
-  heading: "Excluded nations",
+  heading: "Excluded nations (required)",
   heading_size: "m",
   error: errors_for_input(edition.errors, :nation_inapplicabilities),
   no_hint_text: true,


### PR DESCRIPTION
## What 

Currently on Whitehall the excluded nations field is required on certain content types but is not consistent with other required fields using the 'required' as a heading label.

This PR updates the text to add (required) in brackets

## Screenshots

Old:
<img width="920" alt="Screenshot 2023-08-03 at 10 30 43" src="https://github.com/alphagov/whitehall/assets/55087909/6ef7b810-1718-4c09-8479-f59893448549">

New:
![Screenshot 2023-08-03 at 14 33 48](https://github.com/alphagov/whitehall/assets/55087909/87b556fb-a815-4cab-aa5b-659a436c371c)

## Why
It's consistent with other headings, and makes it easier for users to see what fields are required.

## Trello card

https://trello.com/c/gwXsSfb4/1551-add-required-to-excluded-nations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
