### PR TITLE
Provide a relative date validator

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -57,7 +57,7 @@ class Edition < ApplicationRecord
   validates_each :first_published_at do |record, attr, value|
     record.errors.add(attr, "can't be set to a future date") if value && Time.zone.now < value
   end
-  validate :scheduled_publication_must_be_in_future
+  validates :scheduled_publication, relative_date: { after: -> { Time.zone.now }, after_message: "must be in the future" }, if: :draft?
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
@@ -716,12 +716,6 @@ EXISTS (
 
   def publishing_api_presenter
     PublishingApi::GenericEditionPresenter
-  end
-
-  def scheduled_publication_must_be_in_future
-    if draft? && scheduled_publication.present? && scheduled_publication <= Time.zone.now
-      errors.add(:scheduled_publication, "must be in the future")
-    end
   end
 
 private

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -13,7 +13,7 @@ class ReviewReminder < ApplicationRecord
 
   validates :document, :creator, :review_at, :email_address, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
-  validate :review_date_cannot_be_in_the_past, if: :review_at_changed?
+  validates :review_at, relative_date: { after: -> { Time.zone.today }, after_message: "can't be in the past" }, if: :review_at_changed?
 
   before_update :reset_reminder_sent_at, if: :review_at_changed?
 
@@ -31,12 +31,6 @@ class ReviewReminder < ApplicationRecord
   end
 
 private
-
-  def review_date_cannot_be_in_the_past
-    if review_at && review_at < Time.zone.today
-      errors.add(:review_at, "can't be in the past")
-    end
-  end
 
   def reset_reminder_sent_at
     self.reminder_sent_at = nil

--- a/app/validators/relative_date_validator.rb
+++ b/app/validators/relative_date_validator.rb
@@ -1,0 +1,12 @@
+class RelativeDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+
+    if options[:before].present? && options[:before].call <= value
+      record.errors.add(attribute, :date_before, message: options[:before_message] || "must be before #{options[:before].call}")
+    end
+    if options[:after].present? && options[:after].call >= value
+      record.errors.add(attribute, :date_after, message: options[:after_message] || "must be after #{options[:after].call}")
+    end
+  end
+end

--- a/test/factories/review_reminder.rb
+++ b/test/factories/review_reminder.rb
@@ -11,23 +11,20 @@ FactoryBot.define do
 
     trait(:reminder_due) do
       review_at { Time.zone.today }
-      reminder_sent_at { nil }
+      # Attempting to set review_at to today usually causes a validation error, because review date should be set to a future date
+      to_create { |instance| instance.save(validate: false) }
     end
 
     trait(:reminder_sent) do
-      review_at { Time.zone.today }
       reminder_sent_at { Time.zone.now }
     end
 
-    trait(:due_but_never_published) do
-      review_at { Time.zone.today }
-      reminder_sent_at { nil }
+    trait(:document_never_published) do
       document { create(:document, editions: [build(:draft_edition, first_published_at: nil)]) }
     end
 
     trait(:not_due_yet) do
       review_at { 1.month.from_now }
-      reminder_sent_at { nil }
     end
   end
 end

--- a/test/unit/app/models/review_reminder_test.rb
+++ b/test/unit/app/models/review_reminder_test.rb
@@ -61,7 +61,7 @@ class ReviewReminderTest < ActiveSupport::TestCase
   end
 
   test "it resets reminder_sent_at when the review_at date is changed" do
-    reminder = create(:review_reminder, :reminder_sent)
+    reminder = create(:review_reminder, :reminder_due, :reminder_sent)
 
     reminder.update!(review_at: 10.days.from_now)
 
@@ -74,8 +74,8 @@ class ReviewReminderTest < ActiveSupport::TestCase
 
   test "#reminder_due? returns false when the reminder email does not need to be sent" do
     assert_not build(:review_reminder, :not_due_yet).reminder_due?
-    assert_not build(:review_reminder, :due_but_never_published).reminder_due?
-    assert_not build(:review_reminder, :reminder_sent).reminder_due?
+    assert_not build(:review_reminder, :reminder_due, :document_never_published).reminder_due?
+    assert_not build(:review_reminder, :reminder_due, :reminder_sent).reminder_due?
   end
 
   test "#reminder_sent! marks the reminder as sent without changing updated_at" do
@@ -100,8 +100,8 @@ class ReviewReminderTest < ActiveSupport::TestCase
     reminders = [
       due = build(:review_reminder, :reminder_due),
       overdue = build(:review_reminder, :reminder_due, review_at: 1.week.ago),
-      already_sent = build(:review_reminder, :reminder_sent),
-      due_but_never_published = build(:review_reminder, :due_but_never_published),
+      already_sent = build(:review_reminder, :reminder_due, :reminder_sent),
+      document_never_published = build(:review_reminder, :reminder_due, :document_never_published),
       not_due_yet = build(:review_reminder, :not_due_yet),
     ]
 
@@ -111,7 +111,7 @@ class ReviewReminderTest < ActiveSupport::TestCase
     assert_includes ReviewReminder.reminder_due, due
     assert_includes ReviewReminder.reminder_due, overdue
     assert_not_includes ReviewReminder.reminder_due, already_sent
-    assert_not_includes ReviewReminder.reminder_due, due_but_never_published
+    assert_not_includes ReviewReminder.reminder_due, document_never_published
     assert_not_includes ReviewReminder.reminder_due, not_due_yet
   end
 end

--- a/test/unit/app/validators/relative_date_validator_test.rb
+++ b/test/unit/app/validators/relative_date_validator_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class RelativeDateValidatorTest < ActiveSupport::TestCase
+  class StubModel
+    include ActiveModel::API
+    attr_accessor :some_date
+  end
+
+  test "validation is not applied if attribute value is nil" do
+    model = StubModel.new(some_date: nil)
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 3) }, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_empty model.errors
+  end
+
+  test "model is valid if datetime is between before and after dates" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 3) }, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_empty model.errors
+  end
+
+  test "adds an error with the default message if date is later than before date" do
+    before = Time.zone.local(2022, 1, 1, 1, 1)
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { before })
+    validator.validate(model)
+    assert_not_empty model.errors
+    assert_equal "must be before #{before}", model.errors[:some_date].first
+  end
+
+  test "adds an error if date is equal to before date" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_not_empty model.errors
+  end
+
+  test "adds an error with the default message if date is earlier than after date" do
+    after = Time.zone.local(2022, 1, 1, 1, 2)
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { after })
+    validator.validate(model)
+    assert_not_empty model.errors
+    assert_equal "must be after #{after}", model.errors[:some_date].first
+  end
+
+  test "adds an error if date is equal to after date" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_not_empty model.errors
+  end
+
+  test "before error message can be overriden" do
+    before_message = "should be in the past"
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 1) }, before_message:)
+    validator.validate(model)
+    assert_equal before_message, model.errors[:some_date].first
+  end
+
+  test "after error message can be overriden" do
+    after_message = "should be in the future"
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { Time.zone.local(2022, 1, 1, 1, 2) }, after_message:)
+    validator.validate(model)
+    assert_equal after_message, model.errors[:some_date].first
+  end
+end

