### PR TITLE
Redirect to document summary page after saving an edition

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -311,12 +311,15 @@ private
     if params[:save].present?
       [:edit, :admin, @edition]
     else
-      edit_admin_edition_tags_path(@edition.id)
+      admin_edition_path @edition
     end
   end
 
   def saved_confirmation_notice
-    { notice: "The document has been saved" }
+    link_path = edit_admin_edition_tags_path(@edition)
+    message = "Your document has been saved. You need to #{view_context.link_to 'add topic tags', link_path} before you can publish this document."
+
+    { flash: { notice: message, html_safe: true } }
   end
 
   def new_edition

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -316,10 +316,15 @@ private
   end
 
   def saved_confirmation_notice
-    link_path = edit_admin_edition_tags_path(@edition)
-    message = "Your document has been saved. You need to #{view_context.link_to 'add topic tags', link_path} before you can publish this document."
-
-    { flash: { notice: message, html_safe: true } }
+    if @edition.has_been_tagged? || params[:save].present?
+      notice = "Your document has been saved"
+      html_safe = false
+    else
+      link_path = edit_admin_edition_tags_path(@edition)
+      notice = "Your document has been saved. You need to #{view_context.link_to 'add topic tags', link_path} before you can publish this document."
+      html_safe = true
+    end
+    { flash: { notice:, html_safe: } }
   end
 
   def new_edition

--- a/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
+++ b/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
@@ -12,7 +12,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Save and continue",
+    text: "Save and go to document summary",
     secondary_solid: true,
     data_attributes: {
       module: "gem-track-click",

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -154,7 +154,7 @@
     <% end %>
     <% unless @edition_taxons.any? %>
       <%= render "govuk_publishing_components/components/warning_text", {
-        text: "Please add a tag before publishing"
+        text: "Add topic tags before you can publish this document."
       } %>
     <% end %>
   </section>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -154,7 +154,7 @@
     <% end %>
     <% unless @edition_taxons.any? %>
       <%= render "govuk_publishing_components/components/warning_text", {
-        text: "Add topic tags before you can publish this document."
+        text: "You need to add topic tags before you can publish this document."
       } %>
     <% end %>
   </section>

--- a/app/views/admin/statistics_announcements/show/_main.html.erb
+++ b/app/views/admin/statistics_announcements/show/_main.html.erb
@@ -135,7 +135,7 @@
     <% end %>
     <% unless @edition_taxons.any? %>
       <%= render "govuk_publishing_components/components/warning_text", {
-        text: "Please add a tag before publishing"
+        text: "Add topic tags before you can publish this document."
       } %>
     <% end %>
   </section>

--- a/app/views/admin/statistics_announcements/show/_main.html.erb
+++ b/app/views/admin/statistics_announcements/show/_main.html.erb
@@ -135,7 +135,7 @@
     <% end %>
     <% unless @edition_taxons.any? %>
       <%= render "govuk_publishing_components/components/warning_text", {
-        text: "Add topic tags before you can publish this document."
+        text: "You need to add topic tags before you can publish this document."
       } %>
     <% end %>
   </section>

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -6,8 +6,7 @@ When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/
       fill_in "URL of corresponding content", with: "http://www.#{nation_name}.com/"
     end
   end
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   add_external_attachment
 end
 

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -1,8 +1,7 @@
 When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/) do |title, location_name|
   begin_drafting_publication(title)
   select location_name, from: "World locations"
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   add_external_attachment
 end
 

--- a/features/step_definitions/call_for_evidence_steps.rb
+++ b/features/step_definitions/call_for_evidence_steps.rb
@@ -48,8 +48,7 @@ When(/^I save and publish the amended call for evidence$/) do
   ensure_path edit_admin_call_for_evidence_path(call_for_evidence)
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   publish force: true
 end
 

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -52,8 +52,7 @@ When(/^I save and publish the amended consultation$/) do
   ensure_path edit_admin_consultation_path(consultation)
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   publish force: true
 end
 

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -19,7 +19,6 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   publish(force: true)
 end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -145,9 +145,8 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   click_on "Create new edition"
   choose "Yes - information has been added, updated or removed"
   fill_in "edition_change_note", with: "changes"
