### PR TITLE
Add taxonomy_topic_email_override to the document collection model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
     PREVIEW_NEXT_RELEASE = "Preview next release".freeze
     PREVIEW_CALL_FOR_EVIDENCE = "Preview call for evidence".freeze
     USE_NON_LEGACY_ENDPOINTS = "Use non legacy endpoints".freeze
+    EMAIL_OVERRIDE_EDITOR = "Email override editor".freeze
   end
 
   def role
@@ -115,6 +116,10 @@ class User < ApplicationRecord
 
   def can_handle_fatalities?
     gds_editor? || (organisation && organisation.handles_fatalities?)
+  end
+
+  def can_edit_email_overrides?
+    has_permission?(Permissions::EMAIL_OVERRIDE_EDITOR)
   end
 
   def fuzzy_last_name

--- a/db/migrate/20230711090830_add_taxonomy_topic_email_override_to_editions.rb
+++ b/db/migrate/20230711090830_add_taxonomy_topic_email_override_to_editions.rb
@@ -1,0 +1,5 @@
+class AddTaxonomyTopicEmailOverrideToEditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :editions, :taxonomy_topic_email_override, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -384,6 +384,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_110128) do
     t.string "image_display_option"
     t.string "auth_bypass_id", null: false
     t.string "mapped_specialist_topic_content_id"
+    t.string "taxonomy_topic_email_override"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/unit/app/models/document_collection_test.rb
+++ b/test/unit/app/models/document_collection_test.rb
@@ -153,4 +153,10 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     doc = create(:document_collection, mapped_specialist_topic_content_id: "123")
     assert doc.specialist_topic_conversion?
   end
+
+  test "taxonomy_topic_email_override cannot be changed when doc is in UNMODIFIABLE_STATE" do
+    doc = create(:published_document_collection, taxonomy_topic_email_override: "a-content-id")
+    exception = assert_raises(Exception) { doc.update!(taxonomy_topic_email_override: "foo") }
+    assert_equal("Validation failed: Taxonomy topic email override cannot be modified when edition is in the published state", exception.message)
+  end
 end

--- a/test/unit/app/models/user_test.rb
+++ b/test/unit/app/models/user_test.rb
@@ -172,6 +172,13 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_handle_fatalities?
   end
 
+  test "can edit email overrides if the permission is set" do
+    not_allowed = build(:user)
+    assert_not not_allowed.can_edit_email_overrides?
+    user = build(:user, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR])
+    assert user.can_edit_email_overrides?
+  end
+
   test "can be associated to world locations" do
     location1 = build(:world_location)
     location2 = build(:world_location)


### PR DESCRIPTION
## What

- Add a new column to the document collection model called `taxonomy_topic_email_override`.
- Add a new signon permission called `Email override editor`

## Why

- We are adding a new feature to the publishing UI of Whitehall, that will only be visible to `Email override editor`s. This feature is being built out in https://github.com/alphagov/whitehall/pull/7950
- The form being added to whitehall will allow the user to select a single taxonomy topic which will be added to the document collection `links` attribute under the key `taxonomy_topic_email_override`.
- `taxonomy_topic_email_override` will be separate to the `taxons` attribute. In other words a document collection can be tagged to many taxonomy topics (stored in the `taxons` key), but it can have only one single `taxonomy_topic_email_override`.

## Next steps
- When the document collection is rendered by government-frontend, if `taxonomy_topic_email_override` is populated we will set the destination of the email signup link to the taxonomy topic. If it is not populated, the email signup will be for the document collection page itself.

## Related PR's

- https://github.com/alphagov/whitehall/pull/7950
- https://github.com/alphagov/publishing-api/pull/2440
- https://github.com/alphagov/whitehall/pull/8056
- https://github.com/alphagov/whitehall/pull/8057

https://trello.com/c/WyVHMADH/1939-add-taxonomy-topic-email-override-column-to-document-collections-table-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
