### PR TITLE
Rename topic taxonomy to topic tags

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -1,6 +1,6 @@
-<% content_for :page_title, "#{@edition.title}: Topic taxonomy tags" %>
+<% content_for :page_title, "#{@edition.title}: Topic tags" %>
 <% content_for :context, @edition.title %>
-<% content_for :title, "Topic taxonomy tags" %>
+<% content_for :title, "Topic tags" %>
 
 <%= render 'admin/shared/tagging/taxonomy_group_description' %>
 

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -132,7 +132,7 @@
 
   <section class="app-view-summary__section app-view-summary__taxonomy-topics">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Topic taxonomy tags",
+      text: "Topic tags",
       heading_level: 2,
       font_size: "l",
       margin_bottom: 3,

--- a/app/views/admin/shared/tagging/_show_tags_box.html.erb
+++ b/app/views/admin/shared/tagging/_show_tags_box.html.erb
@@ -1,5 +1,5 @@
 <section class="taxonomy-topics" id="topic-new-taxonomy">
-  <h2>Topic taxonomy tags
+  <h2>Topic tags
     <%= link_to path_to_edit_tags, class:"btn btn-default pull-right" do %>
       <% if selected_taxon_paths.any? %>
         <span class="glyphicon glyphicon-edit"></span> Change tags

--- a/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-8 govuk-body" >
-      <p>The topic taxonomy groups content based on what it’s about.</p>
+      <p>The topic tags group content based on what it’s about.</p>
       <p>Choose the tag or tags that best describe what this content is about.</p>
       <p>You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
-      <p><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
+      <p><%= link_to "Find out more about tagging to the topic tags", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank" %> (open in new tab)</p>
     </div>
     <div class="govuk-!-margin-bottom-8 govuk-body">
       <p><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank" %> (open in new tab)</p>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Edit topics: " + @statistics_announcement.title %>
 <% content_for :context, @statistics_announcement.title %>
-<% content_for :title, "Topic taxonomy tags"%>
+<% content_for :title, "Topic tags"%>
 
 <%= render 'admin/shared/tagging/taxonomy_group_description' %>
 

--- a/app/views/admin/statistics_announcements/show/_main.html.erb
+++ b/app/views/admin/statistics_announcements/show/_main.html.erb
@@ -112,7 +112,7 @@
 
   <section class="app-view-summary__section">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Topic taxonomy tags",
+      text: "Topic tags",
       heading_level: 2,
       font_size: "l",
       margin_bottom: 3,

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -210,7 +210,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     get :edit, params: { edition_id: @edition }
 
     assert_select ".govuk-caption-xl", @edition[:title]
-    assert_select "h1", "Topic taxonomy tags"
+    assert_select "h1", "Topic tags"
     assert_select "h2", "Selected topics"
     assert_select "miller-columns", count: 1
     assert_select "miller-columns-selected", count: 1

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -152,7 +152,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "show a button to tag to the topic taxonomy" do
+  view_test "show a button to tag to the topic tags" do
     publication = create(:publication)
 
     publication_has_no_expanded_links(publication.content_id)


### PR DESCRIPTION
Trello card: https://trello.com/c/DcdTBWJv/1561-remove-topic-tags-from-the-editor-workflow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
