### PR TITLE
Republish parent when offsite link is updated

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -46,6 +46,8 @@ class OffsiteLink < ApplicationRecord
   belongs_to :parent, polymorphic: true
   has_many :features, inverse_of: :offsite_link, dependent: :destroy
 
+  after_commit :republish_parent_to_publishing_api
+
   validates :title, :summary, :link_type, :url, presence: true, length: { maximum: 255 }
   validate :check_url_is_allowed
   validates :link_type, presence: true, inclusion: { in: LinkTypes.all }
@@ -102,5 +104,9 @@ private
     ]
 
     permitted_hosts.any? { |permitted_host| host =~ /(?:^|\.)#{permitted_host}$/ }
+  end
+
+  def republish_parent_to_publishing_api
+    Whitehall::PublishingApi.republish_async(parent)
   end
 end

--- a/test/unit/app/models/offsite_link_test.rb
+++ b/test/unit/app/models/offsite_link_test.rb
@@ -147,4 +147,23 @@ class OffsiteLinkTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "creating an existing offsite link republishes the parent" do
+    parent = create(:world_location_news, world_location: create(:world_location))
+
+    offsite_link = create(:offsite_link, parent:)
+    offsite_link.title = "Updated title"
+
+    Whitehall::PublishingApi.expects(:republish_async).with(parent).once
+
+    offsite_link.save!
+  end
+
+  test "updating an existing offsite link republishes the parent" do
+    parent = create(:world_location_news, world_location: create(:world_location))
+
+    Whitehall::PublishingApi.expects(:republish_async).with(parent).once
+
+    create(:offsite_link, parent:)
+  end
 end


### PR DESCRIPTION
When an offsite link is updated or created, we need to republish the parent page (i.e. Organisation, Topical Event or World Location News) to Publishing API for those changes to become live.

[Trello card](https://trello.com/c/31tbGq2H)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
