### PR TITLE
Update subtitle for Financial reports index page.

### DIFF
--- a/app/views/admin/financial_reports/index.html.erb
+++ b/app/views/admin/financial_reports/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <% content_for :page_title, "#{@organisation.name} financial reports" %>
 <% content_for :title, @organisation.name %>
-<% content_for :context, "Organisation" %>
+<% content_for :context, organisation_context_block(current_user, @organisation) %>
 <% content_for :title_margin_bottom, 4 %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
This PR updates subtitle of financial reports index page.
It changes the subtitle 'Organisation' to 'My organisation' if organisation belongs to the user.

**Screen shot:**
**When organisation belongs to user:**
![image](https://github.com/alphagov/whitehall/assets/131259138/cf012edc-1acf-4925-86ae-d418fd7bf810)

**When organisation does not belong to user:**
![image](https://github.com/alphagov/whitehall/assets/131259138/8e54dfa8-32ff-4068-85b7-9aa8e4d435f6)


**Trello:**
https://trello.com/c/zIhlSb0R/504-update-subtitle-for-financial-reports

