### PR TITLE
Apply translated components to translation pages

### DIFF
--- a/app/assets/stylesheets/admin/_overrides.scss
+++ b/app/assets/stylesheets/admin/_overrides.scss
@@ -25,3 +25,10 @@ code {
     display: block;
   }
 }
+
+.app-c-translated-textarea,
+.app-c-translated-input {
+  & > *:first-child > .govuk-form-group {
+    margin-bottom: govuk-spacing(2) !important; // stylelint-disable-line declaration-no-important
+  }
+}

--- a/app/assets/stylesheets/admin/views/_translation.scss
+++ b/app/assets/stylesheets/admin/views/_translation.scss
@@ -1,3 +1,0 @@
-.app-view-translation__english-content {
-  color: $govuk-secondary-text-colour;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,7 +42,6 @@ $govuk-page-width: 1140px;
 @import "./admin/views/summary";
 @import "./admin/views/take-part";
 @import "./admin/views/topical-events-index";
-@import "./admin/views/translation";
 @import "./admin/views/unpublish-withdrawal";
 @import "./admin/views/whats-new";
 @import "./admin/views/worldwide-organisations-choose-main-office";

--- a/app/views/admin/contact_translations/edit.html.erb
+++ b/app/views/admin/contact_translations/edit.html.erb
@@ -5,139 +5,149 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @translated_contact, url: admin_organisation_contact_translation_path(@contactable, @translated_contact, translation_locale), method: :put do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title (required)",
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Title (required)",
+          },
+          heading_size: "l",
+          name: "contact[title]",
+          id: "contact_title",
+          value: @translated_contact.title,
+          error_items: errors_for(form.object.errors, :title),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        heading_size: "l",
-        name: "contact[title]",
-        id: "contact_title",
-        value: @translated_contact.title,
-        error_items: errors_for(form.object.errors, :title),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_contact.title
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.title %></p>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
+      <%= render "components/translated_textarea", {
+        textarea: {
+           label: {
           heading_size: "l",
           text: "Comments",
+          },
+          name: "contact[comments]",
+          id: "contact_comments",
+          value: @translated_contact.comments,
+          error_items: errors_for(form.object.errors, :comments),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        name: "contact[comments]",
-        id: "contact_comments",
-        value: @translated_contact.comments,
-        error_items: errors_for(form.object.errors, :comments),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_contact.comments
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.comments %></p>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Recipient",
-        },
-        heading_size: "l",
-        name: "contact[recipient]",
-        id: "contact_recipient",
-        value: @translated_contact.recipient,
-        error_items: errors_for(form.object.errors, :recipient),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.recipient %></p>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Recipient",
+          },
           heading_size: "l",
-          text: "Street address (required)",
+          name: "contact[recipient]",
+          id: "contact_recipient",
+          value: @translated_contact.recipient,
+          error_items: errors_for(form.object.errors, :recipient),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        name: "contact[street_address]",
-        id: "contact_street_address",
-        value: @translated_contact.street_address,
-        error_items: errors_for(form.object.errors, :street_address),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.street_address %></p>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Locality",
-        },
-        heading_size: "l",
-        name: "contact[locality]",
-        id: "contact_locality",
-        value: @translated_contact.locality,
-        error_items: errors_for(form.object.errors, :locality),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_contact.recipient
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.locality %></p>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Region",
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Street address (required)",
+          },
+          name: "contact[street_address]",
+          id: "contact_street_address",
+          value: @translated_contact.street_address,
+          error_items: errors_for(form.object.errors, :street_address),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        heading_size: "l",
-        name: "contact[region]",
-        id: "contact_region",
-        value: @translated_contact.region,
-        error_items: errors_for(form.object.errors, :region),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+         details: {
+          text: @english_contact.street_address
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.region %></p>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Email",
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Locality",
+          },
+          heading_size: "l",
+          name: "contact[locality]",
+          id: "contact_locality",
+          value: @translated_contact.locality,
+          error_items: errors_for(form.object.errors, :locality),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        heading_size: "l",
-        name: "contact[email]",
-        id: "contact_email",
-        value: @translated_contact.email,
-        error_items: errors_for(form.object.errors, :email),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_contact.locality
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.email %></p>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Contact form URL",
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Region",
+          },
+          heading_size: "l",
+          name: "contact[region]",
+          id: "contact_region",
+          value: @translated_contact.region,
+          error_items: errors_for(form.object.errors, :region),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        heading_size: "l",
-        name: "contact[contact_form_url]",
-        id: "contact_contact_form_url",
-        value: @translated_contact.contact_form_url,
-        error_items: errors_for(form.object.errors, :contact_form_url),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_contact.region
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English
-        translation:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @translated_contact.contact_form_url %></p>
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Email",
+          },
+          heading_size: "l",
+          name: "contact[email]",
+          id: "contact_email",
+          value: @translated_contact.email,
+          error_items: errors_for(form.object.errors, :email),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
+        },
+        details: {
+          text: @english_contact.email
+        }
+      } %>
+
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Contact form URL",
+          },
+          heading_size: "l",
+          name: "contact[contact_form_url]",
+          id: "contact_contact_form_url",
+          value: @translated_contact.contact_form_url,
+          error_items: errors_for(form.object.errors, :contact_form_url),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false
+        },
+        details: {
+          text: @english_contact.contact_form_url
+        }
+      } %>
 
       <div class="govuk-!-margin-bottom-8 app-view-contacts__phone">
         <% if @translated_contact.contact_numbers.present? %>
