### PR TITLE
Fix review reminder timezone issue

### DIFF
--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -2,6 +2,12 @@ class ReviewReminder < ApplicationRecord
   belongs_to :document
   belongs_to :creator, class_name: "User"
 
+  scope :reminder_due, lambda {
+    where(review_at: ..Time.zone.today, reminder_sent_at: nil)
+      .joins(document: :latest_edition)
+      .where.not(document: { editions: { first_published_at: nil } })
+  }
+
   validates :document, :creator, :review_at, :email_address, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
   validate :review_date_cannot_be_in_the_past, if: -> { review_at.present? }

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -18,6 +18,10 @@ class ReviewReminder < ApplicationRecord
     Time.zone.today >= review_at
   end
 
+  def reminder_due?
+    review_due? && reminder_sent_at.nil? && document.latest_edition.first_published_at?
+  end
+
 private
 
   def review_date_cannot_be_in_the_past

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -10,7 +10,7 @@ class ReviewReminder < ApplicationRecord
 
   validates :document, :creator, :review_at, :email_address, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
-  validate :review_date_cannot_be_in_the_past, if: -> { review_at.present? }
+  validate :review_date_cannot_be_in_the_past, if: :review_at_changed?
 
   before_update :reset_reminder_sent_at, if: :review_at_changed?
 
@@ -20,6 +20,11 @@ class ReviewReminder < ApplicationRecord
 
   def reminder_due?
     review_due? && reminder_sent_at.nil? && document.latest_edition.first_published_at?
+  end
+
+  def reminder_sent!
+    assign_attributes(reminder_sent_at: Time.zone.now)
+    save!(touch: false)
   end
 
 private

--- a/app/workers/review_reminder_notifier_worker.rb
+++ b/app/workers/review_reminder_notifier_worker.rb
@@ -11,6 +11,6 @@ class ReviewReminderNotifierWorker < WorkerBase
       recipient_address: email_address,
     ).deliver_now
 
-    review_reminder.update_columns(reminder_sent_at: Time.zone.now)
+    review_reminder.reminder_sent!
   end
 end

--- a/app/workers/review_reminder_notifier_worker.rb
+++ b/app/workers/review_reminder_notifier_worker.rb
@@ -1,18 +1,16 @@
 class ReviewReminderNotifierWorker < WorkerBase
   def perform(id)
     review_reminder = ReviewReminder.find(id)
-    return if review_reminder.reminder_sent_at.present?
+    return unless review_reminder.reminder_due?
 
     edition = review_reminder.document.latest_edition
     email_address = review_reminder.email_address
 
-    ActiveRecord::Base.transaction do
-      MailNotifications.review_reminder(
-        edition,
-        recipient_address: email_address,
-      ).deliver_now
+    MailNotifications.review_reminder(
+      edition,
+      recipient_address: email_address,
+    ).deliver_now
 
-      review_reminder.update_columns(reminder_sent_at: Time.zone.now)
-    end
+    review_reminder.update_columns(reminder_sent_at: Time.zone.now)
   end
 end

--- a/db/migrate/20230804105900_change_review_at_datetime_to_date.rb
+++ b/db/migrate/20230804105900_change_review_at_datetime_to_date.rb
@@ -1,0 +1,23 @@
+class ChangeReviewAtDatetimeToDate < ActiveRecord::Migration[7.0]
+  # This migration makes two changes to the review_at column:
+  #   1. Shifts values by +01:00 hour
+  #   2. Changes the column from DATETIME to DATE
+  #
+  # Existing review_at values will be converted automatically by MySQL.
+  #
+  # Due to the DATETIME dates being entered by users during BST but stored as UTC,
+  # the timezone shift is necessary to preserve the date as it was originally
+  # entered & intended.
+  #
+  # For more details, use 'git blame' to see the commit message.
+
+  def up
+    ActiveRecord::Base.connection.execute("UPDATE review_reminders SET review_at = CONVERT_TZ(review_at, '+00:00', '+01:00')")
+    change_column :review_reminders, :review_at, :date
+  end
+
+  def down
+    change_column :review_reminders, :review_at, :datetime
+    ActiveRecord::Base.connection.execute("UPDATE review_reminders SET review_at = CONVERT_TZ(review_at, '+01:00', '+00:00')")
+  end
+end

