### PR TITLE
Fix csv preview url

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -30,9 +30,12 @@ class Admin::AttachmentsController < Admin::BaseController
   def edit; end
 
   def update
+    use_non_legacy_endpoints = attachment.attachment_data&.use_non_legacy_endpoints
     attachment.attributes = attachment_params
     message = "Attachment '#{attachment.title}' updated"
     if attachment.is_a?(FileAttachment)
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints
+
       attachment.attachment_data.attachable = attachable
       if attachment.filename_changed? && attachable.allows_inline_attachments?
         message += ". You must replace the attachment markdown with the new markdown below."
@@ -69,12 +72,6 @@ private
 
   def attachment
     @attachment ||= find_attachment || build_attachment
-
-    if @attachment.attachment_data
-      @attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
-    end
-
-    @attachment
   end
   helper_method :attachment
 
@@ -107,6 +104,7 @@ private
     FileAttachment.new(attachment_params).tap do |file_attachment|
       file_attachment.build_attachment_data unless file_attachment.attachment_data
       file_attachment.attachment_data.attachable = attachable
+      file_attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
     end
   end
 

--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -193,11 +193,8 @@ private
     end
 
     if attachable_is_an_edition?
-      @draft_updater ||= Whitehall.edition_services.draft_updater(attachable)
-
-      if @draft_updater.can_perform?
-        @draft_updater.perform!
-      end
+      draft_updater = Whitehall.edition_services.draft_updater(attachable)
+      draft_updater.perform!
     end
 
     result

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -261,13 +261,6 @@ module Admin::EditionsHelper
     end
   end
 
