### PR TITLE
Remove rendering of public API 'gone' response

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -3,9 +3,6 @@ class WorldLocationsController < PublicFacingController
 
   def index
     respond_to do |format|
-      format.json do
-        redirect_to api_world_locations_path(format: :json)
-      end
       format.any do
         @world_locations = WorldLocation.all_by_type
         set_meta_description("Help and services in a country")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,19 +27,6 @@ Whitehall::Application.routes.draw do
   root to: redirect("/admin/"),
        constraints: ->(request) { AdminRequest.valid_admin_host?(request.host) }
 
-  # Temporary addition in response to Whitehall's public API's being retired
-  deprecated_api_410 = proc { [410, {}, ["This API has been deprecated. See [GOVUK RFC-159](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-159-switch-off-whitehall-apis.md)."]] }
-
-  # This API is documented here:
-  # https://github.com/alphagov/whitehall/blob/master/docs/api.md
-  namespace "api" do
-    resources :governments, to: deprecated_api_410
-    resources :world_locations, path: "world-locations", to: deprecated_api_410 do
-      resources :worldwide_organisations, path: "organisations", to: deprecated_api_410
-    end
-    resources :worldwide_organisations, path: "worldwide-organisations", to: deprecated_api_410
-  end
-
   # Override the /auth/failure route in gds-sso, as Slimmer gets
   # involved and causes the page to fail to render
   #

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -22,9 +22,4 @@ class WorldLocationsControllerTest < ActionController::TestCase
       assert_select_object png
     end
   end
-
-  test "index when asked for json should redirect to the api controller" do
-    get :index, format: :json
-    assert_redirected_to api_world_locations_path(format: :json)
-  end
 end


### PR DESCRIPTION
This response has been moved to be rendered by Government Frontend in https://github.com/alphagov/whitehall/pull/8059, therefore the code can be removed from Whitehall.

[Trello card](https://trello.com/c/n01ipRSA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
