### PR TITLE
Add links to all roles to worldwide organisation content item presenter

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -51,6 +51,7 @@ module PublishingApi
         office_staff:,
         sponsoring_organisations:,
         world_locations:,
+        roles:,
       }
     end
 
@@ -88,6 +89,10 @@ module PublishingApi
 
     def office_staff
       item.office_staff_roles.map(&:current_person).map(&:content_id)
+    end
+
+    def roles
+      item.roles.distinct.pluck(:content_id)
     end
 
     def corporate_information_pages

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -100,6 +100,9 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       world_locations: [
         worldwide_org.world_locations.first.content_id,
       ],
+      roles: [
+        ambassador.roles.first.content_id, deputy_head_of_mission.roles.first.content_id
+      ],
     }
 
     presented_item = present(worldwide_org)


### PR DESCRIPTION
> [!WARNING]  
> 🚨 Do not merge! 🚨 Depends on https://github.com/alphagov/publishing-api/pull/2478 being merged

https://trello.com/c/54I3mDxr

People linked to a worldwide organisation may have multiple roles, some of which are related to other organsaitions. Currently, we are incorrectly displaying these roles on the world wide organisation pages.

This copies the approach taken in alphagov/collections#1719. We link to all roles from the worldwide organisation, then filter out the incorrect ones in the rendering app.

See also https://github.com/alphagov/publishing-api/pull/2478 and https://github.com/alphagov/government-frontend/pull/2906.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