--- a/db/migrate/20230808144847_add_index_to_review_reminder_fields.rb
+++ b/db/migrate/20230808144847_add_index_to_review_reminder_fields.rb
@@ -1,0 +1,11 @@
+class AddIndexToReviewReminderFields < ActiveRecord::Migration[7.0]
+  def change
+    # Create a 'multiple-column index' (a.k.a. a 'composite index')
+    # https://dev.mysql.com/doc/refman/8.1/en/multiple-column-indexes.html
+    #
+    # This enables finding by 'review_at' alone, or by both
+    # 'review_at' and 'reminder_sent_at' combined.
+    # This optimises for the 'ReviewReminder.reminder_due' scope.
+    add_index(:review_reminders, %i[review_at reminder_sent_at])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_110128) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_04_105900) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -834,7 +834,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_110128) do
     t.integer "document_id"
     t.integer "creator_id"
     t.string "email_address"
-    t.datetime "review_at", precision: nil
+    t.date "review_at"
     t.datetime "reminder_sent_at", precision: nil
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_04_105900) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_08_144847) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -840,6 +840,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_04_105900) do
     t.datetime "updated_at", precision: nil
     t.index ["creator_id"], name: "index_review_reminders_on_creator_id"
     t.index ["document_id"], name: "index_review_reminders_on_document_id"
+    t.index ["review_at", "reminder_sent_at"], name: "index_review_reminders_on_review_at_and_reminder_sent_at"
   end
 
   create_table "role_appointments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/lib/tasks/send_review_reminders.rake
+++ b/lib/tasks/send_review_reminders.rake
@@ -1,11 +1,6 @@
-desc "Send review reminder emails for when the review_at datetime has passed"
+desc "Send review reminder emails for when the review_at date has passed"
 task send_review_reminders: :environment do
-  ReviewReminder
-  .joins(document: :latest_edition)
-  .where(reminder_sent_at: nil)
-  .where("review_at < ?", Time.zone.today)
-  .where.not(document: { editions: { first_published_at: nil } })
-  .find_each do |reminder|
-    ReviewReminderNotifierWorker.perform_async(reminder.id.to_s)
+  ReviewReminder.reminder_due.pluck(:id).each do |id|
+    ReviewReminderNotifierWorker.perform_async(id)
   end
 end

--- a/test/factories/review_reminder.rb
+++ b/test/factories/review_reminder.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :review_reminder do
     creator
-    document
+    document { create(:document, editions: [build(:published_edition)]) }
 
     sequence :email_address do |n|
       "creator-#{n}@example.com"
@@ -9,8 +9,25 @@ FactoryBot.define do
 
     review_at { Time.zone.now + 1.day }
 
-    trait(:with_reminder_sent_at) do
-      reminder_sent_at { 1.day.ago }
+    trait(:reminder_due) do
+      review_at { Time.zone.today }
+      reminder_sent_at { nil }
+    end
+
+    trait(:reminder_sent) do
+      review_at { Time.zone.today }
+      reminder_sent_at { Time.zone.now }
+    end
+
+    trait(:due_but_never_published) do
+      review_at { Time.zone.today }
+      reminder_sent_at { nil }
+      document { create(:document, editions: [build(:draft_edition, first_published_at: nil)]) }
+    end
+
+    trait(:not_due_yet) do
+      review_at { 1.month.from_now }
+      reminder_sent_at { nil }
     end
   end
 end

--- a/test/unit/app/models/review_reminder_test.rb
+++ b/test/unit/app/models/review_reminder_test.rb
@@ -68,6 +68,16 @@ class ReviewReminderTest < ActiveSupport::TestCase
     assert_nil reminder.reload.reminder_sent_at
   end
 
