### PR TITLE
Add a preview link to the HTML attachment form

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -59,6 +59,27 @@
           }
         } %>
       </div>
+
+      <% if !attachment.new_record? %>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          } do %>
+          <p class="govuk-body">
+            <%= link_to("Preview on website (opens in new tab)",
+            attachment.url(preview: true, full_url: true),
+            class: "govuk-link",
+            target: "_blank",
+            data: {
+              module: "gem-track-click",
+              "track-category": "button-clicked",
+              "track-action": "#{attachable.model_name.singular.dasherize}-button",
+              "track-label": "Preview on website",
+            })%>
+          </p>
+          <p class="govuk-body">
+            To preview your document on GOV.UK you must save it first.
+          </p>
+        <% end %>
+      <% end %>
     <% end %>
   <% elsif attachment.is_a?(ExternalAttachment) %>
     <div class="govuk-!-margin-bottom-8">

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -27,9 +27,26 @@ Feature: Managing attachments on editions
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
-    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    And I begin editing an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    Then I cannot see a preview link
+    When I save the attachment
     Then I can see the attachment title "Beard Length Graphs 2012"
     And I can see the preview link to the attachment "HTML attachment"
+    When I edit the attachment
+    Then I can see a preview link
+
+  Scenario: Previewing HTML attachment on consultation responses
+    Given I am a writer
+    And a draft closed consultation "Should We Ban Beards" with an outcome exists
+    When I go to the outcome for the consultation "Should We Ban Beards"
+    And I begin editing an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    Then I cannot see a preview link
+    When I save the attachment
+    Then I can see the attachment title "Beard Length Graphs 2012"
+    And I can see the preview link to the attachment "HTML attachment"
+    When I edit the attachment
+    Then I can see a preview link
+
 
   Scenario: Adding attachments on consultation responses
     Given I am a writer

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -13,6 +13,21 @@ When(/^I upload a file attachment with the title "(.*?)" and the file "(.*?)"$/)
   click_on "Save"
 end
 
+When(/^I begin editing an html attachment with the title "(.*?)" and the body "(.*?)"$/) do |title, body|
+  click_on "Add new HTML attachment"
+  fill_in "Title", with: title
+  fill_in "Body", with: body
+  check "Use manually numbered headings"
+end
+
+When(/^I save the attachment$/) do
+  click_on "Save"
+end
+
+When(/^I edit the attachment$/) do
+  click_on "Edit attachment"
+end
+
 When(/^I upload an html attachment with the title "(.*?)" and the body "(.*?)"$/) do |title, body|
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
@@ -83,6 +98,14 @@ end
 
 Then(/^I can see the preview link to the attachment "(.*?)"$/) do |attachment_title|
   expect(page).to have_link("a", href: /draft-origin/, text: attachment_title)
+end
+
+Then(/^I cannot see a preview link$/) do
+  expect(page).to_not have_link("a", href: /draft-origin/)
+end
+
+Then(/^I can see a preview link$/) do
+  expect(page).to have_link("a", href: /draft-origin/)
 end
 
 When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)"$/) do |title, isbn|


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This was originally submitted as part of https://github.com/alphagov/whitehall/pull/8150 and reverted in https://github.com/alphagov/whitehall/pull/8190 due to an issue with the preview on consultations and calls for evidence.

This PR is the same as the previous PR but uses `attachable` instead of `@edition` and includes a test for the scenario that broke.

# What
- Add a link to preview an HTML Attachment in the edit page when the it has been saved

https://trello.com/c/sNmuIgvs/1562-add-document-preview-link-to-edit-screens

# Why
- To reduce the clicks for editors to preview back and forth.

# Screenshot
![untitled](https://github.com/alphagov/whitehall/assets/9594455/83207a1b-3389-4f2b-b383-bb949084007a)