@@ -146,46 +156,47 @@
             margin_bottom: 6,
             font_size: "l",
           } %>
+
           <%= form.fields_for :contact_numbers, @translated_contact.contact_numbers do |number_form| %>
-            <%= render "govuk_publishing_components/components/input", {
-              label: {
-                text: "Label"
+            <%= render "components/translated_input", {
+              input: {
+                label: {
+                  text: "Label"
+                },
+                name: "contact[contact_numbers_attributes][#{number_form.index}][label]",
+                id: "contact_contact_number_#{number_form.index}_label",
+                value: number_form.object.label,
+                heading_size: "m",
+                error_items: errors_for(number_form.object.errors, :label),
+                right_to_left: number_form.object.translation_locale.rtl?,
+                right_to_left_help: false
               },
-              name: "contact[contact_numbers_attributes][#{number_form.index}][label]",
-              id: "contact_contact_number_#{number_form.index}_label",
-              value: number_form.object.label,
-              heading_size: "m",
-              error_items: errors_for(number_form.object.errors, :label),
-              right_to_left: number_form.object.translation_locale.rtl?,
-              right_to_left_help: false
+              details: {
+                text: number_form.object.label
+              }
             } %>
-            <% if number_form.object.label.present? %>
-              <div class="govuk-!-margin-bottom-8">
-                <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English translation:</h2>
-                <p class="app-view-translation__english-content govuk-body"><%= number_form.object.label %></p>
-              </div>
-            <% end %>
-            <%= render "govuk_publishing_components/components/input", {
-              label: {
-                text: "Number"
+
+            <%= render "components/translated_input", {
+              input: {
+                label: {
+                  text: "Number"
+                },
+                name: "contact[contact_numbers_attributes][#{number_form.index}][number]",
+                id: "contact_contact_number_#{number_form.index}_number",
+                value: number_form.object.number,
+                heading_size: "m",
+                error_items: errors_for(number_form.object.errors, :number),
+                right_to_left: number_form.object.translation_locale.rtl?,
+                right_to_left_help: false
               },
-              name: "contact[contact_numbers_attributes][#{number_form.index}][number]",
-              id: "contact_contact_number_#{number_form.index}_number",
-              value: number_form.object.number,
-              heading_size: "m",
-              error_items: errors_for(number_form.object.errors, :number),
-              right_to_left: number_form.object.translation_locale.rtl?,
-              right_to_left_help: false
+               details: {
+                text: number_form.object.number
+              }
             } %>
-            <% if number_form.object.number.present? %>
-              <div class="govuk-!-margin-bottom-8">
-                <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English translation:</h2>
-                <p class="app-view-translation__english-content govuk-body"><%= number_form.object.number %></p>
-              </div>
-            <% end %>
           <% end %>
         <% end %>
       </div>
+
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",

--- a/app/views/admin/contact_translations/edit.html.erb
+++ b/app/views/admin/contact_translations/edit.html.erb
@@ -59,11 +59,11 @@
         }
       } %>
 
-      <%= render "components/translated_textarea", {
-        textarea: {
+      <%= render "components/translated_input", {
+        input: {
           label: {
             heading_size: "l",
-            text: "Street address (required)",
+            text: "Street address",
           },
           name: "contact[street_address]",
           id: "contact_street_address",

--- a/app/views/admin/edition_translations/edit.html.erb
+++ b/app/views/admin/edition_translations/edit.html.erb
@@ -8,57 +8,64 @@
     <%= form_for @translated_edition, as: :edition, url: admin_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
 
       <% unless @edition.is_a?(CorporateInformationPage) %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Translated title (required)",
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "Translated title (required)",
+            },
+            name: "edition[title]",
+            id: "edition_title",
+            heading_level: 2,
+            heading_size: "l",
+            value: @translated_edition.title,
+            error_items: errors_for(form.object.errors, :title),
+            right_to_left: form.object.translation_rtl?,
+            right_to_left_help: false,
           },
-          name: "edition[title]",
-          id: "edition_title",
-          heading_level: 2,
-          heading_size: "l",
-          value: @translated_edition.title,
-          error_items: errors_for(form.object.errors, :title),
-          right_to_left: form.object.translation_rtl?,
-          right_to_left_help: false
+          details: {
+            text: @edition.title,
+          }
         } %>
-
-        <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English title content:</h3>
-        <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.title %></p>
       <% end %>
 
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "l",
-          text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
+          },
+          name: "edition[summary]",
+          id: "edition_summary",
+          value: @translated_edition.summary,
+          rows: 2,
+          error_items: errors_for(form.object.errors, :summary),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
         },
-        name: "edition[summary]",
-        id: "edition_summary",
-        value: @translated_edition.summary,
-        rows: 2,
-        error_items: errors_for(form.object.errors, :summary),
-        right_to_left: form.object.translation_rtl?,
-        right_to_left_help: false
+        details: {
+          text: @edition.summary,
+        }
       } %>
 
-      <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English summary content:</h3>
-      <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.summary %></p>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "l",
-          text: "Translated body (required)",
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Translated body (required)",
+          },
+          name: "edition[body]",
+          id: "edition_body",
+          value: @translated_edition.body,
+          rows: 20,
+          error_items: errors_for(form.object.errors, :body),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
         },
