### PR TITLE
Add missing callbacks for Worldwide Organisations

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -51,7 +51,7 @@ class Role < ApplicationRecord
 
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
-  after_save :republish_organisations_to_publishing_api
+  after_save :republish_organisations_to_publishing_api, :republish_worldwide_organisations_to_publishing_api
 
   extend FriendlyId
   friendly_id
@@ -62,6 +62,12 @@ class Role < ApplicationRecord
   def republish_organisations_to_publishing_api
     organisations.each do |organisation|
       republish_organisation_to_publishing_api(organisation)
+    end
+  end
+
+  def republish_worldwide_organisations_to_publishing_api
+    worldwide_organisations.each do |worldwide_organisation|
+      republish_organisation_to_publishing_api(worldwide_organisation)
     end
   end
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -28,6 +28,7 @@ class RoleAppointment < ApplicationRecord
   belongs_to :role
   belongs_to :person
   has_many :organisations, through: :role
+  has_many :worldwide_organisations, through: :role
 
   delegate :slug, to: :person
   delegate :name, to: :role, prefix: true
@@ -69,12 +70,18 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
+  after_save :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
 
   def republish_organisation_to_publishing_api
     organisations.each do |organisation|
       Whitehall::PublishingApi.republish_async(organisation)
+    end
+  end
+
+  def republish_worldwide_organisations_to_publishing_api
+    worldwide_organisations.each do |worldwide_organisation|
+      Whitehall::PublishingApi.republish_async(worldwide_organisation)
     end
   end
 

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -12,7 +12,7 @@ class SocialMediaAccount < ApplicationRecord
   translates :url, :title
 
   def republish_organisation_to_publishing_api
-    if socialable_type == "Organisation" && socialable.persisted?
+    if (socialable_type == "Organisation" || socialable_type == "WorldwideOrganisation") && socialable.persisted?
       Whitehall::PublishingApi.republish_async(socialable)
     end
   end

--- a/app/models/social_media_account_translation.rb
+++ b/app/models/social_media_account_translation.rb
@@ -5,7 +5,7 @@ class SocialMediaAccountTranslation < ApplicationRecord
   after_destroy :republish_organisation_to_publishing_api
 
   def republish_organisation_to_publishing_api
-    if social_media_account.socialable_type == "Organisation" && social_media_account.socialable.persisted?
+    if (social_media_account.socialable_type == "Organisation" || social_media_account.socialable_type == "WorldwideOrganisation") && social_media_account.socialable.persisted?
       Whitehall::PublishingApi.republish_async(social_media_account.socialable)
     end
   end

--- a/app/models/worldwide_organisation_role.rb
+++ b/app/models/worldwide_organisation_role.rb
@@ -3,4 +3,11 @@ class WorldwideOrganisationRole < ApplicationRecord
   belongs_to :role
 
   validates :worldwide_organisation, :role, presence: true
+
+  after_save :republish_worldwide_organisation_to_publishing_api
+  after_destroy :republish_worldwide_organisation_to_publishing_api
+
+  def republish_worldwide_organisation_to_publishing_api
+    Whitehall::PublishingApi.republish_async(worldwide_organisation)
+  end
 end

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -515,4 +515,36 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     create(:role_appointment, person: create(:person), role:)
   end
+
+  test "republishes a worldwide organisation when a role appointment is created" do
+    worldwide_organisation = create(:worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:worldwide_organisation_role, role:, worldwide_organisation:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+
+    create(:role_appointment, role:)
+  end
+
+  test "republishes a worldwide organisation when a role appointment is updated" do
+    worldwide_organisation = create(:worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:worldwide_organisation_role, role:, worldwide_organisation:)
+    role_appointment = create(:role_appointment, role:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+
+    role_appointment.update!(ended_at: Time.zone.now)
+  end
+
+  test "republishes a worldwide organisation when a role appointment is destroyed" do
+    worldwide_organisation = create(:worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:worldwide_organisation_role, role:, worldwide_organisation:)
+    role_appointment = create(:role_appointment, role:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+
+    role_appointment.destroy!
+  end
 end

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -255,4 +255,15 @@ class RoleTest < ActiveSupport::TestCase
     role.update!(organisations: [organisation])
     role.update!(organisations: [])
   end
+
+  test "republishes a worldwide organisation when a role is updated" do
+    worldwide_organisation = create(:worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:worldwide_organisation_role, role:, worldwide_organisation:)
+    role.reload
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+
+    role.update!(name: "New role name")
+  end
 end

--- a/test/unit/app/models/social_media_account_test.rb
+++ b/test/unit/app/models/social_media_account_test.rb
@@ -32,7 +32,28 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
     social_media_account.destroy!
   end
 
-  test "creating a new social media account does not republish the linked socialable if it's not an Organisation" do
+  test "creating a new social media account republishes the linked socialable if it's a WorldwideOrganisation" do
+    test_object = create(:worldwide_organisation)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    create(:social_media_account, socialable: test_object)
+  end
+
+  test "updating an existing social media account republishes the linked socialable if it's a WorldwideOrganisation" do
+    test_object = create(:worldwide_organisation)
+    social_media_account = create(:social_media_account, socialable: test_object)
+    social_media_account.title = "Test"
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    social_media_account.save!
+  end
+
+  test "deleting a social media account republishes the linked socialable if it's a Worldwide Organisation" do
+    test_object = create(:worldwide_organisation)
+    social_media_account = create(:social_media_account, socialable: test_object)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    social_media_account.destroy!
+  end
+
+  test "creating a new social media account does not republish the linked socialable if it's not an Organisation or WorldwideOrganisation" do
     test_object = create(:world_location)
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).never
     create(:social_media_account, socialable: test_object)

--- a/test/unit/app/models/worldwide_organisation_role_test.rb
+++ b/test/unit/app/models/worldwide_organisation_role_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class WorldwideOfficeRoleTest < ActiveSupport::TestCase
+class WorldwideOrganisationRoleTest < ActiveSupport::TestCase
   test "should be invalid without a worldwide organisation" do
     organisation_role = build(:worldwide_organisation_role, worldwide_organisation_id: nil)
     assert_not organisation_role.valid?
@@ -9,5 +9,33 @@ class WorldwideOfficeRoleTest < ActiveSupport::TestCase
   test "should be invalid without a role" do
     organisation_role = build(:worldwide_organisation_role, role_id: nil)
     assert_not organisation_role.valid?
+  end
+
+  test "creating a new worldwide organisation role republished the linked worldwide orgaisation" do
+    worldwide_organisation = create(:worldwide_organisation)
+    role = create(:role)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation).once
+
+    create(:worldwide_organisation_role, worldwide_organisation:, role:)
+  end
+
+  test "updating an existing worldwide organisation role republished the linked worldwide orgaisation" do
+    worldwide_organisation = create(:worldwide_organisation)
+    worldwide_organisation_role = create(:worldwide_organisation_role, worldwide_organisation:)
+    new_role = create(:role)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation).once
+
+    worldwide_organisation_role.update!(role: new_role)
+  end
+
+  test "deleting a worldwide organisation role republished the linked worldwide orgaisation" do
+    worldwide_organisation = create(:worldwide_organisation)
+    worldwide_organisation_role = create(:worldwide_organisation_role, worldwide_organisation:)
+
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation).once
+
+    worldwide_organisation_role.destroy!
   end
 end


### PR DESCRIPTION
This adds callbacks that are missing, to republish Worldwide Organisation pages to Publishing API when associated roles or social media account are updated.

Zendesk tickets: [1](https://govuk.zendesk.com/agent/tickets/5443342), [2](https://govuk.zendesk.com/agent/tickets/5439939)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
