### PR TITLE
Work in Progress - moving Alternative Format Provider Email for Attac…

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -168,7 +168,7 @@ module Admin::EditionsHelper
   def standard_edition_form(edition)
     form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
       concat render("standard_fields", form:, edition:)
-      yield(form)
+      yield(form) if block_given?
       concat render("access_limiting_fields", form:, edition:)
       concat render("scheduled_publication_fields", form:, edition:)
       concat render("review_reminder_fields", form:, review_reminder: edition.document.review_reminder)

--- a/app/views/admin/attachments/_inline_attachments_info.html.erb
+++ b/app/views/admin/attachments/_inline_attachments_info.html.erb
@@ -5,26 +5,26 @@
     id: "edition_alternative_format_provider",
     error_message: errors_for_input(edition.errors, :alternative_format_provider)
   } do %>
-    <% if edition.new_record? %>
-      <p class="govuk-body">
-        <% if edition.allows_image_attachments? %>
-          To add images and attachments you must save the document first. After
-          saving, use the tabs at the top of the page to upload, edit and
-          delete images and attachments.
-        <% else %>
-          If you’d like to add an attachment to this document, please save
-          it first. You’ll then find a tab at the top of the page that you
-          can use to upload, edit and delete attachments.
-        <% end %>
-      </p>
-    <% else %>
-      <% if edition.allows_image_attachments? %>
-        <p class="govuk-body">
-          Use the tabs at the top of the page to upload, edit and delete images
-          and attachments.
-        </p>
-      <% end %>
-    <% end %>
+    <%# if edition.new_record? %>
+<!--      <p class="govuk-body">-->
+        <%# if edition.allows_image_attachments? %>
+<!--          To add images and attachments you must save the document first. After-->
+<!--          saving, use the tabs at the top of the page to upload, edit and-->
+<!--          delete images and attachments.-->
+        <%# else %>
+<!--          If you’d like to add an attachment to this document, please save-->
+<!--          it first. You’ll then find a tab at the top of the page that you-->
+<!--          can use to upload, edit and delete attachments.-->
+        <%# end %>
+<!--      </p>-->
+    <%# else %>
+      <%# if edition.allows_image_attachments? %>
+<!--        <p class="govuk-body">-->
+<!--          Use the tabs at the top of the page to upload, edit and delete images-->
+<!--          and attachments.-->
+<!--        </p>-->
+      <%# end %>
+    <%# end %>
     <% if edition.respond_to?(:alternative_format_provider) %>
       <div class="govuk-form-group gem-c-select">
         <label class="govuk-label govuk-label--m govuk-!-font-weight-bold" for="alternative_format_provider_id">

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -51,6 +51,8 @@
       <% end %>
     </div>
 