-        name: "edition[body]",
-        id: "edition_body",
-        value: @translated_edition.body,
-        rows: 20,
-        error_items: errors_for(form.object.errors, :body),
-        right_to_left: form.object.translation_rtl?,
-        right_to_left_help: false
+        details: {
+          text: @edition.body,
+        },
+        govspeak_editor: true,
       } %>
-
-      <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English body content:</h3>
-      <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @edition.body %></p>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/organisation_translations/edit.html.erb
+++ b/app/views/admin/organisation_translations/edit.html.erb
@@ -5,59 +5,70 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @translated_organisation, url: admin_organisation_translation_path(@translated_organisation, translation_locale) do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Name (required)",
-        },
-        heading_size: "l",
-        name: "organisation[name]",
-        id: "organisation_name",
-        value: @translated_organisation.name,
-        error_items: errors_for(form.object.errors, :name),
-        right_to_left: @translated_organisation.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English name
-        content:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @organisation.name %></p>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Acronym",
-        },
-        heading_size: "l",
-        name: "organisation[acronym]",
-        id: "organisation_acronym",
-        value: @translated_organisation.acronym,
-        error_items: errors_for(form.object.errors, :acronym),
-        right_to_left: @translated_organisation.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Name (required)",
+          },
           heading_size: "l",
-          text: "Logo formatted name (required)",
+          name: "organisation[name]",
+          id: "organisation_name",
+          value: @translated_organisation.name,
+          error_items: errors_for(@translated_organisation.errors, :name),
+          right_to_left: @translated_organisation.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        name: "organisation[logo_formatted_name]",
-        id: "organisation_logo_formatted_name",
-        value: @translated_organisation.logo_formatted_name,
-        rows: 4,
-        error_items: errors_for(form.object.errors, :logo_formatted_name),
-        right_to_left: @translated_organisation.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @organisation.name
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @organisation.logo_formatted_name %></p>
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Acronym",
+          },
+          heading_size: "l",
+          name: "organisation[acronym]",
+          id: "organisation_acronym",
+          value: @translated_organisation.acronym,
+          error_items: errors_for(@translated_organisation.errors, :acronym),
+          right_to_left: @translated_organisation.translation_locale.rtl?,
+          right_to_left_help: false
+        },
+        details: {
+          text: @organisation.acronym
+        }
+      } %>
+
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Logo formatted name (required)",
+          },
+          name: "organisation[logo_formatted_name]",
+          id: "organisation_logo_formatted_name",
+          value: @translated_organisation.logo_formatted_name,
+          rows: 4,
+          error_items: errors_for(@translated_organisation.errors, :logo_formatted_name),
+          right_to_left: @translated_organisation.translation_locale.rtl?,
+          right_to_left_help: false
+        },
+        details: {
+          text: @organisation.logo_formatted_name
+        }
+      } %>
 
       <%= render 'admin/shared/featured_link_fields', form: form %>
+
       <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",
           data_attributes: {
             module: "gem-track-click",
             "track-category": "form-button",
-            "track-action": "#{form.object.class.name.demodulize.underscore.dasherize}-button",
+            "track-action": "#{@translated_organisation.class.name.demodulize.underscore.dasherize}-button",
             "track-label": "Save"
           }
         } %>

--- a/app/views/admin/person_translations/edit.html.erb
+++ b/app/views/admin/person_translations/edit.html.erb
@@ -5,23 +5,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @translated_person, url: admin_person_translation_path(@translated_person, translation_locale), method: :put do |form| %>
-
-      <%= render "components/govspeak-editor", {
-        label: {
-          heading_size: "l",
-          text: "Biography",
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Biography",
+          },
+          name: "person[biography]",
+          id: "person_biography",
+          value: @translated_person.biography,
+          rows: 20,
+          error_items: errors_for(@translated_person.errors, :biography),
+          right_to_left: @translated_person.translation_locale.rtl?,
+          right_to_left_help: false
         },
-        name: "person[biography]",
-        id: "person_biography",
-        value: @translated_person.biography,
-        rows: 20,
-        error_items: errors_for(form.object.errors, :biography),
-        right_to_left: @translated_person.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @person.biography
+        },
+        govspeak_editor: true,
       } %>
-
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English biography content:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @person.biography %></p>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/role_translations/edit.html.erb
+++ b/app/views/admin/role_translations/edit.html.erb
@@ -5,38 +5,43 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @translated_role, as: :role, url: admin_role_translation_path(@translated_role, translation_locale) do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Name (required)",
-        },
-        heading_size: "l",
-        name: "role[name]",
-        id: "role_name",
-        value: @translated_role.name,
-        error_items: errors_for(form.object.errors, :name),
-        right_to_left: @translated_role.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English name content:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @role.name %></p>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Name (required)",
+          },
           heading_size: "l",
-          text: "Responsibilities",
+          name: "role[name]",
+          id: "role_name",
+          value: @translated_role.name,
+          error_items: errors_for(form.object.errors, :name),
+          right_to_left: @translated_role.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "role[responsibilities]",
-        id: "role_responsibilities",
-        value: @translated_role.responsibilities,
-        rows: 20,
-        error_items: errors_for(form.object.errors, :responsibilities),
-        right_to_left: @translated_role.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @role.name
+        }
       } %>
 
