### PR TITLE
Enable es6 for standardx

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,23 +16,18 @@
     "env": {
       "browser": true,
       "jquery": true,
-      "jasmine": true
+      "jasmine": true,
+      "es6": true
     },
     "globals": [
       "GOVUK",
       "GOVUKAdmin"
     ],
     "ignore": [
-      "app/assets/javascripts/vendor/"
+      "app/assets/javascripts/vendor/",
+      "app/assets/javascripts/admin_legacy/**/*",
+      "spec/javascripts/admin_legacy/**/*"
     ]
-  },
-  "eslintConfig": {
-    "env": {
-      "es6": true
-    },
-    "rules": {
-      "no-var": 0
-    }
   },
   "dependencies": {
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Enable es6 for standardx

# Why
- Now that we don't need to support IE11 we can use es6 syntax across the application.
