### PR TITLE
Remove 

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -1,7 +1,6 @@
 <div class="format-advice">
-  <p class="govuk-body"><strong>Use this format for:</strong> Consultations (officially “documents requiring collective agreement across government”, including calls for evidence).</p>
-
-  <p class="govuk-body">Check you have read the <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
+  <p class="govuk-body"><strong>Use this format for:</strong> <%= link_to "Consultations", "https://www.gov.uk/guidance/content-design/content-types", class: "govuk-link" %>following the <%= link_to "consultation principles", "https://www.gov.uk/government/publications/consultation-principles-guidance", class: "govuk-link" %>.</p>
+  <p class="govuk-body">Do not use for calls for evidence. If you are not sure, ask your legal team before uploading your content.</p>
 </div>
 
 <%= standard_edition_form(edition) do |form| %>


### PR DESCRIPTION
## What
This PR removes the guidance to use calls for evidence as part of a consultation content type, as call for evidence is now live.

## Text before
<img width="776" alt="Screenshot 2023-08-10 at 22 30 54" src="https://github.com/alphagov/whitehall/assets/55087909/6895eca4-b21f-4776-8321-088e4c6755f1">

## New text

Use this for [consultations](https://www.gov.uk/guidance/content-design/content-types) following the [consultation principles](https://www.gov.uk/government/publications/consultation-principles-guidance).

Do not user for calls for evidence. If you are not sure, ask your legal team before uploading your content


## Why
To ensure guidance to publishers is clear. We now do not advise to use a consultation content type to produce a call for evidence, so this is a text update

## Trello card

https://trello.com/c/YCr9rinL/1303-update-current-guidance-on-consultations-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