-      <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English responsibilities content:</h2>
-      <p class="app-view-translation__english-content govuk-body"><%= @role.responsibilities %></p>
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Responsibilities",
+          },
+          name: "role[responsibilities]",
+          id: "role_responsibilities",
+          value: @translated_role.responsibilities,
+          rows: 20,
+          error_items: errors_for(form.object.errors, :responsibilities),
+          right_to_left: @translated_role.translation_locale.rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @role.responsibilities
+        },
+        govspeak_editor: true
+      } %>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/shared/_featured_link_fields.html.erb
+++ b/app/views/admin/shared/_featured_link_fields.html.erb
@@ -21,33 +21,57 @@
 <div data-module="AddAnother" data-add-text="Add another featured link">
   <%= form.fields_for :featured_links do |featured_link_form| %>
     <div class="js-duplicate-fields-set govuk-!-margin-bottom-6">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title"
-        },
-        heading_size: "m",
-        value: featured_link_form.object.title,
-        name: "#{model}[featured_links_attributes][#{featured_link_form.index}][title]",
-        id: "#{model}_featured_links[#{featured_link_form.index}]_title",
-      } %>
-
       <% if @translation_locale && @translation_locale.code != I18n.default_locale %>
-        <p class="app-view-translation__english-content govuk-body">English: <%= featured_link_form.object.title %></p>
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "Title"
+            },
+            heading_size: "m",
+            value: featured_link_form.object.title,
+            name: "#{model}[featured_links_attributes][#{featured_link_form.index}][title]",
+            id: "#{model}_featured_links[#{featured_link_form.index}]_title",
+          },
+          details: {
+            text: featured_link_form.object.title,
+          }
+        } %>
+
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "URL",
+            },
+            heading_size: "m",
+            value: featured_link_form.object.url,
+            name: "#{model}[featured_links_attributes][#{featured_link_form.index}][url]",
+            id: "#{model}_featured_links[#{featured_link_form.index}]_url",
+          },
+          details: {
+            text: featured_link_form.object.url,
+          }
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Title"
+          },
+          heading_size: "m",
+          value: featured_link_form.object.title,
+          name: "#{model}[featured_links_attributes][#{featured_link_form.index}][title]",
+          id: "#{model}_featured_links[#{featured_link_form.index}]_title",
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "URL",
+          },
+          heading_size: "m",
+          value: featured_link_form.object.url,
+          name: "#{model}[featured_links_attributes][#{featured_link_form.index}][url]",
+          id: "#{model}_featured_links[#{featured_link_form.index}]_url",
+        } %>
       <% end %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "URL",
-        },
-        heading_size: "m",
-        value: featured_link_form.object.url,
-        name: "#{model}[featured_links_attributes][#{featured_link_form.index}][url]",
-        id: "#{model}_featured_links[#{featured_link_form.index}]_url",
-      } %>
-
-    <% if @translation_locale && @translation_locale.code != I18n.default_locale %>
-      <p class="app-view-translation__english-content govuk-body">English: <%= featured_link_form.object.url %></p>
-    <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/world_location_news_translations/edit.html.erb
+++ b/app/views/admin/world_location_news_translations/edit.html.erb
@@ -14,53 +14,60 @@
             text: "Changes to worldwide locations appear instantly on the live site.",
           } %>
 
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Translation Name (required)",
-            },
-            heading_size: "l",
-            value: @translated_world_location_news.name,
-            name: "world_location_news[world_location_attributes][name]",
-            error_items: errors_for(@translated_world_location.errors, :name),
-            id: "world_location_news_world_location_name",
-            right_to_left: @translated_world_location_news.translation_locale.rtl?,
-            right_to_left_help: false
-          } %>
-
-          <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English name content:</h3>
-          <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @english_world_location_news.name %></p>
-
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Title (required)"
-            },
-            heading_size: "l",
-            value: @translated_world_location_news.title,
-            name: "world_location_news[title]",
-            id: "world_location_news_title",
-            error_items: errors_for(@translated_world_location_news.errors, :title),
-            right_to_left: @translated_world_location_news.translation_locale.rtl?,
-            right_to_left_help: false
-          } %>
-
-          <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English title content:</h3>
-          <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @english_world_location_news.title %></p>
-
-          <%= render "components/govspeak-editor", {
-            label: {
-              text: "Mission statement",
+          <%= render "components/translated_input", {
+            input: {
+              label: {
+                text: "Translation Name (required)",
+              },
               heading_size: "l",
+              value: @translated_world_location_news.name,
+              name: "world_location_news[world_location_attributes][name]",
+              error_items: errors_for(@translated_world_location.errors, :name),
+              id: "world_location_news_world_location_name",
+              right_to_left: @translated_world_location_news.translation_locale.rtl?,
+              right_to_left_help: false,
             },
-            name: "world_location_news[mission_statement]",
-            id: "world_location_news_mission_statement",
-            value: @translated_world_location_news.mission_statement,
-            rows: 10,
-            right_to_left: @translated_world_location_news.translation_locale.rtl?,
-            right_to_left_help: false
+            details: {
+              text:  @english_world_location_news.name,
+            }
           } %>
 
-          <h3 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English mission statement content:</h3>
-          <p class="app-view-translation__english-content govuk-body govuk-!-margin-bottom-8"><%= @english_world_location_news.mission_statement %></p>
+          <%= render "components/translated_input", {
+            input: {
+              label: {
+                text: "Title (required)",
+              },
+              heading_size: "l",
+              value: @translated_world_location_news.title,
+              name: "world_location_news[title]",
+              id: "world_location_news_title",
+              error_items: errors_for(@translated_world_location_news.errors, :title),
+              right_to_left: @translated_world_location_news.translation_locale.rtl?,
+              right_to_left_help: false,
+            },
+            details: {
+              text:  @english_world_location_news.title,
+            }
+          } %>
+
+          <%= render "components/translated_textarea", {
+            textarea: {
+              label: {
+                text: "Mission statement",
+                heading_size: "l",
+              },
+              name: "world_location_news[mission_statement]",
+              id: "world_location_news_mission_statement",
+              value: @translated_world_location_news.mission_statement,
+              rows: 10,
+              right_to_left: @translated_world_location_news.translation_locale.rtl?,
+              right_to_left_help: false,
+            },
+             details: {
+              text: @english_world_location_news.mission_statement,
+            },
+            govspeak_editor: true,
+          } %>
 
           <div class="govuk-button-group govuk-!-margin-bottom-8">
             <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/world_location_news_translations/edit.html.erb
+++ b/app/views/admin/world_location_news_translations/edit.html.erb
@@ -5,85 +5,83 @@
   .english_language_name}) translation for: #{@english_world_location.name}" %>
   <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_world_location_news)) %>
 
