### PR TITLE
Add data migration to clean up historical accounts

### DIFF
--- a/db/data_migration/20230823130609_remove_non_prime_minister_historical_accounts.rb
+++ b/db/data_migration/20230823130609_remove_non_prime_minister_historical_accounts.rb
@@ -1,0 +1,13 @@
+## Historical accounts should only be able to be created for prime minsters and should be have
+## one rather than many. This does two things:
+## 1. Destroys any historical accounts that exist for foreign secretaries
+## 2. Ensures that the only role which supports historical accounts is the prime minister.
+HistoricalAccount
+.joins(:roles)
+.where
+.not(roles: { slug: "prime-minister" })
+.each(&:destroy!)
+
+Role.where(supports_historical_accounts: true).each do |role|
+  role.update!(supports_historical_accounts: false) unless role.slug == "prime-minister"
+end


### PR DESCRIPTION
## Description

Historical accounts should now only be able to be created for prime minsters and should be have one rather than many. The work to do this will be added in a separate PR.

This does two things:
1. Destroys any historical accounts that exist for foreign secretaries
2. Ensures that the only role which supports historical accounts is the prime minister.

## Trello card

https://trello.com/c/XBvhkwbl/390-historical-accounts-is-not-working-as-expected

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
