### PR TITLE
Enable GA4 tracking on the phase banner

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,7 +25,7 @@
   <% if t('admin.whats_new.show_banner') %>
     <div class="govuk-design-system-styling">
       <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
-        <%= render "shared/phase_banner", tracking_module: "track-link-click" %>
+        <%= render "shared/phase_banner", tracking_module: "track-link-click", ga4_tracking: true %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -35,6 +35,7 @@
   <div class="govuk-width-container">
     <%= render "shared/phase_banner", {
         show_feedback_banner: t('admin.feedback.show_banner'),
+        ga4_tracking: true
       } %>
 
     <%= yield(:back_link) %>

--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -4,6 +4,7 @@
 <%if t('admin.whats_new.show_banner') %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "What's new",
+      ga4_tracking: true,
       message: sanitize("New review date functionality -
         #{
           link_to(
@@ -24,6 +25,7 @@
 <% elsif show_feedback_banner %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "Feedback",
+      ga4_tracking: true,
       message: mail_to(
         "publishing-service-feedback@digital.cabinet-office.gov.uk",
         "Give feedback on the recent changes to Whitehall",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
