### PR TITLE
Add confirm export page in the GOV.UK Design System

### DIFF
--- a/app/views/admin/editions/confirm_export.html.erb
+++ b/app/views/admin/editions/confirm_export.html.erb
@@ -1,19 +1,32 @@
-<% page_title "Export: #{@filter.page_title}"  %>
+<% content_for :page_title, "Export: #{@filter.page_title}" %>
+<% content_for :title, "Export CSV" %>
+<% content_for :context, @filter.page_title %>
+<% content_for :title_margin_bottom, 6 %>
 
-<div class="row">
-  <section class="col-md-8">
-    <h1>Export as CSV</h1>
-    <p>Please confirm you want to export the documents list. The following will be emailed to <strong><%= current_user.email %></strong>:</p>
-    <ul>
-      <li><%= @filter.page_title %></li>
-    </ul>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Please confirm you want to export the documents list to "<%= current_user.email %>"</p>
+
     <% if Whitehall.integration_or_staging? %>
-      <p class="warning">Warning: in staging and integration environments, if you are not on the permitted recipients list for GOV.UK Notify, this email will not be exported.</p>
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: "In staging and integration environments, if you are not on the permitted recipients list for GOV.UK Notify, this email will not be exported."
+      } %>
     <% end %>
-    <%= form_tag "#{export_admin_editions_path}?#{@filter.options.to_param}" %>
-      <%= submit_tag "Export as CSV", class: 'btn btn-primary' %>
 
-      <%= link_to "Cancel and return to list", "#{admin_editions_path}?#{@filter.options.to_param}", class: 'btn btn-default' %>
+    <%= form_with url: "#{export_admin_editions_path}?#{@filter.options.to_param}" %>
+      <div class="govuk-button-group govuk-!-margin-top-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Export CSV",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "edition-csv-export-button",
+            "track-label": "Export CSV"
+          }
+        } %>
+
+        <%= link_to("Cancel", "#{admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
     </form>
-  </section>
+  </div>
 </div>


### PR DESCRIPTION
## Description

This page was missed as part of the previous release which added the remaining edition pages in the GOV.UK Design System. After searching for a list of documents you can export them as a CSV. This is a confirm export page that emails a CSV of the results off to the user.

## Screenshots

### Before

<img width="776" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a8d25844-5d71-4315-86a7-4cffcc3b32bf">

### After

<img width="654" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ee57a3bb-f5fd-4d58-8b55-994facb225c7">

## Trello card

https://trello.com/c/ykN3bSTW/506-broken-css-styling-on-export-csv-under-documents-tab

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
