### PR TITLE
Update text for access limiting

### DIFF
--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Access limiting",
+    legend_text: "Limit access",
     heading_level: 3,
     heading_size: "l"
   } do %>
@@ -12,7 +12,7 @@
       error_items: errors_for(edition.errors, :access_limited),
       items: [
         {
-          label: "Limit access to producing organisations prior to publication",
+          label: "Limit access to publishers from organisations associated with this document before you publish",
           value: 1,
           checked: edition.access_limited,
         }

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -34,7 +34,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
         context "when document is marked as access limited in Whitehall" do
           before do
             visit edit_admin_news_article_path(edition)
-            check "Limit access to producing organisations prior to publication"
+            check "Limit access"
             click_button "Save"
             assert_text "The document has been saved"
           end
@@ -53,7 +53,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
           before do
             visit edit_admin_news_article_path(edition)
-            uncheck "Limit access to producing organisations prior to publication"
+            uncheck "Limit access"
             click_button "Save"
             assert_text "The document has been saved"
           end
@@ -345,7 +345,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
             before do
               visit edit_admin_news_article_path(edition)
-              check "Limit access to producing organisations prior to publication"
+              check "Limit access"
               click_button "Save"
               assert_text "The document has been saved"
             end
@@ -362,7 +362,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           context "when document is unmarked as access limited in Whitehall" do
             before do
               visit edit_admin_news_article_path(edition)
-              uncheck "Limit access to producing organisations prior to publication"
+              uncheck "Limit access"
               click_button "Save"
               assert_text "The document has been saved"
             end


### PR DESCRIPTION
## What

We know from user research that many users are confused what 'access limiting' does in Whitehall. This PR updates the text so that users are more informed

## Why

- Some users are unclear what access limiting does
- The text in Content Publisher is different and more clear
- We think more users might limit access if they know what it does

## Screenshot before

<img width="796" alt="Screenshot 2023-08-21 at 23 00 05" src="https://github.com/alphagov/whitehall/assets/55087909/a6326820-a24f-44b3-9af3-73efa92eab6c">

## Screenshot after

<img width="817" alt="Screenshot 2023-08-25 at 08 30 07" src="https://github.com/alphagov/whitehall/assets/55087909/7f8e1207-dd2d-454b-b31e-448c9eb61ae1">

## Trello card

https://trello.com/c/vhw09XML/1666-review-and-update-access-limiting-text

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
