### PR TITLE
Remove contacts guidance in formatting help

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -203,8 +203,8 @@
     <p class='govuk-body'>You can also embed contact information:</p>
     <pre class='govspeak-help__pre'>[Contact:<em>n</em>]</pre>
     <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
-    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path, class: "govuk-link" %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path, class: "govuk-link" %> or you can type ‘[Contact: ’ and then type a keyword to find your contact (if it exists).</p>
-    <p class='govuk-body'>If it doesn’t exist you will have to add it (see your ‘Publishing explained’ guidance). </p>
+    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to 'organisation', admin_organisations_path, class: "govuk-link" %> or <%= link_to 'worldwide organisation', admin_worldwide_organisations_path, class: "govuk-link" %>.</p>
+    <p class='govuk-body'>If it doesn’t exist you will have to add it (see <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages'>‘Organisation pages’ guidance). </p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {


### PR DESCRIPTION
## What

Currently the in-app guidance on Whitehall suggests that users can search for a contact by typing ‘[Contact: ’ and then type a keyword to find your contact (if it exists).

Since the move to the GOV.UK design system, this hasn't worked, and the functionality no longer exists. We think that it's difficult to make this accessible, so this PR removes the guidance to suggest that as an option for users. 

Also updated what appeared to be a broken link in the guidance as it didn't go anywhere, and have linked to the organisations guidance.

## Why

We received a Zendesk ticket asking about this feature, although it's only one piece of feedback from one user. We believe the feature is under-utilised, and actually most publishers copy and paste from the organisations tab, which has also been made clearer in the move to the design system.

## What has been removed?

<img width="360" alt="Screenshot 2023-08-24 at 21 06 01" src="https://github.com/alphagov/whitehall/assets/55087909/d532a8c4-d4b9-4f8f-be07-6307fcc36cd1">

## Links

https://trello.com/c/tsyOqfLj
https://govuk.zendesk.com/agent/#/tickets/5351274


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
