### PR TITLE
Update historical accounts associations to reflect usage and fix bugs

### DIFF
--- a/app/controllers/admin/historical_accounts_controller.rb
+++ b/app/controllers/admin/historical_accounts_controller.rb
@@ -4,15 +4,15 @@ class Admin::HistoricalAccountsController < Admin::BaseController
   layout "design_system"
 
   def index
-    @historical_accounts = @person.historical_accounts.includes(roles: :translations)
+    @historical_account = @person.historical_account
   end
 
   def new
-    @historical_account = @person.historical_accounts.build
+    @historical_account = @person.build_historical_account
   end
 
   def create
-    @historical_account = @person.historical_accounts.build(historical_account_params)
+    @historical_account = @person.build_historical_account(historical_account_params)
     if @historical_account.save
       redirect_to admin_person_historical_accounts_url(@person), notice: "Historical account created"
     else
@@ -31,7 +31,7 @@ class Admin::HistoricalAccountsController < Admin::BaseController
   end
 
   def confirm_destroy
-    @roles = @historical_account.roles.collect(&:name).to_sentence
+    @roles = @historical_account.role.name
   end
 
   def destroy
@@ -46,7 +46,7 @@ private
   end
 
   def load_historical_account
-    @historical_account = @person.historical_accounts.find(params[:id])
+    @historical_account = @person.historical_account
   end
 
   def historical_account_params

--- a/app/controllers/admin/historical_accounts_controller.rb
+++ b/app/controllers/admin/historical_accounts_controller.rb
@@ -8,12 +8,13 @@ class Admin::HistoricalAccountsController < Admin::BaseController
   end
 
   def new
-    @historical_account = @person.build_historical_account
+    @historical_account = @person.build_historical_account(role: Role.prime_minister_role)
   end
 
   def create
-    @historical_account = @person.build_historical_account(historical_account_params)
-    if @historical_account.save
+    @historical_account = @person.build_historical_account(role: Role.prime_minister_role)
+
+    if @historical_account.update(historical_account_params)
       redirect_to admin_person_historical_accounts_url(@person), notice: "Historical account created"
     else
       render :new
@@ -57,7 +58,6 @@ private
       :died,
       :major_acts,
       :interesting_facts,
-      role_ids: [],
       political_party_ids: [],
     )
   end

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -2,14 +2,14 @@ class HistoricalAccount < ApplicationRecord
   include PublishesToPublishingApi
 
   belongs_to :person, inverse_of: :historical_account
-  has_many   :historical_account_roles
-  has_many   :roles, through: :historical_account_roles
+  has_one   :historical_account_role
+  has_one   :role, through: :historical_account_role
 
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
-  validates :person, :roles, :summary, :body, :political_parties, presence: true
+  validates :person, :role, :summary, :body, :political_parties, presence: true
   validates :born, :died, length: { maximum: 256 }
-  validate :roles_support_historical_accounts
+  validate :roles_support_historical_accounts, if: -> { role.present? }
   validate :validate_correct_political_party
   after_save :republish_prime_ministers_index_page_to_publishing_api
   after_destroy :republish_prime_ministers_index_page_to_publishing_api
@@ -36,10 +36,6 @@ class HistoricalAccount < ApplicationRecord
 
   def political_membership
     political_parties.collect(&:membership).to_sentence
-  end
-
-  def role
-    roles.first
   end
 
   def republish_prime_ministers_index_page_to_publishing_api
@@ -69,12 +65,12 @@ class HistoricalAccount < ApplicationRecord
 private
 
   def previous_prime_minister?
-    roles.map(&:slug).include?("prime-minister")
+    role.slug == "prime-minister"
   end
 
   def roles_support_historical_accounts
-    unless roles.all?(&:supports_historical_accounts?)
-      errors.add(:base, "The selected role(s) do not all support historical accounts")
+    unless role.supports_historical_accounts?
+      errors.add(:base, "The selected role does not support historical accounts")
     end
   end
 

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -1,7 +1,7 @@
 class HistoricalAccount < ApplicationRecord
   include PublishesToPublishingApi
 
