### PR TITLE
Retain a users org when resetting search fields on document search page

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -351,4 +351,14 @@ module Admin::EditionsHelper
       edition.state.capitalize
     end
   end
+
+  def reset_search_fields_query_string_params(user, filter_action, anchor)
+    query_string_params = if user.organisation.present? && filter_action == admin_editions_path
+                            "?state=active&organisation=#{user.organisation.id}"
+                          else
+                            "?state=active"
+                          end
+
+    filter_action + query_string_params + anchor
+  end
 end

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -148,6 +148,7 @@
       }
     } %>
 
-    <p class="govuk-body"><%= link_to "Reset all fields", filter_action + "?state=active" + anchor, class: "govuk-link" %></p>
+    <p class="govuk-body">
+    <%= link_to "Reset all fields", reset_search_fields_query_string_params(current_user, filter_action, anchor), class: "govuk-link" %></p>
   <% end %>
 </div>

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -50,4 +50,27 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     LinkCheckerApiService.expects(:has_links?).never
     show_link_check_report?(edition)
   end
+
+  test "#reset_search_fields_query_string_params returns the correct params when the user has no organisation" do
+    user = build_stubbed(:user)
+    expected_result = "#{admin_editions_path}?state=active#anchor"
+
+    assert_equal expected_result, reset_search_fields_query_string_params(user, admin_editions_path, "#anchor")
+  end
+
+  test "#reset_search_fields_query_string_params returns the correct params when the user belongs to an organisation and the filter action isn't the admin_editions_path" do
+    organisation = build_stubbed(:organisation)
+    user = build_stubbed(:user, organisation:)
+    expected_result = "/any-other-path?state=active#anchor"
+
+    assert_equal expected_result, reset_search_fields_query_string_params(user, "/any-other-path", "#anchor")
+  end
+
+  test "#reset_search_fields_query_string_params returns the correct params when the user belongs to an organisation and the filter action is the admin_editions_path" do
+    organisation = build_stubbed(:organisation)
+    user = build_stubbed(:user, organisation:)
+    expected_result = "#{admin_editions_path}?state=active&organisation=#{organisation.id}#anchor"
+
+    assert_equal expected_result, reset_search_fields_query_string_params(user, admin_editions_path, "#anchor")
+  end
 end


### PR DESCRIPTION
## Description

At the moment, when you're searching for a document and click the "Reset all fields" it doesn't retain the users organisation and shows documents from all organisation's.

As the filter_options partial is reused across multiple views, some of which don't have the option to filter by organisation, we need to ensure that only the document search page is affected.

This adds in a helper method which handles this.

## Trello card

https://trello.com/c/NFLPGBCm/422-reset-all-fields-on-document-list-should-reset-to-your-department-not-everyone

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
