### PR TITLE
Present taxonomy_topic_email_override in document collection links

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -43,6 +43,7 @@ module PublishingApi
         %i[organisations topics parent government],
       )
       links[:documents] = item.content_ids.uniq
+      links[:taxonomy_topic_email_override] = [item.taxonomy_topic_email_override] if item.taxonomy_topic_email_override
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -462,3 +462,28 @@ class PublishingApi::DocumentCollectionWithMappedSpecialistTopicTest < ActiveSup
     assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
   end
 end
+
+class PublishingApi::DocumentCollectionWithTaxonomyTopicEmailOverrideTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+  end
+
+  test "presents the taxonomy_topic_email_override when one exists" do
+    taxonomy_topic_email_override = "9b889c60-2191-11ee-be56-0242ac120002"
+    document_collection = create(:document_collection, taxonomy_topic_email_override:)
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    assert_equal [taxonomy_topic_email_override], presented_document_collection.links[:taxonomy_topic_email_override]
+
+    assert_valid_against_links_schema({ links: presented_document_collection.links }, "document_collection")
+  end
+
+  test "does not present the taxonomy_topic_email_override if it is nil" do
+    document_collection = create(:document_collection)
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    assert_not presented_document_collection.links.key?(:taxonomy_topic_email_override)
+
+    assert_valid_against_links_schema({ links: presented_document_collection.links }, "document_collection")
+  end
+end


### PR DESCRIPTION
## What

- Add the `taxonomy_topic_email_override` field to document collection links, if present on the model.

## Why

- We are adding a new feature to the publishing UI of Whitehall, that will only be visible to `Email override editor`s. This feature is being built out in https://github.com/alphagov/whitehall/pull/7950
- The form being added to whitehall will allow the user to select a single taxonomy topic which will be added to the document collection `links` attribute under the key `taxonomy_topic_email_override`.
- `taxonomy_topic_email_override` will be separate to the `taxons` attribute. In other words a document collection can be tagged to many taxonomy topics (stored in the `taxons` key), but it can have only one single `taxonomy_topic_email_override`.

## Next steps
- When the document collection is rendered by government-frontend, if `taxonomy_topic_email_override` is populated we will set the destination of the email signup link to the taxonomy topic. If it is not populated, the email signup will be for the document collection page itself.

## Related PR's

- https://github.com/alphagov/whitehall/pull/7950
- https://github.com/alphagov/publishing-api/pull/2440
- https://github.com/alphagov/whitehall/pull/8056

https://trello.com/c/fircZ3SH/1940-update-whitehalls-document-collection-presenter-to-add-taxonomytopicemailoverride-to-the-links-of-a-document-colleciton

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