-  belongs_to :person, inverse_of: :historical_accounts
+  belongs_to :person, inverse_of: :historical_account
   has_many   :historical_account_roles
   has_many   :roles, through: :historical_account_roles
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -20,7 +20,7 @@ class Person < ApplicationRecord
   has_many :organisation_roles, through: :current_roles
   has_many :organisations, through: :organisation_roles
 
-  has_many :historical_accounts, inverse_of: :person
+  has_one :historical_account, inverse_of: :person
 
   validates :name, presence: true
   validates_with SafeHtmlValidator

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -59,6 +59,10 @@ class Role < ApplicationRecord
   include TranslatableModel
   translates :name, :responsibilities
 
+  def self.prime_minister_role
+    find_by(slug: "prime-minister")
+  end
+
   def republish_organisations_to_publishing_api
     organisations.each do |organisation|
       republish_organisation_to_publishing_api(organisation)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -31,8 +31,8 @@ class Role < ApplicationRecord
   has_many :worldwide_organisation_roles, inverse_of: :role
   has_many :worldwide_organisations, through: :worldwide_organisation_roles
 
-  has_many :historical_account_roles, inverse_of: :role
-  has_many :historical_accounts, through: :historical_account_roles
+  has_one :historical_account_role, inverse_of: :role
+  has_one :historical_account, through: :historical_account_role
 
   scope :alphabetical_by_person,     -> { includes(:current_people, :organisations).order("people.surname", "people.forename") }
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -162,9 +162,7 @@ class RoleAppointment < ApplicationRecord
     ended_at.nil? || date <= ended_at
   end
 
-  def historical_account
-    person.historical_accounts.includes(:roles).detect { |historical_account| historical_account.roles.include?(role) }
-  end
+  delegate :historical_account, to: :person
 
   def has_historical_account?
     historical_account.present?

--- a/app/presenters/publishing_api/historical_account_presenter.rb
+++ b/app/presenters/publishing_api/historical_account_presenter.rb
@@ -54,14 +54,14 @@ module PublishingApi
         .distinct(&:person)
         .order(:started_at)
         .map(&:person)
-        .select { |person| person.historical_accounts.present? }
+        .select { |person| person.historical_account.present? }
 
       person_to_present = historical_account.person
 
       return [] unless all_appointees.include?(person_to_present)
 
       neighbouring_role_holders(all_appointees, person_to_present).map do |person|
-        person.historical_accounts.for_role(role.id).first.content_id
+        person.historical_account.content_id
       end
     end
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -1,26 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for [:admin, person, historical_account] do |form| %>
-      <%= render "components/autocomplete", {
-        id: "historical_account_roles",
-        name: "historical_account[role_ids][]",
-        error_items: errors_for(historical_account.errors, :roles),
-        label: {
-          text: "Role(s) (required)",
-          heading_size: "l",
-        },
-        select: {
-          options: (person.roles.where(supports_historical_accounts: true).distinct.map do |role|
-            [
-              role.name,
-              role.id,
-            ]
-          end),
-          multiple: true,
-          selected: historical_account.role_ids,
-        },
-      } %>
-
       <%= render "govuk_publishing_components/components/character_count", {
         textarea: {
           label: {

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -31,7 +31,7 @@
       margin_bottom: 6,
     } %>
 
-    <% if @person.can_have_historical_accounts? && @historical_accounts.present? %>
+    <% if @person.can_have_historical_accounts? && @historical_account.present? %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Create new historical account",
         href: new_admin_person_historical_account_path,
@@ -51,23 +51,22 @@
               text: tag.span("Actions", class: "govuk-visually-hidden"),
             }
           ],
