### PR TITLE
Extend schema validation test

### DIFF
--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -422,6 +422,7 @@ class PublishingApi::DocumentCollectionWithTaxonomyTopicEmailOverrideTest < Acti
 
     assert_equal [taxonomy_topic_email_override], presented_document_collection.links[:taxonomy_topic_email_override]
 
+    assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
     assert_valid_against_links_schema({ links: presented_document_collection.links }, "document_collection")
   end
 


### PR DESCRIPTION
This test will fail until https://github.com/alphagov/publishing-api/pull/2491 is merged

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
