### PR TITLE
Fix `StackLevelTooDeep` error when adding images to news articles

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -42,7 +42,7 @@ class NewsArticle < Announcement
   def search_index
     super.merge(
       "news_article_type" => news_article_type.slug,
-      "image_url" => image_url,
+      "image_url" => lead_image_url,
     )
   end
 
@@ -93,10 +93,6 @@ class NewsArticle < Announcement
   end
 
 private
-
-  def image_url
-    PublishingApi::NewsArticlePresenter::Image.for(self).dig(:image, :url)
-  end
 
   def organisations_are_not_associated
     if edition_organisations.present? && !all_edition_organisations_marked_for_destruction?


### PR DESCRIPTION
Following the deployment of #8100 we have seen `StackLevelTooDeep` errors where the `Edition::LeadImage` module included in the `NewsArticle` model is recursively calling the `PublishingApi::NewsArticlePresenter`.

This is happening because `image_url` which is defined in the `Edition::LeadImage` is overridden by `NewsArticle`.

To fix, we can remove the override, it's only called in one place which can be replaced with a more direct call instead.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
