### PR TITLE
Modify scheduled publication date validation error message

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -736,7 +736,7 @@ EXISTS (
 
   def valid_date
     if @date_field_validity.present? && @date_field_validity[:scheduled_publication] == false
-      errors.add(:scheduled_publication, "must be a valid date in the format XX XX XXXX")
+      errors.add(:scheduled_publication, "must be a valid date in the correct format")
     end
   end
 


### PR DESCRIPTION
The updated message is closer to the guidance provided at https://design-system.service.gov.uk/components/date-input/, but the guidance doesn't cover cases where the user enters, for example, a string instead of a number for one of the date parts. It also assumes that invidividual parts of the date can be validated separately. For this reason I have had to improvise a little, but I believe the new message is closer to the spirit of the guidance and does not feature the unapproved XX style formatting advice. Given the format is already provided in the input hint there is no need to specify it again in the error message.
