### PR TITLE
Removed calls for evidence text from consultations form

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -1,7 +1,6 @@
 <div class="format-advice">
-  <p class="govuk-body"><strong>Use this format for:</strong> Consultations (officially “documents requiring collective agreement across government”, including calls for evidence).</p>
-
-  <p class="govuk-body">Check you have read the <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
+  <p class="govuk-body"><strong>Use this format for:</strong> <%= link_to "Consultations", "https://www.gov.uk/guidance/content-design/content-types", class: "govuk-link" %>following the <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
+  <p class="govuk-body">Do not use for calls for evidence. If you are not sure, ask your legal team before uploading your content.</p>
 </div>
 
 <%= standard_edition_form(edition) do |form| %>


### PR DESCRIPTION
## What

This PR removes the guidance to use calls for evidence as part of a consultation content type, as call for evidence is now live.

### Text before

<img width="793" alt="Screenshot 2023-08-09 at 17 55 13" src="https://github.com/alphagov/whitehall/assets/55087909/f20a244f-3a87-4d9f-ac6d-4eaa5de9f236">

We now do not advise to use a consultation content type to produce a call for evidence, so this is a text update 

## Why 

To ensure guidance to publishers is clear

## Trello card 

https://trello.com/c/YCr9rinL/1303-update-current-guidance-on-consultations-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
