### PR TITLE
Fix broken draft previews for corporate information pages

### DIFF
--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -12,6 +12,10 @@ module HasCorporateInformationPages
     about_us.summary if about_us.present?
   end
 
+  def draft_summary
+    draft_about_us.summary if draft_about_us.present?
+  end
+
   def body
     about_us.body if about_us.present?
   end
@@ -31,10 +35,10 @@ module HasCorporateInformationPages
   end
 
   def about_us
-    @about_us ||= corporate_information_pages.published.for_slug("about")
+    corporate_information_pages.published.for_slug("about")
   end
 
   def draft_about_us
-    @draft_about_us ||= corporate_information_pages.draft.for_slug("about")
+    corporate_information_pages.draft.for_slug("about")
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -3,11 +3,12 @@ module PublishingApi
     include Rails.application.routes.url_helpers
     include ActionView::Helpers::UrlHelper
 
-    attr_accessor :item, :update_type
+    attr_accessor :item, :update_type, :state
 
-    def initialize(item, update_type: nil)
+    def initialize(item, update_type: nil, state: "published")
       self.item = item
       self.update_type = update_type || "major"
+      self.state = state
     end
 
     delegate :content_id, to: :item
@@ -56,11 +57,20 @@ module PublishingApi
     end
 
     def description
-      item.summary
+      if state == "draft"
+        item.draft_summary
+      else
+        item.summary
+      end
     end
 
     def body
-      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item.about_us) || ""
+      about_us = if state == "draft"
+                   item.draft_about_us
+                 else
+                   item.about_us
+                 end
+      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(about_us) || ""
     end
 
     def main_office

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -105,11 +105,22 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
 
   test "republishes owning worldwide organisation after commit when present" do
     worldwide_organisation = create(:worldwide_organisation)
-    corporate_information_page = create(:corporate_information_page, organisation: nil, worldwide_organisation:)
+    corporate_information_page = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation:)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation).once
+    Services.publishing_api.expects(:put_content).once
 
     corporate_information_page.update!(body: "new body")
+  end
+
+  test "republishes owning worldwide organisation after commit when present and updates draft corporate information page" do
+    worldwide_organisation = create(:worldwide_organisation)
+    corporate_information_page = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation:)
+
+    Services.publishing_api.expects(:put_content).once
+
+    corporate_information_page.update!(body: "new body")
+
+    assert_equal "new body", corporate_information_page.body
   end
 
   test "does not republish owning organisation when absent" do


### PR DESCRIPTION
Work to move rendering out of whitehall unintentionally broke draft previews for corporate
information pages. This PR fixes the issue by allowing the publication of draft 'about_us'
bodies to publishing-api.

WorldwideOrganisations not being editionable doesn't allow them to have a draft workflow that uses normal publishing methods, so the `put_content` solution is necessary to prevent publishing-api defaulting to live content. Making WorldwideOrganisations editionable would be the ideal solution in the future, but is a lot of work and far out of the scope of this bugfix. 

Trello: https://trello.com/c/dlZFPXcK/749-fix-the-broken-previews-for-corporate-information-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
