### PR TITLE
Remove `/government` as a route that can be published

### DIFF
--- a/app/models/special_route.rb
+++ b/app/models/special_route.rb
@@ -2,12 +2,6 @@ class SpecialRoute
   def self.all
     [
       {
-        base_path: "/government",
-        content_id: "4672b1ff-f147-4d49-a5f4-4959588da5a8",
-        title: "Government prefix",
-        description: "The prefix route under which almost all government content is published.",
-      },
-      {
         base_path: "/government/feed",
         content_id: "725a346f-9e5b-486d-873d-2b050c126e09",
         title: "Government feed",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -13,7 +13,6 @@ namespace :publishing_api do
         {
           format: "special_route",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           update_type: "major",
           type: "prefix",
           public_updated_at: Time.zone.now.iso8601,

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -15,7 +15,6 @@ class PublishingApiRake < ActiveSupport::TestCase
         params = {
           format: "special_route",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           update_type: "major",
           type: "prefix",
           public_updated_at: Time.zone.now.iso8601,


### PR DESCRIPTION
This route was previously used as a "catch all" for any content that was to be rendered by Whitehall that didn't have a content item.

As all content now has a content item and Whitehall renders no content, we have published this route (as a redirect) in Short URL Manager.

Therefore we no longer need to publish this route from Whitehall.

The other two remaining Special Routes should also be moved to Special Routes Publisher, as they do not require any data from Whitehall's database, but that is outside the scope of this work.

[Trello card](https://trello.com/c/EzST71Hl)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
