### PR TITLE
Update current_release_date to use FK association

### DIFF
--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -72,14 +72,19 @@ private
   end
 
   def build_statistics_announcement(attributes = {})
-    if attributes[:current_release_date_attributes]
-      attributes[:current_release_date_attributes][:creator_id] = current_user.id
-    end
+    if attributes[:statistics_announcement_dates_attributes]
+      attributes[:statistics_announcement_dates_attributes][:creator_id] = current_user.id
+      date_attributes = attributes.delete(:statistics_announcement_dates_attributes)
 
-    current_user.statistics_announcements.new(attributes)
+      statistics_announcement = current_user.statistics_announcements.new(attributes)
+      statistics_announcement.statistics_announcement_dates.build(date_attributes)
+      statistics_announcement
+    else
+      current_user.statistics_announcements.new(attributes)
+    end
   end
 
-  def set_release_date_params(attributes = params[:statistics_announcement][:current_release_date_attributes])
+  def set_release_date_params(attributes = params[:statistics_announcement][:statistics_announcement_dates_attributes])
     return if attributes.blank?
 
     if attributes[:precision] == "exact_confirmed"
@@ -101,7 +106,7 @@ private
         :cancellation_reason,
         organisation_ids: [],
         topic_ids: [],
-        current_release_date_attributes: %i[id release_date precision confirmed],
+        statistics_announcement_dates_attributes: %i[id release_date precision confirmed],
       )
   end
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -28,7 +28,7 @@ class Publication < Publicationesque
   after_save :touch_statistics_announcement
   def touch_statistics_announcement
     if published? && !statistics_announcement.nil?
-      statistics_announcement.touch
+      statistics_announcement.reload.touch
     end
   end
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -52,7 +52,7 @@ class StatisticsAnnouncement < ApplicationRecord
               message: "must be a statistical type",
             }
 
-  accepts_nested_attributes_for :current_release_date
+  accepts_nested_attributes_for :statistics_announcement_dates
 
   scope :with_title_containing,
         lambda { |*keywords|

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -25,7 +25,10 @@ class StatisticsAnnouncement < ApplicationRecord
   belongs_to :publication
 
   has_one  :current_release_date,
-           -> { order("created_at DESC") },
+           lambda {
+             joins(:statistics_announcement)
+                .where("statistics_announcements.current_release_date_id = statistics_announcement_dates.id")
+           },
            class_name: "StatisticsAnnouncementDate",
            inverse_of: :statistics_announcement
   has_many :statistics_announcement_dates,
@@ -41,7 +44,7 @@ class StatisticsAnnouncement < ApplicationRecord
   validates :redirect_url, presence: { message: "must be provided when unpublishing an announcement" }, if: :unpublished?
   validates :redirect_url, uri: true, allow_blank: true
   validates :redirect_url, gov_uk_url_format: true, allow_blank: true
-  validates :title, :summary, :organisations, :creator, :current_release_date, presence: true
+  validates :title, :summary, :organisations, :creator, :statistics_announcement_dates, presence: true
   validates :cancellation_reason, presence: { message: "must be provided when cancelling an announcement" }, if: :cancelled?
   validates :publication_type_id,
             inclusion: {
@@ -49,7 +52,7 @@ class StatisticsAnnouncement < ApplicationRecord
               message: "must be a statistical type",
             }
 
-  accepts_nested_attributes_for :current_release_date, reject_if: :persisted?
+  accepts_nested_attributes_for :current_release_date
 
   scope :with_title_containing,
         lambda { |*keywords|

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -65,11 +65,11 @@
   } %>
 
   <% if statistics_announcement.new_record? %>
-      <%= render '/admin/shared/release_date', {
-        current_release_date: statistics_announcement.current_release_date,
-        name_prefix: "#{statistics_announcement.class.name&.underscore}[current_release_date_attributes]",
-        id_prefix: "#{statistics_announcement.class.name&.underscore}_current_release_date"
-      } %>
+    <%= render '/admin/shared/release_date', {
+      current_release_date: statistics_announcement.current_release_date,
+      name_prefix: "#{statistics_announcement.class.name&.underscore}[statistics_announcement_dates_attributes]",
+      id_prefix: "#{statistics_announcement.class.name&.underscore}_statistics_announcement_dates"
+    } %>
   <% end %>
 
   <div class="govuk-button-group govuk-!-margin-top-8">

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -20,14 +20,14 @@ Given(/^there are statistics announcements by my organisation$/) do
   @past_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.day.ago),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.day.ago)],
     publication: create(:draft_statistics),
   )
 
   @future_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.week.from_now),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.week.from_now)],
   )
 end
 
@@ -35,25 +35,25 @@ Given(/^there are statistics announcements by my organisation that are unlinked 
   @past_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.day.ago),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.day.ago)],
   )
 
   @tomorrow_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.day.from_now),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.day.from_now)],
   )
 
   @next_week_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.week.from_now),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.week.from_now)],
   )
 
   @next_year_announcement = create(
     :statistics_announcement,
     organisation_ids: [@user.organisation.id],
-    current_release_date: create(:statistics_announcement_date, release_date: 1.year.from_now),
+    statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.year.from_now)],
   )
 end
 

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -116,7 +116,7 @@ When(/^I announce an upcoming statistics publication called "(.*?)"$/) do |annou
   choose "statistics_announcement_publication_type_id_5" # Statistics
   fill_in :statistics_announcement_title, with: announcement_title
   fill_in :statistics_announcement_summary, with: "Summary of publication"
