### PR TITLE
Update buttons on edit topics page

### DIFF
--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -4,31 +4,17 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
   before_action :limit_edition_access!
   layout "design_system"
 
-  def edit
-    @path = get_path
-  end
+  def edit; end
 
   def update
     @edition.assign_attributes(edition_params)
     if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
     end
-    redirect_to get_path, saved_confirmation_notice
+    redirect_to admin_edition_path(@edition), notice: "The associations have been saved"
   end
 
 private
-
-  def get_path
-    paths = {
-      "edit" => edit_admin_edition_path(@edition),
-      "tags" => edit_admin_edition_tags_path(@edition),
-    }
-    paths[params[:return]] || admin_edition_path(@edition)
-  end
-
-  def saved_confirmation_notice
-    { notice: "The associations have been saved" }
-  end
 
   def updater
     @updater ||= Whitehall.edition_services.draft_updater(@edition)

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -16,22 +16,14 @@ class Admin::EditionTagsController < Admin::BaseController
       invisible_taxons: invisible_taxons + previously_selected_world_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
     )
-    redirect_to redirect_path,
-                notice: "The tags have been updated."
+    redirect_to admin_edition_path(@edition),
+                notice: "Your topic tags have been saved."
   rescue GdsApi::HTTPConflict
     redirect_to edit_admin_edition_tags_path(@edition),
                 alert: "Somebody changed the tags before you could. Your changes have not been saved."
   end
 
 private
-
-  def redirect_path
-    if params[:save]
-      admin_edition_path(@edition)
-    else
-      edit_admin_edition_legacy_associations_path(@edition, return: :tags)
-    end
-  end
 
   def enforce_permissions!
     enforce_permission!(:update, @edition)

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -20,7 +20,7 @@
           }
         } %>
 
-        <%= link_to("Cancel", @path, class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -23,27 +23,12 @@
 
       <div class="govuk-button-group govuk-!-margin-top-7">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Update tags",
-          name: "save",
-          value: "save",
+          text: "Save",
           data_attributes: {
               module: 'gem-track-click',
               track_category: 'form-button',
               track_label: "Save tagging changes",
               track_action: "taxonomy-tag-form-button",
-          }
-        } %>
-
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Update and review specialist topic tags",
-          name: "legacy_tags",
-          value: "legacy_tags",
-          secondary_solid: true,
-          data_attributes: {
-            module: 'gem-track-click',
-            track_category: 'form-button',
-            track_label: "Save and review specialist topic tagging",
-            track_action: "taxonomy-tag-form-button",
           }
         } %>
 

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -23,7 +23,7 @@
 
       <div class="govuk-button-group govuk-!-margin-top-7">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Update tags",
