### PR TITLE
Use govuk date component for schedule publication date field

### DIFF
--- a/app/views/admin/editions/_scheduled_publication_fields.html.erb
+++ b/app/views/admin/editions/_scheduled_publication_fields.html.erb
@@ -13,24 +13,33 @@
         label: "Schedule for publication",
         value: 1,
         checked: edition.scheduled_publication.present?,
-        conditional: render("components/datetime_fields", {
+        conditional: render("components/datetime_fields_with_govuk_date_component", {
               field_name: "scheduled_publication",
               prefix: "edition",
               error_items: errors_for(edition.errors, :scheduled_publication),
               date_heading: "Date",
-              date_hint: "For example, 01 August 2022",
+              date_hint: "For example, 01 08 2022",
               time_hint: "For example, 09:30 or 19:30",
               year: {
                 value: edition.scheduled_publication&.year || Time.zone.today.year,
                 id: "edition_scheduled_publication_1i",
+                name: "edition[scheduled_publication(1i)]",
+                label: "Year",
+                width: 4,
               },
               month: {
                 value: edition.scheduled_publication&.month || Time.zone.today.month,
                 id: "edition_scheduled_publication_2i",
+                name: "edition[scheduled_publication(2i)]",
+                label: "Month",
+                width: 2,
               },
               day: {
                 value: edition.scheduled_publication&.day || Time.zone.today.day,
                 id: "edition_scheduled_publication_3i",
+                name: "edition[scheduled_publication(3i)]",
+                label: "Day",
+                width: 2,
               },
               hour: {
                 value: edition.scheduled_publication&.hour || 9,

--- a/app/views/components/_datetime_fields_with_govuk_date_component.html.erb
+++ b/app/views/components/_datetime_fields_with_govuk_date_component.html.erb
@@ -1,0 +1,118 @@
+<%
+  prefix = prefix
+  field_name = field_name
+  id = id
+  date_id = "#{id}_date"
+  date_only ||= false
+  date_heading ||= nil
+
+  error_items = error_items ||= nil
+
+  heading_level = heading_level ||= nil
+  heading_size = heading_size ||= nil
+
+  date_hint = date_hint ||= nil
+
+  time_hint = time_hint ||= nil
+  time_hint_id = "time-hint-#{SecureRandom.hex(4)}"
+
+  year ||= {}
+
+  month ||= {}
+
+  day ||= {}
+
+  hour ||= {}
+  hour_value = hour[:value]
+  hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
+  hour_label_id = "hour-#{SecureRandom.hex(4)}"
+
+  minute ||= {}
+  minute_value = minute[:value]
+  minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
+  minute_label_id = "minute-#{SecureRandom.hex(4)}"
+
+  root_classes = %w[app-c-datetime-fields govuk-form-group]
+  root_classes << "govuk-form-group--error" if error_items.present?
+  data_attributes ||= {}
+%>
+
+<%= tag.div class: root_classes, data: data_attributes, id: id do %>
+  <% unless date_only && !date_heading %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: date_heading || "Date (required)",
+      heading_level: heading_level || 3,
+      font_size: heading_size || "m",
+      padding: true,
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/date_input", {
+    id: date_id,
+    hint: date_hint,
+    error_items: error_items,
+    items: [day, month, year]
+  } %>
+
+  <% unless date_only %>
+    <div class="govuk-!-margin-top-3">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Time",
+        heading_level: heading_level || 3,
+        font_size: heading_size || "m",
+        padding: true,
+      } %>
+    </div>
+
+    <% if time_hint %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: time_hint,
+        id: time_hint_id
+      } %>
+    <% end %>
+
+    <div class="app-c-datetime-fields__date-time-wrapper">
+      <div class="app-c-datetime-fields__date-time">
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Hour",
+          html_for: hour_select_id,
+          id: hour_label_id,
+        } %>
+
+        <%= select_hour hour_value,
+                        {
+                          include_blank: true,
+                          prefix: prefix,
+                          field_name: "#{field_name}(4i)"
+                        },
+                        {
+                          id: hour_select_id,
+                          class: "govuk-select app-c-datetime-fields__date-time-input",
+                          "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip
+                        } %>
+      </div>
+
+      <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
+
+      <div class="app-c-datetime-fields__date-time">
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Minute",
+          html_for: minute_select_id,
+          id: minute_label_id,
+        } %>
+
+        <%= select_minute minute_value,
+                          {
+                            include_blank: true,
+                            prefix: prefix,
+                            field_name: "#{field_name}(5i)"
+                          },
+                          {
+                            id: minute_select_id,
+                            class: "govuk-select app-c-datetime-fields__date-time-input",
+                            "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip
+                          } %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
+++ b/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
@@ -21,7 +21,8 @@ module AdminEditionControllerScheduledPublishingTestHelpers
 
         assert_select "form#new_edition" do
           assert_select "input[type=checkbox][name='scheduled_publication_active']"
