### PR TITLE
Fix a user facing crash on access limited editions

### DIFF
--- a/app/presenters/publishing_api/payload_builder/access_limitation.rb
+++ b/app/presenters/publishing_api/payload_builder/access_limitation.rb
@@ -4,7 +4,7 @@ module PublishingApi
       def self.for(item)
         return {} unless item.access_limited? && !item.publicly_visible?
 
-        { access_limited: { organisations: item.organisations.pluck(:content_id).compact } }
+        { access_limited: { organisations: item.organisations.pluck(:content_id).uniq } }
       end
     end
   end


### PR DESCRIPTION
We recently started receiving reports from users that they were getting a 500 Internal Server Error when trying to apply 'access limiting' to their draft editions.

Looking [in Sentry][1], we identified the cause of the crash as a bad response being received from the Publishing API:

```
[{"schema":{"scheme":null,"user":null,"password":null,"host":null,"port":null,"path":"d0f74ee9-3ef3-5f84-a82c-e7b0abe86020","query":null,"fragment":""},"fragment":"#/access_limited/organisations","message":"The property '#/access_limited/organisations' contained duplicated array values in schema d0f74ee9-3ef3-5f84-a82c-e7b0abe86020#","failed_attribute":"UniqueItems"}]
```

The Publishing API was rejecting the property
`#/access_limited/organisations` due to it containing duplicate organisation content IDs.

Digging into this with an example edition with one associated organisation in the Rails console, we were surprised to find:

```
edition.organisations.pluck(:content_id)
```

would _sometimes_ return an array of two duplicate organisation content IDs.

Whereas:

```
edition.organisations.map(&:content_id)
```

seemed to reliably return just one organisation content ID, as expected.

Even more confusingly, the `pluck(:content_id)` call would return just one organisation if it was done on an edition that had already run `map(&:content_id)` first. And then it'd reset again after calling `edition.reload`.

We've not been able to get to the bottom of this unusual behaviour - and therefore are unable to create a test case that reliably covers this scenario.

So as a mitigation to the immediate issue, we've applied `.uniq` to the array in the presenter so it will no longer upset the Publishing API.

We also deemed it safe to remove the `.compact` call because every organisation has a content ID, so it would never be needed. It was previously needed when user IDs were used, prior to PR #8019, because there are a few users with nil uids.

[1]: https://govuk.sentry.io/issues/3725318257/

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
