### PR TITLE
Removed DfE's services and information page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -510,7 +510,6 @@ class Organisation < ApplicationRecord
   def organisations_with_services_and_information_link
     %w[
       charity-commission
-      department-for-education
       hm-revenue-customs
     ]
   end


### PR DESCRIPTION
We are un-publishing and redirecting DfE's service and information page, as part of our work to retire specialist topics. Removing the slug from the organisation's `organisations_with_services_and_information_link` list means we won't accidentally republish the page next time the org is updated.

https://trello.com/c/IQD8PfE8/2067-archive-and-redirect-services-and-info-page-dfe-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
