### PR TITLE
Add temporary rake task to unpublish Whitehall APIs

### DIFF
--- a/lib/tasks/temp_unpublish_api.rake
+++ b/lib/tasks/temp_unpublish_api.rake
@@ -1,0 +1,17 @@
+desc "Manually unpublish content as gone"
+task temp_unpublish_api: :environment do |_, _args|
+  content_ids = %w[2a63b605-77be-4af5-932d-224a054dd5a5
+                   2d5bafcc-2c45-4a84-8fbc-525b75dd6d19
+                   736f8a5a-ce6f-4a6f-b0cb-954442aa23c1]
+
+  content_ids.each do |content_id|
+    Services.publishing_api.unpublish(
+      content_id,
+      type: "gone",
+      locale: "en",
+      explanation: "This API has been deprecated. See <a href=\"https://github.com/alphagov/govuk-rfcs/blob/main/rfc-159-switch-off-whitehall-apis.md\" class=\"govuk-link\">RFC-159</a>.",
+    )
+
+    puts "Unpublished #{content_id}"
+  end
+end

--- a/test/unit/lib/tasks/temp_unpublish_api_test.rb
+++ b/test/unit/lib/tasks/temp_unpublish_api_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+require "rake"
+
+class TempUnpublishApiTest < ActiveSupport::TestCase
+  teardown do
+    Sidekiq::Worker.clear_all
+  end
+
+  test "it should issue gone payloads to Publishing API" do
+    Rake.application.invoke_task "temp_unpublish_api"
+
+    content_ids = %w[2a63b605-77be-4af5-932d-224a054dd5a5
+                     2d5bafcc-2c45-4a84-8fbc-525b75dd6d19
+                     736f8a5a-ce6f-4a6f-b0cb-954442aa23c1]
+
+    content_ids.each do |content_id|
+      request = stub_publishing_api_unpublish(
+        content_id,
+        body: {
+          type: "gone",
+          explanation: "This API has been deprecated. See <a href=\"https://github.com/alphagov/govuk-rfcs/blob/main/rfc-159-switch-off-whitehall-apis.md\" class=\"govuk-link\">RFC-159</a>.",
+          locale: "en",
+        },
+      )
+
+      assert_requested request
+    end
+  end
+end


### PR DESCRIPTION
This will publish a "gone" content item at the path of the APIs, therefore resulting in router returning a 410 response at the given paths.

[Trello card](https://trello.com/c/n01ipRSA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
