### PR TITLE
530 reordering groups

### DIFF
--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -32,6 +32,10 @@
         {
           label: "Add group",
           href: new_admin_document_collection_group_path(@collection),
+        },
+        {
+          label: "Reorder group",
+          href: reorder_admin_document_collection_groups_path(@collection)
         }
       ],
     } %>

--- a/app/views/admin/document_collection_groups/reorder.html.erb
+++ b/app/views/admin/document_collection_groups/reorder.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title, "Reorder groups for #{@collection.title}" %>
+<% content_for :title, "Reorder groups" %>
+<% content_for :context, @collection.title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with url: order_admin_document_collection_groups_path(@collection, @group), method: :put do |form| %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder pages, or select and hold on a page to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @collection.groups.map do |group|
+          {
+            id: group.id,
+            title: group.heading
+          }
+        end
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "document-collection-groups-reorder-button",
+            "track-label": "Save"
+          }
+        } %>
+        <%= link_to("Cancel", admin_document_collection_groups_path(@collection), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Whitehall::Application.routes.draw do
           resources :document_collection_group_memberships, path: "members", only: %i[index destroy] do
             get :confirm_destroy, on: :member
           end
+          get :reorder, on: :collection
+          put :order, on: :collection
         end
         post "whitehall-member" => "document_collection_group_memberships#create_whitehall_member", as: :new_whitehall_member
         post "non-whitehall-member" => "document_collection_group_memberships#create_non_whitehall_member", as: :new_non_whitehall_member

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -72,3 +72,21 @@ Feature: Grouping documents into a collection
     Given a published publication called "Document to be removed" in a published document collection
     When I remove the publication "Document to be removed" from the group
     Then I can see that "Document to be removed" has been removed from the group
+
+  @design-system-only
+  Scenario: Reordering groups
+    Given a document collection "May 2012 Update" exists
+    And the following groups exist within "May 2012 Update":
+      | name    |
+      | Group 1 |
+      | Group 2 |
+    When I visit the Reorder page
+    And I set the order of "May 2012 Update" groups to:
+      | name    | order |
+      | Group 1 | 1     |
+      | Group 2 | 0     |
+    Then I can see a "Group has been reordered" success flash
+    And the groups should be in the following order:
+      | name    |
+      | Group 2 |
+      | Group 1 |

--- a/test/functional/admin/legacy_document_collection_groups_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_groups_controller_test.rb
@@ -251,6 +251,18 @@ class Admin::LegacyDocumentCollectionGroupsControllerTest < ActionController::Te
     assert_includes "Sorry, you don’t have access to this document", @response.body
   end
 
+  test "GET #reorder forbids the user to see anything" do
+    get :reorder, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #order forbids the user to see anything" do
+    get :order, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
   def given_two_groups_with_memberships
     @group1 = build(:document_collection_group)
     @group2 = build(:document_collection_group)


### PR DESCRIPTION
[Trello](https://trello.com/c/tvSssCqa/530-allow-for-the-reordering-of-groups)

The changes in this PR
- Add the "Reorder group" link to the Group landing page
- Creates the new reorder page

Screenshots below

|Page|Screenshot|
|-|-|
|Landing page|![Screenshot 2023-09-12 at 15 09 53](https://github.com/alphagov/whitehall/assets/6080548/002e511d-a46e-4ee1-93a0-33506bc20b19)|
|Reorder page|![Screenshot 2023-09-12 at 15 10 08](https://github.com/alphagov/whitehall/assets/6080548/011abe34-4e77-429d-9067-076c052d99d1)|
|Landing page after reorder|![Screenshot 2023-09-12 at 15 10 25](https://github.com/alphagov/whitehall/assets/6080548/dcf6cda1-53d2-46d6-a8b7-80f765ed4581)|