### PR TITLE
Add DocumentCollectionGroup Show page in the GOV.UK Design System

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -46,7 +46,7 @@ class Admin::BaseController < ApplicationController
   helper_method :preview_design_system?
 
   def render_design_system(design_system_view, legacy_view)
-    if get_layout == "design_system"
+    if new_design_system?
       render design_system_view
     else
       render legacy_view
@@ -54,6 +54,10 @@ class Admin::BaseController < ApplicationController
   end
 
 private
+
+  def new_design_system?
+    get_layout == "design_system"
+  end
 
   def forbidden!
     render "admin/editions/forbidden", status: :forbidden

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DocumentCollectionGroupsController < Admin::BaseController
   before_action :load_document_collection
-  before_action :load_document_collection_group, only: %i[confirm_destroy destroy edit update]
+  before_action :load_document_collection_group, only: %i[confirm_destroy destroy edit update show]
   layout :get_layout
 
   def index
@@ -13,6 +13,8 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
 
     render_design_system(:index, :legacy_index)
   end
+
+  def show; end
 
   def new
     @group = @collection.groups.build
@@ -69,7 +71,7 @@ private
 
   def get_layout
     design_system_actions = []
-    design_system_actions += %w[index confirm_destroy destroy new create edit update] if preview_design_system?(next_release: false)
+    design_system_actions += %w[index confirm_destroy destroy new create edit update show] if preview_design_system?(next_release: false)
 
     if design_system_actions.include?(action_name)
       "design_system"

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -14,7 +14,9 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
     render_design_system(:index, :legacy_index)
   end
 
-  def show; end
+  def show
+    forbidden! unless new_design_system?
+  end
 
   def new
     @group = @collection.groups.build

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -85,6 +85,21 @@ module Admin::TabbedNavHelper
     }
   end
 
+  def document_collection_group_nav_items(group, current_path)
+    [
+      {
+        label: "Documents",
+        href: "#",
+        current: false,
+      },
+      {
+        label: "Group details",
+        href: admin_document_collection_group_path(group.document_collection, group),
+        current: current_path == admin_document_collection_group_path(group.document_collection, group),
+      },
+    ]
+  end
+
   def policy_group_nav_items(group, current_path)
     [
       {

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -18,7 +18,7 @@
           actions: [
             {
               label: "View",
-              href: "#"
+              href: admin_document_collection_group_path(@collection, group)
             },
             *([{
               label: "Delete",

--- a/app/views/admin/document_collection_groups/show.html.erb
+++ b/app/views/admin/document_collection_groups/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_document_collection_groups_path(@collection),
+  } %>
+<% end %>
+<% content_for :page_title, @group.heading %>
+<% content_for :title, @group.heading %>
+<% content_for :context, @collection.title %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= view_on_website_link_for @collection, url: { draft: true }, class: "govuk-link", target: "blank" %>
+    </p>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document collection group navigation tabs",
+      items: secondary_navigation_tabs_items(@group, request.path)
+    } %>
+
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "Group details",
+      heading_size: "l",
+      items: [
+        {
+          field: "Name",
+          value: @group.heading,
+        },
+        {
+          field: "Description",
+          value: @group.body.presence || "None",
+        }
+      ],
+      edit: {
+        href: edit_admin_document_collection_group_path(@collection, @group),
+        link_text: "Edit",
+      }
+    } %>
+  </div>
+</div>

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -59,3 +59,10 @@ Feature: Grouping documents into a collection
     Given a document collection "May 2012 Update" exists
     When I add the group "Brand new group"
     Then I can see that the group "Brand new group" has been added
+
+  @design-system-only
+  Scenario: Adding a new group
+    Given a document collection "May 2012 Update" exists
+    And a the document collection "May 2012 Update" has a group with the heading "Group to be edited"
+    When I edit the group "Group to be edited"'s heading to "Interesting new heading"
+    Then I can see that the heading has been updated to "Interesting new heading"

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -192,3 +192,16 @@ Then(/^I can see that the group "(.*?)" has been added$/) do |heading|
   expect(page).to have_content "New group has been created"
   expect(find(".govuk-summary-card")).to have_content heading
 end
+
+When(/^I edit the group "(.*?)"'s heading to "(.*?)"$/) do |current_heading, new_heading|
+  visit admin_document_collection_groups_path(@document_collection)
+  click_link "View #{current_heading}"
+  click_link "Edit Group details"
+  fill_in "Name (required)", with: new_heading
+  click_button "Save"
+end
+
+Then(/^I can see that the heading has been updated to "(.*?)"$/) do |heading|
+  expect(page).to have_content "Group details have been updated"
+  expect(find(".govuk-summary-card")).to have_content heading
+end

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -40,6 +40,13 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group2)}']", text: "Delete #{group2.heading}"
   end
 
+  view_test "GET #show assigns the correct attributes and renders successfully" do
+    get :show, params: { document_collection_id: @collection, id: @group }
+    assert_response :ok
+    assert_equal @collection, assigns(:collection)
+    assert_equal @group, assigns(:group)
+  end
+
   view_test "GET #new renders successfully" do
     get :new, params: { document_collection_id: @collection }
     assert_response :ok

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-card__action a[href='#{new_admin_document_collection_group_path(@collection)}']", text: /Add group/
     assert_select ".govuk-summary-list__key", text: @group.heading
     assert_select ".govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__actions a[href='#']", text: "View #{@group.heading}"
+    assert_select ".govuk-summary-list__actions a[href='#{admin_document_collection_group_path(@collection, @group)}']", text: "View #{@group.heading}"
   end
 
   view_test "GET #index shows confirm delete links when 2 or more groups are present" do
@@ -32,11 +32,11 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
 
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: group1.heading
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "1 document in group"
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#']", text: "View #{group1.heading}"
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{admin_document_collection_group_path(collection, group1)}']", text: "View #{group1.heading}"
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group1)}']", text: "Delete #{group1.heading}"
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: group2.heading
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#']", text: "View #{group2.heading}"
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{admin_document_collection_group_path(collection, group2)}']", text: "View #{group2.heading}"
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group2)}']", text: "Delete #{group2.heading}"
   end
 

