### PR TITLE
Fix broken `include` in `OfficeSummaryCardComponent`

### DIFF
--- a/app/components/admin/worldwide_offices/index/office_summary_card_component.rb
+++ b/app/components/admin/worldwide_offices/index/office_summary_card_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::WorldwideOffices::Index::OfficeSummaryCardComponent < ViewComponent::Base
-  include ContactsHelper
+  include Admin::ContactsHelper
   include ApplicationHelper
 
   attr_reader :worldwide_office, :worldwide_organisation, :contact


### PR DESCRIPTION
This occured because the namespace of `ContactsHelper` was changed in https://github.com/alphagov/whitehall/pull/8078 but then included in https://github.com/alphagov/whitehall/pull/8033.

As the PR wasn't rebased against `main` before merging, the change in namespace wasn't noticed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