-  def attachment_uploading_status(attachment)
-    return unless attachment.attachment_data
-
-    tag.p("Uploading", class: "asset-manager-uploading") unless
-      attachment.attachment_data.uploaded_to_asset_manager?
-  end
-
   def attachment_metadata_tag(attachment)
     labels = {
       isbn: "ISBN",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,16 @@ module ApplicationHelper
 
     name = attachment.name_for_link
     html_class = options.delete(:class)
-    link_to name, attachment.url(options), class: html_class
+
+    return link_to name, attachment.url(options), class: html_class if !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded?
+
+    tag.span(name)
+  end
+
+  def link_to_attachment_data(attachment_data)
+    return link_to attachment_data.filename, attachment_data.url, class: "govuk-link" if attachment_data.all_asset_variants_uploaded?
+
+    tag.span(attachment_data.filename)
   end
 
   def worldwide_office_type_options

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -14,6 +14,12 @@ module AttachmentsHelper
   end
 
   def preview_path_for_attachment(attachment)
+    if attachment.attachment_data.use_non_legacy_endpoints
+      if attachment.attachment_data.all_asset_variants_uploaded?
+        return "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      end
+      return nil
+    end
     "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
   end
 

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -16,12 +16,12 @@ module AttachmentsHelper
   def preview_path_for_attachment(attachment)
     if attachment.attachment_data.use_non_legacy_endpoints
       if attachment.attachment_data.all_asset_variants_uploaded?
-        return Plek.find('frontend') + "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+        return Plek.find("frontend") + "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
       end
 
       return nil
     end
-    Plek.find('frontend')+ "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
+    Plek.find("frontend") + "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
   end
 
   def attachment_component_params(attachment, alternative_format_contact_email: nil)

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -60,7 +60,9 @@ module AttachmentsHelper
   end
 
   def block_attachments(attachments = [], alternative_format_contact_email = nil)
-    attachments.map do |attachment|
+    attachments
+      .select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+      .map do |attachment|
       render(
         partial: "govuk_publishing_components/components/attachment",
         locals: {

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -16,11 +16,12 @@ module AttachmentsHelper
   def preview_path_for_attachment(attachment)
     if attachment.attachment_data.use_non_legacy_endpoints
       if attachment.attachment_data.all_asset_variants_uploaded?
-        return "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+        return Plek.find('frontend') + "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
       end
+
       return nil
     end
-    "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
+    Plek.find('frontend')+ "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
   end
 
   def attachment_component_params(attachment, alternative_format_contact_email: nil)

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -63,7 +63,9 @@ module GovspeakHelper
   end
 
   def prepare_attachments(attachments, alternative_format_contact_email)
-    attachments.map do |attachment|
+    attachments
+      .select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+      .map do |attachment|
       attachment_component_params(attachment, alternative_format_contact_email:)
     end
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -4,6 +4,7 @@ class Asset < ApplicationRecord
   validates :asset_manager_id, presence: true
   validates :assetable, presence: true
   validates :variant, presence: true
+  validates :filename, presence: true
 
   enum variant: {
     original: "original".freeze,

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -41,6 +41,10 @@ module Attachable
         end
       end
     end
+
+    def attachments_ready_for_publishing
+      attachments.select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+    end
   end
 
   class Null

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -95,7 +95,7 @@ module Attachable
     attachments
       .map(&:attachment_data)
       .compact
-      .all?(&:uploaded_to_asset_manager?)
+      .all?(&:all_asset_variants_uploaded?)
   end
 
   def allows_attachments?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -16,7 +16,7 @@ class AttachmentData < ApplicationRecord
   validates :file, presence: true
   validate :file_is_not_empty
 
-  attr_accessor :to_replace_id, :attachable, :use_non_legacy_endpoints
+  attr_accessor :to_replace_id, :attachable
 
   belongs_to :replaced_by, class_name: "AttachmentData"
   validate :cant_be_replaced_by_self

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -63,7 +63,7 @@ class AttachmentData < ApplicationRecord
 
   def all_asset_variants_uploaded?
     if use_non_legacy_endpoints
-      return pdf? ? assets.size == 2 : assets.size == 1
+      return assets.size == (pdf? ? 2 : 1)
     end
 
     uploaded_to_asset_manager?
@@ -185,7 +185,7 @@ class AttachmentData < ApplicationRecord
     attachable && attachable.respond_to?(:auth_bypass_id) ? [attachable.auth_bypass_id] : []
   end
 
-  private
+private
 
   def filtered_attachments(include_deleted_attachables: false)
     if include_deleted_attachables

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -57,7 +57,7 @@ class Edition < ApplicationRecord
   validates_each :first_published_at do |record, attr, value|
     record.errors.add(attr, "can't be set to a future date") if value && Time.zone.now < value
   end
-  validate :scheduled_publication_must_be_in_future
+  validates :scheduled_publication, relative_date: { after: -> { Time.zone.now }, after_message: "must be in the future" }, if: :draft?
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
@@ -716,12 +716,6 @@ EXISTS (
 
   def publishing_api_presenter
     PublishingApi::GenericEditionPresenter
-  end
-
-  def scheduled_publication_must_be_in_future
-    if draft? && scheduled_publication.present? && scheduled_publication <= Time.zone.now
-      errors.add(:scheduled_publication, "must be in the future")
-    end
   end
 
 private

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -68,8 +68,20 @@ private
 
   def preview_url
     if csv? && attachable.is_a?(Edition)
+      if attachment_data.use_non_legacy_endpoints
+        return non_legacy_csv_preview
+      end
+
       Plek.asset_root + "/government/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/#{filename}/preview"
     end
+  end
+
+  def non_legacy_csv_preview
+    if attachment_data.all_asset_variants_uploaded?
+      return Plek.asset_root + "/media/#{attachment_data.id}/#{filename}/preview"
+    end
+
+    nil
   end
 
   def filename_is_unique

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -7,6 +7,9 @@ class ImageData < ApplicationRecord
   VALID_HEIGHT = 640
 
   has_many :images
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
 
   mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
 

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -1,7 +1,7 @@
 require "mini_magick"
 
 class ImageData < ApplicationRecord
-  attr_accessor :validate_on_image, :use_non_legacy_endpoints
+  attr_accessor :validate_on_image
 
   VALID_WIDTH = 960
   VALID_HEIGHT = 640

--- a/app/models/review_reminder.rb
+++ b/app/models/review_reminder.rb
@@ -13,7 +13,7 @@ class ReviewReminder < ApplicationRecord
 
   validates :document, :creator, :review_at, :email_address, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, if: -> { email_address.present? } }
-  validate :review_date_cannot_be_in_the_past, if: :review_at_changed?
+  validates :review_at, relative_date: { after: -> { Time.zone.today }, after_message: "can't be in the past" }, if: :review_at_changed?
 
   before_update :reset_reminder_sent_at, if: :review_at_changed?
 
@@ -31,12 +31,6 @@ class ReviewReminder < ApplicationRecord
   end
 
 private
-
-  def review_date_cannot_be_in_the_past
-    if review_at && review_at < Time.zone.today
-      errors.add(:review_at, "can't be in the past")
-    end
-  end
 
   def reset_reminder_sent_at
     self.reminder_sent_at = nil

--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -139,7 +139,7 @@ module PublishingApi
       end
 
       def featured_attachments
-        call_for_evidence.attachments.map { |a| a.publishing_api_details[:id] }
+        call_for_evidence.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
     end
 
@@ -203,7 +203,7 @@ module PublishingApi
       end
 
       def outcome_attachments
-        outcome.attachments.map { |a| a.publishing_api_details[:id] }
+        outcome.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
     end
 

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -140,7 +140,7 @@ module PublishingApi
       end
 
       def featured_attachments
-        consultation.attachments.map { |a| a.publishing_api_details[:id] }
+        consultation.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
     end
 
@@ -204,7 +204,7 @@ module PublishingApi
       end
 
       def final_outcome_attachments
-        outcome.attachments.map { |a| a.publishing_api_details[:id] }
+        outcome.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
     end
 
@@ -272,7 +272,7 @@ module PublishingApi
       end
 
       def attachments
-        public_feedback.attachments.map { |a| a.publishing_api_details[:id] }
+        public_feedback.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
 
       def publication_date

--- a/app/presenters/publishing_api/payload_builder/attachments.rb
+++ b/app/presenters/publishing_api/payload_builder/attachments.rb
@@ -19,7 +19,9 @@ module PublishingApi
       def attachments
         items.flat_map do |item|
           if item
-            item.attachments.map(&:publishing_api_details)
+            item.attachments
+                .select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+                .map(&:publishing_api_details)
           else
             []
           end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -101,7 +101,7 @@ module PublishingApi
     end
 
     def attachments_for_current_locale
-      attachments = item.attachments
+      attachments = item.attachments_ready_for_publishing
       # nil/"" locale should always be returned
       locales_that_match = [I18n.locale.to_s, ""]
       attachments.to_a.select do |attachment|

--- a/app/services/asset_manager/attachment_deleter.rb
+++ b/app/services/asset_manager/attachment_deleter.rb
@@ -2,13 +2,13 @@ class AssetManager::AttachmentDeleter
   def self.call(attachment_data)
     return unless attachment_data.deleted?
 
-    if attachment_data.assets.empty?
-      AssetManager::AssetDeleter.call(attachment_data.file.asset_manager_path, nil)
-      AssetManager::AssetDeleter.call(attachment_data.file.thumbnail.asset_manager_path, nil) if attachment_data.pdf?
-    else
+    if attachment_data.use_non_legacy_endpoints
       attachment_data.assets.each do |asset|
         AssetManager::AssetDeleter.call(nil, asset.asset_manager_id)
       end
+    else
+      AssetManager::AssetDeleter.call(attachment_data.file.asset_manager_path, nil)
+      AssetManager::AssetDeleter.call(attachment_data.file.thumbnail.asset_manager_path, nil) if attachment_data.pdf?
     end
   end
 end

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -50,7 +50,7 @@ class AssetManager::AttachmentUpdater
       access_limited_organisation_ids: access_limited ? get_access_limited(attachment_data) : nil,
       draft: draft_status ? get_draft(attachment_data) : nil,
       parent_document_url: link_header ? get_link_header(attachment_data) : nil,
-      replacement_id: replacement_id ? get_replacement_id(attachment_data, asset) : nil,
+      replacement_id: replacement_id ? get_replacement_id(attachment_data, asset.variant) : nil,
     }.compact
     new_attributes.merge!(redirect_url: get_redirect_url(attachment_data)) if redirect_url
 
@@ -91,15 +91,18 @@ class AssetManager::AttachmentUpdater
     attachment_data.unpublished_edition.unpublishing.document_url
   end
 
-  def self.get_replacement_id(attachment_data, asset)
-    return nil unless attachment_data.replaced?
+  def self.get_replacement_id(replaced_attachment_data, variant)
+    return nil unless replaced_attachment_data.replaced?
 
-    replacement = attachment_data.replaced_by
-    replacement_asset = replacement.assets.where(variant: asset.variant).first
+    replacement = replaced_attachment_data.replaced_by
+    replacement_asset = replacement.assets.where(variant:).first
+
     if replacement_asset
       replacement_asset.asset_manager_id
     else
-      replacement.assets.where(variant: Asset.variants[:original]).first.asset_manager_id
+      original_variant = replacement.assets.where(variant: Asset.variants[:original]).first
+
+      original_variant ? original_variant.asset_manager_id : nil
     end
   end
 end

--- a/app/validators/relative_date_validator.rb
+++ b/app/validators/relative_date_validator.rb
@@ -1,0 +1,12 @@
+class RelativeDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+
+    if options[:before].present? && options[:before].call <= value
+      record.errors.add(attribute, :date_before, message: options[:before_message] || "must be before #{options[:before].call}")
+    end
+    if options[:after].present? && options[:after].call >= value
+      record.errors.add(attribute, :date_after, message: options[:after_message] || "must be after #{options[:after].call}")
+    end
+  end
+end

--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -1,7 +1,7 @@
 <%= form.fields_for(:attachment_data, include_id: false) do |attachment_data_fields| %>
   <% if attachment_data_fields.object.filename %>
     <%= attachment_data_fields.hidden_field(:to_replace_id, value: attachment_data_fields.object.to_replace_id || attachment_data_fields.object.id) %>
-    <p class="govuk-body">Current file: <%= link_to attachment_data_fields.object.filename, attachment_data_fields.object.url, class: "govuk-link" %></p>
+    <p class="govuk-body">Current file: <%= link_to_attachment_data(attachment_data_fields.object) %></p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/file_upload", {

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -7,7 +7,7 @@
     <li class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <p class="govuk-body">
-          <strong>Title:</strong> <%= attachment.title %> <% unless attachment.attachment_data.blank? || attachment.attachment_data.uploaded_to_asset_manager? %><span class="govuk-tag govuk-tag--green">Uploading</span><% end %>
+          <strong>Title:</strong> <%= attachment.title %> <% unless attachment.attachment_data.blank? || attachment.attachment_data.all_asset_variants_uploaded? %><span class="govuk-tag govuk-tag--green">Uploading</span><% end %>
         </p>
         <p class="govuk-body">
           <strong>Type: </strong><%= attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize %>

--- a/app/workers/asset_manager_attachment_metadata_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_worker.rb
@@ -3,7 +3,7 @@ class AssetManagerAttachmentMetadataWorker < WorkerBase
 
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find(attachment_data_id)
-    return unless attachment_data.present? && attachment_data.uploaded_to_asset_manager_at
+    return unless attachment_data.present? && attachment_data.all_asset_variants_uploaded?
 
     AssetManager::AttachmentUpdater.call(
       attachment_data,

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -20,12 +20,23 @@ class AssetManagerCreateAssetWorker < WorkerBase
       AttachmentData.find(assetable_id).uploaded_to_asset_manager!
     end
 
+    perform_draft_update(attachable_model_class, attachable_model_id)
+
     file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
   end
 
 private
+
+  def perform_draft_update(attachable_model_class, attachable_model_id)
+    if attachable_model_class && attachable_model_id && attachable_model_class.constantize.ancestors.include?(Edition)
+      attachable = attachable_model_class.constantize.find(attachable_model_id)
+      draft_updater = Whitehall.edition_services.draft_updater(attachable)
+
+      draft_updater.perform!
+    end
+  end
 
   def get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
     if attachable_model_class && attachable_model_id

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -16,7 +16,7 @@ class AssetManagerCreateAssetWorker < WorkerBase
     response = asset_manager.create_asset(asset_options)
     save_asset_id_to_assets(assetable_id, assetable_type, asset_variant, response, filename)
 
-    if assetable_type == AttachmentData.name && asset_variant == Asset.variants[:original]
+    if assetable_type == AttachmentData.name
       AttachmentData.find(assetable_id).uploaded_to_asset_manager!
     end
 

--- a/db/migrate/20230831161457_add_use_non_legacy_endpoints_to_attachment_data_and_image_data.rb
+++ b/db/migrate/20230831161457_add_use_non_legacy_endpoints_to_attachment_data_and_image_data.rb
@@ -1,0 +1,6 @@
+class AddUseNonLegacyEndpointsToAttachmentDataAndImageData < ActiveRecord::Migration[7.0]
+  def change
+    add_column :attachment_data, :use_non_legacy_endpoints, :boolean, null: false, default: false
+    add_column :image_data, :use_non_legacy_endpoints, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20230906151938_add_filename_to_assets.rb
+++ b/db/migrate/20230906151938_add_filename_to_assets.rb
@@ -1,0 +1,5 @@
+class AddFilenameToAssets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assets, :filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_31_161457) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_151938) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_31_161457) do
     t.datetime "updated_at", null: false
     t.string "assetable_type"
     t.bigint "assetable_id"
+    t.string "filename"
     t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_075602) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_31_161457) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_075602) do
     t.integer "replaced_by_id"
     t.datetime "uploaded_to_asset_manager_at", precision: nil
     t.boolean "present_at_unpublish"
