### PR TITLE
Add a preview link to the edit page

### DIFF
--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -69,6 +69,27 @@
     } %>
   </div>
 
+  <% if !edition.new_record? && @edition.versioning_completed? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      } do %>
+      <p class="govuk-body">
+        <%= link_to("Preview on website (opens in new tab)",
+        @edition.public_url(draft: true, locale: @edition.primary_locale),
+        class: "govuk-link",
+        target: "_blank",
+        data: {
+          module: "gem-track-click",
+          "track-category": "button-clicked",
+          "track-action": "#{@edition.model_name.singular.dasherize}-button",
+          "track-label": "Preview on website",
+        }) %>
+      </p>
+      <p class="govuk-body">
+        To preview your document on GOV.UK you must save it first.
+      </p>
+    <% end %>
+  <% end %>
+
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
   <% if edition.document && edition.document.live? && can?(:mark_political, edition) %>

--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -4,3 +4,9 @@ Feature: Previewing unpublished editions
     Given I am an editor
     When I draft a new publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
+
+  Scenario: Unpublished editions link to preview from the edit page
+    Given I am an editor
+    When I draft a new publication "Test publication"
+    When I am on the edit page for publication "Test publication"
+    Then I should see a link to the preview version of the publication "Test publication"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This was originally submitted as part of https://github.com/alphagov/whitehall/pull/8150 and reverted in https://github.com/alphagov/whitehall/pull/8190 due to an issue with the preview on HTML attachments.
An updated PR for HTML attachments will follow but I'm submitting this to get the functionality back to the edit page ASAP.

# What
- Add a link to the preview a document directly below the body field when a document is saved, publicly visible and has an appropriate change note.

https://trello.com/c/sNmuIgvs/1562-add-document-preview-link-to-edit-screens

# Why
- To reduce the clicks for editors to preview back and forth.

# Screenshot
![untitled](https://github.com/alphagov/whitehall/assets/9594455/83207a1b-3389-4f2b-b383-bb949084007a)
