### PR TITLE
Remove Access and opening tab from sub nav of world wide organisations

### DIFF
--- a/app/helpers/admin/worldwide_organisations_helper.rb
+++ b/app/helpers/admin/worldwide_organisations_helper.rb
@@ -33,11 +33,6 @@ module Admin::WorldwideOrganisationsHelper
         current: current_path == admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation),
       },
       {
-        label: "Access and opening times",
-        href: access_info_admin_worldwide_organisation_path(worldwide_organisation),
-        current: current_path == access_info_admin_worldwide_organisation_path(worldwide_organisation),
-      },
-      {
         label: "Social media accounts",
         href: admin_worldwide_organisation_social_media_accounts_path(worldwide_organisation),
         current: current_path == admin_worldwide_organisation_social_media_accounts_path(worldwide_organisation),

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -53,12 +53,14 @@ Feature: Administering worldwide organisation
     When I choose "Head office" to be the main office
     Then the "Head office" should be marked as the main office
 
+  @bootstrap-only
   Scenario: Adding default access information to a worldwide organisation
     Given a worldwide organisation "Department of Beards in France" with offices "Head office" and "Branch office"
     When I add default access information to the worldwide organisation
     Then I should see the default access information on the edit "Head office" office page
     And I should see the default access information on the edit "Branch office" office page
 
+  @bootstrap-only
   Scenario: Editing the default access information for a worldwide organisation
     Given a worldwide organisation "Department of Beards in France" with default access information
     When I edit the default access information for the worldwide organisation

--- a/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
+++ b/test/unit/app/helpers/admin/worldwide_organisations_helper_test.rb
@@ -10,7 +10,6 @@ class Admin::WorldwideOrganisationsHelperTest < ActionView::TestCase
       { label: "About", href: about_admin_worldwide_organisation_path(worldwide_organisation), current: false },
       { label: "Translations", href: admin_worldwide_organisation_translations_path(worldwide_organisation), current: false },
       { label: "Offices", href: admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation), current: false },
-      { label: "Access and opening times", href: access_info_admin_worldwide_organisation_path(worldwide_organisation), current: false },
       { label: "Social media accounts", href: admin_worldwide_organisation_social_media_accounts_path(worldwide_organisation), current: false },
       { label: "Pages", href: admin_worldwide_organisation_corporate_information_pages_path(worldwide_organisation), current: false },
       { label: "History", href: history_admin_worldwide_organisation_path(worldwide_organisation), current: false },


### PR DESCRIPTION
This PR removes access and opening times in sub nav.
It does the following

- Removes access and opening from worldwide organisations nav
- Updates related tests.

**Screen shots:**
**Before**
![image](https://github.com/alphagov/whitehall/assets/131259138/375183e5-3de1-405d-b92b-147225289c6b)

**After:**
![image](https://github.com/alphagov/whitehall/assets/131259138/56e989f8-8918-4ed1-a055-6fd189f2b13e)



**Trello:**
https://trello.com/c/h5e9TTkC/512-remove-access-and-opening-times-in-sub-nav