-<div class="govuk-!-margin-bottom-8">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= form_for @translated_world_location_news, url: admin_world_location_news_translation_path(@translated_world_location_news, translation_locale), method: :patch do |form| %>
-        <%= form.fields_for :world_location, @translated_world_location do |location_form| %>
-          <%= render "govuk_publishing_components/components/warning_text", {
-            text: "Changes to worldwide locations appear instantly on the live site.",
-          } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @translated_world_location_news, url: admin_world_location_news_translation_path(@translated_world_location_news, translation_locale), method: :patch do |form| %>
+      <%= form.fields_for :world_location, @translated_world_location do |location_form| %>
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: "Changes to worldwide locations appear instantly on the live site.",
+        } %>
 
-          <%= render "components/translated_input", {
-            input: {
-              label: {
-                text: "Translation Name (required)",
-              },
-              heading_size: "l",
-              value: @translated_world_location_news.name,
-              name: "world_location_news[world_location_attributes][name]",
-              error_items: errors_for(@translated_world_location.errors, :name),
-              id: "world_location_news_world_location_name",
-              right_to_left: @translated_world_location_news.translation_locale.rtl?,
-              right_to_left_help: false,
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "Translation Name (required)",
             },
+            heading_size: "l",
+            value: @translated_world_location_news.name,
+            name: "world_location_news[world_location_attributes][name]",
+            error_items: errors_for(@translated_world_location.errors, :name),
+            id: "world_location_news_world_location_name",
+            right_to_left: @translated_world_location_news.translation_locale.rtl?,
+            right_to_left_help: false,
+          },
+          details: {
+            text:  @english_world_location_news.name,
+          }
+        } %>
+
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "Title (required)",
+            },
+            heading_size: "l",
+            value: @translated_world_location_news.title,
+            name: "world_location_news[title]",
+            id: "world_location_news_title",
+            error_items: errors_for(@translated_world_location_news.errors, :title),
+            right_to_left: @translated_world_location_news.translation_locale.rtl?,
+            right_to_left_help: false,
+          },
+          details: {
+            text:  @english_world_location_news.title,
+          }
+        } %>
+
+        <%= render "components/translated_textarea", {
+          textarea: {
+            label: {
+              text: "Mission statement",
+              heading_size: "l",
+            },
+            name: "world_location_news[mission_statement]",
+            id: "world_location_news_mission_statement",
+            value: @translated_world_location_news.mission_statement,
+            rows: 10,
+            right_to_left: @translated_world_location_news.translation_locale.rtl?,
+            right_to_left_help: false,
+          },
             details: {
-              text:  @english_world_location_news.name,
+            text: @english_world_location_news.mission_statement,
+          },
+          govspeak_editor: true,
+        } %>
+
+        <div class="govuk-button-group govuk-!-margin-top-8">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save",
+            data_attributes: {
+              module: "gem-track-click",
+              "track-category": "form-button",
+              "track-action": "world-location-news-button",
+              "track-label": "Save"
             }
           } %>
 
-          <%= render "components/translated_input", {
-            input: {
-              label: {
-                text: "Title (required)",
-              },
-              heading_size: "l",
-              value: @translated_world_location_news.title,
-              name: "world_location_news[title]",
-              id: "world_location_news_title",
-              error_items: errors_for(@translated_world_location_news.errors, :title),
-              right_to_left: @translated_world_location_news.translation_locale.rtl?,
-              right_to_left_help: false,
-            },
-            details: {
-              text:  @english_world_location_news.title,
-            }
-          } %>
-
-          <%= render "components/translated_textarea", {
-            textarea: {
-              label: {
-                text: "Mission statement",
-                heading_size: "l",
-              },
-              name: "world_location_news[mission_statement]",
-              id: "world_location_news_mission_statement",
-              value: @translated_world_location_news.mission_statement,
-              rows: 10,
-              right_to_left: @translated_world_location_news.translation_locale.rtl?,
-              right_to_left_help: false,
-            },
-             details: {
-              text: @english_world_location_news.mission_statement,
-            },
-            govspeak_editor: true,
-          } %>
-
-          <div class="govuk-button-group govuk-!-margin-bottom-8">
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Save",
-              data_attributes: {
-                module: "gem-track-click",
-                "track-category": "form-button",
-                "track-action": "world-location-news-button",
-                "track-label": "Save"
-              }
-            } %>
-
-            <%= link_to("cancel", admin_world_location_news_translations_path(@world_location_news), class: "govuk-link") %>
-          </div>
-        <% end %>
+          <%= link_to("cancel", admin_world_location_news_translations_path(@world_location_news), class: "govuk-link") %>
+        </div>
       <% end %>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/worldwide_office_translations/edit.html.erb
