### PR TITLE
Change the namespace of multiple helpers

### DIFF
--- a/app/helpers/admin/javascript_helper.rb
+++ b/app/helpers/admin/javascript_helper.rb
@@ -1,4 +1,4 @@
-module JavascriptHelper
+module Admin::JavascriptHelper
   def initialise_script(constructor_or_singleton_name, params = {})
     content_for :javascript_initialisers, raw("GOVUK.init(#{constructor_or_singleton_name}, #{params.to_json});\n")
   end

--- a/app/helpers/admin/locale_helper.rb
+++ b/app/helpers/admin/locale_helper.rb
@@ -1,4 +1,4 @@
-module LocaleHelper
+module Admin::LocaleHelper
   def select_locale(attribute, locales, options = {})
     select_tag attribute, options_for_select(options_for_locales(locales)), **options
   end
@@ -8,10 +8,5 @@ module LocaleHelper
       locale = Locale.coerce(locale)
       [locale.native_and_english_language_name, locale.code.to_s]
     end
-  end
-
-  def options_for_foreign_language_locale(edition)
-    options = [["Choose foreign language...", nil]] + options_for_locales(Locale.non_english)
-    options_for_select(options, edition.non_english_edition? ? edition.primary_locale : nil)
   end
 end

--- a/app/helpers/admin/person_helper.rb
+++ b/app/helpers/admin/person_helper.rb
@@ -1,4 +1,4 @@
-module PersonHelper
+module Admin::PersonHelper
   def disambiguated_people_names
     people = Person.includes(:current_roles)
     name_counts = Hash.new(0)

--- a/app/helpers/admin/topical_events_helper.rb
+++ b/app/helpers/admin/topical_events_helper.rb
@@ -1,4 +1,4 @@
-module TopicalEventsHelper
+module Admin::TopicalEventsHelper
   def topical_event_contents_breakdown(topical_event)
     capture do
       concat tag.span(pluralize(topical_event.published_detailed_guides.count, "published detailed guide"))

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,7 +12,7 @@ SimpleCov.merge_timeout 3600
 require "cucumber/rails"
 
 World DocumentHelper
-World PersonHelper
+World Admin::PersonHelper
 
 # frozen_string_literal: true
 

--- a/test/unit/app/helpers/admin/javascript_helper_test.rb
+++ b/test/unit/app/helpers/admin/javascript_helper_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
-class JavascriptHelperTest < ActionView::TestCase
-  include JavascriptHelper
+class Admin::JavascriptHelperTest < ActionView::TestCase
+  include Admin::JavascriptHelper
 
   test "initialise_script should render a script initialisation to :javascript_initialisers" do
     stubs(:content_for).with do |yield_block, script|

--- a/test/unit/app/helpers/admin/person_helper_test.rb
+++ b/test/unit/app/helpers/admin/person_helper_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PersonHelperTest < ActionView::TestCase
+class Admin::PersonHelperTest < ActionView::TestCase
   include ApplicationHelper
 
   test "it disambiguates names with trailing spaces" do


### PR DESCRIPTION
These things are only used by the admin interface so they've been moved to that namespace

Trello - https://trello.com/c/mcIdxTTJ/762-update-namespace-for-some-whitehall-code

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