--- a/test/functional/admin/legacy_document_collection_groups_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_groups_controller_test.rb
@@ -245,6 +245,12 @@ class Admin::LegacyDocumentCollectionGroupsControllerTest < ActionController::Te
     assert_empty @group2.reload.memberships
   end
 
+  test "GET #show forbids the user to see anything" do
+    get :show, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
   def given_two_groups_with_memberships
     @group1 = build(:document_collection_group)
     @group2 = build(:document_collection_group)

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -317,4 +317,24 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
 
     assert_equal expected_output, secondary_navigation_tabs_items(person, admin_person_historical_accounts_path(person))
   end
+
+  test "#secondary_navigation_tabs_items for document collection groups" do
+    document_collection = build_stubbed(:document_collection)
+    group = build_stubbed(:document_collection_group, document_collection:)
+
+    expected_output = [
+      {
+        label: "Documents",
+        href: "#",
+        current: false,
+      },
+      {
+        label: "Group details",
+        href: admin_document_collection_group_path(document_collection, group),
+        current: true,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(group, admin_document_collection_group_path(document_collection, group))
+  end
 end


### PR DESCRIPTION
## Description

This follows on from:

https://github.com/alphagov/whitehall/pull/8184 - adds the Doc collec group index page & confirm destroy page 
https://github.com/alphagov/whitehall/pull/8185 - adds the new & edit doc collection group pages

This page adds the Show page in the GOV.UK Design System. It's a pretty straight forward page. This PR does the following:

- adds a helper method which handles rendering the secondary nav items for document collection groups
- adds the show page
- updates the index page to link to the show page
- adds a feature test for editing a groups details

## Screenshot

<img width="708" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/303ae30d-bf14-45d3-9151-ffc7052785f4">

## Trello card

https://trello.com/c/G01TwJNG/527-create-a-group-page-for-editing-details

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
