### PR TITLE
Add Group Documents (memberships) Index and Confirm Destroy pages

### DIFF
--- a/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
+++ b/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
@@ -1,0 +1,9 @@
+.app-view-document-collection-group-memberships-index__table {
+  .govuk-table__cell {
+    word-break: break-word;
+
+    &:last-child {
+      width: 7em;
+    }
+  }
+}

--- a/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
+++ b/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
@@ -1,9 +1,12 @@
-.app-view-document-collection-group-memberships-index__table {
-  .govuk-table__cell {
-    word-break: break-word;
+.app-view-document-collection-group-memberships-index__heading {
+  display: flex;
+  justify-content: space-between;
+}
 
-    &:last-child {
-      width: 7em;
-    }
+.app-view-document-collection-group-memberships-index__table .govuk-table__cell{
+  word-break: break-word;
+
+  &:last-child {
+    white-space: nowrap;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@ $govuk-page-width: 1140px;
 @import "./admin/views/contacts";
 @import "./admin/views/dashboard-index";
 @import "./admin/views/document-history-tab";
+@import "./admin/views/document-collection-group-memberships-index";
 @import "./admin/views/edit-edition";
 @import "./admin/views/edit-person";
 @import "./admin/views/edition-resource";

--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -2,6 +2,9 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
   before_action :load_document_collection
   before_action :load_document_collection_group
   before_action :find_document, only: :create_whitehall_member
+  layout :get_layout
+
+  def index; end
 
   def create_whitehall_member
     membership = DocumentCollectionGroupMembership.new(document: @document, document_collection_group: @group)
@@ -44,6 +47,16 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
 
 private
 
+  def get_layout
+    design_system_actions = %w[index]
+
+    if design_system_actions.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
+
   def moving?
     params[:commit] == "Move"
   end
@@ -72,7 +85,7 @@ private
   end
 
   def load_document_collection
-    @collection = DocumentCollection.find(params[:document_collection_id])
+    @collection = DocumentCollection.includes(document: :latest_edition).find(params[:document_collection_id])
   end
 
   def load_document_collection_group

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -89,8 +89,8 @@ module Admin::TabbedNavHelper
     [
       {
         label: "Documents",
-        href: "#",
-        current: false,
+        href: admin_document_collection_group_members_path(group.document_collection, group),
+        current: current_path == admin_document_collection_group_members_path(group.document_collection, group),
       },
       {
         label: "Group details",

--- a/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
+++ b/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Remove document from #{@group.heading}" %>
+<% content_for :title, "Remove document" %>
+<% content_for :context, @group.heading %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_document_collection_group_document_collection_group_membership_path(@collection, @group, @membership), method: :delete do |form| %>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to remove "<%= @membership.document.latest_edition.title %>" from this collection?</p>
+
+       <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", admin_document_collection_group_members_path(@collection, @group), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
+++ b/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
@@ -9,7 +9,7 @@
 
        <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Delete",
+          text: "Remove",
           destructive: true,
         } %>
         <%= link_to("Cancel", admin_document_collection_group_members_path(@collection, @group), class: "govuk-link govuk-link--no-visited-state") %>

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -45,7 +45,7 @@
               },
               {
                 text: link_to(sanitize("View #{tag.span(title, class: "govuk-visually-hidden")}"), membership.document.latest_edition.public_url, class: "govuk-link") +
-                  link_to(sanitize("Delete #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
+                  link_to(sanitize("Remove #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
               }
             ]
           end

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -20,14 +20,12 @@
     } %>
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
+      <div class="govuk-grid-column-full app-view-document-collection-group-memberships-index__heading">
         <%= render "govuk_publishing_components/components/heading", {
           text: "Documents",
           margin_bottom: 6,
         } %>
-      </div>
 
-      <div class="govuk-grid-column-one-quarter">
         <p class="govuk-body govuk-!-text-align-right">
           <%= link_to "Add document", "#", class: "govuk-link" %>
         </p>

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -38,13 +38,14 @@
       <div class="govuk-table--with-actions">
         <%= render "govuk_publishing_components/components/table", {
           rows: @group.memberships.map do |membership|
+            title =  membership.document.latest_edition.title
             [
               {
-                text: membership.document.latest_edition.title,
+                text: title,
               },
               {
-                text: link_to("View", membership.document.latest_edition.public_url, class: "govuk-link") +
-                  link_to("Delete", "#", class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
+                text: link_to(sanitize("View #{tag.span(title, class: "govuk-visually-hidden")}"), membership.document.latest_edition.public_url, class: "govuk-link") +
+                  link_to(sanitize("Delete #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
               }
             ]
           end

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -35,7 +35,7 @@
     </div>
 
     <% if @group.memberships.present? %>
-      <div class="govuk-table--with-actions">
+      <div class="govuk-table--with-actions app-view-document-collection-group-memberships-index__table">
         <%= render "govuk_publishing_components/components/table", {
           rows: @group.memberships.map do |membership|
             title =  membership.document.latest_edition.title

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -1,0 +1,61 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_document_collection_groups_path(@collection),
+  } %>
+<% end %>
+<% content_for :page_title, @group.heading %>
+<% content_for :title, @group.heading %>
+<% content_for :context, @collection.title %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= view_on_website_link_for @collection, url: { draft: true }, class: "govuk-link", target: "blank" %>
+    </p>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document collection group navigation tabs",
+      items: secondary_navigation_tabs_items(@group, request.path)
+    } %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Documents",
+          margin_bottom: 6,
+        } %>
+      </div>
+
+      <div class="govuk-grid-column-one-quarter">
+        <p class="govuk-body govuk-!-text-align-right">
+          <%= link_to "Add document", "#", class: "govuk-link" %>
+        </p>
+      </div>
+    </div>
+
+    <% if @group.memberships.present? %>
+      <div class="govuk-table--with-actions">
+        <%= render "govuk_publishing_components/components/table", {
+          rows: @group.memberships.map do |membership|
+            [
+              {
+                text: membership.document.latest_edition.title,
+              },
+              {
+                text: link_to("View", membership.document.latest_edition.public_url, class: "govuk-link") +
+                  link_to("Delete", "#", class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
+              }
+            ]
+          end
+        } %>
+      </div>
+    <% else %>
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: "There are no documents inside this group"
+      } %>
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/document_collection_groups/_form.html.erb
+++ b/app/views/admin/document_collection_groups/_form.html.erb
@@ -35,6 +35,8 @@
       }
     } %>
 
-    <%= link_to "Cancel", admin_document_collection_groups_path(collection), class: "govuk-link govuk-link--no-visited-state" %>
+    <%= link_to "Cancel",
+      group.persisted? ?  admin_document_collection_group_path(collection, group) : admin_document_collection_groups_path(collection),
+      class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -18,7 +18,7 @@
           actions: [
             {
               label: "View",
-              href: admin_document_collection_group_path(@collection, group)
+              href:  admin_document_collection_group_members_path(@collection, group)
             },
             *([{
               label: "Delete",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -48,42 +48,32 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "656f73517fd3a3c2527e021c3c70f28623c96ff02855a9df480e05c7fb8c3355",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 30,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id]).world_locations.map do\n link_to(l.name, l.public_path, :class => \"govuk-link\")\n end.to_sentence",
+      "warning_code": 4,
+      "fingerprint": "74d3a4465c125ab5ddf5b1e56fec3063ceac4cc0e9aede73cee0c0dff8a461c0",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/admin/document_collection_groups/show.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Preview on website (opens in a new tab)\", DocumentCollection.find(params[:document_collection_id]).public_url(:draft => true), :class => \"govuk-link\", :target => \"_blank\", :rel => \"noopener\")",
       "render_path": [
         {
           "type": "controller",
-          "class": "CorporateInformationPagesController",
+          "class": "Admin::DocumentCollectionGroupsController",
           "method": "show",
-          "line": 8,
-          "file": "app/controllers/corporate_information_pages_controller.rb",
+          "line": 18,
+          "file": "app/controllers/admin/document_collection_groups_controller.rb",
           "rendered": {
-            "name": "corporate_information_pages/show_worldwide_organisation",
-            "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "corporate_information_pages/show_worldwide_organisation",
-          "line": 4,
-          "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb",
-          "rendered": {
-            "name": "worldwide_organisations/_header",
-            "file": "app/views/worldwide_organisations/_header.html.erb"
+            "name": "admin/document_collection_groups/show",
+            "file": "app/views/admin/document_collection_groups/show.html.erb"
           }
         }
       ],
       "location": {
         "type": "template",
-        "template": "worldwide_organisations/_header"
+        "template": "admin/document_collection_groups/show"
       },
-      "user_input": "WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])",
+      "user_input": "DocumentCollection.find(params[:document_collection_id]).public_url(:draft => true)",
       "confidence": "Weak",
       "cwe_id": [
         79
@@ -143,7 +133,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/admin/editions/show/_main.html.erb",
-      "line": 38,
+      "line": 42,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"Preview on website #{if Edition.find(params[:edition_id]).translatable? and Edition.find(params[:edition_id]).available_in_multiple_languages? then\n  \"- English\"\nend} (opens in new tab)\".strip, Edition.find(params[:edition_id]).public_url(:draft => true, :locale => Edition.find(params[:edition_id]).primary_locale), :class => \"govuk-link\", :target => \"_blank\", :data => ({ :module => \"gem-track-click\", :\"track-category\" => \"button-clicked\", :\"track-action\" => (\"#{Edition.find(params[:edition_id]).model_name.singular.dasherize}-button\"), :\"track-label\" => \"Preview on website\" }))",
       "render_path": [
@@ -151,7 +141,7 @@
           "type": "controller",
           "class": "Admin::EditionsController",
           "method": "show",
-          "line": 76,
+          "line": 77,
           "file": "app/controllers/admin/editions_controller.rb",
           "rendered": {
             "name": "admin/editions/show",
@@ -161,7 +151,7 @@
         {
           "type": "template",
           "name": "admin/editions/show",
-          "line": 13,
+          "line": 30,
           "file": "app/views/admin/editions/show.html.erb",
           "rendered": {
             "name": "admin/editions/show/_main",
@@ -187,7 +177,7 @@
       "check_name": "RenderInline",
       "message": "Unescaped model attribute rendered inline",
       "file": "app/views/admin/people/show.html.erb",
-      "line": 10,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
       "code": "render(text => Person.friendly.find(params[:id]).current_role_appointments_title, {})",
       "render_path": [
@@ -221,7 +211,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/admin/topical_event_featurings/index.html.erb",
-      "line": 7,
+      "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"View on website\", TopicalEvent.find(params[:topical_event_id]).public_url({ :locale => params[:locale] }.merge(cachebust_url_options)), :class => \"govuk-link\", :target => \"_blank\")",
       "render_path": [
@@ -229,7 +219,7 @@
           "type": "controller",
           "class": "Admin::TopicalEventFeaturingsController",
           "method": "index",
-          "line": 19,
+          "line": 21,
           "file": "app/controllers/admin/topical_event_featurings_controller.rb",
           "rendered": {
             "name": "admin/topical_event_featurings/index",
@@ -263,7 +253,7 @@
           "type": "controller",
           "class": "Admin::EditionsController",
           "method": "show",
-          "line": 76,
+          "line": 77,
           "file": "app/controllers/admin/editions_controller.rb",
           "rendered": {
             "name": "admin/editions/show",
@@ -273,7 +263,7 @@
         {
           "type": "template",
           "name": "admin/editions/show",
-          "line": 13,
+          "line": 30,
           "file": "app/views/admin/editions/show.html.erb",
           "rendered": {
             "name": "admin/editions/show/_main",
@@ -283,7 +273,7 @@
         {
           "type": "template",
           "name": "admin/editions/show/_main",
-          "line": 26,
+          "line": 30,
           "file": "app/views/admin/editions/show/_main.html.erb",
           "rendered": {
             "name": "admin/editions/show/_main_notices",
@@ -351,46 +341,12 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c4b40274a6e6d5a420ea1cf02c2a29e14817c60e5d3d4b870ce2e2a8b868754f",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/admin/worldwide_organisations/show.html.erb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "WorldwideOrganisation.friendly.find(params[:id]).sponsoring_organisations.map do\n link_to(o.name, [:admin, o])\n end.to_sentence",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::WorldwideOrganisationsController",
-          "method": "show",
-          "line": 38,
-          "file": "app/controllers/admin/worldwide_organisations_controller.rb",
-          "rendered": {
-            "name": "admin/worldwide_organisations/show",
-            "file": "app/views/admin/worldwide_organisations/show.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "admin/worldwide_organisations/show"
-      },
-      "user_input": "WorldwideOrganisation.friendly.find(params[:id])",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": "We don't link directly to any unescaped model attribute."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
       "warning_code": 84,
       "fingerprint": "c4b5157a5184f935bbe15ecfc3a443b6e4e4ce57fe6969bf8bf5afa988ae4779",
       "check_name": "RenderInline",
       "message": "Unescaped model attribute rendered inline",
       "file": "app/views/admin/historical_accounts/index.html.erb",
-      "line": 10,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
       "code": "render(text => Person.friendly.find(params[:person_id]).current_role_appointments.collect(&:role_name).to_sentence, {})",
       "render_path": [
@@ -442,50 +398,6 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "f16bbddbc3733b7cec86224f3f7973c65a90d2962eb0749ca74b547890987ee3",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/worldwide_organisations/_header.html.erb",
-      "line": 33,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id]).sponsoring_organisations.map do\n link_to(o.name, o.public_path, :class => \"sponsoring-organisation govuk-link\")\n end.to_sentence",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "CorporateInformationPagesController",
-          "method": "show",
-          "line": 8,
-          "file": "app/controllers/corporate_information_pages_controller.rb",
-          "rendered": {
-            "name": "corporate_information_pages/show_worldwide_organisation",
-            "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "corporate_information_pages/show_worldwide_organisation",
-          "line": 4,
-          "file": "app/views/corporate_information_pages/show_worldwide_organisation.html.erb",
-          "rendered": {
-            "name": "worldwide_organisations/_header",
-            "file": "app/views/worldwide_organisations/_header.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "worldwide_organisations/_header"
-      },
-      "user_input": "WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "f27b865264b3fc651a9e170c09972a709832270b5ad4baf33ba4b395a1a87113",
       "check_name": "LinkToHref",
@@ -519,6 +431,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-07-11 12:38:05 +0000",
-  "brakeman_version": "5.4.1"
+  "updated": "2023-08-30 12:08:47 +0100",
+  "brakeman_version": "5.3.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,9 @@ Whitehall::Application.routes.draw do
                    as: :members,
                    path: "members",
                    only: [:destroy]
-         resources :document_collection_group_memberships, path: "members", only: %i[index]
+          resources :document_collection_group_memberships, path: "members", only: %i[index destroy] do
+            get :confirm_destroy, on: :member
+          end
         end
         post "whitehall-member" => "document_collection_group_memberships#create_whitehall_member", as: :new_whitehall_member
         post "non-whitehall-member" => "document_collection_group_memberships#create_non_whitehall_member", as: :new_non_whitehall_member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Whitehall::Application.routes.draw do
                    as: :members,
                    path: "members",
                    only: [:destroy]
+         resources :document_collection_group_memberships, path: "members", only: %i[index]
         end
         post "whitehall-member" => "document_collection_group_memberships#create_whitehall_member", as: :new_whitehall_member
         post "non-whitehall-member" => "document_collection_group_memberships#create_non_whitehall_member", as: :new_non_whitehall_member

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -66,3 +66,9 @@ Feature: Grouping documents into a collection
     And a the document collection "May 2012 Update" has a group with the heading "Group to be edited"
     When I edit the group "Group to be edited"'s heading to "Interesting new heading"
     Then I can see that the heading has been updated to "Interesting new heading"
+
+  @design-system-only
+  Scenario: Deleting a document from a group
+    Given a published publication called "Document to be deleted" in a published document collection
+    When I delete the publication "Document to be deleted" from the group
+    Then I can see that "Document to be deleted" has been deleted from the group

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -68,7 +68,7 @@ Feature: Grouping documents into a collection
     Then I can see that the heading has been updated to "Interesting new heading"
 
   @design-system-only
-  Scenario: Deleting a document from a group
-    Given a published publication called "Document to be deleted" in a published document collection
-    When I delete the publication "Document to be deleted" from the group
-    Then I can see that "Document to be deleted" has been deleted from the group
+  Scenario: Removing a document from a group
+    Given a published publication called "Document to be removed" in a published document collection
+    When I remove the publication "Document to be removed" from the group
+    Then I can see that "Document to be removed" has been removed from the group

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -205,3 +205,15 @@ Then(/^I can see that the heading has been updated to "(.*?)"$/) do |heading|
   expect(page).to have_content "Group details have been updated"
   expect(find(".govuk-summary-card")).to have_content heading
 end
+
+When(/^I delete the publication "(.*?)" from the group$/) do |title|
+  visit admin_document_collection_group_document_collection_group_memberships_path(@document_collection, @group)
+  click_link "Delete #{title}"
+  click_button "Delete"
+end
+
+Then(/^I can see that "(.*?)" has been deleted from the group$/) do |title|
+  expect(page).to have_content "Document has been removed from the group"
+  expect(page).to have_content "There are no documents inside this group"
+  expect(all(".govuk-table")).to be_empty
+end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -207,13 +207,13 @@ Then(/^I can see that the heading has been updated to "(.*?)"$/) do |heading|
   expect(find(".govuk-summary-card")).to have_content heading
 end
 
-When(/^I delete the publication "(.*?)" from the group$/) do |title|
+When(/^I remove the publication "(.*?)" from the group$/) do |title|
   visit admin_document_collection_group_document_collection_group_memberships_path(@document_collection, @group)
-  click_link "Delete #{title}"
-  click_button "Delete"
+  click_link "Remove #{title}"
+  click_button "Remove"
 end
 
-Then(/^I can see that "(.*?)" has been deleted from the group$/) do |title|
+Then(/^I can see that "(.*?)" has been removed from the group$/) do |title|
   expect(page).to have_content "Document has been removed from the group"
   expect(page).to have_content "There are no documents inside this group"
   expect(page).not_to have_content title

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -196,6 +196,7 @@ end
 When(/^I edit the group "(.*?)"'s heading to "(.*?)"$/) do |current_heading, new_heading|
   visit admin_document_collection_groups_path(@document_collection)
   click_link "View #{current_heading}"
+  click_link "Group details"
   click_link "Edit Group details"
   fill_in "Name (required)", with: new_heading
   click_button "Save"
@@ -215,5 +216,5 @@ end
 Then(/^I can see that "(.*?)" has been deleted from the group$/) do |title|
   expect(page).to have_content "Document has been removed from the group"
   expect(page).to have_content "There are no documents inside this group"
-  expect(all(".govuk-table")).to be_empty
+  expect(page).not_to have_content title
 end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -13,55 +13,6 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     { document_collection_id: @collection, group_id: @group }
   end
 
-  test "POST #create_whitehall_member adds a whitehall document to a group and redirects" do
-    document = create(:publication).document
-    assert_difference "@group.reload.documents.size" do
-      post :create_whitehall_member, params: id_params.merge(document_id: document.id)
-    end
-    assert_redirected_to admin_document_collection_groups_path(@collection)
-  end
-
-  test "POST #create_whitehall_member warns user when document not found" do
-    post :create_whitehall_member, params: id_params.merge(document_id: 1234, title: "blah")
-    assert_match %r{couldn't find.*blah}, flash[:alert]
-  end
-
-  test "POST #create_non_whitehall_member adds a non-whitehall document to a group and redirects" do
-    stub_publishing_api_has_lookups("/government/news/test" => "51ac4247-fd92-470a-a207-6b852a97f2db")
-    res = stub_publishing_api_has_item(
-      content_id: "51ac4247-fd92-470a-a207-6b852a97f2db",
-      base_path: "/government/news/test",
-      publishing_app: "content-publisher",
-      title: "Lots of news",
-    )
-
-    assert_difference "@group.reload.non_whitehall_links.size" do
-      post :create_non_whitehall_member, params: id_params.merge(url: "https://www.gov.uk/government/news/test")
-    end
-    response = JSON.parse(res.response.body)
-
-    assert_match "'#{response['title']}' added to '#{@group.heading}'", flash[:notice]
-    assert_redirected_to admin_document_collection_groups_path(@collection)
-  end
-
-  test "POST #create_non_whitehall_member warns user when url is not from gov.uk" do
-    post :create_non_whitehall_member, params: id_params.merge(url: "https://www.peters-animals.com")
-    assert_match "Url must be a valid GOV.UK URL.", flash[:alert]
-  end
-
-  test "POST #create_non_whitehall_member warns user when url is invalid" do
-    post :create_non_whitehall_member, params: id_params.merge(url: "https://wwww.too-many-dubs.com")
-    assert_match "Url must be a valid GOV.UK URL", flash[:alert]
-  end
-
-  def remove_params
-    id_params.merge(commit: "Remove")
-  end
-
-  def move_params
-    id_params.merge(commit: "Move")
-  end
-
   view_test "GET #index renders a link to add a document and informs the user there are no documents in the group if none are present" do
     get :index, params: { document_collection_id: @collection, group_id: @group }
 
@@ -73,48 +24,14 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     document = create(:document)
     edition = create(:edition, document:)
     membership = create(:document_collection_group_membership, document:)
+    confirm_destroy_path = confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership)
 
     @group.memberships << membership
 
     get :index, params: { document_collection_id: @collection, group_id: @group }
 
     assert_select ".govuk-link[href='#']", text: "Add document"
-    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{edition.public_url}']", text: "View"
-    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#']", text: "Delete"
-  end
-
-  view_test "DELETE #destroy removes memberships and redirects when Remove clicked" do
-    memberships = [create(:document_collection_group_membership),
-                   create(:document_collection_group_membership)]
-    @group.memberships << memberships
-    assert_difference "@group.reload.memberships.size", -1 do
-      delete :destroy, params: remove_params.merge(memberships: [memberships.first.id])
-    end
-    assert_redirected_to admin_document_collection_groups_path(@collection)
-    assert_match %r{1 document removed}, flash[:notice]
-  end
-
-  test "DELETE #destroy sets flash message if no documents selected" do
-    delete :destroy, params: remove_params
-    assert_match %r{select one or more documents}i, flash[:alert]
-  end
-
-  test "DELETE #destroy moves documents and redirects when Move clicked" do
-    memberships = [create(:document_collection_group_membership),
-                   create(:document_collection_group_membership)]
-    @group.memberships << memberships
-    new_group = build(:document_collection_group)
-    @collection.groups << new_group
-    assert_difference "new_group.reload.memberships.size", 1 do
-      assert_difference "@group.reload.memberships.size", -1 do
-        delete :destroy,
-               params: move_params.merge(
-                 memberships: [memberships.first.id],
-                 new_group_id: new_group.id,
-               )
-      end
-    end
-    assert_redirected_to admin_document_collection_groups_path(@collection)
-    assert_match %r{1 document moved to '#{new_group.heading}'}, flash[:notice]
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{edition.public_url}']", text: "View #{edition.title}"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{confirm_destroy_path}']", text: "Delete #{edition.title}"
   end
 end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -32,6 +32,6 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
 
     assert_select ".govuk-link[href='#']", text: "Add document"
     assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{edition.public_url}']", text: "View #{edition.title}"
-    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{confirm_destroy_path}']", text: "Delete #{edition.title}"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{confirm_destroy_path}']", text: "Remove #{edition.title}"
   end
 end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -8,7 +8,6 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   def id_params
     { document_collection_id: @collection, group_id: @group }
@@ -61,6 +60,27 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
 
   def move_params
     id_params.merge(commit: "Move")
+  end
+
+  view_test "GET #index renders a link to add a document and informs the user there are no documents in the group if none are present" do
+    get :index, params: { document_collection_id: @collection, group_id: @group }
+
+    assert_select ".govuk-link[href='#']", text: "Add document"
+    assert_select ".govuk-warning-text__text", text: /There are no documents inside this group/
+  end
+
+  view_test "GET #index renders a link to add a document and a table of memberships with view and delete links" do
+    document = create(:document)
+    edition = create(:edition, document:)
+    membership = create(:document_collection_group_membership, document:)
+
+    @group.memberships << membership
+
+    get :index, params: { document_collection_id: @collection, group_id: @group }
+
+    assert_select ".govuk-link[href='#']", text: "Add document"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#{edition.public_url}']", text: "View"
+    assert_select ".govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='#']", text: "Delete"
   end
 
   view_test "DELETE #destroy removes memberships and redirects when Remove clicked" do

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-card__action a[href='#{new_admin_document_collection_group_path(@collection)}']", text: /Add group/
     assert_select ".govuk-summary-list__key", text: @group.heading
     assert_select ".govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__actions a[href='#{admin_document_collection_group_path(@collection, @group)}']", text: "View #{@group.heading}"
+    assert_select ".govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(@collection, @group)}']", text: "View #{@group.heading}"
   end
 
   view_test "GET #index shows confirm delete links when 2 or more groups are present" do
@@ -32,11 +32,11 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
 
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: group1.heading
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "1 document in group"
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{admin_document_collection_group_path(collection, group1)}']", text: "View #{group1.heading}"
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(collection, group1)}']", text: "View #{group1.heading}"
     assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group1)}']", text: "Delete #{group1.heading}"
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: group2.heading
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{admin_document_collection_group_path(collection, group2)}']", text: "View #{group2.heading}"
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(collection, group2)}']", text: "View #{group2.heading}"
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group2)}']", text: "Delete #{group2.heading}"
   end
 

--- a/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
-class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController::TestCase
+class Admin::LegacyDocumentCollectionGroupMembershipsControllerTest < ActionController::TestCase
+  tests Admin::DocumentCollectionGroupMembershipsController
+
   setup do
     @collection = create(:document_collection, :with_group)
     @group = @collection.groups.first
-    login_as_preview_design_system_user :writer
+    login_as create(:writer)
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
@@ -10,7 +10,6 @@ class Admin::LegacyDocumentCollectionGroupMembershipsControllerTest < ActionCont
   end
 
   should_be_an_admin_controller
-  should_render_bootstrap_implementation_with_preview_next_release
 
   def id_params
     { document_collection_id: @collection, group_id: @group }

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -325,7 +325,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
     expected_output = [
       {
         label: "Documents",
-        href: "#",
+        href: admin_document_collection_group_members_path(document_collection, group),
         current: false,
       },
       {


### PR DESCRIPTION
## Description

## Screenshots

<img width="725" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/589c744c-36d1-43ea-a854-22b0a5c9d69e">

<img width="688" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/395bfe50-712e-435e-8227-0d2c1c36d6cd">

<img width="608" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/5cbe3373-2b34-42d2-97ba-68f725e2e4af">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

https://trello.com/c/szAfNI2T/526-create-a-group-landing-page-for-adding-documents
