### PR TITLE
Remove `WHITEHALL_FRONTEND` constant

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -554,10 +554,6 @@ EXISTS (
     end
   end
 
-  def rendering_app
-    Whitehall::RenderingApp::WHITEHALL_FRONTEND
-  end
-
   def format_name
     self.class.format_name
   end

--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
         details: PayloadBuilder::TagDetails.for(item),
         document_type:,
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "placeholder_#{item.class.name.underscore}",
         auth_bypass_ids: [item.auth_bypass_id],
       )

--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -21,7 +21,6 @@ module PublishingApi
         details: {},
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "world_location",
       )
       if item.international_delegation?

--- a/lib/whitehall/rendering_app.rb
+++ b/lib/whitehall/rendering_app.rb
@@ -1,6 +1,5 @@
 module Whitehall
   module RenderingApp
-    WHITEHALL_FRONTEND = "whitehall-frontend".freeze
     GOVERNMENT_FRONTEND = "government-frontend".freeze
     COLLECTIONS_FRONTEND = "collections".freeze
   end

--- a/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -29,7 +29,7 @@ module PublishingApi
         locale: "en",
         public_updated_at: edition.updated_at,
         publishing_app: Whitehall::PublishingApp::WHITEHALL,
-        rendering_app: "government-frontend",
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         routes: [
           { path: public_path, type: "exact" },
         ],

--- a/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
@@ -15,7 +15,6 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
       document_type: "world_location",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "whitehall-frontend",
       public_updated_at: world_location.updated_at,
       redirects: [],
       details: {},


### PR DESCRIPTION
This removes the remaining (unused) uses of `WHITEHALL_FRONTEND` and deletes the constant.

[Trello card](https://trello.com/c/QWJnPXYf)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
