### PR TITLE
Update Call for Evidence email reminder to include GOV.UK guidance

### DIFF
--- a/app/views/mail_notifications/call_for_evidence_reminder.text.erb
+++ b/app/views/mail_notifications/call_for_evidence_reminder.text.erb
@@ -1,3 +1,5 @@
 This is a reminder that the call for evidence "<%= @title %>" closed 8 weeks ago and you may want to publish responses. You can do this in the Outcome section.
 
 It is optional to publish responses for a call for evidence.
+
+Read how to write good call for evidences pages here: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/calls-for-evidence

--- a/app/views/mail_notifications/call_for_evidence_reminder.text.erb
+++ b/app/views/mail_notifications/call_for_evidence_reminder.text.erb
@@ -2,4 +2,4 @@ This is a reminder that the call for evidence "<%= @title %>" closed 8 weeks ago
 
 It is optional to publish responses for a call for evidence.
 
-Read how to write good call for evidences pages here: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/calls-for-evidence
+Read how to write good call for evidence pages here: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/calls-for-evidence


### PR DESCRIPTION
## What

Updates the email template to include a link to the GOV.UK guidance on creating a call for evidence

## Why 

Publishers can see the guidance in the email when they are reminded to update a call for Evidence

## Trello card

https://trello.com/c/dj7mjSBD

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
