### PR TITLE
Apply remove orphaned edition search index records migration

### DIFF
--- a/db/data_migration/20230817121124_remove_orphaned_edition_search_index_records_two.rb
+++ b/db/data_migration/20230817121124_remove_orphaned_edition_search_index_records_two.rb
@@ -1,0 +1,5 @@
+# We want to find all editions which are publicly visible and therefore might once have been indexed, but are currently not searchable
+# We then ask Search API to remove the record for these editions if a corresponding record is present
+# Note that this doesn't seem to capture all foreign language content in the search index, but it has removed at least some
+editions_with_possible_orphaned_search_index_records = Edition.publicly_visible.where.not(id: Edition.search_only.select(:id))
+editions_with_possible_orphaned_search_index_records.each { |e| ServiceListeners::SearchIndexer.new(e).remove! }

--- a/db/data_migration/README.md
+++ b/db/data_migration/README.md
@@ -24,11 +24,20 @@ own rake task and database table for tracking which ones have been run.
 
 ## How to add one
 
-Just like a normal migration, there is a Rails command:
+There isn't currently a generator specifically for data migrations. The easiest way to
+generate one is to generate a normal Rails migration using the command below and then
+to move the new file to the `db/data_migration` directory.
 
 ```
   bundle exec rails g migration MyDataMigrationName
 ```
+
+**N.B. This will not generate a valid data migration! Data migrations are just plain Ruby
+scripts, not ActiveRecord migrations. Remove the contents of the generated migration before
+you start writing code.**
+
+Alternatively, you could manually create a new data migration and carefully name the file with
+a correct leading timestamp.
 
 ## How to run them
 


### PR DESCRIPTION
This is a correct implementation of https://github.com/alphagov/whitehall/commit/402f27c32721100a1c504416c8400c1db21c70ba. There are a number of documents appearing in search results which are written in a non-English language (we're aware of many Welsh language documents but there could be others). This migration finds all publicly visible documents which should not be searchable (we expect this to be largely non-English language documents) and attempts to ensure they are removed from the search index. Testing in the integration environment suggests that this does not remove all of the orphans but it has tidied up at least some of them.

I have also updated the data migration documentation. The previous instruction generated a plain Active Record migration, not a data migration, which caused the failure of the original attempt .