### PR TITLE
Move flash to view component

### DIFF
--- a/app/components/admin/flash_alert_component.rb
+++ b/app/components/admin/flash_alert_component.rb
@@ -1,0 +1,9 @@
+class Admin::FlashAlertComponent < Admin::FlashMessageComponent
+  def component_name
+    "error_alert"
+  end
+
+  def data_track_action
+    "alert-danger"
+  end
+end

--- a/app/components/admin/flash_message_component.html.erb
+++ b/app/components/admin/flash_message_component.html.erb
@@ -1,0 +1,5 @@
+<%=
+content_tag(:div, data: { module: "auto-track-event", track_category: "flash-message", track_action: data_track_action, track_label: message }) do
+  render "govuk_publishing_components/components/#{component_name}", { message: }
+end
+%>

--- a/app/components/admin/flash_message_component.rb
+++ b/app/components/admin/flash_message_component.rb
@@ -1,0 +1,14 @@
+class Admin::FlashMessageComponent < ViewComponent::Base
+  def initialize(message:, html_safe: false)
+    @html_safe = html_safe
+    @message = message
+  end
+
+  def message
+    if @html_safe
+      @message.html_safe
+    else
+      @message
+    end
+  end
+end

--- a/app/components/admin/flash_notice_component.rb
+++ b/app/components/admin/flash_notice_component.rb
@@ -1,0 +1,9 @@
+class Admin::FlashNoticeComponent < Admin::FlashMessageComponent
+  def component_name
+    "success_alert"
+  end
+
+  def data_track_action
+    "alert-success"
+  end
+end

--- a/app/controllers/concerns/historic_content_concern.rb
+++ b/app/controllers/concerns/historic_content_concern.rb
@@ -6,7 +6,7 @@ module HistoricContentConcern
     # to redirect with a nice message rather than just "permission denied".
     if @edition.historic? && !can?(:modify, @edition)
       redirect_to [:admin, @edition],
-                  alert: %(This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode" class="govuk-link">history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.)
+                  { flash: { alert: "This document is in <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode' class='govuk-link'>history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.", html_safe: true } }
     end
   end
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -41,21 +41,9 @@
     <%= yield(:breadcrumbs) %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank?%>" id="main-content" role="main">
-      <% if flash["notice"].present? %>
-        <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-success" data-track-label="<%= flash["notice"] %>">
-          <%= render "govuk_publishing_components/components/success_alert", {
-            message: flash["notice"]
-          } %>
-        </div>
-      <% end %>
 
-      <% if flash["alert"].present? && yield(:error_summary).blank? %>
-        <div data-module="auto-track-event" data-track-category="flash-message" data-track-action="alert-danger" data-track-label="<%= flash["alert"] %>">
-          <%= render "govuk_publishing_components/components/error_alert", {
-            message: flash["alert"].html_safe
-          } %>
-        </div>
-      <% end %>
+      <%= render Admin::FlashNoticeComponent.new(message: flash[:notice], html_safe: flash["html_safe"]) if flash[:notice] %>
+      <%= render Admin::FlashAlertComponent.new(message: flash[:alert], html_safe: flash["html_safe"]) if flash[:alert] && yield(:error_summary).blank? %>
 
       <% column_width = yield(:page_full_width).present? ? "full" : "two-thirds" %>
 

--- a/test/components/admin/flash_alert_component_test.rb
+++ b/test/components/admin/flash_alert_component_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Admin::FlashMessageComponentTest < ViewComponent::TestCase
+  def setup
+    @flash = {
+      message: "This is an alert",
+    }
+  end
+
+  test "renders an error alert with the correct message" do
+    render_inline(Admin::FlashAlertComponent.new(message: @flash[:message]))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-danger']", text: "This is an alert")
+  end
+
+  test "escapes HTML tags in the flash message by default" do
+    @flash[:message] = "<b>This is unsafe</b>"
+    render_inline(Admin::FlashAlertComponent.new(message: @flash[:message]))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-danger']", text: "<b>This is unsafe</b>")
+    assert_no_selector "b"
+  end
+
+  test "allows HTML tags in the flash message when html_safe: true" do
+    @flash[:message] = "<b>This is an alert</b>"
+    render_inline(Admin::FlashAlertComponent.new(message: @flash[:message], html_safe: true))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-danger'] b", text: "This is an alert")
+  end
+end

--- a/test/components/admin/flash_notice_component_test.rb
+++ b/test/components/admin/flash_notice_component_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Admin::FlashNoticeComponentTest < ViewComponent::TestCase
+  def setup
+    @flash = {
+      message: "This is a notice",
+    }
+  end
+
+  test "renders a success alert with the correct message" do
+    render_inline(Admin::FlashNoticeComponent.new(message: @flash[:message]))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-success']", text: "This is a notice")
+  end
+
+  test "escapes HTML tags in the flash message by default" do
+    @flash[:message] = "<b>This is unsafe</b>"
+    render_inline(Admin::FlashNoticeComponent.new(message: @flash[:message]))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-success']", text: "<b>This is unsafe</b>")
+    assert_no_selector "b"
+  end
+
+  test "allows HTML tags in the flash message when html_safe: true" do
+    @flash[:message] = "<b>This is a notice</b>"
+    render_inline(Admin::FlashNoticeComponent.new(message: @flash[:message], html_safe: true))
+    assert_selector("div[data-track-category='flash-message'][data-track-action='alert-success'] b", text: "This is a notice")
+  end
+end


### PR DESCRIPTION
As part of the work to remove the topic taxonomy from the edition workflow (trello card below). We wanted to render a flash[:notice] with a link. However we found that while all flash[:alert] messages were marked as html_safe no flash[:notice] message could be marked as safe. While there were no flash[:alert] messages which showed user input, this was not documented and meant that an alert with user input may have been added by an unknowing dev. 

This work was intended to allow both flash[:notice] and flash[:alert] messages to be able to be marked as html_safe when safe and default to not html_safe in order to keep our application secure and prevent any malicious content from being injected. 

We added this to a view component instead of leaving it in the view to ensure that we could test the work properly.

This work is a precursor to the work done in https://github.com/alphagov/whitehall/pull/8126

Trello card: https://trello.com/c/2jmWV2Ur/1638-update-buttons-in-topic-taxonomy-tags-page