### PR TITLE
Remove `ContactsHelper`

### DIFF
--- a/app/helpers/admin/contacts_helper.rb
+++ b/app/helpers/admin/contacts_helper.rb
@@ -1,4 +1,8 @@
 module Admin::ContactsHelper
+  def render_hcard_address(contact)
+    AddressFormatter::HCard.from_contact(contact).render
+  end
+
   def contact_translation_css_class(translated_contact)
     c = %w[contact-translation]
     c << "right-to-left" if translated_contact.translation_locale.rtl?

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -1,5 +1,0 @@
-module ContactsHelper
-  def render_hcard_address(contact)
-    AddressFormatter::HCard.from_contact(contact).render
-  end
-end

--- a/test/unit/app/helpers/admin/contacts_helper_test.rb
+++ b/test/unit/app/helpers/admin/contacts_helper_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class Admin::ContactsHelperTest < ActionView::TestCase
-  include ContactsHelper
   include Admin::OrganisationHelper
 
   test "method contact_rows return correct default rows" do


### PR DESCRIPTION
https://trello.com/c/3BVNCw0N

Following the removal of public facing rendering from Whitehall, we want to tidy up any helpers that aren't under the `admin` namespace.

Move the `render_hcard_address` method into the `Admin::ContactsHelper` so that we can remove the `ContactsHelper`.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
