### PR TITLE
Ensure org is republished after reordering people

### DIFF
--- a/app/controllers/admin/organisation_people_controller.rb
+++ b/app/controllers/admin/organisation_people_controller.rb
@@ -23,6 +23,8 @@ class Admin::OrganisationPeopleController < Admin::BaseController
       @organisation.organisation_roles.find(organisation_role_id).update_column(:ordering, ordering)
     end
 
+    Whitehall::PublishingApi.republish_async(@organisation)
+
     redirect_to admin_organisation_people_path(@organisation), notice: "#{params[:type].capitalize.gsub('_', ' ')} roles re-ordered"
   end
 

--- a/test/functional/admin/organisation_people_controller_test.rb
+++ b/test/functional/admin/organisation_people_controller_test.rb
@@ -267,6 +267,8 @@ class Admin::OrganisationPeopleControllerTest < ActionController::TestCase
     organisation_senior_ministerial_role = create(:organisation_role, organisation:)
     organisation_junior_ministerial_role = create(:organisation_role, organisation:)
 
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
+
     put :order,
         params: {
           organisation_id: organisation,


### PR DESCRIPTION
## Description 

At the moment, update_column is used to ensure that the uniq validation on ordering is not triggered while the updates take place.

However, this also skips any callbacks which handle republishing the org.

I think it makes sense to retain this behaviour and manually republish the org, so the org isn't republished for each role that is reordered.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
