### PR TITLE
Fix test so that it tests the right method

### DIFF
--- a/test/unit/app/helpers/errors_helper_test.rb
+++ b/test/unit/app/helpers/errors_helper_test.rb
@@ -38,7 +38,7 @@ class ErrorsHelperTest < ActionView::TestCase
   end
 
   test "#errors_for does not return an empty string when object has unrelated error" do
-    assert_nil errors_for_input(@object_with_unrelated_errors.errors, :title)
+    assert_nil errors_for(@object_with_unrelated_errors.errors, :title)
   end
 
   class ErrorTestObject


### PR DESCRIPTION
There are a set of tests for `errors_for_input` and another set for `errors_for` in `errors_helper_test.rb`, but one of the tests for `errors_for` actually calls `errors_for_input`. It looks like this was copy/pasted and the test name was updated, but the test body was not.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
