### PR TITLE
If user doesn't have preview design system access, don't allow access…

### DIFF
--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -3,6 +3,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
   before_action :load_document_collection_group
   before_action :load_membership, only: %i[confirm_destroy]
   before_action :find_document, only: :create_whitehall_member
+  before_action :check_new_design_system_permissions, only: %i[index confirm_destroy]
   layout :get_layout
 
   def index; end
@@ -59,14 +60,17 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
 private
 
   def get_layout
-    design_system_actions = %w[index confirm_destroy]
-    design_system_actions += %w[destroy] if preview_design_system?(next_release: false)
+    design_system_actions = %w[index confirm_destroy destroy] if preview_design_system?(next_release: false)
 
-    if design_system_actions.include?(action_name)
+    if design_system_actions&.include?(action_name)
       "design_system"
     else
       "admin"
     end
+  end
+
+  def check_new_design_system_permissions
+    forbidden! unless new_design_system?
   end
 
   def moving?

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -72,10 +72,9 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = []
-    design_system_actions += %w[index confirm_destroy destroy new create edit update show] if preview_design_system?(next_release: false)
+    design_system_actions = %w[index confirm_destroy destroy new create edit update show] if preview_design_system?(next_release: false)
 
-    if design_system_actions.include?(action_name)
+    if design_system_actions&.include?(action_name)
       "design_system"
     else
       "admin"

--- a/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
@@ -98,4 +98,18 @@ class Admin::LegacyDocumentCollectionGroupMembershipsControllerTest < ActionCont
     assert_redirected_to admin_document_collection_groups_path(@collection)
     assert_match %r{1 document moved to '#{new_group.heading}'}, flash[:notice]
   end
+
+  test "GET #index forbids the user to see anything" do
+    get :index, params: { document_collection_id: @collection, group_id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #confirm_destroy forbids the user to see anything" do
+    membership = create(:document_collection_group_membership)
+    @group.memberships << membership
+    get :confirm_destroy, params: { document_collection_id: @collection, group_id: @group, id: membership }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
 end


### PR DESCRIPTION
… to new pages

Add additional checks to stop users from accessing new pages since they are still work in progress. At the moment there's no way to access the pages through UI anyways, but this check will stop users without preview privelege from seeing the pages through direct URL access as well.

<img width="927" alt="image" src="https://github.com/alphagov/whitehall/assets/568730/9fc0e5f5-7e86-4fe0-8c22-81da2260e32a">

https://trello.com/c/szAfNI2T/526-create-a-group-landing-page-for-adding-documents

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