-  click_button "Save and continue"
+  click_button "Save and go to document summary"
   save_screenshot
-  click_button "Update tags"
 
   click_on "Edit draft"
   click_on "Collection documents"

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -93,8 +93,7 @@ When("I force publish {edition}") do |edition|
   click_link "Edit draft"
   fill_in_change_note_if_required
   apply_to_all_nations_if_required
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   publish(force: true)
 end
 

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -10,14 +10,12 @@ end
 
 When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
 end
 
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   add_external_attachment
 end
 
@@ -25,16 +23,14 @@ Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   user = User.find_by(name: user_name)
   as_user(user) do
     begin_drafting_publication(title)
-    click_button "Save and continue"
-    click_button "Update tags"
+    click_button "Save and go to document summary"
   end
 end
 
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
   select data_set_name, from: "Statistical data sets"
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   add_external_attachment
 end
 

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -5,8 +5,7 @@ And(/^I add a review date of "([^"]*)" and the email address "([^"]*)" on the ed
     fill_in_date_fields(date)
     fill_in "Email address", with: email
   end
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
 end
 
 And(/^I add a review date of "([^"]*)" and the email address "([^"]*)"$/) do |date, email|

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -21,7 +21,8 @@ Then(/^I can tag it to some specialist sectors$/) do
 
   click_on "Edit draft"
   check "Applies to all UK nations"
-  click_on "Save and continue"
+  click_on "Save and go to document summary"
+  click_on "Add tags"
   click_on "Update and review specialist topic tags"
 
   expect("WELLS").to eq(find_field(primary_select).value)

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -7,8 +7,7 @@ Given(/^"([^"]*)" submitted a speech "([^"]*)" with body "([^"]*)"$/) do |author
   step %(I am a writer called "#{author}")
   visit new_admin_speech_path
   begin_drafting_speech(title:, body:)
-  click_button "Save and continue"
-  click_button "Update tags"
+  click_button "Save and go to document summary"
   click_button "Submit"
 end
 

--- a/features/step_definitions/statistical_data_set_steps.rb
+++ b/features/step_definitions/statistical_data_set_steps.rb
@@ -1,6 +1,5 @@
 When(/^I draft a new statistical data set "([^"]*)" for organisation "([^"]*)"$/) do |title, organisation_name|
   begin_drafting_statistical_data_set(title:)
   set_lead_organisation_on_document(Organisation.find_by(name: organisation_name))
-  click_button "Save and continue"
-  click_button "Update and review specialist topic tags"
+  click_button "Save and go to document summary"
 end

--- a/features/step_definitions/tagging_steps.rb
+++ b/features/step_definitions/tagging_steps.rb
@@ -1,5 +1,6 @@
 When(/^I continue to the tagging page$/) do
-  click_button "Save and continue"
+  click_button "Save and go to document summary"
+  click_link "Add tags"
 end
 
 When(/^I continue to the legacy tagging page$/) do

--- a/features/support/fatalities_helper.rb
+++ b/features/support/fatalities_helper.rb
@@ -4,8 +4,7 @@ module FatalitiesHelper
     begin_drafting_document type: "fatality_notice", title:, summary: "fatality notice summary", previously_published: false
     fill_in "Introduction", with: "fatality notice roll call introduction"
     select field, from: "Field of operation"
-    click_button "Save and continue"
-    click_button "Update and review specialist topic tags"
+    click_button "Save and go to document summary"
   end
 end
 

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -38,8 +38,9 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     edition = Edition.last
 
     assert page = @organisation.corporate_information_pages.last
-    assert_redirected_to edit_admin_edition_tags_path(edition.id)
-    assert_equal "The document has been saved", flash[:notice]
+    assert_redirected_to @controller.admin_edition_path(edition)
+    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+    assert_equal expected_message, flash[:notice]
     assert_equal corporate_information_page_attributes[:body], page.body
     assert_equal corporate_information_page_attributes[:corporate_information_page_type_id], page.corporate_information_page_type_id
     assert_equal corporate_information_page_attributes[:summary], page.summary
@@ -52,8 +53,9 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     edition = Edition.last
 
     assert page = organisation.corporate_information_pages.last
-    assert_redirected_to edit_admin_edition_tags_path(edition.id)
-    assert_equal "The document has been saved", flash[:notice]
+    assert_redirected_to @controller.admin_edition_path(edition)
+    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+    assert_equal expected_message, flash[:notice]
     assert_equal corporate_information_page_attributes[:body], page.body
     assert_equal corporate_information_page_attributes[:corporate_information_page_type_id], page.corporate_information_page_type_id
     assert_equal corporate_information_page_attributes[:summary], page.summary
@@ -88,8 +90,8 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
     assert_equal new_attributes[:body], corporate_information_page.body
     assert_equal new_attributes[:summary], corporate_information_page.summary
-    assert_equal "The document has been saved", flash[:notice]
-    assert_redirected_to edit_admin_edition_tags_path(edition.id)
+    assert_equal "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
+    assert_redirected_to @controller.admin_edition_path(edition)
   end
 
   view_test "PUT :update should redisplay form on failure" do

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -54,8 +54,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
     assert page = organisation.corporate_information_pages.last
     assert_redirected_to @controller.admin_edition_path(edition)
-    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
-    assert_equal expected_message, flash[:notice]
+    assert_equal "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
     assert_equal corporate_information_page_attributes[:body], page.body
     assert_equal corporate_information_page_attributes[:corporate_information_page_type_id], page.corporate_information_page_type_id
     assert_equal corporate_information_page_attributes[:summary], page.summary

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -7,18 +7,18 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
     login_as :writer
   end
 
-  test "POST :create redirects to edit page when 'Save and continue editing' button clicked" do
+  test "POST :create redirects to document summary page when 'Save and continue editing' button clicked" do
     params = attributes_for(:edition)
     assert_difference "GenericEdition.count" do
       post :create, params: { edition: params, save_and_continue: "Save and continue editing" }
     end
-    assert_redirected_to edit_admin_edition_tags_path(GenericEdition.last.id)
+    assert_redirected_to @controller.admin_edition_path(GenericEdition.last)
   end
 
-  test "PUT :update redirects to edit page when 'Save and continue' button clicked" do
+  test "PUT :update redirects to document summary page when 'Save and continue' button clicked" do
     edition = create(:edition)
     put :update, params: { id: edition, edition: { title: "New title" }, save_and_continue: "Save and continue editing" }
-    assert_redirected_to edit_admin_edition_tags_path(GenericEdition.last.id)
+    assert_redirected_to @controller.admin_edition_path(edition)
   end
 
   view_test "GET :edit shows the similar slug warning as an error which links to the input when user has 'Preview design system' permission" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -60,7 +60,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     publication = Publication.last
 
     assert publication.present?, assigns(:edition).errors.full_messages.inspect
-    assert_redirected_to edit_admin_edition_tags_path(publication.id)
+    assert_redirected_to @controller.admin_edition_path(publication)
     assert_equal publication, statistics_announcement.reload.publication
   end
 

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -228,7 +228,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     announcement_has_no_expanded_links(announcement.content_id)
     get :show, params: { id: announcement }
 
-    assert_select ".govuk-warning-text", /Please add a tag before publishing/
+    assert_select ".govuk-warning-text", /Add topic tags before you can publish this document./
     refute_select ".govuk-breadcrumbs__list"
   end
 

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -228,7 +228,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     announcement_has_no_expanded_links(announcement.content_id)
     get :show, params: { id: announcement }
 
-    assert_select ".govuk-warning-text", /Add topic tags before you can publish this document./
+    assert_select ".govuk-warning-text", /You need to add topic tags before you can publish this document./
     refute_select ".govuk-breadcrumbs__list"
   end
 

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -36,7 +36,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             visit edit_admin_news_article_path(edition)
             check "Limit access"
             click_button "Save"
-            assert_text "The document has been saved"
+            assert_text "Your document has been saved"
           end
 
           it "marks attachment as access limited in Asset Manager" do
@@ -55,7 +55,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             visit edit_admin_news_article_path(edition)
             uncheck "Limit access"
             click_button "Save"
-            assert_text "The document has been saved"
+            assert_text "Your document has been saved"
           end
 
           it "unmarks attachment as access limited in Asset Manager" do
@@ -347,7 +347,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
               visit edit_admin_news_article_path(edition)
               check "Limit access"
               click_button "Save"
-              assert_text "The document has been saved"
+              assert_text "Your document has been saved"
             end
 
             it "marks attachment as access limited in Asset Manager" do
@@ -364,7 +364,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
               visit edit_admin_news_article_path(edition)
               uncheck "Limit access"
               click_button "Save"
-              assert_text "The document has been saved"
+              assert_text "Your document has been saved"
             end
 
             it "unmarks attachment as access limited in Asset Manager" do

--- a/test/integration/race_condition_test.rb
+++ b/test/integration/race_condition_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class RaceConditionTest < ActionDispatch::IntegrationTest
   setup do
     stub_any_publishing_api_call
+    Edition.any_instance.stubs(:has_been_tagged?).returns(false)
   end
 
   # Monkeypatch to control response timings

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -78,7 +78,7 @@ module AdminEditionControllerTestHelpers
         assert_equal attributes[:body], edition.body
       end
 
-      test "create should take the writer to the topic tagging page" do
+      test "create should take the writer to the document summary page" do
         organisation = create(:organisation)
 
         attributes = controller_attributes_for(edition_type).merge(
@@ -92,9 +92,9 @@ module AdminEditionControllerTestHelpers
              }
 
         edition = edition_class.last
-
-        assert_redirected_to edit_admin_edition_tags_path(edition.id)
-        assert_equal "The document has been saved", flash[:notice]
+        assert_redirected_to @controller.admin_edition_path(edition)
+        expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        assert_equal expected_message, flash[:notice]
       end
 
       test "create should email content second line if the user is monitored" do
@@ -205,7 +205,7 @@ module AdminEditionControllerTestHelpers
         assert_equal "new-body", edition.body
       end
 
-      test "update should take the writer to the topic tagging page after updating" do
+      test "update should take the writer to the document summary page after updating" do
         edition = create(edition_type) # rubocop:disable Rails/SaveBang
 
         organisation = create(:organisation)
@@ -218,8 +218,9 @@ module AdminEditionControllerTestHelpers
               },
             }
 
-        assert_redirected_to edit_admin_edition_tags_path(edition.id)
-        assert_equal "The document has been saved", flash[:notice]
+        assert_redirected_to @controller.admin_edition_path(edition)
+        expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        assert_equal expected_message, flash[:notice]
       end
 
       test "update records the user who changed the edition" do


### PR DESCRIPTION
### What

We think as part of editor quick wins that we should remove the taxonomy from being the next page on save and continue, so that publishers don’t add it each time

Save and continue should go to the document summary

### Why

We believe that removing topic tags from the workflow will save publishers time when editing and help publishers stay on task.

We believe this will not have negative consequences when they first create a document and they'll be able to easily add topic tags from summary or a secondary nav instead

**We know this is true when:**

- We see overall less time spent on topic tags page (because instead of forcing publishes to land on it each time, they'll only navigate to topic tags when they actually need to)
- Positive feedback from publishers

**Trello**: https://trello.com/c/DcdTBWJv
