### PR TITLE
Prepare release 1.12

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -42,6 +42,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release && !Rails.env.test?
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/app/controllers/admin/contact_translations_controller.rb
+++ b/app/controllers/admin/contact_translations_controller.rb
@@ -11,9 +11,7 @@ class Admin::ContactTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[edit index update] if preview_design_system?(next_release: false)
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -62,10 +62,7 @@ class Admin::ContactsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy reorder]
-    design_system_actions += %w[new edit create update index] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -28,10 +28,7 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy show edit update new create]
-    design_system_actions += %w[index] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -39,7 +39,7 @@ class Admin::FeaturesController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/financial_reports_controller.rb
+++ b/app/controllers/admin/financial_reports_controller.rb
@@ -45,10 +45,7 @@ class Admin::FinancialReportsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index new create edit update confirm_destroy] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -43,7 +43,7 @@ class Admin::OffsiteLinksController < Admin::BaseController
 private
 
   def get_layout
-    if preview_design_system?(next_release: false)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"
@@ -78,6 +78,6 @@ private
 
   def offsite_link_params
     params.require(:offsite_link)
-    .permit(:title, :summary, :link_type, :url, :date)
+          .permit(:title, :summary, :link_type, :url, :date)
   end
 end

--- a/app/controllers/admin/organisation_people_controller.rb
+++ b/app/controllers/admin/organisation_people_controller.rb
@@ -35,10 +35,7 @@ private
   end
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index order reorder] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/organisation_translations_controller.rb
+++ b/app/controllers/admin/organisation_translations_controller.rb
@@ -9,10 +9,7 @@ class Admin::OrganisationTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[index edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -88,10 +88,7 @@ private
   end
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[index show features people new create edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -53,10 +53,7 @@ class Admin::SocialMediaAccountsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[index new create edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/test/functional/admin/contact_translations_controller_test.rb
+++ b/test/functional/admin/contact_translations_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "should be able to visit new index page for adding translations " do
     organisation = create(:organisation)

--- a/test/functional/admin/contacts_controller_test.rb
+++ b/test/functional/admin/contacts_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates contact" do
     organisation = create(:organisation)

--- a/test/functional/admin/financial_reports_controller_test.rb
+++ b/test/functional/admin/financial_reports_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index lists the organisation's reports" do
     report = create(:financial_report, funding: 20_000)

--- a/test/functional/admin/legacy_contact_translations_controller_test.rb
+++ b/test/functional/admin/legacy_contact_translations_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::LegacyContactTranslationsControllerTest < ActionController::TestCas
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "create redirects to edit for the chosen language" do
     organisation = create(:organisation)

--- a/test/functional/admin/legacy_contacts_controller_test.rb
+++ b/test/functional/admin/legacy_contacts_controller_test.rb
@@ -8,7 +8,6 @@ class Admin::LegacyContactsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates contact" do
     organisation = create(:organisation)

--- a/test/functional/admin/legacy_financial_reports_controller_test.rb
+++ b/test/functional/admin/legacy_financial_reports_controller_test.rb
@@ -8,7 +8,6 @@ class Admin::LegacyFinancialReportsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :index lists the organisation's reports" do
     report = create(:financial_report, funding: 20_000)

--- a/test/functional/admin/legacy_organisation_people_controller_test.rb
+++ b/test/functional/admin/legacy_organisation_people_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::LegacyOrganisationPeopleControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :reorder access denied if not a gds admin" do
     organisation = create(:organisation)

--- a/test/functional/admin/legacy_organisations_controller_test.rb
+++ b/test/functional/admin/legacy_organisations_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::LegacyOrganisationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   def example_organisation_attributes
     attributes_for(:organisation).except(:logo, :analytics_identifier)

--- a/test/functional/admin/legacy_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/legacy_social_media_accounts_controller_test.rb
@@ -9,7 +9,6 @@ class Admin::LegacySocialMediaAccountsControllerTest < ActionController::TestCas
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates social media account" do
     worldwide_organisation = create(:worldwide_organisation)

--- a/test/functional/admin/legcy_organisation_translations_controller_test.rb
+++ b/test/functional/admin/legcy_organisation_translations_controller_test.rb
@@ -14,7 +14,6 @@ class Admin::LegacyOrganisationTranslationsControllerTest < ActionController::Te
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { organisation_id: @organisation }

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -9,7 +9,6 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "GET :new should render new offsite links form" do
     get :new, params: { world_location_news_id: @world_location_news.slug }

--- a/test/functional/admin/organisation_people_controller_test.rb
+++ b/test/functional/admin/organisation_people_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::OrganisationPeopleControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :reorder access denied if not a gds admin" do
     organisation = create(:organisation)

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -12,7 +12,6 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { organisation_id: @organisation }

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -6,8 +6,6 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
-
   def example_organisation_attributes
     attributes_for(:organisation).except(:logo, :analytics_identifier)
   end

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "POST on :create creates social media account" do
     worldwide_organisation = create(:worldwide_organisation)


### PR DESCRIPTION
This PR make changes to the list of cards for preparing 1.12 release.
It does the following

- It updates the get_layout method in each controller with "next_release: true".
- It removes bootstrap implementation layout from controller test files.

**Trello:**
https://trello.com/c/HHFGqV7N/372-prepare-release-112