+    <%= render('inline_attachments_info', edition: attachable) if attachable.is_a?(Edition) %>
+
     <%= render "govuk_publishing_components/components/heading", {
       text: "Attachments",
       font_size: "l",

--- a/app/views/admin/calls_for_evidence/_form.html.erb
+++ b/app/views/admin/calls_for_evidence/_form.html.erb
@@ -158,7 +158,6 @@
   </div>
 
   <%= render 'html_version_fields', form: form, edition: edition %>
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
 
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -158,7 +158,6 @@
   </div>
 
   <%= render 'html_version_fields', form: form, edition: edition %>
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
 
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",

--- a/app/views/admin/corporate_information_pages/_form.html.erb
+++ b/app/views/admin/corporate_information_pages/_form.html.erb
@@ -1,5 +1,1 @@
-<%= standard_edition_form(edition) do |form| %>
-  <div class="js-external-url-set">
-    <%= render 'inline_attachments_info', form: form, edition: edition %>
-  </div>
-<% end %>
+<%= standard_edition_form(edition) %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -36,8 +36,6 @@
     </div>
   <% end %>
 
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
-
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Related mainstream content",
     heading_level: 3,

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -5,7 +5,6 @@
 </div>
 
 <%= standard_edition_form(edition) do |form| %>
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -4,7 +4,6 @@
 
 <%= standard_edition_form(edition) do |form| %>
   <%= form.hidden_field :statistics_announcement_id %>
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
   <%= render 'html_version_fields', form: form, edition: edition %>
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -5,7 +5,6 @@
 
 
 <%= standard_edition_form(edition) do |form| %>
-  <%= render 'inline_attachments_info', form: form, edition: edition %>
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 3,

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
 
   should_allow_organisations_for :call_for_evidence
   should_prevent_modification_of_unmodifiable :call_for_evidence
-  should_allow_alternative_format_provider_for :call_for_evidence
+  # should_allow_alternative_format_provider_for :call_for_evidence
   should_allow_scheduled_publication_of :call_for_evidence
   should_allow_access_limiting_of :call_for_evidence
   should_render_govspeak_history_and_fact_checking_tabs_for :call_for_evidence

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
 
   should_allow_organisations_for :consultation
   should_prevent_modification_of_unmodifiable :consultation
-  should_allow_alternative_format_provider_for :consultation
+  # should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
   should_allow_access_limiting_of :consultation
   should_render_govspeak_history_and_fact_checking_tabs_for :consultation

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_organisations_for :detailed_guide
   should_prevent_modification_of_unmodifiable :detailed_guide
   should_allow_association_with_related_mainstream_content :detailed_guide
-  should_allow_alternative_format_provider_for :detailed_guide
+  # should_allow_alternative_format_provider_for :detailed_guide
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
   should_allow_access_limiting_of :detailed_guide

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_references_to_statistical_data_sets_for :publication
   should_allow_association_between_world_locations_and :publication
   should_prevent_modification_of_unmodifiable :publication
-  should_allow_alternative_format_provider_for :publication
+  # should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
   should_allow_access_limiting_of :publication
   should_render_govspeak_history_and_fact_checking_tabs_for :publication

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
 
   should_allow_organisations_for :statistical_data_set
   should_prevent_modification_of_unmodifiable :statistical_data_set
-  should_allow_alternative_format_provider_for :statistical_data_set
+  # should_allow_alternative_format_provider_for :statistical_data_set
   should_allow_overriding_of_first_published_at_for :statistical_data_set
   should_allow_scheduled_publication_of :statistical_data_set
   should_allow_access_limiting_of :statistical_data_set

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -864,41 +864,42 @@ module AdminEditionControllerTestHelpers
       end
     end
 
-    def should_allow_alternative_format_provider_for(edition_type)
-      view_test "when creating allow selection of alternative format provider for #{edition_type}" do
-        get :new
-
-        assert_select "form#new_edition" do
-          assert_select "select[name='edition[alternative_format_provider_id]']"
-        end
-      end
-
-      view_test "when editing allow selection of alternative format provider for #{edition_type}" do
-        draft = create("draft_#{edition_type}")
-
-        get :edit, params: { id: draft }
-
-        assert_select "form#edit_edition" do
-          assert_select "select[name='edition[alternative_format_provider_id]']"
-        end
-      end
-
-      test "update should save modified #{edition_type} alternative format provider" do
-        organisation = create(:organisation_with_alternative_format_contact_email)
-        edition = create(edition_type) # rubocop:disable Rails/SaveBang
-
-        put :update,
-            params: {
-              id: edition,
-              edition: {
-                alternative_format_provider_id: organisation.id,
-              },
-            }
-
-        saved_edition = edition.reload
-        assert_equal organisation, saved_edition.alternative_format_provider
-      end
-    end
+    # TODO: Move to attachments tab
+    # def should_allow_alternative_format_provider_for(edition_type)
+    #   view_test "when creating allow selection of alternative format provider for #{edition_type}" do
+    #     get :new
+    #
+    #     assert_select "form#new_edition" do
+    #       assert_select "select[name='edition[alternative_format_provider_id]']"
+    #     end
+    #   end
+    #
+    #   view_test "when editing allow selection of alternative format provider for #{edition_type}" do
+    #     draft = create("draft_#{edition_type}")
+    #
+    #     get :edit, params: { id: draft }
+    #
+    #     assert_select "form#edit_edition" do
+    #       assert_select "select[name='edition[alternative_format_provider_id]']"
+    #     end
+    #   end
+    #
+    #   test "update should save modified #{edition_type} alternative format provider" do
+    #     organisation = create(:organisation_with_alternative_format_contact_email)
+    #     edition = create(edition_type) # rubocop:disable Rails/SaveBang
+    #
+    #     put :update,
+    #         params: {
+    #           id: edition,
+    #           edition: {
+    #             alternative_format_provider_id: organisation.id,
+    #           },
+    #         }
+    #
+    #     saved_edition = edition.reload
+    #     assert_equal organisation, saved_edition.alternative_format_provider
+    #   end
+    # end
 
     def should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)


### PR DESCRIPTION
…hments

- just moved the field from the view to the attachments page.
- commented out tests that require attachment email provider to be available. These tests will need to move to the attachments page.
- Added a null check for yielding blocks in editions helper since Corporate Information Page only requires the block to render the email provider. We might as well not pass in the block in that scenario.

Other things to consider:
- When moving the field, we will now have to default the email for edition creation. This needs to be done
- What happens when the lead org doesn't have an email set, what do we default it to?
- The text for Image and Attachments need to stay in the document forms - but as a separate piece of info label
- Creating new page for saving the actual email

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

https://trello.com/c/b6ftq7IE/1563-move-accessible-attachments-email-to-attachments-section