+++ b/app/views/admin/worldwide_office_translations/edit.html.erb
@@ -7,151 +7,151 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @translated_contact, as: :contact, url: admin_worldwide_organisation_worldwide_office_translation_path(@worldwide_organisation, @worldwide_office, translation_locale), method: :put do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title (required)"
-        },
-        name: "contact[title]",
-        id: "contact_title",
-        value: @translated_contact.title,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :title),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
-      } %>
-
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.title %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Comments",
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Title (required)",
+          },
+          name: "contact[title]",
+          id: "contact_title",
+          value: @translated_contact.title,
           heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :title),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[comments]",
-        id: "contact_comments",
-        value: @translated_contact.comments,
-        rows: 10,
-        error_items: errors_for(@translated_contact.errors, :comments),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.title,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.comments %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Recipient"
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            text: "Comments",
+            heading_size: "l",
+          },
+          name: "contact[comments]",
+          id: "contact_comments",
+          value: @translated_contact.comments,
+          rows: 10,
+          error_items: errors_for(@translated_contact.errors, :comments),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[recipient]",
-        id: "contact_recipient",
-        value: @translated_contact.recipient,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :recipient),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.comments,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.recipient %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Street address",
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Recipient",
+          },
+          name: "contact[recipient]",
+          id: "contact_recipient",
+          value: @translated_contact.recipient,
           heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :recipient),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[street_address]",
-        id: "contact_street_address",
-        value: @translated_contact.street_address,
-        rows: 10,
-        error_items: errors_for(@translated_contact.errors, :street_address),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.recipient,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.street_address %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Locality"
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            text: "Street address",
+            heading_size: "l",
+          },
+          name: "contact[street_address]",
+          id: "contact_street_address",
+          value: @translated_contact.street_address,
+          rows: 10,
+          error_items: errors_for(@translated_contact.errors, :street_address),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[locality]",
-        id: "contact_locality",
-        value: @translated_contact.locality,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :locality),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.street_address,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.locality %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Region"
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Locality"
+          },
+          name: "contact[locality]",
+          id: "contact_locality",
+          value: @translated_contact.locality,
+          heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :locality),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[region]",
-        id: "contact_region",
-        value: @translated_contact.region,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :region),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.locality,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.region %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Email"
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Region"
+          },
+          name: "contact[region]",
+          id: "contact_region",
+          value: @translated_contact.region,
+          heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :region),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[email]",
-        id: "contact_email",
-        value: @translated_contact.email,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :email),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.region,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.email %></p>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Contact form URL"
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Email"
+          },
+          name: "contact[email]",
+          id: "contact_email",
+          value: @translated_contact.email,
+          heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :email),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "contact[contact_form_url]",
-        id: "contact_contact_form_url",
-        value: @translated_contact.contact_form_url,
-        heading_size: "l",
-        error_items: errors_for(@translated_contact.errors, :contact_form_url),
-        right_to_left: @translated_contact.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @contact.email,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @contact.contact_form_url %></p>
-      </div>
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Contact form URL"
+          },
+          name: "contact[contact_form_url]",
+          id: "contact_contact_form_url",
+          value: @translated_contact.contact_form_url,
+          heading_size: "l",
+          error_items: errors_for(@translated_contact.errors, :contact_form_url),
+          right_to_left: @translated_contact.translation_locale.rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @contact.contact_form_url,
+        }
+      } %>
 
       <% if @translated_contact.contact_numbers.present? %>
         <%= render "govuk_publishing_components/components/heading", {
@@ -161,41 +161,41 @@
         } %>
 
         <%= form.fields_for :contact_numbers, @translated_contact.contact_numbers do |number_form| %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Label"
+          <%= render "components/translated_input", {
+            input: {
+              label: {
+                text: "Label"
+              },
+              name: "contact[contact_numbers_attributes][#{number_form.index}][label]",
+              id: "contact_contact_number_#{number_form.index}_label",
+              value: number_form.object.label,
+              heading_size: "m",
+              error_items: errors_for(number_form.object.errors, :label),
+              right_to_left: number_form.object.translation_locale.rtl?,
+              right_to_left_help: false,
             },
-            name: "contact[contact_numbers_attributes][#{number_form.index}][label]",
-            id: "contact_contact_number_#{number_form.index}_label",
-            value: number_form.object.label,
-            heading_size: "m",
-            error_items: errors_for(number_form.object.errors, :label),
-            right_to_left: number_form.object.translation_locale.rtl?,
-            right_to_left_help: false
+            details: {
+              text: number_form.object.label,
+            }
           } %>
 
