### PR TITLE
Prepare release 1.13

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -41,6 +41,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release && !Rails.env.test?
+
     current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
   end
   helper_method :preview_design_system?

--- a/app/controllers/admin/worldwide_office_translations_controller.rb
+++ b/app/controllers/admin/worldwide_office_translations_controller.rb
@@ -11,10 +11,7 @@ class Admin::WorldwideOfficeTranslationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[index confirm_destroy]
-    design_system_actions += %w[edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -70,10 +70,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy reorder]
-    design_system_actions += %w[index new create edit] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -69,10 +69,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy choose_main_office]
-    design_system_actions += %w[index show new create edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/app/controllers/admin/worldwide_organisations_translations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_translations_controller.rb
@@ -15,10 +15,7 @@ class Admin::WorldwideOrganisationsTranslationsController < Admin::BaseControlle
 private
 
   def get_layout
-    design_system_actions = %w[confirm_destroy]
-    design_system_actions += %w[index edit update] if preview_design_system?(next_release: false)
-
-    if design_system_actions.include?(action_name)
+    if preview_design_system?(next_release: true)
       "design_system"
     else
       "admin"

--- a/test/functional/admin/legacy_worldwide_offices_controller_test.rb
+++ b/test/functional/admin/legacy_worldwide_offices_controller_test.rb
@@ -8,7 +8,6 @@ class Admin::LegacyWorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "post create creates worldwide office" do
     worldwide_organisation = create(:worldwide_organisation)

--- a/test/functional/admin/legacy_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/legacy_worldwide_organisations_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::LegacyWorldwideOrganisationsControllerTest < ActionController::Test
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "shows a list of worldwide organisations" do
     organisation = create(:worldwide_organisation)

--- a/test/functional/admin/legacy_worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/legacy_worldwide_organisations_translations_controller_test.rb
@@ -13,7 +13,6 @@ class Admin::LegacyWorldwideOrganisationsTranslationsControllerTest < ActionCont
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { worldwide_organisation_id: @worldwide_organisation }

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "GET :edit correctly renders the form page for editing" do
     worldwide_organisation, office = create_worldwide_organisation_and_office

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -6,7 +6,6 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   test "shows a list of worldwide organisations" do
     organisation = create(:worldwide_organisation)

--- a/test/functional/admin/worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_translations_controller_test.rb
@@ -11,7 +11,6 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows a form to create missing translations" do
     get :index, params: { worldwide_organisation_id: @worldwide_organisation }


### PR DESCRIPTION
This PR make changes to the list of cards for preparing 1.13 release.
It does the following

It updates the get_layout method in each controller with "next_release: true".
It removes bootstrap implementation layout from controller test files.

**Trello:**
https://trello.com/c/4zKMVVJk/499-prepare-release-113