+    t.boolean "use_non_legacy_endpoints", default: false, null: false
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id"
   end
 
@@ -590,6 +591,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_075602) do
     t.string "carrierwave_image"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.boolean "use_non_legacy_endpoints", default: false, null: false
   end
 
   create_table "images", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -24,8 +24,9 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     if should_save_an_asset?
       assetable_id = uploader.model.id
       assetable_type = uploader.model.class.to_s
+      filename = uploader.identifier
       asset_variant = uploader.version_name ? Asset.variants[uploader.version_name] : Asset.variants[:original]
-      asset_params = { assetable_id:, asset_variant:, assetable_type: }.deep_stringify_keys
+      asset_params = { assetable_id:, asset_variant:, assetable_type:, filename: }.deep_stringify_keys
 
       # Separating the journey based on feature flag so its easier to make future changes and also decommission old journey
       AssetManagerCreateAssetWorker.perform_async(temporary_location, asset_params, draft, attachable_model_class, attachable_model_id, auth_bypass_ids)
@@ -60,7 +61,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
         asset_variant = @version ? Asset.variants[@version] : Asset.variants[:original]
         asset = @model.assets.where(variant: asset_variant).first
         if asset
-          URI.join(Plek.asset_root, Addressable::URI.encode("media/#{asset.asset_manager_id}/#{filename}")).to_s
+          URI.join(Plek.asset_root, Addressable::URI.encode("media/#{asset.asset_manager_id}/#{asset.filename}")).to_s
         end
       else
         URI.join(Plek.asset_root, Addressable::URI.encode(@legacy_url_path)).to_s

--- a/test/factories/asset.rb
+++ b/test/factories/asset.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :asset do
+  end
+end

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -23,6 +23,14 @@ FactoryBot.define do
     end
   end
 
+  factory :attachment_data_with_csv_asset, parent: :attachment_data do
+    use_non_legacy_endpoints { true }
+    file { File.open(Rails.root.join("test/fixtures/dft_statistical_data_set_sample.csv")) }
+    after(:build) do |attachment_data|
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "dft_statistical_data_set_sample.csv")
+    end
+  end
+
   factory :image_attachment_data, parent: :attachment_data do
     file { File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")) }
   end

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -4,6 +4,25 @@ FactoryBot.define do
     uploaded_to_asset_manager_at { Time.zone.now }
   end
 
+  factory :attachment_data_with_assets, parent: :attachment_data do
+    use_non_legacy_endpoints { true }
+
+    after(:build) do |attachment_data|
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original])
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_thumbnail", variant: Asset.variants[:thumbnail])
+    end
+  end
+
+  factory :attachment_data_with_asset, class: AttachmentData do
+    file { File.open(Rails.root.join("test/fixtures/sample.docx")) }
+    uploaded_to_asset_manager_at { Time.zone.now }
+    use_non_legacy_endpoints { true }
+
+    after(:build) do |attachment_data|
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original])
+    end
+  end
+
   factory :image_attachment_data, parent: :attachment_data do
     file { File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")) }
   end

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     use_non_legacy_endpoints { true }
 
     after(:build) do |attachment_data|
-      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original])
-      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_thumbnail", variant: Asset.variants[:thumbnail])
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "greenpaper.pdf")
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_thumbnail", variant: Asset.variants[:thumbnail], filename: "thumbnail_greenpaper.pdf.png")
     end
   end
 
@@ -19,7 +19,7 @@ FactoryBot.define do
     use_non_legacy_endpoints { true }
 
     after(:build) do |attachment_data|
-      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original])
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "sample.docx")
     end
   end
 

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -10,8 +10,33 @@ FactoryBot.define do
     transient do
       file { File.open(Rails.root.join("test/fixtures/greenpaper.pdf")) }
     end
+
     after(:build) do |attachment, evaluator|
       attachment.attachment_data ||= build(:attachment_data, file: evaluator.file, content_type: AttachmentUploader::PDF_CONTENT_TYPE)
+    end
+    accessible { false }
+  end
+
+  factory :file_attachment_with_asset, class: FileAttachment, traits: [:abstract_attachment] do
+    sequence(:title) { |index| "file-attachment-title-#{index}" }
+    transient do
+      file { File.open(Rails.root.join("test/fixtures/sample.docx")) }
+    end
+
+    after(:build) do |attachment, evaluator|
+      attachment.attachment_data = build(:attachment_data_with_asset, file: evaluator.file)
+    end
+    accessible { false }
+  end
+
+  factory :file_attachment_with_assets, parent: :file_attachment, traits: [:abstract_attachment] do
+    sequence(:title) { |index| "file-attachment-title-#{index}" }
+    transient do
+      file { File.open(Rails.root.join("test/fixtures/greenpaper.pdf")) }
+    end
+
+    after(:build) do |attachment, evaluator|
+      attachment.attachment_data = build(:attachment_data_with_assets, file: evaluator.file, content_type: AttachmentUploader::PDF_CONTENT_TYPE)
     end
     accessible { false }
   end

--- a/test/factories/review_reminder.rb
+++ b/test/factories/review_reminder.rb
@@ -11,23 +11,20 @@ FactoryBot.define do
 
     trait(:reminder_due) do
       review_at { Time.zone.today }
-      reminder_sent_at { nil }
+      # Attempting to set review_at to today usually causes a validation error, because review date should be set to a future date
+      to_create { |instance| instance.save(validate: false) }
     end
 
     trait(:reminder_sent) do
-      review_at { Time.zone.today }
       reminder_sent_at { Time.zone.now }
     end
 
-    trait(:due_but_never_published) do
-      review_at { Time.zone.today }
-      reminder_sent_at { nil }
+    trait(:document_never_published) do
       document { create(:document, editions: [build(:draft_edition, first_published_at: nil)]) }
     end
 
     trait(:not_due_yet) do
       review_at { 1.month.from_now }
-      reminder_sent_at { nil }
     end
   end
 end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -374,7 +374,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "use_non_legacy_endpoints is true -  PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager" do
     login_as_use_non_legacy_endpoints_user :gds_editor
-    attachment = create(:file_attachment, attachable: @edition)
+    attachment = create(:file_attachment_with_assets, attachable: @edition)
     variant = Asset.variants[:original]
     model_type = attachment.attachment_data.class.to_s
 
@@ -507,7 +507,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "use_non_legacy_endpoints is true - PUT :discards file_cache when a file is provided" do
     login_as_use_non_legacy_endpoints_user :gds_editor
-    attachment = create(:file_attachment, attachable: @edition)
+    attachment = create(:file_attachment_with_assets, attachable: @edition)
     attachment_data = attachment.attachment_data
     greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -335,7 +335,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             stub_asset(asset_manager_id, draft: true)
 
             add_file_attachment("logo.png", to: edition)
-            edition.attachments[0].attachment_data.assets.create!(asset_manager_id:, variant:)
+            edition.attachments[0].attachment_data.assets.create!(asset_manager_id:, variant:, filename: "logo.png")
             edition.attachments[0].attachment_data.uploaded_to_asset_manager!
             edition.save!
           end

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -184,7 +184,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             click_button "Upload zip"
             fill_in "Title", with: "file-title"
             click_button "Save"
