### PR TITLE
Replace supporting organisation component

### DIFF
--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -1,6 +1,6 @@
 <% if edition.can_be_related_to_organisations? %>
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Organisations",
+    legend_text: "Lead organisations",
     heading_level: 3,
     heading_size: "m",
     id: "edition_organisations",
@@ -34,30 +34,18 @@
       <% end %>
     </div>
 
-    <% 0.upto(5) do |index| %>
-      <% supporting_organisation_id = supporting_organisation_id_at_index(edition, index) %>
-      <% cache_if supporting_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
-        <%= render "components/select-with-search", {
-          id: "edition_supporting_organisation_ids_#{index + 1}",
-          name: "edition[supporting_organisation_ids][]",
-          label: "Supporting organisation #{index + 1}",
-          heading_size: "s",
-          include_blank: true,
-          options: taggable_organisations_container.map do |name, id|
-          {
-            text: name,
-            value: id,
-            selected: id == supporting_organisation_id,
-            data_attributes: {
-                module: 'track-select-click',
-                track_category: 'supportingOrgSelection',
-                track_action: name,
-                track_label: request.path
-            },
-          }
-         end
-        } %>
-      <% end %>
-    <% end %>
+    <%= render "components/autocomplete", {
+      id: "edition_supporting_organisation_ids",
+      name: "edition[supporting_organisation_ids][]",
+      label: {
+        text: "Supporting organisations",
+        heading_size: "m",
+      },
+      select: {
+        multiple: true,
+        selected: edition.edition_organisations.reject(&:lead?).map(&:organisation_id),
+        options: [""] + taggable_organisations_container,
+      },
+    } %>
   <% end %>
 <% end %>

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -431,15 +431,7 @@ module AdminEditionControllerTestHelpers
             end
           end
           refute_select "#edition_lead_organisation_ids_5"
-          (1..6).each do |i|
-            assert_select "label[for=edition_supporting_organisation_ids_#{i}]", text: "Supporting organisation #{i}"
-
-            assert_select("#edition_supporting_organisation_ids_#{i}") do |elements|
-              assert_equal 1, elements.length
-              assert_data_attributes_for_supporting_org(element: elements.first, track_label: new_edition_path(edition_type))
-            end
-          end
-          refute_select "#edition_supporting_organisation_ids_7"
+          assert_select("#edition_supporting_organisation_ids_")
         end
       end
 
@@ -484,15 +476,7 @@ module AdminEditionControllerTestHelpers
             end
           end
           refute_select "#edition_lead_organisation_ids_5"
-          (1..6).each do |i|
-            assert_select "label[for=edition_supporting_organisation_ids_#{i}]", text: "Supporting organisation #{i}"
-
-            assert_select("#edition_supporting_organisation_ids_#{i}") do |elements|
-              assert_equal 1, elements.length
-              assert_data_attributes_for_supporting_org(element: elements.first, track_label: edit_edition_path(edition))
-            end
-          end
-          refute_select "#edition_supporting_organisation_ids_7"
+          assert_select("#edition_supporting_organisation_ids_")
         end
       end
 
@@ -1203,13 +1187,6 @@ private
     # TODO: Add tracking back in. This is covered in this Trello card https://trello.com/c/eKGeFCQu/975-add-tracking-in-for-associations-on-the-edit-page
     # assert_equal "track-select-click", element["data-module"]
     # assert_equal "leadOrgSelection", element["data-track-category"]
-    # assert_equal track_label, element["data-track-label"]
-  end
-
-  def assert_data_attributes_for_supporting_org(element:, track_label:)
-    # TODO: Add tracking back in. This is covered in this Trello card https://trello.com/c/eKGeFCQu/975-add-tracking-in-for-associations-on-the-edit-page
-    # assert_equal "track-select-click", element["data-module"]
-    # assert_equal "supportingOrgSelection", element["data-track-category"]
     # assert_equal track_label, element["data-track-label"]
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Replace supporting organisation selects with autocomplete
- Remove the click track as it didn't actually do any tracking (have consulted with Ruth and have agreed that we don't need to specifically track this at this time)

https://trello.com/c/RpZP9L4J/1641-lead-org-and-support-org-change-component-to-reduce-number-of-fields

# Why
- The 6 supporting organisation fields on the page demand a lot of screen real estate
- The order doesn't matter for supporting organisations
- The limit of 6 is arbitrary

# Screenshots
# After
![whitehall-admin dev gov uk_government_admin_calls-for-evidence_1374135_edit(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/104d0757-5c99-4908-9059-38c2dcd14b73)

# Before
![whitehall-admin dev gov uk_government_admin_calls-for-evidence_1374135_edit(iPad Pro) (1)](https://github.com/alphagov/whitehall/assets/9594455/8659eab2-d456-43d0-8b28-2c5d602a2858)
