### PR TITLE
Fix to generate accurate path for CfE

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -92,6 +92,8 @@ class HtmlAttachment < Attachment
       "/government/consultations/#{attachable.slug}/outcome/#{identifier}"
     when "consultation_public_feedback"
       "/government/consultations/#{attachable.slug}/public-feedback/#{identifier}"
+    when "call_for_evidence"
+      "/government/calls-for-evidence/#{attachable.slug}/#{identifier}"
     when "call_for_evidence_outcome"
       "/government/calls-for-evidence/#{attachable.slug}/outcome/#{identifier}"
     else

--- a/test/factories/calls_for_evidence.rb
+++ b/test/factories/calls_for_evidence.rb
@@ -55,4 +55,5 @@ FactoryBot.define do
 
   factory :call_for_evidence_with_excluded_nations, parent: :call_for_evidence, traits: [:has_excluded_nations]
   factory :published_call_for_evidence_with_excluded_nations, parent: :published_call_for_evidence, traits: [:has_excluded_nations]
+  factory :call_for_evidence_with_html_attachment, parent: :call_for_evidence, traits: [:with_html_attachment]
 end

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -139,6 +139,12 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "/government/calls-for-evidence/#{call_for_evidence.slug}/outcome/#{attachment.slug}", attachment.url
   end
 
+  test "#url works when call for evidence has html attachment" do
+    call_for_evidence = create(:call_for_evidence_with_html_attachment)
+    attachment = call_for_evidence.attachments.first
+    assert_equal "/government/calls-for-evidence/#{call_for_evidence.slug}/#{attachment.slug}", attachment.url
+  end
+
   test "slug is copied from previous edition's attachment" do
     edition = create(
       :published_publication,


### PR DESCRIPTION
We want the path to has underscores rather than - when creating HTML attachment directly on the Call for Evidence.

[Trello card](https://trello.com/c/BGYoIsbC/1542-call-for-evidence-url-uses-underscores-rather-than)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