-            assert find("li a", text: "greenpaper.pdf")
+            assert find("li", text: "greenpaper.pdf")
           end
 
           it "marks attachment as access limited in Asset Manager" do
@@ -309,7 +309,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             click_button "Upload zip"
             fill_in "Title", with: "file-title"
             click_button "Save"
-            assert find("li a", text: "greenpaper.pdf")
+            assert find("li", text: "greenpaper.pdf")
           end
 
           it "marks attachment as access limited in Asset Manager" do

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -95,8 +95,8 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
 
         let(:edition) { create(:news_article) }
 
-        let(:first_asset) { Asset.new(asset_manager_id: first_asset_id, variant: Asset.variants[:original]) }
-        let(:second_asset) { Asset.new(asset_manager_id: second_asset_id, variant: Asset.variants[:original]) }
+        let(:first_asset) { Asset.new(asset_manager_id: first_asset_id, variant: Asset.variants[:original], filename: first_filename) }
+        let(:second_asset) { Asset.new(asset_manager_id: second_asset_id, variant: Asset.variants[:original], filename: second_filename) }
 
         before do
           login_as(managing_editor)

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -162,7 +162,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
             force_publish_document
             visit admin_news_article_path(edition)
             unpublish_document_published_in_error
-            attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+            attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
             attachable.attachments << attachment
             attachable.save!
             Attachment.last.attachment_data.uploaded_to_asset_manager!
@@ -179,7 +179,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
         before do
           setup_publishing_api_for(edition)
-          attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+          attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
           attachable.attachments << attachment
           attachable.save!
         end
@@ -251,7 +251,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
         it "marks attachment as published in Asset Manager when added to policy group" do
           visit admin_policy_group_attachments_path(policy_group)
           add_attachment(filename)
-          Attachment.last.attachment_data.assets.create!(asset_manager_id:, variant:)
+          Attachment.last.attachment_data.assets.create!(asset_manager_id:, variant:, filename:)
           Attachment.last.attachment_data.uploaded_to_asset_manager!
 
           assert_sets_draft_status_in_asset_manager_to false

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -9,7 +9,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
   describe "attachment draft status" do
     let(:filename) { "sample.docx" }
-    let(:asset_manager_id) { "asset-id" }
+    let(:asset_manager_id) { "asset_manager_id" }
     let(:topic_taxon) { build(:taxon_hash) }
 
     context "updates with legacy_url_path" do
@@ -142,9 +142,8 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "given a file attachment added after unpublishing" do
-        let(:file) { File.open(path_to_attachment(filename)) }
         let(:attachable) { edition }
-        let(:attachment) { build(:file_attachment, attachable:, file:) }
+        let(:attachment) { build(:file_attachment_with_asset, attachable:) }
 
         before do
           setup_publishing_api_for(edition)
@@ -162,7 +161,6 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
             force_publish_document
             visit admin_news_article_path(edition)
             unpublish_document_published_in_error
-            attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
             attachable.attachments << attachment
             attachable.save!
             Attachment.last.attachment_data.uploaded_to_asset_manager!
@@ -173,13 +171,11 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "given a file attachment" do
-        let(:file) { File.open(path_to_attachment(filename)) }
-        let(:attachment) { build(:file_attachment, attachable:, file:) }
+        let(:attachment) { build(:file_attachment_with_asset, attachable:) }
         let(:attachable) { edition }
 
         before do
           setup_publishing_api_for(edition)
-          attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
           attachable.attachments << attachment
           attachable.save!
         end
@@ -253,6 +249,9 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
           add_attachment(filename)
           Attachment.last.attachment_data.assets.create!(asset_manager_id:, variant:, filename:)
           Attachment.last.attachment_data.uploaded_to_asset_manager!
+          attachment_data = Attachment.last.attachment_data
+          attachment_data.use_non_legacy_endpoints = true
+          attachment_data.save!
 
           assert_sets_draft_status_in_asset_manager_to false
         end

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -67,7 +67,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
 
         before do
           setup_publishing_api_for(edition)
-          attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+          attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
           attachable.attachments << attachment
           attachable.save!
         end

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -9,7 +9,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
 
   describe "attachment link header" do
     let(:filename) { "sample.docx" }
-    let(:asset_manager_id) { "asset-id" }
+    let(:asset_manager_id) { "asset_manager_id" }
 
     context "updates with legacy_url_path" do
       before do
@@ -60,14 +60,12 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "given a file attachment" do
-        let(:file) { File.open(path_to_attachment(filename)) }
-        let(:attachment) { build(:file_attachment, attachable:, file:) }
+        let(:attachment) { build(:file_attachment_with_asset, attachable:) }
         let(:attachable) { edition }
         let(:topic_taxon) { build(:taxon_hash) }
 
         before do
           setup_publishing_api_for(edition)
-          attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
           attachable.attachments << attachment
           attachable.save!
         end

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -12,7 +12,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:file) { File.open(path_to_attachment(filename)) }
     let(:attachment) { build(:file_attachment, attachable:, file:) }
     let(:attachable) { edition }
-    let(:asset_manager_id) { "asset-id" }
+    let(:asset_manager_id) { "asset_manager_id" }
     let(:redirect_path) { edition.public_path }
     let(:redirect_url) { edition.public_url }
     let(:topic_taxon) { build(:taxon_hash) }
@@ -213,12 +213,12 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
 
     context "updates with asset_manager_id" do
       let(:variant) { Asset.variants[:original] }
+      let(:attachment) { build(:file_attachment_with_asset, attachable:) }
 
       before do
         stub_publishing_api_has_linkables([], document_type: "topic")
         login_as create(:managing_editor)
         setup_publishing_api_for(edition)
-        attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
         attachable.attachments << attachment
         stub_asset(asset_manager_id)
         attachable.save!

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -218,7 +218,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
         stub_publishing_api_has_linkables([], document_type: "topic")
         login_as create(:managing_editor)
         setup_publishing_api_for(edition)
-        attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+        attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
         attachable.attachments << attachment
         stub_asset(asset_manager_id)
         attachable.save!

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -12,7 +12,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     let(:filename) { "sample.docx" }
     let(:file) { File.open(path_to_attachment(filename)) }
     let(:attachment) { build(:file_attachment, title: "attachment-title", attachable: edition, file:) }
-    let(:asset_manager_id) { "asset-id" }
+    let(:asset_manager_id) { "asset_manager_id" }
 
     let(:replacement_filename) { "sample.rtf" }
     let(:replacement_asset_manager_id) { "replacement-asset-id" }
@@ -93,11 +93,11 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
 
     context "updates with asset_manager_id" do
       let(:variant) { Asset.variants[:original] }
+      let(:attachment) { build(:file_attachment_with_asset, title: "attachment-title", attachable: edition) }
 
       before do
         create(:government)
         login_as(managing_editor)
-        attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
         edition.attachments << attachment
         stub_publishing_api_has_linkables([], document_type: "topic")
         setup_publishing_api_for(edition)

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -97,7 +97,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
       before do
         create(:government)
         login_as(managing_editor)
-        attachment.attachment_data.assets.new(asset_manager_id:, variant:)
+        attachment.attachment_data.assets.new(asset_manager_id:, variant:, filename:)
         edition.attachments << attachment
         stub_publishing_api_has_linkables([], document_type: "topic")
         setup_publishing_api_for(edition)
@@ -120,7 +120,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
             click_button "Save"
             assert_text "Attachment 'Attachment Title' updated"
 
-            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:)
+            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:, filename: replacement_filename)
             Attachment.last.attachment_data.uploaded_to_asset_manager!
             stub_asset(replacement_asset_manager_id)
           end
@@ -152,7 +152,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
             attach_file "Replace file", path_to_attachment(replacement_filename)
             click_button "Save"
             assert_text "Attachment 'attachment-title' updated"
-            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:)
+            Attachment.last.attachment_data.assets.create!(asset_manager_id: replacement_asset_manager_id, variant:, filename: replacement_filename)
             Attachment.last.attachment_data.uploaded_to_asset_manager!
             stub_asset(replacement_asset_manager_id)
           end