-  within "#statistics_announcement_current_release_date_release_date" do
+  within "#statistics_announcement_statistics_announcement_dates_release_date" do
     fill_in_date_and_time_field(1.year.from_now.to_s)
   end
   select organisation.name, from: :statistics_announcement_organisations

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
       end
 
       if evaluator.previous_display_date.present?
+        announcement.statistics_announcement_dates.first.save!
         announcement.statistics_announcement_dates <<
           create(
             :statistics_announcement_date_change,

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -12,22 +12,22 @@ FactoryBot.define do
     organisations { FactoryBot.build_list :organisation, 1 }
 
     association :creator, factory: :writer
-    association :current_release_date, factory: :statistics_announcement_date
+    statistics_announcement_dates { build_list(:statistics_announcement_date, 1) }
 
     after :build do |announcement, evaluator|
       if evaluator.release_date.present?
-        announcement.current_release_date.release_date = evaluator.release_date
+        announcement.statistics_announcement_dates.last.release_date = evaluator.release_date
       end
 
       if evaluator.change_note.present?
-        announcement.current_release_date.change_note = evaluator.change_note
+        announcement.statistics_announcement_dates.last.change_note = evaluator.change_note
       end
 
       if evaluator.previous_display_date.present?
         announcement.statistics_announcement_dates <<
           create(
             :statistics_announcement_date_change,
-            current_release_date: announcement.current_release_date,
+            current_release_date: announcement.statistics_announcement_dates.last,
             release_date: evaluator.previous_display_date,
           )
       end

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -20,12 +20,12 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     @future_announcement = create(
       :statistics_announcement,
       organisation_ids: [@organisation.id],
-      current_release_date: create(:statistics_announcement_date, release_date: 1.week.from_now),
+      statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.week.from_now)],
     )
     @past_announcement = create(
       :statistics_announcement,
       organisation_ids: [@organisation.id],
-      current_release_date: create(:statistics_announcement_date, release_date: 1.day.ago),
+      statistics_announcement_dates: [create(:statistics_announcement_date, release_date: 1.day.ago)],
     )
     @other_announcement = create(:statistics_announcement)
 
@@ -49,7 +49,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
              summary: "Summary text",
              publication_type_id: PublicationType::OfficialStatistics.id,
              organisation_ids: [@organisation.id],
-             current_release_date_attributes: {
+             statistics_announcement_dates_attributes: {
                release_date: 1.year.from_now,
                precision: StatisticsAnnouncementDate::PRECISION[:one_month],
              },
@@ -74,7 +74,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
              summary: "Summary text",
              publication_type_id: PublicationType::OfficialStatistics.id,
              organisation_ids: [@organisation.id],
-             current_release_date_attributes: {
+             statistics_announcement_dates_attributes: {
                release_date: 1.year.from_now,
                precision: "exact_confirmed",
              },

--- a/test/unit/app/models/admin/statistics_announcement_filter_test.rb
+++ b/test/unit/app/models/admin/statistics_announcement_filter_test.rb
@@ -187,7 +187,8 @@ class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
 private
 
   def statistics_announcement_for(datetime, attributes = {})
-    create(:statistics_announcement, attributes.reverse_merge(release_date: datetime))
+    statistics_announcement_date = build(:statistics_announcement_date, release_date: datetime)
+    create(:statistics_announcement, statistics_announcement_dates: [statistics_announcement_date], **attributes)
   end
 
   def filter(options = {})

--- a/test/unit/app/models/statistics_announcement_date_test.rb
+++ b/test/unit/app/models/statistics_announcement_date_test.rb
@@ -60,8 +60,8 @@ class StatisticsAnnouncementDateTest < ActiveSupport::TestCase
   end
 
   test "updates the statistics_announcements calls 'update_current_release_date' after save" do
-    statistics_announcement = build(:statistics_announcement)
-    statistics_announcement.expects(:update_current_release_date).times(3)
+    statistics_announcement = create(:statistics_announcement)
+    statistics_announcement.expects(:update_current_release_date).times(2)
     create(:statistics_announcement_date, statistics_announcement:)
     create(:statistics_announcement_date, statistics_announcement:)
   end

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -125,7 +125,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test "#build_statistics_announcement_date_change returns a date change based on the current date" do
-    announcement = build(:statistics_announcement)
+    announcement = create(:statistics_announcement)
     current_date = announcement.current_release_date
     date_change  = announcement.build_statistics_announcement_date_change
 
@@ -138,7 +138,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test "#build_statistics_announcement_date_change can override attributes" do
-    announcement = build(:statistics_announcement)
+    announcement = create(:statistics_announcement)
     current_date = announcement.current_release_date
     date_change  = announcement.build_statistics_announcement_date_change(change_note: "Some changes being made")
 
@@ -157,7 +157,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test 'a cancelled announcement is in a "cancelled" state, even when previously confirmed' do
-    announcement = build(:cancelled_statistics_announcement)
+    announcement = create(:cancelled_statistics_announcement)
     assert_equal "cancelled", announcement.state
 
     announcement.current_release_date.confirmed = true


### PR DESCRIPTION
## Description 

This updates the statistics_announcements model to use the new backfilled FK rather than mnaually sorting the statistics_announcement_dates based on the most recently created.

This will both be more performant and allow us to more easily scope and order DB queries based on the current_release_date of the statistics_announcement.

Using this in place of the current_release_date association in the factory requires us to update some tests to use create rather than build due to various callbacks occurring that require the current_release_date_id
to be persisted and the association reloaded.

## Trello card

https://trello.com/c/8578hcqj/335-statistic-announcements-ordering-borked
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
