### PR TITLE
Use govuk date component for review dates

### DIFF
--- a/app/models/date_validation.rb
+++ b/app/models/date_validation.rb
@@ -1,0 +1,48 @@
+module DateValidation
+  extend ActiveSupport::Concern
+
+  attr_reader :invalid_date_attributes
+
+  included do
+    validates_with DateValidator
+
+    # @param attribute Symbol
+    # @param date Hash|Date|DateTime|String|nil
+    # @return Hash|Date|DateTime|String|nil
+    def pre_validate_date_attribute(attribute, date)
+      if date.is_a?(Hash)
+        begin
+          raise ArgumentError if date.values.any?(&:nil?)
+          raise ArgumentError if date[1].to_i.zero? || date[2].to_i.zero? || date[3].to_i.zero?
+
+          Date.new(date[1], date[2], date[3])
+        rescue ArgumentError
+          @invalid_date_attributes = [] if @invalid_date_attributes.nil?
+          @invalid_date_attributes << attribute
+          date = nil
+        end
+      end
+      date
+    end
+  end
+
+  class_methods do
+    def date_attributes(*attributes)
+      attributes.each do |attribute|
+        define_method("#{attribute}=") do |value|
+          super(pre_validate_date_attribute(attribute, value))
+        end
+      end
+    end
+  end
+
+  class DateValidator < ActiveModel::Validator
+    def validate(record)
+      return if record.invalid_date_attributes.nil?
+
+      record.invalid_date_attributes.each do |date_attribute|
+        record.errors.add date_attribute, "must be a valid date in the correct format"
+      end
+    end
+  end
+end

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -1,4 +1,7 @@
 class ReviewReminder < ApplicationRecord
+  include DateValidation
+  date_attributes :review_at
+
   belongs_to :document
   belongs_to :creator, class_name: "User"
 

--- a/app/views/admin/editions/_review_reminder_fields.html.erb
+++ b/app/views/admin/editions/_review_reminder_fields.html.erb
@@ -17,26 +17,33 @@
               track_label: "Set a reminder to review this content after it has been published",
               track_action: "clicked",
             },
