### PR TITLE
Fix an error in the "What's new" page YAML

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -31,6 +31,7 @@ en:
             date: 9 August 2023
             body_govspeak: |
               We have released a call for evidence content type in Whitehall. This is similar to consultations, but is now available in the new document menu. Outcomes are optional, but for details [read more in the GOV.UK guidance](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/calls-for-evidence).
+          - heading: New images
             area: Creating and updating documents
             type: new
             date: 3 August 2023


### PR DESCRIPTION
There was a missing list item in the YAML which meant the two most recent "What's new" entries were showing as one.

The heading was showing "New call for evidence content type" but the rest of the content was being overwritten by the "New images" item.

This fixes the error introduced by PR #8101 / commit 753201a1d738c57855bd65bd03b0287d379c988f.

| Before | After |
| --- | --- |
| <img width="750" alt="whats_new_before" src="https://github.com/alphagov/whitehall/assets/7735945/10120b5f-a498-4f4f-be5d-ac9ee8b0c798"> | <img width="750" alt="whats_new_after" src="https://github.com/alphagov/whitehall/assets/7735945/802ce551-fd78-4abf-8e96-c6118e71d196"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
