### PR TITLE
Turn off Whitehall what's new and feedback banner

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -3,7 +3,7 @@ en:
     feedback:
       show_banner: false
     whats_new:
-      show_banner: true
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates to Whitehall Publisher, content design guidance, or the design of GOV.UK.


### PR DESCRIPTION
## What

This PR turns off the banners in Whitehall so that neither the feedback or what's new banner shows

## Why

We've had the what's new banner up for review dates for a while and they have now been promoted 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
