### PR TITLE
Updated what's new page for images on document summary

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -7,7 +7,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 18 July 2023
+      last_updated: Last updated 3 August 2023
       introduction:
         heading: Our roadmap
         body_govspeak: |
@@ -25,6 +25,12 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: New images 
+            area: Creating and updating documents
+            type: new
+            date: 3 August 2023
+            body_govspeak: |
+              Images that have been added now display on the document summary page, before you publish. You can also go to the images edit screen from the document summary.
           - heading: New Markdown for attachments
             area: Creating and updating documents
             type: improvement


### PR DESCRIPTION
## What

- Updated what's new page to add addition of images on the document summary page
- Updated the last updated date

## Why 

To update users on the changes from this PR https://github.com/alphagov/whitehall/pull/8048


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
