### PR TITLE
Ensure document slug can never change once an edition has been published

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -81,7 +81,7 @@ class Document < ApplicationRecord
   end
 
   def update_slug_if_possible(new_title)
-    return if live? || invalid?
+    return if ever_published_editions.present? || invalid?
 
     candidate_slug = normalize_friendly_id(new_title)
     unless candidate_slug == slug

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -132,6 +132,15 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
     assert_equal "this-is-my-publication", existing_edition.document.reload.slug
   end
 
+  test "should not update slug when after an edition has been unpublished" do
+    unpublished_edition = create(:superseded_publication, title: "This is my publication")
+    draft_edition = create(:draft_publication, title: "This is my publication", document: unpublished_edition.document)
+
+    draft_edition.title = "New title"
+    draft_edition.save!
+    assert_equal "this-is-my-publication", draft_edition.document.reload.slug
+  end
+
   test "updating an edition updates the parent document timestamp" do
     edition = create(:edition)
 


### PR DESCRIPTION
### What?

Without this change, updating the title on the draft edition created after the previous edition was unpublished will cause the document slug to update. 

### Why?

The current behaviour is confusing for publishers, who are probably not aware that the document slug has changed when they update the title of the draft.

This has lead to them reporting that unpublishing is not working correctly, because they have expected to see the unpublishing notice or redirect at the new slug rather than the old one. They can easily reach the new slug by previewing on the draft stack and then changing the domain to the live stack in their browser address bar, but they will see a 404 instead of the unpublished notice/redirect.

Also, we probably don't want a re-published document to appear at a different slug, as documents are intended to be uniquely identifiable.

Trello: https://trello.com/c/nvJMKBRv
