### PR TITLE
Remove the word 'current' in create new consultation.

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="format-advice">
   <p class="govuk-body"><strong>Use this format for:</strong> Consultations (officially “documents requiring collective agreement across government”, including calls for evidence).</p>
 
-  <p class="govuk-body">Check you have read the current <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
+  <p class="govuk-body">Check you have read the <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
 </div>
 
 <%= standard_edition_form(edition) do |form| %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/lHRTK1IP/1548-remove-the-word-current-in-check-you-have-read-the-current-consultation-principles-in-create-new-consultation

# What
Remove the word 'current' in 'Check you have read the current consultation principles' 

# Why
It is unnecessary
