### PR TITLE
Fix typo on organisations table from organistions to organisations

### DIFF
--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -21,7 +21,7 @@
       text: "Name"
     },
     {
-      text: "Organistions"
+      text: "Organisations"
     },
     {
       text: "Currently appointed"


### PR DESCRIPTION
## What

'Organisations' was spelt wrong in the change to the design system.

This PR updates it so that it says organisations instead. 

## Why

Fixing a typo

## Zendesk ticket 
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5441409

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
