### PR TITLE
Add current release date foreign key to Statistics Announcments

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -28,7 +28,9 @@ class StatisticsAnnouncement < ApplicationRecord
            -> { order("created_at DESC") },
            class_name: "StatisticsAnnouncementDate",
            inverse_of: :statistics_announcement
-  has_many :statistics_announcement_dates, dependent: :destroy
+  has_many :statistics_announcement_dates,
+           -> { order(created_at: :asc, id: :asc) },
+           dependent: :destroy
 
   has_many :statistics_announcement_organisations, inverse_of: :statistics_announcement, dependent: :destroy
   has_many :organisations, through: :statistics_announcement_organisations
@@ -215,6 +217,12 @@ class StatisticsAnnouncement < ApplicationRecord
 
   def publishing_api_presenter
     PublishingApi::StatisticsAnnouncementPresenter
+  end
+
+  def update_current_release_date
+    latest = statistics_announcement_dates.reverse_order
+    update!(current_release_date_id: latest.pick(:id))
+    reload_current_release_date
   end
 
 private

--- a/app/models/statistics_announcement_date.rb
+++ b/app/models/statistics_announcement_date.rb
@@ -4,7 +4,7 @@ class StatisticsAnnouncementDate < ApplicationRecord
   belongs_to :statistics_announcement, touch: true
   belongs_to :creator, class_name: "User"
 
-  after_save :update_statistics_announcement_current_release_date
+  after_save :update_statistics_announcement_current_release_date, if: -> { statistics_announcement.present? }
 
   validates :release_date, presence: true
   validates :precision, presence: true, inclusion: { in: PRECISION.values }
@@ -24,7 +24,7 @@ class StatisticsAnnouncementDate < ApplicationRecord
 private
 
   def update_statistics_announcement_current_release_date
-    statistics_announcement.try(:reload_current_release_date)
+    statistics_announcement.update_current_release_date
   end
 
   def confirmed_date_must_be_exact

--- a/db/data_migration/20230817104012_backfill_current_release_date_id.rb
+++ b/db/data_migration/20230817104012_backfill_current_release_date_id.rb
@@ -1,0 +1,8 @@
+count = 0
+total = StatisticsAnnouncement.count
+StatisticsAnnouncement.find_each do |statistics_announcement|
+  latest = statistics_announcement.statistics_announcement_dates.reverse_order
+  statistics_announcement.update_column(:current_release_date_id, latest.pick(:id))
+  count += 1
+  puts "#{count}/#{total} completed"
+end

--- a/db/migrate/20230824075602_add_current_release_date_to_statistics_announcments.rb
+++ b/db/migrate/20230824075602_add_current_release_date_to_statistics_announcments.rb
@@ -1,0 +1,13 @@
+class AddCurrentReleaseDateToStatisticsAnnouncments < ActiveRecord::Migration[7.0]
+  def change
+    change_table :statistics_announcements, bulk: true do |t|
+      fk_options = {
+        to_table: :statistics_announcement_dates,
+        on_delete: :nullify,
+        on_update: :cascade,
+      }
+
+      t.references :current_release_date, foreign_key: fk_options, type: :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_22_071629) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_24_075602) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -992,8 +992,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_071629) do
     t.string "publishing_state", default: "published", null: false
     t.string "redirect_url"
     t.string "content_id", null: false
+    t.integer "current_release_date_id"
     t.index ["cancelled_by_id"], name: "index_statistics_announcements_on_cancelled_by_id"
     t.index ["creator_id"], name: "index_statistics_announcements_on_creator_id"
+    t.index ["current_release_date_id"], name: "index_statistics_announcements_on_current_release_date_id"
     t.index ["publication_id"], name: "index_statistics_announcements_on_publication_id"
     t.index ["slug"], name: "index_statistics_announcements_on_slug"
     t.index ["title"], name: "index_statistics_announcements_on_title"
@@ -1246,4 +1248,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_071629) do
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
+  add_foreign_key "statistics_announcements", "statistics_announcement_dates", column: "current_release_date_id", on_update: :cascade, on_delete: :nullify
 end

--- a/test/unit/app/models/statistics_announcement_date_test.rb
+++ b/test/unit/app/models/statistics_announcement_date_test.rb
@@ -58,4 +58,11 @@ class StatisticsAnnouncementDateTest < ActiveSupport::TestCase
       confirmed: true,
     ).valid?
   end
+
+  test "updates the statistics_announcements calls 'update_current_release_date' after save" do
+    statistics_announcement = build(:statistics_announcement)
+    statistics_announcement.expects(:update_current_release_date).times(3)
+    create(:statistics_announcement_date, statistics_announcement:)
+    create(:statistics_announcement_date, statistics_announcement:)
+  end
 end

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -279,6 +279,19 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     end
   end
 
+  test "updates the statistics_announcements current_release_date_id to the most recently created statistics_announcement_dates id" do
+    statistics_announcement = create(:statistics_announcement)
+    assert_equal statistics_announcement.statistics_announcement_dates.first.id, statistics_announcement.reload.current_release_date_id
+
+    statistics_announcement_date2 = create(:statistics_announcement_date, statistics_announcement:)
+
+    assert_equal statistics_announcement_date2.id, statistics_announcement.reload.current_release_date_id
+
+    statistics_announcement_date3 = create(:statistics_announcement_date, statistics_announcement:)
+
+    assert_equal statistics_announcement_date3.id, statistics_announcement.reload.current_release_date_id
+  end
+
 private
 
   def create_announcement_with_changes


### PR DESCRIPTION
## Description

We've recently run into an issue on the statistics announcements index page where ordering statistics announcements based on the release date isn't working correctly.

This is due to the ordering of the release dates not being scoped to the current_release_date. It's difficult to isolate the current_release_date for a statistics announcements due to it being a non-performant has_one association that orders release dates by DESC then selects the first one.

We've decided to treat this in the same way we did editions where we will persist the current_release_date's id as a column that lives on the statistics announcement. We can then join the announcements via the association ensuring that only the current_release_date is used when ordering by the release date.

There's prior art for this on documents here https://github.com/alphagov/whitehall/pull/6733

## Trello card 

https://trello.com/c/8578hcqj/335-statistic-announcements-ordering-borked

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
