### PR TITLE
Update statistics_announcement_filter to order on current_release_date

### DIFF
--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -75,24 +75,14 @@ module Admin
     end
 
     def unfiltered_scope
-      # We are doing a "greatest n by group" query here, but on a joined model,
-      # i.e. the StatisticsAnnouncementDate, or in this case the
-      # :current_release_date, which is the most recent one. The JOINs and the
-      # GROUP combine to ensure the correct things are loaded and in the correct
-      # order.
-      StatisticsAnnouncement.includes(:current_release_date, publication: :translations, organisations: :translations)
-                            .joins("INNER JOIN statistics_announcement_dates
-                              ON (statistics_announcement_dates.statistics_announcement_id = statistics_announcements.id)")
-                            .joins("LEFT OUTER JOIN statistics_announcement_dates sd2
-                              ON (sd2.statistics_announcement_id = statistics_announcements.id
-                              AND statistics_announcement_dates.created_at > sd2.created_at)")
-                            .group("statistics_announcement_dates.statistics_announcement_id")
+      StatisticsAnnouncement.joins(:current_release_date)
+                            .includes(publication: :translations, organisations: :translations)
                             .page(options[:page])
                             .per(options[:per_page])
     end
 
     def unlinked_scope
-      StatisticsAnnouncement.where("publication_id is NULL")
+      StatisticsAnnouncement.where(publication_id: nil)
     end
 
     def date_and_order_scope

--- a/test/unit/app/models/admin/statistics_announcement_filter_test.rb
+++ b/test/unit/app/models/admin/statistics_announcement_filter_test.rb
@@ -15,6 +15,13 @@ class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
                  filter.statistics_announcements
   end
 
+  test "ordering is scoped to a statistics announcements current_release_date" do
+    statistics_announcement1 = statistics_announcement_for(1.hour.from_now)
+    statistics_announcement2 = statistics_announcement_for(5.hours.from_now)
+    create(:statistics_announcement_date, release_date: 10.hours.from_now, statistics_announcement: statistics_announcement1)
+    assert_equal [statistics_announcement1, statistics_announcement2], filter.statistics_announcements
+  end
+
   test "filtering past releases returns them in reverse date order" do
     last_week  = statistics_announcement_for(1.week.ago)
     _future    = statistics_announcement_for(1.day.from_now)


### PR DESCRIPTION
## Description

This updates and simplfies the statistics_announcement_filter to order on the release date of the current_release_date.

Previously it was ordering on all statistics_release_dates which was causing the ordering on the index page to order things incorrectly.

## Before

<img width="1074" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/23a0b4f4-5f5a-4ba2-bb9d-e2a96eb7377d">
 
## After

<img width="1076" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e2a70f8b-a2d6-4171-bda0-bf5296da8d3b">

## Trello card

https://trello.com/c/8578hcqj/335-statistic-announcements-ordering-borked

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