-          rows: @historical_accounts.map do |historical_account|
-            roles = historical_account.roles.collect(&:name).to_sentence
-
+          rows:
             [
-              {
-                text: roles,
-              },
-              {
-                text: historical_account.summary,
-              },
-              {
-                text: link_to(sanitize("View #{tag.span(roles, class: 'govuk-visually-hidden')}"), Whitehall.public_host + historical_account.public_path, class: "govuk-link") +
-                  link_to(sanitize("Edit #{tag.span(roles, class: 'govuk-visually-hidden')}"), edit_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2") +
-                  link_to(sanitize("Delete #{tag.span(roles, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_historical_account_path(@person, historical_account), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive"),
-              }
+              [
+                {
+                  text: @historical_account.role.name,
+                },
+                {
+                  text: @historical_account.summary,
+                },
+                {
+                  text: link_to(sanitize("View #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), Whitehall.public_host + @historical_account.public_path, class: "govuk-link") +
+                    link_to(sanitize("Edit #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), edit_admin_person_historical_account_path(@person, @historical_account), class: "govuk-link govuk-!-margin-left-2") +
+                    link_to(sanitize("Delete #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_historical_account_path(@person, @historical_account), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive"),
+                }
+              ]
             ]
-          end
         } %>
       </div>
     <% elsif @person.can_have_historical_accounts? %>

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -32,12 +32,6 @@
     } %>
 
     <% if @person.can_have_historical_accounts? && @historical_account.present? %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Create new historical account",
-        href: new_admin_person_historical_account_path,
-        margin_bottom: 4,
-      } %>
-
       <div class="app-view-historical-accounts-index__table govuk-table--with-actions">
         <%= render "govuk_publishing_components/components/table", {
           head: [

--- a/test/factories/historical_accounts.rb
+++ b/test/factories/historical_accounts.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     political_parties { [PoliticalParty::Labour] }
 
     after(:build) do |account|
-      if account.roles.blank?
-        account.roles << build(:historic_role_appointment, person: account.person).role
+      if account.role.blank?
+        account.role = build(:historic_role_appointment, person: account.person).role
       end
     end
   end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -15,10 +15,6 @@ FactoryBot.define do
     type { "permanent_secretary" }
   end
 
-  factory :historic_role, parent: :ministerial_role do
-    supports_historical_accounts { true }
-  end
-
   trait :occupied do
     after :create do |role, _|
       role.role_appointments = [FactoryBot.create(:role_appointment)]
@@ -31,7 +27,7 @@ FactoryBot.define do
     end
   end
 
-  factory :prime_minister_role, class: MinisterialRole do
+  factory :prime_minister_role, class: MinisterialRole, aliases: %i[historic_role] do
     name { "Prime Minister" }
     slug { "prime-minister" }
     role_type { "minister" }

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -16,7 +16,19 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
     assert_equal @person, assigns(:person)
     assert_equal @person.historical_account, assigns(:historical_account)
   end
+  view_test "GET on :index should not show Create historical accounts button when historical account is already created" do
+    @historical_account = create(:historical_account, person: @person, role: @role)
+    get :index, params: { person_id: @person }
 
+    assert_select(".govuk-button", text: "Create historical account", count: 0)
+  end
+
+  view_test "GET on :index should show Create historical accounts button when historical account is not created" do
+    create(:historic_role_appointment, person: @person, role: @role)
+    get :index, params: { person_id: @person }
+
+    assert_select(".govuk-button", text: "Create historical account", count: 1)
+  end
   test "GET on :new assigns the person, a fresh historical account and renders the :new template" do
     get :new, params: { person_id: @person }
 

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -31,7 +31,6 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
     historical_account_params = {
       summary: "Summary",
       body: "Body",
-      role_ids: [@role.id],
       political_party_ids: [PoliticalParty::Labour.id],
       interesting_facts: "Stuff",
       major_acts: "Mo Stuff",

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -5,16 +5,16 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
     login_as :writer
     @person = create(:person)
     @role = create(:historic_role)
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
   end
 
   test "GET on :index assigns the person, their historical accounts and renders the :index template" do
+    @historical_account = create(:historical_account, person: @person, roles: [@role])
     get :index, params: { person_id: @person }
 
     assert_response :success
     assert_template :index
     assert_equal @person, assigns(:person)
-    assert_equal @person.historical_accounts, assigns(:historical_accounts)
+    assert_equal @person.historical_account, assigns(:historical_account)
   end
 
   test "GET on :new assigns the person, a fresh historical account and renders the :new template" do
@@ -37,13 +37,11 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
       major_acts: "Mo Stuff",
     }
 
-    assert_difference("@person.historical_accounts.count") do
-      post :create, params: { person_id: @person, historical_account: historical_account_params }
-    end
+    post :create, params: { person_id: @person, historical_account: historical_account_params }
 
     assert_redirected_to admin_person_historical_accounts_path(@person)
 
-    historical_account = @person.historical_accounts.last
+    historical_account = @person.historical_account
     assert_equal [@role], historical_account.roles
     assert_equal "Summary", historical_account.summary
     assert_equal "Body", historical_account.body
@@ -53,14 +51,14 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "POST on :create with invalid paramters re-renders :new template" do
-    assert_no_difference("@person.historical_accounts.count") do
-      post :create, params: { person_id: @person, historical_account: { summary: "Only summary" } }
-    end
+    post :create, params: { person_id: @person, historical_account: { summary: "Only summary" } }
+
     assert_template :new
     assert_equal "Only summary", assigns(:historical_account).summary
   end
 
   test "GET on :edit loads the historical account and renders the :edit template" do
+    @historical_account = create(:historical_account, person: @person, roles: [@role])
     get :edit, params: { person_id: @person, id: @historical_account }
 
     assert_response :success
@@ -70,6 +68,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "PUT on :update updates the details of the historical account" do
+    @historical_account = create(:historical_account, person: @person, roles: [@role])
     put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: "New summary" } }
 
     assert_redirected_to admin_person_historical_accounts_path(@person)
@@ -77,6 +76,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "PUT on :update with invalid paramters re-renders the :edit template" do
+    @historical_account = create(:historical_account, person: @person, roles: [@role])
     summary_before = @historical_account.summary
     put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: "" } }
     assert_template :edit
@@ -85,6 +85,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "Delete on :destroy destroys the historical account" do
+    @historical_account = create(:historical_account, person: @person, roles: [@role])
     delete :destroy, params: { person_id: @person, id: @historical_account }
     assert_not HistoricalAccount.exists?(@historical_account.id)
     assert_redirected_to admin_person_historical_accounts_path(@person)

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "GET on :index assigns the person, their historical accounts and renders the :index template" do
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
+    @historical_account = create(:historical_account, person: @person, role: @role)
     get :index, params: { person_id: @person }
 
     assert_response :success
@@ -42,7 +42,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
     assert_redirected_to admin_person_historical_accounts_path(@person)
 
     historical_account = @person.historical_account
-    assert_equal [@role], historical_account.roles
+    assert_equal @role, historical_account.role
     assert_equal "Summary", historical_account.summary
     assert_equal "Body", historical_account.body
     assert_equal [PoliticalParty::Labour], historical_account.political_parties
@@ -58,7 +58,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "GET on :edit loads the historical account and renders the :edit template" do
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
+    @historical_account = create(:historical_account, person: @person, role: @role)
     get :edit, params: { person_id: @person, id: @historical_account }
 
     assert_response :success
@@ -68,7 +68,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "PUT on :update updates the details of the historical account" do
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
+    @historical_account = create(:historical_account, person: @person, role: @role)
     put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: "New summary" } }
 
     assert_redirected_to admin_person_historical_accounts_path(@person)