+  test "#reminder_due? returns true when the reminder email needs to be sent" do
+    assert build(:review_reminder, :reminder_due).reminder_due?
+  end
+
+  test "#reminder_due? returns false when the reminder email does not need to be sent" do
+    assert_not build(:review_reminder, :not_due_yet).reminder_due?
+    assert_not build(:review_reminder, :due_but_never_published).reminder_due?
+    assert_not build(:review_reminder, :reminder_sent).reminder_due?
+  end
+
   test ".reminder_due scope returns reminders that are due to be sent" do
     reminders = [
       due = build(:review_reminder, :reminder_due),

--- a/test/unit/lib/tasks/send_review_reminders_test.rb
+++ b/test/unit/lib/tasks/send_review_reminders_test.rb
@@ -1,34 +1,26 @@
 require "test_helper"
 require "rake"
 
-class ResluggingTest < ActiveSupport::TestCase
+class SendReviewRemindersTest < ActiveSupport::TestCase
   teardown do
     Sidekiq::Worker.clear_all
   end
 
-  test "it calls the ReviewReminderNotifierWorker with the correct review_reminders" do
-    document1 = create(:document)
-    create(:published_edition, document: document1)
-    review_reminder_to_be_sent = build(:review_reminder, document: document1, review_at: Time.zone.now - 1.day)
-    review_reminder_to_be_sent.save!(validate: false)
+  test "it queues a ReviewReminderNotifierWorker for every reminder that is due" do
+    reminders = [
+      due = build(:review_reminder, :reminder_due),
+      overdue = build(:review_reminder, :reminder_due, review_at: 1.week.ago),
+      already_sent = build(:review_reminder, :reminder_sent),
+      not_due_yet = build(:review_reminder, :not_due_yet),
+    ]
 
-    document2 = create(:document)
-    create(:published_edition, document: document2)
-    review_reminder_with_future_review_at = create(:review_reminder, document: document2, review_at: Time.zone.now + 1.day)
+    # Bypass validation so review_at dates in the past can be saved
+    reminders.each { |r| r.save!(validate: false) }
 
-    document3 = create(:document)
-    create(:published_edition, document: document3)
-    review_reminder_with_sent_reminder = create(:review_reminder, :with_reminder_sent_at, document: document3)
-
-    document4 = create(:document)
-    create(:edition, document: document4)
-    review_reminder_with_no_published_editions = build(:review_reminder, document: document4, review_at: Time.zone.now - 1.day)
-    review_reminder_with_no_published_editions.save!(validate: false)
-
-    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_to_be_sent.id.to_s).once
-    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_future_review_at.id.to_s).never
-    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_sent_reminder.id.to_s).never
-    ReviewReminderNotifierWorker.expects(:perform_async).with(review_reminder_with_no_published_editions.id.to_s).never
+    ReviewReminderNotifierWorker.expects(:perform_async).with(due.id).once
+    ReviewReminderNotifierWorker.expects(:perform_async).with(overdue.id).once
+    ReviewReminderNotifierWorker.expects(:perform_async).with(already_sent.id).never
+    ReviewReminderNotifierWorker.expects(:perform_async).with(not_due_yet.id).never
 
     Rake.application.invoke_task "send_review_reminders"
   end


### PR DESCRIPTION
**Note:** Changes in this PR are best reviewed commit by commit.

## Context

Document ‘review at’ dates were being stored as DateTime values, which intrinsically come with a timezone in Rails. However in the UI they’re only able to choose dates, not times.

The database values were being stored in UTC meaning the values entered by users were being wound back 1 hour from BST (current timezone) to UTC. That means a user supplied date of “07/08/2023” was represented as the DateTime “07/08/2023 00:00:00 BST” which got stored in the database as “06/08/2023 23:00:00 UTC”. Notice the date actually changed because of this automatic timezone conversion.

## What this PR changes

This PR makes a few changes to resolve the timezone issue and improve code readability:

1. **Converts `review_at` to Date rather than a DateTime.** This helps avoid timezone confusion because dates do not have timezones. Users can only choose a review _date_ and cannot specify a _time_ – so it makes sense for us to store values in the same format users provide them in.
2. **Introduces the scope `ReviewReminder.reminder_due`** for finding documents that are due for a review reminder email. This means we can simplify the 'send review reminder emails' Rake task by removing the business logic required to find reminders that are due.
3. **Introduces methods `ReviewReminder#reminder_due?` and `ReviewReminder#reminder_sent!`** to simplify the logic required when working out if a particular reminder is due, and then marking it as sent.

## Why

- So users get reminders on the day they expected.
- Consolidate business logic for review reminders into one place (i.e. the `ReviewReminder` model).

Follows on from #8047
Trello: https://trello.com/c/HOwOTb4u/1558-fix-a-timezone-bug-in-review-reminders

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
