### PR TITLE
Add option to filter documents by overdue review reminders

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -402,7 +402,7 @@ private
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links, :review_overdue)
           .permit!
           .to_h
   end

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -35,7 +35,7 @@ module Admin
     end
 
     def page_title
-      "#{ownership} #{edition_state} #{type_for_display}#{title_matches}#{location_matches} #{date_range_string}".squeeze(" ").strip
+      "#{ownership} #{edition_state} #{type_for_display}#{title_matches}#{location_matches} #{date_range_string} #{review_reminder_string}".squeeze(" ").strip
     end
 
     def default_page_size
@@ -92,6 +92,10 @@ module Admin
       end
     end
 
+    def review_reminder_string
+      "with overdue reviews" if review_overdue
+    end
+
     def exportable?
       unpaginated_editions.count <= MAX_EXPORT_SIZE
     end
@@ -114,6 +118,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_broken_links if only_broken_links
+      editions = editions.review_overdue if review_overdue
 
       editions = editions.includes(:unpublishing) if include_unpublishing?
       editions = editions.includes(:link_check_reports) if include_link_check_reports?
@@ -232,6 +237,10 @@ module Admin
 
     def only_broken_links
       options[:only_broken_links].present?
+    end
+
+    def review_overdue
+      options[:review_overdue].present?
     end
 
     def include_unpublishing?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -98,6 +98,12 @@ class Edition < ApplicationRecord
   scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
   scope :live_edition, -> { joins(:document).where("documents.live_edition_id = editions.id") }
 
+  scope :review_overdue, lambda {
+    joins("INNER JOIN documents ON documents.id = editions.document_id INNER JOIN review_reminders ON review_reminders.document_id = documents.id")
+      .where(document: { review_reminders: { review_at: ..Time.zone.today } })
+      .where.not(first_published_at: nil)
+  }
+
   # @!group Callbacks
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <%
-  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links]
+  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :review_overdue]
   anchor ||= anchor || ""
   raise "filter action required" unless defined?(filter_action)
 %>
@@ -132,6 +132,21 @@
             value: "1",
             bold: true,
             checked: params["only_broken_links"],
+          }
+        ]
+      } %>
+    <% end %>
+
+    <% if filter_by.include?(:review_overdue) %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "review_overdue",
+        small: true,
+        items: [
+          {
+            label: "Review overdue",
+            value: "1",
+            bold: true,
+            checked: params["review_overdue"],
           }
         ]
       } %>

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -32,3 +32,12 @@ Feature: Filtering documents by author in admin
     When I filter by organisation "Department of Thumbtacks"
     Then I should see the publication "Thumbtack Publication"
     And I should not see the publication "Another Publication"
+
+  Scenario: Viewing only documents with an overdue review reminder
+    Given a published publication "Standard Beard Lengths" with a PDF attachment
+    And a review reminder exists for "Standard Beard Lengths" with the date "2032-1-1"
+    And a published publication "I moustache you a question" with a PDF attachment
+    And a review reminder exists for "I moustache you a question" and the review date has passed
+    When I filter by review overdue
+    Then I should see the publication "I moustache you a question"
+    And I should not see the publication "Standard Beard Lengths"

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -35,3 +35,14 @@ And(/^I update the review date to "([^"]*)"$/) do |date|
   fill_in_date_fields(date)
   click_button "Save"
 end
+
+And(/^a review reminder exists for "([^"]*)" and the review date has passed$/) do |title|
+  edition = Edition.find_by!(title:)
+  create(:review_reminder, :reminder_due, document: edition.document)
+end
+
+When(/^I filter by review overdue$/) do
+  visit admin_editions_path
+  check "Review overdue"
+  click_on "Search"
+end

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -236,6 +236,15 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
+  test "should filter by overdue reviews" do
+    document = create(:document)
+    edition_with_overdue_reminder = create(:published_edition, document:)
+    create(:review_reminder, :reminder_due, document:)
+    create(:published_edition)
+
+    assert_equal [edition_with_overdue_reminder], Admin::EditionFilter.new(Edition, @current_user, review_overdue: true).editions
+  end
+
   test "should return the editions ordered by most recent first" do
     older_news_article = create(:draft_news_article, updated_at: 3.days.ago)
     newer_news_article = create(:draft_news_article, updated_at: 1.minute.ago)
@@ -334,6 +343,11 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   test "should generate page title for to date" do
     filter = Admin::EditionFilter.new(Edition, build(:user), to_date: "09/11/2011")
     assert_equal "Everyone’s documents before 09/11/2011", filter.page_title
+  end
+
+  test "should generate page title for overdue reviews" do
+    filter = Admin::EditionFilter.new(Edition, build(:user), review_overdue: "1")
+    assert_equal "Everyone’s documents with overdue reviews", filter.page_title
   end
 
   test "should paginate editions" do


### PR DESCRIPTION
## Description

This adds in an additional filter to the documents search page which allows users to be able to filter by review reminders that are overdue.

Unforunately i've had to manually adds the joins to the documents and review reminder tables due to some custom sql written in the :with_title_containing scope

```
in_default_locale
  .includes(:document)
  .where("edition_translations.title LIKE :like_clause OR documents.slug = :slug", like_clause:, slug: keywords)
  .references(:document)
```

This expects the documents table to be called documents, but when you use active record to inner join a has one relationship it aliases the table to singular.

So in this case, when you inner join the document it aliases the documents table to 'document'. This causes  the above where clause to blow up as it can't find the documents table. Interestingly the same behaviour doesn't seem to occur for left outer join.

## Screenshots

<img width="699" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/f73b43c3-04d4-46bc-a555-61d8073c98ce">

## Trello card

https://trello.com/c/IX8jDbW9/379-add-review-overdue-to-the-states-search-list-on-the-document-search-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
