### PR TITLE
Remove services and information page for DEFRA

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -511,7 +511,6 @@ class Organisation < ApplicationRecord
     %w[
       charity-commission
       department-for-education
-      department-for-environment-food-rural-affairs
       hm-revenue-customs
       natural-england
     ]


### PR DESCRIPTION
Services and information pages are being retired. When an organisation is published or updated, a service and information page is created/or republished based on the inclusion of the org's slug in this [list](https://github.com/alphagov/whitehall/pull/7971/commits/240bacfa98b94b48e6fbf18f9b1f6c2a4a2a44f9). Removing DEFRA's slug means that we can safely un-publish its services and information page, and it won't be accidentally republished when the org page is updated.

Trello card: https://trello.com/c/osKx0Y0e/2003-archive-and-redirect-services-and-info-page-for-defra

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