-          <div class="govuk-!-margin-bottom-8">
-            <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-            <p class="app-view-translation__english-content govuk-body"><%= number_form.object.label %></p>
-          </div>
-
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Number"
+          <%= render "components/translated_input", {
+            input: {
+              label: {
+                text: "Number"
+              },
+              name: "contact[contact_numbers_attributes][#{number_form.index}][number]",
+              id: "contact_contact_number_#{number_form.index}_number",
+              value: number_form.object.number,
+              heading_size: "m",
+              error_items: errors_for(number_form.object.errors, :number),
+              right_to_left: number_form.object.translation_locale.rtl?,
+              right_to_left_help: false,
             },
-            name: "contact[contact_numbers_attributes][#{number_form.index}][number]",
-            id: "contact_contact_number_#{number_form.index}_number",
-            value: number_form.object.number,
-            heading_size: "m",
-            error_items: errors_for(number_form.object.errors, :number),
-            right_to_left: number_form.object.translation_locale.rtl?,
-            right_to_left_help: false
+            details: {
+              text: number_form.object.number,
+            }
           } %>
-
-          <div class="govuk-!-margin-bottom-8">
-            <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-            <p class="app-view-translation__english-content govuk-body"><%= number_form.object.number %></p>
-          </div>
         <% end %>
       <% end %>
 

--- a/app/views/admin/worldwide_office_translations/edit.html.erb
+++ b/app/views/admin/worldwide_office_translations/edit.html.erb
@@ -62,8 +62,8 @@
         }
       } %>
 
