### PR TITLE
Prevent image cropper from being initialised twice

### DIFF
--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -36,7 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   ImageCropper.prototype.initCropper = function () {
-    if (!this.$image.complete) {
+    if (!this.$image || !this.$image.complete || this.cropper) {
       return
     }
 
@@ -48,22 +48,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     const minCropBoxWidth = Math.ceil(this.$targetWidth * scaledRatio)
     const minCropBoxHeight = Math.ceil(this.$targetHeight * scaledRatio)
 
-    if (this.$image) {
-      this.cropper = new window.Cropper(this.$image, { // eslint-disable-line
-        viewMode: 2,
-        aspectRatio: 3 / 2,
-        autoCrop: true,
-        autoCropArea: 1,
-        guides: false,
-        zoomable: false,
-        highlight: false,
-        minCropBoxWidth: minCropBoxWidth,
-        minCropBoxHeight: minCropBoxHeight,
-        rotatable: false,
-        scalable: false
-      })
-      this.setupFormListener()
-    }
+    this.cropper = new window.Cropper(this.$image, { // eslint-disable-line
+      viewMode: 2,
+      aspectRatio: 3 / 2,
+      autoCrop: true,
+      autoCropArea: 1,
+      guides: false,
+      zoomable: false,
+      highlight: false,
+      minCropBoxWidth: minCropBoxWidth,
+      minCropBoxHeight: minCropBoxHeight,
+      rotatable: false,
+      scalable: false
+    })
+    this.setupFormListener()
   }
 
   ImageCropper.prototype.initKeyboardControls = function () {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Early exit `initCropper` when the cropper has already been initialised.

# Why
- There is an edge case where both an image is both 'complete' and triggers a 'load' event.
- This was causing the image cropper to be initialised twice resulting in a bug for the user a cropped image could not be saved.

https://trello.com/c/Bn1TJJZv/1669-investigate-bug-where-image-cropper-doesnt-always-work