--- a/test/unit/app/helpers/application_helper_test.rb
+++ b/test/unit/app/helpers/application_helper_test.rb
@@ -12,8 +12,41 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "#link_to_attachment returns link to an attachment given attachment" do
-    attachment = create(:file_attachment)
-    assert_equal %(<a href="#{attachment.url}">#{File.basename(attachment.filename)}</a>), link_to_attachment(attachment)
+    attachment = build(:file_attachment)
+    assert_equal %(<a href="#{attachment.url}">#{attachment.filename}</a>), link_to_attachment(attachment)
+  end
+
+  test "#link_to_attachment returns a link to external attachment" do
+    attachment = build(:external_attachment)
+    assert_equal %(<a href="#{attachment.url}">#{attachment.external_url}</a>), link_to_attachment(attachment)
+  end
+
+  test "#link_to_attachment returns link to file attachment if attachment has all asset variants" do
+    attachment = build(:file_attachment_with_assets)
+    assert_equal %(<a href="#{attachment.url}">#{attachment.filename}</a>), link_to_attachment(attachment)
+  end
+
+  test "#link_to_attachment returns a span element if file attachment has no assets" do
+    attachment = build(:file_attachment)
+    attachment.attachment_data.use_non_legacy_endpoints = true
+    assert_equal %(<span>#{attachment.filename}</span>), link_to_attachment(attachment)
+  end
+
+  test "#link_to_attachment_data returns a link to attachment" do
+    attachment_data = build(:attachment_data)
+    assert_equal %(<a class="govuk-link" href="#{attachment_data.url}">#{attachment_data.filename}</a>), link_to_attachment_data(attachment_data)
+  end
+
+  test "#link_to_attachment_data returns a link if file attachment has all asset variants" do
+    attachment_data = build(:attachment_data_with_assets)
+    attachment_data.content_type = AttachmentUploader::PDF_CONTENT_TYPE
+    assert_equal %(<a class="govuk-link" href="#{attachment_data.url}">#{attachment_data.filename}</a>), link_to_attachment_data(attachment_data)
+  end
+
+  test "#link_to_attachment_data returns a span if attachment has no assets" do
+    attachment_data = build(:attachment_data)
+    attachment_data.use_non_legacy_endpoints = true
+    assert_equal %(<span>#{attachment_data.filename}</span>), link_to_attachment_data(attachment_data)
   end
 
   test "should format into paragraphs" do

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -16,15 +16,23 @@ class AttachmentsHelperTest < ActionView::TestCase
     assert_not previewable?(csv_on_policy_group)
   end
 
-  test "block_attachments renders an array of rendered attachments" do
+  test "block_attachments renders an array of rendered attachments and ignores attachments with missing assets" do
     alternative_format_contact_email = "test@example.com"
+    file_attachment_with_no_permissions = create(:file_attachment)
+    file_attachment_with_all_assets = create(:file_attachment_with_asset)
+    file_attachment_with_missing_assets = create(:file_attachment)
+    file_attachment_with_missing_assets.attachment_data.use_non_legacy_endpoints = true
     attachments = [
       create(:html_attachment),
       create(:external_attachment),
-      create(:file_attachment, accessible: false),
+      file_attachment_with_no_permissions,
+      file_attachment_with_all_assets,
+      file_attachment_with_missing_assets,
     ]
 
     rendered_attachments = block_attachments(attachments, alternative_format_contact_email)
+
+    assert_equal attachments.length - 1, rendered_attachments.length
 
     rendered_attachments.each.with_index do |rendered, index|
       attachment = attachments[index]

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -173,7 +173,6 @@ class AttachmentsHelperTest < ActionView::TestCase
   end
 
   context "use_non_legacy_endpoints" do
-
     test "component params for previewable CSV attachment when has no asset" do
       attachment = file_attachment("sample.csv", attachable: create(:edition))
       attachment.attachment_data.use_non_legacy_endpoints = true
@@ -199,7 +198,7 @@ class AttachmentsHelperTest < ActionView::TestCase
         content_type: "text/csv",
         filename: attachment.filename,
         file_size: attachment.file_size,
-        preview_url: "/media/asset_manager_id_original/dft_statistical_data_set_sample.csv/preview"
+        preview_url: "/media/asset_manager_id_original/dft_statistical_data_set_sample.csv/preview",
       }
       assert_equal expect_params, attachment_component_params(attachment)
     end

--- a/test/unit/app/helpers/govspeak_helper_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_test.rb
@@ -180,7 +180,7 @@ class GovspeakHelperTest < ActionView::TestCase
     body = "#Heading\n\n#{embed_code}\n\n##Subheading"
     attachment = build(:file_attachment, title: "Green paper")
     attachment.attachment_data.use_non_legacy_endpoints = true
-    document = create(:published_detailed_guide, :with_file_attachment, attachments: [attachment], body:)
+    document = build(:draft_detailed_guide, :with_file_attachment, attachments: [attachment], body:)
 
     html = govspeak_edition_to_html(document)
     refute_select_within_html html, ".gem-c-attachment"

--- a/test/unit/app/helpers/govspeak_helper_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_test.rb
@@ -175,6 +175,17 @@ class GovspeakHelperTest < ActionView::TestCase
     refute_select_within_html html, ".gem-c-attachment-link"
   end
 
+  test "should ignore file attachments with missing asset variants" do
+    embed_code = "[Attachment: greenpaper.pdf]"
+    body = "#Heading\n\n#{embed_code}\n\n##Subheading"
+    attachment = build(:file_attachment, title: "Green paper")
+    attachment.attachment_data.use_non_legacy_endpoints = true
+    document = create(:published_detailed_guide, :with_file_attachment, attachments: [attachment], body:)
+
+    html = govspeak_edition_to_html(document)
+    refute_select_within_html html, ".gem-c-attachment"
+  end
+
   test "should not convert documents with no block attachments" do
     text = "#Heading\n\n!@2"
     document = build(:published_detailed_guide, body: text)

--- a/test/unit/app/models/asset_test.rb
+++ b/test/unit/app/models/asset_test.rb
@@ -28,7 +28,7 @@ class AssetTest < ActiveSupport::TestCase
   end
 
   test "should be valid if all fields present" do
-    asset = Asset.new(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant)
+    asset = Asset.new(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant, filename: "greenpaper.pdf")
 
     assert asset.valid?
   end

--- a/test/unit/app/models/attachable_test.rb
+++ b/test/unit/app/models/attachable_test.rb
@@ -405,4 +405,14 @@ class AttachableTest < ActiveSupport::TestCase
     assert attachable_edition.allows_attachments?
     assert_equal [attachable_edition], attachable_edition.attachables
   end
+
+  test "#uploaded_to_asset_manager? returns false if any of the assets are not ready" do
+    first_attachment = build(:file_attachment)
+    second_attachment = build(:file_attachment)
+    first_attachment.attachment_data.use_non_legacy_endpoints = true
+    attachable_edition = build(:edition)
+    attachable_edition.attachments = [first_attachment, second_attachment]
+
+    assert_not attachable_edition.uploaded_to_asset_manager?
+  end
 end

--- a/test/unit/app/models/attachable_test.rb
+++ b/test/unit/app/models/attachable_test.rb
@@ -415,4 +415,24 @@ class AttachableTest < ActiveSupport::TestCase
 
     assert_not attachable_edition.uploaded_to_asset_manager?
   end
+
+  test "attachments_ready_for_publishing filters out file attachments with missing assets" do
+    file_attachment_with_no_permissions = create(:file_attachment)
+    file_attachment_with_all_assets = build(:file_attachment_with_asset)
+    file_attachment_with_missing_assets = build(:file_attachment)
+    file_attachment_with_missing_assets.attachment_data.use_non_legacy_endpoints = true
+    external_attachment = build(:external_attachment)
+
+    publication = build(
+      :publication,
+      attachments: [
+        file_attachment_with_no_permissions,
+        file_attachment_with_all_assets,
+        file_attachment_with_missing_assets,
+        external_attachment,
+      ],
+    )
+
+    assert_equal publication.attachments.length - 1, publication.attachments_ready_for_publishing.length
+  end
 end

--- a/test/unit/app/models/edition/publishing_test.rb
+++ b/test/unit/app/models/edition/publishing_test.rb
@@ -156,4 +156,21 @@ class Edition::PublishingTest < ActiveSupport::TestCase
 
     assert_equal edition, edition.unpublished_edition
   end
+
+  test "is valid if all assets have been uploaded" do
+    published_edition = build(:published_edition)
+    attachment = build(:file_attachment_with_assets)
+    published_edition.attachments << attachment
+
+    assert published_edition.valid?
+  end
+
+  test "is invalid if some assets are missing" do
+    published_edition = build(:published_edition)
+    attachment = build(:file_attachment)
+    attachment.attachment_data.use_non_legacy_endpoints = true
+    published_edition.attachments << attachment
+
+    assert_not published_edition.valid?
+  end
 end

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -63,4 +63,14 @@ class FileAttachmentTest < ActiveSupport::TestCase
     attachment.attachment_data.file = {}
     assert attachment.filename_changed?
   end
+
+  test "return legacy preview_url by default" do
+    attachment = create(:csv_attachment, attachable: create(:edition))
+    assert_equal Plek.asset_root + "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
+  end
+
+  test "return non legacy preview_url if use_non_legacy_endpoints is true" do
+    attachment = create(:file_attachment, attachable: create(:edition), attachment_data: build(:attachment_data_with_csv_asset))
+    assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/dft_statistical_data_set_sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
+  end
 end

--- a/test/unit/app/models/review_reminder_test.rb
+++ b/test/unit/app/models/review_reminder_test.rb
@@ -61,7 +61,7 @@ class ReviewReminderTest < ActiveSupport::TestCase
   end
 
   test "it resets reminder_sent_at when the review_at date is changed" do
-    reminder = create(:review_reminder, :reminder_sent)
+    reminder = create(:review_reminder, :reminder_due, :reminder_sent)
 
     reminder.update!(review_at: 10.days.from_now)
 
@@ -74,8 +74,8 @@ class ReviewReminderTest < ActiveSupport::TestCase
 
   test "#reminder_due? returns false when the reminder email does not need to be sent" do
     assert_not build(:review_reminder, :not_due_yet).reminder_due?
-    assert_not build(:review_reminder, :due_but_never_published).reminder_due?
-    assert_not build(:review_reminder, :reminder_sent).reminder_due?
+    assert_not build(:review_reminder, :reminder_due, :document_never_published).reminder_due?
+    assert_not build(:review_reminder, :reminder_due, :reminder_sent).reminder_due?
   end
 
   test "#reminder_sent! marks the reminder as sent without changing updated_at" do
@@ -100,8 +100,8 @@ class ReviewReminderTest < ActiveSupport::TestCase
     reminders = [
       due = build(:review_reminder, :reminder_due),
       overdue = build(:review_reminder, :reminder_due, review_at: 1.week.ago),
-      already_sent = build(:review_reminder, :reminder_sent),
-      due_but_never_published = build(:review_reminder, :due_but_never_published),
+      already_sent = build(:review_reminder, :reminder_due, :reminder_sent),
+      document_never_published = build(:review_reminder, :reminder_due, :document_never_published),
       not_due_yet = build(:review_reminder, :not_due_yet),
     ]
 
@@ -111,7 +111,7 @@ class ReviewReminderTest < ActiveSupport::TestCase
     assert_includes ReviewReminder.reminder_due, due
     assert_includes ReviewReminder.reminder_due, overdue
     assert_not_includes ReviewReminder.reminder_due, already_sent
-    assert_not_includes ReviewReminder.reminder_due, due_but_never_published
+    assert_not_includes ReviewReminder.reminder_due, document_never_published
     assert_not_includes ReviewReminder.reminder_due, not_due_yet
   end
 end

--- a/test/unit/app/presenters/publishing_api/payload_builder/attachments_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/attachments_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module PublishingApi
+  module PayloadBuilder
+    class AttachmentsTest < ActiveSupport::TestCase
+      test "ignores file attachments with missing asset variants" do
+        attachment = build(:file_attachment)
+        attachment.attachment_data.use_non_legacy_endpoints = true
+        document = build(:news_article, :with_file_attachment, attachments: [attachment])
+
+        assert_equal 0, PayloadBuilder::Attachments.for(document)[:attachments].count
+      end
+
+      test "allows file attachments that have all asset variants" do
+        attachment = build(:file_attachment_with_assets)
+        document = build(:news_article, :with_file_attachment, attachments: [attachment])
+
+        assert_equal 1, PayloadBuilder::Attachments.for(document)[:attachments].count
+      end
+
+      test "allows non-file attachments" do
+        attachment = build(:external_attachment)
+        document = build(:news_article, :with_file_attachment, attachments: [attachment])
+
+        assert_equal 1, PayloadBuilder::Attachments.for(document)[:attachments].count
+      end
+    end
+  end
+end

--- a/test/unit/app/services/asset_manager/attachment_deleter_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_deleter_test.rb
@@ -66,15 +66,7 @@ class AssetManager::AttachmentDeleterTest < ActiveSupport::TestCase
       end
 
       context "attachment_data has associated assets" do
-        let(:file) { File.open(fixture_path.join("simple.pdf")) }
-        let(:original_file_id) { "original_file_id" }
-        let(:variant_file_id) { "variant_file_id" }
-        let(:original_asset) { Asset.new(asset_manager_id: original_file_id, variant: Asset.variants[:original]) }
-        let(:variant_asset) { Asset.new(asset_manager_id: variant_file_id, variant: Asset.variants[:thumbnail]) }
-
-        before do
-          attachment_data.assets = [original_asset, variant_asset]
-        end
+        let(:attachment_data) { build(:attachment_data_with_assets) }
 
         context "and attachment data is not deleted" do
           let(:deleted) { false }
@@ -92,8 +84,8 @@ class AssetManager::AttachmentDeleterTest < ActiveSupport::TestCase
           let(:deleted) { true }
 
           it "deletes attachment & thumbnail asset in Asset Manager" do
-            delete_worker.expects(:call).with(nil, original_file_id)
-            delete_worker.expects(:call).with(nil, variant_file_id)
+            delete_worker.expects(:call).with(nil, "asset_manager_id_original")
+            delete_worker.expects(:call).with(nil, "asset_manager_id_thumbnail")
 
             worker.call(attachment_data)
           end

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -36,8 +36,8 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
       let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
       let(:original) { Asset.variants[:original] }
       let(:thumbnail) { Asset.variants[:thumbnail] }
-      let(:original_asset) { Asset.new(asset_manager_id: "original_asset_manager_id", variant: original) }
-      let(:thumbnail_asset) { Asset.new(asset_manager_id: "thumbnail_asset_manager_id", variant: thumbnail) }
+      let(:original_asset) { Asset.new(asset_manager_id: "original_asset_manager_id", variant: original, filename: "simple.pdf") }
+      let(:thumbnail_asset) { Asset.new(asset_manager_id: "thumbnail_asset_manager_id", variant: thumbnail, filename: "thumbnail_simple.pdf.png") }
 
       around do |test|
         AssetManager.stub_const(:AssetUpdater, update_service) do
@@ -242,7 +242,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
 
           it "does not update asset manager" do
-            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original)
+            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original, filename: "sample.rtf")
             update_service.expects(:call).never
 
             updater.call(attachment_data, replacement_id: true)
@@ -254,8 +254,8 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
           let(:replacement_attributes) { { "replacement_id" => replacement_original_asset.asset_manager_id } }
           let(:replacement_thumbnail_attributes) { { "replacement_id" => replacement_thumbnail_asset.asset_manager_id } }
-          let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_original_asset_manager_id", variant: original) }
-          let(:replacement_thumbnail_asset) { Asset.new(asset_manager_id: "replacement_thumbnail_asset_manager_id", variant: thumbnail) }
+          let(:replacement_original_asset) { Asset.new(asset_manager_id: "replacement_original_asset_manager_id", variant: original, filename: "whitepaper.pdf") }
+          let(:replacement_thumbnail_asset) { Asset.new(asset_manager_id: "replacement_thumbnail_asset_manager_id", variant: thumbnail, filename: "thumbnail_whitepaper.pdf.png") }
 
           before do
             attachment_data.replaced_by = replacement
@@ -296,8 +296,8 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           let(:replacement) { AttachmentData.create!(file: sample_docx) }
 
           it "raises a AssetNotFound error" do
-            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original)
-            replacement.assets.create!(asset_manager_id: "replacement_asset_manager_id", variant: original)
+            attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original, filename: "sample.rtf")
+            replacement.assets.create!(asset_manager_id: "replacement_asset_manager_id", variant: original, filename: "sample.docx")
 
             update_service.expects(:call)
                           .raises(AssetManager::ServiceHelper::AssetNotFound.new("asset not found"))

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -46,6 +46,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
       end
 
       before do
+        attachment_data.use_non_legacy_endpoints = true
         attachment_data.assets = [original_asset, thumbnail_asset]
       end
 

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -288,6 +288,17 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
               updater.call(attachment_data, replacement_id: true)
             end
           end
+
+          context "but replacement has no assets" do
+            let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
+            let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+
+            it "does not update asset manager" do
+              update_service.expects(:call).never
+
+              updater.call(attachment_data, replacement_id: true)
+            end
+          end
         end
 
         context "when attachment is not synced with asset manager" do

--- a/test/unit/app/validators/relative_date_validator_test.rb
+++ b/test/unit/app/validators/relative_date_validator_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class RelativeDateValidatorTest < ActiveSupport::TestCase
+  class StubModel
+    include ActiveModel::API
+    attr_accessor :some_date
+  end
+
+  test "validation is not applied if attribute value is nil" do
+    model = StubModel.new(some_date: nil)
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 3) }, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_empty model.errors
+  end
+
+  test "model is valid if datetime is between before and after dates" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 3) }, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_empty model.errors
+  end
+
+  test "adds an error with the default message if date is later than before date" do
+    before = Time.zone.local(2022, 1, 1, 1, 1)
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { before })
+    validator.validate(model)
+    assert_not_empty model.errors
+    assert_equal "must be before #{before}", model.errors[:some_date].first
+  end
+
+  test "adds an error if date is equal to before date" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_not_empty model.errors
+  end
+
+  test "adds an error with the default message if date is earlier than after date" do
+    after = Time.zone.local(2022, 1, 1, 1, 2)
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { after })
+    validator.validate(model)
+    assert_not_empty model.errors
+    assert_equal "must be after #{after}", model.errors[:some_date].first
+  end
+
+  test "adds an error if date is equal to after date" do
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { Time.zone.local(2022, 1, 1, 1, 1) })
+    validator.validate(model)
+    assert_not_empty model.errors
+  end
+
+  test "before error message can be overriden" do
+    before_message = "should be in the past"
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 2))
+    validator = RelativeDateValidator.new(attributes: :some_date, before: -> { Time.zone.local(2022, 1, 1, 1, 1) }, before_message:)
+    validator.validate(model)
+    assert_equal before_message, model.errors[:some_date].first
+  end
+
+  test "after error message can be overriden" do
+    after_message = "should be in the future"
+    model = StubModel.new(some_date: Time.zone.local(2022, 1, 1, 1, 1))
+    validator = RelativeDateValidator.new(attributes: :some_date, after: -> { Time.zone.local(2022, 1, 1, 1, 2) }, after_message:)
+    validator.validate(model)
+    assert_equal after_message, model.errors[:some_date].first
+  end
+end