-      <%= render "components/translated_textarea", {
-        textarea: {
+      <%= render "components/translated_input", {
+        input: {
           label: {
             text: "Street address",
             heading_size: "l",

--- a/app/views/admin/worldwide_organisations_translations/edit.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/edit.html.erb
@@ -5,26 +5,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @translated_worldwide_organisation, url: admin_worldwide_organisation_translation_path(@translated_worldwide_organisation, translation_locale), method: :put do |form| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Name (required)"
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Name (required)"
+          },
+          name: "worldwide_organisation[name]",
+          id: "worldwide_organisation_name",
+          value: @translated_worldwide_organisation.name,
+          heading_level: 2,
+          heading_size: "l",
+          error_items: errors_for(form.object.errors, :name),
+          right_to_left: @translated_worldwide_organisation.translation_locale.rtl?,
+          right_to_left_help: false,
         },
-        name: "worldwide_organisation[name]",
-        id: "worldwide_organisation_name",
-        value: @translated_worldwide_organisation.name,
-        heading_level: 2,
-        heading_size: "l",
-        error_items: errors_for(form.object.errors, :name),
-        right_to_left: @translated_worldwide_organisation.translation_locale.rtl?,
-        right_to_left_help: false
+        details: {
+          text: @english_worldwide_organisation.name,
+        }
       } %>
 
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="app-view-translation__english-content govuk-heading-m govuk-!-margin-bottom-2">English:</h2>
-        <p class="app-view-translation__english-content govuk-body"><%= @english_worldwide_organisation.name %></p>
-      </div>
-
-      <div class="govuk-button-group">
+      <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",
           data_attributes: {

--- a/app/views/components/_translated_input.html.erb
+++ b/app/views/components/_translated_input.html.erb
@@ -19,6 +19,8 @@
       <% end %>
     </div>
   <% else %>
-    <%= render "govuk_publishing_components/components/inset_text", text: "There is no #{details_title.downcase}" %>
+    <div class="app-c-translated-textarea__english-translation--no-text govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/hint", text: "There is no #{details_title.downcase}" %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/components/_translated_input.html.erb
+++ b/app/views/components/_translated_input.html.erb
@@ -18,5 +18,7 @@
         <%= details_text %>
       <% end %>
     </div>
+  <% else %>
+    <%= render "govuk_publishing_components/components/inset_text", text: "There is no #{details_title.downcase}" %>
   <% end %>
 <% end %>

--- a/app/views/components/_translated_input.html.erb
+++ b/app/views/components/_translated_input.html.erb
@@ -4,7 +4,7 @@
   input_label = input.dig(:label, :text).gsub("(required)", "").strip
   details ||= {}
   details_text = details[:text]
-  details_title = details[:title] || sanitize("English translation #{tag.span("for #{input_label}", class: "govuk-visually-hidden")}")
+  details_title = details[:title] || sanitize("Original text for #{input_label.downcase}")
 %>
 
 <%= content_tag :div, class: "app-c-translated-input", id: id do %>

--- a/app/views/components/_translated_input.html.erb
+++ b/app/views/components/_translated_input.html.erb
@@ -1,7 +1,7 @@
 <%
   id ||= "app-c-translated-input-#{SecureRandom.hex(4)}"
   input ||= {}
-  input_label = input.dig(:label, :text).gsub("(required)", "").strip!
+  input_label = input.dig(:label, :text).gsub("(required)", "").strip
   details ||= {}
   details_text = details[:text]
   details_title = details[:title] || sanitize("English translation #{tag.span("for #{input_label}", class: "govuk-visually-hidden")}")
@@ -14,9 +14,7 @@
 
   <% if details_text.present? %>
     <div class="app-c-translated-input__english-translation govuk-!-margin-bottom-6">
-      <%= render "govuk_publishing_components/components/details", {
-        title: details_title
-      } do %>
+      <%= render("govuk_publishing_components/components/details", title: details_title) do %>
         <%= details_text %>
       <% end %>
     </div>

--- a/app/views/components/_translated_textarea.html.erb
+++ b/app/views/components/_translated_textarea.html.erb
@@ -26,6 +26,8 @@
       <% end %>
     </div>
   <% else %>
-    <%= render "govuk_publishing_components/components/inset_text", text: "There is no #{details_title.downcase}" %>
+    <div class="app-c-translated-textarea__english-translation--no-text govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/hint", text: "There is no #{details_title.downcase}" %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/components/_translated_textarea.html.erb
+++ b/app/views/components/_translated_textarea.html.erb
@@ -1,7 +1,7 @@
 <%
   id ||= "app-c-translated-textarea-#{SecureRandom.hex(4)}"
   textarea ||= {}
-  textarea_label = textarea.dig(:label, :text).gsub("(required)", "").strip!
+  textarea_label = textarea.dig(:label, :text).gsub("(required)", "").strip
   details ||= {}
   details_text = details[:text]
   details_title = details[:title] || sanitize("English translation #{tag.span("for #{textarea_label}", class: "govuk-visually-hidden")}")
@@ -21,9 +21,7 @@
 
   <% if details_text.present? %>
     <div class="app-c-translated-textarea__english-translation govuk-!-margin-bottom-6">
-      <%= render "govuk_publishing_components/components/details", {
-        title: details_title
-      } do %>
+      <%= render("govuk_publishing_components/components/details", title: details_title) do %>
         <%= details_text %>
       <% end %>
     </div>

--- a/app/views/components/_translated_textarea.html.erb
+++ b/app/views/components/_translated_textarea.html.erb
@@ -25,5 +25,7 @@
         <%= details_text %>
       <% end %>
     </div>
+  <% else %>
+    <%= render "govuk_publishing_components/components/inset_text", text: "There is no #{details_title.downcase}" %>
   <% end %>
 <% end %>

--- a/app/views/components/_translated_textarea.html.erb
+++ b/app/views/components/_translated_textarea.html.erb
@@ -4,7 +4,7 @@
   textarea_label = textarea.dig(:label, :text).gsub("(required)", "").strip
   details ||= {}
   details_text = details[:text]
-  details_title = details[:title] || sanitize("English translation #{tag.span("for #{textarea_label}", class: "govuk-visually-hidden")}")
+  details_title = details[:title] || sanitize("Original text for #{textarea_label.downcase}")
   govspeak_editor ||= false
 %>
 

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -67,9 +67,9 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: edition, id: "fr" }
 
-    assert_select ".app-view-translation__english-content", text: edition.title
-    assert_select ".app-view-translation__english-content", text: edition.summary
-    assert_select ".app-view-translation__english-content", text: edition.body
+    assert_select ".app-c-translated-input__english-translation .govuk-details__text", text: edition.title
+    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.summary
+    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.body
   end
 
   view_test "edit shows the govspeak helper" do

--- a/test/functional/admin/worldwide_office_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_office_translations_controller_test.rb
@@ -53,7 +53,7 @@ class Admin::WorldwideOfficeTranslationsControllerTest < ActionController::TestC
       assert_select "input[type=text][name='contact[title]'][value='#{french_translation.title}']"
       assert_select "textarea[name='contact[comments]']", text: french_translation.comments
       assert_select "input[type=text][name='contact[recipient]'][value='#{french_translation.recipient}']"
-      assert_select "textarea[name='contact[street_address]']", text: french_translation.street_address
+      assert_select "input[type=text][name='contact[street_address]'][value='#{french_translation.street_address}']"
       assert_select "input[type=text][name='contact[locality]'][value='#{french_translation.locality}']"
       assert_select "input[type=text][name='contact[region]'][value='#{french_translation.region}']"
       assert_select "input[type=text][name='contact[email]'][value='#{french_translation.email}']"


### PR DESCRIPTION
## Description

This follows on from https://github.com/alphagov/whitehall/pull/8207 which added two new components

- translated_input
- translated_textarea

Essentially they combine a text input or textarea and a details component. This PR adds these components to the various translation pages.

I've also cleaned up a few things like:

- govspeak-component being used on the edit page but not the edit translation page
- inconsistent formatting
- textareas being used on the edit translation page when a text input is used on the edit page

## Screenshots

### Contact translations

<img width="561" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/3b4e0f04-9146-4d18-86ab-fa06ee3ab64d">

### Organisation translations

<img width="596" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9cc5869a-75e8-492b-b431-5a6933c735e5">

### Person translations

<img width="584" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/54b09e8b-a209-4d4f-9957-fbf62a83684c">

### Role translations

<img width="606" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/f3aec2c8-bb01-49da-88cf-0371ff94b2a7">

### World news story translations

<img width="629" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/177e4dc8-e388-4bad-acd0-7b61b842d11b">

### Worldwide org translations

<img width="563" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/88762ef1-d8a1-4e38-85f7-34b568d2d292">

### Worldwide office translations

<img width="563" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/08f2b066-4a05-46e0-b8ec-af67ff2d5253">

### Edition translations

<img width="711" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/95882462-6d58-4cdc-977a-345b6000ba33">

## Trello cards

https://trello.com/c/T6gEl6CR/486-create-translated-textarea-and-input-components
https://trello.com/c/8vp9mX1f/365-ui-revisit-translation-page-update-original-language-inside-the-details-component



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
