### PR TITLE
Update what's new page to reflect Call for Evidence

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -7,13 +7,13 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.
-      last_updated: Last updated 3 August 2023
+      last_updated: Last updated 9 August 2023
       introduction:
         heading: Our roadmap
         body_govspeak: |
           This quarter we are focussing on:
 
-          - finish our work on the design system
+          - finish our work on the move to the GOV.UK design system
           - explore how to improve the editor journey when creating or editing a draft
           - review how you navigate in Whitehall, as well as add document collections
 
@@ -25,7 +25,12 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
-          - heading: New images 
+         - heading: New call for evidence content type
+            area: Creating and updating documents
+            type: new
+            date: 9 August 2023
+            body_govspeak: |
+              We have released a call for evidence content type in Whitehall. This is similar to consultations, but is now available in the new document menu. Outcomes are optional, but for details [read more in the GOV.UK guidance](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/calls-for-evidence).
             area: Creating and updating documents
             type: new
             date: 3 August 2023

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -25,7 +25,7 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
-         - heading: New call for evidence content type
+          - heading: New call for evidence content type
             area: Creating and updating documents
             type: new
             date: 9 August 2023


### PR DESCRIPTION
This PR supersedes #8096 – I'm opening it because I don't have write permission on @mjwhitehouse's fork/branch, but needed to push up some whitespace fixes to make the YAML file valid.

---

## What

This PR updates the What's new page to reflect that we've added Call for Evidence as a new content type. 

The text has been updated and has a link to the guidance now live on GOV.UK

## Why

To inform publishers that this is available

## Linked Trello

https://trello.com/c/3ervkwyc/1057-release-call-for-evidence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
