### PR TITLE
Remove `teaspoon` fixture file

### DIFF
--- a/app/views/teaspoon/suite/_qunit_fixture.html.erb
+++ b/app/views/teaspoon/suite/_qunit_fixture.html.erb
@@ -1,1 +1,0 @@
-<div id="qunit-fixture"></div>


### PR DESCRIPTION
`teaspoon` was removed in 468359f9ff18facd3b7b572a9faad0705c1a3760.

We can therefore remove this file that should've been deleted at the time.

[Trello card](https://trello.com/c/nWfYKfkB)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
