### PR TITLE
Delete search index records when an edition becomes unindexable

### DIFF
--- a/app/services/service_listeners/search_indexer.rb
+++ b/app/services/service_listeners/search_indexer.rb
@@ -8,6 +8,10 @@ module ServiceListeners
 
         Whitehall::SearchIndex.add(edition)
         reindex_collection_documents
+      elsif edition.previous_edition&.can_index_in_search?
+        # If the previous edition was indexed but the current edition cannot be, we must delete the previous edition from the index
+        Whitehall::SearchIndex.delete(edition.previous_edition)
+        reindex_collection_documents
       end
     end
 

--- a/db/data_migration/20230816152924_remove_orphaned_edition_search_index_records.rb
+++ b/db/data_migration/20230816152924_remove_orphaned_edition_search_index_records.rb
@@ -1,0 +1,9 @@
+class RemoveOrphanedEditionSearchIndexRecords < ActiveRecord::Migration[7.0]
+  def change
+    # We want to find all editions which are publicly visible and therefore might once have been indexed, but are currently not searchable
+    # We then ask Search API to remove the record for these editions if a corresponding record is present
+    # Note that this doesn't seem to capture all foreign language content in the search index, but it has removed at least some
+    editions_with_possible_orphaned_search_index_records = Edition.publicly_visible.where.not(id: Edition.search_only.select(:id))
+    editions_with_possible_orphaned_search_index_records.each { |e| ServiceListeners::SearchIndexer.new(e).remove! }
+  end
+end

--- a/test/unit/app/services/service_listeners/search_indexer_test.rb
+++ b/test/unit/app/services/service_listeners/search_indexer_test.rb
@@ -41,6 +41,17 @@ class ServiceListeners::SearchIndexerTest < ActiveSupport::TestCase
     ServiceListeners::SearchIndexer.new(edition).index!
   end
 
+  test "#index! removes the edition from the search index if the current edition cannot be indexed, but the previous edition was indexed" do
+    english_edition = create(:news_article_world_news_story, :published)
+    ServiceListeners::SearchIndexer.new(english_edition).index!
+    non_english_edition = I18n.with_locale(:fr) do
+      create(:news_article_world_news_story, :published, primary_locale: :fr, document: english_edition.document)
+    end
+
+    expect_removal_from_index(english_edition)
+    ServiceListeners::SearchIndexer.new(non_english_edition).index!
+  end
+
   test "#remove! removes the edition from the search index" do
     edition = create(:published_news_article)
 


### PR DESCRIPTION
This commit solves an issue that resulted in 404s from some search results pages. At present, only English language content should appear in search results. Currently, if a document is created with a primary locale of English, and then the locale is switched to another language, the document will still appear in the search index. This is mostly commonly seen with consultation documents. This commit ensures that the document is deleted from the search index if it is no longer indexable, but the previous edition was.

This solution was preferred over preventing users from changing the locale of a document once it has been created, due to the disruption this would cause to their workflows. We believe it is common for users to create a draft consultation in English and then switch to Welsh where necessary.