@@ -76,7 +76,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "PUT on :update with invalid paramters re-renders the :edit template" do
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
+    @historical_account = create(:historical_account, person: @person, role: @role)
     summary_before = @historical_account.summary
     put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: "" } }
     assert_template :edit
@@ -85,7 +85,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "Delete on :destroy destroys the historical account" do
-    @historical_account = create(:historical_account, person: @person, roles: [@role])
+    @historical_account = create(:historical_account, person: @person, role: @role)
     delete :destroy, params: { person_id: @person, id: @historical_account }
     assert_not HistoricalAccount.exists?(@historical_account.id)
     assert_redirected_to admin_person_historical_accounts_path(@person)

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -385,14 +385,6 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     assert_equal historical_account, role_appointment.reload.historical_account
   end
 
-  test "does not return an historical account if the appointee has one for another role" do
-    role_appointment   = create(:historic_role_appointment)
-    second_appointment = create(:historic_role_appointment, person: role_appointment.person)
-    create(:historical_account, roles: [second_appointment.role], person: role_appointment.person)
-
-    assert_nil role_appointment.historical_account
-  end
-
   test "can scope appointments between dates" do
     today       = create(:role_appointment, started_at: Time.zone.now)
     last_month  = create(:role_appointment, started_at: 1.month.ago)

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -381,7 +381,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     assert_nil role_appointment.historical_account
 
