### PR TITLE
Add tracking to contacts page-card-291.

### DIFF
--- a/app/helpers/admin/contacts_helper.rb
+++ b/app/helpers/admin/contacts_helper.rb
@@ -20,6 +20,12 @@ module Admin::ContactsHelper
         id: "general_and_media_contacts",
         title: tab_title(title_text, general_contacts, contactable),
         label: title_text,
+        tab_data_attributes: {
+          module: "gem-track-click",
+          "track-category": "tab",
+          "track-action": "contact-general-tab",
+          "track-label": title_text,
+        },
         content: render("admin/contacts/contacts", contacts: general_contacts, contactable:, title: "Translated general and media contacts"),
       }
     end
@@ -33,6 +39,12 @@ module Admin::ContactsHelper
         id: "freedom_of_information_contacts",
         title: tab_title(title_text, foi_contacts, contactable),
         label: title_text,
+        tab_data_attributes: {
+          module: "gem-track-click",
+          "track-category": "tab",
+          "track-action": "contact-foi-tab",
+          "track-label": title_text,
+        },
         content: render("admin/contacts/contacts", contacts: foi_contacts, contactable:, title: "Translated freedom of information contacts"),
       }
     end

--- a/app/views/admin/contacts/index.html.erb
+++ b/app/views/admin/contacts/index.html.erb
@@ -27,7 +27,13 @@
 <%= render "govuk_publishing_components/components/button", {
   text: "Add contact",
   href: new_polymorphic_path([:admin, @contactable, Contact.new]),
-  margin_bottom: 6
+  margin_bottom: 6,
+  data_attributes: {
+    module: "gem-track-click",
+    "track-category": "form-button",
+    "track-action": "contact-button",
+    "track-label": "Add contact"
+  }
 } %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This PR adds tracking to contacts page.
It does the following:

- Adds tracking to 'Add contact' button.
- Adds tracking to tab 'general and media contacts'.
- Adds tracking to tab 'freedom of information contacts'.

Trello:
https://trello.com/c/mtPOJuqk/291-contacts-page