### PR TITLE
Add a preview link to the edit page

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -59,6 +59,27 @@
           }
         } %>
       </div>
+
+      <% if !attachment.new_record? %>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          } do %>
+          <p class="govuk-body">
+            <%= link_to("Preview on website (opens in new tab)",
+            attachment.url(preview: true, full_url: true),
+            class: "govuk-link",
+            target: "_blank",
+            data: {
+              module: "gem-track-click",
+              "track-category": "button-clicked",
+              "track-action": "#{@edition.model_name.singular.dasherize}-button",
+              "track-label": "Preview on website",
+            })%>
+          </p>
+          <p class="govuk-body">
+            To preview your document on GOV.UK you must save it first.
+          </p>
+        <% end %>
+      <% end %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
     <div class="govuk-!-margin-bottom-8">

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -69,6 +69,27 @@
     } %>
   </div>
 
+  <% if !edition.new_record? && @edition.versioning_completed? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      } do %>
+      <p class="govuk-body">
+        <%= link_to("Preview on website (opens in new tab)",
+        @edition.public_url(draft: true, locale: @edition.primary_locale),
+        class: "govuk-link",
+        target: "_blank",
+        data: {
+          module: "gem-track-click",
+          "track-category": "button-clicked",
+          "track-action": "#{@edition.model_name.singular.dasherize}-button",
+          "track-label": "Preview on website",
+        }) %>
+      </p>
+      <p class="govuk-body">
+        To preview your document on GOV.UK you must save it first.
+      </p>
+    <% end %>
+  <% end %>
+
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
   <% if edition.document && edition.document.live? && can?(:mark_political, edition) %>

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -27,9 +27,13 @@ Feature: Managing attachments on editions
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
-    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    And I begin editing an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    Then I cannot see a preview link
+    When I save the attachment
     Then I can see the attachment title "Beard Length Graphs 2012"
     And I can see the preview link to the attachment "HTML attachment"
+    When I edit the attachment
+    Then I can see a preview link
 
   Scenario: Adding attachments on consultation responses
     Given I am a writer

--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -4,3 +4,9 @@ Feature: Previewing unpublished editions
     Given I am an editor
     When I draft a new publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
+
+  Scenario: Unpublished editions link to preview from the edit page
+    Given I am an editor
+    When I draft a new publication "Test publication"
+    When I am on the edit page for publication "Test publication"
+    Then I should see a link to the preview version of the publication "Test publication"

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -13,6 +13,21 @@ When(/^I upload a file attachment with the title "(.*?)" and the file "(.*?)"$/)
   click_on "Save"
 end
 
+When(/^I begin editing an html attachment with the title "(.*?)" and the body "(.*?)"$/) do |title, body|
+  click_on "Add new HTML attachment"
+  fill_in "Title", with: title
+  fill_in "Body", with: body
+  check "Use manually numbered headings"
+end
+
+When(/^I save the attachment$/) do
+  click_on "Save"
+end
+
+When(/^I edit the attachment$/) do
+  click_on "Edit attachment"
+end
+
 When(/^I upload an html attachment with the title "(.*?)" and the body "(.*?)"$/) do |title, body|
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
@@ -83,6 +98,14 @@ end
 
 Then(/^I can see the preview link to the attachment "(.*?)"$/) do |attachment_title|
   expect(page).to have_link("a", href: /draft-origin/, text: attachment_title)
+end
+
+Then(/^I cannot see a preview link$/) do
+  expect(page).to_not have_link("a", href: /draft-origin/)
+end
+
+Then(/^I can see a preview link$/) do
+  expect(page).to have_link("a", href: /draft-origin/)
 end
 
 When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)"$/) do |title, isbn|


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Add a link to the preview a document directly below the body field when a document is saved, publicly visible and has an appropriate change note.
- Add a link to preview an HTML Attachment in the edit page.

https://trello.com/c/sNmuIgvs/1562-add-document-preview-link-to-edit-screens

# Why
- To reduce the clicks for editors to preview back and forth.

# Screenshot
![whitehall-admin dev gov uk_government_admin_editions_1374136_attachments_sed-fringilla-mauris-sit-amet_edit(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/54fda25a-1777-4251-a8b9-9bba65b24d09)
