### PR TITLE
Add state argument to `worldwide_corporate_information_pages` task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -259,9 +259,10 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
-    desc "Republish all published Worldwide CorporateInformationPages"
-    task worldwide_corporate_information_pages: :environment do
-      worldwide_corporate_information_pages = CorporateInformationPage.joins(:worldwide_organisation).where(state: "published")
+    desc "Republish all Worldwide CorporateInformationPages"
+    task :worldwide_corporate_information_pages, [:states] => :environment do |_, args|
+      states = args[:states]&.split("|") || "published"
+      worldwide_corporate_information_pages = CorporateInformationPage.joins(:worldwide_organisation).where(state: states)
       puts "Enqueueing #{worldwide_corporate_information_pages.count} Worldwide CorporateInformationPages"
       worldwide_corporate_information_pages.each do |corporate_information_page|
         PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", corporate_information_page.document_id, true)


### PR DESCRIPTION
https://trello.com/c/En4l42d7

We want to republish all of the published and draft worldwide corporate information pages.

This adds a state argument to the `worldwide_corporate_information_pages` task. There isn't a nice way of passing an array to Rails tasks, so I've opted for a pipe separated argument e.g.,
`publishing_api:bulk_republish:worldwide_corporate_information_pages\["published|draft"]`.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