--- a/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
@@ -23,5 +23,18 @@ class AssetManagerAttachmentMetadataWorkerTest < ActiveSupport::TestCase
 
       worker.perform(attachment_data.id)
     end
+
+    context "attachment data has missing assets" do
+      it "does not call updater nor deleter" do
+        attachment_data.use_non_legacy_endpoints = true
+        attachment_data.save!
+
+        AssetManager::AttachmentUpdater.expects(:call).never
+
+        AssetManager::AttachmentDeleter.expects(:call).never
+
+        worker.perform(attachment_data.id)
+      end
+    end
   end
 end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -118,4 +118,22 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
 
     assert_nil AttachmentData.find(@model.id).uploaded_to_asset_manager_at
   end
+
+  test "triggers an update to publishing api after asset has been saved" do
+    consultation = FactoryBot.create(:consultation)
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    Services.publishing_api.stubs(:put_content).once
+
+    @worker.perform(@file.path, @asset_args, true, consultation.class.to_s, consultation.id)
+  end
+
+  test "does not trigger an update to publishing api if attachable is not an edition" do
+    consultation_outcome = FactoryBot.create(:consultation_outcome)
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    Services.publishing_api.stubs(:put_content).never
+
+    @worker.perform(@file.path, @asset_args, true, consultation_outcome.class.to_s, consultation_outcome.id)
+  end
 end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -8,7 +8,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @organisation = FactoryBot.create(:organisation)
     @model = FactoryBot.create(:attachment_data)
     @asset_manager_response = { "id" => "http://asset-manager/assets/#{@asset_manager_id}" }
