### PR TITLE
Update to turn on the what's new banner

### DIFF
--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -1,11 +1,11 @@
-<% show_feedback_banner ||= false %>
+<% show_feedback_banner ||= true %>
 <% tracking_module ||= "gem-track-click" %>
 
 <%if t('admin.whats_new.show_banner') %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "What's new",
       ga4_tracking: true,
-      message: sanitize("New review date functionality -
+      message: sanitize("improvements to the editor workflow -
         #{
           link_to(
             "read more about the changes",


### PR DESCRIPTION
## What

I needed a PR on my last day! This turns the what's new banner back on for the work we've done on editor improvements, following the Basecamp message.

## Why

Users can know we've changed things! 

## Mike being sentimental

It's been a true honour to work on GOV.UK, I've had the chance to work with some amazing people that are also great friends. Together we've done some amazing work, and I'm really proud of what we've achieved. I can't wait to see what you do next. Over and out! 👍🏻 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
