### PR TITLE
Ensure ministerial reordering publishes changes to Publishing API

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -60,7 +60,9 @@ private
     return unless params.include?(key)
 
     params[key]["ordering"].keys.each do |id|
-      Role.where(id:).update_all("#{column}": params[key]["ordering"][id.to_s])
+      role = Role.find(id)
+      role.assign_attributes({ "#{column}": params[key]["ordering"][id.to_s] })
+      role.save!(validate: false)
     end
   end
 
@@ -68,9 +70,9 @@ private
     return unless params.include?(:organisation)
 
     params[:organisation]["ordering"].each_pair do |id, order|
-      Organisation.where(id:).update_all(
-        ministerial_ordering: order,
-      )
+      organisation = Organisation.find(id)
+      organisation.assign_attributes({ ministerial_ordering: order })
+      organisation.save!(validate: false)
     end
   end
 end

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -16,6 +16,8 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
 
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).twice
+
     put :update,
         params: {
           roles: {
@@ -34,6 +36,8 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     @request.env["HTTP_REFERER"] = Plek.website_root + reorder_also_attends_cabinet_roles_admin_cabinet_ministers_path
     role2 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation])
+
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).twice
 
     put :update,
         params: {
@@ -54,6 +58,8 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     role2 = create(:ministerial_role, name: "Whip 1", whip_organisation_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Whip 2", whip_organisation_id: 2, organisations: [organisation])
 
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).twice
+
     put :update,
         params: {
           whips: {
@@ -73,6 +79,9 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     @request.env["HTTP_REFERER"] = Plek.website_root + reorder_ministerial_organisations_admin_cabinet_ministers_path
     org2 = create(:organisation)
     org1 = create(:organisation)
+
+    Whitehall::PublishingApi.expects(:publish).with(org2).once
+    Whitehall::PublishingApi.expects(:publish).with(org1).once
 
     put :update,
         params: {


### PR DESCRIPTION
## Description

We've had tickets come through stating that the ministerial ordering page is not working correctly.

At the moment, when you reorder ministerial roles and organisations, it calls update_all which skips validations and callbacks.

This means that the after_save which pushes changes to Publishing API is not called, so the changes are not passed downstream.

We've decided to retain the behaviour where validations are skipped as it feels like this functionality shouldn't be blocked via an invalid role or organisation.

We may want to come back and discuss if this is appropriate after the fix is rolled out.

However, save!(validate: false) does trigger the callbacks so the roles organisations will continue to be republished.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