-    historical_account = create(:historical_account, roles: [role_appointment.role], person: role_appointment.person)
+    historical_account = create(:historical_account, role: role_appointment.role, person: role_appointment.person)
     assert_equal historical_account, role_appointment.reload.historical_account
   end
 
@@ -461,7 +461,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
                                  died: "1975",
                                  interesting_facts: "They were a very interesting person",
                                  major_acts: "Significant legislation changes",
-                                 roles: [role])
+                                 role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)

--- a/test/unit/app/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_account_presenter_test.rb
@@ -61,7 +61,7 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
 
     expected_links = {
       person: [historical_account.person.content_id],
-      ordered_related_items: [person2.historical_accounts.first.content_id],
+      ordered_related_items: [person2.historical_account.content_id],
       parent: %w[db95a864-874f-4f50-a483-352a5bc7ba18],
     }
 

--- a/test/unit/app/presenters/publishing_api/historical_account_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_account_presenter_test.rb
@@ -13,11 +13,11 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
                                 died: "1975",
                                 interesting_facts: "They were a very interesting person",
                                 major_acts: "Significant legislation changes",
-                                roles: [role])
+                                role:)
 
     person2 = create(:person, forename: "Some Other", surname: "Person")
     create(:historic_role_appointment, person: person2, role:, started_at: Date.civil(1940), ended_at: Date.civil(1950))
-    historical_account2 = create(:historical_account, person: person2, roles: [role])
+    historical_account2 = create(:historical_account, person: person2, role:)
 
     public_path = "/government/history/past-prime-ministers/some-person"
 
@@ -80,7 +80,7 @@ class PublishingApi::HistoricalAccountPresenterTest < ActiveSupport::TestCase
     historical_accounts_in_descending_order = (0..7).to_a.map do |i|
       person = create(:person, forename: "Prime Minister #{i}")
       create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950 - i), ended_at: Date.civil(1950 - i))
-      create(:historical_account, person:, roles: [role])
+      create(:historical_account, person:, role:)
     end
 
     # Related prime ministers for each individual prime minister should be based on a sliding window of the surrounding historical accounts

--- a/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -11,7 +11,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
                                  died: "1975",
                                  interesting_facts: "They were a very interesting person",
                                  major_acts: "Significant legislation changes",
-                                 roles: [@role])
+                                 role: @role)
   end
 
   test "presents a valid content item" do

--- a/test/unit/lib/present_page_to_publishing_api_test.rb
+++ b/test/unit/lib/present_page_to_publishing_api_test.rb
@@ -12,7 +12,7 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     role = create(:prime_minister_role)
     person = create(:person, forename: "Some", surname: "Person")
     create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
-    create(:historical_account, person:, born: "1900", died: "1975", roles: [role])
+    create(:historical_account, person:, born: "1900", died: "1975", role:)
 
     assert_content_is_presented_to_publishing_api(PublishingApi::HistoricalAccountsIndexPresenter)
   end


### PR DESCRIPTION
## Description

There's a bunch of details on the [trello card](https://trello.com/c/XBvhkwbl/390-historical-accounts-is-not-working-as-expected) but essentially after some digging and discussion with other teams who have touched this area of the codebase, historical accounts should only be for past prime ministers, and they should only be able to have one, not many. 

Other historical accounts have now been hardcoded on Collections.

Due to this we've decided to do the following:

1. Cleanup the data in the DB so that the Prime Minister role is the only role that can have historical accounts &  delete all other existing historical accounts (they don't work anyway). This was handled in this PR https://github.com/alphagov/whitehall/pull/8163
2. Update the people model to only have one historical account
3. Update the historical account model to only have one role
4. Remove the "Role" select from the new/edit historical account page and pass the Prime Minister role to the historical account in the controller
5. Hide the Create historical account button if one is already present on the person.

## Trello card

https://trello.com/c/XBvhkwbl/390-historical-accounts-is-not-working-as-expected

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
