### PR TITLE
Fix bug preventing hour and minute date time components being set to 0

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -721,7 +721,7 @@ EXISTS (
 
       begin
         raise ArgumentError if date.values.any?(&:nil?)
-        raise ArgumentError if date.values.any? { |date_part| date_part.to_i.zero? }
+        raise ArgumentError if date[1].to_i.zero? || date[2].to_i.zero? || date[3].to_i.zero?
 
         Date.new(date[1], date[2], date[3])
         @date_field_validity[:scheduled_publication] = true

--- a/test/unit/app/models/edition/validation_test.rb
+++ b/test/unit/app/models/edition/validation_test.rb
@@ -196,7 +196,7 @@ class Edition::ValidationTest < ActiveSupport::TestCase
   end
 
   test "should be valid when scheduled publication date is a valid date" do
-    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => 9, 3 => 10 })
+    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => 9, 3 => 10, 4 => 0, 5 => 0 })
     assert edition.valid?
   end
 


### PR DESCRIPTION
Rails parses date input from the request and provides it to the model as a hash. We are converting the date values to integers (we decided this was simpler than using regexes) and then checking the result is not zero to ensure that non-numeric values are flagged as invalid. However, we accidentally applied the check to the time elements of the date hash as well, causing a bug where it was not possible to set the minute or hour values to 0. This should solve the problem.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5477483