+          text: "Save",
           data_attributes: {
             module: 'gem-track-click',
             track_category: 'form-button',

--- a/features/new-tagging-workflow.feature
+++ b/features/new-tagging-workflow.feature
@@ -15,7 +15,7 @@ Feature: New Tagging Workflow
     Given I am a writer
     When I start editing a draft document which cannot be tagged to the new taxonomy
     And I continue to the tagging page
-    And I continue to the legacy tagging page
+    And I navigate to the legacy tagging page
     Then I should be on the legacy tagging page
     And I should be able to update the legacy tags
 
@@ -24,4 +24,4 @@ Feature: New Tagging Workflow
     When I start editing a draft document which can be tagged to the new taxonomy
     And I continue to the tagging page
     Then I should be on the taxonomy tagging page
-    And I should be able to update the taxonomy and click the "Update tags" button
+    And I should be able to update the taxonomy and click the "Save" button

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -8,5 +8,5 @@ Feature: Tagging content with specialist sectors
     And there are some specialist sectors
     When I start editing a draft document
     And I continue to the tagging page
-    And I continue to the legacy tagging page
+    And I navigate to the legacy tagging page
     Then I can tag it to some specialist sectors

--- a/features/step_definitions/new_tagging_workflow_steps.rb
+++ b/features/step_definitions/new_tagging_workflow_steps.rb
@@ -29,7 +29,7 @@ Then(/^I should be on the legacy tagging page$/) do
   @publication = Publication.last
 
   expect(page).to have_current_path(
-    edit_admin_edition_legacy_associations_path(@publication, return: "tags"),
+    edit_admin_edition_legacy_associations_path(@publication),
   )
 end
 

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -22,8 +22,7 @@ Then(/^I can tag it to some specialist sectors$/) do
   click_on "Edit draft"
   check "Applies to all UK nations"
   click_on "Save and go to document summary"
-  click_on "Add tags"
-  click_on "Update and review specialist topic tags"
+  click_link "Change specialist topic tags"
 
   expect("WELLS").to eq(find_field(primary_select).value)
   expect(%w[OFFSHORE FIELDS DISTILL].to_set)

--- a/features/step_definitions/tagging_steps.rb
+++ b/features/step_definitions/tagging_steps.rb
@@ -3,6 +3,7 @@ When(/^I continue to the tagging page$/) do
   click_link "Add tags"
 end
 
-When(/^I continue to the legacy tagging page$/) do
-  click_button "Update and review specialist topic tags"
+When(/^I navigate to the legacy tagging page$/) do
+  click_button "Save"
+  click_link "Add specialist topic tags"
 end

--- a/spec/javascripts/admin/modules/track-selected-taxon.spec.js
+++ b/spec/javascripts/admin/modules/track-selected-taxon.spec.js
@@ -87,13 +87,7 @@ describe('GOVUK.Modules.TrackSelectedTaxons', function () {
       <div class="govuk-button-group govuk-!-margin-top-7">
         <button
           class="gem-c-button govuk-button" type="submit"
-          name="save" value="save">
-          Update tags
-        </button>
-        <button
-          class="gem-c-button govuk-button govuk-button--secondary" type="submit"
-          name="legacy_tags" value="legacy_tags">
-          Update and review specialist topic tags
+          Save
         </button>
       </div>
     `

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -39,7 +39,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     assert_equal "Somebody changed the tags before you could. Your changes have not been saved.", flash[:alert]
   end
 
-  test "should post taxons to publishing-api" do
+  test "should post taxons to publishing-api, set the correct flash and redirect to the document summary page" do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 
     put :update, params: { edition_id: @edition, taxonomy_tag_form: { taxons: [child_taxon_content_id], previous_version: 1 } }
@@ -51,32 +51,8 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
       },
       previous_version: "1",
     )
-  end
-
-  test 'should redirect to edition admin page when "Save Tagging Changes" is clicked' do
-    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
-
-    put :update,
-        params: {
-          edition_id: @edition,
-          taxonomy_tag_form: { taxons: [child_taxon_content_id], previous_version: 1 },
-          save: "Some Value",
-        }
-
     assert_redirected_to @controller.admin_edition_path(@edition)
-  end
-
-  test 'should redirect to legacy associations page when "Legacy tags" is clicked' do
-    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
-
-    put :update,
-        params: {
-          edition_id: @edition,
-          taxonomy_tag_form: { taxons: [child_taxon_content_id], previous_version: 1 },
-          legacy_tags: "Some Value",
-        }
-
-    assert_redirected_to edit_admin_edition_legacy_associations_path(@edition, return: :tags)
+    assert_equal "Your topic tags have been saved.", flash[:notice]
   end
 
   test "should post empty array to publishing api if no taxons are selected" do
@@ -132,25 +108,11 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: @edition }
 
-    assert_select "button[name*='save']" do |elements|
+    assert_select "button", text: "Save" do |elements|
       assert_equal 1, elements.length
       assert_tracking_attributes(
         element: elements.first,
         track_label: "Save tagging changes",
-      )
-    end
-  end
-
-  view_test "should render save and review legacy button with tracking attributes" do
-    stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
-
-    get :edit, params: { edition_id: @edition }
-
-    assert_select "button[name*='legacy_tags']" do |elements|
-      assert_equal 1, elements.length
-      assert_tracking_attributes(
-        element: elements.first,
-        track_label: "Save and review specialist topic tagging",
       )
     end
   end

--- a/test/functional/edition_legacy_associations_controller_test.rb
+++ b/test/functional/edition_legacy_associations_controller_test.rb
@@ -47,24 +47,7 @@ class Admin::EditionLegacyAssociationsControllerTest < ActionController::TestCas
     assert_select "#edition_secondary_specialist_sector_tags option[value='OFFSHORE'][selected='selected']", "Oil and Gas: Offshore"
     assert_select "#edition_secondary_specialist_sector_tags option[value='DISTILL']", "Oil and Gas: Distillation (draft)"
     refute_select "#edition_secondary_specialist_sector_tags option[value='DISTILL'][selected='selected']"
-  end
-
-  view_test "should render the cancel button back to the admin page" do
-    @edition = create(:publication)
-    get :edit, params: { edition_id: @edition.id }
     assert_select ".govuk-button-group  a:contains('Cancel')[href='#{@controller.admin_edition_path(@edition)}']"
-  end
-
-  view_test "should render the cancel button back to the tags page" do
-    @edition = create(:publication)
-    get :edit, params: { edition_id: @edition.id, return: "tags" }
-    assert_select ".govuk-button-group a:contains('Cancel')[href='#{@controller.edit_admin_edition_tags_path(@edition)}']"
-  end
-
-  view_test "should render the cancel button back to the edit page" do
-    @edition = create(:publication)
-    get :edit, params: { edition_id: @edition.id, return: "edit" }
-    assert_select ".govuk-button-group  a:contains('Cancel')[href='#{@controller.edit_admin_edition_path(@edition)}']"
   end
 
   test "should update the edition with the selected legacy tags" do


### PR DESCRIPTION
**This is coupled to https://trello.com/c/DcdTBWJv/1561-remove-topic-tags-from-the-editor-workflow. Do no merge until both are ready to be shipped**

## Description

This PR updates the workflow for adding topics and specialist topics to an edition. It does the following:

- updates the copy for the "Update tags" button to "Save",
- removes the "Update and review specialist topic tags" button
- removes the routing previously required for multiple flows from the edition tags controller
- removes additional routing from the legacy associations controller (specialist tags)
- updates the feature and controller specs to use/pass with the new flow

## Guidance for review

I've not added a flash for when the user clicks the `Cancel` link. Generally flashes are reserved for successful/unsuccessful changes in the state of objects.

I suspect it's not worth adding this for some additional reasons:

1. there are `Cancel` links throughout Whitehall, none of which trigger flashes so it would be inconsistent with all other usages
2. it adds additional complexity as the document summary page would need to be arrived at with a query stringwould be checked for before rendering the page. If we consistently do this it'll add a good amount of extra work and controller bloat.

Very happy to discuss.

## Screenshots

<img width="739" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8da6be84-5956-4c9f-a7dc-ec9342d98a45">

<img width="732" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d21f5539-8146-4636-9baf-9c2baaf370d7">

## Trello card

https://trello.com/c/2jmWV2Ur/1638-update-buttons-in-topic-taxonomy-tags-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
