### PR TITLE
Replace errant 'style' attribute with 'class'

### DIFF
--- a/app/views/admin/editions/_style_guidance.html.erb
+++ b/app/views/admin/editions/_style_guidance.html.erb
@@ -38,7 +38,7 @@
     <li>utilise</li>
   </ul>
 
-  <p style="govuk-body">Always avoid metaphors. For example:</p>
+  <p class="govuk-body">Always avoid metaphors. For example:</p>
 
   <ul class='gem-c-list govuk-list govuk-list--bullet'>
     <li>drive (you can only drive vehicles; not schemes or people)</li>


### PR DESCRIPTION
A paragraph tag is using a 'style' attribute when it should be using a 'class' one (and is in fact setting the style to a class, not a style).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