--- a/test/unit/app/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/app/workers/review_reminder_notifier_worker_test.rb
@@ -27,7 +27,7 @@ class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
     not_due_yet = create(:review_reminder, :not_due_yet)
     ReviewReminderNotifierWorker.new.perform(not_due_yet.id)
 
-    already_sent = create(:review_reminder, :reminder_sent)
+    already_sent = create(:review_reminder, :reminder_due, :reminder_sent)
     ReviewReminderNotifierWorker.new.perform(already_sent.id)
   end
 end

--- a/test/unit/lib/tasks/send_review_reminders_test.rb
+++ b/test/unit/lib/tasks/send_review_reminders_test.rb
@@ -10,7 +10,7 @@ class SendReviewRemindersTest < ActiveSupport::TestCase
     reminders = [
       due = build(:review_reminder, :reminder_due),
       overdue = build(:review_reminder, :reminder_due, review_at: 1.week.ago),
-      already_sent = build(:review_reminder, :reminder_sent),
+      already_sent = build(:review_reminder, :reminder_due, :reminder_sent),
       not_due_yet = build(:review_reminder, :not_due_yet),
     ]
 


### PR DESCRIPTION
At present, each model duplicates date validation logic, or relies on setting constraints on select inputs which won't be viable when me move towards the design system date component. It therefore seems sensible to provide a single validator which can be responsible for validating dates relative to other dates.

I will gradually apply the relative date validator to other fields whilst working on replacing the date components

I had to disable validation on the review reminder factory in circumstances where the `review_at` date was being set to the current day (i.e. the review is due), because generally users can only set future dates. I tweaked the factory traits a bit so that they can be composed together for flexibility rather than duplicating the logic.
