### PR TITLE
Improve performance of OffsiteLinksController#create endpoint to reduce timeouts

### DIFF
--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -8,9 +8,9 @@ class Admin::OffsiteLinksController < Admin::BaseController
   end
 
   def create
-    @offsite_link = OffsiteLink.new(offsite_link_params)
-    @parent.offsite_links << @offsite_link
-    if @parent.save
+    @offsite_link = OffsiteLink.new(offsite_link_params.merge(parent: @parent))
+
+    if @offsite_link.save
       flash[:notice] = "An offsite link has been created for #{@parent.name}"
       redirect_to offsite_links_path
     else


### PR DESCRIPTION
## Description

At the moment, when you create a new offsite link it persists the parent object rather than the link itself. When an organisation is the parent, this causes a bunch of after_save callbacks to be called within memory which is causing timeouts.

This behaviour should and hopefully will be fixed in a separate bit of work, but we can improve the performance of this endpoint by assigning the parent to the link and saving. Rather than, adding the offsite link to the parents offsite links and saving the parent.

This reduces response time locally by about 95%.

## Zendesk ticket 

https://govuk.zendesk.com/agent/tickets/5476639

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