-          assert_select "select[name*='edition[scheduled_publication']", count: 5
+          assert_select "input[type=text][name*='edition[scheduled_publication']", count: 3
+          assert_select "select[name*='edition[scheduled_publication']", count: 2
         end
       end
 
@@ -121,9 +122,9 @@ module AdminEditionControllerScheduledPublishingTestHelpers
 
         assert_select "form#edit_edition" do
           assert_select "input[type=checkbox][name='scheduled_publication_active'][checked='checked']"
-          assert_select "select[name='edition[scheduled_publication(1i)]'] option[value='#{Time.zone.today.year + 1}'][selected='selected']"
-          assert_select "select[name='edition[scheduled_publication(2i)]'] option[value='6'][selected='selected']"
-          assert_select "select[name='edition[scheduled_publication(3i)]'] option[value='3'][selected='selected']"
+          assert_select "input[type=text][name='edition[scheduled_publication(1i)]'][value='#{Time.zone.today.year + 1}']"
+          assert_select "input[type=text][name='edition[scheduled_publication(2i)]'][value='6']"
+          assert_select "input[type=text][name='edition[scheduled_publication(3i)]'][value='3']"
           assert_select "select[name='edition[scheduled_publication(4i)]'] option[value='10'][selected='selected']"
           assert_select "select[name='edition[scheduled_publication(5i)]'] option[value='30'][selected='selected']"
         end
@@ -138,9 +139,9 @@ module AdminEditionControllerScheduledPublishingTestHelpers
         assert_select "form#edit_edition" do
           assert_select "input[type=checkbox][name='scheduled_publication_active']"
           assert_select "input[type=checkbox][name='scheduled_publication_active'][checked='checked']", count: 0
-          assert_select "select[name='edition[scheduled_publication(1i)]'] option[value='#{date.year}'][selected='selected']"
-          assert_select "select[name='edition[scheduled_publication(2i)]'] option[value='#{date.month}'][selected='selected']"
-          assert_select "select[name='edition[scheduled_publication(3i)]'] option[value='#{date.day}'][selected='selected']"
+          assert_select "input[name='edition[scheduled_publication(1i)]'][value='#{date.year}']"
+          assert_select "input[name='edition[scheduled_publication(2i)]'][value='#{date.month}']"
+          assert_select "input[name='edition[scheduled_publication(3i)]'][value='#{date.day}']"
           assert_select "select[name='edition[scheduled_publication(4i)]'] option[value='09'][selected='selected']"
           assert_select "select[name='edition[scheduled_publication(5i)]'] option[value='30'][selected='selected']"
         end


### PR DESCRIPTION
### What

This PR switches the schedule publication field to use a new date time field component that leverages the GOVUK shared date field component. It maintains the existing request shape and data types. Once all uses of the existing date time component have been replaced with our new component, we will delete the old component and remove the awkward `with_govuk_date_component` filename suffix from the new one.

The switch to the GOVUK component requires us to add date validation which was previously considered unnecessary because the select element limited the options a user could input.

### Why

We are making this change to make Whitehall more consistent with other GOVUK interfaces and because we believe the GOVUK component offers a better user experience. However, it is also more easily possible to input invalid dates to the GOVUK component, so this PR also adds date validation based on the behaviour in content publisher to ensure that users have a good experience if they make a mistake.

Trello: https://trello.com/c/IFGDegsk