-    @asset_args = { assetable_id: @model.id, asset_variant: Asset.variants[:original], assetable_type: @model.class.to_s }.deep_stringify_keys
+    @asset_args = { assetable_id: @model.id, asset_variant: Asset.variants[:original], assetable_type: @model.class.to_s, filename: File.basename(@file) }.deep_stringify_keys
   end
 
   test "upload an asset using a file object at the correct path" do

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -108,7 +108,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     assert_not_nil AttachmentData.find(@model.id).uploaded_to_asset_manager_at
   end
 
-  test "does not update uploaded_to_asset_manager when asset variant is not :original" do
+  test "updates uploaded_to_asset_manager for :thumbnail asset variant" do
     @model.uploaded_to_asset_manager_at = nil
     @model.save!
     @asset_args["asset_variant"] = Asset.variants[:thumbnail]
@@ -116,7 +116,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
 
     @worker.perform(@file.path, @asset_args)
 
-    assert_nil AttachmentData.find(@model.id).uploaded_to_asset_manager_at
+    assert_not_nil AttachmentData.find(@model.id).uploaded_to_asset_manager_at
   end
 
   test "triggers an update to publishing api after asset has been saved" do

--- a/test/unit/app/workers/review_reminder_notifier_worker_test.rb
+++ b/test/unit/app/workers/review_reminder_notifier_worker_test.rb
@@ -27,7 +27,7 @@ class ReviewReminderNotifierWorkerTest < ActiveSupport::TestCase
     not_due_yet = create(:review_reminder, :not_due_yet)
     ReviewReminderNotifierWorker.new.perform(not_due_yet.id)
 
-    already_sent = create(:review_reminder, :reminder_sent)
+    already_sent = create(:review_reminder, :reminder_due, :reminder_sent)
     ReviewReminderNotifierWorker.new.perform(already_sent.id)
   end
 end

--- a/test/unit/lib/tasks/send_review_reminders_test.rb
+++ b/test/unit/lib/tasks/send_review_reminders_test.rb
@@ -10,7 +10,7 @@ class SendReviewRemindersTest < ActiveSupport::TestCase
     reminders = [
       due = build(:review_reminder, :reminder_due),
       overdue = build(:review_reminder, :reminder_due, review_at: 1.week.ago),
-      already_sent = build(:review_reminder, :reminder_sent),
+      already_sent = build(:review_reminder, :reminder_due, :reminder_sent),
       not_due_yet = build(:review_reminder, :not_due_yet),
     ]
 

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -16,6 +16,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     @file = Tempfile.new("asset")
     @uploader = AssetManagerUploader.new
     FileUtils.mkdir_p(Whitehall.asset_manager_tmp_dir)
+    @filename = File.basename(@file)
   end
 
   teardown do
@@ -153,7 +154,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
       test "calls worker with assetable and default original asset_variant" do
         variant = Asset.variants[:original]
-        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type }.deep_stringify_keys
+        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type, filename: @filename }.deep_stringify_keys
 
         AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, asset_args, anything, anything, anything, anything)
 
@@ -163,7 +164,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       test "calls worker with assetable and variant" do
         variant = Asset.variants[:thumbnail]
         @uploader.stubs(:version_name).returns(:thumbnail)
-        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type }.deep_stringify_keys
+        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type, filename: @filename }.deep_stringify_keys
 
         AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, asset_args, anything, anything, anything, anything)
 
@@ -182,7 +183,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
       test "calls worker with assetable and default original variant" do
         variant = Asset.variants[:original]
