### PR TITLE
Remove remaining references to Whitehall Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # Whitehall
 
-Whitehall is deployed in two modes:
-
-- 'admin' for publishers to create and manage content (e.g. <http://whitehall-admin.dev.gov.uk/government/admin/news/new>)
-- 'frontend' is a legacy mode that was used for rendering content to the public that had yet to be migrated to using Publishing API work to remove this is being carried out by the Publishing Platform team
+Whitehall (also known as 'Whitehall Admin' or 'Whitehall Publisher') is used by publishers to create and manage content (e.g. <http://whitehall-admin.dev.gov.uk/government/admin/news/new>).
 
 ## Running the Application
 
 **Use [GOV.UK Docker](https://github.com/alphagov/govuk-docker) to run any commands that follow.**
-
-Traditionally, the two sides of Whitehall are available on different domains in development, which reflect their counterparts in production:
-
-While this usually results in different routing behaviour, in development [all routes can be accessed from either domain](https://github.com/alphagov/whitehall/blob/main/config/routes.rb#L3-L5), although [the redirect behaviour may differ](https://github.com/alphagov/whitehall/blob/main/config/routes.rb#L25-L28).
 
 ## Nomenclature
 

--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -1,8 +1,8 @@
 // This is a manifest file used by the runner for JavaScript unit tests.
 // It is not used in the main application. If you add something to
-// frontend.js (for whitehall-frontend) or admin_legacy.js (for whitehall-admin)
-// make sure to add it here.  Or if you remove something from application.js
-// that you get from static when deployed, then make sure to add it in here.
+// admin_legacy.js make sure to add it here.  Or if you remove something
+// from application.js that you get from static when deployed, then make
+// sure to add it in here.
 //
 //= require govuk-admin-template
 //= require jquery-ui

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,9 +11,6 @@ development:
   username: whitehall
   password: whitehall
   url: <%= ENV["DATABASE_URL"] %>
-  # Note that there is also a 'whitehall_fe' user, used
-  # by the 'whitehall_frontend' machines. It should have
-  # only 'SELECT' privileges on the database.
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/docs/css.md
+++ b/docs/css.md
@@ -69,8 +69,6 @@ Legacy files will remain in the following folders structures:
     - stylesheets
       - admin_legacy
         - ...
-      - frontend
-        - ...
       - vendor
       admin_legacy.scss
 ```

--- a/docs/legacy_css.md
+++ b/docs/legacy_css.md
@@ -10,24 +10,7 @@ Please note that this documentation is now deprecated and will be removed with t
 
 Tech-debt creep in CSS is usually an symptom of a lack of confidence in changing or removing existing CSS. By structuring CSS in the following way, we can help reduce this risk by clearly communicating the scope of any given CSS.
 
-The stylesheets are split between frontend and admin. The frontend ones are in a much better state and should be the way the admin ones move in the future.
-
-They are structured to take advantage of the conditionals from the frontend_toolkit. This means you should put your IE fixes inline not in a separate file.
-
-Within the frontend folder the basic structure of the files looks like:
-
-    ./base.scss
-    ./base-ie6.scss
-    ./base-ie7.scss
-    ./base-ie8.scss
-    ./helpers/
-    ./views/
-    ./resets/
-    ./styleguide/
-
-The `base.scss` is the file that will be compiled with Sass.
-All other files should be referenced from it in the relevant sections.
-The IE variants (`base-ie[6-8].scss` which you should never need to edit as they include `base.scss`) enable us to use mixins which only show css to certain IE versions.
+The stylesheets are structured to take advantage of the conditionals from the frontend_toolkit. This means you should put your IE fixes inline not in a separate file.
 
 ### `./helpers`
 

--- a/docs/legacy_javascript.md
+++ b/docs/legacy_javascript.md
@@ -12,9 +12,6 @@ Each JavaScript object should be stored in its own file with a filename reflecti
 
 ```
 ./helpers/
-./frontend/views/
-./frontend/modules/
-./frontend/helpers/
 ./admin_legacy/views/
 ./admin_legacy/modules/
 ./admin_legacy/helpers/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ## Whitehall troubleshooting
 
-You may run into errors while working locally and trying to render pages on the Frontend.
+You may run into errors while working locally and trying to render pages.
 
 Problem:
 
@@ -36,7 +36,7 @@ Problem:
 /.rvm/rubies/ruby-2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_gem.rb:67:in `synchronize': dead
 ```
 
-Solution: 
+Solution:
 `gem update --system`
 
 Problem:
@@ -60,7 +60,7 @@ govuk-docker up search-api-app
 Problem:
 
 ```
-Error: Failed to load config "standard" to extend from 
+Error: Failed to load config "standard" to extend from
 ```
 
 Solution:

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -1,14 +1,6 @@
 require "gds_api/test_helpers/content_store"
 
 Before do
-  # FIXME: This stubs out calls to the content store, returning an empty
-  # response. Calls to this endpoint are only needed in SpecialistTagFinder,
-  # for rendering the header in Whitehall frontend. Ideally this should be
-  # replaced by explicit stubs in every feature that renders a frontend page.
-  # That's a fairly large reworking of the tests, however, and those pages are
-  # in the process of being migrated to government-frontend. For now then, this
-  # stub should be overriden in specific features where this behaviour needs to
-  # be tested.
   stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
   stub_publishing_api_has_linkables([], document_type: "topic")
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whitehall",
-  "description": "Publishing and frontend rendering application for GOV.UK",
+  "description": "Publishing application for GOV.UK",
   "private": true,
   "author": "Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
Whitehall existed in two modes: Whitehall Admin and Whitehall Frontend.

The frontend side has been switched off, therefore we can remove the remaining references to it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