-            conditional: render("components/datetime_fields", {
+            conditional: render("components/datetime_fields_with_govuk_date_component", {
               field_name: "review_at",
               prefix: "edition[document_attributes][review_reminder_attributes]",
               date_only: true,
               error_items: errors_for(review_reminder.errors, :review_at),
               date_heading: "Date",
-              date_hint: "For example, 01 August 2025",
+              date_hint: "For example, 01 08 2025",
               year: {
-                value: review_reminder.review_at&.year,
+                value: params.dig("edition", "document_attributes", "review_reminder_attributes", "review_at(1i)") || review_reminder.review_at&.year,
                 id: "edition_document_review_reminder_review_at_1i",
-                start_year: Time.zone.now.year,
-                end_year: Time.zone.now.year + 10,
+                name: "edition[document_attributes[review_reminder_attributes[review_at(1i)]]]",
+                label: "Year",
+                width: 4,
               },
               month: {
-                value: review_reminder.review_at&.month,
+                value: params.dig("edition", "document_attributes", "review_reminder_attributes", "review_at(2i)") || review_reminder.review_at&.month,
                 id: "edition_document_review_reminder_review_at_2i",
+                name: "edition[document_attributes[review_reminder_attributes[review_at(2i)]]]",
+                label: "Month",
+                width: 2,
               },
               day: {
-                value: review_reminder.review_at&.day,
+                value: params.dig("edition", "document_attributes", "review_reminder_attributes", "review_at(3i)") || review_reminder.review_at&.day,
                 id: "edition_document_review_reminder_review_at",
+                name: "edition[document_attributes[review_reminder_attributes[review_at(3i)]]]",
+                label: "Day",
+                width: 2,
               },
             }) +
             render("govuk_publishing_components/components/input", {

--- a/app/views/admin/review_reminders/_form.html.erb
+++ b/app/views/admin/review_reminders/_form.html.erb
@@ -1,25 +1,32 @@
 <%= form_with model: review_reminder, url: [:admin, document, review_reminder] do |form| %>
-  <%= render("components/datetime_fields", {
+  <%= render("components/datetime_fields_with_govuk_date_component", {
     field_name: "review_at",
     prefix: "review_reminder",
     date_only: true,
     error_items: errors_for(review_reminder.errors, :review_at),
-    date_hint: "For example, 01 August 2025",
+    date_hint: "For example, 01 08 2025",
     date_heading: "Date (required)",
     heading_size: "l",
     year: {
-      value: review_reminder.review_at&.year,
       id: "review_reminder_review_at_1i",
-      start_year: Time.zone.now.year,
-      end_year: Time.zone.now.year + 10,
+      value: params.dig("review_reminder", "review_at(1i)") || review_reminder.review_at&.year,
+      name: "review_reminder[review_at(1i)]",
+      label: "Year",
+      width: 4,
     },
     month: {
-      value: review_reminder.review_at&.month,
       id: "review_reminder_review_at_2i",
+      value: params.dig("review_reminder", "review_at(2i)") || review_reminder.review_at&.month,
+      name: "review_reminder[review_at(2i)]",
+      label: "Month",
+      width: 2,
     },
     day: {
-      value: review_reminder.review_at&.day,
-      id: "review_reminder_review_at",
+      id: "review_reminder_review_at_3i",
+      value: params.dig("review_reminder", "review_at(3i)") || review_reminder.review_at&.day,
+      name: "review_reminder[review_at(3i)]",
+      label: "Day",
+      width: 2,
     },
   }) %>
 

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -9,7 +9,7 @@ And(/^I add a review date of "([^"]*)" and the email address "([^"]*)" on the ed
 end
 
 And(/^I add a review date of "([^"]*)" and the email address "([^"]*)"$/) do |date, email|
-  fill_in_date_fields(date)
+  fill_in_govuk_publishing_date_fields(date)
   fill_in "Email address (required)", with: email
   click_button "Save"
 end
@@ -31,7 +31,7 @@ And(/^a review reminder exists for "([^"]*)" with the date "([^"]*)"$/) do |titl
 end
 
 And(/^I update the review date to "([^"]*)"$/) do |date|
-  fill_in_date_fields(date)
+  fill_in_govuk_publishing_date_fields(date)
   click_button "Save"
 end
 

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -2,7 +2,7 @@ And(/^I add a review date of "([^"]*)" and the email address "([^"]*)" on the ed
   click_link "Edit draft"
   check "Set a reminder to review this content after it has been published"
   within_conditional_reveal "Set a reminder to review this content after it has been published" do
-    fill_in_date_fields(date)
+    fill_in_govuk_publishing_date_fields(date)
     fill_in "Email address", with: email
   end
   click_button "Save and go to document summary"

--- a/features/support/datetime_field_helper.rb
+++ b/features/support/datetime_field_helper.rb
@@ -16,5 +16,13 @@ module DatetimeFieldHelper
     select date.strftime("%B"), from: "Month"
     select date.day, from: "Day"
   end
+
+  def fill_in_govuk_publishing_date_fields(date)
+    date = Time.zone.parse(date)
+
+    fill_in "Year", with: date.year
+    fill_in "Month", with: date.month
+    fill_in "Day", with: date.day
+  end
 end
 World(DatetimeFieldHelper)

--- a/test/unit/app/models/date_validation_test.rb
+++ b/test/unit/app/models/date_validation_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class DateValidationTest < ActiveSupport::TestCase
+  class StubBaseRecord
+    include ActiveModel::Model
+    attr_accessor :some_date
+  end
+
+  class StubModel < StubBaseRecord
+    include DateValidation
+    date_attributes :some_date
+  end
+
+  test "should be valid when date attribute is a valid date" do
+    model = StubModel.new(some_date: { 1 => 2023, 2 => 9, 3 => 10, 4 => 0, 5 => 0 })
+    assert model.valid?
+  end
+
+  test "should be invalid when date attribute is an invalid date" do
+    model = StubModel.new(some_date: { 1 => 2023, 2 => 9, 3 => 40 })
+    assert_not model.valid?
+  end
+
+  test "should be invalid when date attribute is partially completed" do
+    model = StubModel.new(some_date: { 1 => 2023, 2 => nil, 3 => 9 })
+    assert_not model.valid?
+  end
+
+  test "should be invalid when not all date attribute parts are numeric" do
+    model = StubModel.new(some_date: { 1 => 2023, 2 => "January", 3 => 20 })
+    assert_not model.valid?
+  end
+end

--- a/test/unit/app/models/edition/validation_test.rb
+++ b/test/unit/app/models/edition/validation_test.rb
@@ -195,26 +195,6 @@ class Edition::ValidationTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "should be valid when scheduled publication date is a valid date" do
-    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => 9, 3 => 10, 4 => 0, 5 => 0 })
-    assert edition.valid?
-  end
-
-  test "should be invalid when scheduled publication date is an invalid date" do
-    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => 9, 3 => 40 })
-    assert_not edition.valid?
-  end
-
-  test "should be invalid when scheduled publication date is partially completed" do
-    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => nil, 3 => 9 })
-    assert_not edition.valid?
-  end
-
-  test "should be invalid when not all scheduled publication date parts are numeric" do
-    edition = build(:draft_edition, scheduled_publication: { 1 => 2023, 2 => "January", 3 => 20 })
-    assert_not edition.valid?
-  end
-
   test "should be invalid when scheduled publication date is not in the future" do
     now = Time.zone.now
     edition = build(:draft_edition, scheduled_publication: { 1 => now.year, 2 => now.month, 3 => now.day })


### PR DESCRIPTION
### What

We are gradually replacing all usages of the select-based date inputs with the GOV.UK Publishing date input component, which uses text inputs. This PR applies that change to the review date field on review reminders.

### Why

The Publishing date component is backed by user research which suggests text inputs are more efficient for users when they are entering arbitrary dates.

### Development Notes

As part of this PR I have included a refactoring to abstract the date validation logic into its own concern. The concern can be applied as follows:

```ruby
class MyModel < ApplicationRecord
  include DateValidation
  date_attributes :my_date_attribute, :my_other_date_attribute
end
```
Now, if a user provides an incorrectly formatted or invalid date for any of the specified attributes, an error message will be added to the model.

Trello: https://trello.com/c/IFGDegsk