-        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type }.deep_stringify_keys
+        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type, filename: @filename }.deep_stringify_keys
 
         AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, asset_args, anything, anything, anything, anything)
 
@@ -192,7 +193,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       test "calls worker with assetable and variant" do
         variant = Asset.variants[:s960]
         @uploader.stubs(:version_name).returns(:s960)
-        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type }.deep_stringify_keys
+        asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type, filename: @filename }.deep_stringify_keys
 
         AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, asset_args, anything, anything, anything, anything)
 

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -16,7 +16,6 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     @file = Tempfile.new("asset")
     @uploader = AssetManagerUploader.new
     FileUtils.mkdir_p(Whitehall.asset_manager_tmp_dir)
-    @auth_bypass_id = "86385d6a-f918-4c93-96bf-087218a48ced"
   end
 
   teardown do
@@ -24,8 +23,6 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   end
 
   test "store! returns an asset manager file" do
-    AssetManagerCreateWhitehallAssetWorker.stubs(:perform_async)
-
     storage = Whitehall::AssetManagerStorage.new(@uploader)
     file = CarrierWave::SanitizedFile.new(@file)
 
@@ -36,7 +33,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     storage = Whitehall::AssetManagerStorage.new(@uploader)
     @uploader.stubs(:store_path).with("identifier").returns("asset-path")
 
-    Whitehall::AssetManagerStorage::File.expects(:new).with("asset-path")
+    Whitehall::AssetManagerStorage::File.expects(:new).with("asset-path", nil, nil)
 
     storage.retrieve!("identifier")
   end
@@ -49,35 +46,12 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     assert_equal file, storage.retrieve!("identifier")
   end
 
-  describe "when use_non_legacy_endpoints permission is false and uploader model is not an AttachmentData" do
-    context "uploader.model.instance_of?(AttachmentData) is false" do
-      test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to images" do
-        model = build(:image_data)
-        model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
-        @uploader.stubs(:model).returns(model)
-
-        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
-
-        @uploader.store!(@file)
-      end
-
-      test "creates a sidekiq job with and passes through the auth_bypass_id but not model class or id if the uploader's model responds to consultation_response_form" do
-        model = ConsultationResponseFormData.new
-        model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
-        @uploader.stubs(:model).returns(model)
-
-        AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
-
-        @uploader.store!(@file)
-      end
-    end
-  end
-
   describe "when use_non_legacy_endpoints permission is false and uploader model is AttachmentData" do
     setup do
       model = build(:attachment_data)
       model.stubs(:use_non_legacy_endpoints).returns(false)
       @uploader.stubs(:model).returns(model)
+      @auth_bypass_id = "86385d6a-f918-4c93-96bf-087218a48ced"
     end
 
     test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
@@ -133,50 +107,50 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   end
 
   describe "when use_non_legacy_endpoints permission is true" do
-    setup do
-      model = build(:attachment_data)
-      model.stubs(:use_non_legacy_endpoints).returns(true)
-      model.id = 1
-      @uploader.stubs(:model).returns(model)
-      @assetable_type = AttachmentData.name
-    end
-
-    test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
-      AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, _|
-        uploaded_file_name = File.basename(@file.path)
-        expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
-        actual_path =~ expected_path
-      end
-      @uploader.store!(@file)
-    end
-
-    test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
-      @uploader.assets_protected = true
-
-      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, true, anything, anything, anything)
-
-      @uploader.store!(@file)
-    end
-
-    test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
-      @uploader.assets_protected = false
-
-      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, false, anything, anything, anything)
-
-      @uploader.store!(@file)
-    end
-
-    test "creates a sidekiq job and passes through the model class and id and auth_bypass_id if the model responds to attachable" do
-      model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
-      model.stubs(:use_non_legacy_endpoints).returns(true)
-      @uploader.stubs(:model).returns(model)
-
-      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
-
-      @uploader.store!(@file)
-    end
-
     context "uploader model is AttachmentData" do
+      setup do
+        model = build(:attachment_data)
+        model.stubs(:use_non_legacy_endpoints).returns(true)
+        model.id = 1
+        @uploader.stubs(:model).returns(model)
+        @assetable_type = AttachmentData.name
+      end
+
+      test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
+        AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, _|
+          uploaded_file_name = File.basename(@file.path)
+          expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
+          actual_path =~ expected_path
+        end
+        @uploader.store!(@file)
+      end
+
+      test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
+        @uploader.assets_protected = true
+
+        AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, true, anything, anything, anything)
+
+        @uploader.store!(@file)
+      end
+
+      test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
+        @uploader.assets_protected = false
+
+        AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, false, anything, anything, anything)
+
+        @uploader.store!(@file)
+      end
+
+      test "creates a sidekiq job and passes through the model class and id and auth_bypass_id if the model responds to attachable" do
+        model = AttachmentData.new(attachable: Consultation.new(id: 1, auth_bypass_id: @auth_bypass_id))
+        model.stubs(:use_non_legacy_endpoints).returns(true)
+        @uploader.stubs(:model).returns(model)
+
+        AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, "Consultation", 1, [@auth_bypass_id])
+
+        @uploader.store!(@file)
+      end
+
       test "calls worker with assetable and default original asset_variant" do
         variant = Asset.variants[:original]
         asset_args = { assetable_id: @uploader.model.id, asset_variant: variant, assetable_type: @assetable_type }.deep_stringify_keys
@@ -233,20 +207,13 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     asset_path = "path/to/asset.png"
     @asset_url_path = "/government/uploads/#{asset_path}"
     @file = Whitehall::AssetManagerStorage::File.new(asset_path)
+    Plek.stubs(:new).returns(stub("plek", asset_root: "http://assets-host"))
   end
 
   test "queues the call to delete the asset from asset manager" do
     AssetManagerDeleteAssetWorker.expects(:perform_async).with(@asset_url_path, nil)
 
     @file.delete
-  end
-
-  test "constructs the url of the file using the assets root and legacy url path" do
-    Plek.stubs(:new).returns(stub("plek", asset_root: "http://assets-host"))
-
-    expected_asset_url = URI.join("http://assets-host", @asset_url_path).to_s
-
-    assert_equal expected_asset_url, @file.url
   end
 
   test "returns the legacy filename as the path" do
@@ -265,8 +232,48 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     asset_path = "path/to/ässet.png"
     file = Whitehall::AssetManagerStorage::File.new(asset_path)
 
-    Plek.stubs(:new).returns(stub("plek", asset_root: "http://assets-host"))
-
     assert_equal "http://assets-host/government/uploads/path/to/%C3%A4sset.png", file.url
+  end
+
+  test "constructs the url of the file using the assets root and legacy url path" do
+    expected_asset_url = URI.join("http://assets-host", @asset_url_path).to_s
+
+    assert_equal expected_asset_url, @file.url
+  end
+
+  test "returns file url using asset_manager_id when the model has the original asset" do
+    model = build(:attachment_data_with_asset)
+    model.use_non_legacy_endpoints = true
+    model.save!
+    model.reload
+
+    assert_equal "http://assets-host/media/asset_manager_id/sample.docx", model.file.url
+  end
+
+  test "returns file url using asset_manager_id when the model has an asset variant" do
+    model = build(:attachment_data_with_assets)
+    model.use_non_legacy_endpoints = true
+    model.save!
+    model.reload
+
+    assert_equal "http://assets-host/media/asset_manager_id_thumbnail/thumbnail_greenpaper.pdf.png", model.file.url(:thumbnail)
+  end
+
+  test "returns nil when the model has assets but the requested variant is not available" do
+    model = build(:attachment_data_with_asset)
+    model.use_non_legacy_endpoints = true
+    model.save!
+    model.reload
+
+    assert_nil model.file.url(:thumbnail)
+  end
+
+  test "returns legacy path when the model has no assets, although it should (still uploading or error has occurred)" do
+    model = build(:attachment_data)
+    model.use_non_legacy_endpoints = true
+    model.save!
+    model.reload
+
+    assert_equal model.file.path, model.file.url
   end
 end


### PR DESCRIPTION

To move away from legacy url path, we needed csv previews to work with `/media/:id/:filename` endpoint in asset manager.

We added check for non legacy endpoints so that we can return the non legacy preview url correctly.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Trello Card](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)
