### PR TITLE
Replace speech document type "Delivered On" date input with GOVUK Publishing date component

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -198,8 +198,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       const month = form.querySelector('#edition_delivered_on_2i')
       const year = form.querySelector('#edition_delivered_on_1i')
 
-      deliveredOnFieldset.querySelectorAll('select').forEach(function (select) {
-        select.addEventListener('change', function () {
+      deliveredOnFieldset.querySelectorAll('input').forEach(function (input) {
+        input.addEventListener('change', function () {
           const dateIsInvalid =
             day.value === '' || month.value === '' || year.value === ''
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -32,7 +32,7 @@ class Edition < ApplicationRecord
   include Searchable
 
   include DateValidation
-  date_attributes :scheduled_publication
+  date_attributes :scheduled_publication, :delivered_on
 
   has_many :editorial_remarks, dependent: :destroy
   has_many :edition_authors, dependent: :destroy

--- a/app/views/admin/speeches/_delivered_on_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_on_fields.html.erb
@@ -1,33 +1,47 @@
+<%
+  hour_param = params.dig("edition", "delivered_on(4i)")
+  minute_param = params.dig("edition", "delivered_on(5i)")
+%>
+
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: edition.authored_article? ? "Written on" : "Delivered on",
     heading_size: "l",
     id: "edition_delivered_on",
   } do %>
-    <%= render "components/datetime_fields", {
+    <%= render "components/datetime_fields_with_govuk_date_component", {
         field_name: "delivered_on",
         prefix: "edition",
         error_items: errors_for(edition.errors, :delivered_on),
-        date_hint: "For example, 01 August 2022",
+        date_hint: "For example, 01 08 2022",
         time_hint: "For example, 09:30 or 19:30",
         year: {
-          value: edition.delivered_on&.year,
+          value: params.dig("edition", "delivered_on(1i)") || edition.delivered_on&.year,
           id: "edition_delivered_on_1i",
+          name: "edition[delivered_on(1i)]",
+          label: "Year",
+          width: 4,
         },
         month: {
-          value: edition.delivered_on&.month,
+          value: params.dig("edition", "delivered_on(2i)") || edition.delivered_on&.month,
           id: "edition_delivered_on_2i",
+          name: "edition[delivered_on(2i)]",
+          label: "Month",
+          width: 2,
         },
         day: {
-          value: edition.delivered_on&.day,
+          value: params.dig("edition", "delivered_on(3i)") || edition.delivered_on&.day,
           id: "edition_delivered_on_3i",
+          name: "edition[delivered_on(3i)]",
+          label: "Day",
+          width: 2,
         },
         hour: {
-          value: edition.delivered_on&.hour,
+          value: hour_param ? hour_param.to_i : edition.delivered_on&.hour,
           id: "edition_delivered_on_4i",
         },
         minute: {
-          value: edition.delivered_on&.min,
+          value: minute_param ? minute_param.to_i : edition.delivered_on&.min,
           id: "edition_delivered_on_5i",
         },
       }

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -45,7 +45,7 @@ end
 
 Then(/^I should be able to choose the date it was written on$/) do
   within "#edition_delivered_on" do
-    fill_in_date_and_time_field(1.day.ago.to_s)
+    fill_in_govuk_publishing_date_fields(1.day.ago.to_s)
   end
 end
 

--- a/features/support/datetime_field_helper.rb
+++ b/features/support/datetime_field_helper.rb
@@ -18,7 +18,9 @@ module DatetimeFieldHelper
   end
 
   def fill_in_govuk_publishing_date_fields(date)
-    date = Time.zone.parse(date)
+    if date.is_a? String
+      date = Time.zone.parse(date)
+    end
 
     fill_in "Year", with: date.year
     fill_in "Month", with: date.month

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -94,7 +94,7 @@ module DocumentHelper
     select "Colonel Mustard, Attorney General"
 
     within_fieldset "Delivered on" do
-      select_date 1.day.ago.to_s, base_dom_id: "edition_delivered_on"
+      fill_in_govuk_publishing_date_fields(1.day.ago)
     end
 
     fill_in "Location", with: "The Drawing Room"

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -283,15 +283,14 @@ describe('GOVUK.Modules.EditionForm', function () {
         editionForm.init()
       })
 
-      it('shows the speech delivered_on in future warning to the user when they select a date in the future', function () {
+      it('shows the speech delivered_on in future warning to the user when they input a date in the future', function () {
         const deliveredOnFieldset = form.querySelector('#edition_delivered_on')
-        deliveredOnFieldset.querySelector('select').value = '1'
-        deliveredOnFieldset.querySelectorAll('select')[1].value = '1'
-        deliveredOnFieldset.querySelectorAll('select')[2].value =
-          currentYear + 1
+        deliveredOnFieldset.querySelector('input').value = '1'
+        deliveredOnFieldset.querySelectorAll('input')[1].value = '1'
+        deliveredOnFieldset.querySelectorAll('input')[2].value = currentYear + 1
 
         deliveredOnFieldset
-          .querySelector('select')
+          .querySelector('input')
           .dispatchEvent(new Event('change'))
 
         const warning = form.querySelector(
@@ -305,9 +304,9 @@ describe('GOVUK.Modules.EditionForm', function () {
 
       it('does not show the speech delivered_on in future warning to the user when they select a date in the past', function () {
         const deliveredOnFieldset = form.querySelector('#edition_delivered_on')
-        deliveredOnFieldset.querySelector('select').value = '1'
-        deliveredOnFieldset.querySelectorAll('select')[1].value = '1'
-        deliveredOnFieldset.querySelectorAll('select')[2].value = currentYear
+        deliveredOnFieldset.querySelector('input').value = '1'
+        deliveredOnFieldset.querySelectorAll('input')[1].value = '1'
+        deliveredOnFieldset.querySelectorAll('input')[2].value = currentYear
 
         deliveredOnFieldset.dispatchEvent(new Event('change'))
 
@@ -431,18 +430,9 @@ describe('GOVUK.Modules.EditionForm', function () {
         '<fieldset class="govuk-fieldset" id="edition_delivered_on">' +
           '<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Delivered on</legend>' +
           '<div class="app-c-datetime-fields__date-time-wrapper">' +
-            '<select id="edition_delivered_on_3i" name="edition[delivered_on(3i)]">' +
-              '<option value="" label=" "></option>' +
-              '<option value="1">1</option>' +
-            '</select>'
-            '<select id="edition_delivered_on_2i" name="edition[delivered_on(2i)]">' +
-              '<option value="" label=" "></option>' +
-              '<option value="1">January</option>' +
-            '</select>' +
-            '<select id="edition_delivered_on_1i" name="edition[delivered_on(1i)]">' +
-              '<option value="${currentYear}">${currentYear}</option>' +
-              '<option value="${currentYear + 1}">${currentYear + 1}</option>' +
-            '</select>' +
+            '<input type="text" id="edition_delivered_on_3i" name="edition[delivered_on(3i)]" />' +
+            '<input type="text" id="edition_delivered_on_2i" name="edition[delivered_on(2i)]" />' +
+            '<input type="text" id="edition_delivered_on_1i" name="edition[delivered_on(1i)]" />' +
           '</div>' +
         '</fieldset>' +
         '<div class="js-app-view-edit-edition__delivered-on-warning app-view-edit-edition__delivered-on-warning--hidden">' +

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -23,7 +23,8 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
       assert_select "select[name='edition[speech_type_id]']"
       assert_select "select[name='edition[role_appointment_id]']"
       assert_select "input[name='edition[person_override]']"
-      assert_select "select[name*='edition[delivered_on']", count: 5
+      assert_select "input[name*='edition[delivered_on']", count: 3
+      assert_select "select[name*='edition[delivered_on']", count: 2
       assert_select "input[name='edition[location]'][type='text']"
     end
   end
@@ -37,7 +38,8 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
       assert_select "select[name='edition[speech_type_id]']"
       assert_select "select[name='edition[role_appointment_id]']"
       assert_select "input[name='edition[person_override]']"
-      assert_select "select[name*='edition[delivered_on']", count: 5
+      assert_select "input[name*='edition[delivered_on']", count: 3
+      assert_select "select[name*='edition[delivered_on']", count: 2
       assert_select "input[name='edition[location]'][type='text']"
       assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A verbatim report of exactly what the speaker said (checked against delivery)."
     end


### PR DESCRIPTION
The GOV.UK publishing component has proven during user research to provide a superior user experience to Rails' built-in date selection component

Before:

![Screenshot 2023-09-13 at 15 15 39](https://github.com/alphagov/whitehall/assets/137083285/f95b509f-8ba9-41fd-8d9e-2b5a18a34d36)

After:

![Screenshot 2023-09-13 at 15 15 51](https://github.com/alphagov/whitehall/assets/137083285/1253fd8d-3bb5-4c9e-91e1-453050cb994b)


Trello: https://trello.com/c/IFGDegsk
